### PR TITLE
Fix erroneous options for default slices

### DIFF
--- a/caravel/data/__init__.py
+++ b/caravel/data/__init__.py
@@ -285,7 +285,7 @@ def load_world_bank_health_n_pop():
                 metric="sum__SP_RUR_TOTL_ZS",
                 num_period_compare="10")),
         Slice(
-            slice_name="Life Expexctancy VS Rural %",
+            slice_name="Life Expectancy VS Rural %",
             viz_type='bubble',
             datasource_type='table',
             table=tbl,
@@ -368,7 +368,7 @@ def load_world_bank_health_n_pop():
                     'sum__SP_RUR_TOTL_ZS',
                     'sum__SH_DYN_AIDS'],
                 secondary_metric='sum__SP_POP_TOTL',
-                series=["country_name"],)),
+                series="country_name",)),
     ]
     for slc in slices:
         merge_slice(slc)
@@ -1068,6 +1068,7 @@ def load_multiformat_time_series_data():
         dttm_and_expr = dttm_and_expr_dict[col.column_name]
         col.python_date_format = dttm_and_expr[0]
         col.dbatabase_expr = dttm_and_expr[1]
+        col.is_dttm = True
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()

--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -551,7 +551,7 @@ class FormFactory(object):
                 "default": default_groupby,
                 "description": _(
                     "Defines the grouping of entities. "
-                    "Each serie is shown as a specific color on the chart and "
+                    "Each series is shown as a specific color on the chart and "
                     "has a legend toggle")
             }),
             'entity': (SelectField, {


### PR DESCRIPTION
Incorrect `granularity_sqla` field in multiformat slices due to columns not having `is_dttm=True`.

Parallel coordinates using an array for `series`

<img width="508" alt="screen shot 2016-07-07 at 9 02 37 pm" src="https://cloud.githubusercontent.com/assets/3867546/16677080/5a1f84c2-4486-11e6-91b3-43f3ad3f7d4a.png">
