### PR TITLE
Add cache warmup endpoint

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -252,7 +252,7 @@ class Slice(Model, AuditMixinNullable):
         return '<a href="{url}">{obj.slice_name}</a>'.format(
             url=url, obj=self)
 
-    def get_viz(self, url_params_multidict):
+    def get_viz(self, url_params_multidict=None):
         """Creates BaseViz object from the url_params_multidict.
 
         Parameters
@@ -270,9 +270,9 @@ class Slice(Model, AuditMixinNullable):
         slice_params['slice_id'] = self.id
         slice_params['json'] = "false"
         slice_params['slice_name'] = self.slice_name
-        viz_type = url_params_multidict.get("viz_type", self.viz_type)
-        slice_params['viz_type'] = viz_type if viz_type else "table"
-        slice_params.update(url_params_multidict)
+        slice_params['viz_type'] = self.viz_type if self.viz_type else "table"
+        if url_params_multidict:
+            slice_params.update(url_params_multidict)
         immutable_slice_params = ImmutableMultiDict(slice_params)
         return viz_types[immutable_slice_params.get('viz_type')](
             self.datasource,

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -253,18 +253,14 @@ class Slice(Model, AuditMixinNullable):
             url=url, obj=self)
 
     def get_viz(self, url_params_multidict=None):
-        """Creates BaseViz object from the url_params_multidict.
+        """Creates :py:class:viz.BaseViz object from the url_params_multidict.
 
-        Parameters
-        ----------
-        url_params_multidict: MultiDict, contains the visualization params,
-                              they override the self.params stored in the
-                              database
-        Returns
-        -------
-        BaseViz object of the 'viz_type' type that is taken from the
-        url_params_multidict or self.params.
-
+        :param werkzeug.datastructures.MultiDict url_params_multidict:
+            Contains the visualization params, they override the self.params
+            stored in the database
+        :return: object of the 'viz_type' type that is taken from the
+            url_params_multidict or self.params.
+        :rtype: :py:class:viz.BaseViz
         """
         slice_params = json.loads(self.params)  # {}
         slice_params['slice_id'] = self.id

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -276,12 +276,12 @@ class BaseViz(object):
             return self.datasource.database.cache_timeout
         return config.get("CACHE_DEFAULT_TIMEOUT")
 
-    def get_json(self):
+    def get_json(self, force=False):
         """Handles caching around the json payload retrieval"""
         cache_key = self.cache_key
         payload = None
-
-        if self.form_data.get('force') != 'true':
+        force = force if force else self.form_data.get('force') == 'true'
+        if not force:
             payload = cache.get(cache_key)
 
         if payload:

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -114,6 +114,20 @@ class CoreTests(CaravelTestCase):
         assert self.client.get('/health').data.decode('utf-8') == "OK"
         assert self.client.get('/ping').data.decode('utf-8') == "OK"
 
+    def test_warm_up_cache(self):
+        slice = db.session.query(models.Slice).first()
+        resp = self.client.get(
+            '/caravel/warm_up_cache?slice_id={}'.format(slice.id),
+            follow_redirects=True)
+        data = json.loads(resp.data.decode('utf-8'))
+        assert data == [{'slice_id': slice.id, 'slice_name': slice.slice_name}]
+
+        resp = self.client.get(
+            '/caravel/warm_up_cache?table_name=energy_usage&db_name=main',
+            follow_redirects=True)
+        data = json.loads(resp.data.decode('utf-8'))
+        assert len(data) == 3
+
     def test_shortner(self):
         self.login(username='admin')
         data = (


### PR DESCRIPTION
Implements the FR: https://github.com/airbnb/caravel/issues/1021
Based on the PR: https://github.com/airbnb/caravel/pull/1062

This PR adds 2 types of the cache warm up endpoints:
- Via table name and db name: 
  /caravel/warm_up_cache?table_name=energy_usage&db_name=main
- Via slice id: /caravel/warm_up_cache?slice_id=1
