### PR TITLE
add tzinfo config, useful when start druid without utc timezone

### DIFF
--- a/panoramix/config.py
+++ b/panoramix/config.py
@@ -1,6 +1,7 @@
 import os
 from flask_appbuilder.security.manager import AUTH_OID, AUTH_REMOTE_USER, AUTH_DB, AUTH_LDAP, AUTH_OAUTH
 basedir = os.path.abspath(os.path.dirname(__file__))
+from dateutil import tz
 
 """
 All configuration in this file can be overridden by providing a local_config
@@ -40,6 +41,12 @@ APP_NAME = "Panoramix"
 
 # Uncomment to setup Setup an App icon
 APP_ICON = "/static/chaudron_white.png"
+
+# Druid query timezone
+# tz.tzutc() : Using utc timezone
+# tz.tzlocal() : Using local timezone
+# other tz can be overridden by providing a local_config
+DRUID_TZ = tz.tzutc()
 
 #----------------------------------------------------
 # AUTHENTICATION CONFIG

--- a/panoramix/models.py
+++ b/panoramix/models.py
@@ -23,6 +23,7 @@ import requests
 import textwrap
 
 from panoramix import db, get_session
+import config
 
 QueryResult = namedtuple('namedtuple', ['df', 'query', 'duration'])
 
@@ -524,6 +525,8 @@ class Datasource(Model, AuditMixin, Queryable):
             timeseries_limit=None,
             row_limit=None):
         qry_start_dttm = datetime.now()
+        from_dttm = from_dttm.replace(tzinfo=config.DRUID_TZ)  # add tzinfo to native datetime with config
+        to_dttm = to_dttm.replace(tzinfo=config.DRUID_TZ)
 
         query_str = ""
         aggregations = {


### PR DESCRIPTION
I startup druid cluster with `America/Los_Angeles` timezone(both cluster instances and druid commands).

Then I found the query of table view(Now: 02:05:56 PDT / 10:05:56 UTC), the intervals of query using none timezone information:

```
// Two phase query
// Phase 1
{
  "dimensions": [], 
  "aggregations": [
    {
      "type": "count", 
      "name": "count"
    }
  ], 
  "intervals": "2015-09-05T02:05:56/2015-09-06T02:05:56", 
  "dataSource": "..."
...
```

It queried data before `2015-09-06T02:05:56 UTC`, but can not query data between `2015-09-06T02:05:57 UTC ~ 2015-09-06T10:05:56 UTC`. May be it would be `"intervals": "2015-09-05T02:05:56-07:00/2015-09-06T02:05:56-07:00"`.

so I add this tzinfo configure, setting `DRUID_TZ = tz.tzlocal()` when start druid without UTC timezone(of course, it also work fine if both cluster instances and druid using UTC timezone).
