### PR TITLE
Cosmetric tweaks in the CRUD list view

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -90,6 +90,10 @@ class AuditMixinNullable(AuditMixin):
         return '{}'.format(self.changed_by or '')
 
     @renders('changed_on')
+    def changed_on_(self):
+        return '<span class="no-wrap">{}</span>'.format(self.changed_on)
+
+    @renders('changed_on')
     def modified(self):
         s = humanize.naturaltime(datetime.now() - self.changed_on)
         return '<span class="no-wrap">{}</nobr>'.format(s)

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -188,7 +188,7 @@ appbuilder.add_view_no_menu(DruidMetricInlineView)
 
 class DatabaseView(CaravelModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.Database)
-    list_columns = ['database_name', 'sql_link', 'creator', 'changed_on']
+    list_columns = ['database_name', 'sql_link', 'creator', 'changed_on_']
     add_columns = [
         'database_name', 'sqlalchemy_uri', 'cache_timeout', 'extra']
     search_exclude_columns = ('password',)
@@ -235,7 +235,7 @@ class TableModelView(CaravelModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.SqlaTable)
     list_columns = [
         'table_link', 'database', 'sql_link', 'is_featured',
-        'changed_by_', 'changed_on', 'perm']
+        'changed_by_', 'changed_on_']
     add_columns = [
         'table_name', 'database', 'schema',
         'default_endpoint', 'offset', 'cache_timeout']


### PR DESCRIPTION
@williaster @georgeke 
This was bugging me as sometimes the date would wrap in the middle in the list view. For the record the @renders decorator is provided by FAB (flask appbuilder) and allows to define a property for rendering a field. It's better than `@property` (which also works), because the sort options in the list views work and are bound to the field defined in `@renders`
