### PR TITLE
Fixing multiple refresh bug in filter_box

### DIFF
--- a/panoramix/assets/.eslintrc
+++ b/panoramix/assets/.eslintrc
@@ -58,7 +58,7 @@
     "max-depth": [2, 5],
     "max-len": [0, 80, 4],
     "max-nested-callbacks": [1, 2],
-    "max-params": [1, 3],
+    "max-params": [1, 4],
     "new-parens": [2],
     "newline-after-var": [0],
     "no-bitwise": [0],

--- a/panoramix/assets/visualizations/filter_box.js
+++ b/panoramix/assets/visualizations/filter_box.js
@@ -7,21 +7,17 @@ var d3 = window.d3 || require('d3');
 require('./filter_box.css');
 require('../javascripts/panoramix-select2.js');
 
-
 function filterBox(slice) {
   var filtersObj = {};
   var d3token = d3.select(slice.selector);
 
   var fltChanged = function () {
-    for (var filter in filtersObj) {
-      var obj = filtersObj[filter];
-      var val = obj.val();
-      var vals = [];
-      if (val !== '') {
-        vals = val.split(',');
-      }
-      slice.setFilter(filter, vals);
+    var val = $(this).val();
+    var vals = [];
+    if (val !== '') {
+      vals = val.split(',');
     }
+    slice.setFilter($(this).attr('name'), vals);
   };
 
   var refresh = function () {


### PR DESCRIPTION
Addresses https://github.com/mistercrunch/panoramix/issues/170

@williaster, cranking up the lint `max-params` for functions to accept 4 params as it's acceptable in many cases. This allows us to be 100% lint free.
