### PR TITLE
Added support for Vertica Grains

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -424,6 +424,7 @@ class Database(Model, AuditMixinNullable):
             ),
         }
         db_time_grains['redshift'] = db_time_grains['postgresql']
+        db_time_grains['vertica'] = db_time_grains['postgresql']
         for db_type, grains in db_time_grains.items():
             if self.sqlalchemy_uri.startswith(db_type):
                 return grains


### PR DESCRIPTION
Added support for HP Vertica

Vertica works with Caravel using the proper SQLAlchemy dialects (The original dialects has a problem with reflection https://github.com/LAlbertalli/vertica-sqlalchemy).
This patch adds the time grains specifications (from PgSQL) needed to do time aggregate.
