### PR TITLE
Fix caching in python3

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -177,8 +177,10 @@ caching purpose. Configuring your caching backend is as easy as providing
 a ``CACHE_CONFIG``, constant in your ``caravel_config.py`` that
 complies with the Flask-Cache specifications.
 
-Flask-Cache supports multiple caching backends (Redis, Memcache,
-SimpleCache (in-memory), or the local filesystem).
+Flask-Cache supports multiple caching backends (Redis, Memcached,
+SimpleCache (in-memory), or the local filesystem). If you are going to use
+Memcached please use the pylibmc client library as python-memcached does
+not handle storing binary data correctly.
 
 For setting your timeouts, this is done in the Caravel metadata and goes
 up the "timeout searchpath", from your slice configuration, to your


### PR DESCRIPTION
Caching in python3 is broken as zlib handles bytes and not strings. While at it add a note about using a proper client library for memcached as python-memcached cannot read back the binary data it stored. 
