### PR TITLE
Make text in sunburst path more readable

### DIFF
--- a/caravel/assets/visualizations/sunburst.css
+++ b/caravel/assets/visualizations/sunburst.css
@@ -1,5 +1,5 @@
 .sunburst text {
-  shape-rendering: crispEdges;
+  text-rendering: optimizeLegibility;
 }
 .sunburst path {
   stroke: #333;

--- a/caravel/assets/visualizations/sunburst.js
+++ b/caravel/assets/visualizations/sunburst.js
@@ -270,6 +270,11 @@ function sunburstVis(slice) {
           .attr("x", (breadcrumbDims.width + breadcrumbDims.tipTailWidth) / 2)
           .attr("y", breadcrumbDims.height / 4)
           .attr("dy", "0.35em")
+          .style("fill", function (d) {
+            // Make text white or black based on the lightness of the background
+            var col = d3.hsl(colorByCategory ? px.color.category21(d.name) : colorScale(d.m2 / d.m1));
+            return col.l < 0.5 ? 'white' : 'black';
+          })
           .attr("class", "step-label")
           .text(function (d) { return d.name.replace(/_/g, " "); })
           .call(wrapSvgText, breadcrumbDims.width, breadcrumbDims.height / 2);


### PR DESCRIPTION
Make the text color be black or white based on lightness of background color.
<img width="825" alt="screen shot 2016-06-24 at 8 44 11 am" src="https://cloud.githubusercontent.com/assets/487433/16342616/f1e38e38-39e7-11e6-8b82-1d66d7bf72c7.png">
@williaster @xrmx 

superseeds https://github.com/airbnb/caravel/pull/674/files
