### PR TITLE
Reactify dashboard grid

### DIFF
--- a/caravel/assets/javascripts/dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard.jsx
@@ -140,7 +140,7 @@ var Dashboard = function (dashboardData) {
           var slice = this.props.slice,
               pos = this.props.pos;
 
-          return (<li
+          return (<div
             id={"slice_" + slice.slice_id}
             slice_id={slice.slice_id}
             className={"widget " + slice.viz_name}
@@ -157,26 +157,26 @@ var Dashboard = function (dashboardData) {
                 <div className="col-md-12 chart-controls">
                   <div className="pull-left">
                     <a title="Move chart" data-toggle="tooltip">
-                      <i className="fa fa-arrows drag"></i>
+                      <i className="fa fa-arrows drag"/>
                     </a>
                     <a className="refresh" title="Force refresh data" data-toggle="tooltip">
-                      <i className="fa fa-repeat"></i>
+                      <i className="fa fa-repeat"/>
                     </a>
                   </div>
                   <div className="pull-right">
                     {slice.description ?
                       <a title="Toggle chart description">
-                        <i className="fa fa-info-circle slice_info" slice_id={slice.slice_id} title={slice.description} data-toggle="tooltip"></i>
+                        <i className="fa fa-info-circle slice_info" slice_id={slice.slice_id} title={slice.description} data-toggle="tooltip"/>
                       </a>
                     : ""}
                     <a href={slice.edit_url} title="Edit chart" data-toggle="tooltip">
-                      <i className="fa fa-pencil"></i>
+                      <i className="fa fa-pencil"/>
                     </a>
                     <a href={slice.slice_url} title="Explore chart" data-toggle="tooltip">
-                      <i className="fa fa-share"></i>
+                      <i className="fa fa-share"/>
                     </a>
                     <a className="remove-chart" title="Remove chart from dashboard" data-toggle="tooltip">
-                      <i className="fa fa-close"></i>
+                      <i className="fa fa-close"/>
                     </a>
                   </div>
                 </div>
@@ -184,32 +184,36 @@ var Dashboard = function (dashboardData) {
               </div>
             </div>
             <div
-              className="slice_description bs-callout bs-callout-default">
-                        {slice.description_markeddown}
+              className="slice_description bs-callout bs-callout-default"
+              style={expandedSlices && expandedSlices[slice.slice_id + ""] ? {} : {display: "none"}}>
+                {slice.description_markeddown}
             </div>
             <div className="row chart-container">
               <input type="hidden" slice_id={slice.slice_id} value="false"/>
               <div id={slice.token} className="token col-md-12">
+                <img src={loadingImgUrl} className="loading" alt="loading"/>
                 <div className="slice_container" id={slice.token + "_con"}></div>
               </div>
             </div>
-          </li>)
+          </div>)
         }
       });
-// <img src="{{ url_for("static", filename="assets/images/loading.gif") }}" className="loading" alt="loading">
-// style="{{ 'display: none;' if "{}".format(slice.id) not in dashboard.metadata_dejson.expanded_slices }}"
+
       var GridLayout = React.createClass({
         render: function () {
           var layout = [],
               sliceElements = [],
               slices = this.props.slices,
-              posDict = this.props.posDict;
+              posDict = this.props.posDict,
+              onResizeStop = function (layout, oldItem, newItem, placeholder, e, element) {
+                dashboard.getSlice(newItem.i).resize();
+              };
 
           slices.forEach(function (slice) {
             var pos = posDict[slice.slice_id];
             if (!pos) return;
 
-            sliceElements.push(<div key={slice.slice_id}><SliceCell slice={slice} pos={pos}/></div>);
+            sliceElements.push(<div key={slice.slice_id} className="widget-wrapper"><SliceCell slice={slice} pos={pos} /></div>);
             layout.push({
               i: slice.slice_id + "",
               x: pos.col,
@@ -219,15 +223,14 @@ var Dashboard = function (dashboardData) {
             });
           });
 
-          console.log(layout)
-
           return (
-            <ReactGridLayout className="layout" layout={layout}
-              cols={12} rowHeight={100} width={1200}>
+            <ReactGridLayout className="layout" layout={layout} onResizeStop={onResizeStop}
+              cols={12} width={1200}>
               {sliceElements}
             </ReactGridLayout>
           )
-        }
+        },
+
       });
 
       render(<GridLayout slices={this.slices} posDict={posDict}/>, document.getElementById("grid-container"));

--- a/caravel/assets/javascripts/dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard.jsx
@@ -113,16 +113,6 @@ class GridLayout extends React.Component {
     });
   }
 
-  onBreakpointChange() {
-    if (!this.props.dashboard.initialized) {
-      return;
-    }
-
-    this.state.slices.forEach(function (slice) {
-      this.props.dashboard.getSlice(slice.slice_id).resize();
-    }, this);
-  }
-
   serialize() {
     return this.state.layout.map(function (reactPos) {
       return {
@@ -180,7 +170,6 @@ class GridLayout extends React.Component {
         layouts={{ lg: this.state.layout }}
         onResizeStop={this.onResizeStop.bind(this)}
         onDragStop={this.onDragStop.bind(this)}
-        onBreakpointChange={this.onBreakpointChange.bind(this)}
         cols={{ lg: 12, md: 12, sm: 10, xs: 8, xxs: 6 }}
         rowHeight={100}
         autoSize={true}

--- a/caravel/assets/javascripts/dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard.jsx
@@ -22,10 +22,10 @@ const ResponsiveReactGridLayout = WidthProvider(Responsive);
 
 class SliceCell extends React.Component {
   render() {
-    var slice = this.props.slice,
-        createMarkup = function () {
-          return { __html: slice.description_markeddown };
-        };
+    const slice = this.props.slice,
+          createMarkup = function () {
+            return { __html: slice.description_markeddown };
+          };
 
     return (
       <div>

--- a/caravel/assets/javascripts/dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard.jsx
@@ -152,9 +152,7 @@ class GridLayout extends React.Component {
 
       sliceElements.push(
         <div key={slice.slice_id} className="slice-container">
-        <div style={{ position: "relative", height: "inherit", width: "inherit" }}>
           <SliceCell slice={slice} removeSlice={this.removeSlice.bind(this)}/>
-        </div>
         </div>
       );
 
@@ -187,7 +185,7 @@ class GridLayout extends React.Component {
         rowHeight={100}
         autoSize={true}
         margin={[20, 20]}
-        useCSSTransforms={true}
+        useCSSTransforms={false}
         draggableHandle=".drag">
         {this.state.sliceElements}
       </ResponsiveReactGridLayout>

--- a/caravel/assets/javascripts/dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard.jsx
@@ -138,7 +138,10 @@ var Dashboard = function (dashboardData) {
       var SliceCell = React.createClass({
         render: function () {
           var slice = this.props.slice,
-              pos = this.props.pos;
+              pos = this.props.pos,
+              createMarkup = function () {
+                return {__html: slice.description_markeddown};
+              };
 
           return (<div
             id={"slice_" + slice.slice_id}
@@ -185,8 +188,8 @@ var Dashboard = function (dashboardData) {
             </div>
             <div
               className="slice_description bs-callout bs-callout-default"
-              style={expandedSlices && expandedSlices[slice.slice_id + ""] ? {} : {display: "none"}}>
-                {slice.description_markeddown}
+              style={expandedSlices && expandedSlices[slice.slice_id + ""] ? {} : {display: "none"}}
+              dangerouslySetInnerHTML={createMarkup()}>
             </div>
             <div className="row chart-container">
               <input type="hidden" slice_id={slice.slice_id} value="false"/>

--- a/caravel/assets/javascripts/dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard.jsx
@@ -18,7 +18,6 @@ require('../node_modules/react-resizable/css/styles.css');
 require('../stylesheets/dashboard.css');
 
 import {Responsive, WidthProvider} from "react-grid-layout";
-const ReactGridLayout = require("react-grid-layout");
 
 var Dashboard = function (dashboardData) {
   const ResponsiveReactGridLayout = WidthProvider(Responsive);
@@ -210,58 +209,38 @@ var Dashboard = function (dashboardData) {
               posDict = this.props.posDict,
               onResizeStop = function (layout, oldItem, newItem, placeholder, e, element) {
                 dashboard.getSlice(newItem.i).resize();
-              };
+              },
+              maxCol = -1;
 
           slices.forEach(function (slice) {
             var pos = posDict[slice.slice_id];
             if (!pos) return;
 
-            sliceElements.push(<div key={slice.slice_id} className="widget-wrapper"><SliceCell slice={slice} pos={pos} /></div>);
+            sliceElements.push(<div key={slice.slice_id}><SliceCell slice={slice} pos={pos}/></div>);
             layout.push({
               i: slice.slice_id + "",
-              x: pos.col,
+              x: pos.col - 1,
               y: pos.row,
               w: pos.size_x,
               h: pos.size_y
             });
+
+            maxCol = Math.max(maxCol, pos.col + pos.size_x - 1);
           });
 
           return (
-            <ReactGridLayout className="layout" layout={layout} onResizeStop={onResizeStop}
-              cols={12} width={1200}>
+            <ResponsiveReactGridLayout className="layout" layouts={{lg:layout}} onResizeStop={onResizeStop}
+              cols={{lg:maxCol, md:maxCol, sm:Math.max(1, maxCol-2), xs:Math.max(1, maxCol-4), xxs:Math.max(1, maxCol-6)}}
+              rowHeight={112.5}>
               {sliceElements}
-            </ReactGridLayout>
+            </ResponsiveReactGridLayout>
           )
-        },
-
+        }
       });
 
       render(<GridLayout slices={this.slices} posDict={posDict}/>, document.getElementById("grid-container"));
 
       dashboard = this;
-      // var gridster = $(".gridster ul").gridster({
-      //   autogrow_cols: true,
-      //   widget_margins: [10, 10],
-      //   widget_base_dimensions: [95, 95],
-      //   draggable: {
-      //     handle: '.drag'
-      //   },
-      //   resize: {
-      //     enabled: true,
-      //     stop: function (e, ui, element) {
-      //       dashboard.getSlice($(element).attr('slice_id')).resize();
-      //     }
-      //   },
-      //   serialize_params: function (_w, wgd) {
-      //     return {
-      //       slice_id: $(_w).attr('slice_id'),
-      //       col: wgd.col,
-      //       row: wgd.row,
-      //       size_x: wgd.size_x,
-      //       size_y: wgd.size_y
-      //     };
-      //   }
-      // }).data('gridster');
 
       // Displaying widget controls on hover
       $('.chart-header').hover(

--- a/caravel/assets/javascripts/dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard.jsx
@@ -137,7 +137,6 @@ var Dashboard = function (dashboardData) {
       var SliceCell = React.createClass({
         render: function () {
           var slice = this.props.slice,
-              pos = this.props.pos,
               createMarkup = function () {
                 return {__html: slice.description_markeddown};
               };
@@ -145,11 +144,7 @@ var Dashboard = function (dashboardData) {
           return (<div
             id={"slice_" + slice.slice_id}
             slice_id={slice.slice_id}
-            className={"widget " + slice.viz_name}
-            data-row={pos.row || 1}
-            data-col={pos.col || loop.index}
-            data-sizex={pos.size_x || 4}
-            data-sizey={pos.size_y || 4}>
+            className={"widget " + slice.viz_name}>
 
             <div className="chart-header">
               <div className="row">
@@ -168,7 +163,7 @@ var Dashboard = function (dashboardData) {
                   <div className="pull-right">
                     {slice.description ?
                       <a title="Toggle chart description">
-                        <i className="fa fa-info-circle slice_info" slice_id={slice.slice_id} title={slice.description} data-toggle="tooltip"/>
+                        <i className="fa fa-info-circle slice_info" title={slice.description} data-toggle="tooltip"/>
                       </a>
                     : ""}
                     <a href={slice.edit_url} title="Edit chart" data-toggle="tooltip">
@@ -191,7 +186,7 @@ var Dashboard = function (dashboardData) {
               dangerouslySetInnerHTML={createMarkup()}>
             </div>
             <div className="row chart-container">
-              <input type="hidden" slice_id={slice.slice_id} value="false"/>
+              <input type="hidden" value="false"/>
               <div id={slice.token} className="token col-md-12">
                 <img src={loadingImgUrl} className="loading" alt="loading"/>
                 <div className="slice_container" id={slice.token + "_con"}></div>
@@ -212,18 +207,27 @@ var Dashboard = function (dashboardData) {
               },
               maxCol = -1;
 
-          slices.forEach(function (slice) {
+          slices.forEach(function (slice, index) {
             var pos = posDict[slice.slice_id];
-            if (!pos) return;
+            if (!pos) {
+              pos = {
+                col: (index * 4 + 1) % 12,
+                row: 1,
+                size_x: 4,
+                size_y: 4
+              }
+            }
 
-            sliceElements.push(<div key={slice.slice_id}><SliceCell slice={slice} pos={pos}/></div>);
-            layout.push({
-              i: slice.slice_id + "",
-              x: pos.col - 1,
-              y: pos.row,
-              w: pos.size_x,
-              h: pos.size_y
-            });
+            sliceElements.push(<div key={slice.slice_id}><SliceCell slice={slice}/></div>);
+            if (pos) {
+              layout.push({
+                i: slice.slice_id + "",
+                x: pos.col - 1,
+                y: pos.row,
+                w: pos.size_x,
+                h: pos.size_y
+              });
+            }
 
             maxCol = Math.max(maxCol, pos.col + pos.size_x - 1);
           });
@@ -231,7 +235,10 @@ var Dashboard = function (dashboardData) {
           return (
             <ResponsiveReactGridLayout className="layout" layouts={{lg:layout}} onResizeStop={onResizeStop}
               cols={{lg:maxCol, md:maxCol, sm:Math.max(1, maxCol-2), xs:Math.max(1, maxCol-4), xxs:Math.max(1, maxCol-6)}}
-              rowHeight={112.5}>
+              rowHeight={100}
+              autoSize={true}
+              margin={[20, 20]}
+              useCSSTransforms={true}>
               {sliceElements}
             </ResponsiveReactGridLayout>
           )

--- a/caravel/assets/javascripts/dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard.jsx
@@ -65,13 +65,13 @@ class SliceCell extends React.Component {
         </div>
         <div
           className="slice_description bs-callout bs-callout-default"
-          style={expandedSlices && expandedSlices[String(slice.slice_id)] ? {} : { display: "none" }}
+          style={this.props.expandedSlices && this.props.expandedSlices[String(slice.slice_id)] ? {} : { display: "none" }}
           dangerouslySetInnerHTML={createMarkup()}>
         </div>
         <div className="row chart-container">
           <input type="hidden" value="false"/>
           <div id={slice.token} className="token col-md-12">
-            <img src={loadingImgUrl} className="loading" alt="loading"/>
+            <img src={"/static/assets/images/loading.gif"} className="loading" alt="loading"/>
             <div className="slice_container" id={slice.token + "_con"}></div>
           </div>
         </div>
@@ -145,7 +145,10 @@ class GridLayout extends React.Component {
           key={slice.slice_id}
           data-slice-id={slice.slice_id}
           className={"widget " + slice.viz_name}>
-          <SliceCell slice={slice} removeSlice={this.removeSlice.bind(this)}/>
+          <SliceCell
+            slice={slice}
+            removeSlice={this.removeSlice.bind(this)}
+            expandedSlices={this.props.dashboard.metadata.expanded_slices}/>
         </div>
       );
 
@@ -300,6 +303,11 @@ var Dashboard = function (dashboardData) {
       }
     },
     initDashboardView: function () {
+      var posDict = {}
+      this.position_json.forEach(function (position) {
+        posDict[position.slice_id] = position;
+      });
+
       reactGridLayout = render(
         <GridLayout slices={this.slices} posDict={posDict} dashboard={dashboard}/>,
         document.getElementById("grid-container")

--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -65,6 +65,8 @@
     "react": "^0.14.7",
     "react-bootstrap": "^0.28.3",
     "react-dom": "^0.14.7",
+    "react-grid-layout": "^0.12.3",
+    "react-resizable": "^1.3.3",
     "select2": "3.5",
     "select2-bootstrap-css": "^1.4.6",
     "style-loader": "^0.13.0",

--- a/caravel/assets/stylesheets/caravel.css
+++ b/caravel/assets/stylesheets/caravel.css
@@ -189,6 +189,7 @@ div.widget .chart-controls {
   position: absolute;
   right: 0;
   left: 0;
+  top: 5px;
   padding: 5px 5px;
   opacity: 0.75;
   display: none;

--- a/caravel/assets/stylesheets/caravel.css
+++ b/caravel/assets/stylesheets/caravel.css
@@ -184,11 +184,12 @@ div.widget .chart-header a {
 }
 
 div.widget .chart-controls {
+  background-clip: content-box;
   background-color: #f1f1f1;
   position: absolute;
   right: 0;
   left: 0;
-  padding: 0px 5px;
+  padding: 5px 5px;
   opacity: 0.75;
   display: none;
 }

--- a/caravel/assets/stylesheets/caravel.css
+++ b/caravel/assets/stylesheets/caravel.css
@@ -170,12 +170,12 @@ li.widget:hover {
   z-index: 1000;
 }
 
-li.widget .chart-header {
+div.widget .chart-header {
   padding: 5px;
   background-color: #f1f1f1;
 }
 
-li.widget .chart-header a {
+div.widget .chart-header a {
   margin-left: 5px;
 }
 
@@ -183,7 +183,7 @@ li.widget .chart-header a {
   display: none;
 }
 
-li.widget .chart-controls {
+div.widget .chart-controls {
   background-color: #f1f1f1;
   position: absolute;
   right: 0;
@@ -193,6 +193,6 @@ li.widget .chart-controls {
   display: none;
 }
 
-li.widget .slice_container {
+div.widget .slice_container {
   overflow: auto;
 }

--- a/caravel/assets/stylesheets/dashboard.css
+++ b/caravel/assets/stylesheets/dashboard.css
@@ -4,23 +4,24 @@
 .dashboard i.drag {
   cursor: move !important;
 }
-.dashboard .gridster .preview-holder {
+.dashboard .slice-grid .preview-holder {
   z-index: 1;
   position: absolute;
   background-color: #AAA;
   border-color: #AAA;
   opacity: 0.3;
 }
-.gridster li.widget{
-  list-style-type: none;
-  border-radius: 0;
+
+.slice-grid div.widget{
+  height: inherit;
   margin: 5px;
+  border-radius: 0;
   border: 1px solid #ccc;
   box-shadow: 2px 1px 5px -2px #aaa;
   background-color: #fff;
 }
-.dashboard .gridster .dragging,
-.dashboard .gridster .resizing {
+.dashboard .slice-grid .dragging,
+.dashboard .slice-grid .resizing {
   opacity: 0.5;
 }
 .dashboard img.loading {

--- a/caravel/assets/stylesheets/dashboard.css
+++ b/caravel/assets/stylesheets/dashboard.css
@@ -12,12 +12,7 @@
   opacity: 0.3;
 }
 
-.react-resizable-handle {
-  display: none;
-  margin: 4px;
-}
 .slice-grid div.widget{
-  height: inherit;
   border-radius: 0;
   border: 1px solid #ccc;
   box-shadow: 2px 1px 5px -2px #aaa;

--- a/caravel/assets/stylesheets/dashboard.css
+++ b/caravel/assets/stylesheets/dashboard.css
@@ -14,7 +14,6 @@
 
 .slice-grid div.widget{
   height: inherit;
-  margin: 5px;
   border-radius: 0;
   border: 1px solid #ccc;
   box-shadow: 2px 1px 5px -2px #aaa;

--- a/caravel/assets/stylesheets/dashboard.css
+++ b/caravel/assets/stylesheets/dashboard.css
@@ -12,6 +12,10 @@
   opacity: 0.3;
 }
 
+.react-resizable-handle {
+  display: none;
+  margin: 4px;
+}
 .slice-grid div.widget{
   height: inherit;
   border-radius: 0;

--- a/caravel/assets/visualizations/pivot_table.css
+++ b/caravel/assets/visualizations/pivot_table.css
@@ -1,4 +1,4 @@
-.gridster .widget.pivot_table .slice_container {
+.slice-grid .widget.pivot_table .slice_container {
     overflow: auto !important;
 }
 

--- a/caravel/assets/visualizations/table.css
+++ b/caravel/assets/visualizations/table.css
@@ -1,4 +1,4 @@
-.gridster .widget.table .slice_container {
+.slice-grid .widget.table .slice_container {
     overflow: auto !important;
 }
 

--- a/caravel/assets/webpack.config.js
+++ b/caravel/assets/webpack.config.js
@@ -6,7 +6,7 @@ var config = {
   // for now generate one compiled js file per entry point / html page
   entry: {
     'css-theme': APP_DIR + '/javascripts/css-theme.js',
-    dashboard: APP_DIR + '/javascripts/dashboard.js',
+    dashboard: APP_DIR + '/javascripts/dashboard.jsx',
     explore: APP_DIR + '/javascripts/explore.js',
     welcome: APP_DIR + '/javascripts/welcome.js',
     sql: APP_DIR + '/javascripts/sql.js',

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -315,6 +315,7 @@ class Dashboard(Model, AuditMixinNullable):
             'dashboard_title': self.dashboard_title,
             'slug': self.slug,
             'slices': [slc.data for slc in self.slices],
+            'position_json': json.loads(self.position_json),
         }
         return json.dumps(d)
 

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -205,6 +205,11 @@ class Slice(Model, AuditMixinNullable):
         except Exception as e:
             d['error'] = str(e)
         d['slice_id'] = self.id
+        d['slice_name'] = self.slice_name
+        d['description'] = self.description
+        d['slice_url'] = self.slice_url
+        d['edit_url'] = self.edit_url
+        d['description_markeddown'] = self.description_markeddown
         return d
 
     @property

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -197,6 +197,7 @@ class Slice(Model, AuditMixinNullable):
 
     @property
     def data(self):
+        """Data used to render slice in templates"""
         d = {}
         self.token = ''
         try:

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -7,7 +7,11 @@
 {% block title %}[dashboard] {{ dashboard.dashboard_title }}{% endblock %}
 {% block body %}
 
-<script>var posDict = {{pos_dict | safe}}</script>
+<script>
+  var posDict = {{ pos_dict | safe }},
+    expandedSlices = {{ dashboard.metadata_dejson | safe }}.expanded_slices,
+    loadingImgUrl = "{{ url_for('static', filename='assets/images/loading.gif') }}";
+</script>
 
 <div class="dashboard container-fluid" data-dashboard="{{ dashboard.json_data }}" data-css="{{ dashboard.css }}">
 
@@ -100,7 +104,7 @@
     </div>
 </div>
 
-<div id="grid-container">
+<div id="grid-container" class="slice-grid">
 </div>
 
 </div>

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -104,7 +104,8 @@
     </div>
 </div>
 
-<div id="grid-container" class="slice-grid">
+<!-- gridster class used for backwards compatibility -->
+<div id="grid-container" class="slice-grid gridster">
 </div>
 
 </div>

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -7,9 +7,9 @@
 {% block title %}[dashboard] {{ dashboard.dashboard_title }}{% endblock %}
 {% block body %}
 
-<script>
+<script type=text/javascript>
   var posDict = {{ pos_dict | safe }},
-    expandedSlices = {{ dashboard.json_data | safe }}.metadata.expanded_slices,
+    expandedSlices = {{ dashboard.metadata_dejson | tojson | safe }}.expanded_slices,
     loadingImgUrl = "{{ url_for('static', filename='assets/images/loading.gif') }}";
 </script>
 

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -6,6 +6,9 @@
 {% endblock %}
 {% block title %}[dashboard] {{ dashboard.dashboard_title }}{% endblock %}
 {% block body %}
+
+<script>var posDict = {{pos_dict | safe}}</script>
+
 <div class="dashboard container-fluid" data-dashboard="{{ dashboard.json_data }}" data-css="{{ dashboard.css }}">
 
 <!-- Modal -->
@@ -97,71 +100,8 @@
     </div>
 </div>
 
-<div class="gridster content_fluid" style="visibility: hidden;">
-    <ul>
-        {% for slice in dashboard.slices %}
-          {% set pos = pos_dict.get(slice.id, {}) %}
-
-
-          <li
-            id="slice_{{ slice.id }}"
-            slice_id="{{ slice.id }}"
-            class="widget {{ slice.viz_type }}"
-            data-row="{{ pos.row or 1 }}"
-            data-col="{{ pos.col or loop.index }}"
-            data-sizex="{{ pos.size_x or 4 }}"
-            data-sizey="{{ pos.size_y or 4 }}">
-
-            <div class="chart-header">
-              <div class="row">
-                <div class="col-md-12 text-center header">
-                  {{ slice.slice_name }}
-                </div>
-                <div class="col-md-12 chart-controls">
-                  <div class="pull-left">
-                    <a title="Move chart" data-toggle="tooltip">
-                      <i class="fa fa-arrows drag"></i>
-                    </a>
-                    <a class="refresh" title="Force refresh data" data-toggle="tooltip">
-                      <i class="fa fa-repeat"></i>
-                    </a>
-                  </div>
-                  <div class="pull-right">
-                    {% if slice.description %}
-                      <a title="Toggle chart description">
-                        <i class="fa fa-info-circle slice_info" slice_id="{{ slice.id }}" title="{{ slice.description }}" data-toggle="tooltip"></i>
-                      </a>
-                    {% endif %}
-                    <a href="{{ slice.edit_url }}" title="Edit chart" data-toggle="tooltip">
-                      <i class="fa fa-pencil"></i>
-                    </a>
-                    <a href="{{ slice.slice_url }}" title="Explore chart" data-toggle="tooltip">
-                      <i class="fa fa-share"></i>
-                    </a>
-                    <a class="remove-chart" title="Remove chart from dashboard" data-toggle="tooltip">
-                      <i class="fa fa-close"></i>
-                    </a>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-            <div
-              class="slice_description bs-callout bs-callout-default"
-              style="{{ 'display: none;' if "{}".format(slice.id) not in dashboard.metadata_dejson.expanded_slices }}">
-                        {{ slice.description_markeddown | safe }}
-            </div>
-            <div class="row chart-container">
-              <input type="hidden" slice_id="{{ slice.id }}" value="false">
-              <div id="{{ slice.token }}" class="token col-md-12">
-                <img src="{{ url_for("static", filename="assets/images/loading.gif") }}" class="loading" alt="loading">
-                <div class="slice_container" id="{{ slice.token }}_con"></div>
-              </div>
-            </div>
-          </li>
-
-        {% endfor %}
-    </ul>
+<div id="grid-container">
 </div>
+
 </div>
 {% endblock %}

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -7,12 +7,6 @@
 {% block title %}[dashboard] {{ dashboard.dashboard_title }}{% endblock %}
 {% block body %}
 
-<script type=text/javascript>
-  var posDict = {{ pos_dict | safe }},
-    expandedSlices = {{ dashboard.metadata_dejson | tojson | safe }}.expanded_slices,
-    loadingImgUrl = "{{ url_for('static', filename='assets/images/loading.gif') }}";
-</script>
-
 <div class="dashboard container-fluid" data-dashboard="{{ dashboard.json_data }}" data-css="{{ dashboard.css }}">
 
 <!-- Modal -->

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -9,7 +9,7 @@
 
 <script>
   var posDict = {{ pos_dict | safe }},
-    expandedSlices = {{ dashboard.metadata_dejson | safe }}.expanded_slices,
+    expandedSlices = {{ dashboard.json_data | safe }}.metadata.expanded_slices,
     loadingImgUrl = "{{ url_for('static', filename='assets/images/loading.gif') }}";
 </script>
 

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -883,15 +883,9 @@ class Caravel(BaseView):
             pass
         dashboard(dashboard_id=dash.id)
 
-        pos_dict = {}
-        if dash.position_json:
-            pos_dict = {
-                int(o['slice_id']): o
-                for o in json.loads(dash.position_json)}
         return self.render_template(
             "caravel/dashboard.html", dashboard=dash,
             templates=templates,
-            pos_dict=json.dumps(pos_dict),
             dash_save_perm=appbuilder.sm.has_access('can_save_dash', 'Caravel'),
             dash_edit_perm=appbuilder.sm.has_access('can_edit', 'DashboardModelView'))
 

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -891,7 +891,7 @@ class Caravel(BaseView):
         return self.render_template(
             "caravel/dashboard.html", dashboard=dash,
             templates=templates,
-            pos_dict=pos_dict,
+            pos_dict=json.dumps(pos_dict),
             dash_save_perm=appbuilder.sm.has_access('can_save_dash', 'Caravel'),
             dash_edit_perm=appbuilder.sm.has_access('can_edit', 'DashboardModelView'))
 


### PR DESCRIPTION
Using [react-grid-layout](https://github.com/STRML/react-grid-layout).
##### Notable changes:
- Resizing and dragging are smoother
- the grid is now responsive, the number of columns as well as column width will change based on browser width

---
##### Considerations:
- this may break some custom CSS. The most notable change is that slices are now `divs` instead of `lis`. The `gridster` class is still in place for legacy purposes.
- layouts that use less than 12 columns will not be centered anymore. We recommend always using 12 columns.
- you cannot increase the number of rows of a slice past the screen/browser bounds
- responsiveness isn't perfect yet, the number of columns at each breakpoint is fixed and can be made better. Also, you have to do a dashboard refresh to resize your slices after changing window size
