### PR TITLE
[heatmap] several improvements

### DIFF
--- a/caravel/assets/visualizations/heatmap.css
+++ b/caravel/assets/visualizations/heatmap.css
@@ -1,5 +1,13 @@
+.heatmap .slice_container {
+  position: relative;
+  top: 0;
+  left: 0;
+  height: 100%;
+}
+
 .heatmap .axis text {
   font: 10px sans-serif;
+  text-rendering: optimizeLegibility;
 }
 
 .heatmap .axis path,
@@ -30,6 +38,7 @@
   color: #fff;
   border-radius: 2px;
   pointer-events: none;
+  z-index: 1000;
 }
 
 /* Creates a small triangle extender for the tooltip */

--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -139,7 +139,7 @@ class FormFactory(object):
                 'Color Scheme', choices=self.choicify([
                     'fire', 'blue_white_yellow', 'white_black',
                     'black_white']),
-                default='fire',
+                default='blue_white_yellow',
                 description=""),
             'normalize_across': SelectField(
                 'Normalize Across', choices=self.choicify([


### PR DESCRIPTION
@mistercrunch @michellethomas 

This PR fixes some bugs and adds improvements to the heatmap vis:
- fix bug to display this view properly in dashboards (was not displaying at all)
- fix bug to display heatmap d3-tip tooltips in dashboards (z-index was off)
- don't show empty tooltips on heatmap (pretty bad UI before / not useful)
- update logic for margins so they fit dynamically based on label size (see pic); this was pretty bad and could vary hugely based on dataset
- remove `fire` as default heatmap color scheme in favor of `blue_white_yellow` because it looks nicer

![image](https://cloud.githubusercontent.com/assets/4496521/14399694/163a2b8c-fda4-11e5-8a7d-f66dfd6a2e4c.png)
