### PR TITLE
split sunburst breadcrumb names on '_' to apply ' '-dependent wrapping more freqently

### DIFF
--- a/caravel/assets/visualizations/sunburst.js
+++ b/caravel/assets/visualizations/sunburst.js
@@ -272,7 +272,7 @@ function sunburstVis(slice) {
           .attr("y", breadcrumbDims.height / 4)
           .attr("dy", "0.35em")
           .attr("class", "step-label")
-          .text(function (d) { return d.name; })
+          .text(function (d) { return d.name.replace(/_/g, " "); })
           .call(wrapSvgText, breadcrumbDims.width, breadcrumbDims.height / 2);
 
       // Set position for entering and updating nodes.


### PR DESCRIPTION
breadcrumb text is written in a way that wraps long label names based on word breaks. this doesn't work for `words_separated_by_underscores`, so this PR replaces `_` in breadcrumbs names with ` ` so that long labels wrap more often.
