### PR TITLE
Check ownership before a slice is deleted

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -469,6 +469,9 @@ class SliceModelView(CaravelModelView, DeleteMixin):  # noqa
     def pre_update(self, obj):
         check_ownership(obj)
 
+    def pre_delete(self, obj):
+        check_ownership(obj)
+
 appbuilder.add_view(
     SliceModelView,
     "Slices",


### PR DESCRIPTION
Only the owner can update the slice, so I think it makes sense to only allow the owner to delete the slices as well.
