### PR TITLE
Schemas

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -310,7 +310,6 @@ class Database(Model, AuditMixinNullable):
     def get_sqla_engine(self):
         extra = self.get_extra()
         params = extra.get('engine_params', {})
-
         return create_engine(self.sqlalchemy_uri_decrypted, **params)
 
     def safe_sqlalchemy_uri(self):
@@ -377,7 +376,6 @@ class Database(Model, AuditMixinNullable):
     def get_table(self, table_name):
         extra = self.get_extra()
         meta = MetaData(**extra.get('metadata_params', {}))
-
         return Table(
             table_name, meta,
             autoload=True,
@@ -653,7 +651,6 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
         engine = self.database.get_sqla_engine()
         sql = "{}".format(
             qry.compile(engine, compile_kwargs={"literal_binds": True}))
-
         df = pd.read_sql_query(
             sql=sql,
             con=engine

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -509,7 +509,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
 
     @property
     def schema(self):
-        return self.database.schema()
+        return self.database.schema() or None
 
     def query(  # sqla
             self, groupby, metrics,

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -381,8 +381,7 @@ class Database(Model, AuditMixinNullable):
         return Table(
             table_name, meta,
             autoload=True,
-            autoload_with=self.get_sqla_engine(),
-            schema=self.schema)
+            autoload_with=self.get_sqla_engine())
 
     def get_columns(self, table_name):
         engine = self.get_sqla_engine()


### PR DESCRIPTION
This PR adds support for specifying database schemas when creating a new database source. I've tested it against redshift. It should address all or parts of the following: #336, #325, and #252, and #217.

To specify a schema, create a data source with the schema specified in the extras, like so:

```
{
    "metadata_params": {
          "schema":"myschema"
     },
    "engine_params": {
          "connect_args":{
        }
     }
}
```

Note that it does specify the schema right on the database source, and not on individual tables. I think this is preferable, so that you don't have to specify schemas on every table you create. You can also segment your database sources based on the schema you are using, which is probably what you want anyway.
