### PR TITLE
Add refresh druid datasources endpoint.

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -1277,6 +1277,79 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable):
             col.generate_metrics()
 
     @classmethod
+    def sync_to_db_from_config(cls, druid_config, user, cluster):
+        """Merges the ds config from druid_config into one stored in the db."""
+        session = db.session()
+        datasource = (
+            session.query(DruidDatasource)
+            .filter_by(
+                datasource_name=druid_config['name'])
+        ).first()
+        # Create a new datasource.
+        if not datasource:
+            datasource = DruidDatasource(
+                datasource_name=druid_config['name'],
+                cluster=cluster,
+                owner=user,
+                changed_by_fk=user.id,
+                created_by_fk=user.id,
+            )
+            session.add(datasource)
+
+        dimensions = druid_config['dimensions']
+        for dim in dimensions:
+            col_obj = (
+                session.query(DruidColumn)
+                .filter_by(
+                    datasource_name=druid_config['name'],
+                    column_name=dim)
+            ).first()
+            if not col_obj:
+                col_obj = DruidColumn(
+                    datasource_name=druid_config['name'],
+                    column_name=dim,
+                    groupby=True,
+                    filterable=True,
+                    # TODO: fetch type from Hive.
+                    type="STRING",
+                    datasource=datasource
+                )
+                session.add(col_obj)
+        # Import Druid metrics
+        for metric_spec in druid_config["metrics_spec"]:
+            metric_name = metric_spec["name"]
+            metric_type = metric_spec["type"]
+            metric_json = json.dumps(metric_spec)
+
+            if metric_type == "count":
+                metric_type = "longSum"
+                metric_json = json.dumps({
+                    "type": "longSum",
+                    "name": metric_name,
+                    "fieldName": metric_name,
+                })
+
+            metric_obj = (
+                session.query(DruidMetric)
+                .filter_by(
+                    datasource_name=druid_config['name'],
+                    metric_name=metric_name)
+            ).first()
+            if not metric_obj:
+                metric_obj = DruidMetric(
+                    metric_name=metric_name,
+                    metric_type=metric_type,
+                    verbose_name="%s(%s)" % (metric_type, metric_name),
+                    datasource=datasource,
+                    json=metric_json,
+                    description=(
+                        "Imported from the airolap config dir for %s" %
+                        druid_config['name']),
+                )
+                session.add(metric_obj)
+        session.commit()
+
+    @classmethod
     def sync_to_db(cls, name, cluster):
         """Fetches metadata for that datasource and merges the Caravel db"""
         logging.info("Syncing Druid datasource [{}]".format(name))


### PR DESCRIPTION
Provides the endpoint to refresh the druid datasources for the cases when the druid datasource schema is stored outside of the druid cluster.

Configuration should include:
- `name`: datasource_name
- `dimensions`: list of the dimensions, they become druid columns with the type STRING
- `metrics_spec`: list of `metrics` (dictionary). `metric` consists of 2 attributes: `type` and `name`. `type` can be `count`, etc. `count` type is stored internally as `longSum`
- other fields will be ignored.

Example config:

```
{
  "name": "test_click", 
  "metrics_spec": [{"type": "count", "name": "count"}], 
  "dimensions": ["affiliate_id", "campaign", "first_seen"]
}
```

Reviewers:
- @mistercrunch 
- @kim-pham-airbnb 
- @hongbozeng
- @vera-liu 
- @ascott 
