### PR TITLE
blacklist druid datasources to be refreshed 

### DIFF
--- a/caravel/config.py
+++ b/caravel/config.py
@@ -132,6 +132,12 @@ CACHE_CONFIG = {'CACHE_TYPE': 'null'}
 
 VIZ_TYPE_BLACKLIST = []
 
+# ---------------------------------------------------
+# List of data sources not to be refreshed in druid cluster
+# ---------------------------------------------------
+
+DRUID_DATA_SOURCE_BLACKLIST = []
+
 """
 1) http://docs.python-guide.org/en/latest/writing/logging/
 2) https://docs.python.org/2/library/logging.config.html

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -903,7 +903,8 @@ class DruidCluster(Model, AuditMixinNullable):
 
     def refresh_datasources(self):
         for datasource in self.get_datasources():
-            DruidDatasource.sync_to_db(datasource, self)
+            if datasource not in config.get('DRUID_DATA_SOURCE_BLACKLIST'):
+                DruidDatasource.sync_to_db(datasource, self)
 
 
 class DruidDatasource(Model, AuditMixinNullable, Queryable):


### PR DESCRIPTION
it takes forever to load all druid datasources metadata which is not even required (given the use cases user should be able to blacklist data sources which are not required to be refreshed).
