### PR TITLE
Set up istanbul with codeclimate and travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 
 language: python
 addons:
+  code_climate:
+    repo_token: 5f3a06c425eef7be4b43627d7d07a3e46c45bdc07155217825ff7c49cb6a470c
   apt:
     sources:
       - deadsnakes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 language: python
 addons:
   apt:
@@ -5,14 +6,13 @@ addons:
       - deadsnakes
     packages:
       - python3.5
-  code_climate:
-    repo_token: 5f3a06c425eef7be4b43627d7d07a3e46c45bdc07155217825ff7c49cb6a470c
 cache:
   directories:
     - $HOME/.wheelhouse/
 env:
   global:
     - TRAVIS_CACHE=$HOME/.travis_cache/
+    - TRAVIS_NODE_VERSION="5.11"
   matrix:
     #- TOX_ENV=py27-mysql
     - TOX_ENV=py27-sqlite
@@ -22,7 +22,7 @@ env:
     - TOX_ENV=py34-postgres
     - TOX_ENV=javascript
 before_install:
-  - npm install -g npm@'>=2.7.1'
+  - npm install -g npm@'>=3.9.5'
 before_script:
   - mysql -e 'drop database if exists caravel; create database caravel DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci' -u root
   - psql -c 'create database caravel;' -U postgres
@@ -30,4 +30,6 @@ before_script:
 install:
   - pip install --upgrade pip
   - pip install tox tox-travis
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  - npm install
 script: tox -e $TOX_ENV

--- a/caravel/assets/.eslintignore
+++ b/caravel/assets/.eslintignore
@@ -3,3 +3,4 @@ vendor/*
 dist/*
 stylesheets/*
 spec/*
+coverage/**

--- a/caravel/assets/.istanbul.yml
+++ b/caravel/assets/.istanbul.yml
@@ -1,0 +1,54 @@
+verbose: true
+instrumentation:
+    root: './javascripts'
+    extensions: ['.js', '.jsx']
+    excludes: [
+        'dist/**'
+    ]
+    embed-source: false
+    variable: __coverage__
+    compact: true
+    preserve-comments: false
+    complete-copy: false
+    save-baseline: true
+    baseline-file: ./coverage/coverage-baseline.json
+    include-all-sources: true
+    include-pid: false
+    es-modules: true
+reporting:
+    print: summary
+    reports:
+        - lcov
+    dir: ./coverage
+    watermarks:
+        statements: [50, 80]
+        lines: [50, 80]
+        functions: [50, 80]
+        branches: [50, 80]
+    report-config:
+        clover: {file: clover.xml}
+        cobertura: {file: cobertura-coverage.xml}
+        json: {file: coverage-final.json}
+        json-summary: {file: coverage-summary.json}
+        lcovonly: {file: lcov.info}
+        teamcity: {file: null, blockName: Code Coverage Summary}
+        text: {file: null, maxCols: 0}
+        text-lcov: {file: lcov.info}
+        text-summary: {file: null}
+hooks:
+    hook-run-in-context: false
+    post-require-hook: null
+    handle-sigint: false
+check:
+    global:
+        statements: 0
+        lines: 0
+        branches: 0
+        functions: 0
+        excludes: []
+    each:
+        statements: 0
+        lines: 0
+        branches: 0
+        functions: 0
+        excludes: []

--- a/caravel/assets/js_build.sh
+++ b/caravel/assets/js_build.sh
@@ -8,4 +8,4 @@ npm run lint
 npm run test
 npm run prod
 npm run cover
-./node_modules/.bin/codeclimate-test-reporter < ./coverage/lcov.info
+CODECLIMATE_REPO_TOKEN=5f3a06c425eef7be4b43627d7d07a3e46c45bdc07155217825ff7c49cb6a470c ./node_modules/.bin/codeclimate-test-reporter < ./coverage/lcov.info

--- a/caravel/assets/js_build.sh
+++ b/caravel/assets/js_build.sh
@@ -2,7 +2,10 @@
 set -e
 cd "$(dirname "$0")"
 npm --version
+node --version
 npm install
 npm run lint
 npm run test
 npm run prod
+npm run cover
+./node_modules/.bin/codeclimate-test-reporter < ./coverage/lcov.info

--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -7,7 +7,8 @@
     "test": "spec"
   },
   "scripts": {
-    "test": "npm run lint && mocha --compilers js:babel-core/register --required spec/helpers/browser.js spec/**/*_spec.*",
+    "test": "npm run lint && mocha --compilers js:babel-core/register --require spec/helpers/browser.js --recursive spec/**/*_spec.*",
+    "cover": "babel-node ./node_modules/.bin/istanbul cover _mocha -- --require spec/helpers/browser.js --recursive spec/**/*_spec.*",
     "dev": "NODE_ENV=dev webpack -d --watch --colors --progress",
     "prod": "NODE_ENV=production webpack -p --colors --progress",
     "lint": "npm run --silent lint:js",
@@ -36,6 +37,7 @@
   "homepage": "https://github.com/airbnb/caravel#readme",
   "dependencies": {
     "autobind-decorator": "^1.3.3",
+    "babel-cli": "^6.14.0",
     "bootstrap": "^3.3.6",
     "bootstrap-datepicker": "^1.6.0",
     "brace": "^0.7.0",
@@ -90,6 +92,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "chai": "^3.5.0",
+    "codeclimate-test-reporter": "^0.3.3",
     "css-loader": "^0.23.1",
     "enzyme": "^2.0.0",
     "eslint": "^2.13.1",
@@ -98,6 +101,7 @@
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^5.2.2",
     "exports-loader": "^0.6.3",
+    "istanbul": "^1.0.0-alpha",
     "file-loader": "^0.8.5",
     "imports-loader": "^0.6.5",
     "jsdom": "^8.0.1",

--- a/caravel/assets/spec/helpers/browser.js
+++ b/caravel/assets/spec/helpers/browser.js
@@ -18,5 +18,3 @@ Object.keys(document.defaultView).forEach((property) => {
 global.navigator = {
   userAgent: 'node.js',
 };
-
-documentRef = document;


### PR DESCRIPTION
Set of changes:
- Code climate repo token is moved to the repository settings. This allows forks to have test coverage too. More here: https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings
- upgraded npm on the travis to be 3.9.5 and installed manually node v 5.11 on the travis to allow test to pass.  Error message was ``jsdom 7.x onward only works on Node.js 4 or newer: https://github.com/t`. More logs are here: https://travis-ci.org/bkyryliuk/caravel/jobs/156381431
- Configured istanbul to run on the javascripts folder. There are couple limitations:
- \* include-all-sources flag enforces the tool to process recursively all js and jsx files in the root directory (./javascripts). Because of it we should avoid placing libraries and generated code into that directory as it will drastically slow down the code analysis or will lead node to run out of the memory.
- Fixed the npm test command the test helper file.
- Added babel-cli to run the istanbul command.
- Added codeclimate-test-reporter package to report the stats to the codeclimate.
- Fixed couple linting errors that were failing the build.

Open issues:
- codeclimate picks up the coverage data for the default branch and I couldn't make it working for the PRs yet. Waiting for the support to get back to me.
- codeclimate report script isn't picking up the travis env variable. The hack around it is to include the token in the command.
