### PR TITLE
Persistent Dashboard refresh settings.

### DIFF
--- a/caravel/migrations/versions/27ae655e4247_make_creator_owners.py
+++ b/caravel/migrations/versions/27ae655e4247_make_creator_owners.py
@@ -11,18 +11,67 @@ revision = '27ae655e4247'
 down_revision = 'd8bc074f7aad'
 
 from alembic import op
-from caravel import db, models
+from caravel import db
+
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+from sqlalchemy import (
+    Column, Integer, ForeignKey, Table)
+
+Base = declarative_base()
+
+slice_user = Table(
+    'slice_user', Base.metadata,
+    Column('id', Integer, primary_key=True),
+    Column('user_id', Integer, ForeignKey('ab_user.id')),
+    Column('slice_id', Integer, ForeignKey('slices.id'))
+)
+
+dashboard_user = Table(
+    'dashboard_user', Base.metadata,
+    Column('id', Integer, primary_key=True),
+    Column('user_id', Integer, ForeignKey('ab_user.id')),
+    Column('dashboard_id', Integer, ForeignKey('dashboards.id'))
+)
+
+
+class User(Base):
+
+    """Declarative class to do query in upgrade"""
+
+    __tablename__ = 'ab_user'
+    id = Column(Integer, primary_key=True)
+
+
+class Slice(Base):
+
+    """Declarative class to do query in upgrade"""
+
+    __tablename__ = 'slices'
+    id = Column(Integer, primary_key=True)
+    owners = relationship("User", secondary=slice_user)
+    created_by_fk = Column(Integer)
+
+
+class Dashboard(Base):
+
+    """Declarative class to do query in upgrade"""
+
+    __tablename__ = 'dashboards'
+    id = Column(Integer, primary_key=True)
+    owners = relationship("User", secondary=dashboard_user)
+    created_by_fk = Column(Integer)
 
 
 def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
 
-    objects = session.query(models.Slice).all()
-    objects += session.query(models.Dashboard).all()
+    objects = session.query(Slice).all()
+    objects += session.query(Dashboard).all()
     for obj in objects:
-        if obj.created_by and obj.created_by not in obj.owners:
-            obj.owners.append(obj.created_by)
+        if obj.created_by_fk and obj.created_by_fk not in obj.owners:
+            obj.owners.append(obj.created_by_fk)
         session.commit()
     session.close()
 

--- a/caravel/migrations/versions/79aef3baedae_adding_columns_for_dashboard_refresh_.py
+++ b/caravel/migrations/versions/79aef3baedae_adding_columns_for_dashboard_refresh_.py
@@ -1,0 +1,29 @@
+"""Adding Columns for Dashboard Refresh Properties
+
+Revision ID: 79aef3baedae
+Revises: f162a1dea4c4
+Create Date: 2016-07-02 14:51:00.106192
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '79aef3baedae'
+down_revision = 'f162a1dea4c4'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    try:
+        op.add_column('dashboards', sa.Column('autorefresh_from_cache', sa.Boolean(), nullable=False, server_default='True'))
+    except:
+        # To pick up databases (like some MySQL variants) without a true Boolean value
+        op.add_column('dashboards', sa.Column('autorefresh_from_cache', sa.Boolean(), nullable=False, server_default='1'))
+
+    op.add_column('dashboards', sa.Column('autorefresh_seconds', sa.Integer(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('dashboards', 'autorefresh_seconds')
+    op.drop_column('dashboards', 'autorefresh_from_cache')

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -291,6 +291,9 @@ class Dashboard(Model, AuditMixinNullable):
     slices = relationship(
         'Slice', secondary=dashboard_slices, backref='dashboards')
     owners = relationship("User", secondary=dashboard_user)
+    # A zero for autorefresh seconds implies no autorefresh
+    autorefresh_seconds = Column(Integer, default=0, nullable=False)
+    autorefresh_from_cache = Column(Boolean, default=True, nullable=False)
 
     def __repr__(self):
         return self.dashboard_title
@@ -315,6 +318,7 @@ class Dashboard(Model, AuditMixinNullable):
 
     @property
     def json_data(self):
+        """Returns the configuration data for the dashboard as json"""
         d = {
             'id': self.id,
             'metadata': self.metadata_dejson,
@@ -322,6 +326,8 @@ class Dashboard(Model, AuditMixinNullable):
             'slug': self.slug,
             'slices': [slc.data for slc in self.slices],
             'position_json': json.loads(self.position_json) if self.position_json else [],
+            'autorefresh_seconds': self.autorefresh_seconds,
+            'autorefresh_from_cache': self.autorefresh_from_cache,
         }
         return json.dumps(d)
 

--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -44,21 +44,22 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="myModalLabel">Refresh Interval</h4>
-                <h6><strong>Choose how frequent should the dashboard refresh</strong></h6>
+                <h4 class="modal-title" id="myModalLabel">Autorefresh Interval and Settings</h4>
+                <h6><strong>Choose if and how frequently the dashboard should refresh</strong></h6>
             </div>
             <div class="modal-body">
-                <select id="refresh_dash_interval" class="select2" style="margin-bottom: 5px;">
-                    <option value="0">Don't refresh</option>
-                    <option value="10">10 seconds</option>
-                    <option value="30">30 seconds</option>
-                    <option value="60">1 minute</option>
-                    <option value="300">5 minutes</option>
-                </select><br>
+                <label for="refresh_dash_interval">Dashboard Refresh Interval</label>
+                <input id="refresh_dash_interval" value="{{ dashboard.autorefresh_seconds }}" />
+                <p class="help-block">Number of seconds between refreshes. Set to 0 for no auto-refresh</p>
+                <br>
+                <label for="refresh_dash_from_cache">Refresh from Cache</label>
+                <input type="checkbox" id="refresh_dash_force" {{ "checked" if dashboard.autorefresh_from_cache }}/>
+                <p class="help-block">If unchecked the dashboard will force fresh values from the database. While checked the dashboard will allow values from the cache resulting in better performance for multiple users.</p>
+                <br>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">
-                    Close
+                <button type="button" class="btn btn-default" data-dismiss="modal" id="refresh_dash_apply">
+                    Apply and Close
                 </button>
             </div>
         </div>
@@ -84,7 +85,7 @@
               <i class="fa fa-plus" data-toggle="tooltip" title="Add a new slice to the dashboard"></i>
           </button>
           <button type="button" id="refresh_dash_periodic" class="btn btn-default" data-toggle="modal" data-target="#refresh_modal">
-              <i class="fa fa-clock-o" data-toggle="tooltip" title="Decide how frequent should the dashboard refresh"></i>
+              <i class="fa fa-clock-o" data-toggle="tooltip" title="Decide if and how frequently should the dashboard refresh"></i>
           </button>
           <button type="button" id="filters" class="btn btn-default" data-toggle="tooltip" title="View the list of active filters">
             <i class="fa fa-filter"></i>
@@ -95,7 +96,7 @@
           <a id="editdash" class="btn btn-default {{ "disabled disabledButton" if not dash_edit_perm }} " href="/dashboardmodelview/edit/{{ dashboard.id }}" title="Edit this dashboard's property" data-toggle="tooltip" >
               <i class="fa fa-edit"></i>
           </a>
-          <button type="button" id="savedash" class="btn btn-default {{ "disabled disabledButton" if not dash_save_perm }}" data-toggle="tooltip" title="Save the current positioning and CSS">
+          <button type="button" id="savedash" class="btn btn-default {{ "disabled disabledButton" if not dash_save_perm }}" data-toggle="tooltip" title="Save the current refresh settings, positioning and CSS">
             <i class="fa fa-save"></i>
           </button>
         </div>

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -628,12 +628,22 @@ class DashboardModelView(CaravelModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.Dashboard)
     list_columns = ['dashboard_link', 'creator', 'modified']
     edit_columns = [
-        'dashboard_title', 'slug', 'slices', 'owners', 'position_json', 'css',
-        'json_metadata']
+        'dashboard_title', 'slug', 'slices', 'owners',
+        'autorefresh_seconds', 'autorefresh_from_cache',
+        'position_json', 'css', 'json_metadata']
     show_columns = edit_columns + ['table_names']
     add_columns = edit_columns
     base_order = ('changed_on', 'desc')
     description_columns = {
+        'autorefresh_seconds': _(
+            "The number of seconds between automatic refreshes "
+            "of the dashboard. The default value of 0 means the "
+            "dashboard will not automatically refresh."),
+        'autorefresh_from_cache': _(
+            "If checked the dashboard will use cached values when "
+            "refreshing. To force the dashboard to always use fresh "
+            "values then uncheck this option. Performance with many "
+            "users will be lower if unchecked."),
         'position_json': _(
             "This json object describes the positioning of the widgets in "
             "the dashboard. It is dynamically generated when adjusting "
@@ -660,6 +670,8 @@ class DashboardModelView(CaravelModelView, DeleteMixin):  # noqa
         'owners': _("Owners"),
         'creator': _("Creator"),
         'modified': _("Modified"),
+        'autorefresh_seconds': _("Dashboard Refresh Frequency"),
+        'autorefresh_from_cache': _("Refresh From Cache"),
         'position_json': _("Position JSON"),
         'css': _("CSS"),
         'json_metadata': _("JSON Metadata"),
@@ -1066,6 +1078,8 @@ class Caravel(BaseCaravelView):
         md['expanded_slices'] = data['expanded_slices']
         dash.json_metadata = json.dumps(md, indent=4)
         dash.css = data['css']
+        dash.autorefresh_seconds = data['autorefresh_seconds']
+        dash.autorefresh_from_cache = data['autorefresh_from_cache']
         session.merge(dash)
         session.commit()
         session.close()

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -196,6 +196,8 @@ class CoreTests(CaravelTestCase):
             'css': '',
             'expanded_slices': {},
             'positions': positions,
+            'autorefresh_seconds': 60,
+            'autorefresh_from_cache': True,
         }
         url = '/caravel/save_dash/{}/'.format(dash.id)
         resp = self.client.post(url, data=dict(data=json.dumps(data)))


### PR DESCRIPTION
Revision of https://github.com/airbnb/caravel/pull/718
Also resolves https://github.com/airbnb/caravel/issues/686

Dashboard refresh settings persist and option to set whether to use cache or not when fetching fresh data.

Required a fix of migration 27ae655e4247 to avoid problems with referencing models which weren't up to date yet. Have moved to declarative base.

New pull request because the history of the previous one was getting really tangled.
