### PR TITLE
move staging alert out of nav

### DIFF
--- a/caravel/templates/appbuilder/navbar.html
+++ b/caravel/templates/appbuilder/navbar.html
@@ -18,14 +18,6 @@
         {% include 'appbuilder/navbar_menu.html' %}
       </ul>
       <ul class="nav navbar-nav navbar-right">
-        {% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
-        {% if WARNING_MSG %}
-          <li>
-            <div class="alert alert-danger" role="alert">
-              {{ WARNING_MSG | safe }}
-            </div>
-          </li>
-        {% endif %}
         <li><a href="https://github.com/airbnb/caravel" title="Caravel's Github">
           <i class="fa fa-github fa-lg"></i></a>
         </li>
@@ -37,3 +29,12 @@
     </div>
   </div>
 </div>
+
+{% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
+{% if WARNING_MSG %}
+  <div class="container">
+    <div class="alert alert-danger">
+      {{ WARNING_MSG | safe }}
+    </div>
+  </div>
+{% endif %}


### PR DESCRIPTION
the staging alert in the nav breaks the ui even when it's not shown (including on the theme page) moving it just below the nav and above any content.

<img width="1279" alt="screenshot 2016-08-22 23 33 03" src="https://cloud.githubusercontent.com/assets/130878/17882311/95f55bda-68c0-11e6-9901-8c66335954a1.png">

<img width="1280" alt="screenshot 2016-08-22 23 35 15" src="https://cloud.githubusercontent.com/assets/130878/17882339/cec61eea-68c0-11e6-97ba-abbdcac8bd25.png">

<img width="1280" alt="screenshot 2016-08-22 23 33 28" src="https://cloud.githubusercontent.com/assets/130878/17882312/95f8d2f6-68c0-11e6-8904-118998b4800a.png">

plz review @mistercrunch 
