### PR TITLE
Change Scaling to Operate on SVG instead of Div

### DIFF
--- a/panoramix/static/panoramix.js
+++ b/panoramix/static/panoramix.js
@@ -328,8 +328,10 @@ var px = (function() {
     });
 
     // this makes the whole chart fit within the dashboard div
-    $("div.chart").each(function() {
-      $(this).css('height', '95%');
+    $(".slice_container > svg").each(function(index){
+      w = $( this ).width();
+      h = $( this ).height();
+      $( this ).get(0).setAttribute('viewBox', '0 0 '+w+' '+(h+30));
     });
   }
 


### PR DESCRIPTION
It looks like the DOM had changed and it broke some of the overflowing. 
You can see here:
https://panoramix.d.musta.ch/panoramix/dashboard/shared_itinerary/

This should do the fix by rescaling the svg chart. 
