### PR TITLE
fixing cache timeout setting

### DIFF
--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -233,7 +233,14 @@ class BaseViz(object):
             logging.info("Serving from cache")
         else:
             is_cached = False
-            cache_timeout = self.cache_timeout
+            config_cache_timeout = config.get("CACHE_DEFAULT_TIMEOUT")
+            try:
+                cache_timeout = self.cache_timeout
+            except Exception as e:
+                if config_cache_timeout:
+                   cache_timeout = config_cache_timeout
+                else:
+                   cache_timeout = 0
             payload = {
                 'data': self.get_data(),
                 'query': self.query,
@@ -246,7 +253,7 @@ class BaseViz(object):
             payload['cached_dttm'] = datetime.now().isoformat().split('.')[0]
             logging.info("Caching for the next {} seconds".format(
                 cache_timeout))
-            cache.set(cache_key, payload, timeout=self.cache_timeout)
+            cache.set(cache_key, payload, timeout=cache_timeout)
         payload['is_cached'] = is_cached
         return dumps(payload)
 

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -237,10 +237,11 @@ class BaseViz(object):
             try:
                 cache_timeout = self.cache_timeout
             except Exception as e:
+                logging.exception(e)
                 if config_cache_timeout:
-                   cache_timeout = config_cache_timeout
+                    cache_timeout = config_cache_timeout
                 else:
-                   cache_timeout = 0
+                    cache_timeout = 0
             payload = {
                 'data': self.get_data(),
                 'query': self.query,


### PR DESCRIPTION
the current v0.8.4 fails if the cache timeout setting on the UI is not provided in edit datasource settings view: http://hostname:port/druiddatasourcemodelview/list/ 

self.cache_timeout causes the exception. The new logic is as follows:

1) try to find the cache timeout value from the UI 
2) If not then get the default value in the caravel_config.py
3) If the value is not defined in both config and the UI then set it to 0. 
