### PR TITLE
Clean up the druid sync api.

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1388,9 +1388,10 @@ class Caravel(BaseCaravelView):
                 "dimensions": ["affiliate_id", "campaign", "first_seen"]
             }
         """
-        druid_config = json.loads(request.form.get('config'))
-        user_name = request.form.get('user')
-        cluster_name = request.form.get('cluster')
+        payload = request.get_json(force=True)
+        druid_config = payload['config']
+        user_name = payload['user']
+        cluster_name = payload['cluster']
 
         user = sm.find_user(username=user_name)
         if not user:

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -218,35 +218,25 @@ class CoreTests(CaravelTestCase):
         db.session.commit()
 
         cfg = {
-            "name": "test_click",
-            "dimensions": ["affiliate_id", "campaign", "first_seen"],
-            "metrics_spec": [{"type": "count", "name": "count"},
-                             {"type": "sum", "name": "sum"}],
-            "batch_ingestion": {
-                "sql": "SELECT * FROM clicks WHERE d='{{ ds }}'",
-                "ts_column": "d",
-                "sources": [{
-                    "table": "clicks",
-                    "partition": "d='{{ ds }}'"
-                }]
+            "user": "admin",
+            "cluster": "new_druid",
+            "config": {
+                "name": "test_click",
+                "dimensions": ["affiliate_id", "campaign", "first_seen"],
+                "metrics_spec": [{"type": "count", "name": "count"},
+                                 {"type": "sum", "name": "sum"}],
+                "batch_ingestion": {
+                    "sql": "SELECT * FROM clicks WHERE d='{{ ds }}'",
+                    "ts_column": "d",
+                    "sources": [{
+                        "table": "clicks",
+                        "partition": "d='{{ ds }}'"
+                    }]
+                }
             }
         }
-        resp = self.client.post(
-            '/caravel/sync_druid/', data=dict(
-                config=json.dumps(cfg), user="admin", cluster="new_druid"))
+        resp = self.client.post('/caravel/sync_druid/', data=json.dumps(cfg))
 
-        druid_ds = db.session.query(DruidDatasource).filter_by(
-            datasource_name="test_click").first()
-        assert set([c.column_name for c in druid_ds.columns]) == set(
-            ["affiliate_id", "campaign", "first_seen"])
-        assert set([m.metric_name for m in druid_ds.metrics]) == set(
-            ["count", "sum"])
-        assert resp.status_code == 201
-
-        # Datasource exists, not changes required
-        resp = self.client.post(
-            '/caravel/sync_druid/', data=dict(
-                config=json.dumps(cfg), user="admin", cluster="new_druid"))
         druid_ds = db.session.query(DruidDatasource).filter_by(
             datasource_name="test_click").first()
         assert set([c.column_name for c in druid_ds.columns]) == set(
@@ -256,17 +246,29 @@ class CoreTests(CaravelTestCase):
         assert resp.status_code == 201
 
         # datasource exists, not changes required
+        resp = self.client.post('/caravel/sync_druid/', data=json.dumps(cfg))
+        druid_ds = db.session.query(DruidDatasource).filter_by(
+            datasource_name="test_click").first()
+        assert set([c.column_name for c in druid_ds.columns]) == set(
+            ["affiliate_id", "campaign", "first_seen"])
+        assert set([m.metric_name for m in druid_ds.metrics]) == set(
+            ["count", "sum"])
+        assert resp.status_code == 201
+
+        # datasource exists, add new metrics and dimentions
         cfg = {
-            "name": "test_click",
-            "dimensions": ["affiliate_id", "second_seen"],
-            "metrics_spec": [
-                {"type": "bla", "name": "sum"},
-                {"type": "unique", "name": "unique"}
-            ],
+            "user": "admin",
+            "cluster": "new_druid",
+            "config": {
+                "name": "test_click",
+                "dimensions": ["affiliate_id", "second_seen"],
+                "metrics_spec": [
+                    {"type": "bla", "name": "sum"},
+                    {"type": "unique", "name": "unique"}
+                ],
+            }
         }
-        resp = self.client.post(
-            '/caravel/sync_druid/', data=dict(
-                config=json.dumps(cfg), user="admin", cluster="new_druid"))
+        resp = self.client.post('/caravel/sync_druid/', data=json.dumps(cfg))
         druid_ds = db.session.query(DruidDatasource).filter_by(
             datasource_name="test_click").first()
         # columns and metrics are not deleted if config is changed as


### PR DESCRIPTION
Cleans up the druid sync api to pass the data as the json blob rather than 3 separate attributes.

Reviewers:
- @mistercrunch 
- @ascott 
- @vera-liu 
