### PR TITLE
Allow for multiple columns in NOT GROUP BY

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -721,7 +721,7 @@ class Caravel(BaseView):
         d = args.to_dict(flat=False)
         del d['action']
         del d['previous_viz_type']
-        as_list = ('metrics', 'groupby', 'columns')
+        as_list = ('metrics', 'groupby', 'columns', 'all_columns')
         for k in d:
             v = d.get(k)
             if k in as_list and not isinstance(v, list):


### PR DESCRIPTION
Without this, choosing multiple columns for NOT GROUP BY (all_columns field) in TableViz and saving/overwriting the slice will only save the first column chosen.
