### PR TITLE
Let the user decide the label type of pie charts

### DIFF
--- a/caravel/assets/visualizations/nvd3_vis.js
+++ b/caravel/assets/visualizations/nvd3_vis.js
@@ -117,9 +117,10 @@ function nvd3Vis(slice) {
             chart.valueFormat(f);
             if (fd.donut) {
               chart.donut(true);
-              chart.labelsOutside(true);
             }
-            chart.labelsOutside(true);
+            chart.labelsOutside(fd.labels_outside);
+            chart.labelThreshold(0.05)  //Configure the minimum slice size for labels to show up
+              .labelType(fd.pie_label_type);
             chart.cornerRadius(true);
             break;
 

--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -695,6 +695,16 @@ class FormFactory(object):
                 "default": 'linear',
                 "description": _("Line interpolation as defined by d3.js")
             }),
+            'pie_label_type': (SelectField, {
+                "label": _("Label Type"),
+                "default": 'key',
+                "choices": (
+                    ('key', _("Category Name")),
+                    ('value', _("Value")),
+                    ('percent', _("Percentage")),
+                ),
+                "description": _("What should be shown on the label?")
+            }),
             'code': (TextAreaField, {
                 "label": _("Code"),
                 "description": _("Put your code here"),
@@ -788,6 +798,11 @@ class FormFactory(object):
                 "label": _("Donut"),
                 "default": False,
                 "description": _("Do you want a donut or a pie?")
+            }),
+            'labels_outside': (BetterBooleanField, {
+                "label": _("Put labels outside"),
+                "default": True,
+                "description": _("Put the labels outside the pie?")
             }),
             'contribution': (BetterBooleanField, {
                 "label": _("Contribution"),

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -1175,7 +1175,9 @@ class DistributionPieViz(NVD3Viz):
         'fields': (
             'metrics', 'groupby',
             'limit',
+            'pie_label_type',
             ('donut', 'show_legend'),
+            'labels_outside',
         )
     },)
 


### PR DESCRIPTION
The user can choose the label type from "Category Name", "Value", and "Percentage". The user can also decide whether the labels should be outside or inside the pie.
![screen shot 2016-07-26 at 12 59 24 pm](https://cloud.githubusercontent.com/assets/1527501/17126778/cf5f9352-5332-11e6-9969-a8e657982dfa.png)
![screen shot 2016-07-26 at 12 59 36 pm](https://cloud.githubusercontent.com/assets/1527501/17126776/cf5e9006-5332-11e6-80d5-1b931883350d.png)
![screen shot 2016-07-26 at 12 59 47 pm](https://cloud.githubusercontent.com/assets/1527501/17126777/cf5ee5f6-5332-11e6-8241-44a608b877ab.png)
