### PR TITLE
Filter Enhancement - Show column values in drop down

### DIFF
--- a/caravel/assets/javascripts/modules/caravel.js
+++ b/caravel/assets/javascripts/modules/caravel.js
@@ -59,6 +59,7 @@ const px = function () {
     const selector = '#' + containerId;
     const container = $(selector);
     const sliceId = data.sliceId;
+    const filterSelectEnabled = data.filter_select_enabled;
     let dttm = 0;
     const stopwatch = function () {
       dttm += 10;
@@ -75,6 +76,7 @@ const px = function () {
       data,
       container,
       containerId,
+      filterSelectEnabled,
       selector,
       querystring(params) {
         const newParams = params || {};
@@ -110,6 +112,11 @@ const px = function () {
         endpoint += '&json=true';
         endpoint += '&force=' + this.force;
         return endpoint;
+      },
+      filterEndpoint(column) {
+        const parser = document.createElement('a');
+        parser.href = data.filter_endpoint;
+        return parser.pathname + column + '/' + this.querystring();
       },
       d3format(col, number) {
         // uses the utils memoized d3format function and formats based on

--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -1071,13 +1071,17 @@ class FormFactory(object):
                             _('Filter 1'),
                             default=col_choices[0][0],
                             choices=col_choices))
-                setattr(QueryForm, field_prefix + '_op_' + str(i), SelectField(
-                    _('Filter 1'),
-                    default=op_choices[0][0],
-                    choices=op_choices))
-                setattr(
-                    QueryForm, field_prefix + '_eq_' + str(i),
-                    TextField(_("Super"), default=''))
+                setattr(QueryForm, field_prefix + '_op_' + str(i),
+                        SelectField(
+                            _('Filter 1'),
+                            default=op_choices[0][0],
+                            choices=op_choices))
+                if viz.datasource.filter_select_enabled and not is_having_filter:
+                    setattr(QueryForm, field_prefix + '_eq_' + str(i),
+                            FreeFormSelectField(_("Super"), choices=[]))
+                else:
+                    setattr(QueryForm, field_prefix + '_eq_' + str(i),
+                            TextField(_("Super"), default=''))
 
         if time_fields:
             QueryForm.fieldsets = ({

--- a/caravel/migrations/versions/17fc73813b42_datasource_table_filter_select.py
+++ b/caravel/migrations/versions/17fc73813b42_datasource_table_filter_select.py
@@ -1,14 +1,14 @@
 """datasource_table_filter_select
 
 Revision ID: 17fc73813b42
-Revises: f162a1dea4c4
+Revises: 3c3ffe173e4f
 Create Date: 2016-08-12 16:41:25.629004
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '17fc73813b42'
-down_revision = 'f162a1dea4c4'
+down_revision = '3c3ffe173e4f'
 
 from alembic import op
 import sqlalchemy as sa

--- a/caravel/migrations/versions/17fc73813b42_datasource_table_filter_select.py
+++ b/caravel/migrations/versions/17fc73813b42_datasource_table_filter_select.py
@@ -1,0 +1,24 @@
+"""datasource_table_filter_select
+
+Revision ID: 17fc73813b42
+Revises: f162a1dea4c4
+Create Date: 2016-08-12 16:41:25.629004
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '17fc73813b42'
+down_revision = 'f162a1dea4c4'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('datasources', sa.Column('filter_select_enabled', sa.Boolean(), default=False))
+    op.add_column('tables', sa.Column('filter_select_enabled', sa.Boolean(), default=False))
+
+
+def downgrade():
+    op.drop_column('tables', 'filter_select_enabled')
+    op.drop_column('datasources', 'filter_select_enabled')

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -27,6 +27,7 @@ from flask_appbuilder.models.decorators import renders
 from flask_babel import lazy_gettext as _
 
 from pydruid.client import PyDruid
+from pydruid.utils.aggregators import count
 from pydruid.utils.filters import Dimension, Filter
 from pydruid.utils.postaggregator import Postaggregator
 from pydruid.utils.having import Aggregation
@@ -606,6 +607,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
     default_endpoint = Column(Text)
     database_id = Column(Integer, ForeignKey('dbs.id'), nullable=False)
     is_featured = Column(Boolean, default=False)
+    filter_select_enabled = Column(Boolean, default=False)
     user_id = Column(Integer, ForeignKey('ab_user.id'))
     owner = relationship('User', backref='tables', foreign_keys=[user_id])
     database = relationship(
@@ -697,6 +699,42 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
         for col in columns:
             if col_name == col.column_name:
                 return col
+
+    def values_for_column(self,
+                          column_name,
+                          from_dttm,
+                          to_dttm,
+                          limit=500):
+        """Runs query against sqla to retrieve some sample values for the given column."""
+        granularity = self.main_dttm_col
+
+        cols = {col.column_name: col for col in self.columns}
+        target_col = cols[column_name]
+
+        dttm_col = cols[granularity]
+        timestamp = dttm_col.sqla_col.label('timestamp')
+        time_filter = [
+            timestamp >= text(dttm_col.dttm_sql_literal(from_dttm)),
+            timestamp <= text(dttm_col.dttm_sql_literal(to_dttm)),
+        ]
+
+        tbl = table(self.table_name)
+        qry = select([target_col.sqla_col])
+        qry = qry.select_from(tbl)
+        qry = qry.where(and_(*time_filter))
+        qry = qry.distinct(column_name)
+        qry = qry.limit(limit)
+
+        engine = self.database.get_sqla_engine()
+        sql = "{}".format(
+            qry.compile(
+                engine, compile_kwargs={"literal_binds": True}, ),
+        )
+
+        return pd.read_sql_query(
+            sql=sql,
+            con=engine
+        )
 
     def query(  # sqla
             self, groupby, metrics,
@@ -1135,6 +1173,7 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable):
     datasource_name = Column(String(255), unique=True)
     is_featured = Column(Boolean, default=False)
     is_hidden = Column(Boolean, default=False)
+    filter_select_enabled = Column(Boolean, default=False)
     description = Column(Text)
     default_endpoint = Column(Text)
     user_id = Column(Integer, ForeignKey('ab_user.id'))
@@ -1288,6 +1327,35 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable):
             col_obj.datasource = datasource
             col_obj.generate_metrics()
             session.flush()
+
+    def values_for_column(self,
+                          column_name,
+                          from_dttm,
+                          to_dttm,
+                          limit=500):
+        """Runs query against Druid to retrieve some values for the given column"""
+        # TODO: Use Lexicographic TopNMeticSpec onces supported by PyDruid
+        from_dttm = from_dttm.replace(tzinfo=config.get("DRUID_TZ"))
+        to_dttm = to_dttm.replace(tzinfo=config.get("DRUID_TZ"))
+
+        qry = dict(
+            datasource=self.datasource_name,
+            granularity="all",
+            intervals=from_dttm.isoformat() + '/' + to_dttm.isoformat(),
+            aggregations=dict(count=count("count")),
+            dimension=column_name,
+            metric="count",
+            threshold=limit,
+        )
+
+        client = self.cluster.get_pydruid_client()
+        client.topn(**qry)
+        df = client.export_pandas()
+
+        if df is None or df.size == 0:
+            raise Exception(_("No data was returned."))
+
+        return df
 
     def query(  # druid
             self, groupby, metrics,

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -476,8 +476,8 @@ class TableModelView(CaravelModelView, DeleteMixin):  # noqa
         'table_name', 'database', 'schema',
         'default_endpoint', 'offset', 'cache_timeout']
     edit_columns = [
-        'table_name', 'sql', 'is_featured', 'database', 'schema',
-        'description', 'owner',
+        'table_name', 'sql', 'is_featured', 'filter_select_enabled',
+        'database', 'schema', 'description', 'owner',
         'main_dttm_col', 'default_endpoint', 'offset', 'cache_timeout']
     related_views = [TableColumnInlineView, SqlMetricInlineView]
     base_order = ('changed_on', 'desc')
@@ -501,6 +501,7 @@ class TableModelView(CaravelModelView, DeleteMixin):  # noqa
         'database': _("Database"),
         'changed_on_': _("Last Changed"),
         'is_featured': _("Is Featured"),
+        'filter_select_enabled': _("Enable Filter Select"),
         'schema': _("Schema"),
         'default_endpoint': _("Default Endpoint"),
         'offset': _("Offset"),
@@ -783,8 +784,8 @@ class DruidDatasourceModelView(CaravelModelView, DeleteMixin):  # noqa
     related_views = [DruidColumnInlineView, DruidMetricInlineView]
     edit_columns = [
         'datasource_name', 'cluster', 'description', 'owner',
-        'is_featured', 'is_hidden', 'default_endpoint', 'offset',
-        'cache_timeout']
+        'is_featured', 'is_hidden', 'filter_select_enabled', 'default_endpoint',
+        'offset', 'cache_timeout']
     add_columns = edit_columns
     page_size = 500
     base_order = ('datasource_name', 'asc')
@@ -801,6 +802,7 @@ class DruidDatasourceModelView(CaravelModelView, DeleteMixin):  # noqa
         'owner': _("Owner"),
         'is_featured': _("Is Featured"),
         'is_hidden': _("Is Hidden"),
+        'filter_select_enabled': _("Enable Filter Select"),
         'default_endpoint': _("Default Endpoint"),
         'offset': _("Time Offset"),
         'cache_timeout': _("Cache Timeout"),
@@ -1012,6 +1014,58 @@ class Caravel(BaseCaravelView):
                     mimetype="application/json")
 
             return resp
+
+    @api
+    @has_access_api
+    @expose("/filter/<datasource_type>/<datasource_id>/<column>/")
+    def filter(self, datasource_type, datasource_id, column):
+        """
+        Endpoint to retrieve values for specified column.
+
+        :param datasource_type: Type of datasource e.g. table
+        :param datasource_id: Datasource id
+        :param column: Column name to retrieve values for
+        :return:
+        """
+        # TODO: Cache endpoint by user, datasource and column
+        error_redirect = '/slicemodelview/list/'
+        datasource_class = models.SqlaTable \
+            if datasource_type == "table" else models.DruidDatasource
+
+        datasource = db.session.query(
+            datasource_class).filter_by(id=datasource_id).first()
+
+        if not datasource:
+            flash(__("The datasource seems to have been deleted"), "alert")
+            return redirect(error_redirect)
+
+        all_datasource_access = self.can_access(
+            'all_datasource_access', 'all_datasource_access')
+        datasource_access = self.can_access(
+            'datasource_access', datasource.perm)
+        if not (all_datasource_access or datasource_access):
+            flash(__("You don't seem to have access to this datasource"), "danger")
+            return redirect(error_redirect)
+
+        viz_type = request.args.get("viz_type")
+        if not viz_type and datasource.default_endpoint:
+            return redirect(datasource.default_endpoint)
+        if not viz_type:
+            viz_type = "table"
+        try:
+            obj = viz.viz_types[viz_type](
+                datasource,
+                form_data=request.args,
+                slice_=None)
+        except Exception as e:
+            flash(str(e), "danger")
+            return redirect(error_redirect)
+        status = 200
+        payload = obj.get_values_for_column(column)
+        return Response(
+            payload,
+            status=status,
+            mimetype="application/json")
 
     def save_or_overwrite_slice(
             self, args, slc, slice_add_perm, slice_edit_perm):

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -145,6 +145,28 @@ class BaseViz(object):
             del od['force']
         return href(od)
 
+    def get_filter_url(self):
+        """Returns the URL to retrieve column values used in the filter dropdown"""
+        d = self.orig_form_data.copy()
+        # Remove unchecked checkboxes because HTML is weird like that
+        od = MultiDict()
+        for key in sorted(d.keys()):
+            if d[key] is False:
+                del d[key]
+            else:
+                if isinstance(d, MultiDict):
+                    v = d.getlist(key)
+                else:
+                    v = d.get(key)
+                if not isinstance(v, list):
+                    v = [v]
+                for item in v:
+                    od.add(key, item)
+        href = Href(
+            '/caravel/filter/{self.datasource.type}/'
+            '{self.datasource.id}/'.format(**locals()))
+        return href(od)
+
     def get_df(self, query_obj=None):
         """Returns a pandas dataframe based on the query object"""
         if not query_obj:
@@ -308,6 +330,7 @@ class BaseViz(object):
                 'form_data': self.form_data,
                 'json_endpoint': self.json_endpoint,
                 'query': self.query,
+                'filter_endpoint': self.filter_endpoint,
                 'standalone_endpoint': self.standalone_endpoint,
             }
             payload['cached_dttm'] = datetime.now().isoformat().split('.')[0]
@@ -341,9 +364,11 @@ class BaseViz(object):
             'csv_endpoint': self.csv_endpoint,
             'form_data': self.form_data,
             'json_endpoint': self.json_endpoint,
+            'filter_endpoint': self.filter_endpoint,
             'standalone_endpoint': self.standalone_endpoint,
             'token': self.token,
             'viz_name': self.viz_type,
+            'filter_select_enabled': self.datasource.filter_select_enabled,
             'column_formats': {
                 m.metric_name: m.d3format
                 for m in self.datasource.metrics
@@ -357,12 +382,44 @@ class BaseViz(object):
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, encoding="utf-8")
 
+    def get_values_for_column(self, column):
+        """
+        Retrieves values for a column to be used by the filter dropdown.
+
+        :param column: column name
+        :return: JSON containing the some values for a column
+        """
+        form_data = self.form_data
+
+        since = form_data.get("since", "1 year ago")
+        from_dttm = utils.parse_human_datetime(since)
+        now = datetime.now()
+        if from_dttm > now:
+            from_dttm = now - (from_dttm - now)
+        until = form_data.get("until", "now")
+        to_dttm = utils.parse_human_datetime(until)
+        if from_dttm > to_dttm:
+            flasher("The date range doesn't seem right.", "danger")
+            from_dttm = to_dttm  # Making them identical to not raise
+
+        kwargs = dict(
+            column_name=column,
+            from_dttm=from_dttm,
+            to_dttm=to_dttm,
+        )
+        df = self.datasource.values_for_column(**kwargs)
+        return df[column].to_json()
+
     def get_data(self):
         return []
 
     @property
     def json_endpoint(self):
         return self.get_url(json="true")
+
+    @property
+    def filter_endpoint(self):
+        return self.get_filter_url()
 
     @property
     def cache_key(self):

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -151,17 +151,23 @@ class BaseViz(object):
         # Remove unchecked checkboxes because HTML is weird like that
         od = MultiDict()
         for key in sorted(d.keys()):
-            if d[key] is False:
-                del d[key]
+            # if MultiDict is initialized with MD({key:[emptyarray]}),
+            # key is included in d.keys() but accessing it throws
+            try:
+                if d[key] is False:
+                    del d[key]
+                    continue
+            except IndexError:
+                pass
+
+            if isinstance(d, (MultiDict, ImmutableMultiDict)):
+                v = d.getlist(key)
             else:
-                if isinstance(d, MultiDict):
-                    v = d.getlist(key)
-                else:
-                    v = d.get(key)
-                if not isinstance(v, list):
-                    v = [v]
-                for item in v:
-                    od.add(key, item)
+                v = d.get(key)
+            if not isinstance(v, list):
+                v = [v]
+            for item in v:
+                od.add(key, item)
         href = Href(
             '/caravel/filter/{self.datasource.type}/'
             '{self.datasource.id}/'.format(**locals()))


### PR DESCRIPTION
## Overview

This PR address the issue https://github.com/airbnb/caravel/issues/933, which is to replace the filter TextField with a FreeFormSelect to make it easier for the user to know what types of values are possible for a filter.

If their desired value is not in the list, they can still type in their custom value. (Especially common for regex operation)

The feature must be enabled on the table/datasource.
## Technical Changes
- Added new API endpoint `/filter/<datasource_type>/<datasource_id>/<column>/`
- Added new function `values_for_column` to `models.DruidDatasource` and `models.SqlaTable` (migration script included)
  - `values_for_column` uses the same querystring as `query`
  - Currently limited to **500 values**
- Added new boolean column to `datasources` and `tables` to indicate allowing filter value select
- `add_filter` in `explore.jsx` will now fix the filter IDs upon render instead of by `prepForm` on query submit
## Screenshots

How filter looks:
<img width="353" alt="screen shot 2016-08-15 at 2 07 56 pm" src="https://cloud.githubusercontent.com/assets/1399237/17679977/c7edc362-62f2-11e6-880b-6973f29324c5.png">

Option on table:
<img width="1175" alt="screen shot 2016-08-15 at 2 12 18 pm" src="https://cloud.githubusercontent.com/assets/1399237/17679993/d999901e-62f2-11e6-9050-5aa04678020a.png">
## TODO for Future PR
- Entire filter can be redone in React
- Cache filter endpoint

@mistercrunch 
