### PR TITLE
using slice_id instead of url to do caching

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -184,6 +184,7 @@ class Slice(Model, AuditMixinNullable):
     @utils.memoized
     def viz(self):
         d = json.loads(self.params)
+        d['slice_id'] = self.id
         viz_class = viz_types[self.viz_type]
         return viz_class(self.datasource, form_data=d)
 

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -301,7 +301,10 @@ class BaseViz(object):
     @property
     def cache_key(self):
         url = self.get_url(json="true", force="false")
-        return hashlib.md5(url.encode('utf-8')).hexdigest()
+        if self.form_data['slice_id']:
+            return self.form_data['slice_id']
+        else:
+            return hashlib.md5(url.encode('utf-8')).hexdigest()
 
     @property
     def csv_endpoint(self):


### PR DESCRIPTION
I use slice_id as the cache key. When slices are cached from dashboard I add manually add slice_id into form_data since sometimes form_data['slice_id'] is empty.
