### PR TITLE
slice/explore header

### DIFF
--- a/caravel/templates/caravel/explore.html
+++ b/caravel/templates/caravel/explore.html
@@ -188,36 +188,7 @@
             <div class="panel-title">
               <div class="row">
                 <div class="col-md-6">
-                  {% if slice %}
-                    {% if slice.slice_name %}
-                      <h2>
-                        {{ slice.slice_name }}
-                        <small class="star-edit-icons">
-                          <span class="favstar" obj_id="{{ slice.id }}"></span>
-                          <span>
-                            <a
-                              href="/slicemodelview/edit/{{ slice.id }}"
-                              data-toggle="tooltip"
-                              title="Edit Description"
-                              class="edit-slice-description-icon"
-                            >
-                              {% if slice.description %}
-                                <i
-                                  class="fa fa-question-circle-o"
-                                  data-toggle="tooltip"
-                                  data-placement="bottom"
-                                  title="{{ slice.description }}">
-                                </i>
-                              {% endif %}
-                              <i class="fa fa-edit"></i>
-                            </a>
-                          </span>
-                        </small>
-                      </h2>
-                    {% else %}
-                      <h2>untitled</h2>
-                    {% endif %}
-                  {% endif %}
+                  {% include 'caravel/partials/_slice_header.html' %}
                 </div>
                 <div class="col-md-6">
                   <div class="slice-meta-controls pull-right">

--- a/caravel/templates/caravel/explore.html
+++ b/caravel/templates/caravel/explore.html
@@ -188,7 +188,7 @@
             <div class="panel-title">
               <div class="row">
                 <div class="col-md-6">
-                  {% include 'caravel/partials/_slice_header.html' %}
+                  {% include 'caravel/partials/_explore_title.html' %}
                 </div>
                 <div class="col-md-6">
                   <div class="slice-meta-controls pull-right">

--- a/caravel/templates/caravel/partials/_explore_title.html
+++ b/caravel/templates/caravel/partials/_explore_title.html
@@ -26,5 +26,5 @@
     </h2>
   {% endif %}
 {% else %}
-  <h2 class="text-muted"><small>[explore] {{viz.datasource.table_name}}</small></h2>
+  <h2>{{viz.datasource.table_name}}</h2>
 {% endif %}

--- a/caravel/templates/caravel/partials/_explore_title.html
+++ b/caravel/templates/caravel/partials/_explore_title.html
@@ -26,5 +26,5 @@
     </h2>
   {% endif %}
 {% else %}
-  <h2>{{viz.datasource.table_name}}</h2>
+  <h2>{{ viz.datasource.table_name }}</h2>
 {% endif %}

--- a/caravel/templates/caravel/partials/_explore_title.html
+++ b/caravel/templates/caravel/partials/_explore_title.html
@@ -26,5 +26,5 @@
     </h2>
   {% endif %}
 {% else %}
-  <h2>{{ viz.datasource.table_name }}</h2>
+  <h2>[{{ viz.datasource.table_name }}] - untitled</h2>
 {% endif %}

--- a/caravel/templates/caravel/partials/_slice_header.html
+++ b/caravel/templates/caravel/partials/_slice_header.html
@@ -1,0 +1,30 @@
+{% if slice %}
+  {% if slice.slice_name %}
+    <h2>
+      {{ slice.slice_name }}
+      <small class="star-edit-icons">
+        <span class="favstar" obj_id="{{ slice.id }}"></span>
+        <span>
+          <a
+            href="/slicemodelview/edit/{{ slice.id }}"
+            data-toggle="tooltip"
+            title="Edit Description"
+            class="edit-slice-description-icon"
+          >
+            {% if slice.description %}
+              <i
+                class="fa fa-question-circle-o"
+                data-toggle="tooltip"
+                data-placement="bottom"
+                title="{{ slice.description }}">
+              </i>
+            {% endif %}
+            <i class="fa fa-edit"></i>
+          </a>
+        </span>
+      </small>
+    </h2>
+  {% endif %}
+{% else %}
+  <h2 class="text-muted"><small>[explore] {{viz.datasource.table_name}}</small></h2>
+{% endif %}


### PR DESCRIPTION
if a table is being explored, and not a slice, use the datasource name rather than nothing.

![screenshot 2016-08-23 00 07 05](https://cloud.githubusercontent.com/assets/130878/17883122/8967b46c-68c5-11e6-9a1c-a89e0f395ad7.png)

![screenshot 2016-08-23 00 14 35](https://cloud.githubusercontent.com/assets/130878/17883232/4da9c928-68c6-11e6-9125-b0ef2b1b01f1.png)

@mistercrunch @bkyryliuk thoughts on this?
