### PR TITLE
[ui bug] show tooltips above all slices

### DIFF
--- a/caravel/assets/javascripts/dashboard/main.css
+++ b/caravel/assets/javascripts/dashboard/main.css
@@ -28,8 +28,8 @@ div.widget .chart-controls {
   box-shadow: 2px 1px 5px -2px #aaa;
   background-color: #fff;
   overflow: visible;
-  z-index: 5;
 }
+
 .dashboard .slice-grid .dragging,
 .dashboard .slice-grid .resizing {
   opacity: 0.5;
@@ -51,10 +51,6 @@ div.widget .chart-controls {
 .dashboard div.slice_content {
   width: 100%;
   height: 100%;
-}
-
-.dashboard  div.nvtooltip {
-  z-index: 888;  /* this lets tool tips go on top of other slices  */
 }
 
 .modal img.loading {


### PR DESCRIPTION
fixes https://github.com/airbnb/caravel/issues/790

before:
![screenshot 2016-07-20 15 12 38](https://cloud.githubusercontent.com/assets/130878/17004956/6d6130c0-4e8c-11e6-9417-5a43b5003ac8.png)

after:
![screenshot 2016-07-20 15 01 49](https://cloud.githubusercontent.com/assets/130878/17004687/f87f58e6-4e8a-11e6-8746-2907852b3774.png)
