### PR TITLE
clear chart container element before redrawing sankey

### DIFF
--- a/caravel/assets/visualizations/sankey.js
+++ b/caravel/assets/visualizations/sankey.js
@@ -20,6 +20,7 @@ function sankeyVis(slice) {
 
     var formatNumber = d3.format(",.0f");
 
+    div.selectAll("*").remove();
     var svg = div.append("svg")
       .attr("width", width + margin.left + margin.right)
       .attr("height", height + margin.top + margin.bottom)


### PR DESCRIPTION
Clears element before re-drawing sankey, preventing drawing twice (#254)
