### PR TITLE
Fix week and month Time grain in MySQL

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -337,8 +337,10 @@ class Database(Model, AuditMixinNullable):
             'mysql': (
                 Grain('Time Column', '{col}'),
                 Grain('day', 'DATE({col})'),
-                Grain('week', 'DATE_SUB({col}, INTERVAL DAYOFWEEK({col}) - 1 DAY)'),
-                Grain('month', 'DATE_SUB({col}, INTERVAL DAYOFMONTH({col}) - 1 DAY)'),
+                Grain("week", "DATE(DATE_SUB({col}, "
+                      "INTERVAL DAYOFWEEK({col}) - 1 DAY))"),
+                Grain("month", "DATE(DATE_SUB({col}, "
+                      "INTERVAL DAYOFMONTH({col}) - 1 DAY))"),
             ),
             'postgresql': (
                 Grain("Time Column", "{col}"),


### PR DESCRIPTION
With mysql datetime and timestamp columns, currently the Time grain "week" and "month" options don't remove the time part. This results in groupings like this:

timestamp count
2015-04-05 07:00:00 1
2015-04-05 10:00:00 1
2015-04-05 11:00:00 2
2015-04-05 11:50:00 1
2015-04-05 12:00:00 5
2015-04-05 14:20:00 1
2015-04-05 14:30:00 1

and so on.

This is solved by wrapping the DATE_SUB with DATE().
