### PR TITLE
[bug] don't show password column on /show/:id

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -356,6 +356,17 @@ class DatabaseView(CaravelModelView, DeleteMixin):  # noqa
         'database_name', 'sqlalchemy_uri', 'cache_timeout', 'extra']
     search_exclude_columns = ('password',)
     edit_columns = add_columns
+    show_columns = [
+        'tables',
+        'cache_timeout',
+        'extra',
+        'database_name',
+        'sqlalchemy_uri',
+        'created_by',
+        'created_on',
+        'changed_by',
+        'changed_on'
+    ]
     add_template = "caravel/models/database/add.html"
     edit_template = "caravel/models/database/edit.html"
     base_order = ('changed_on', 'desc')


### PR DESCRIPTION
fixes this issue: https://github.com/airbnb/caravel/issues/745

before:
<img width="1278" alt="screenshot 2016-07-11 16 32 06" src="https://cloud.githubusercontent.com/assets/130878/16750298/be27e20a-4785-11e6-8618-7e2ec33d6602.png">

after:
<img width="1277" alt="screenshot 2016-07-11 16 31 47" src="https://cloud.githubusercontent.com/assets/130878/16750301/c42d2caa-4785-11e6-9507-a785183083e8.png">

plz review @mistercrunch @georgeke 
