### PR TITLE
Adding a big number total viz type that is not a timeseries metric

### DIFF
--- a/caravel/assets/javascripts/modules/caravel.js
+++ b/caravel/assets/javascripts/modules/caravel.js
@@ -8,6 +8,7 @@ var sourceMap = {
   bar: 'nvd3_vis.js',
   bubble: 'nvd3_vis.js',
   big_number: 'big_number.js',
+  big_number_total: 'big_number.js',
   compare: 'nvd3_vis.js',
   dist_bar: 'nvd3_vis.js',
   directed_force: 'directed_force.js',

--- a/caravel/assets/visualizations/big_number.css
+++ b/caravel/assets/visualizations/big_number.css
@@ -1,4 +1,4 @@
-.big_number g.axis text {
+.big_number g.axis text, .big_number_total g.axis text {
   font-size: 10px;
   font-weight: normal;
   color: gray;
@@ -8,18 +8,18 @@
   font-weight: none;
 }
 
-.big_number text.big {
+.big_number text.big, .big_number_total text.big{
   stroke: black;
   text-anchor: middle;
   fill: black;
 }
 
-.big_number g.tick line {
+.big_number g.tick line, .big_number_total g.tick line{
   stroke-width: 1px;
   stroke: grey;
 }
 
-.big_number .domain {
+.big_number .domain, .big_number_total .domain{
   fill: none;
   stroke: black;
   stroke-width: 1;

--- a/caravel/assets/visualizations/big_number.css
+++ b/caravel/assets/visualizations/big_number.css
@@ -1,4 +1,5 @@
-.big_number g.axis text, .big_number_total g.axis text {
+.big_number g.axis text,
+.big_number_total g.axis text {
   font-size: 10px;
   font-weight: normal;
   color: gray;
@@ -8,18 +9,21 @@
   font-weight: none;
 }
 
-.big_number text.big, .big_number_total text.big{
+.big_number text.big,
+.big_number_total text.big{
   stroke: black;
   text-anchor: middle;
   fill: black;
 }
 
-.big_number g.tick line, .big_number_total g.tick line{
+.big_number g.tick line,
+.big_number_total g.tick line{
   stroke-width: 1px;
   stroke: grey;
 }
 
-.big_number .domain, .big_number_total .domain{
+.big_number .domain,
+.big_number_total .domain{
   fill: none;
   stroke: black;
   stroke-width: 1;

--- a/caravel/assets/visualizations/big_number.js
+++ b/caravel/assets/visualizations/big_number.js
@@ -6,7 +6,6 @@ require('./big_number.css');
 
 var px = require('../javascripts/modules/caravel.js');
 
-
 function bigNumberVis(slice) {
   var div = d3.select(slice.selector);
 
@@ -32,11 +31,11 @@ function bigNumberVis(slice) {
       var data = json.data;
       var compare_suffix = ' ' + json.compare_suffix;
       var v_compare = null;
+      var v = null;
       if (data.length > 1) {
-          var v = data[data.length - 1][1];
-      }
-      else{
-          var v = data[data.length - 1][0];
+          v = data[data.length - 1][1];
+      } else {
+          v = data[data.length - 1][0];
       }
       if (json.compare_lag > 0) {
         var pos = data.length - (json.compare_lag + 1);
@@ -104,7 +103,7 @@ function bigNumberVis(slice) {
         .attr('fill', 'white');
 
       //Printing big number subheader text
-      if (json.subheader !== null){
+      if (json.subheader !== null) {
         g.append('text')
           .attr('x', width / 2)
           .attr('y', y + d3.min([height, width]) / 4.5)

--- a/caravel/assets/visualizations/big_number.js
+++ b/caravel/assets/visualizations/big_number.js
@@ -6,6 +6,7 @@ require('./big_number.css');
 
 var px = require('../javascripts/modules/caravel.js');
 
+
 function bigNumberVis(slice) {
   var div = d3.select(slice.selector);
 
@@ -31,7 +32,12 @@ function bigNumberVis(slice) {
       var data = json.data;
       var compare_suffix = ' ' + json.compare_suffix;
       var v_compare = null;
-      var v = data[data.length - 1][1];
+      if (data.length > 1) {
+          var v = data[data.length - 1][1];
+      }
+      else{
+          var v = data[data.length - 1][0];
+      }
       if (json.compare_lag > 0) {
         var pos = data.length - (json.compare_lag + 1);
         if (pos >= 0) {
@@ -96,6 +102,19 @@ function bigNumberVis(slice) {
         .text(f(v))
         .style('font-size', d3.min([height, width]) / 3.5)
         .attr('fill', 'white');
+
+      //Printing big number subheader text
+      if (json.subheader !== null){
+        g.append('text')
+          .attr('x', width / 2)
+          .attr('y', y + d3.min([height, width]) / 4.5)
+          .text(json.subheader)
+          .attr('id', 'subheader_text')
+          .style('font-size', d3.min([height, width]) / 16)
+          .style('text-anchor', 'middle')
+          .attr('fill', c)
+          .attr('stroke', c);
+      }
 
       var c = scale_color(v_compare);
 

--- a/caravel/data/__init__.py
+++ b/caravel/data/__init__.py
@@ -534,6 +534,16 @@ def load_birth_names():
                 viz_type="big_number", granularity="ds",
                 compare_lag="5", compare_suffix="over 5Y")),
         Slice(
+            slice_name="Number of Girls",
+            viz_type='big_number_total',
+            datasource_type='table',
+            table=tbl,
+            params=get_slice_json(
+                defaults,
+                viz_type="big_number_total", granularity="ds",
+                flt_col_1='gender', flt_eq_1='girl',
+                subheader='total female participants')),
+        Slice(
             slice_name="Genders",
             viz_type='pie',
             datasource_type='table',

--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -504,6 +504,11 @@ class FormFactory(object):
                     "relative time period. Expects relative time delta "
                     "in natural language (example: 24 hours, 7 days, "
                     "56 weeks, 365 days")),
+            'subheader': TextField(
+                'Subheader',
+                description=(
+                    "Description text that shows up below your Big "
+                    "Number")),
         }
 
     @staticmethod

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -601,6 +601,7 @@ class BigNumberViz(BaseViz):
             'compare_suffix': form_data.get('compare_suffix', ''),
         }
 
+
 class BigNumberTotalViz(BaseViz):
 
     """Put emphasis on a single metric with this big number viz"""
@@ -612,8 +613,6 @@ class BigNumberTotalViz(BaseViz):
         'label': None,
         'fields': (
             'metric',
-            'compare_lag',
-            'compare_suffix',
             'subheader',
             'y_axis_format',
         )
@@ -642,12 +641,8 @@ class BigNumberTotalViz(BaseViz):
         form_data = self.form_data
         df = self.get_df()
         df = df.sort(columns=df.columns[0])
-        compare_lag = form_data.get("compare_lag", "")
-        compare_lag = int(compare_lag) if compare_lag and compare_lag.isdigit() else 0
         return {
             'data': df.values.tolist(),
-            'compare_lag': compare_lag,
-            'compare_suffix': form_data.get('compare_suffix', ''),
             'subheader': form_data.get('subheader', ''),
         }
 

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -558,7 +558,7 @@ class BigNumberViz(BaseViz):
     """Put emphasis on a single metric with this big number viz"""
 
     viz_type = "big_number"
-    verbose_name = "Big Number"
+    verbose_name = "Big Number with Trendline"
     is_timeseries = True
     fieldsets = ({
         'label': None,
@@ -607,7 +607,7 @@ class BigNumberTotalViz(BaseViz):
     """Put emphasis on a single metric with this big number viz"""
 
     viz_type = "big_number_total"
-    verbose_name = "Big Number Total"
+    verbose_name = "Big Number"
     is_timeseries = False
     fieldsets = ({
         'label': None,

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -601,6 +601,56 @@ class BigNumberViz(BaseViz):
             'compare_suffix': form_data.get('compare_suffix', ''),
         }
 
+class BigNumberTotalViz(BaseViz):
+
+    """Put emphasis on a single metric with this big number viz"""
+
+    viz_type = "big_number_total"
+    verbose_name = "Big Number Total"
+    is_timeseries = False
+    fieldsets = ({
+        'label': None,
+        'fields': (
+            'metric',
+            'compare_lag',
+            'compare_suffix',
+            'subheader',
+            'y_axis_format',
+        )
+    },)
+    form_overrides = {
+        'y_axis_format': {
+            'label': 'Number format',
+        }
+    }
+
+    def reassignments(self):
+        metric = self.form_data.get('metric')
+        if not metric:
+            self.form_data['metric'] = self.orig_form_data.get('metrics')
+
+    def query_obj(self):
+        d = super(BigNumberTotalViz, self).query_obj()
+        metric = self.form_data.get('metric')
+        if not metric:
+            raise Exception("Pick a metric!")
+        d['metrics'] = [self.form_data.get('metric')]
+        self.form_data['metric'] = metric
+        return d
+
+    def get_data(self):
+        form_data = self.form_data
+        df = self.get_df()
+        df = df.sort(columns=df.columns[0])
+        compare_lag = form_data.get("compare_lag", "")
+        compare_lag = int(compare_lag) if compare_lag and compare_lag.isdigit() else 0
+        return {
+            'data': df.values.tolist(),
+            'compare_lag': compare_lag,
+            'compare_suffix': form_data.get('compare_suffix', ''),
+            'subheader': form_data.get('subheader', ''),
+        }
+
 
 class NVD3TimeSeriesViz(NVD3Viz):
 
@@ -1290,6 +1340,7 @@ viz_types_list = [
     MarkupViz,
     WordCloudViz,
     BigNumberViz,
+    BigNumberTotalViz,
     SunburstViz,
     DirectedForceViz,
     SankeyViz,


### PR DESCRIPTION
@williaster @mistercrunch 

I'm adding a new big number total viz type that uses the same d3 as the big number but it is not a timeseries metric, so it will aggregate over whatever time period is given (this will allow us to do WAUs). I've also added functionality to add descriptive text below the number. I originally tried to adjust the text size based on the length but couldn't get it to work because of the loading order of the viz. 
