### PR TITLE
Fix initialization of Database sqlalchemy_uri and password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,10 @@ before_install:
   - npm install -g npm@'>=3.9.5'
 before_script:
   - mysql -e 'drop database if exists caravel; create database caravel DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci' -u root
+  - mysql -u root -e "CREATE USER 'mysqluser'@'localhost' IDENTIFIED BY 'mysqluserpassword';"
+  - mysql -u root -e "GRANT ALL ON caravel.* TO 'mysqluser'@'localhost';"
   - psql -c 'create database caravel;' -U postgres
+  - psql -c "CREATE USER postgresuser WITH PASSWORD 'pguserpassword';" -U postgres
   - export PATH=${PATH}:/tmp/hive/bin
 install:
   - pip install --upgrade pip

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -433,6 +433,12 @@ class Database(Model, AuditMixinNullable):
         url = make_url(self.sqlalchemy_uri_decrypted)
         return url.get_backend_name()
 
+    def set_sqlalchemy_uri(self, uri):
+        conn = sqla.engine.url.make_url(uri)
+        self.password = conn.password
+        conn.password = "X" * 10 if conn.password else None
+        self.sqlalchemy_uri = str(conn)  # hides the password
+
     def get_sqla_engine(self, schema=None):
         extra = self.get_extra()
         url = make_url(self.sqlalchemy_uri_decrypted)

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -100,7 +100,7 @@ def get_or_create_main_db(caravel):
     if not dbobj:
         dbobj = DB(database_name="main")
     logging.info(config.get("SQLALCHEMY_DATABASE_URI"))
-    dbobj.sqlalchemy_uri = config.get("SQLALCHEMY_DATABASE_URI")
+    dbobj.set_sqlalchemy_uri(config.get("SQLALCHEMY_DATABASE_URI"))
     dbobj.expose_in_sqllab = True
     db.session.add(dbobj)
     db.session.commit()

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -115,16 +115,29 @@ class CoreTests(CaravelTestCase):
         assert self.client.get('/ping').data.decode('utf-8') == "OK"
 
     def test_testconn(self):
-        data = json.dumps({'uri': 'sqlite:////tmp/caravel_unittests.db'})
-        response = self.client.post('/caravel/testconn', data=data, content_type='application/json')
-        assert response.status_code == 200
+        database = (
+            db.session
+            .query(models.Database)
+            .filter_by(database_name='main')
+            .first()
+        )
 
+        # validate that the endpoint works with the password-masked sqlalchemy uri
         data = json.dumps({
-            'uri': 'postgresql+psycopg2://foo:XXXXXXXXXX@127.0.0.1/bar',
+            'uri': database.safe_sqlalchemy_uri(),
             'name': 'main'
         })
         response = self.client.post('/caravel/testconn', data=data, content_type='application/json')
         assert response.status_code == 200
+
+        # validate that the endpoint works with the decrypted sqlalchemy uri
+        data = json.dumps({
+            'uri': database.sqlalchemy_uri_decrypted,
+            'name': 'main'
+        })
+        response = self.client.post('/caravel/testconn', data=data, content_type='application/json')
+        assert response.status_code == 200
+
 
     def test_warm_up_cache(self):
         slice = db.session.query(models.Slice).first()

--- a/tox.ini
+++ b/tox.ini
@@ -37,17 +37,17 @@ commands =
 [testenv:py27-mysql]
 basepython = python2.7
 setenv =
-    CARAVEL__SQLALCHEMY_DATABASE_URI = mysql://root@localhost/caravel
+    CARAVEL__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/caravel
 
 [testenv:py34-mysql]
 basepython = python3.4
 setenv =
-    CARAVEL__SQLALCHEMY_DATABASE_URI = mysql://root@localhost/caravel
+    CARAVEL__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/caravel
 
 [testenv:py35-mysql]
 basepython = python3.5
 setenv =
-    CARAVEL__SQLALCHEMY_DATABASE_URI = mysql://root@localhost/caravel
+    CARAVEL__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/caravel
 
 [testenv:py27-sqlite]
 basepython = python2.7
@@ -62,12 +62,12 @@ setenv =
 [testenv:py27-postgres]
 basepython = python2.7
 setenv =
-    CARAVEL__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://postgres@localhost/caravel
+    CARAVEL__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://postgresuser:pguserpassword@localhost/caravel
 
 [testenv:py34-postgres]
 basepython = python3.4
 setenv =
-    CARAVEL__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://postgres@localhost/caravel
+    CARAVEL__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://postgresuser:pguserpassword@localhost/caravel
 
 [testenv:javascript]
 commands = {toxinidir}/caravel/assets/js_build.sh


### PR DESCRIPTION
Move initialization of Database sqlalchemy_uri and password from DatabaseView.pre_add to utils.get_or_create_main_db.  This fixes an issue where a clean install of Caravel using a database with a username and password failed to initialize properly.

Updates the unit tests for mysql and postgres to include username and password in the SQLALCHEMY_DATABASE_URI.  Previously, including a username and password in these URIs would lead to failing tests.

This fixes issue #1070 
This supercedes PR #1092 (now closed).
