### PR TITLE
Smarter redirect on slice creation

### DIFF
--- a/caravel/templates/caravel/add_slice.html
+++ b/caravel/templates/caravel/add_slice.html
@@ -1,6 +1,0 @@
-<script>
-  var msg = "Click on a datasource link to create a Slice, " +
-          "or click on a table link <a href='/tablemodelview/list/'>here</a> " +
-          "to create a Slice for a table";
-  window.location = "/r/msg/?url={{ '/druiddatasourcemodelview/list/' }}&msg=" + msg;
-</script>

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -520,7 +520,6 @@ if config['DRUID_IS_ACTIVE']:
 
 class SliceModelView(CaravelModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.Slice)
-    add_template = "caravel/add_slice.html"
     can_add = False
     label_columns = {
         'datasource_link': 'Datasource',
@@ -567,6 +566,28 @@ class SliceModelView(CaravelModelView, DeleteMixin):  # noqa
 
     def pre_delete(self, obj):
         check_ownership(obj)
+
+    @expose('/add', methods=['GET', 'POST'])
+    @has_access
+    def add(self):
+        widget = self._add()
+        if not widget:
+            return redirect(self.get_redirect())
+
+        a_druid_datasource = db.session.query(models.DruidDatasource).first()
+        if a_druid_datasource is not None:
+            url = "/druiddatasourcemodelview/list/"
+            msg = _(
+                "Click on a datasource link to create a Slice, "
+                "or click on a table link <a href='/tablemodelview/list/'>here</a> "
+                "to create a Slice for a table"
+            )
+        else:
+            url = "/tablemodelview/list/"
+            msg = _("Click on a table link to create a Slice")
+
+        redirect_url = "/r/msg/?url={}&msg={}".format(url, msg)
+        return redirect(redirect_url)
 
 appbuilder.add_view(
     SliceModelView,


### PR DESCRIPTION
After ea8a7ec1ba26393047f70bcacd335b9e22fc63b8 creating a slice
started redirecting to druid datasource from sqlalchemy tables.
That's quite painful for sqlalchemy tables users.
Instead of hardcoding a choice just query the db, if we don't
have any druid datasource fallback to sqlalchemy tables.
Bonus points we remove hacky javascript and make the message
translatable.

While at it fix druid client test to not hardcode datasource id.
