### PR TITLE
Adding a DRUID_IS_ACTIVE flag and changing nav bar

### DIFF
--- a/dashed/config.py
+++ b/dashed/config.py
@@ -53,6 +53,7 @@ APP_NAME = "Dashed"
 # tz.tzutc() : Using utc timezone
 # tz.tzlocal() : Using local timezone
 # other tz can be overridden by providing a local_config
+DRUID_IS_ACTIVE = True
 DRUID_TZ = tz.tzutc()
 
 # ----------------------------------------------------

--- a/dashed/views.py
+++ b/dashed/views.py
@@ -207,12 +207,14 @@ class DruidClusterModelView(DashedModelView, DeleteMixin):  # noqa
     edit_columns = add_columns
     list_columns = ['cluster_name', 'metadata_last_refreshed']
 
-appbuilder.add_view(
-    DruidClusterModelView,
-    "Druid Clusters",
-    icon="fa-cubes",
-    category="Sources",
-    category_icon='fa-database',)
+
+if config['DRUID_IS_ACTIVE']:
+    appbuilder.add_view(
+        DruidClusterModelView,
+        "Druid Clusters",
+        icon="fa-cubes",
+        category="Sources",
+        category_icon='fa-database',)
 
 
 class SliceModelView(DashedModelView, DeleteMixin):  # noqa
@@ -326,11 +328,12 @@ class DruidDatasourceModelView(DashedModelView, DeleteMixin):  # noqa
     def post_update(self, datasource):
         self.post_add(datasource)
 
-appbuilder.add_view(
-    DruidDatasourceModelView,
-    "Druid Datasources",
-    category="Sources",
-    icon="fa-cube")
+if config['DRUID_IS_ACTIVE']:
+    appbuilder.add_view(
+        DruidDatasourceModelView,
+        "Druid Datasources",
+        category="Sources",
+        icon="fa-cube")
 
 
 @app.route('/health')
@@ -778,12 +781,14 @@ class Dashed(BaseView):
             utils=utils)
 
 appbuilder.add_view_no_menu(Dashed)
-appbuilder.add_link(
-    "Refresh Druid Metadata",
-    href='/dashed/refresh_datasources/',
-    category='Sources',
-    category_icon='fa-database',
-    icon="fa-cog")
+
+if config['DRUID_IS_ACTIVE']:
+    appbuilder.add_link(
+        "Refresh Druid Metadata",
+        href='/dashed/refresh_datasources/',
+        category='Sources',
+        category_icon='fa-database',
+        icon="fa-cog")
 
 
 class CssTemplateModelView(DashedModelView, DeleteMixin):


### PR DESCRIPTION
@mistercrunch @michellethomas 

My second dashed change! I added a DRUID_IS_ACTIVE flag, and if that's false, then the Druid specific items in the "Sources" dropdown disappear.

![screen shot 2016-03-25 at 11 25 02 am](https://cloud.githubusercontent.com/assets/4268311/14050988/f1285df0-f27c-11e5-8f81-6a5af914e042.png)
![screen shot 2016-03-25 at 11 25 18 am](https://cloud.githubusercontent.com/assets/4268311/14050990/f232d306-f27c-11e5-957c-f4a2ce0a9f3c.png)
