### PR TITLE
fix tableviz timestamp conversion issue

### DIFF
--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -351,10 +351,13 @@ class TableViz(BaseViz):
 
     def get_data(self):
         df = self.get_df()
-        return dict(
+        dict_obj = dict(
             records=df.to_dict(orient="records"),
-            columns=list(df.columns),
+            columns=list(df.columns)
         )
+        # convert Timestamp in the dict_obj to iso timestamp by default.
+        json_conversion = json.dumps(dict_obj, default=utils.json_iso_dttm_ser,)
+        return json.loads(json_conversion)
 
 
 class PivotTableViz(BaseViz):


### PR DESCRIPTION
fix timestamp conversion in tableviz from epoch time to human readable. The logic is taken from panoramix v0.7.0. This fixes #318 
