### PR TITLE
Change 'timestamp' to '_timestamp_' for Apache Kylin compatibility

### DIFF
--- a/caravel/assets/visualizations/table.js
+++ b/caravel/assets/visualizations/table.js
@@ -74,7 +74,7 @@ function tableVis(slice) {
         .data(function (row, i) {
           return data.columns.map(function (c) {
             var val = row[c];
-            if (c === '_timestamp_') {
+            if (c === 'time_serial') {
               val = timestampFormatter(val);
             }
             return {

--- a/caravel/assets/visualizations/table.js
+++ b/caravel/assets/visualizations/table.js
@@ -74,7 +74,7 @@ function tableVis(slice) {
         .data(function (row, i) {
           return data.columns.map(function (c) {
             var val = row[c];
-            if (c === 'timestamp') {
+            if (c === '_timestamp_') {
               val = timestampFormatter(val);
             }
             return {

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -336,7 +336,7 @@ class Queryable(object):
 
     @property
     def main_dttm_col(self):
-        return "timestamp"
+        return "_timestamp_"
 
     @property
     def groupby_column_names(self):
@@ -651,7 +651,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
 
         if granularity:
             dttm_col = cols[granularity]
-            dttm_expr = dttm_col.sqla_col.label('timestamp')
+            dttm_expr = dttm_col.sqla_col.label('_timestamp_')
             timestamp = dttm_expr
 
             # Transforming time grain into an expression based on configuration
@@ -659,7 +659,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
             if time_grain_sqla:
                 udf = self.database.grains_dict().get(time_grain_sqla, '{col}')
                 timestamp_grain = literal_column(
-                    udf.function.format(col=dttm_expr)).label('timestamp')
+                    udf.function.format(col=dttm_expr)).label('_timestamp_')
             else:
                 timestamp_grain = timestamp
 
@@ -1352,13 +1352,13 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable):
         if (
                 not is_timeseries and
                 granularity == "all" and
-                'timestamp' in df.columns):
-            del df['timestamp']
+                '_timestamp_' in df.columns):
+            del df['_timestamp_']
 
         # Reordering columns
         cols = []
-        if 'timestamp' in df.columns:
-            cols += ['timestamp']
+        if '_timestamp_' in df.columns:
+            cols += ['_timestamp_']
         cols += [col for col in groupby if col in df.columns]
         cols += [col for col in metrics if col in df.columns]
         df = df[cols]

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -336,7 +336,7 @@ class Queryable(object):
 
     @property
     def main_dttm_col(self):
-        return "_timestamp_"
+        return "time_serial"
 
     @property
     def groupby_column_names(self):
@@ -651,7 +651,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
 
         if granularity:
             dttm_col = cols[granularity]
-            dttm_expr = dttm_col.sqla_col.label('_timestamp_')
+            dttm_expr = dttm_col.sqla_col.label('time_serial')
             timestamp = dttm_expr
 
             # Transforming time grain into an expression based on configuration
@@ -659,7 +659,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
             if time_grain_sqla:
                 udf = self.database.grains_dict().get(time_grain_sqla, '{col}')
                 timestamp_grain = literal_column(
-                    udf.function.format(col=dttm_expr)).label('_timestamp_')
+                    udf.function.format(col=dttm_expr)).label('time_serial')
             else:
                 timestamp_grain = timestamp
 
@@ -1352,13 +1352,13 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable):
         if (
                 not is_timeseries and
                 granularity == "all" and
-                '_timestamp_' in df.columns):
-            del df['_timestamp_']
+                'time_serial' in df.columns):
+            del df['time_serial']
 
         # Reordering columns
         cols = []
-        if '_timestamp_' in df.columns:
-            cols += ['_timestamp_']
+        if 'time_serial' in df.columns:
+            cols += ['time_serial']
         cols += [col for col in groupby if col in df.columns]
         cols += [col for col in metrics if col in df.columns]
         df = df[cols]

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -164,18 +164,18 @@ class BaseViz(object):
         if df is None or df.empty:
             raise Exception("No data, review your incantations!")
         else:
-            if '_timestamp_' in df.columns:
+            if 'time_serial' in df.columns:
                 if timestamp_format == "epoch_s":
-                    df._timestamp_ = pd.to_datetime(
-                        df._timestamp_, utc=False, unit="s")
+                    df.time_serial = pd.to_datetime(
+                        df.time_serial, utc=False, unit="s")
                 elif timestamp_format == "epoch_ms":
-                    df._timestamp_ = pd.to_datetime(
-                        df._timestamp_, utc=False, unit="ms")
+                    df.time_serial = pd.to_datetime(
+                        df.time_serial, utc=False, unit="ms")
                 else:
-                    df._timestamp_ = pd.to_datetime(
-                        df._timestamp_, utc=False, format=timestamp_format)
+                    df.time_serial = pd.to_datetime(
+                        df.time_serial, utc=False, format=timestamp_format)
                 if self.datasource.offset:
-                    df._timestamp_ += timedelta(hours=self.datasource.offset)
+                    df.time_serial += timedelta(hours=self.datasource.offset)
         df.replace([np.inf, -np.inf], np.nan)
         df = df.fillna(0)
         return df
@@ -407,8 +407,8 @@ class TableViz(BaseViz):
         df = super(TableViz, self).get_df(query_obj)
         if (
                 self.form_data.get("granularity") == "all" and
-                '_timestamp_' in df):
-            del df['_timestamp_']
+                'time_serial' in df):
+            del df['time_serial']
         return df
 
     def get_data(self):
@@ -465,8 +465,8 @@ class PivotTableViz(BaseViz):
         df = super(PivotTableViz, self).get_df(query_obj)
         if (
                 self.form_data.get("granularity") == "all" and
-                '_timestamp_' in df):
-            del df['_timestamp_']
+                'time_serial' in df):
+            del df['time_serial']
         df = df.pivot_table(
             index=self.form_data.get('groupby'),
             columns=self.form_data.get('columns'),
@@ -614,8 +614,8 @@ class CalHeatmapViz(BaseViz):
         df = self.get_df()
         form_data = self.form_data
 
-        df.columns = ["_timestamp_", "metric"]
-        timestamps = {str(obj["_timestamp_"].value / 10**9):
+        df.columns = ["time_serial", "metric"]
+        timestamps = {str(obj["time_serial"].value / 10**9):
                       obj.get("metric") for obj in df.to_dict("records")}
 
         start = utils.parse_human_datetime(form_data.get("since"))
@@ -979,7 +979,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
             raise Exception("Pick a time granularity for your time series")
 
         df = df.pivot_table(
-            index="_timestamp_",
+            index="time_serial",
             columns=form_data.get('groupby'),
             values=form_data.get('metrics'))
 
@@ -1039,7 +1039,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
             ys = series[name]
             if df[name].dtype.kind not in "biufc":
                 continue
-            df['_timestamp_'] = pd.to_datetime(df.index, utc=False)
+            df['time_serial'] = pd.to_datetime(df.index, utc=False)
             if isinstance(name, string_types):
                 series_title = name
             else:
@@ -1056,7 +1056,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
                 "classed": classed,
                 "values": [
                     {'x': ds, 'y': ys[ds] if ds in ys else None}
-                    for ds in df._timestamp_
+                    for ds in df.time_serial
                 ],
             }
             chart_data.append(d)

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -164,18 +164,18 @@ class BaseViz(object):
         if df is None or df.empty:
             raise Exception("No data, review your incantations!")
         else:
-            if 'timestamp' in df.columns:
+            if '_timestamp_' in df.columns:
                 if timestamp_format == "epoch_s":
-                    df.timestamp = pd.to_datetime(
-                        df.timestamp, utc=False, unit="s")
+                    df._timestamp_ = pd.to_datetime(
+                        df._timestamp_, utc=False, unit="s")
                 elif timestamp_format == "epoch_ms":
-                    df.timestamp = pd.to_datetime(
-                        df.timestamp, utc=False, unit="ms")
+                    df._timestamp_ = pd.to_datetime(
+                        df._timestamp_, utc=False, unit="ms")
                 else:
-                    df.timestamp = pd.to_datetime(
-                        df.timestamp, utc=False, format=timestamp_format)
+                    df._timestamp_ = pd.to_datetime(
+                        df._timestamp_, utc=False, format=timestamp_format)
                 if self.datasource.offset:
-                    df.timestamp += timedelta(hours=self.datasource.offset)
+                    df._timestamp_ += timedelta(hours=self.datasource.offset)
         df.replace([np.inf, -np.inf], np.nan)
         df = df.fillna(0)
         return df
@@ -407,8 +407,8 @@ class TableViz(BaseViz):
         df = super(TableViz, self).get_df(query_obj)
         if (
                 self.form_data.get("granularity") == "all" and
-                'timestamp' in df):
-            del df['timestamp']
+                '_timestamp_' in df):
+            del df['_timestamp_']
         return df
 
     def get_data(self):
@@ -465,8 +465,8 @@ class PivotTableViz(BaseViz):
         df = super(PivotTableViz, self).get_df(query_obj)
         if (
                 self.form_data.get("granularity") == "all" and
-                'timestamp' in df):
-            del df['timestamp']
+                '_timestamp_' in df):
+            del df['_timestamp_']
         df = df.pivot_table(
             index=self.form_data.get('groupby'),
             columns=self.form_data.get('columns'),
@@ -614,8 +614,8 @@ class CalHeatmapViz(BaseViz):
         df = self.get_df()
         form_data = self.form_data
 
-        df.columns = ["timestamp", "metric"]
-        timestamps = {str(obj["timestamp"].value / 10**9):
+        df.columns = ["_timestamp_", "metric"]
+        timestamps = {str(obj["_timestamp_"].value / 10**9):
                       obj.get("metric") for obj in df.to_dict("records")}
 
         start = utils.parse_human_datetime(form_data.get("since"))
@@ -979,7 +979,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
             raise Exception("Pick a time granularity for your time series")
 
         df = df.pivot_table(
-            index="timestamp",
+            index="_timestamp_",
             columns=form_data.get('groupby'),
             values=form_data.get('metrics'))
 
@@ -1039,7 +1039,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
             ys = series[name]
             if df[name].dtype.kind not in "biufc":
                 continue
-            df['timestamp'] = pd.to_datetime(df.index, utc=False)
+            df['_timestamp_'] = pd.to_datetime(df.index, utc=False)
             if isinstance(name, string_types):
                 series_title = name
             else:
@@ -1056,7 +1056,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
                 "classed": classed,
                 "values": [
                     {'x': ds, 'y': ys[ds] if ds in ys else None}
-                    for ds in df.timestamp
+                    for ds in df._timestamp_
                 ],
             }
             chart_data.append(d)


### PR DESCRIPTION
The query is failed when make Apache Kylin as the datasource. The 'timestamp' is a key word in Kylin SQL. So the query "select xxx as timestamp ..." failed. Change 'timestamp' to '_timestamp_' to avoid that.
