### PR TITLE
Preserve order of breakdowns in bar_dist

### DIFF
--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -926,9 +926,8 @@ class DistributionBarViz(DistributionPieViz):
 
     def get_data(self):
         df = self.get_df()
-        series = df.to_dict('series')
         chart_data = []
-        for name, ys in series.items():
+        for name, ys in df.iteritems():
             if df[name].dtype.kind not in "biufc":
                 continue
             if isinstance(name, string_types):


### PR DESCRIPTION
This preserves the order of the "Breakdowns" input value as it exists in the source DataFrame. The way it is now it is reordered however the `to_dict()` method decides to order them.
