### PR TITLE
Adding impyla to support impala as a DB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ pyhive
 mysqlclient>=1.3.6, <2.0.0
 six
 sqlalchemy==1.0.8
+impyla


### PR DESCRIPTION
Adding dependency for impyla (Impala's python based client) so that we can now support impala as a DB
