### PR TITLE
utils: add special serializer for numpy.int64

### DIFF
--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import functools
 import json
 import logging
+import numpy
 from datetime import datetime
 
 import parsedatetime
@@ -221,6 +222,12 @@ def json_iso_dttm_ser(obj):
     """
     if isinstance(obj, datetime):
         obj = obj.isoformat()
+    elif isinstance(obj, numpy.int64):
+        obj = int(obj)
+    else:
+        raise TypeError(
+             "Unserializable object {} of type {}".format(obj, type(obj))
+        )
     return obj
 
 


### PR DESCRIPTION
I don't know if this is papering over another issue but it looks to fix the issue for me :)

It looks like COUNT(*) returns a numpy.int64 value that the
default JSONEncoder does not handle.

While at if we get a type we are not handling make it easier to
debug the issue by throwing a TypeError exception with useful
data.

Fix #486
