### PR TITLE
[sql-lab] ui polish

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -260,7 +260,7 @@ class SqlEditor extends React.Component {
                   mode="sql"
                   name={this.props.queryEditor.id}
                   theme="github"
-                  minLines={5}
+                  minLines={7}
                   maxLines={30}
                   onChange={this.textChange.bind(this)}
                   height="200px"

--- a/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
@@ -38,8 +38,6 @@ class TableElement extends React.Component {
         <Link
           href="#"
           onClick={this.props.actions.collapseTable.bind(this, this.props.table)}
-          placement="right"
-          tooltip="Collapse the table's structure information"
         >
           {this.props.table.name} <i className="fa fa-caret-up" />
         </Link>
@@ -60,8 +58,6 @@ class TableElement extends React.Component {
         <Link
           href="#"
           onClick={this.props.actions.expandTable.bind(this, this.props.table)}
-          placement="right"
-          tooltip="Expand the table's structure information"
         >
           {this.props.table.name} <i className="fa fa-caret-down" />
         </Link>

--- a/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
@@ -10,6 +10,7 @@ class TableElement extends React.Component {
   setSelectStar() {
     this.props.actions.queryEditorSetSql(this.props.queryEditor, this.selectStar());
   }
+
   selectStar() {
     let cols = '';
     this.props.table.columns.forEach((col, i) => {
@@ -20,6 +21,7 @@ class TableElement extends React.Component {
     });
     return `SELECT ${cols}\nFROM ${this.props.table.name}`;
   }
+
   popSelectStar() {
     const qe = {
       id: shortid.generate(),
@@ -30,24 +32,40 @@ class TableElement extends React.Component {
     };
     this.props.actions.addQueryEditor(qe);
   }
+
+  collapseTable(e) {
+    e.preventDefault();
+    this.props.actions.collapseTable.bind(this, this.props.table)();
+  }
+
+  expandTable(e) {
+    e.preventDefault();
+    this.props.actions.expandTable.bind(this, this.props.table)();
+  }
+
   render() {
     let metadata = null;
     let buttonToggle;
     if (this.props.table.expanded) {
       buttonToggle = (
-        <Link
+        <a
           href="#"
-          onClick={this.props.actions.collapseTable.bind(this, this.props.table)}
+          onClick={(e) => { this.collapseTable(e); }}
         >
-          {this.props.table.name} <i className="fa fa-caret-up" />
-        </Link>
+          <strong>{this.props.table.name}</strong>
+          <small className="m-l-5"><i className="fa fa-minus" /></small>
+        </a>
       );
       metadata = (
         <div>
           {this.props.table.columns.map((col) => (
-            <div className="clearfix">
-              <span className="pull-left m-l-5">{col.name}</span>
-              <span className="pull-right text-muted">{col.type}</span>
+            <div className="row">
+              <div className="col-sm-8">
+                <div className="m-l-5">{col.name}</div>
+              </div>
+              <div className="col-sm-4">
+                <div className="pull-right text-muted"><small>{col.type}</small></div>
+              </div>
             </div>
           ))}
           <hr />
@@ -55,37 +73,44 @@ class TableElement extends React.Component {
       );
     } else {
       buttonToggle = (
-        <Link
+        <a
           href="#"
-          onClick={this.props.actions.expandTable.bind(this, this.props.table)}
+          onClick={(e) => { this.expandTable(e); }}
         >
-          {this.props.table.name} <i className="fa fa-caret-down" />
-        </Link>
+          {this.props.table.name}
+          <small className="m-l-5"><i className="fa fa-plus" /></small>
+        </a>
       );
     }
     return (
-      <div className="ws-el">
-        {buttonToggle}
-        <ButtonGroup className="ws-el-controls pull-right">
-          <Link
-            className="fa fa-pencil m-l-2"
-            onClick={this.setSelectStar.bind(this)}
-            tooltip="Run query in a new tab"
-            href="#"
-          />
-          <Link
-            className="fa fa-plus-circle m-l-2"
-            onClick={this.popSelectStar.bind(this)}
-            tooltip="Run query in a new tab"
-            href="#"
-          />
-          <Link
-            className="fa fa-trash m-l-2"
-            onClick={this.props.actions.removeTable.bind(this, this.props.table)}
-            tooltip="Remove from workspace"
-            href="#"
-          />
-        </ButtonGroup>
+      <div>
+        <div className="row">
+          <div className="col-sm-9 m-b-10">
+            {buttonToggle}
+          </div>
+          <div className="col-sm-3">
+            <ButtonGroup className="ws-el-controls pull-right">
+              <Link
+                className="fa fa-pencil pull-left m-l-2"
+                onClick={this.setSelectStar.bind(this)}
+                tooltip="Run query in this tab"
+                href="#"
+              />
+              <Link
+                className="fa fa-plus-circle pull-left  m-l-2"
+                onClick={this.popSelectStar.bind(this)}
+                tooltip="Run query in a new tab"
+                href="#"
+              />
+              <Link
+                className="fa fa-trash pull-left m-l-2"
+                onClick={this.props.actions.removeTable.bind(this, this.props.table)}
+                tooltip="Remove from workspace"
+                href="#"
+              />
+            </ButtonGroup>
+          </div>
+        </div>
         {metadata}
       </div>
     );

--- a/caravel/assets/javascripts/SqlLab/main.css
+++ b/caravel/assets/javascripts/SqlLab/main.css
@@ -141,15 +141,12 @@ div.Workspace {
     max-height: 600px;
     box-shadow: rgba(0, 0, 0, 0.8) 5px 5px 25px
 }
-.SqlLab {
-    font-size: 12px;
-}
 .SqlLab pre {
     padding: 0px !important;
     margin: 0px;
     border: none;
-    font-size: 11px;
-    line-height: 125%;
+    font-size: 12px;
+    line-height: @line-height-base;
     background-color: transparent !important;
 }
 

--- a/caravel/assets/javascripts/SqlLab/main.css
+++ b/caravel/assets/javascripts/SqlLab/main.css
@@ -235,14 +235,6 @@ div.tablePopover:hover {
 .ace_content {
     background-color: #f4f4f4;
 }
-.ws-el > .ws-el-controls {
-    opacity: 0;
-    transition: visibility 0s, opacity 0.3s linear;
-}
-.ws-el:hover > .ws-el-controls {
-    opacity: 1;
-    transition: visibility 0s, opacity 0.3s linear;
-}
 
 .SouthPane .tab-content {
     padding-top: 10px;

--- a/caravel/assets/stylesheets/less/cosmo/variables.less
+++ b/caravel/assets/stylesheets/less/cosmo/variables.less
@@ -48,7 +48,7 @@
 @font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 @font-family-base:        @font-family-sans-serif;
 
-@font-size-base:          15px;
+@font-size-base:          14px;
 @font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
 @font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
 

--- a/caravel/templates/caravel/welcome.html
+++ b/caravel/templates/caravel/welcome.html
@@ -34,7 +34,7 @@
         </div>
         <div class="panel-body">
           <img class="loading" src="/static/assets/images/loading.gif"/>
-          <table id="dash_table" class="table table-condensed" width="100%"></table>
+          <table id="dash_table" class="table" width="100%"></table>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- we don't need tooltips on accordion menu, known ui pattern, also was blocking the table action icons
- use consistent type sizes for sql-lab (same as other views), bump body type down to 14px in the theme
- adjust sql editor height
- table meta data accordion menu 
  ---prevent default on accordion clicks
  --- always show table actions, they are more discoverable like that
  --- polish spacing/layout
- make welcome view type same as body copy (don't used `table-condensed`)

before: 
<img width="1280" alt="screenshot 2016-09-08 01 03 05" src="https://cloud.githubusercontent.com/assets/130878/18341615/a1469d2c-755f-11e6-9e82-4f6a3c5fc4c7.png">

<img width="1280" alt="screenshot 2016-09-08 01 01 35" src="https://cloud.githubusercontent.com/assets/130878/18341585/7bacfc6e-755f-11e6-8c4f-7e24b9cb3bca.png">

after:

<img width="1280" alt="screenshot 2016-09-08 00 54 41" src="https://cloud.githubusercontent.com/assets/130878/18341430/d1dacebe-755e-11e6-85f7-cb5d52da559b.png">

![sql-lab-polish](https://cloud.githubusercontent.com/assets/130878/18341361/7e88a902-755e-11e6-9ac9-cdc28c336ff8.gif)

plz review @mistercrunch @bkyryliuk @vera-liu 
