### PR TITLE
Fix Markup Widget bug

### DIFF
--- a/panoramix/forms.py
+++ b/panoramix/forms.py
@@ -151,7 +151,7 @@ class FormFactory(object):
                     'step-before', 'step-after']),
                 default='linear',
                 description="Line interpolation as defined by d3.js"),
-            'code': TextAreaField("Code", description="Put your code here"),
+            'code': TextAreaField("Code", description="Put your code here", default=''),
             'size_from': TextField(
                 "Font Size From",
                 default="20",


### PR DESCRIPTION
@mistercrunch 

The Markup widget wasn't working because the code form element was lacking a default value, which threw an error when trying to convert the text into markdown (or when trying to switch between two visualizations)
