### PR TITLE
Fix the mapbox for Druid

### DIFF
--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -295,11 +295,13 @@ class FormFactory(object):
             'all_columns_x': (SelectField, {
                 "label": _("X"),
                 "choices": self.choicify(datasource.column_names),
+                "default": datasource.column_names[0],
                 "description": _("Columns to display")
             }),
             'all_columns_y': (SelectField, {
                 "label": _("Y"),
                 "choices": self.choicify(datasource.column_names),
+                "default": datasource.column_names[0],
                 "description": _("Columns to display")
             }),
             'druid_time_origin': (FreeFormSelectField, {
@@ -829,6 +831,7 @@ class FormFactory(object):
                     ("mapbox://styles/mapbox/satellite-v9", "Satellite"),
                     ("mapbox://styles/mapbox/outdoors-v9", "Outdoors"),
                 ],
+                "default": "mapbox://styles/mapbox/streets-v9",
                 "description": _("Base layer map style")
             }),
             'clustering_radius': (FreeFormSelectField, {

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -1190,7 +1190,8 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable):
             inner_from_dttm=None, inner_to_dttm=None,
             orderby=None,
             extras=None,  # noqa
-            select=None,):  # noqa
+            select=None,  # noqa
+            columns=None, ):
         """Runs a query against Druid and returns a dataframe.
 
         This query interface is common to SqlAlchemy and Druid


### PR DESCRIPTION
Currently when we try to use mapbox on a Druid datasource, it will show 'Invalid Choice' error of SelectField and "query() got an unexpected keyword argument 'columns'" due to the inconsistent interface between SqlTable and DruidDatasource. With this patch, mapbox still won't work on Druid, because you can not select columns in Druid queries. But at least it helps reducing some errors.

If I want to move one step forward, what can I do to make it work on Druid? Should I use metrics_combo as the choices of all_columns_x and all_columns_y instead of column_names?
