### PR TITLE
Better support for Druid cardinality estimation mertics

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -1419,9 +1419,20 @@ class DruidColumn(Model, AuditMixinNullable):
                     'type': mt, 'name': name, 'fieldName': self.column_name})
             ))
         if self.count_distinct:
-            if self.type == 'STRING':
+            name = 'count_distinct__' + self.column_name
+            if self.type == 'hyperUnique' or self.type == 'thetaSketch':
+                metrics.append(DruidMetric(
+                    metric_name=name,
+                    verbose_name='COUNT(DISTINCT {})'.format(self.column_name),
+                    metric_type=self.type,
+                    json=json.dumps({
+                        'type': self.type,
+                        'name': name,
+                        'fieldName': self.column_name
+                    })
+                ))
+            else:
                 mt = 'count_distinct'
-                name = 'count_distinct__' + self.column_name
                 metrics.append(DruidMetric(
                     metric_name=name,
                     verbose_name='COUNT(DISTINCT {})'.format(self.column_name),
@@ -1430,17 +1441,6 @@ class DruidColumn(Model, AuditMixinNullable):
                         'type': 'cardinality',
                         'name': name,
                         'fieldNames': [self.column_name]})
-                ))
-            else:
-                metrics.append(DruidMetric(
-                    metric_name='count_distinct_by_' + self.type,
-                    verbose_name=self.type + '_ESTIMATE(DISTINCT {})'.format(self.column_name),
-                    metric_type=self.type + '_estimate_distinct',
-                    json=json.dumps({
-                        'type': self.type,
-                        'name': self.type + '_' + self.column_name,
-                        'fieldName': self.column_name
-                    })
                 ))
         session = get_session()
         for metric in metrics:


### PR DESCRIPTION
Default Druid aggregators include some aggregation operation in ingestion time that works specified for cardinality estimation. hyperUnique and [thetaSketch](http://druid.io/docs/0.9.0/development/extensions-core/datasketches-aggregators.html) are two aggregations that are already included in Druid package. They will create two metric columns after ingestion and we want caravel automatically add the count_distinct metric by using these two kinds of metrics for our users. 

The change keeps the original logic for `is_count_distinct` column, but for hyperUnique and thetaSketch columns, it will set `is_count_distinct` to true when refreshing metadata and the metric for those columns will be automatically generated with the corresponding aggregator JSON.

Some screen shots for this feature applying on wikiticker database:
![screenshot_5](https://cloud.githubusercontent.com/assets/10549439/16025693/c324b8e6-317d-11e6-806a-df52c6daae2c.png)
The columns after refreshing wikiticker's metadata. hyperUnique and thetaSketch columns are marked as count_distinct columns.
![screenshot_6](https://cloud.githubusercontent.com/assets/10549439/16025694/c328005a-317d-11e6-860a-1a45f1f00662.png)
The metrics generated from those columns.
![screenshot_7](https://cloud.githubusercontent.com/assets/10549439/16025695/c328dfb6-317d-11e6-8e30-5575c50abc62.png)
