### PR TITLE
Reduced number of ticks provided as hint to d3.ticks

### DIFF
--- a/caravel/assets/visualizations/histogram.js
+++ b/caravel/assets/visualizations/histogram.js
@@ -32,7 +32,7 @@ function histogram(slice) {
     const yAxis = d3.svg.axis()
     .scale(y)
     .orient('left')
-    .ticks(numBins * 3);
+    .ticks(numBins);
     // Calculate bins for the data
     const bins = d3.layout.histogram().bins(numBins)(data);
 


### PR DESCRIPTION
The number of the ticks suggested scales with 3 times as much
as the number of bins. This is unwanted since the number
of ticks is a hint to d3 as per (https://github.com/d3/d3-3.x-api-reference/blob/master/Quantitative-Scales.md#identity_ticks) The high number of suggesting ticks leads to a congested y-axis.
