### PR TITLE
add presto dttm format

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -438,7 +438,8 @@ class Database(Model, AuditMixinNullable):
             'oracle':
                 """TO_TIMESTAMP('{}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')""".format(
                     dttm.isoformat()),
-            'presto': default,
+            'presto': "CAST('{}' AS TIMESTAMP)".format(
+                    dttm.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]),
             'sqlite': default,
         }
         for k, v in d.items():


### PR DESCRIPTION
the default dttm string was giving me `GREATER_THAN_OR_EQUAL(timestamp, varchar) not registered` errors with presto, this resolves that.
