### PR TITLE
Fix mapbox radius calculations being off when changing latitude

### DIFF
--- a/caravel/assets/visualizations/mapbox.jsx
+++ b/caravel/assets/visualizations/mapbox.jsx
@@ -137,12 +137,13 @@ class ScatterPlotGlowOverlay extends ScatterPlotOverlay {
             let pointLabel;
 
              if (radiusProperty !== null) {
+              const pointLatitude = props.lngLatAccessor(location)[1];
               if (props.pointRadiusUnit === 'Kilometers') {
                 pointLabel = d3.round(pointRadius, 2) + 'km';
-                pointRadius = kmToPixels(pointRadius, props.latitude, props.zoom);
+                pointRadius = kmToPixels(pointRadius, pointLatitude, props.zoom);
               } else if (props.pointRadiusUnit === 'Miles') {
                 pointLabel = d3.round(pointRadius, 2) + 'mi';
-                pointRadius = kmToPixels(pointRadius * MILES_PER_KM, props.latitude, props.zoom);
+                pointRadius = kmToPixels(pointRadius * MILES_PER_KM, pointLatitude, props.zoom);
               }
             }
 


### PR DESCRIPTION
Instead of passing the latitude of the center of the viewport, pass the latitude of the point which radius is being calculate for. Currently, the radius of points will change slightly based on what the viewport latitude is.
