### PR TITLE
Add synctable command into caravel

### DIFF
--- a/caravel/bin/caravel
+++ b/caravel/bin/caravel
@@ -125,6 +125,21 @@ def refresh_druid():
             "[" + cluster.cluster_name + "]")
     session.commit()
 
+@manager.command
+def synctable():
+    exists_tables = []
+    for row in db.session.query(caravel.models.SqlaTable).all():
+        exists_tables += [(row.database, row.name)]
+    
+    all_tables = []
+    for _db in db.session.query(caravel.models.Database).all():
+        for _tablename in _db.get_sqla_engine().table_names():
+            all_tables += [(_db.database_name, _tablename)]
+    all_tables = [_ for _ in all_tables if _[1].startswith('data_')]
+    
+    need_insert = list(set(all_tables) - set(exists_tables))
+
+    print(need_insert)
 
 if __name__ == "__main__":
     manager.run()

--- a/caravel/bin/caravel
+++ b/caravel/bin/caravel
@@ -139,7 +139,17 @@ def synctable():
     
     need_insert = list(set(all_tables) - set(exists_tables))
 
-    print(need_insert)
+    for row in need_insert:
+        db_name = row[0]
+        table_name = row[1]
+
+        tbl = caravel.models.SqlaTable(table_name=table_name)
+        tbl.description = ""
+        tbl.is_featured = False
+        tbl.database = db.session.query(caravel.models.Database).filter_by(database_name=db_name).first()
+        db.session.merge(tbl)
+        db.session.commit()
+        tbl.fetch_metadata()
 
 if __name__ == "__main__":
     manager.run()

--- a/caravel/bin/caravel
+++ b/caravel/bin/caravel
@@ -125,8 +125,11 @@ def refresh_druid():
             "[" + cluster.cluster_name + "]")
     session.commit()
 
-@manager.command
-def synctable():
+@manager.option(
+    '-p', '--prefix', default='data_',
+    help="Sync Table Prefix")
+def synctable(prefix):
+    ''' Sync DB Table with Caravel Table'''
     exists_tables = []
     for row in db.session.query(caravel.models.SqlaTable).all():
         exists_tables += [(row.database, row.name)]
@@ -135,7 +138,7 @@ def synctable():
     for _db in db.session.query(caravel.models.Database).all():
         for _tablename in _db.get_sqla_engine().table_names():
             all_tables += [(_db.database_name, _tablename)]
-    all_tables = [_ for _ in all_tables if _[1].startswith('data_')]
+    all_tables = [_ for _ in all_tables if _[1].startswith(prefix)]
     
     need_insert = list(set(all_tables) - set(exists_tables))
 

--- a/caravel/bin/caravel
+++ b/caravel/bin/caravel
@@ -151,5 +151,9 @@ def synctable(prefix):
         db.session.commit()
         tbl.fetch_metadata()
 
+        print("[{db}] {table} insert success.".format(db=db_name, table=table_name))
+
+    print("[{}] Sync table complete.".format(len(need_insert)))
+
 if __name__ == "__main__":
     manager.run()

--- a/caravel/bin/caravel
+++ b/caravel/bin/caravel
@@ -132,8 +132,7 @@ def synctable(prefix):
     ''' Sync DB Table with Caravel Table'''
     existing_tables = []
     for row in db.session.query(caravel.models.SqlaTable).all():
-        existing_tables += [(row.database, row.name)]
-    
+        existing_tables += [(row.database.database_name, row.name)]
     all_tables = []
     for caravel_db in db.session.query(caravel.models.Database).all():
         for table_name in caravel_db.get_sqla_engine().table_names():

--- a/caravel/bin/caravel
+++ b/caravel/bin/caravel
@@ -130,22 +130,20 @@ def refresh_druid():
     help="Sync Table Prefix")
 def synctable(prefix):
     ''' Sync DB Table with Caravel Table'''
-    exists_tables = []
+    existing_tables = []
     for row in db.session.query(caravel.models.SqlaTable).all():
-        exists_tables += [(row.database, row.name)]
+        existing_tables += [(row.database, row.name)]
     
     all_tables = []
-    for _db in db.session.query(caravel.models.Database).all():
-        for _tablename in _db.get_sqla_engine().table_names():
-            all_tables += [(_db.database_name, _tablename)]
-    all_tables = [_ for _ in all_tables if _[1].startswith(prefix)]
+    for caravel_db in db.session.query(caravel.models.Database).all():
+        for table_name in caravel_db.get_sqla_engine().table_names():
+            all_tables += [(caravel_db.database_name, table_name)]
     
-    need_insert = list(set(all_tables) - set(exists_tables))
+    all_tables = [row for row in all_tables if row[1].startswith(prefix)]
+    
+    need_insert = list(set(all_tables) - set(existing_tables))
 
-    for row in need_insert:
-        db_name = row[0]
-        table_name = row[1]
-
+    for db_name, table_name in need_insert:
         tbl = caravel.models.SqlaTable(table_name=table_name)
         tbl.description = ""
         tbl.is_featured = False

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -180,7 +180,8 @@ complies with the Flask-Cache specifications.
 Flask-Cache supports multiple caching backends (Redis, Memcached,
 SimpleCache (in-memory), or the local filesystem). If you are going to use
 Memcached please use the pylibmc client library as python-memcached does
-not handle storing binary data correctly.
+not handle storing binary data correctly. If you use Redis, please install 
+[python-redis](https://pypi.python.org/pypi/redis).
 
 For setting your timeouts, this is done in the Caravel metadata and goes
 up the "timeout searchpath", from your slice configuration, to your


### PR DESCRIPTION
Sometime we have many table need insert to caravel tables, I write a command can help people to do this, set a table name prefix or default is data_ , this cmd will scan caravel has table and database all table, compare and insert it.
