### PR TITLE
Add dashboard creator as owner of the dashboard

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -822,7 +822,8 @@ class DashboardModelView(CaravelModelView, DeleteMixin):  # noqa
         if obj.slug:
             obj.slug = obj.slug.replace(" ", "-")
             obj.slug = re.sub(r'\W+', '', obj.slug)
-        obj.owners.append(g.user)
+        if g.user not in obj.owners:
+            obj.owners.append(g.user)
 
     def pre_update(self, obj):
         check_ownership(obj)

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -822,6 +822,7 @@ class DashboardModelView(CaravelModelView, DeleteMixin):  # noqa
         if obj.slug:
             obj.slug = obj.slug.replace(" ", "-")
             obj.slug = re.sub(r'\W+', '', obj.slug)
+        obj.owners.append(g.user)
 
     def pre_update(self, obj):
         check_ownership(obj)


### PR DESCRIPTION
Adds creator as a owner of the dashboard.
Tested locally.

Issue:
https://github.com/airbnb/caravel/issues/780

Reviewers:
- @mistercrunch 
- @ascott 
- @vera-liu 
