### PR TITLE
sunburst improvements

### DIFF
--- a/panoramix/assets/javascripts/modules/utils.js
+++ b/panoramix/assets/javascripts/modules/utils.js
@@ -1,0 +1,55 @@
+var d3 = require('d3');
+
+/*
+    Utility function that takes a d3 svg:text selection and a max width, and splits the
+    text's text across multiple tspan lines such that any given line does not exceed max width
+
+    If text does not span multiple lines AND adjustedY is passed, will set the text to the passed val
+ */
+function wrapSvgText(text, width, adjustedY) {
+  var lineHeight = 1; // ems
+
+  text.each(function () {
+    var text = d3.select(this),
+        words = text.text().split(/\s+/),
+        word,
+        line = [],
+        lineNumber = 0,
+        x = text.attr("x"),
+        y = text.attr("y"),
+        dy = parseFloat(text.attr("dy")),
+        tspan = text.text(null)
+          .append("tspan")
+          .attr("x", x)
+          .attr("y", y)
+          .attr("dy", dy + "em");
+
+    var didWrap = false;
+
+    for (var i = 0; i < words.length; i++) {
+      word = words[i];
+      line.push(word);
+      tspan.text(line.join(" "));
+
+      if (tspan.node().getComputedTextLength() > width) {
+        line.pop(); // remove word that pushes over the limit
+        tspan.text(line.join(" "));
+        line = [word];
+        tspan = text.append("tspan")
+          .attr("x", x)
+          .attr("y", y)
+          .attr("dy", ++lineNumber * lineHeight + dy + "em")
+          .text(word);
+
+        didWrap = true;
+      }
+    }
+    if (!didWrap && typeof adjustedY !== "undefined") {
+      tspan.attr("y", adjustedY);
+    }
+  });
+}
+
+module.exports = {
+  wrapSvgText: wrapSvgText
+};

--- a/panoramix/assets/visualizations/sunburst.css
+++ b/panoramix/assets/visualizations/sunburst.css
@@ -1,24 +1,45 @@
-.sunburst text.middle{
-    text-anchor: middle;
+.sunburst text {
+  shape-rendering: crispEdges;
 }
-
-.sunburst #sequence {
-}
-
-.sunburst #legend {
-  padding: 10px 0 0 3px;
-}
-
-.sunburst #sequence text, #legend text {
-  font-weight: 600;
-  fill: #fff;
-}
-
 .sunburst path {
   stroke: #fff;
+  stroke-width: 1px;
 }
 
-.sunburst #percentage {
+.sunburst .center-label {
+  text-anchor: middle;
+  fill: #000;
+}
+.sunburst .path-percent {
+  font-size: 4em;
+}
+.sunburst .path-metrics {
+  font-size: 1.75em;
+}
+.sunburst .path-ratio {
+  font-size: 1.2em;
+}
+
+.sunburst .breadcrumbs {
+  fill: #00D1C1; /*default*/
+}
+
+.sunburst .breadcrumbs text {
+  font-weight: 600;
+  font-size: 1.2em;
+  text-anchor: middle;
+  fill: #fff;
+}
+.sunburst .breadcrumbs text.end-label {
+  fill: #000;
+}
+
+.dashboard .sunburst text {
+  font-size: 1em;
+}
+.dashboard .sunburst .path-percent {
   font-size: 2.5em;
 }
-
+.dashboard .sunburst .path-metrics {
+  font-size: 1em;
+}

--- a/panoramix/assets/visualizations/sunburst.css
+++ b/panoramix/assets/visualizations/sunburst.css
@@ -2,13 +2,13 @@
   shape-rendering: crispEdges;
 }
 .sunburst path {
-  stroke: #fff;
-  stroke-width: 1px;
+  stroke: #333;
+  stroke-width: 0.5px;
 }
-
 .sunburst .center-label {
   text-anchor: middle;
   fill: #000;
+  pointer-events: none;
 }
 .sunburst .path-percent {
   font-size: 4em;
@@ -20,20 +20,14 @@
   font-size: 1.2em;
 }
 
-.sunburst .breadcrumbs {
-  fill: #00D1C1; /*default*/
-}
-
 .sunburst .breadcrumbs text {
   font-weight: 600;
   font-size: 1.2em;
   text-anchor: middle;
-  fill: #fff;
-}
-.sunburst .breadcrumbs text.end-label {
   fill: #000;
 }
 
+/* dashboard specific */
 .dashboard .sunburst text {
   font-size: 1em;
 }

--- a/panoramix/assets/visualizations/sunburst.js
+++ b/panoramix/assets/visualizations/sunburst.js
@@ -8,10 +8,10 @@ function sunburstVis(slice) {
 
   var render = function () {
     // vars with shared scope within this function
-    var margin = { top: 5, right: 5, bottom: 5, left: 5 };
-    var containerWidth   =  slice.width();
+    var margin = { top: 10, right: 5, bottom: 10, left: 5 };
+    var containerWidth   = slice.width();
     var containerHeight  = slice.height();
-    var breadcrumbHeight = containerHeight * 0.075;
+    var breadcrumbHeight = containerHeight * 0.065;
     var visWidth         = containerWidth - margin.left - margin.right;
     var visHeight        = containerHeight - margin.top - margin.bottom - breadcrumbHeight;
     var radius           = Math.min(visWidth, visHeight) / 2;
@@ -62,11 +62,12 @@ function sunburstVis(slice) {
     });
 
     function createBreadcrumbs(rawData) {
-      maxBreadcrumbs = 8.75; //rawData.form_data.groupby.length + 1.75; // +extra for %label and buffer
+      var firstRowData = rawData.data[0];
+      maxBreadcrumbs = (firstRowData.length - 2) + 1; // -2 bc row contains 2x metrics, +extra for %label and buffer
 
       breadcrumbDims = {
         width: visWidth / maxBreadcrumbs,
-        height: breadcrumbHeight,
+        height: breadcrumbHeight *0.8, // more margin
         spacing: 3,
         tipTailWidth: 10
       };
@@ -85,7 +86,7 @@ function sunburstVis(slice) {
 
       vis = svg.append("svg:g")
         .attr("class", "sunburst-vis")
-        .attr("transform", "translate(" + (containerWidth / 2) + "," + (breadcrumbHeight + (containerHeight / 2)) + ")")
+        .attr("transform", "translate(" + (margin.left + (visWidth / 2)) + "," + (margin.top + breadcrumbHeight + (visHeight / 2)) + ")")
         .on("mouseleave", mouseleave);
 
       arcs = vis.append("svg:g")
@@ -108,7 +109,7 @@ function sunburstVis(slice) {
 
       var ext, colorScale;
 
-      if (slice.metric !== slice.secondary_metric) {
+      if (rawData.form_data.metric !== rawData.form_data.secondary_metric) {
         colorByCategory = false;
 
         ext = d3.extent(nodes, function (d) {
@@ -164,8 +165,10 @@ function sunburstVis(slice) {
 
       var sequenceArray = getAncestors(d);
 
-      // Fade all the segments.
+      // Reset and fade all the segments.
       arcs.selectAll("path")
+        .style("stroke-width", null)
+        .style("stroke", null)
         .style("opacity", 0.3);
 
       // Then highlight only those that are an ancestor of the current segment.

--- a/panoramix/assets/visualizations/sunburst.js
+++ b/panoramix/assets/visualizations/sunburst.js
@@ -190,7 +190,7 @@ function sunburstVis(slice) {
     function mouseleave(d) {
 
       // Hide the breadcrumb trail
-      // breadcrumbs.style("visibility", "hidden");
+      breadcrumbs.style("visibility", "hidden");
 
       gMiddleText.selectAll("*").remove();
 

--- a/panoramix/viz.py
+++ b/panoramix/viz.py
@@ -881,7 +881,8 @@ class SunburstViz(BaseViz):
             'label': 'Secondary Metric',
             'description': (
                 "This secondary metric is used to "
-                "define the color as a ratio against the primary metric"),
+                "define the color as a ratio against the primary metric. "
+                "If the two metrics match, color is mapped level groups"),
         },
         'groupby': {
             'label': 'Hierarchy',


### PR DESCRIPTION
this commit adds some additions to the sunburst vis:
- trim '0' groups from sunburst paths to show null groups (previously, all levels were filled in completely with filler groups even if the counts were 0; those should have been trimmed)
- add ability to map color to sunburst groupby groups, instead of ratio. Until we refactor controls, this was implemented simply by checking if m1 == m2. 
- add fancier breadcrumbs to sunburst re derek's request

trickiest part was making sizing of breadcrumbs etc dynamic based on the number of levels and within a dasboard, but tested it a fair amount.
