### PR TITLE
Prevent the cannot-overwrite error message from being removed

### DIFF
--- a/caravel/assets/javascripts/explore.js
+++ b/caravel/assets/javascripts/explore.js
@@ -64,7 +64,9 @@ function query(force, pushState) {
   }
   $('.query-and-save button').attr('disabled', 'disabled');
   $('.btn-group.results span,a').attr('disabled', 'disabled');
-  $('div.alert').remove();
+  if (force) {  // Don't hide the alert message when the page is just loaded
+    $('div.alert').remove();
+  }
   $('#is_cached').hide();
   prepForm();
   slice.render(force);

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -828,7 +828,7 @@ class Caravel(BaseView):
     def overwrite_slice(self, slc):
         can_update = check_ownership(slc, raise_if_false=False)
         if not can_update:
-            flash("You cannot overwrite [{}]".format(slc))
+            flash("You cannot overwrite [{}]".format(slc), "danger")
         else:
             session = db.session()
             session.merge(slc)


### PR DESCRIPTION
There was 2 problems about the cannot-overwrite error message
1. No alert-danger CSS, so the message is in white with white background
2. It's removed right after the page is loaded, before the user can see it
This PR attempts to fix these two issues
