### PR TITLE
[explore] giving more room to Slice title

### DIFF
--- a/caravel/templates/caravel/explore.html
+++ b/caravel/templates/caravel/explore.html
@@ -189,11 +189,11 @@
         <div class="panel panel-default">
           <div class="panel-heading">
             <div class="panel-title">
-              <div class="row">
-                <div class="col-md-6">
+              <div class="clearfix">
+                <div class="pull-left">
                   {% include 'caravel/partials/_explore_title.html' %}
                 </div>
-                <div class="col-md-6">
+                <div class="pull-right">
                   <div class="slice-meta-controls pull-right">
                     <span id="is_cached" class="label label-default m-r-3" title="{{ _("Force refresh" )}}" data-toggle="tooltip">
                       cached

--- a/caravel/templates/caravel/partials/_explore_title.html
+++ b/caravel/templates/caravel/partials/_explore_title.html
@@ -26,5 +26,5 @@
     </h2>
   {% endif %}
 {% else %}
-  <h2>[{{ viz.datasource.table_name }}] - untitled</h2>
+  <h3>[{{ viz.datasource.table_name }}] - untitled</h3>
 {% endif %}


### PR DESCRIPTION
Alternate solution to https://github.com/airbnb/caravel/pull/1115/files
Before:
<img width="1260" alt="screen shot 2016-09-15 at 9 10 03 am" src="https://cloud.githubusercontent.com/assets/487433/18557704/dade3fe8-7b24-11e6-8669-0c2fb2d348e2.png">

After:
<img width="1262" alt="screen shot 2016-09-15 at 9 13 15 am" src="https://cloud.githubusercontent.com/assets/487433/18557706/dadf5f22-7b24-11e6-8161-085c339c0b6b.png">
<img width="1260" alt="screen shot 2016-09-15 at 9 12 37 am" src="https://cloud.githubusercontent.com/assets/487433/18557705/dade41be-7b24-11e6-9839-4b77c5316e78.png">
