### PR TITLE
config: there's no such thing as WEBSERVER_THREADS

### DIFF
--- a/caravel/config.py
+++ b/caravel/config.py
@@ -18,10 +18,10 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 # ---------------------------------------------------------
-# Caravel specifix config
+# Caravel specific config
 # ---------------------------------------------------------
 ROW_LIMIT = 50000
-WEBSERVER_THREADS = 8
+CARAVEL_WORKERS = 16
 
 CARAVEL_WEBSERVER_PORT = 8088
 CARAVEL_WEBSERVER_TIMEOUT = 60

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -88,10 +88,10 @@ To configure your application, you need to create a file (module)
 of the parameters you can copy / paste in that configuration module: ::
 
     #---------------------------------------------------------
-    # Caravel specifix config
+    # Caravel specific config
     #---------------------------------------------------------
     ROW_LIMIT = 5000
-    WEBSERVER_THREADS = 8
+    CARAVEL_WORKERS = 16
 
     CARAVEL_WEBSERVER_PORT = 8088
     #---------------------------------------------------------


### PR DESCRIPTION
The config option is CARAVEL_WORKERS. Bump example to 16 processes
to keep backward compatibility with the current default.
