### PR TITLE
Remove hack in fields with multiselect

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -685,7 +685,6 @@ class Caravel(BaseView):
         if not (all_datasource_access or datasource_access):
             flash(__("You don't seem to have access to this datasource"), "danger")
             return redirect(error_redirect)
-
         action = request.args.get('action')
         if action in ('save', 'overwrite'):
             return self.save_or_overwrite_slice(
@@ -760,12 +759,11 @@ class Caravel(BaseView):
         d = args.to_dict(flat=False)
         del d['action']
         del d['previous_viz_type']
-        as_list = ('metrics', 'groupby', 'columns', 'all_columns')
+        # Unwrap length 1 lists
         for k in d:
             v = d.get(k)
-            if k in as_list and not isinstance(v, list):
-                d[k] = [v] if v else []
-            if k not in as_list and isinstance(v, list):
+            assert isinstance(v, list)
+            if len(v) == 1:
                 d[k] = v[0]
 
         table_id = druid_datasource_id = None

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -685,6 +685,7 @@ class Caravel(BaseView):
         if not (all_datasource_access or datasource_access):
             flash(__("You don't seem to have access to this datasource"), "danger")
             return redirect(error_redirect)
+
         action = request.args.get('action')
         if action in ('save', 'overwrite'):
             return self.save_or_overwrite_slice(


### PR DESCRIPTION
to_dict() will always return a dict with its value being a dictionary, so we unwrap the dicts of length 1 which would be for non-multiselect fields.
