### PR TITLE
[bugfix] dashboard list doesn't populate in explore->saveas

### DIFF
--- a/caravel/assets/javascripts/welcome.js
+++ b/caravel/assets/javascripts/welcome.js
@@ -14,13 +14,14 @@ function modelViewTable(selector, modelView, orderCol, order) {
   url += '?_oc_' + modelView + '=' + orderCol;
   url += '&_od_' + modelView + '=' + order;
   $.getJSON(url, function (data) {
+    const columns = ['dashboard_link', 'creator', 'modified'];
     const tableData = $.map(data.result, function (el) {
-      const row = $.map(data.list_columns, function (col) {
+      const row = $.map(columns, function (col) {
         return el[col];
       });
       return [row];
     });
-    const cols = $.map(data.list_columns, function (col) {
+    const cols = $.map(columns, function (col) {
       return { sTitle: data.label_columns[col] };
     });
     const panel = $(selector).parents('.panel');

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -728,7 +728,7 @@ appbuilder.add_view(
 
 
 class DashboardModelViewAsync(DashboardModelView):  # noqa
-    list_columns = ['dashboard_link', 'creator', 'modified']
+    list_columns = ['dashboard_link', 'creator', 'modified', 'dashboard_title']
     label_columns = {
         'dashboard_link': 'Dashboard',
     }


### PR DESCRIPTION
https://github.com/airbnb/caravel/pull/951 broke the dropdown that was using the same endpoint as the welcome page. 
@vera-liu  @ascott 
