### PR TITLE
expose /slice/<slice_id>/ endpoint to redirect to a slice's url

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -724,7 +724,6 @@ class Caravel(BaseView):
                 .filter_by(id=slice_id)
                 .first()
             )
-            print("CHRIS", slc.slice_url)
         if not datasource:
             flash(__("The datasource seems to have been deleted"), "alert")
             return redirect(error_redirect)

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -724,6 +724,7 @@ class Caravel(BaseView):
                 .filter_by(id=slice_id)
                 .first()
             )
+            print("CHRIS", slc.slice_url)
         if not datasource:
             flash(__("The datasource seems to have been deleted"), "alert")
             return redirect(error_redirect)
@@ -952,6 +953,19 @@ class Caravel(BaseView):
         return Response(
             json.dumps({'count': count}),
             mimetype="application/json")
+
+    @has_access
+    @expose("/slice/<slice_id>/")
+    def slice(self, slice_id):
+        """Redirects a request for a slice id to its corresponding URL"""
+        session = db.session()
+        qry = session.query(models.Slice).filter_by(id=int(slice_id))
+        slc = qry.first()
+        if slc:
+            return redirect(slc.slice_url)
+        else:
+            flash("The specified slice could not be found", "danger")
+            return redirect('/slicemodelview/list/')
 
     @has_access
     @expose("/dashboard/<dashboard_id>/")

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -140,13 +140,14 @@ class CoreTests(CaravelTestCase):
         assert 'Energy' in resp.data.decode('utf-8')
 
     def test_slices(self):
-        # Testing by running all the examples
+        # Testing by hitting the two supported end points for all slices
         self.login(username='admin')
         Slc = models.Slice
         urls = []
         for slc in db.session.query(Slc).all():
             urls += [
-                (slc.slice_name, 'slice_url',  slc.slice_url),
+                (slc.slice_name, 'slice_url', slc.slice_url),
+                (slc.slice_name, 'slice_id_endpoint', '/caravel/slices/{}'.format(slc.id)),
                 (slc.slice_name, 'json_endpoint', slc.viz.json_endpoint),
                 (slc.slice_name, 'csv_endpoint', slc.viz.csv_endpoint),
             ]


### PR DESCRIPTION
I'm not sure what the implications for this are for short urls, but this PR just exposes a convenience endpoint to redirect a slice id to its fully-expanded url (note that the dashboard equivalent already exists: `dashboard/id`).
