### PR TITLE
Overriding granularity by extra parameters since and until

### DIFF
--- a/panoramix/assets/javascripts/modules/panoramix.js
+++ b/panoramix/assets/javascripts/modules/panoramix.js
@@ -167,6 +167,16 @@ var px = (function () {
         } else {
           qrystr = '?' + $('#query').serialize();
         }
+        return this.overrideGranularity(qrystr);
+      },
+      overrideGranularity: function(qrystr){
+        if (dashboard !== undefined &&
+            dashboard.granularity !== undefined &&
+            dashboard.granularity.since &&
+            dashboard.granularity.until) {
+            return qrystr.replace(/(since)\=([^\&]*)/, 'since=' + dashboard.granularity.since)
+                    .replace(/(until)\=([^\&]*)/, 'until=' + dashboard.granularity.until);
+        }
         return qrystr;
       },
       jsonEndpoint: function () {

--- a/panoramix/models.py
+++ b/panoramix/models.py
@@ -181,6 +181,7 @@ class Dashboard(Model, AuditMixinNullable):
     slug = Column(String(255), unique=True)
     slices = relationship(
         'Slice', secondary=dashboard_slices, backref='dashboards')
+    granularity = {'since': None, 'until': None}
 
     def __repr__(self):
         return self.dashboard_title
@@ -219,10 +220,15 @@ class Dashboard(Model, AuditMixinNullable):
             'id': self.id,
             'metadata': self.metadata_dejson,
             'dashboard_title': self.dashboard_title,
+            'granularity': self.granularity,
             'slug': self.slug,
             'slices': [slc.data for slc in self.slices],
         }
         return json.dumps(d)
+
+    def set_granularity(self, since, until):
+        self.granularity['since'] = since
+        self.granularity['until'] = until
 
 
 class Queryable(object):

--- a/panoramix/views.py
+++ b/panoramix/views.py
@@ -566,6 +566,11 @@ class Panoramix(BaseView):
             pass
         dashboard(dashboard_id=dash.id)
 
+        since = request.args.get('since')
+        until = request.args.get('until')
+        if since and until:
+            dash.set_granularity(since, until)
+
         pos_dict = {}
         if dash.position_json:
             pos_dict = {


### PR DESCRIPTION
Hi,

With this feature we can use "since= .. & until= ..." parameters when calling a dashboard and override slices granularity. Syntax is the same as when you edit the slice.

Example: .../dashboard/6/?since=1 day ago&until=now
