### PR TITLE
Fix #529 1 "This Session's transaction has been rolled back"

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1001,12 +1001,13 @@ class Caravel(BaseView):
         """endpoint that refreshes druid datasources metadata"""
         session = db.session()
         for cluster in session.query(models.DruidCluster).all():
+            cluster_name = cluster.cluster_name
             try:
                 cluster.refresh_datasources()
             except Exception as e:
                 flash(
                     "Error while processing cluster '{}'\n{}".format(
-                        cluster, str(e)),
+                        cluster_name, str(e)),
                     "danger")
                 logging.exception(e)
                 return redirect('/druidclustermodelview/list/')

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -317,13 +317,14 @@ class TableModelView(CaravelModelView, DeleteMixin):  # noqa
     }
 
     def post_add(self, table):
+        table_name = table.table_name
         try:
             table.fetch_metadata()
         except Exception as e:
             logging.exception(e)
             flash(
                 "Table [{}] doesn't seem to exist, "
-                "couldn't fetch metadata".format(table.table_name),
+                "couldn't fetch metadata".format(table_name),
                 "danger")
         utils.merge_perm(sm, 'datasource_access', table.perm)
 


### PR DESCRIPTION
Fix one of the issues found in #529 

Background:
- When an object is modified by SQLAlchemy, it is invalidated so need to be fetched again from the DB
- If there's an exception during a transaction, SQLAlchemy performs a rollback and mark the connection as dirty.

Bug:
- When handling exceptions, the exception handler tries to access the name of the cluster in the main object. Since the name has been invalidated due to a write, SQLAlchemy tries to fetch it on a 'dirty' connection and spits out an error.
  Solution:
- Fetch the information for handling the exception before starting the process.
