### PR TITLE
Add missing dependency "babel-preset-stage-0" needed for building JSX

### DIFF
--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -78,6 +78,7 @@
     "babel-preset-airbnb": "^1.1.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
+    "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
     "css-loader": "^0.23.1",
     "enzyme": "^2.0.0",


### PR DESCRIPTION
In webpack.config.js

```
  module: {
    loaders: [
      {
        test: /\.jsx?$/,
        exclude: APP_DIR + '/node_modules',
        loader: 'babel',
        query: {
          presets: ['react', 'es2015', 'stage-0']
        }
      },
```

There seems to be a missing dependency "babel-preset-stage-0"
