### PR TITLE
[bugfix] controls info bubble don't show up

### DIFF
--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -49,7 +49,7 @@
     "datamaps": "^0.4.4",
     "datatables-bootstrap3-plugin": "^0.4.0",
     "datatables.net-bs": "^1.10.11",
-    "font-awesome": "^4.5.0",
+    "font-awesome": "^4.6.3",
     "gridster": "^0.5.6",
     "immutability-helper": "^2.0.0",
     "jquery": "^2.2.1",


### PR DESCRIPTION
It turns out the new icon referenced (`fa-question-circle-o`) was in a newer version of font-awesome.

<img width="88" alt="screen shot 2016-08-09 at 3 50 50 pm" src="https://cloud.githubusercontent.com/assets/487433/17536378/77f9a158-5e49-11e6-9f62-0711a118e792.png">

@ascott @bkyryliuk 
