### PR TITLE
fix sunburst error. add `less` to package.json

### DIFF
--- a/dashed/assets/package.json
+++ b/dashed/assets/package.json
@@ -59,6 +59,7 @@
     "imports-loader": "^0.6.5",
     "jquery": "^2.2.1",
     "jquery-ui": "^1.10.5",
+    "less": "^2.6.1",
     "less-loader": "^2.2.2",
     "nvd3": "1.8.2",
     "react": "^0.14.7",

--- a/dashed/assets/visualizations/sunburst.js
+++ b/dashed/assets/visualizations/sunburst.js
@@ -293,7 +293,7 @@ function sunburstVis(slice) {
         }
         var currentNode = root;
         for (var j = 0; j < levels.length; j++) {
-          var children = currentNode.children;
+          var children = currentNode.children || [];
           var nodeName = levels[j];
           // If the next node has the name "0", it will
           var isLeafNode = (j >= levels.length - 1) || levels[j+1] === 0;


### PR DESCRIPTION
This fixes a JS bug that Lindsay + Dan Frank have been running into in sunbursts that they're eager to get in. See spinner [here](https://panoramix.d.musta.ch/panoramix/explore/table/395/?viz_type=sunburst&groupby=stage_0&groupby=stage_1&groupby=stage_2&metric=sum__cnt&secondary_metric=sum__cnt&row_limit=10&where=&having=&flt_col_0=device&flt_op_0=in&flt_eq_0=&slice_id=&slice_name=&collapsed_fieldsets=&action=&datasource_name=five_axioms&datasource_id=395&datasource_type=table&previous_viz_type=sunburst)

Also on a fresh install `less-loader` says that it requires `less` as a peer dependecny, so I added it to `package.json` We should probably also figure out devDependencies vs dependencies in package.json in the future.
