### PR TITLE
Only initiate permissions of valid metrics

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -873,7 +873,7 @@ class SqlMetric(Model, AuditMixinNullable):
         return (
             "{parent_name}.[{obj.metric_name}](id:{obj.id})"
         ).format(obj=self,
-                 parent_name=self.table.full_name)
+                 parent_name=self.table.full_name) if self.table else None
 
 
 class TableColumn(Model, AuditMixinNullable):
@@ -1372,7 +1372,9 @@ class DruidMetric(Model, AuditMixinNullable):
         return (
             "{parent_name}.[{obj.metric_name}](id:{obj.id})"
         ).format(obj=self,
-                 parent_name=self.datasource.full_name)
+                 parent_name=self.datasource.full_name
+                 ) if self.datasource else None
+
 
 class DruidColumn(Model, AuditMixinNullable):
 

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -228,7 +228,7 @@ def init_metrics_perm(caravel, metrics=None):
         for model in [models.SqlMetric, models.DruidMetric]:
             metrics += list(db.session.query(model).all())
 
-    metric_perms = [metric.perm for metric in metrics]
+    metric_perms = filter(None, [metric.perm for metric in metrics])
     for metric_perm in metric_perms:
         merge_perm(sm, 'metric_access', metric_perm)
 


### PR DESCRIPTION
Because sql_metrics.table_id is nultable , we somehow encountered a problem that self.table is None for some metrics. This PR attempts to fix this issue
