### PR TITLE
Fixing the rendering of the separator widget

### DIFF
--- a/caravel/assets/visualizations/markup.css
+++ b/caravel/assets/visualizations/markup.css
@@ -1,3 +1,14 @@
 .markup .slice_container {
     padding: 10px;
 }
+.separator {
+    background-color: transparent !important;
+}
+.separator hr {
+    border: 0;
+    height: 1px;
+    background-image: linear-gradient(to right, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1), rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
+}
+.separator .chart-header {
+    border: none !important;
+}


### PR DESCRIPTION
before:
<img width="843" alt="screen shot 2016-08-11 at 10 36 36 pm" src="https://cloud.githubusercontent.com/assets/487433/17613616/1c252aec-6014-11e6-829e-c498f46f2620.png">

after:
<img width="638" alt="screen shot 2016-08-11 at 10 34 21 pm" src="https://cloud.githubusercontent.com/assets/487433/17613592/f0ca705a-6013-11e6-912b-fb94c4fa6b25.png">

@ascott 
