### PR TITLE
Hack around the "last migration doesn't stamp" Alembic bug

### DIFF
--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run lint && mocha --compilers js:babel-core/register --required spec/helpers/browser.js spec/**/*_spec.*",
     "dev": "NODE_ENV=dev webpack -d --watch --colors",
-    "prod": "NODE_ENV=production webpack -p --colors",
+    "prod": "NODE_ENV=production webpack -p --colors --progress",
     "lint": "npm run --silent lint:js",
     "lint:js": "eslint --ignore-path=.eslintignore --ext .js ."
   },

--- a/caravel/migrations/env.py
+++ b/caravel/migrations/env.py
@@ -72,11 +72,21 @@ def run_migrations_online():
                                 poolclass=pool.NullPool)
 
     connection = engine.connect()
+    kwargs = {}
+    if engine.name in ('sqlite', 'mysql'):
+        kwargs = {
+            'transaction_per_migration': True,
+            'transactional_ddl': True,
+        }
+    configure_args = current_app.extensions['migrate'].configure_args
+    if configure_args:
+        kwargs.update(configure_args)
+
     context.configure(connection=connection,
                       target_metadata=target_metadata,
                       #compare_type=True,
                       process_revision_directives=process_revision_directives,
-                      **current_app.extensions['migrate'].configure_args)
+                      **kwargs)
 
     try:
         with context.begin_transaction():

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 echo $DB
-rm /tmp/caravel_unittests.db
+rm ~/.caravel/caravel_unittests.db
 rm -f .coverage
 export CARAVEL_CONFIG=tests.caravel_test_config
 set -e
 caravel/bin/caravel db upgrade
+caravel/bin/caravel db upgrade  # running twice on purpose as a test
 caravel/bin/caravel version -v
 python setup.py nosetests


### PR DESCRIPTION
This makes MySQL, Sqlite and Postgres work with a special hard coded
rule. I'm hoping Alembic fixes the root cause eventually.

@bkyryliuk 
