### PR TITLE
dashboard: don't enable buttons that would fail

### DIFF
--- a/caravel/templates/caravel/dashboard.html
+++ b/caravel/templates/caravel/dashboard.html
@@ -80,7 +80,7 @@
           <button type="button" id="refresh_dash" class="btn btn-default" data-toggle="tooltip" title="Force refresh the whole dashboard">
             <i class="fa fa-refresh"></i>
           </button>
-          <button type="button" id="add-slice" class="btn btn-default" data-toggle="modal" data-target="#add_slice_modal">
+          <button type="button" id="add-slice" class="btn btn-default {{ "disabled disabledButton" if not dash_save_perm }}" data-toggle="modal" data-target="#add_slice_modal">
               <i class="fa fa-plus" data-toggle="tooltip" title="Add a new slice to the dashboard"></i>
           </button>
           <button type="button" id="refresh_dash_periodic" class="btn btn-default" data-toggle="modal" data-target="#refresh_modal">

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1165,13 +1165,14 @@ class Caravel(BaseCaravelView):
         def dashboard(**kwargs):  # noqa
             pass
         dashboard(dashboard_id=dash.id)
-
+        dash_edit_perm = check_ownership(dash, raise_if_false=False)
+        dash_save_perm = dash_edit_perm and self.can_access('can_save_dash', 'Caravel')
         return self.render_template(
             "caravel/dashboard.html", dashboard=dash,
             user_id=g.user.get_id(),
             templates=templates,
-            dash_save_perm=self.can_access('can_save_dash', 'Caravel'),
-            dash_edit_perm=check_ownership(dash, raise_if_false=False))
+            dash_save_perm=dash_save_perm,
+            dash_edit_perm=dash_edit_perm)
 
     @has_access
     @expose("/sql/<database_id>/")


### PR DESCRIPTION
With gamma users saving the dashboard model would fail if they
are not the owner of the dashboard.
So just disable the "Add a new slice to the dashboard" and "Save
the current positioning and CSS" .

Refs #359
