### PR TITLE
In subquery use alias to do 'order by'

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -728,6 +728,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
         qry = qry.limit(row_limit)
 
         if timeseries_limit and groupby:
+            inner_select_exprs += [main_metric_expr]
             subq = select(inner_select_exprs)
             subq = subq.select_from(tbl)
             subq = subq.where(and_(*(where_clause_and + inner_time_filter)))

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -728,6 +728,8 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
         qry = qry.limit(row_limit)
 
         if timeseries_limit and groupby:
+            # some sql dialects require for order by expressions 
+            # to also be in the select clause
             inner_select_exprs += [main_metric_expr]
             subq = select(inner_select_exprs)
             subq = subq.select_from(tbl)


### PR DESCRIPTION
Hive only supports actual column or alias for 'order by' , so in subquery if result is ordered by COUNT(*) or some other metrics, Hive won't execute it.
I add that metric to the 'select' statement in subquery. In that way, alias will be used to do 'order by'. 
If there is any metric in the main query, the subquery uses the first one to do 'order by'. Therefore, if I add that one to the 'select' statement in subquery and then do 'join', no additional column would appear in the final result.
