### PR TITLE
Clear sankey vis container on refresh to prevent duplicate charts.

### DIFF
--- a/caravel/assets/visualizations/sankey.js
+++ b/caravel/assets/visualizations/sankey.js
@@ -129,10 +129,11 @@ function sankeyVis(slice) {
     });
   };
 
-  var resize = function() {
+  var resize = function () {
     div.select("svg").remove();
     render();
   };
+
   return {
     render: render,
     resize: resize

--- a/caravel/assets/visualizations/sankey.js
+++ b/caravel/assets/visualizations/sankey.js
@@ -128,9 +128,14 @@ function sankeyVis(slice) {
       slice.done(json);
     });
   };
+
+  var resize = function() {
+    div.select("svg").remove();
+    render();
+  };
   return {
     render: render,
-    resize: render
+    resize: resize
   };
 }
 


### PR DESCRIPTION
Addresses issue [254](https://github.com/airbnb/caravel/issues/254). I prefer this over [PR 255](https://github.com/airbnb/caravel/pull/255) to separate the logic more. 

@mistercrunch 
