### PR TITLE
[ui] add copy to clipboard component

### DIFF
--- a/caravel/assets/javascripts/components/CopyToClipboard.jsx
+++ b/caravel/assets/javascripts/components/CopyToClipboard.jsx
@@ -45,7 +45,7 @@ export default class CopyToClipboard extends React.Component {
         <a
           href="#"
           title="Copy to clipboard"
-          onClick={(e) => { this.copyToClipboard(e) }}
+          onClick={(e) => { this.copyToClipboard(e); }}
         >
           {this.props.copyNode}
         </a>

--- a/caravel/assets/javascripts/components/CopyToClipboard.jsx
+++ b/caravel/assets/javascripts/components/CopyToClipboard.jsx
@@ -1,0 +1,58 @@
+import React, { PropTypes } from 'react';
+
+const propTypes = {
+  copyNode: PropTypes.node,
+  onCopyEnd: PropTypes.func,
+  shouldShowText: PropTypes.bool,
+  text: PropTypes.string.isRequired,
+};
+
+const defaultProps = {
+  copyNode: <span>Copy</span>,
+  onCopyEnd: () => {},
+  shouldShowText: true,
+};
+
+export default class CopyToClipboard extends React.Component {
+  copyToClipboard(e) {
+    e.preventDefault();
+    const textToCopy = this.props.text;
+    const textArea = document.createElement('textarea');
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-1000px';
+    textArea.value = textToCopy;
+    document.body.appendChild(textArea);
+    textArea.select();
+    try {
+      if (!document.execCommand('copy')) {
+        throw new Error('Not successful');
+      }
+    } catch (err) {
+      window.alert('Sorry, your browser does not support copying. Use Ctrl / Cmd + C!'); // eslint-disable-line
+    }
+    document.body.removeChild(textArea);
+
+    this.props.onCopyEnd();
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.shouldShowText &&
+          <span>{this.props.text}</span>
+        }
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        <a
+          href="#"
+          title="Copy to clipboard"
+          onClick={(e) => { this.copyToClipboard(e) }}
+        >
+          {this.props.copyNode}
+        </a>
+      </div>
+    );
+  }
+}
+
+CopyToClipboard.propTypes = propTypes;
+CopyToClipboard.defaultProps = defaultProps;

--- a/caravel/assets/spec/javascripts/components/CopyToClipboard_spec.js
+++ b/caravel/assets/spec/javascripts/components/CopyToClipboard_spec.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import CopyToClipboard from '../../../../javascripts/components/CopyToClipboard';
+
+describe('CopyToClipboard', () => {
+  let defaultProps = {
+    text: 'Some text to copy',
+  };
+
+  // It must render
+  it('renders', () => {
+    expect(React.isValidElement(<CopyToClipboard {...defaultProps} />)).to.equal(true);
+  });
+
+  // Test the output
+  describe('output', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = shallow(<CopyToClipboard {...defaultProps} />);
+    });
+
+    it('renders button with default text', () => {
+      expect(wrapper.find('a').contains('Copy')).to.eql(true);
+    });
+  });
+});


### PR DESCRIPTION
@vera-liu needs this for her work so merging in now.
- shows text with copy link

usage:

```
<CopyToClipboard
  shouldShowText={true}
  text={html}
  copyNode={<i className="fa fa-clipboard" title="Copy to clipboard"></i>}
  onCopyEnd={() => { this.setState({ isCopied: true }); }}
/>
```

<img width="178" alt="screenshot 2016-09-07 15 42 14" src="https://cloud.githubusercontent.com/assets/130878/18331209/f8a56560-7511-11e6-827c-ad5a12d38fee.png">

plz review @mistercrunch @vera-liu 
