### PR TITLE
Don't force formatting when using "Period Ratio"

### DIFF
--- a/caravel/assets/visualizations/nvd3_vis.js
+++ b/caravel/assets/visualizations/nvd3_vis.js
@@ -213,12 +213,7 @@ function nvd3Vis(slice) {
           chart.yAxis.tickFormat(d3.format('.3s'));
         }
 
-        if (fd.contribution || fd.num_period_compare || viz_type === 'compare') {
-          chart.yAxis.tickFormat(d3.format('.3p'));
-          if (chart.y2Axis !== undefined) {
-            chart.y2Axis.tickFormat(d3.format('.3p'));
-          }
-        } else if (fd.y_axis_format) {
+        if (fd.y_axis_format) {
           chart.yAxis.tickFormat(d3.format(fd.y_axis_format));
 
           if (chart.y2Axis !== undefined) {


### PR DESCRIPTION
At the moment, when using the "Period Ratio" option, a percentage
formatting is forced on the Y Axis. This code pre-dates the `Y Axis
Format` option.

People may want to see a growth rate, in which case the current `.3p`
isn't what they want, or they may want only 2 digits of precision or
whatever else. This PR allows that.
