### PR TITLE
Redirect to druid datasource page when the user wants to add slice. Also, provide a link to the table page

### DIFF
--- a/caravel/templates/caravel/add_slice.html
+++ b/caravel/templates/caravel/add_slice.html
@@ -1,4 +1,6 @@
 <script>
-  var msg = "Click on a table link to create a Slice";
-  window.location = "/r/msg/?url={{ '/tablemodelview/list/' }}&msg=" + msg;
+  var msg = "Click on a datasource link to create a Slice, " +
+          "or click on a table link <a href='/tablemodelview/list/'>here</a> " +
+          "to create a Slice for a table";
+  window.location = "/r/msg/?url={{ '/druiddatasourcemodelview/list/' }}&msg=" + msg;
 </script>

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -660,7 +660,7 @@ class R(BaseView):
     @expose("/msg/")
     def msg(self):
         """Redirects to specified url while flash a message"""
-        flash(request.args.get("msg"), "info")
+        flash(Markup(request.args.get("msg")), "info")
         return redirect(request.args.get("url"))
 
 appbuilder.add_view_no_menu(R)


### PR DESCRIPTION
I don't know now this project focus more on druid datasources or tables. Because in the beginning this project was mainly for Druid, I think it makes sense to redirect to the datasource page by default.
At least we should provide a link like one in this pull request, otherwise it's confusing when a user wants to create a Druid slice but ends up being redirected to a table page.
