### PR TITLE
Fix an installation bug.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'gunicorn>=19.3.0, <20.0.0',
         'markdown>=2.6.2, <3.0.0',
         'numpy>=1.9, <2',
-        'pandas==0.18.0, <0.19.0',
+        'pandas==0.18.0',
         'parsedatetime==2.0.0',
         'pydruid>=0.2.2, <0.3',
         'python-dateutil>=2.4.2, <3.0.0',


### PR DESCRIPTION
During the installation `python setup.py install` failed with some error (missing numpy header of some sort). 

`pip install pandas==0.18.0` fixed it. After that `python setup.py install` went smoothly. 

@mistercrunch 
