### PR TITLE
Fix for undefined inner_time_filter in models

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -586,6 +586,8 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
                 inner_time_filter[0] = timestamp >= inner_from_dttm.strftime(tf)
             if inner_to_dttm:
                 inner_time_filter[1] = timestamp <= inner_to_dttm.strftime(tf)
+        else:
+            inner_time_filter = []
 
         select_exprs += metrics_exprs
         qry = select(select_exprs)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -63,6 +63,11 @@ class CaravelTests(unittest.TestCase):
     def test_csv(self):
         self.client.get('/caravel/explore/table/1/?viz_type=table&granularity=ds&since=100+years&until=now&metrics=count&groupby=name&limit=50&show_brush=y&show_brush=false&show_legend=y&show_brush=false&rich_tooltip=y&show_brush=false&show_brush=false&show_brush=false&show_brush=false&y_axis_format=&x_axis_showminmax=y&show_brush=false&line_interpolation=linear&rolling_type=None&rolling_periods=&time_compare=&num_period_compare=&where=&having=&flt_col_0=gender&flt_op_0=in&flt_eq_0=&flt_col_0=gender&flt_op_0=in&flt_eq_0=&slice_id=14&slice_name=Boys&collapsed_fieldsets=&action=&datasource_name=birth_names&datasource_id=1&datasource_type=table&previous_viz_type=line&csv=true')
 
+    def test_bubble_chart_no_time(self):
+        self.login()
+        response = self.client.get('/caravel/explore/table/1/?viz_type=bubble&series=source&entity=source&x=count&y=count&size=count&limit=50&x_log_scale=false&y_log_scale=false&show_legend=y&show_legend=false&max_bubble_size=25&where=&having=&flt_col_0=source&flt_op_0=in&flt_eq_0=&slice_id=&slice_name=&collapsed_fieldsets=&action=&datasource_name=energy_usage&datasource_id=1&datasource_type=table&previous_viz_type=bubble&json=true&force=false')
+        self.assertEqual(response.status_code, 200)
+
     def test_dashboard(self):
         self.login()
         urls = {}


### PR DESCRIPTION
When not specifying a time field, the bubble chart would fail with:

```
local variable 'inner_time_filter' referenced before assignment
[...]
File "caravel/caravel/models.py", line 626, in query
```

This commit fixes the problem and adds the relative test
