### PR TITLE
[webpack] set up proper dev/prod environment

### DIFF
--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "test": "npm run lint && mocha --compilers js:babel-core/register --required spec/helpers/browser.js spec/**/*_spec.*",
-    "dev": "webpack -d --watch --colors",
-    "prod": "webpack -p --colors",
+    "dev": "NODE_ENV=dev webpack -d --watch --colors",
+    "prod": "NODE_ENV=production webpack -p --colors",
     "lint": "npm run --silent lint:js",
     "lint:js": "eslint --ignore-path=.eslintignore --ext .js ."
   },

--- a/caravel/assets/webpack.config.js
+++ b/caravel/assets/webpack.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const path = require('path');
 
 // input dir
@@ -104,6 +105,15 @@ const config = {
     'react/lib/ExecutionEnvironment': true,
     'react/lib/ReactContext': true,
   },
-  plugins: [],
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+      },
+    }),
+  ],
 };
+if (process.env.NODE_ENV === 'production') {
+  config.plugins.push(new webpack.optimize.UglifyJsPlugin());
+}
 module.exports = config;


### PR DESCRIPTION
`process.env.NODE_ENV === 'production'` is now possible in our js code. I'll use that to switch off the devTools in SQL Lab.

also React looks for this as well and will make a more efficient prod build going forward

@ascott @williaster 
