### PR TITLE
fixing a few bugs with tool tip overflow

### DIFF
--- a/panoramix/static/panoramix.css
+++ b/panoramix/static/panoramix.css
@@ -55,9 +55,9 @@ legend.legend-style {
     background-color: transparent;
     font-weight: bold;
 }
-.nvtooltip{
+.nvtooltip {
     position: relative; !important
-    z-index: 10;
+    z-index: 888;
 }
 
 legend {
@@ -185,7 +185,7 @@ legend {
  overflow: visible;  /* This allows elements within these slice typesin a dashboard to overflow */
 }
 .dashboard  div.nvtooltip {
-  z-index: 1;  /* this lets tool tips go on top of other slices  */
+  z-index: 888;  /* this lets tool tips go on top of other slices  */
 }
 .dashboard td.icons {
   width: 50px;

--- a/panoramix/static/panoramix.js
+++ b/panoramix/static/panoramix.js
@@ -217,6 +217,13 @@ function initializeDashboardView(dashboard_id) {
     css = $(this).val();
     $("#user_style").html(css);
   });
+  $('li.widget').each(function() { /* this sets the z-index for left side boxes higher. */
+    current_row = $(this).attr('data-col');
+    $( this ).css('z-index', 100 - current_row);
+  });
+  $("div.chart").each(function() { /* this makes the whole chart fit within the dashboard div */
+    $(this).css('height', '95%');
+  });
 }
 
   // Export public functions


### PR DESCRIPTION
@mistercrunch 
this fixes a few issues with the tooltips that were introduced with my last change. 

Specifically, it makes the tooltips flow over elements to their right by setting the z-index of more left columns in the dashboard thus the tooltip will always flow over the more right elements. 

It also scales the charts in the dashboard down 5% so there is no bleeding out of the bottom.

![image](https://cloud.githubusercontent.com/assets/2367249/11852327/294fec50-a3ec-11e5-904d-52a3c62c59d3.png)
