### PR TITLE
sql editor min height

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -135,6 +135,15 @@ class SqlEditor extends React.Component {
   ctasChanged(event) {
     this.setState({ ctas: event.target.value });
   }
+
+  sqlEditorHeight() {
+    // quick hack to make the white bg of the tab stretch full height.
+    const tabNavHeight = 40;
+    const navBarHeight = 56;
+    const mysteryVerticalHeight = 50;
+    return window.innerHeight - tabNavHeight - navBarHeight - mysteryVerticalHeight;
+  }
+
   render() {
     let runButtons = (
       <ButtonGroup bsSize="small" className="inline m-r-5 pull-left">
@@ -248,7 +257,7 @@ class SqlEditor extends React.Component {
       </div>
     );
     return (
-      <div className="SqlEditor">
+      <div className="SqlEditor" style={{ minHeight: this.sqlEditorHeight() }}>
         <Row>
           <Col md={3}>
             <SqlEditorLeft queryEditor={this.props.queryEditor} />


### PR DESCRIPTION
- make tab full height even when little content, stretch for longer content

before:
<img width="1280" alt="screenshot 2016-09-08 13 00 35" src="https://cloud.githubusercontent.com/assets/130878/18364682/1838c8a6-75c4-11e6-9ec3-94b11a3e52f0.png">

after:
<img width="1280" alt="screenshot 2016-09-08 13 00 49" src="https://cloud.githubusercontent.com/assets/130878/18364686/1d375804-75c4-11e6-9e09-a4a479c40253.png">

@mistercrunch @bkyryliuk @vera-liu 
