### PR TITLE
Try to drop the unique constraint on tables.table_name again

### DIFF
--- a/caravel/migrations/versions/b922b43a4a2c_change_table_unique_constraint.py
+++ b/caravel/migrations/versions/b922b43a4a2c_change_table_unique_constraint.py
@@ -1,0 +1,74 @@
+"""change_table_unique_constraint
+
+Revision ID: b922b43a4a2c
+Revises: f162a1dea4c4
+Create Date: 2016-07-20 22:16:05.087720
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b922b43a4a2c'
+down_revision = 'f162a1dea4c4'
+
+from alembic import op
+from caravel import db
+from caravel.utils import generic_find_unique_constraint_name
+import logging
+
+naming_convention = {
+    "uq": "uq_%(table_name)s_%(column_0_name)s"
+}
+
+
+def default_constraint_name(table_name, column_name):
+    return naming_convention['uq'] % {'table_name': table_name,
+                                      'column_0_name': column_name}
+
+
+def find_constraint_name():
+    return generic_find_unique_constraint_name(
+        table='tables', columns=['table_name'], db=db)
+
+
+# This script basically try to do the same thing as that in
+# b4456560d4f3_change_table_unique_constraint.py.
+# But the constraint name may have been wrong in that script,
+# so we try other possibilities here
+def upgrade():
+    constraint_name = None
+    try:
+        # Trying since sqlite doesn't like constraints
+        table_name = 'tables'
+        column_name = 'table_name'
+        constraint_name = find_constraint_name() or default_constraint_name(
+            table_name, column_name)
+
+        with op.batch_alter_table(table_name,
+                                  naming_convention=naming_convention
+                                  ) as batch_op:
+            batch_op.drop_constraint(constraint_name, type_="unique")
+    except:
+        logging.warning(
+            "Could not find or drop constraint `{}` on `tables`".format(
+                constraint_name))
+
+    try:
+        # Try create this constraint again,
+        # because the creation may have failed in the old script
+        op.create_unique_constraint(
+            u'_customer_location_uc', 'tables',
+            ['database_id', 'schema', 'table_name'])
+    except:
+        logging.warning(
+            "Could not a create unique constraint `_customer_location_uc` "
+            "on `tables`")
+
+
+def downgrade():
+    table_name = 'tables'
+    column_name = 'table_name'
+    constraint_name = find_constraint_name() or default_constraint_name(
+        table_name, column_name)
+    with op.batch_alter_table(table_name,
+                              naming_convention=naming_convention) as batch_op:
+        batch_op.create_unique_constraint(constraint_name, [column_name])

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -346,3 +346,12 @@ def generic_find_constraint_name(table, columns, referenced, db):
                 fk.referred_table.name == referenced and
                 set(fk.column_keys) == columns):
             return fk.name
+
+
+def generic_find_unique_constraint_name(table, columns, db):
+    """Utility to find a unique constraint name in alembic migrations"""
+    t = sa.Table(table, db.metadata, autoload=True, autoload_with=db.engine)
+
+    for idx in t.indexes:
+        if idx.unique and set(c.name for c in idx.columns) == set(columns):
+            return idx.name


### PR DESCRIPTION
There is an existing script `b4456560d4f3_change_table_unique_constraint.py` that tries to drop the unique constraint on `tables`.`table_name`. In that script, it assumes the constraint is named `tables_table_name_key`. But on my MySQL, it is not named that way. This PR tries to find the correct constraint name and tries to drop it again
