### PR TITLE
Renaming Classes related to Druid

### DIFF
--- a/panoramix/models.py
+++ b/panoramix/models.py
@@ -86,7 +86,7 @@ class Slice(Model, AuditMixinNullable):
     table = relationship(
         'SqlaTable', foreign_keys=[table_id], backref='slices')
     druid_datasource = relationship(
-        'Datasource', foreign_keys=[druid_datasource_id], backref='slices')
+        'DruidDatasource', foreign_keys=[druid_datasource_id], backref='slices')
 
     def __repr__(self):
         return self.slice_name
@@ -742,7 +742,7 @@ class TableColumn(Model, AuditMixinNullable):
         return self.type in ('LONG', 'DOUBLE', 'FLOAT')
 
 
-class Cluster(Model, AuditMixinNullable):
+class DruidCluster(Model, AuditMixinNullable):
     __tablename__ = 'clusters'
     id = Column(Integer, primary_key=True)
     cluster_name = Column(String(250), unique=True)
@@ -772,10 +772,10 @@ class Cluster(Model, AuditMixinNullable):
 
         datasources = json.loads(requests.get(endpoint).text)
         for datasource in datasources:
-            Datasource.sync_to_db(datasource, self)
+            DruidDatasource.sync_to_db(datasource, self)
 
 
-class Datasource(Model, AuditMixinNullable, Queryable):
+class DruidDatasource(Model, AuditMixinNullable, Queryable):
     type = "druid"
 
     baselink = "datasourcemodelview"
@@ -792,7 +792,7 @@ class Datasource(Model, AuditMixinNullable, Queryable):
     cluster_name = Column(
         String(250), ForeignKey('clusters.cluster_name'))
     cluster = relationship(
-        'Cluster', backref='datasources', foreign_keys=[cluster_name])
+        'DruidCluster', backref='datasources', foreign_keys=[cluster_name])
     offset = Column(Integer, default=0)
 
     @property
@@ -1059,7 +1059,7 @@ class Metric(Model):
     datasource_name = Column(
         String(250),
         ForeignKey('datasources.datasource_name'))
-    datasource = relationship('Datasource', backref='metrics')
+    datasource = relationship('DruidDatasource', backref='metrics')
     json = Column(Text)
     description = Column(Text)
 
@@ -1072,13 +1072,13 @@ class Metric(Model):
         return obj
 
 
-class Column(Model, AuditMixinNullable):
+class DruidColumn(Model, AuditMixinNullable):
     __tablename__ = 'columns'
     id = Column(Integer, primary_key=True)
     datasource_name = Column(
         String(250),
         ForeignKey('datasources.datasource_name'))
-    datasource = relationship('Datasource', backref='columns')
+    datasource = relationship('DruidDatasource', backref='columns')
     column_name = Column(String(256))
     is_active = Column(Boolean, default=True)
     type = Column(String(32))

--- a/panoramix/models.py
+++ b/panoramix/models.py
@@ -1050,7 +1050,7 @@ class Log(Model):
     dttm = Column(DateTime, default=func.now())
 
 
-class Metric(Model):
+class DruidMetric(Model):
     __tablename__ = 'metrics'
     id = Column(Integer, primary_key=True)
     metric_name = Column(String(512))
@@ -1098,9 +1098,9 @@ class DruidColumn(Model, AuditMixinNullable):
         return self.type in ('LONG', 'DOUBLE', 'FLOAT')
 
     def generate_metrics(self):
-        M = Metric
+        M = DruidMetric
         metrics = []
-        metrics.append(Metric(
+        metrics.append(DruidMetric(
             metric_name='count',
             verbose_name='COUNT(*)',
             metric_type='count',
@@ -1125,7 +1125,7 @@ class DruidColumn(Model, AuditMixinNullable):
         if self.min and self.isnum:
             mt = corrected_type.lower() + 'Min'
             name = 'min__' + self.column_name
-            metrics.append(Metric(
+            metrics.append(DruidMetric(
                 metric_name=name,
                 metric_type='min',
                 verbose_name='MIN({})'.format(self.column_name),
@@ -1135,7 +1135,7 @@ class DruidColumn(Model, AuditMixinNullable):
         if self.max and self.isnum:
             mt = corrected_type.lower() + 'Max'
             name = 'max__' + self.column_name
-            metrics.append(Metric(
+            metrics.append(DruidMetric(
                 metric_name=name,
                 metric_type='max',
                 verbose_name='MAX({})'.format(self.column_name),
@@ -1145,7 +1145,7 @@ class DruidColumn(Model, AuditMixinNullable):
         if self.count_distinct:
             mt = 'count_distinct'
             name = 'count_distinct__' + self.column_name
-            metrics.append(Metric(
+            metrics.append(DruidMetric(
                 metric_name=name,
                 verbose_name='COUNT(DISTINCT {})'.format(self.column_name),
                 metric_type='count_distinct',

--- a/panoramix/utils.py
+++ b/panoramix/utils.py
@@ -172,7 +172,7 @@ def init():
     table_perms = [
             table.perm for table in session.query(models.SqlaTable).all()]
     table_perms += [
-            table.perm for table in session.query(models.Datasource).all()]
+            table.perm for table in session.query(models.DruidDatasource).all()]
     for table_perm in table_perms:
         merge_perm(sm, 'datasource_access', table.perm)
 

--- a/panoramix/views.py
+++ b/panoramix/views.py
@@ -85,7 +85,7 @@ class DruidColumnInlineView(CompactCRUDMixin, PanoramixModelView):
     def post_update(self, col):
         col.generate_metrics()
 
-appbuilder.add_view_no_menu(ColumnInlineView)
+appbuilder.add_view_no_menu(DruidColumnInlineView)
 
 
 class SqlMetricInlineView(CompactCRUDMixin, PanoramixModelView):
@@ -99,8 +99,8 @@ class SqlMetricInlineView(CompactCRUDMixin, PanoramixModelView):
 appbuilder.add_view_no_menu(SqlMetricInlineView)
 
 
-class MetricInlineView(CompactCRUDMixin, PanoramixModelView):
-    datamodel = SQLAInterface(models.Metric)
+class DruidMetricInlineView(CompactCRUDMixin, PanoramixModelView):
+    datamodel = SQLAInterface(models.DruidMetric)
     list_columns = ['metric_name', 'verbose_name', 'metric_type']
     edit_columns = [
         'metric_name', 'description', 'verbose_name', 'metric_type',
@@ -111,7 +111,7 @@ class MetricInlineView(CompactCRUDMixin, PanoramixModelView):
     validators_columns = {
         'json': [validate_json],
     }
-appbuilder.add_view_no_menu(MetricInlineView)
+appbuilder.add_view_no_menu(DruidMetricInlineView)
 
 
 class DatabaseView(PanoramixModelView, DeleteMixin):
@@ -284,7 +284,7 @@ class DruidDatasourceModelView(PanoramixModelView, DeleteMixin):
         'created_by', 'created_on',
         'changed_by_', 'changed_on',
         'offset']
-    related_views = [DruidColumnInlineView, MetricInlineView]
+    related_views = [DruidColumnInlineView, DruidMetricInlineView]
     edit_columns = [
         'datasource_name', 'cluster', 'description', 'owner',
         'is_featured', 'is_hidden', 'default_endpoint', 'offset']

--- a/panoramix/views.py
+++ b/panoramix/views.py
@@ -71,8 +71,8 @@ appbuilder.add_link(
 
 appbuilder.add_separator("Sources")
 
-class ColumnInlineView(CompactCRUDMixin, PanoramixModelView):
-    datamodel = SQLAInterface(models.Column)
+class DruidColumnInlineView(CompactCRUDMixin, PanoramixModelView):
+    datamodel = SQLAInterface(models.DruidColumn)
     edit_columns = [
         'column_name', 'description', 'datasource', 'groupby',
         'count_distinct', 'sum', 'min', 'max']
@@ -185,8 +185,8 @@ appbuilder.add_view(
 appbuilder.add_separator("Sources")
 
 
-class ClusterModelView(PanoramixModelView, DeleteMixin):
-    datamodel = SQLAInterface(models.Cluster)
+class DruidClusterModelView(PanoramixModelView, DeleteMixin):
+    datamodel = SQLAInterface(models.DruidCluster)
     add_columns = [
         'cluster_name',
         'coordinator_host', 'coordinator_port', 'coordinator_endpoint',
@@ -196,7 +196,7 @@ class ClusterModelView(PanoramixModelView, DeleteMixin):
     list_columns = ['cluster_name', 'metadata_last_refreshed']
 
 appbuilder.add_view(
-    ClusterModelView,
+    DruidClusterModelView,
     "Druid Clusters",
     icon="fa-cubes",
     category="Sources",
@@ -277,14 +277,14 @@ appbuilder.add_view(
     icon="fa-list-ol")
 
 
-class DatasourceModelView(PanoramixModelView, DeleteMixin):
-    datamodel = SQLAInterface(models.Datasource)
+class DruidDatasourceModelView(PanoramixModelView, DeleteMixin):
+    datamodel = SQLAInterface(models.DruidDatasource)
     list_columns = [
         'datasource_link', 'cluster', 'owner',
         'created_by', 'created_on',
         'changed_by_', 'changed_on',
         'offset']
-    related_views = [ColumnInlineView, MetricInlineView]
+    related_views = [DruidColumnInlineView, MetricInlineView]
     edit_columns = [
         'datasource_name', 'cluster', 'description', 'owner',
         'is_featured', 'is_hidden', 'default_endpoint', 'offset']
@@ -303,7 +303,7 @@ class DatasourceModelView(PanoramixModelView, DeleteMixin):
         self.post_add(datasource)
 
 appbuilder.add_view(
-    DatasourceModelView,
+    DruidDatasourceModelView,
     "Druid Datasources",
     category="Sources",
     icon="fa-cube")
@@ -362,7 +362,7 @@ class Panoramix(BaseView):
         else:
             datasource = (
                 db.session
-                .query(models.Datasource)
+                .query(models.DruidDatasource)
                 .filter_by(id=datasource_id)
                 .first()
             )
@@ -489,8 +489,8 @@ class Panoramix(BaseView):
         model = None
         if model_view == 'TableColumnInlineView':
             model = models.TableColumn
-        elif model_view == 'ColumnInlineView':
-            model = models.Column
+        elif model_view == 'DruidColumnInlineView':
+            model = models.DruidColumn
 
         obj = db.session.query(model).filter_by(id=id_).first()
         if obj:
@@ -647,7 +647,7 @@ class Panoramix(BaseView):
     @expose("/refresh_datasources/")
     def refresh_datasources(self):
         session = db.session()
-        for cluster in session.query(models.Cluster).all():
+        for cluster in session.query(models.DruidCluster).all():
             try:
                 cluster.refresh_datasources()
             except Exception as e:
@@ -699,7 +699,7 @@ class Panoramix(BaseView):
         session = db.session()
         datasets_sqla = (session.query(models.SqlaTable)
                                         .filter_by(is_featured=True).all())
-        datasets_druid = (session.query(models.Datasource)
+        datasets_druid = (session.query(models.DruidDatasource)
                                          .filter_by(is_featured=True).all())
         featured_datasets = datasets_sqla + datasets_druid
         return self.render_template(

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -26,6 +26,7 @@ class LiveTest(TestCase):
         cli.load_examples(sample=True)
 
     def test_slices(self):
+        # Testing by running all the examples
         Slc = models.Slice
         for slc in db.session.query(Slc).all():
             print(slc)


### PR DESCRIPTION
When the project started it was Druid centric. Now that it allows for connectivity to many database, class names need to be more specific.
