### PR TITLE
Redirect application log to stderr, which is picked up by gunicorn.

### DIFF
--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -22,6 +22,11 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 app = Flask(__name__)
 app.config.from_object(CONFIG_MODULE)
+if not app.debug:
+  # In production mode, add log handler to sys.stderr.
+  app.logger.addHandler(logging.StreamHandler())
+  app.logger.setLevel(logging.INFO)
+
 db = SQLA(app)
 
 cache = Cache(app, config=app.config.get('CACHE_CONFIG'))


### PR DESCRIPTION
According to https://github.com/benoitc/gunicorn/issues/379#issuecomment-7904270 this is what we need to see per request logs in gunicorn log file.

@mistercrunch 
