### PR TITLE
fix missing multiple values for the same parameter name

### DIFF
--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -22,7 +22,7 @@ from flask.ext.babelpkg import lazy_gettext as _
 from markdown import markdown
 from pandas.io.json import dumps
 from six import string_types
-from werkzeug.datastructures import ImmutableMultiDict
+from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from werkzeug.urls import Href
 from dateutil import relativedelta as rdelta
 
@@ -113,12 +113,13 @@ class BaseViz(object):
             del d['action']
         d.update(kwargs)
         # Remove unchecked checkboxes because HTML is weird like that
-        od = OrderedDict()
+        od = MultiDict()
         for key in sorted(d.keys()):
             if d[key] is False:
                 del d[key]
             else:
-                od[key] = d[key]
+                for v in d.getlist(key):
+                    od.add(key, v)
         href = Href(
             '/caravel/explore/{self.datasource.type}/'
             '{self.datasource.id}/'.format(**locals()))


### PR DESCRIPTION
Multiple parameters from forms (e.g. `all_columns` in Table View) get lost in `get_url` function and only the first one is kept. This happens when you try to save Table View as csv. Switching from `OrderedDict` to `MultiDict` does the trick.
- [ ] make the tests pass
