### PR TITLE
Use batch_alter_table to drop column in the migration script

### DIFF
--- a/caravel/migrations/versions/c3a8f8611885_materializing_permission.py
+++ b/caravel/migrations/versions/c3a8f8611885_materializing_permission.py
@@ -30,4 +30,6 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_column('slices', 'perm')
+    # Use batch_alter_table because dropping columns is not supported in SQLite
+    with op.batch_alter_table('slices') as batch_op:
+        batch_op.drop_column('perm')


### PR DESCRIPTION
Should we use render_as_batch=True in context.configure in migrations/env.py as well?
