### PR TITLE
set preferred URL scheme to https in config.py

### DIFF
--- a/caravel/config.py
+++ b/caravel/config.py
@@ -49,6 +49,9 @@ DEBUG = False
 # Whether to show the stacktrace on 500 error
 SHOW_STACKTRACE = True
 
+# URL scheme to be used for URL generation if no URL scheme is available
+PREFERRED_URL_SCHEME = 'https'
+
 # ------------------------------
 # GLOBALS FOR APP Builder
 # ------------------------------


### PR DESCRIPTION
@mistercrunch 

This is actually hard to test locally because 0.0.0.0 uses http, but according to [documentation](http://flask.pocoo.org/docs/0.11/config/) this should prevent the intermediate redirect from `http` -> `https` that blocks iframing slices in some cases.
