### PR TITLE
[bugfix] allow repeated values across levels when building sunburst hierarchy

### DIFF
--- a/caravel/assets/visualizations/sunburst.js
+++ b/caravel/assets/visualizations/sunburst.js
@@ -57,7 +57,6 @@ function sunburstVis(slice) {
         slice.error(error.responseText);
         return '';
       }
-
       createBreadcrumbs(rawData);
       createVisualization(rawData);
 
@@ -299,7 +298,8 @@ function sunburstVis(slice) {
         name: "root",
         children: []
       };
-      for (var i = 0; i < rows.length; i++) {
+
+      for (var i = 0; i < rows.length; i++) { // each record [groupby1val, groupby2val, (<string> or 0)n, m1, m2]
         var row = rows[i];
         var m1 = Number(row[row.length - 2]);
         var m2 = Number(row[row.length - 1]);
@@ -308,19 +308,22 @@ function sunburstVis(slice) {
           continue;
         }
         var currentNode = root;
-        for (var j = 0; j < levels.length; j++) {
+        for (var level = 0; level < levels.length; level++) {
           var children = currentNode.children || [];
-          var nodeName = levels[j];
+          var nodeName = levels[level];
           // If the next node has the name "0", it will
-          var isLeafNode = (j >= levels.length - 1) || levels[j+1] === 0;
-          var childNode;
+          var isLeafNode = (level >= levels.length - 1) || levels[level+1] === 0;
+          var childNode, currChild;
 
           if (!isLeafNode) {
             // Not yet at the end of the sequence; move down the tree.
             var foundChild = false;
             for (var k = 0; k < children.length; k++) {
-              if (children[k].name === nodeName) {
-                childNode = children[k];
+              currChild = children[k];
+              if (currChild.name === nodeName &&
+                  currChild.level === level) { // must match name AND level
+
+                childNode = currChild;
                 foundChild = true;
                 break;
               }
@@ -329,11 +332,13 @@ function sunburstVis(slice) {
             if (!foundChild) {
               childNode = {
                 name: nodeName,
-                children: []
+                children: [],
+                level: level
               };
               children.push(childNode);
             }
             currentNode = childNode;
+
           } else if (nodeName !== 0) {
             // Reached the end of the sequence; create a leaf node.
             childNode = {
@@ -361,6 +366,7 @@ function sunburstVis(slice) {
         }
         return [node.m1, node.m2];
       }
+
       recurse(root);
       return root;
     }


### PR DESCRIPTION
in some cases when there are repeated values across sunburst levels, nodes for a given sequence were not always added to the correct level
e.g.,
    a --> b --> b --> a
    b --> a 

to prevent this, this PR enforces matching level within a sequence, in addition to matching node names, when building out the sunburst hierarchy.

before
<img width="741" alt="screen shot 2016-04-28 at 9 29 53 pm" src="https://cloud.githubusercontent.com/assets/4496521/14908171/63dff602-0d88-11e6-8344-574cbead4da9.png">

after
<img width="531" alt="screen shot 2016-04-28 at 9 29 43 pm" src="https://cloud.githubusercontent.com/assets/4496521/14908172/6a31c134-0d88-11e6-982b-42ce7831eb03.png">
