### PR TITLE
Preselect filters

### DIFF
--- a/caravel/assets/javascripts/dashboard/Dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard/Dashboard.jsx
@@ -2,6 +2,7 @@ var $ = window.$ = require('jquery');
 var jQuery = window.jQuery = $;
 var px = require('../modules/caravel.js');
 var d3 = require('d3');
+var urlLib = require('url');
 var showModal = require('../modules/utils.js').showModal;
 
 import React from 'react';
@@ -39,16 +40,30 @@ var Dashboard = function (dashboardData) {
       });
       this.slices = sliceObjects;
       this.refreshTimer = null;
+      this.loadPreSelectFilters();
       this.startPeriodicRender(0);
       this.bindResizeToWindowResize();
     },
-    setFilter: function (slice_id, col, vals) {
-      this.addFilter(slice_id, col, vals, false);
+    loadPreSelectFilters: function () {
+      try {
+        var filters = JSON.parse(px.getParam("preselect_filters") || "{}");
+        for (var slice_id in filters) {
+          for (var col in filters[slice_id]) {
+            this.setFilter(slice_id, col, filters[slice_id][col], false, false);
+          }
+        }
+      } catch (e) {
+        console.error(e);
+      }
     },
-    addFilter: function (slice_id, col, vals, merge) {
+    setFilter: function (slice_id, col, vals, refresh) {
+      this.addFilter(slice_id, col, vals, false, refresh);
+    },
+    addFilter: function (slice_id, col, vals, merge, refresh) {
       if (merge === undefined) {
         merge = true;
       }
+      refresh = refresh !== false;
       if (!(slice_id in this.filters)) {
         this.filters[slice_id] = {};
       }
@@ -57,11 +72,21 @@ var Dashboard = function (dashboardData) {
       } else {
         this.filters[slice_id][col] = d3.merge([this.filters[slice_id][col], vals]);
       }
-      this.refreshExcept(slice_id);
+      if (refresh) {
+        this.refreshExcept(slice_id);
+      }
+      this.updateFilterParamsInUrl();
     },
     readFilters: function () {
       // Returns a list of human readable active filters
       return JSON.stringify(this.filters, null, 4);
+    },
+    updateFilterParamsInUrl: function () {
+      var urlObj = urlLib.parse(location.href, true);
+      urlObj.query = urlObj.query || {};
+      urlObj.query.preselect_filters = this.readFilters();
+      urlObj.search = null;
+      history.pushState(urlObj.query, window.title, urlLib.format(urlObj));
     },
     bindResizeToWindowResize: function () {
       var resizeTimer;
@@ -118,6 +143,7 @@ var Dashboard = function (dashboardData) {
     clearFilters: function (slice_id) {
       delete this.filters[slice_id];
       this.refreshExcept(slice_id);
+      this.updateFilterParamsInUrl();
     },
     removeFilter: function (slice_id, col, vals) {
       if (slice_id in this.filters) {
@@ -132,6 +158,7 @@ var Dashboard = function (dashboardData) {
         }
       }
       this.refreshExcept(slice_id);
+      this.updateFilterParamsInUrl();
     },
     getSlice: function (slice_id) {
       slice_id = parseInt(slice_id, 10);

--- a/caravel/assets/javascripts/dashboard/Dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard/Dashboard.jsx
@@ -59,11 +59,7 @@ var Dashboard = function (dashboardData) {
     setFilter: function (slice_id, col, vals, refresh) {
       this.addFilter(slice_id, col, vals, false, refresh);
     },
-    addFilter: function (slice_id, col, vals, merge, refresh) {
-      if (merge === undefined) {
-        merge = true;
-      }
-      refresh = refresh !== false;
+    addFilter: function (slice_id, col, vals, merge = true, refresh = true) {
       if (!(slice_id in this.filters)) {
         this.filters[slice_id] = {};
       }

--- a/caravel/assets/javascripts/modules/caravel.js
+++ b/caravel/assets/javascripts/modules/caravel.js
@@ -233,8 +233,8 @@ var px = (function () {
         var parser = document.createElement('a');
         parser.href = data.json_endpoint;
         var endpoint = parser.pathname + this.querystring({
-              extraFilters: params.extraFilters
-            });
+          extraFilters: params.extraFilters
+        });
         endpoint += "&json=true";
         endpoint += "&force=" + this.force;
         return endpoint;

--- a/caravel/assets/javascripts/modules/caravel.js
+++ b/caravel/assets/javascripts/modules/caravel.js
@@ -203,11 +203,13 @@ var px = (function () {
       container: container,
       container_id: container_id,
       selector: selector,
-      querystring: function () {
+      querystring: function (params) {
+        params = params || {};
         var parser = document.createElement('a');
         parser.href = data.json_endpoint;
         if (dashboard !== undefined) {
-          var flts = encodeURIComponent(JSON.stringify(dashboard.filters));
+          var flts = params.extraFilters === false ?
+              '' : encodeURIComponent(JSON.stringify(dashboard.filters));
           qrystr = parser.search + "&extra_filters=" + flts;
         } else if ($('#query').length === 0) {
           qrystr = parser.search;
@@ -226,10 +228,13 @@ var px = (function () {
         };
         return Mustache.render(s, context);
       },
-      jsonEndpoint: function () {
+      jsonEndpoint: function (params) {
+        params = params || {};
         var parser = document.createElement('a');
         parser.href = data.json_endpoint;
-        var endpoint = parser.pathname + this.querystring();
+        var endpoint = parser.pathname + this.querystring({
+              extraFilters: params.extraFilters
+            });
         endpoint += "&json=true";
         endpoint += "&force=" + this.force;
         return endpoint;
@@ -363,6 +368,11 @@ var px = (function () {
       setFilter: function (col, vals) {
         if (dashboard !== undefined) {
           dashboard.setFilter(slice_id, col, vals);
+        }
+      },
+      getFilters: function (col, vals) {
+        if (dashboard !== undefined) {
+          return dashboard.filters[slice_id];
         }
       },
       clearFilter: function () {

--- a/caravel/assets/visualizations/filter_box.js
+++ b/caravel/assets/visualizations/filter_box.js
@@ -26,7 +26,12 @@ function filterBox(slice) {
       .append('div')
       .classed('padded', true);
 
-    $.getJSON(slice.jsonEndpoint(), function (payload) {
+    var preSelectDict = slice.getFilters() || {};
+    $.getJSON(slice.jsonEndpoint({
+        // filter box should ignore the filters
+        // otherwise there will be only a few options in the dropdown menu
+        extraFilters: false
+    }), function (payload) {
         var maxes = {};
 
         for (var filter in payload.data) {
@@ -55,6 +60,11 @@ function filterBox(slice) {
               formatResult: select2Formatter
             })
             .on('change', fltChanged);
+
+          var preSelect = preSelectDict[filter];
+          if (preSelect !== undefined) {
+           filtersObj[filter].select2('val', preSelect);
+          }
         }
         slice.done(payload);
 

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -2,7 +2,7 @@
 
 {% block head_js %}
   {{ super() }}
-  <script src="/static/assets/javascripts/dist/dashboard.entry.js"></script>
+  <script src="/static/assets/javascripts/dist/dashboard.entry.jsx"></script>
 {% endblock %}
 {% block title %}[dashboard] {{ dashboard.dashboard_title }}{% endblock %}
 {% block body %}


### PR DESCRIPTION
In a dashboard, after the user select a filter in a filter box, the GET parameter "preselect_filters" in the URL will be updated. The user can bookmark this URL in the browser. So every time the user enter this URL, the user can see filter pre-selected.
For example, go to `/caravel/dashboard/world_health/?preselect_filters=%7B%0A%20%20%20%20%222%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22country_name%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22United%20States%22%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%7D` , you can see the World's Health Bank Dashboard with the country_name = "United States" chosen in the Region Filter.
