### PR TITLE
[webpack] revert change to output extension

### DIFF
--- a/caravel/assets/webpack.config.js
+++ b/caravel/assets/webpack.config.js
@@ -15,7 +15,7 @@ var config = {
   },
   output: {
     path: BUILD_DIR,
-    filename: '[name].entry.jsx'
+    filename: '[name].entry.js'
   },
   resolve: {
     alias: {

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -2,7 +2,7 @@
 
 {% block head_js %}
   {{ super() }}
-  <script src="/static/assets/javascripts/dist/dashboard.entry.jsx"></script>
+  <script src="/static/assets/javascripts/dist/dashboard.entry.js"></script>
 {% endblock %}
 {% block title %}[dashboard] {{ dashboard.dashboard_title }}{% endblock %}
 {% block body %}

--- a/caravel/templates/caravel/explore.html
+++ b/caravel/templates/caravel/explore.html
@@ -309,5 +309,5 @@
 
 {% block tail_js %}
   {{ super() }}
-  <script src="/static/assets/javascripts/dist/explore.entry.jsx"></script>
+  <script src="/static/assets/javascripts/dist/explore.entry.js"></script>
 {% endblock %}


### PR DESCRIPTION
didn't notice that this was breaking the app because the `.js` files were still being served from `/dist`.

plz review @georgeke 
