### PR TITLE
fix development env  req

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'flask-migrate==1.5.1',
         'flask-script==2.0.5',
         'flask-testing==0.5.0',
+        'flask-sqlalchemy==2.0',
         'humanize==0.5.1',
         'gunicorn==19.6.0',
         'markdown==2.6.6',


### PR DESCRIPTION
when i install for development env , get an error:

> error: Flask-SQLAlchemy 2.1 is installed but Flask-SQLAlchemy==2.0 is required by set(['flask-appbuilder'])
