### PR TITLE
Disable complexity check.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,6 +13,9 @@ engines:
     enabled: false
   radon:
     enabled: true
+    checks:
+      Complexity:
+        enabled: false
 ratings:
   paths:
   - "**.py"


### PR DESCRIPTION
I am not sure that such a check is useful for the repo.
More details are here:
http://radon.readthedocs.io/en/latest/intro.html#cyclomatic-complexity

Existing code has many complexity warnings:
https://codeclimate.com/github/airbnb/caravel/issues?category=complexity&engine=

@mistercrunch - what do you think ?
