### PR TITLE
Include connection parameters in call to Test Connection for a new database

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ export PATH="$HOME/.node/bin:$PATH"
 
 #### npm packages
 To install third party libraries defined in `package.json`, run the
-following within this directory which will install them in a
+following within the `caravel/assets/` directory which will install them in a
 new `node_modules/` folder within `assets/`.
 
 ```

--- a/caravel/templates/caravel/models/database/macros.html
+++ b/caravel/templates/caravel/models/database/macros.html
@@ -7,8 +7,9 @@
       $.ajax({
         method: "POST",
         url: url,
-        data: { uri: $("#sqlalchemy_uri").val() },
-        dataType: 'json'
+        data: JSON.stringify({ uri: $("#sqlalchemy_uri").val(), extras: JSON.parse($("#extra").val()) }),
+        dataType: 'json',
+        contentType: "application/json; charset=utf-8"
       }).done(function(data) {
           alert("Seems OK!");
           if ($('#tables').length == 0)

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -629,8 +629,9 @@ class Caravel(BaseView):
     def testconn(self):
         """Tests a sqla connection"""
         try:
-            uri = request.form.get('uri')
-            engine = create_engine(uri)
+            uri = request.json.get('uri')
+            connect_args = request.json.get('extras', {}).get('engine_params', {}).get('connect_args')
+            engine = create_engine(uri, connect_args=connect_args)
             engine.connect()
             return json.dumps(engine.table_names(), indent=4)
         except Exception:


### PR DESCRIPTION
Just a little thing to make testing database connections easier. As it was, the call to test the connection wasn't taking into account whatever user entered into the Extra field
