### PR TITLE
Fix webpack mapbox-gl build error `Cannot resolve module fs`

### DIFF
--- a/caravel/assets/webpack.config.js
+++ b/caravel/assets/webpack.config.js
@@ -8,6 +8,9 @@ const APP_DIR = path.resolve(__dirname, './');
 const BUILD_DIR = path.resolve(__dirname, './javascripts/dist');
 
 const config = {
+  node: {
+    fs: 'empty',
+  },
   entry: {
     'css-theme': APP_DIR + '/javascripts/css-theme.js',
     dashboard: APP_DIR + '/javascripts/dashboard/Dashboard.jsx',


### PR DESCRIPTION
I don't claim to really understand this but it fixed an error for me.  Maybe it is a windows thing? 
