### PR TITLE
Update sql.js to fix a invalid error msg

### DIFF
--- a/caravel/assets/javascripts/sql.js
+++ b/caravel/assets/javascripts/sql.js
@@ -89,6 +89,7 @@ $(document).ready(function () {
           $('#results').html(data);
 
           $('table.sql_results').DataTable({
+            retrieve: true,
             paging: false,
             searching: true,
             aaSorting: []


### PR DESCRIPTION
when using sql.html page to run sql directly, for any SELECT \* sql, when click run! button for the second time,
the page will show error msg like: DataTables warning: table id={id} - Cannot reinitialise DataTable.
this can be fix by:https://datatables.net/manual/tech-notes/3#retrieve
