### PR TITLE
Implement permission request/approve flow. 

### DIFF
--- a/caravel/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
+++ b/caravel/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5e4a03ef0bf0'
-down_revision = '41f6a59a61f2'
+down_revision = '65903709c321'
 
 
 def upgrade():
@@ -25,8 +25,7 @@ def upgrade():
         sa.Column('created_by_fk', sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(['changed_by_fk'], ['ab_user.id'], ),
         sa.ForeignKeyConstraint(['created_by_fk'], ['ab_user.id'], ),
-        sa.ForeignKeyConstraint(['druid_datasource_id'],
-                                ['datasources.id'], ),
+        sa.ForeignKeyConstraint(['druid_datasource_id'], ['datasources.id'], ),
         sa.ForeignKeyConstraint(['table_id'], ['tables.id'], ),
         sa.PrimaryKeyConstraint('id')
     )

--- a/caravel/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
+++ b/caravel/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
@@ -1,0 +1,36 @@
+"""Add access_request table to manage requests to access datastores.
+
+Revision ID: 5e4a03ef0bf0
+Revises: 41f6a59a61f2
+Create Date: 2016-09-09 17:39:57.846309
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '5e4a03ef0bf0'
+down_revision = '41f6a59a61f2'
+
+
+def upgrade():
+    op.create_table(
+        'access_request',
+        sa.Column('created_on', sa.DateTime(), nullable=True),
+        sa.Column('changed_on', sa.DateTime(), nullable=True),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('table_id', sa.Integer(), nullable=True),
+        sa.Column('druid_datasource_id', sa.Integer(), nullable=True),
+        sa.Column('changed_by_fk', sa.Integer(), nullable=True),
+        sa.Column('created_by_fk', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['changed_by_fk'], ['ab_user.id'], ),
+        sa.ForeignKeyConstraint(['created_by_fk'], ['ab_user.id'], ),
+        sa.ForeignKeyConstraint(['druid_datasource_id'],
+                                ['datasources.id'], ),
+        sa.ForeignKeyConstraint(['table_id'], ['tables.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('access_request')

--- a/caravel/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
+++ b/caravel/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5e4a03ef0bf0'
-down_revision = '65903709c321'
+down_revision = 'b347b202819b'
 
 
 def upgrade():
@@ -19,14 +19,12 @@ def upgrade():
         sa.Column('created_on', sa.DateTime(), nullable=True),
         sa.Column('changed_on', sa.DateTime(), nullable=True),
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('table_id', sa.Integer(), nullable=True),
-        sa.Column('druid_datasource_id', sa.Integer(), nullable=True),
+        sa.Column('datasource_type', sa.String(length=200), nullable=True),
+        sa.Column('datasource_id', sa.Integer(), nullable=True),
         sa.Column('changed_by_fk', sa.Integer(), nullable=True),
         sa.Column('created_by_fk', sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(['changed_by_fk'], ['ab_user.id'], ),
         sa.ForeignKeyConstraint(['created_by_fk'], ['ab_user.id'], ),
-        sa.ForeignKeyConstraint(['druid_datasource_id'], ['datasources.id'], ),
-        sa.ForeignKeyConstraint(['table_id'], ['tables.id'], ),
         sa.PrimaryKeyConstraint('id')
     )
 

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -26,6 +26,7 @@ from flask import escape, g, Markup, request
 from flask_appbuilder import Model
 from flask_appbuilder.models.mixins import AuditMixin
 from flask_appbuilder.models.decorators import renders
+from flask_appbuilder.security.sqla.models import Role, PermissionView
 from flask_babel import lazy_gettext as _
 
 from pydruid.client import PyDruid
@@ -700,6 +701,10 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
             "(id:{obj.id})").format(obj=self)
 
     @property
+    def name(self):
+        return self.table_name
+
+    @property
     def full_name(self):
         return "[{obj.database}].[{obj.table_name}]".format(obj=self)
 
@@ -1199,6 +1204,10 @@ class DruidCluster(Model, AuditMixinNullable):
         for datasource in self.get_datasources():
             if datasource not in config.get('DRUID_DATA_SOURCE_BLACKLIST'):
                 DruidDatasource.sync_to_db(datasource, self)
+    @property
+    def perm(self):
+        return "[{obj.cluster_name}].(id:{obj.id})".format(obj=self)
+
     @property
     def perm(self):
         return "[{obj.cluster_name}].(id:{obj.id})".format(obj=self)
@@ -1997,6 +2006,7 @@ class Query(Model):
             'tempTable': self.tmp_table_name,
             'userId': self.user_id,
         }
+
     @property
     def name(self):
         ts = datetime.now().isoformat()
@@ -2004,3 +2014,66 @@ class Query(Model):
         tab = self.tab_name.replace(' ', '_').lower() if self.tab_name else 'notab'
         tab = re.sub(r'\W+', '', tab)
         return "sqllab_{tab}_{ts}".format(**locals())
+
+
+ROLES_BLACKLIST = set(['Admin', 'Alpha', 'Gamma', 'Public'])
+
+
+class DatasourceAccessRequest(Model, AuditMixinNullable):
+    """ORM model for the access requests for datasources and dbs."""
+    __tablename__ = 'access_request'
+    id = Column(Integer, primary_key=True)
+
+    table_id = Column(Integer, ForeignKey('tables.id'))
+    druid_datasource_id = Column(Integer, ForeignKey('datasources.id'))
+
+    table = relationship('SqlaTable', foreign_keys=[table_id])
+    druid_datasource = relationship(
+        'DruidDatasource', foreign_keys=[druid_datasource_id])
+
+    @property
+    def username(self):
+        return self.creator()
+
+    @property
+    def datasource(self):
+        if self.druid_datasource:
+            return self.druid_datasource
+        return self.table
+
+    @property
+    def datasource_url(self):
+        return self.datasource.link
+
+    @property
+    def permission_view(self):
+        return sm.find_permission_view_menu(
+            'datasource_access', self.datasource.perm)
+
+    @property
+    def roles_with_datasource(self):
+        action_list = ''
+        for r in self.permission_view.role:
+            if r.name in ROLES_BLACKLIST:
+                continue
+            url = (
+                '/caravel/approve?request_access_id={}&role_to_grant={}'
+                .format(self.id, r.name)
+            )
+            href = '<a href="{}">Grant {} Role</a>'.format(url, r.name)
+            action_list = action_list + '<li>' + href + '</li>'
+        return '<ul>' + action_list + '</ul>'
+
+    @property
+    def user_roles(self):
+        action_list = ''
+        for r in self.created_by.roles:
+            url = (
+                '/caravel/approve?request_access_id={}&role_to_extend={}'
+                .format(self.id, r.name)
+            )
+            href = '<a href="{}">Extend {} Role</a>'.format(url, r.name)
+            if r.name in ROLES_BLACKLIST:
+                href = "{} Role".format(r.name)
+            action_list = action_list + '<li>' + href + '</li>'
+        return '<ul>' + action_list + '</ul>'

--- a/caravel/templates/caravel/request_access.html
+++ b/caravel/templates/caravel/request_access.html
@@ -1,0 +1,24 @@
+{% extends "caravel/basic.html" %}
+{% block title %}{{ _("No Access!") }}{% endblock %}
+{% block body %}
+    {% include "caravel/flash_wrapper.html" %}
+    <h4>
+        {{ _("You do not have permissions to access the datasource %(name)s.",
+             name=datasource_name)
+        }}
+    </h4>
+    <div id="app">
+        <div id="buttons">
+            <button  onclick="window.location.href = '{{ request_access_url }}';"
+                     id="request"
+            >
+                {{ _("Request Permissions") }}
+            </button>
+            <button onclick="window.location.href = '{{ slicemodelview_link }}';"
+                    id="cancel"
+            >
+                {{ _("Cancel") }}
+            </button>
+        </div>
+    </div>
+{% endblock %}

--- a/caravel/templates/caravel/request_access.html
+++ b/caravel/templates/caravel/request_access.html
@@ -2,12 +2,12 @@
 {% block title %}{{ _("No Access!") }}{% endblock %}
 {% block body %}
     {% include "caravel/flash_wrapper.html" %}
-    <h4>
-        {{ _("You do not have permissions to access the datasource %(name)s.",
-             name=datasource_name)
-        }}
-    </h4>
-    <div id="app">
+    <div class="container">
+        <h4>
+            {{ _("You do not have permissions to access the datasource %(name)s.",
+                 name=datasource_name)
+            }}
+        </h4>
         <div id="buttons">
             <button  onclick="window.location.href = '{{ request_access_url }}';"
                      id="request"

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -627,16 +627,15 @@ appbuilder.add_view(
 class AccessRequestsModelView(CaravelModelView, DeleteMixin):
     datamodel = SQLAInterface(models.DatasourceAccessRequest)
     list_columns = [
-        'username', 'user_roles', 'datasource_url',
+        'username', 'user_roles', 'datasource_link',
         'roles_with_datasource', 'created_on']
-    order_columns = [
-        'username', 'datasource_url']
+    order_columns = ['username', 'datasource_link']
     base_order = ('changed_on', 'desc')
     label_columns = {
         'username': _("User"),
         'user_roles': _("User Roles"),
         'database': _("Database URL"),
-        'datasource_url': _("Datasource"),
+        'datasource_link': _("Datasource"),
         'roles_with_datasource': _("Roles to grant"),
         'created_on': _("Created On"),
     }
@@ -1020,10 +1019,10 @@ class Caravel(BaseCaravelView):
                 models.DatasourceAccessRequest.table_id == table_id,
                 models.DatasourceAccessRequest.druid_datasource_id ==
                 druid_datasource_id,
-            )
-        ).all()
+            ).all()
+        )
 
-        if len(duplicates) > 0:
+        if duplicates:
             flash(__(
                 "You have already requested access to the datasource %(name)s",
                 name=datasource_name), "warning")

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -22,7 +22,7 @@ class CaravelTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(CaravelTestCase, self).__init__(*args, **kwargs)
         self.client = app.test_client()
-
+        self.maxDiff = None
         utils.init(caravel)
 
         admin = appbuilder.sm.find_user('admin')
@@ -92,42 +92,13 @@ class CaravelTestCase(unittest.TestCase):
         session.close()
         return query
 
-    def get_access_requests(
-            self, username, table_id=None, druid_datasource_id=None):
-        if table_id:
-            return (
-                db.session.query(models.DatasourceAccessRequest)
-                .filter(
-                    models.DatasourceAccessRequest.created_by_fk ==
-                    sm.find_user(username).id,
-                    models.DatasourceAccessRequest.table_id == table_id
-                ).all()
-            )
-        if druid_datasource_id:
-            return (
-                db.session.query(models.DatasourceAccessRequest)
-                .filter(
-                    models.DatasourceAccessRequest.created_by_fk ==
-                    sm.find_user(username).id,
-                    models.DatasourceAccessRequest.druid_datasource_id ==
-                    druid_datasource_id
-                ).all()
-            )
-
-
-    def get_table_by_name(self, table_name):
-        return (
-            db.session.query(models.SqlaTable)
-                .filter(models.SqlaTable.table_name == table_name)
-                .first()
-        )
-
-    def get_druid_ds_by_name(self, druid_ds_name):
-        return (
-            db.session.query(models.DruidDatasource)
-                .filter(models.DruidDatasource.datasource_name == druid_ds_name)
-                .first()
-        )
+    def get_access_requests(self, username, ds_type, ds_id):
+            return db.session.query(models.DatasourceAccessRequest).filter(
+                models.DatasourceAccessRequest.created_by_fk ==
+                sm.find_user(username=username).id,
+                models.DatasourceAccessRequest.datasource_type == ds_type,
+                models.DatasourceAccessRequest.datasource_id == ds_id
+            ).all()
 
     def logout(self):
         self.client.get('/logout/', follow_redirects=True)


### PR DESCRIPTION
This PR implements the basic request permissions flow: https://github.com/airbnb/caravel/issues/1049
**For the 1st iteration it is pretty simple flow:**
- permission requests exist on the user - datasource (table or druid) level
- user is redirected to the request form if he/she doesn't have permissions
- admins, alphas or datasource owners have permissions to approve the requests. only admins can grant roles to the users
- the access request view is visible to admins only
- there are 2 ways to grant the permission to the user, grant the user role that has access to the datasource, extend the role the user already has to provide access to the datasource
- disallows multiple requests to the same datasource
- extensive testing, it was quite tricky to make it working

**Potential future improvements:**
- request access to the databases, not only to the datasources
- include free form message in the request form
- offer to create a role if there are 0 roles granting access to the given datasource
- email notifications 
- batch approval
- automatic clean up of the request if approving one of the requests resolves all others
- store some metadata - dashboard / slide ids
- better support for the dashboards - show the slices you have access to and allow to request access to others

Reviewers:
- @mistercrunch 
- @ascott 
- @vera-liu 

**Screenshots**

![request_flow](https://cloud.githubusercontent.com/assets/5727938/18534979/2e21c362-7aa5-11e6-84ee-bd8e0cbe2125.gif)

![approve_flow](https://cloud.githubusercontent.com/assets/5727938/18534967/1730ae02-7aa5-11e6-9361-3acfe8a2ada2.gif)
