### PR TITLE
[sql-lab] only show the reset state button if location param present

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/SqlEditorLeft.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditorLeft.jsx
@@ -117,6 +117,7 @@ class SqlEditorTopToolbar extends React.Component {
   }
   render() {
     const tables = this.props.tables.filter((t) => (t.queryEditorId === this.props.queryEditor.id));
+    const shouldShowReset = window.location.search === '?reset=1';
     return (
       <div className="clearfix sql-toolbar">
         <div>
@@ -159,9 +160,11 @@ class SqlEditorTopToolbar extends React.Component {
             <TableElement table={table} queryEditor={this.props.queryEditor} />
           ))}
         </div>
-        <Button bsSize="small" bsStyle="danger" onClick={this.resetState.bind(this)}>
-          <i className="fa fa-bomb" /> Reset State
-        </Button>
+        {shouldShowReset &&
+          <Button bsSize="small" bsStyle="danger" onClick={this.resetState.bind(this)}>
+            <i className="fa fa-bomb" /> Reset State
+          </Button>
+        }
       </div>
     );
   }


### PR DESCRIPTION
- by default, hide the reset state button
- to show reset button, add reset param: `/caravel/sqllab?reset=1`

<img width="1275" alt="screenshot 2016-09-07 18 13 24" src="https://cloud.githubusercontent.com/assets/130878/18333738/90ab8b46-7526-11e6-84ad-532ad2bb052b.png">

<img width="1280" alt="screenshot 2016-09-07 18 13 32" src="https://cloud.githubusercontent.com/assets/130878/18333737/90ab8aa6-7526-11e6-838b-fca359d5b8c0.png">

plz review @mistercrunch @bkyryliuk @vera-liu 
