### PR TITLE
adjusting date formats

### DIFF
--- a/panoramix/static/widgets/viz_nvd3.js
+++ b/panoramix/static/widgets/viz_nvd3.js
@@ -9,14 +9,13 @@ function viz_nvd3(data_attribute) {
     return v = new Date(dttm.getUTCFullYear(), dttm.getUTCMonth(), dttm.getUTCDate(),  dttm.getUTCHours(), dttm.getUTCMinutes(), dttm.getUTCSeconds());
   }
   var tickMultiFormat = d3.time.format.multi([
-    [".%L", function(d) { return d.getMilliseconds(); }],
-    [":%S", function(d) { return d.getSeconds(); }],
-    ["%I:%M", function(d) { return d.getMinutes(); }],
-    ["%I %p", function(d) { return d.getHours(); }],
-    ["%a %d", function(d) { return d.getDay() && d.getDate() != 1; }],
-    ["%b %d", function(d) { return d.getDate() != 1; }],
-    ["%B", function(d) { return d.getMonth(); }],
-    ["%Y", function() { return true; }]
+    [".%L", function(d) { return d.getMilliseconds(); }], // If there are millisections, show  only them
+    [":%S", function(d) { return d.getSeconds(); }], // If there are seconds, show only them
+    ["%a %b %d, %I:%M %p", function(d) { return d.getMinutes()!=0; }], // If there are non-zero minutes, show Date, Hour:Minute [AM/PM]
+    ["%a %b %d, %I %p", function(d) { return d.getHours() != 0; }], // If there are hours that are multiples of 3, show date and AM/PM
+    ["%a %b %d, %Y", function(d) { return d.getDate() != 1; }], // If not the first of the month, do "month day, year."
+    ["%B %Y", function(d) { return d.getMonth() != 0 && d.getDate() == 1; }], // If the first of the month, do "month day, year."
+    ["%Y", function(d) { return true; }] // fall back on month, year
   ]);
   function formatDate(dttm) {
     var d = UTC(new Date(dttm));
@@ -44,7 +43,8 @@ function viz_nvd3(data_attribute) {
           chart.lines2.xScale(d3.time.scale.utc());
           chart.x2Axis
             .showMaxMin(viz.form_data.x_axis_showminmax)
-            .tickFormat(formatDate);
+            .tickFormat(formatDate)
+            .staggerLabels(true);
           } else {
             chart = nv.models.lineChart()
           }
@@ -54,9 +54,13 @@ function viz_nvd3(data_attribute) {
           chart.interpolate(viz.form_data.line_interpolation);
           chart.xAxis
             .showMaxMin(viz.form_data.x_axis_showminmax)
-            .tickFormat(formatDate);
+            .tickFormat(formatDate)
+            .staggerLabels(true);
           chart.showLegend(viz.form_data.show_legend);
           chart.yAxis.tickFormat(d3.format('.3s'));
+          if (chart.y2Axis != undefined) {
+              chart.y2Axis.tickFormat(d3.format('.3s'));
+          }
           if (viz.form_data.contribution || viz.form_data.num_period_compare) {
             chart.yAxis.tickFormat(d3.format('.3p'));
             if (chart.y2Axis != undefined) {
@@ -125,6 +129,8 @@ function viz_nvd3(data_attribute) {
           chart.yAxis.tickFormat(d3.format('.3s'));
         }
 
+        // make space for labels on right
+        chart.height($(".chart").height() - 50).margin({"right": 50});
         if ((viz_type === "line" || viz_type === "area") && viz.form_data.rich_tooltip) {
           chart.useInteractiveGuideline(true);
         }


### PR DESCRIPTION
to: @michellethomas @mistercrunch 
Hey guys,

I made some updates to the date formats that I think make them much more useful. The basic problem I was trying to solve is just adding more context to the charts about what you were looking at. Sometimes, the day of week was shown, or just the month and it was unclear what you were looking at. I tried to keep it clean like it was, but also add more context. The goal is to make it less likely to make a mistake when people are passing around screen shots. 

I did another small fix where I made the y-axis format on the context chart the same as on the main y-axis. 

For adjusting the dates, I just changed the rules and then also added margin on the right to accommodate the longer dates, added a staggered effect to prevent overlapping, and took away a little height to make everything fit. 

I tested it with my own dataset which I decided to not include as a default. It isn't all that interesting. 

LMK if you have any questions and here are some pre/post screen shots. 

![image](https://cloud.githubusercontent.com/assets/2367249/11830074/88f5ec54-a356-11e5-921b-b8426c8e77fe.png)

![image](https://cloud.githubusercontent.com/assets/2367249/11830083/9c8264c8-a356-11e5-8dcc-1a9585450012.png)

![image](https://cloud.githubusercontent.com/assets/2367249/11830091/af1d87f2-a356-11e5-9e8f-a0a5ac147823.png)

![image](https://cloud.githubusercontent.com/assets/2367249/11830110/d2ed8d76-a356-11e5-8474-2e9c2f7c26cd.png)
