### PR TITLE
Csv download improvements

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -36,6 +36,15 @@ def validate_json(form, field):  # noqa
         raise ValidationError("json isn't valid")
 
 
+def generate_download_headers(extension):
+    filename = datetime.now().strftime("%Y%m%d_%H%M%S")
+    content_disp = "attachment; filename={}.{}".format(filename, extension)
+    headers = {
+        "Content-Disposition": content_disp,
+    }
+    return headers
+
+
 class DeleteMixin(object):
     @action(
         "muldelete", "Delete", "Delete all Really?", "fa-trash", single=False)
@@ -470,6 +479,7 @@ class Caravel(BaseView):
             resp = Response(
                 payload,
                 status=status,
+                headers=generate_download_headers("json"),
                 mimetype="application/json")
             return resp
         elif request.args.get("csv") == "true":
@@ -478,6 +488,7 @@ class Caravel(BaseView):
             return Response(
                 payload,
                 status=status,
+                headers=generate_download_headers("csv"),
                 mimetype="application/csv")
         else:
             if request.args.get("standalone") == "true":

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -257,7 +257,8 @@ class BaseViz(object):
 
     def get_csv(self):
         df = self.get_df()
-        return df.to_csv(index=False)
+        include_index = not isinstance(df.index, pd.RangeIndex)
+        return df.to_csv(index=include_index)
 
     def get_data(self):
         return []


### PR DESCRIPTION
Hi,

This PR does two things:
- names csv and json files (with extension) via a Content-Disposition header
- includes a header in CSV output where data is meaningful (i.e. index is not generic). Currently, for example, time series data is outputted without timestamps and pivot table data is exported without row names
