### PR TITLE
Add a parameter to allow empty visualization

### DIFF
--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -937,6 +937,12 @@ class FormFactory(object):
                 ],
                 "description": _("The color for points and clusters in RGB")
             }),
+            'allow_empty': (BetterBooleanField, {
+                "label": _("Allow Empty"),
+                "default": False,
+                "description": _(
+                    "Allow the visualization to show empty results")
+            }),
         }
 
         # Override default arguments with form overrides

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -138,7 +138,7 @@ class BaseViz(object):
             del od['force']
         return href(od)
 
-    def get_df(self, query_obj=None):
+    def get_df(self, query_obj=None, return_empty = False):
         """Returns a pandas dataframe based on the query object"""
         if not query_obj:
             query_obj = self.query_obj()
@@ -162,6 +162,8 @@ class BaseViz(object):
         # If the datetime format is unix, the parse will use the corresponding
         # parsing logic.
         if df is None or df.empty:
+            if return_empty and df.empty:
+                return df
             raise Exception("No data, review your incantations!")
         else:
             if 'timestamp' in df.columns:
@@ -417,7 +419,7 @@ class TableViz(BaseViz):
         return d
 
     def get_df(self, query_obj=None):
-        df = super(TableViz, self).get_df(query_obj)
+        df = super(TableViz, self).get_df(query_obj, return_empty = True)
         if (
                 self.form_data.get("granularity") == "all" and
                 'timestamp' in df):

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -396,6 +396,7 @@ class TableViz(BaseViz):
             'table_timestamp_format',
             'row_limit',
             ('include_search', None),
+            ('allow_empty', None),
         )
     })
     form_overrides = ({
@@ -419,7 +420,8 @@ class TableViz(BaseViz):
         return d
 
     def get_df(self, query_obj=None):
-        df = super(TableViz, self).get_df(query_obj, return_empty = True)
+        df = super(TableViz, self).get_df(query_obj, 
+            return_empty = self.form_data['allow_empty'])
         if (
                 self.form_data.get("granularity") == "all" and
                 'timestamp' in df):


### PR DESCRIPTION
Currently, Caravel returns an error when a visualization is empty (i.e: no data is returned).
This patch adds an option to the Table Visualization to fail nicely instead of showing an error message.

It is possible to add the same options to other visualization if it fits.
