### PR TITLE
pass the `standalone` request arg in the /caravel/slices/<slice_id>/ endpoint redirect

### DIFF
--- a/caravel/templates/caravel/standalone.html
+++ b/caravel/templates/caravel/standalone.html
@@ -5,7 +5,6 @@
     <link rel="stylesheet" type="text/css" href="/static/assets/stylesheets/caravel.css" />
     <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/flags/flags16.css" />
     <link rel="icon" type="image/png" href="/static/assets/images/favicon.png">
-
     {% set CSS_THEME = appbuilder.get_app.config.get("CSS_THEME") %}
     {% set height = request.args.get("height", 700) %}
     {% if CSS_THEME %}
@@ -18,6 +17,7 @@
       id="{{ viz.token }}"
       class="widget viz slice {{ viz.viz_type }}"
       data-slice="{{ viz.json_data }}"
+      data-standalone="true"
       style="height: {{ height }}px;">
       <img src="{{ url_for("static", filename="assets/images/loading.gif") }}" class="loading" alt="loading">
       <div id="{{ viz.token }}_con" class="slice_container" style="height: 100%; width: 100%"></div>

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1141,7 +1141,7 @@ class Caravel(BaseCaravelView):
         slc = qry.first()
         if slc:
             url = '{slc.slice_url}&standalone={standalone}'.format(
-                slc=slc, standalone=request.args.get('standalone', False))
+                slc=slc, standalone=request.args.get('standalone', 'false'))
             return redirect(url)
         else:
             flash("The specified slice could not be found", "danger")

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1140,7 +1140,9 @@ class Caravel(BaseCaravelView):
         qry = session.query(models.Slice).filter_by(id=int(slice_id))
         slc = qry.first()
         if slc:
-            return redirect(slc.slice_url)
+            url = '{slc.slice_url}&standalone={standalone}'.format(
+                slc=slc, standalone=request.args.get('standalone', False))
+            return redirect(url)
         else:
             flash("The specified slice could not be found", "danger")
             return redirect('/slicemodelview/list/')

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -147,9 +147,14 @@ class CoreTests(CaravelTestCase):
         for slc in db.session.query(Slc).all():
             urls += [
                 (slc.slice_name, 'slice_url', slc.slice_url),
-                (slc.slice_name, 'slice_id_endpoint', '/caravel/slices/{}'.format(slc.id)),
                 (slc.slice_name, 'json_endpoint', slc.viz.json_endpoint),
                 (slc.slice_name, 'csv_endpoint', slc.viz.csv_endpoint),
+                (slc.slice_name, 'slice_id',
+                    '/caravel/slices/{}/'.format(slc.id)),
+                (slc.slice_name, 'slice_id_standalone',
+                    '/caravel/slices/{}/?standalone=true'.format(slc.id)),
+                (slc.slice_name, 'slice_id_not_standalone',
+                    '/caravel/slices/{}/?standalone=false'.format(slc.id)),
             ]
         for name, method, url in urls:
             print("[{name}]/[{method}]: {url}".format(**locals()))

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -29,7 +29,6 @@ app.config['PUBLIC_ROLE_LIKE_GAMMA'] = True
 BASE_DIR = app.config.get("BASE_DIR")
 cli = imp.load_source('cli', BASE_DIR + "/bin/caravel")
 
-
 class CaravelTestCase(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
@@ -149,16 +148,46 @@ class CoreTests(CaravelTestCase):
                 (slc.slice_name, 'slice_url', slc.slice_url),
                 (slc.slice_name, 'json_endpoint', slc.viz.json_endpoint),
                 (slc.slice_name, 'csv_endpoint', slc.viz.csv_endpoint),
-                (slc.slice_name, 'slice_id',
-                    '/caravel/slices/{}/'.format(slc.id)),
-                (slc.slice_name, 'slice_id_standalone',
-                    '/caravel/slices/{}/?standalone=true'.format(slc.id)),
-                (slc.slice_name, 'slice_id_not_standalone',
-                    '/caravel/slices/{}/?standalone=false'.format(slc.id)),
             ]
         for name, method, url in urls:
             print("[{name}]/[{method}]: {url}".format(**locals()))
             self.client.get(url)
+
+    def test_slice_id_redirects(self, username='admin'):
+        def make_assertions(resp, standalone):
+            decoded = resp.data.decode('utf-8')
+            if standalone:
+                assert "Query" not in decoded
+                assert 'data-standalone="true"' in decoded
+
+            else:
+                assert "Query" in decoded
+                assert 'data-standalone="true"' not in decoded
+
+        self.login(username=username)
+        slc = db.session.query(models.Slice).filter_by(slice_name="Name Cloud").first()
+        get = self.client.get
+
+        # Standard redirect
+        slc_url = slc.slice_url
+        id_url = '/caravel/slice/{slc.id}'.format(slc=slc)
+
+        make_assertions(get(slc_url, follow_redirects=True), False)
+        make_assertions(get(id_url, follow_redirects=True), False)
+
+        # Explicit standalone
+        slc_url_standalone = '{slc_url}&standalone=true'.format(slc_url=slc_url)
+        id_url_standalone = '{id_url}?standalone=true'.format(id_url=id_url)
+
+        make_assertions(get(slc_url_standalone, follow_redirects=True), True)
+        make_assertions(get(id_url_standalone, follow_redirects=True), True)
+
+        # Explicit not-standalone
+        slc_url_notstandalone = '{slc_url}&standalone=false'.format(slc_url=slc_url)
+        id_url_notstandalone = '{id_url}?standalone=false'.format(id_url=id_url)
+
+        make_assertions(get(slc_url_notstandalone, follow_redirects=True), False)
+        make_assertions(get(id_url_notstandalone, follow_redirects=True), False)
 
     def test_dashboard(self):
         self.login(username='admin')


### PR DESCRIPTION
Gave some context in slack, but this will be useful for us to auto-generate standalone viz's from a slice's `id`. This endpoint currently re-directs to a slice's url, but ignores all arguments passed to it.

@mistercrunch 
