### PR TITLE
Fix hive to_date function

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -965,6 +965,7 @@ class TableColumn(Model, AuditMixinNullable):
                         dttm.isoformat()),
                 'presto': default,
                 'sqlite': default,
+                'hive': "TO_DATE('{}')".format(dttm.isoformat()),
             }
             for k, v in d.items():
                 if self.table.database.sqlalchemy_uri.startswith(k):


### PR DESCRIPTION
to_date function in Hive is different with the others type since Caravel can connect to Hive through PyHive.
![to_date function](http://i.imgur.com/DK4AArd.png)
[Document](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF)
