### PR TITLE
Fix world_map appending to old world map when updating

### DIFF
--- a/caravel/assets/visualizations/world_map.js
+++ b/caravel/assets/visualizations/world_map.js
@@ -14,6 +14,7 @@ function worldMapChart(slice) {
     container.css('height', slice.height());
 
     d3.json(slice.jsonEndpoint(), function (error, json) {
+      div.selectAll("*").remove();
       var fd = json.form_data;
 
       if (error !== null) {


### PR DESCRIPTION
Updating or applying a dashboard filter to the World Map viz will create an entirely new map. This PR fixes this issue.
