### PR TITLE
Filter add/remove fix

### DIFF
--- a/caravel/assets/javascripts/explore/explore.jsx
+++ b/caravel/assets/javascripts/explore/explore.jsx
@@ -40,7 +40,7 @@ function prepForm() {
 
     ["col", "op", "eq"].forEach(function (fieldMiddle) {
       var fieldName = fieldPrefix + "_" + fieldMiddle;
-      $filter.find("#" + fieldName + "_0")
+      $filter.find("[id^='" + fieldName + "_']")
           .attr("id", function () {
             return fieldName + "_" + i;
           })


### PR DESCRIPTION
Currently we only 'fix' the ids for newly added filters. Instead, it should be for all filters that have been added. 

This fixes https://github.com/airbnb/caravel/issues/764
