### PR TITLE
Fixing the python and js packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
 recursive-include panoramix/templates *
 recursive-include panoramix/static *
+recursive-exclude panoramix/static/assets/node_modules *
+recursive-include panoramix/static/assets/node_modules/font-awesome *
+recursive-exclude panoramix/static/docs *
+recursive-exclude tests *
 recursive-include panoramix/data *
 recursive-include panoramix/migrations *

--- a/panoramix/assets/javascripts/dashboard.js
+++ b/panoramix/assets/javascripts/dashboard.js
@@ -9,6 +9,7 @@ require('brace/mode/css');
 require('brace/theme/crimson_editor');
 
 require('./panoramix-select2.js');
+require('../node_modules/gridster/dist/jquery.gridster.min.css');
 require('../node_modules/gridster/dist/jquery.gridster.min.js');
 
 var Dashboard = function (dashboardData) {

--- a/panoramix/assets/javascripts/explore.js
+++ b/panoramix/assets/javascripts/explore.js
@@ -14,7 +14,6 @@ require('bootstrap');
 require('./panoramix-select2.js');
 
 require('../node_modules/bootstrap-toggle/js/bootstrap-toggle.min.js');
-require('../vendor/select2.sortable.js');
 
 // css
 require('../vendor/pygments.css');

--- a/panoramix/assets/javascripts/featured.js
+++ b/panoramix/assets/javascripts/featured.js
@@ -1,7 +1,9 @@
 var $ = window.$ = require('jquery');
 var jQuery = window.jQuery = $;
+var px = require('./modules/panoramix.js');
+
 require('datatables');
-require('datatables-bootstrap3-plugin');
+require('../node_modules/datatables-bootstrap3-plugin/media/css/datatables-bootstrap3.css')
 require('bootstrap');
 
 $(document).ready(function () {

--- a/panoramix/assets/javascripts/modules/panoramix.js
+++ b/panoramix/assets/javascripts/modules/panoramix.js
@@ -2,6 +2,8 @@ var $ = require('jquery');
 var jQuery = $;
 var d3 = require('d3');
 
+require('../../stylesheets/panoramix.css');
+
 // vis sources
 var sourceMap = {
   area: 'nvd3_vis.js',

--- a/panoramix/assets/javascripts/panoramix-select2.js
+++ b/panoramix/assets/javascripts/panoramix-select2.js
@@ -1,2 +1,5 @@
+require('../node_modules/select2/select2.css');
 require('../node_modules/select2-bootstrap-css/select2-bootstrap.min.css');
+require('../node_modules/jquery-ui/themes/base/jquery-ui.css')
 require('select2');
+require('../vendor/select2.sortable.js');

--- a/panoramix/assets/stylesheets/panoramix.css
+++ b/panoramix/assets/stylesheets/panoramix.css
@@ -220,9 +220,6 @@ img.loading {
   font-size: 14px;
   padding: 5px;
 }
-.dashboard div.gridster {
-  visibility: hidden
-}
 .dashboard div.slice_content {
   width: 100%;
   height: 100%;

--- a/panoramix/assets/webpack.config.js
+++ b/panoramix/assets/webpack.config.js
@@ -30,9 +30,14 @@ var config = {
         include: APP_DIR,
         loader: "style-loader!css-loader"
       },
-    /* for require('*.less') */
+    /* for css linking images */
+      { test: /\.png$/, loader: "url-loader?limit=100000" },
+      { test: /\.jpg$/, loader: "file-loader" },
+      { test: /\.gif$/, loader: "file-loader" },
+    /* for font-awesome */
       { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader?limit=10000&minetype=application/font-woff" },
       { test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "file-loader" },
+    /* for require('*.less') */
       {
         test: /\.less$/,
         include: APP_DIR,

--- a/panoramix/templates/panoramix/basic.html
+++ b/panoramix/templates/panoramix/basic.html
@@ -7,11 +7,7 @@
     </title>
     {% block head_meta %}{% endblock %}
     {% block head_css %}
-        <link rel="stylesheet" type="text/css" href="/static/assets/node_modules/jquery-ui/themes/base/minified/jquery-ui.min.css" />
-        <link rel="stylesheet" type="text/css" href="/static/assets/node_modules/font-awesome/css/font-awesome.min.css" />
-        <link rel="stylesheet" type="text/css" href="/static/assets/node_modules/select2/select2.css" />
-        <link rel="stylesheet" type="text/css" href="/static/assets/node_modules/select2/select2-bootstrap.css" />
-        <link rel="stylesheet" type="text/css" href="/static/assets/stylesheets/panoramix.css" />
+      <link rel="stylesheet" type="text/css" href="/static/assets/node_modules/font-awesome/css/font-awesome.min.css" />
     {% endblock %}
     {% block head_js %}
       <script src="/static/assets/javascripts/dist/css-theme.entry.js"></script>

--- a/panoramix/templates/panoramix/dashboard.html
+++ b/panoramix/templates/panoramix/dashboard.html
@@ -65,7 +65,7 @@
       </div>
     </div>
 </div>
-<div class="gridster content_fluid">
+<div class="gridster content_fluid" style="visibility: hidden;">
     <ul>
         {% for slice in dashboard.slices %}
           {% set pos = pos_dict.get(slice.id, {}) %}

--- a/panoramix/templates/panoramix/dashboard.html
+++ b/panoramix/templates/panoramix/dashboard.html
@@ -2,7 +2,6 @@
 
 {% block head_css %}
     {{ super() }}
-    <link rel="stylesheet" href="{{ url_for('static', filename="assets/node_modules/gridster/dist/jquery.gridster.min.css") }}">
     <style id="user_style" type="text/css">
       {{ dashboard.css or '' }}
     </style>

--- a/panoramix/templates/panoramix/featured.html
+++ b/panoramix/templates/panoramix/featured.html
@@ -34,11 +34,6 @@
 </div>
 {% endblock %}
 
-{% block head_css %}
-{{ super() }}
-<link rel="stylesheet" type="text/css" href="/static/assets/node_modules/datatables-bootstrap3-plugin/media/css/datatables-bootstrap3.css" />
-{% endblock %}
-
 {% block tail_js %}
   {{ super() }}
   <script src="/static/assets/javascripts/dist/featured.entry.js"></script>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.7.1'
+version = '0.8.0'
 
 setup(
     name='panoramix',
@@ -9,10 +9,6 @@ setup(
         "and druid.io"),
     version=version,
     packages=find_packages(),
-    package_data={'': [
-        'panoramix/migrations/alembic.ini',
-        'panoramix/data/birth_names.csv.gz',
-    ]},
     include_package_data=True,
     zip_safe=False,
     scripts=['panoramix/bin/panoramix'],


### PR DESCRIPTION
@williaster 
This makes it such that we don't have to ship the whole `node_modules` with the python package, to do that I had to move a bunch of `css` html references to the `js` require notation. I managed to do it for everything but the `font-awesome` one.

This also cranks up the version to 0.8.0, I think it's ready to ship to Pypi.
