### PR TITLE
Add support for Werkzeug ProxyFix middleware

### DIFF
--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -14,6 +14,7 @@ from sqlalchemy import event, exc
 from flask_appbuilder.baseviews import expose
 from flask_cache import Cache
 from flask_migrate import Migrate
+from werkzeug.contrib.fixers import ProxyFix
 
 
 APP_DIR = os.path.dirname(__file__)
@@ -76,6 +77,9 @@ if app.config.get('ENABLE_TIME_ROTATE'):
 if app.config.get('ENABLE_CORS'):
     from flask_cors import CORS
     CORS(app, **app.config.get('CORS_OPTIONS'))
+
+if app.config.get('ENABLE_PROXY_FIX'):
+    app.wsgi_app = ProxyFix(app.wsgi_app)
 
 
 class MyIndexView(IndexView):

--- a/caravel/config.py
+++ b/caravel/config.py
@@ -56,6 +56,9 @@ DEBUG = False
 # Whether to show the stacktrace on 500 error
 SHOW_STACKTRACE = True
 
+# Extract and use X-Forwarded-For/X-Forwarded-Proto headers?
+ENABLE_PROXY_FIX = False
+
 # ------------------------------
 # GLOBALS FOR APP Builder
 # ------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -108,6 +108,10 @@ load balancer knows if your caravel instance is running. This is provided
 at ``/health`` which will return a 200 response containing "OK" if the
 webserver is running.
 
+If the load balancer is inserting X-Forwarded-For/X-Forwarded-Proto headers, you
+should set `ENABLE_PROXY_FIX = True` in the caravel config file to extract and use
+the headers.
+
 
 Configuration
 -------------


### PR DESCRIPTION
Add an ENABLE_PROXY_FIX config param.  When set to True, insert the Werkzeug ProxyFix
middleware.  This middleware extracts and applies the X-Forwarded-\* headers that are
inserted by common proxies and load balancers.

Fixes #1139.
