### PR TITLE
caravel: catch only ImportError when loading config

### DIFF
--- a/caravel/config.py
+++ b/caravel/config.py
@@ -176,7 +176,7 @@ BACKUP_COUNT = 30
 
 try:
     from caravel_config import *  # noqa
-except Exception:
+except ImportError:
     pass
 
 if not CACHE_DEFAULT_TIMEOUT:


### PR DESCRIPTION
As you may want to see the exception raised on at leasts SyntaxError
