### PR TITLE
When the label size is too short, the constant for calculating

### DIFF
--- a/caravel/assets/visualizations/nvd3_vis.css
+++ b/caravel/assets/visualizations/nvd3_vis.css
@@ -18,6 +18,11 @@ text.nv-axislabel {
 
 .dist_bar svg.nvd3-svg {
   width: auto;
+  font-size: 14px;
+}
+
+.nv-x text{
+  font-size: 12px;
 }
 
 .bar .slice_container {

--- a/caravel/assets/visualizations/nvd3_vis.js
+++ b/caravel/assets/visualizations/nvd3_vis.js
@@ -69,14 +69,16 @@ function nvd3Vis(slice) {
 
       // Calculates the longest label size for stretching bottom margin
       function calculateStretchMargins(payloadData) {
-        const axisLabels = payloadData.data[0].values;
         let stretchMargin = 0;
         const pixelsPerCharX = 4.5; // approx, depends on font size
-        let maxLabelSize = 0;
-        for (let i = 0; i < axisLabels.length; i++) {
-          maxLabelSize = Math.max(axisLabels[i].x.length, maxLabelSize);
-        }
-        stretchMargin = Math.ceil(Math.max(stretchMargin, pixelsPerCharX * maxLabelSize));
+        let maxLabelSize = 10; // accomodate for shorter labels
+        payloadData.data.forEach((d) => {
+          const axisLabels = d.values;
+          for (let i = 0; i < axisLabels.length; i++) {
+            maxLabelSize = Math.max(axisLabels[i].x.length, maxLabelSize);
+          }
+        });
+        stretchMargin = Math.ceil(pixelsPerCharX * maxLabelSize);
         return stretchMargin;
       }
 


### PR DESCRIPTION
- issue: [https://github.com/airbnb/caravel/issues/1112](url)
- margin_size does not apply. Also nvd3 auto adjusts font-size of axis
  labels.
- Temporary solution here: Setting a fixed font-size on nvd3 axis labels
  and a minimum threshold for label size.

![screen shot 2016-09-15 at 12 00 45 pm](https://cloud.githubusercontent.com/assets/20978302/18563848/09f0c602-7b3e-11e6-85be-5b8a93a99446.png)
![screen shot 2016-09-15 at 12 08 45 pm](https://cloud.githubusercontent.com/assets/20978302/18563854/0ed2ed76-7b3e-11e6-8d0d-9b9f83fababd.png)

needs-review @ascott @mistercrunch @bkyryliuk 
