### PR TITLE
Make sure anonymous user with proper permissions can access data

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -23,7 +23,7 @@ from flask import request, g
 from flask.ext.appbuilder import Model
 from flask.ext.appbuilder.models.mixins import AuditMixin
 from flask.ext.appbuilder.models.decorators import renders
-from flask.ext.babelpkg import lazy_gettext as _
+from flask.ext.babelpkg import gettext as _
 
 from pydruid.client import PyDruid
 from pydruid.utils.filters import Dimension, Filter

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -1238,7 +1238,7 @@ class Log(Model):
         def wrapper(*args, **kwargs):
             user_id = None
             if g.user:
-                user_id = g.user.id
+                user_id = g.user.get_id()
             d = request.args.to_dict()
             d.update(kwargs)
             slice_id = d.get('slice_id', 0)

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -36,7 +36,7 @@ log_this = models.Log.log_this
 
 
 def get_user_roles():
-    if g.user.is_anonymous:
+    if g.user.is_anonymous():
         return [appbuilder.sm.find_role('Public')]
     return g.user.roles
 

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -35,7 +35,7 @@ config = app.config
 log_this = models.Log.log_this
 
 
-def get_roles():
+def get_user_roles():
     if g.user.is_anonymous:
         return [appbuilder.sm.find_role('Public')]
     return g.user.roles
@@ -44,7 +44,7 @@ def get_roles():
 class CaravelFilter(BaseFilter):
     def get_perms(self):
         perms = []
-        for role in get_roles():
+        for role in get_user_roles():
             for perm_view in role.permissions:
                 if perm_view.permission.name == 'datasource_access':
                     perms.append(perm_view.view_menu.name)
@@ -53,7 +53,7 @@ class CaravelFilter(BaseFilter):
 
 class FilterSlice(CaravelFilter):
     def apply(self, query, func):  # noqa
-        if any([r.name in ('Admin', 'Alpha') for r in get_roles()]):
+        if any([r.name in ('Admin', 'Alpha') for r in get_user_roles()]):
             return query
         qry = query.filter(self.model.perm.in_(self.get_perms()))
         print(qry)
@@ -62,7 +62,7 @@ class FilterSlice(CaravelFilter):
 
 class FilterDashboard(CaravelFilter):
     def apply(self, query, func):  # noqa
-        if any([r.name in ('Admin', 'Alpha') for r in get_roles()]):
+        if any([r.name in ('Admin', 'Alpha') for r in get_user_roles()]):
             return query
         Slice = models.Slice  # noqa
         slice_ids_qry = (

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -35,10 +35,16 @@ config = app.config
 log_this = models.Log.log_this
 
 
+def get_roles():
+    if g.user.is_anonymous:
+        return [appbuilder.sm.find_role('Public')]
+    return g.user.roles
+
+
 class CaravelFilter(BaseFilter):
     def get_perms(self):
         perms = []
-        for role in g.user.roles:
+        for role in get_roles():
             for perm_view in role.permissions:
                 if perm_view.permission.name == 'datasource_access':
                     perms.append(perm_view.view_menu.name)
@@ -47,7 +53,7 @@ class CaravelFilter(BaseFilter):
 
 class FilterSlice(CaravelFilter):
     def apply(self, query, func):  # noqa
-        if any([r.name in ('Admin', 'Alpha') for r in g.user.roles]):
+        if any([r.name in ('Admin', 'Alpha') for r in get_roles()]):
             return query
         qry = query.filter(self.model.perm.in_(self.get_perms()))
         print(qry)
@@ -56,7 +62,7 @@ class FilterSlice(CaravelFilter):
 
 class FilterDashboard(CaravelFilter):
     def apply(self, query, func):  # noqa
-        if any([r.name in ('Admin', 'Alpha') for r in g.user.roles]):
+        if any([r.name in ('Admin', 'Alpha') for r in get_roles()]):
             return query
         Slice = models.Slice  # noqa
         slice_ids_qry = (
@@ -721,12 +727,12 @@ class Caravel(BaseView):
         FavStar = models.FavStar  # noqa
         count = 0
         favs = session.query(FavStar).filter_by(
-            class_name=class_name, obj_id=obj_id, user_id=g.user.id).all()
+            class_name=class_name, obj_id=obj_id, user_id=g.user.get_id()).all()
         if action == 'select':
             if not favs:
                 session.add(
                     FavStar(
-                        class_name=class_name, obj_id=obj_id, user_id=g.user.id,
+                        class_name=class_name, obj_id=obj_id, user_id=g.user.get_id(),
                         dttm=datetime.now()))
             count = 1
         elif action == 'unselect':

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -20,7 +20,7 @@ from flask.ext.appbuilder import ModelView, CompactCRUDMixin, BaseView, expose
 from flask.ext.appbuilder.actions import action
 from flask.ext.appbuilder.models.sqla.interface import SQLAInterface
 from flask.ext.appbuilder.security.decorators import has_access
-from flask.ext.babelpkg import lazy_gettext as _
+from flask.ext.babelpkg import gettext as _
 from flask_appbuilder.models.sqla.filters import BaseFilter
 
 from pydruid.client import doublesum

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -64,7 +64,7 @@ class CaravelTestCase(unittest.TestCase):
             follow_redirects=True)
         assert 'Welcome' in resp.data.decode('utf-8')
 
-    def setup_anonimous_superuser(self):
+    def setup_anonymous_superuser(self):
         public_role = appbuilder.sm.find_role('Public')
         perms = db.session.query(ab_models.PermissionView).all()
         for perm in perms:
@@ -169,8 +169,8 @@ class CoreTests(CaravelTestCase):
         resp = self.client.get('/dashboardmodelview/list/')
         assert "List Dashboard" in resp.data.decode('utf-8')
 
-    def test_anonimous_superuser_list_dashboards(self):
-        self.setup_anonimous_superuser()
+    def test_anonymous_superuser_list_dashboards(self):
+        self.setup_anonymous_superuser()
 
         resp = self.client.get('/slicemodelview/list/')
         assert "List Slice" in resp.data.decode('utf-8')
@@ -178,8 +178,8 @@ class CoreTests(CaravelTestCase):
         resp = self.client.get('/dashboardmodelview/list/')
         assert "List Dashboard" in resp.data.decode('utf-8')
 
-    def test_anonimous_superuser_access_dashboards(self):
-        self.setup_anonimous_superuser()
+    def test_anonymous_superuser_access_dashboards(self):
+        self.setup_anonymous_superuser()
         urls = {}
         for dash in db.session.query(models.Dashboard).all():
             urls[dash.dashboard_title] = dash.url

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -213,6 +213,23 @@ class CoreTests(CaravelTestCase):
         data = resp.data.decode('utf-8')
         assert '[dashboard] Births' in data
 
+        resp = self.client.get('/caravel/explore/table/3/')
+        data = resp.data.decode('utf-8')
+        assert '[explore] birth_names' in data
+
+        # Confirm that public doesn't have access to other datasets.
+        resp = self.client.get('/slicemodelview/list/')
+        data = resp.data.decode('utf-8')
+        assert '<a href="/tablemodelview/edit/2">wb_health_population</a>' not in data
+
+        resp = self.client.get('/dashboardmodelview/list/')
+        data = resp.data.decode('utf-8')
+        assert '<a href="/caravel/dashboard/world_health/">' not in data
+
+        resp = self.client.get('/caravel/explore/table/2/', follow_redirects=True)
+        data = resp.data.decode('utf-8')
+        assert "You don&#39;t seem to have access to this datasource" in data
+
 
 SEGMENT_METADATA = [{
   "id": "some_id",


### PR DESCRIPTION
The current implementation will throw exception when listing or accessing dashboards for the anonymous user that belongs to Public role and has proper permissions, because id and roles properties are not defined for flask AnonymousUserMixin.
