### PR TITLE
docs: correct name of local config module in comments

### DIFF
--- a/caravel/config.py
+++ b/caravel/config.py
@@ -1,7 +1,7 @@
 """The main config file for Caravel
 
-All configuration in this file can be overridden by providing a local_config
-in your PYTHONPATH as there is a ``from local_config import *``
+All configuration in this file can be overridden by providing a caravel_config
+in your PYTHONPATH as there is a ``from caravel_config import *``
 at the end of this file.
 """
 from __future__ import absolute_import


### PR DESCRIPTION
The docs mention the local config module name as `local_config`
but the code expects module named `caravel_config`. This fixes
docs to match what code expects.
