### PR TITLE
New viz: box plot

### DIFF
--- a/caravel/assets/javascripts/modules/caravel.js
+++ b/caravel/assets/javascripts/modules/caravel.js
@@ -19,6 +19,7 @@ var sourceMap = {
   markup: 'markup.js',
   para: 'parallel_coordinates.js',
   pie: 'nvd3_vis.js',
+  box_plot: 'nvd3_vis.js',
   pivot_table: 'pivot_table.js',
   sankey: 'sankey.js',
   sunburst: 'sunburst.js',
@@ -45,6 +46,7 @@ var color = function () {
     // Color factory
     var seen = {};
     return function (s) {
+      if (!s) return;
       // next line is for caravel series that should have the same color
       s = s.replace('---', '');
       if (seen[s] === undefined) {

--- a/caravel/assets/javascripts/modules/caravel.js
+++ b/caravel/assets/javascripts/modules/caravel.js
@@ -46,7 +46,7 @@ var color = function () {
     // Color factory
     var seen = {};
     return function (s) {
-      if (!s) return;
+      if (!s) { return; }
       // next line is for caravel series that should have the same color
       s = s.replace('---', '');
       if (seen[s] === undefined) {

--- a/caravel/assets/visualizations/nvd3_vis.js
+++ b/caravel/assets/visualizations/nvd3_vis.js
@@ -123,8 +123,8 @@ function nvd3Vis(slice) {
             case 'box_plot':
               colorKey = 'label';
               chart = nv.models.boxPlotChart();
-              chart.x(function(d) { return d.label })
-              chart.staggerLabels(true)
+              chart.x(function (d) { return d.label; });
+              chart.staggerLabels(true);
               chart.maxBoxWidth(75); // prevent boxes from being incredibly wide
               break;
 

--- a/caravel/assets/visualizations/nvd3_vis.js
+++ b/caravel/assets/visualizations/nvd3_vis.js
@@ -120,6 +120,14 @@ function nvd3Vis(slice) {
                 .staggerLabels(true);
               break;
 
+            case 'box_plot':
+              colorKey = 'label';
+              chart = nv.models.boxPlotChart();
+              chart.x(function(d) { return d.label })
+              chart.staggerLabels(true)
+              chart.maxBoxWidth(75); // prevent boxes from being incredibly wide
+              break;
+
             default:
               throw new Error("Unrecognized visualization for nvd3" + viz_type);
           }

--- a/caravel/data/__init__.py
+++ b/caravel/data/__init__.py
@@ -263,6 +263,18 @@ def load_world_bank_health_n_pop():
                 until="now",
                 viz_type='area',
                 groupby=["region"],)),
+        Slice(
+            slice_name="Box plot",
+            viz_type='box_plot',
+            datasource_type='table',
+            table=tbl,
+            params=get_slice_json(
+                defaults,
+                since="1960-01-01",
+                until="now",
+                whisker_options="Tukey",
+                viz_type='box_plot',
+                groupby=["region"],)),
     ]
     for slc in slices:
         merge_slice(slc)

--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -315,6 +315,17 @@ class FormFactory(object):
                     '100',
                 ])
             ),
+            'whisker_options': FreeFormSelectField(
+                'Whisker/outlier options', default="Tukey",
+                description=(
+                    "Determines how whiskers and outliers are calculated."),
+                choices=self.choicify([
+                    'Tukey',
+                    'Min/max (no outliers)',
+                    '2/98 percentiles',
+                    '9/91 percentiles',
+                ])
+            ),
             'row_limit':
                 FreeFormSelectField(
                     'Row limit',

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -516,7 +516,7 @@ class BoxPlotViz(NVD3Viz):
 
         df = df.fillna(0)
 
-        ## conform to NVD3 names
+        # conform to NVD3 names
         def Q1(series):  # need to be named functions - can't use lambdas
             return np.percentile(series, 25)
 
@@ -533,7 +533,7 @@ class BoxPlotViz(NVD3Viz):
 
             def whisker_low(series):
                 lower_outer_lim = Q1(series) - 1.5 * (Q3(series) - Q1(series))
-                ## find the closest value above the lower outer limit
+                # find the closest value above the lower outer limit
                 series = series[series >= lower_outer_lim]
                 return series[np.abs(series - lower_outer_lim).argmin()]
 
@@ -544,7 +544,6 @@ class BoxPlotViz(NVD3Viz):
 
             def whisker_low(series):
                 return series.min()
-
 
         elif " percentiles" in whisker_type:
             low, high = whisker_type.replace(" percentiles", "").split("/")
@@ -561,7 +560,7 @@ class BoxPlotViz(NVD3Viz):
         def outliers(series):
             above = series[series > whisker_high(series)]
             below = series[series < whisker_low(series)]
-            ## pandas sometimes doesn't like getting lists back here
+            # pandas sometimes doesn't like getting lists back here
             return set(above.tolist() + below.tolist())
 
         aggregate = [Q1, np.median, Q3, whisker_high, whisker_low, outliers]
@@ -581,7 +580,7 @@ class BoxPlotViz(NVD3Viz):
                 boxes[label][key] = value
             for label, box in boxes.items():
                 if len(self.form_data.get("metrics")) > 1:
-                    ## need to render data labels with metrics
+                    # need to render data labels with metrics
                     chart_label = label_sep.join([index_value, label])
                 else:
                     chart_label = index_value

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -16,6 +16,7 @@ from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 
 import pandas as pd
+import numpy as np
 from flask import flash, request, Markup
 from markdown import markdown
 from pandas.io.json import dumps
@@ -486,6 +487,114 @@ class NVD3Viz(BaseViz):
     viz_type = None
     verbose_name = "Base NVD3 Viz"
     is_timeseries = False
+
+
+class BoxPlotViz(NVD3Viz):
+
+    """Box plot viz from ND3"""
+
+    viz_type = "box_plot"
+    verbose_name = "Box Plot"
+    sort_series = False
+    is_timeseries = True
+    fieldsets = ({
+        'label': None,
+        'fields': (
+            'metrics',
+            'groupby', 'limit',
+        ),
+    }, {
+        'label': 'Chart Options',
+        'fields': (
+            'whisker_options',
+        )
+    },)
+
+    def get_df(self, query_obj=None):
+        form_data = self.form_data
+        df = super(BoxPlotViz, self).get_df(query_obj)
+
+        df = df.fillna(0)
+
+        ## conform to NVD3 names
+        def Q1(series):  # need to be named functions - can't use lambdas
+            return np.percentile(series, 25)
+
+        def Q3(series):
+            return np.percentile(series, 75)
+
+        whisker_type = form_data.get('whisker_options')
+        if whisker_type == "Tukey":
+
+            def whisker_high(series):
+                upper_outer_lim = Q3(series) + 1.5 * (Q3(series) - Q1(series))
+                series = series[series <= upper_outer_lim]
+                return series[np.abs(series - upper_outer_lim).argmin()]
+
+            def whisker_low(series):
+                lower_outer_lim = Q1(series) - 1.5 * (Q3(series) - Q1(series))
+                ## find the closest value above the lower outer limit
+                series = series[series >= lower_outer_lim]
+                return series[np.abs(series - lower_outer_lim).argmin()]
+
+        elif whisker_type == "Min/max (no outliers)":
+
+            def whisker_high(series):
+                return series.max()
+
+            def whisker_low(series):
+                return series.min()
+
+
+        elif " percentiles" in whisker_type:
+            low, high = whisker_type.replace(" percentiles", "").split("/")
+
+            def whisker_high(series):
+                return np.percentile(series, int(high))
+
+            def whisker_low(series):
+                return np.percentile(series, int(low))
+
+        else:
+            raise ValueError("Unknown whisker type: {}".format(whisker_type))
+
+        def outliers(series):
+            above = series[series > whisker_high(series)]
+            below = series[series < whisker_low(series)]
+            ## pandas sometimes doesn't like getting lists back here
+            return set(above.tolist() + below.tolist())
+
+        aggregate = [Q1, np.median, Q3, whisker_high, whisker_low, outliers]
+        df = df.groupby(form_data.get('groupby')).agg(aggregate)
+        return df
+
+    def to_series(self, df, classed='', title_suffix=''):
+        label_sep = " - "
+        chart_data = []
+        for index_value, row in zip(df.index, df.to_dict(orient="records")):
+            if isinstance(index_value, tuple):
+                index_value = label_sep.join(index_value)
+            boxes = defaultdict(dict)
+            for (label, key), value in row.items():
+                if key == "median":
+                    key = "Q2"
+                boxes[label][key] = value
+            for label, box in boxes.items():
+                if len(self.form_data.get("metrics")) > 1:
+                    ## need to render data labels with metrics
+                    chart_label = label_sep.join([index_value, label])
+                else:
+                    chart_label = index_value
+                chart_data.append({
+                    "label": chart_label,
+                    "values": box,
+                })
+        return chart_data
+
+    def get_data(self):
+        df = self.get_df()
+        chart_data = self.to_series(df)
+        return chart_data
 
 
 class BubbleViz(NVD3Viz):
@@ -1387,6 +1496,7 @@ viz_types_list = [
     IFrameViz,
     ParallelCoordinatesViz,
     HeatmapViz,
+    BoxPlotViz,
 ]
 
 viz_types = OrderedDict([(v.viz_type, v) for v in viz_types_list])


### PR DESCRIPTION
Hi,

This PR implements an NVD3 box plot (shown below). I added an example slice so it's picked up in the tests.

There is one custom option for box plots for the user to select the whisker calculation method (options are currently Tukey or quartiles +- 1.5*IQR, min/max, 2nd/98th percentile, or 9th/91st percentiles, although easy to add more).

I wasn't sure how to add an image in the gallery, so that's not in this PR, apologies.

I also wasn't 100% on how the `color` function is supposed to work (it seems to recurse through attributes which are lists). For the box plot data structure required by NVD3 to work, I had to add a null check in the color function as the 'outliers' attribute only contains data. Consequently all outliers are all colored black, although I don't think this is a problem.

![image](https://cloud.githubusercontent.com/assets/1504948/14408318/fc3cffd0-ff32-11e5-865a-821dfcca96f7.png)
