### PR TITLE
Adding macro support for SQL expressions

### DIFF
--- a/caravel/migrations/versions/09548f11f197_adding_sql_expr_macro_model.py
+++ b/caravel/migrations/versions/09548f11f197_adding_sql_expr_macro_model.py
@@ -1,0 +1,32 @@
+"""adding_sql_expr_macro_model
+
+Revision ID: 09548f11f197
+Revises: b347b202819b
+Create Date: 2016-08-11 07:45:43.854832
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '09548f11f197'
+down_revision = 'b347b202819b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('sql_expr_macros',
+        sa.Column('created_on', sa.DateTime(), nullable=False),
+        sa.Column('changed_on', sa.DateTime(), nullable=False),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('namespace', sa.String(length=50), nullable=True),
+        sa.Column('source_code', sa.Text(), nullable=True),
+        sa.Column('changed_by_fk', sa.Integer(), nullable=True),
+        sa.Column('created_by_fk', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['changed_by_fk'], ['ab_user.id'], ),
+        sa.ForeignKeyConstraint(['created_by_fk'], ['ab_user.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+def downgrade():
+    op.drop_table('sql_expr_macros')

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -301,8 +301,10 @@ class TableColumnInlineView(CompactCRUDMixin, CaravelModelView):  # noqa
             "[Time Granularity] option, column has to be DATETIME or "
             "DATETIME-like")),
         'expression': utils.markdown(
-            "a valid SQL expression as supported by the underlying backend. "
-            "Example: `substr(name, 1, 1)`", True),
+            "a valid SQL expression as supported by the underlying backend "
+            "Example: `substr(name, 1, 1)`. "
+            "You could also use [SQL expression macros](/sqlmacromodelview/list/) "
+            "Example: `{{ namespace.macro(arg1, arg2) }}`", True),
         'python_date_format': utils.markdown(Markup(
             "The pattern of timestamp format, use "
             "<a href='https://docs.python.org/2/library/"
@@ -377,8 +379,10 @@ class SqlMetricInlineView(CompactCRUDMixin, CaravelModelView):  # noqa
         'expression', 'table', 'd3format', 'is_restricted']
     description_columns = {
         'expression': utils.markdown(
-            "a valid SQL expression as supported by the underlying backend. "
-            "Example: `count(DISTINCT userid)`", True),
+            "a valid SQL expression as supported by the underlying backend "
+            "Example: `substr(name, 1, 1)`. "
+            "You could also use [SQL expression macros](/sqlmacromodelview/list/) "
+            "Example: `{{ namespace.macro(arg1, arg2) }}`", True),
         'is_restricted': _("Whether the access to this metric is restricted "
                            "to certain roles. Only roles with the permission "
                            "'metric access on XXX (the name of this metric)' "
@@ -1794,6 +1798,31 @@ appbuilder.add_link(
     'SQL Lab <span class="label label-danger">alpha</span>',
     href='/caravel/sqllab',
     icon="fa-flask")
+
+
+class SqlMacroModelView(CaravelModelView, DeleteMixin):
+
+    """View for list/add/edit SQL expression macros"""
+
+    datamodel = SQLAInterface(models.SqlExprMacro)
+    list_columns = ['namespace']
+    edit_columns = ['namespace', 'source_code']
+    add_columns = edit_columns
+    description_columns = {
+        'source_code': utils.markdown(
+            "a valid jinja2 template including a list of "
+            "[macros](http://jinja.pocoo.org/docs/dev/templates/#macros). "
+            "Example: `{% macro func(args) %} ... {% endmacro %}`", True)
+    }
+
+appbuilder.add_view(
+    SqlMacroModelView,
+    "SQL Expression Macros",
+    label=__("SQL Expression Macros"),
+    icon="fa-code",
+    category="Sources",
+    category_label=__("Sources"),
+    category_icon='')
 
 
 @app.after_request

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',
         'werkzeug==0.11.10',
+        'Jinja2'
     ],
     extras_require={
         'cors': ['Flask-Cors>=2.0.0'],

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -492,6 +492,16 @@ class CoreTests(CaravelTestCase):
         db.session.commit()
         self.test_save_dash('alpha')
 
+    def test_sql_expr_macro(self, username='admin'):
+        code = """{% macro rate(col1, col2) %}
+        (case when (sum({{ col2 }}) = 0) then 0 else sum({{ col1 }})/sum({{ col2 }}) end)
+        {% endmacro %}"""
+        db.session.add(models.SqlExprMacro(namespace="test", source_code=code))
+        db.session.commit()
+        models.recompile_sql_macros()
+        assert models.render_sql_expr("{{ test.rate('clicks', 'views') }}") == \
+            "(case when (sum(views) = 0) then 0 else sum(clicks)/sum(views) end)"
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adding support to use Jinja2 macros in SQL expression (in Table Column and Metric definition)

Macros could be defined in `Sources -> SQL Expression Macros`, and organized in different namespaces. You could think each namespace as a Jinja2 template containing multiple macros.

When writing expression in Table column or Metrics, those macros could be invoked with `{{ namespace.macro(args...) }}`

``` python
code = """
{% macro rate(col1, col2) %}
(CASE WHEN (SUM({{ col2 }}) = 0) THEN 0 ELSE SUM({{ col1 }})/SUM({{ col2 }}) END)
{% endmacro %}

{% macro int2date(col) %}
(TIMESTAMP 'epoch' + {{ col }} * INTERVAL '1 Second ')
{% endmacro %}
"""
db.session.add(SqlExprMacro(namespace="example", source_code=code))
ctr_metric = SqlMetric(metric_name='CTR', expression="{{ example.rate('clicks', 'views') }}")
```

In my company, we have lots of metrics with complicated SQL expression, and I think those macros could be very handy. Hope it could be useful for others. 

Cheers!
