### PR TITLE
[SQL Lab] Adding indexes to table metadata

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/SqlEditorLeft.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditorLeft.jsx
@@ -102,22 +102,27 @@ class SqlEditorTopToolbar extends React.Component {
     const tableName = tableOpt.value;
     const qe = this.props.queryEditor;
     const url = `/caravel/table/${qe.dbId}/${tableName}/${qe.schema}/`;
+
+    this.setState({ tableLoading: true });
     $.get(url, (data) => {
       this.props.actions.addTable({
         id: shortid.generate(),
         dbId: this.props.queryEditor.dbId,
         queryEditorId: this.props.queryEditor.id,
         name: data.name,
+        indexes: data.indexes,
         schema: qe.schema,
         columns: data.columns,
         expanded: true,
       });
+      this.setState({ tableLoading: false });
     })
     .fail(() => {
       this.props.actions.addAlert({
         msg: 'Error occurred while fetching metadata',
         bsStyle: 'danger',
       });
+      this.setState({ tableLoading: false });
     });
   }
   render() {

--- a/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as Actions from '../actions';
 import shortid from 'shortid';
+import ModalTrigger from '../../components/ModalTrigger.jsx';
 
 class TableElement extends React.Component {
   setSelectStar() {
@@ -86,6 +87,27 @@ class TableElement extends React.Component {
         </a>
       );
     }
+    let keyLink;
+    if (this.props.table.indexes && this.props.table.indexes.length > 0) {
+      keyLink = (
+        <ModalTrigger
+          modalTitle={
+            <div>
+              Keys for table <strong>{this.props.table.name}</strong>
+            </div>
+          }
+          modalBody={
+            <pre>{JSON.stringify(this.props.table.indexes, null, 4)}</pre>
+          }
+          triggerNode={
+            <Link
+              className="fa fa-key pull-left m-l-2"
+              tooltip={`View indexes (${this.props.table.indexes.length})`}
+            />
+          }
+        />
+      );
+    }
     return (
       <div>
         <div className="clearfix">
@@ -94,6 +116,7 @@ class TableElement extends React.Component {
           </div>
           <div className="pull-right">
             <ButtonGroup className="ws-el-controls pull-right">
+              {keyLink}
               <Link
                 className="fa fa-pencil pull-left m-l-2"
                 onClick={this.setSelectStar.bind(this)}

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -641,6 +641,9 @@ class Database(Model, AuditMixinNullable):
     def get_columns(self, table_name, schema=None):
         return self.inspector.get_columns(table_name, schema)
 
+    def get_indexes(self, table_name, schema=None):
+        return self.inspector.get_indexes(table_name, schema)
+
     @property
     def sqlalchemy_uri_decrypted(self):
         conn = sqla.engine.url.make_url(self.sqlalchemy_uri)

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1535,9 +1535,11 @@ class Caravel(BaseCaravelView):
         schema = None if schema in ('null', 'undefined') else schema
         mydb = db.session.query(models.Database).filter_by(id=database_id).one()
         cols = []
+        indexes = []
         t = mydb.get_columns(table_name, schema)
         try:
             t = mydb.get_columns(table_name, schema)
+            indexes = mydb.get_indexes(table_name, schema)
         except Exception as e:
             return Response(
                 json.dumps({'error': utils.error_msg_from_exception(e)}),
@@ -1556,6 +1558,7 @@ class Caravel(BaseCaravelView):
         tbl = {
             'name': table_name,
             'columns': cols,
+            'indexes': indexes,
         }
         return Response(json.dumps(tbl), mimetype="application/json")
 


### PR DESCRIPTION
Showing the json isn't the most polished option, but the keys that SqlAlchemy return aren't 100% homogenous and thought this would do the trick of exposing everything we have with minimal effort.

Based on the PyHive documentation, this will show the partition key for Hive/Presto tables

---
## <img width="308" alt="screen shot 2016-09-20 at 9 23 05 pm" src="https://cloud.githubusercontent.com/assets/487433/18697999/6f88e076-7f7b-11e6-8764-7175adcb89df.png">

<img width="584" alt="screen shot 2016-09-20 at 9 23 13 pm" src="https://cloud.githubusercontent.com/assets/487433/18697998/6f77386c-7f7b-11e6-957a-7cd0efc48509.png">
