### PR TITLE
Chris/remove redirect from slice id endpoint

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1256,19 +1256,6 @@ class Caravel(BaseCaravelView):
             mimetype="application/json")
 
     @has_access
-    @expose("/slice/<slice_id>/")
-    def slice(self, slice_id):
-        """Convenience method for viewing a slice from its id alone"""
-        session = db.session()
-        qry = session.query(models.Slice).filter_by(id=int(slice_id))
-        slc = qry.first()
-        if slc:
-            return self.explore(slc.datasource_type, slc.datasource_id, slice_id=slice_id)
-        else:
-            flash("The specified slice could not be found", "danger")
-            return redirect('/slicemodelview/list/')
-
-    @has_access
     @expose("/dashboard/<dashboard_id>/")
     def dashboard(self, dashboard_id):
         """Server side rendering for a dashboard"""

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -120,7 +120,8 @@ class BaseViz(object):
         # Remove unchecked checkboxes because HTML is weird like that
         od = MultiDict()
         for key in sorted(d.keys()):
-            # If a MultiDict was initialized with MD({key:[]}), accessing key throws
+            # if MultiDict is initialized with MD({key:[emptyarray]}),
+            # key is included in d.keys() but accessing it throws
             try:
                 if d[key] is False:
                     del d[key]

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -86,11 +86,10 @@ class CoreTests(CaravelTestCase):
         for slc in db.session.query(Slc).all():
             urls += [
                 (slc.slice_name, 'slice_url', slc.slice_url),
-                (slc.slice_name, 'slice_id_endpoint', '/caravel/slices/{}'.
-                 format(slc.id)),
                 (slc.slice_name, 'json_endpoint', slc.viz.json_endpoint),
                 (slc.slice_name, 'csv_endpoint', slc.viz.csv_endpoint),
-                (slc.slice_name, 'slice_id_url', "/caravel/slice/{slc.id}/".format(slc=slc)),
+                (slc.slice_name, 'slice_id_url',
+                    "/caravel/{slc.datasource_type}/{slc.datasource_id}/{slc.id}/".format(slc=slc)),
             ]
         for name, method, url in urls:
             print("[{name}]/[{method}]: {url}".format(**locals()))

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -90,46 +90,11 @@ class CoreTests(CaravelTestCase):
                  format(slc.id)),
                 (slc.slice_name, 'json_endpoint', slc.viz.json_endpoint),
                 (slc.slice_name, 'csv_endpoint', slc.viz.csv_endpoint),
+                (slc.slice_name, 'slice_id_url', "/caravel/slice/{slc.id}/".format(slc=slc)),
             ]
         for name, method, url in urls:
             print("[{name}]/[{method}]: {url}".format(**locals()))
             self.client.get(url)
-
-    def test_slice_id_redirects(self, username='admin'):
-        def make_assertions(resp, standalone):
-            decoded = resp.data.decode('utf-8')
-            if standalone:
-                assert "Query" not in decoded
-                assert 'data-standalone="true"' in decoded
-
-            else:
-                assert "Query" in decoded
-                assert 'data-standalone="true"' not in decoded
-
-        self.login(username=username)
-        slc = db.session.query(models.Slice).filter_by(slice_name="Name Cloud").first()
-        get = self.client.get
-
-        # Standard redirect
-        slc_url = slc.slice_url
-        id_url = '/caravel/slice/{slc.id}'.format(slc=slc)
-
-        make_assertions(get(slc_url, follow_redirects=True), False)
-        make_assertions(get(id_url, follow_redirects=True), False)
-
-        # Explicit standalone
-        slc_url_standalone = '{slc_url}&standalone=true'.format(slc_url=slc_url)
-        id_url_standalone = '{id_url}?standalone=true'.format(id_url=id_url)
-
-        make_assertions(get(slc_url_standalone, follow_redirects=True), True)
-        make_assertions(get(id_url_standalone, follow_redirects=True), True)
-
-        # Explicit not-standalone
-        slc_url_notstandalone = '{slc_url}&standalone=false'.format(slc_url=slc_url)
-        id_url_notstandalone = '{id_url}?standalone=false'.format(id_url=id_url)
-
-        make_assertions(get(slc_url_notstandalone, follow_redirects=True), False)
-        make_assertions(get(id_url_notstandalone, follow_redirects=True), False)
 
     def test_dashboard(self):
         self.login(username='admin')


### PR DESCRIPTION
@mistercrunch 

I used the approach we discussed yesterday for avoiding a re-direct for the `/caravel/slice/id` endpoint. It required a bit of refactoring of the `explore` method but not too bad. Overall if a `slice_id` is passed as part of the URL pathname I'll use that, then fall back to the URL query, else None. 

In the case that a `slice_id` is found I update the database slice params with any specified in the URL. I coerce the updated param dict to a `ImmutableMultiDict` so that its type is consistent with `request.args`. I ran into a [reported MultiDict bug](https://github.com/pallets/werkzeug/issues/389) wherein if you initialize an `ImmutableMultiDict` with a dict containing a key whose value is an empty array, if you try to access that key, an `IndexError` is thrown. I added a try catch for this where I was seeing errors. eg:

`md = MultiDict({ groupby: [] })`
`md.keys() # returns ['groupby']`
`md['groupby'] # IndexError`
`md.get('groupby') # IndexError`

As noted I also found another bug where slices that have been over-written are saved with the original `slice_id` which caused weird bugs in the forms. I fixed this in the `save_slice_as` method and explicitly set the `slice_id` in the `slice_params` I use to the value passed in the URL. 

Updated tests / they all passed.
