### PR TITLE
[bugfix] html points to dashboard.entry.js instead of jsx

### DIFF
--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -2,7 +2,7 @@
 
 {% block head_js %}
   {{ super() }}
-  <script src="/static/assets/javascripts/dist/dashboard.entry.js"></script>
+  <script src="/static/assets/javascripts/dist/dashboard.entry.jsx"></script>
 {% endblock %}
 {% block title %}[dashboard] {{ dashboard.dashboard_title }}{% endblock %}
 {% block body %}


### PR DESCRIPTION
@georgeke  @ascott , I needed to change that to get things working after I rebased a branch. I'm confused as to how it worked on your side @georgeke, maybe different version of webpack have different rules as to generating a `.js` vs `.jsx`?
