### PR TITLE
Time grain support for unix-timestamp columns

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -591,6 +591,25 @@ class Database(Model, AuditMixinNullable):
     def grains_dict(self):
         return {grain.name: grain for grain in self.grains()}
 
+    def epoch_to_dttm(self, ms=False):
+        """Database-specific SQL to convert unix timestamp to datetime
+        """
+        ts2date_exprs = {
+            # Although this SQL expression converts unix timestamp to datetime,
+            # in SQLite, it won't work now due to double-percent-sign issue
+            # https://github.com/airbnb/caravel/issues/617
+            # 'sqlite': "strftime('%Y-%m-%d %H:%M:%S', {col}, 'unixepoch')",
+            'postgresql': "(timestamp 'epoch' + {col} * interval '1 second')",
+            'mysql': "from_unixtime({col})",
+            'mssql': "dateadd(S, {col}, '1970-01-01')"
+        }
+        ts2date_exprs['redshift'] = ts2date_exprs['postgresql']
+        ts2date_exprs['vertica'] = ts2date_exprs['postgresql']
+        for db_type, expr in ts2date_exprs.items():
+            if self.sqlalchemy_uri.startswith(db_type):
+                return expr.replace('{col}', '({col}/1000.0)') if ms else expr
+        raise Exception(_("Unable to convert unix epoch to datetime"))
+
     def get_extra(self):
         extra = {}
         if self.extra:
@@ -795,6 +814,12 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
             # Transforming time grain into an expression based on configuration
             time_grain_sqla = extras.get('time_grain_sqla')
             if time_grain_sqla:
+                if dttm_col.python_date_format == 'epoch_s':
+                    dttm_expr = self.database.epoch_to_dttm().format(
+                        col=dttm_expr)
+                elif dttm_col.python_date_format == 'epoch_ms':
+                    dttm_expr = self.database.epoch_to_dttm(ms=True).format(
+                        col=dttm_expr)
                 udf = self.database.grains_dict().get(time_grain_sqla, '{col}')
                 timestamp_grain = literal_column(
                     udf.function.format(col=dttm_expr)).label('timestamp')

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -595,10 +595,7 @@ class Database(Model, AuditMixinNullable):
         """Database-specific SQL to convert unix timestamp to datetime
         """
         ts2date_exprs = {
-            # Although this SQL expression converts unix timestamp to datetime,
-            # in SQLite, it won't work now due to double-percent-sign issue
-            # https://github.com/airbnb/caravel/issues/617
-            # 'sqlite': "strftime('%Y-%m-%d %H:%M:%S', {col}, 'unixepoch')",
+            'sqlite': "datetime({col}, 'unixepoch')",
             'postgresql': "(timestamp 'epoch' + {col} * interval '1 second')",
             'mysql': "from_unixtime({col})",
             'mssql': "dateadd(S, {col}, '1970-01-01')"

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -172,12 +172,9 @@ class BaseViz(object):
             raise Exception("No data, review your incantations!")
         else:
             if 'timestamp' in df.columns:
-                if timestamp_format == "epoch_s":
+                if timestamp_format in ("epoch_s", "epoch_ms"):
                     df.timestamp = pd.to_datetime(
-                        df.timestamp, utc=False, unit="s")
-                elif timestamp_format == "epoch_ms":
-                    df.timestamp = pd.to_datetime(
-                        df.timestamp, utc=False, unit="ms")
+                        df.timestamp, utc=False)
                 else:
                     df.timestamp = pd.to_datetime(
                         df.timestamp, utc=False, format=timestamp_format)


### PR DESCRIPTION
Caravel has basic support for using unix-timestamp as time column when using 'epoch_s' or 'epoch_ms' in python date format. But those unix-timestamp columns don't work well with time grains such as hour/day/week/month, which makes them almost useless. 

This PR adds time grain support for unix-timestamp columns. If a integer/real column stores unix timestamp data, you could toggle `is temporal` flag and set `Python date format` as `epoch_s` (or `epoch_ms` if in milliseconds). And now you could use it as time column in any time series visualization, and could select any time grain.

Below is a screenshot of using `epoch_s` to render a calendar view with example `multi_format_time_series` table
![image](https://cloud.githubusercontent.com/assets/58540/18432854/0363a350-7917-11e6-9699-74509bcc25fb.png)
