### PR TITLE
Bring DB in sync with the models.py

### DIFF
--- a/caravel/migrations/versions/3b626e2a6783_sync_db_with_models.py
+++ b/caravel/migrations/versions/3b626e2a6783_sync_db_with_models.py
@@ -1,0 +1,58 @@
+"""Sync DB with the models.py.
+
+Revision ID: 3b626e2a6783
+Revises: 5e4a03ef0bf0
+Create Date: 2016-09-22 10:21:33.618976
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3b626e2a6783'
+down_revision = '5e4a03ef0bf0'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+def upgrade():
+    # fixed issue: https://github.com/airbnb/caravel/issues/466
+    op.create_foreign_key(
+        None, 'columns', 'datasources', ['datasource_name'],
+        ['datasource_name'])
+    op.create_unique_constraint(None, 'query', ['client_id'])
+    op.drop_column('query', 'name')
+
+    # cleanup after: https://github.com/airbnb/caravel/pull/1078
+    op.drop_constraint('slices_ibfk_2', 'slices', type_='foreignkey')
+    op.drop_constraint('slices_ibfk_1', 'slices', type_='foreignkey')
+    op.drop_column('slices', 'druid_datasource_id')
+    op.drop_column('slices', 'table_id')
+
+
+    op.create_unique_constraint(
+        '_customer_location_uc', 'tables',
+        ['database_id', 'schema', 'table_name'])
+    op.drop_index('table_name', table_name='tables')
+
+
+def downgrade():
+    op.create_index('table_name', 'tables', ['table_name'], unique=True)
+    op.drop_constraint(u'_customer_location_uc', 'tables', type_='unique')
+
+    op.add_column('slices', sa.Column(
+        'table_id', mysql.INTEGER(display_width=11), autoincrement=False,
+        nullable=True))
+    op.add_column(
+        'slices',  sa.Column('druid_datasource_id', sa.Integer(),
+                             autoincrement=False, nullable=True))
+    op.create_foreign_key(
+        'slices_ibfk_1', 'slices', 'datasources',
+        ['druid_datasource_id'], ['id'])
+    op.create_foreign_key(
+        'slices_ibfk_2', 'slices', 'tables', ['table_id'], ['id'])
+
+    op.add_column(
+        'query', sa.Column('name', sa.String(length=256), nullable=True))
+    op.drop_constraint(None, 'query', type_='unique')
+    op.drop_constraint(None, 'columns', type_='foreignkey')

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -670,6 +670,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
     table_name = Column(String(250))
     main_dttm_col = Column(String(250))
     description = Column(Text)
+    default_endpoint = Column(Text)
     database_id = Column(Integer, ForeignKey('dbs.id'), nullable=False)
     is_featured = Column(Boolean, default=False)
     user_id = Column(Integer, ForeignKey('ab_user.id'))

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -670,7 +670,6 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
     table_name = Column(String(250))
     main_dttm_col = Column(String(250))
     description = Column(Text)
-    default_endpoint = Column(Text)
     database_id = Column(Integer, ForeignKey('dbs.id'), nullable=False)
     is_featured = Column(Boolean, default=False)
     user_id = Column(Integer, ForeignKey('ab_user.id'))
@@ -1943,7 +1942,7 @@ class Query(Model):
 
     __tablename__ = 'query'
     id = Column(Integer, primary_key=True)
-    client_id = Column(String(11), unique=True)
+    client_id = Column(String(11), unique=True, nullable=False)
 
     database_id = Column(Integer, ForeignKey('dbs.id'), nullable=False)
 

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -446,6 +446,16 @@ def validate_json(obj):
             raise CaravelException("JSON is not valid")
 
 
+def table_has_constraint(table, name, db):
+    """Utility to find a constraint name in alembic migrations"""
+    t = sa.Table(table, db.metadata, autoload=True, autoload_with=db.engine)
+
+    for c in t.constraints:
+        if c.name == name:
+            return True
+    return False
+
+
 class timeout(object):
     """
     To be used in a ``with`` block and timeout its content.

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -125,7 +125,7 @@ class CeleryTestCase(CaravelTestCase):
             shell=True
         )
 
-    def run_sql(self, dbid, sql, cta='false', tmp_table='tmp',
+    def run_sql(self, dbid, sql, client_id, cta='false', tmp_table='tmp',
                 async='false'):
         self.login()
         resp = self.client.post(
@@ -136,7 +136,7 @@ class CeleryTestCase(CaravelTestCase):
                 async=async,
                 select_as_cta=cta,
                 tmp_table_name=tmp_table,
-                client_id="not_used",
+                client_id=client_id,
             ),
         )
         self.logout()
@@ -185,14 +185,14 @@ class CeleryTestCase(CaravelTestCase):
         # Case 1.
         # Table doesn't exist.
         sql_dont_exist = 'SELECT name FROM table_dont_exist'
-        result1 = self.run_sql(1, sql_dont_exist, cta='true', )
+        result1 = self.run_sql(1, sql_dont_exist, "1", cta='true')
         self.assertTrue('error' in result1)
 
         # Case 2.
         # Table and DB exists, CTA call to the backend.
         sql_where = "SELECT name FROM ab_permission WHERE name='can_sql'"
         result2 = self.run_sql(
-            1, sql_where, tmp_table='tmp_table_2', cta='true')
+            1, sql_where, "2", tmp_table='tmp_table_2', cta='true')
         self.assertEqual(QueryStatus.SUCCESS, result2['query']['state'])
         self.assertEqual([], result2['data'])
         self.assertEqual([], result2['columns'])
@@ -207,7 +207,7 @@ class CeleryTestCase(CaravelTestCase):
         # Table and DB exists, CTA call to the backend, no data.
         sql_empty_result = 'SELECT * FROM ab_user WHERE id=666'
         result3 = self.run_sql(
-            1, sql_empty_result, tmp_table='tmp_table_3', cta='true',)
+            1, sql_empty_result, "3", tmp_table='tmp_table_3', cta='true',)
         self.assertEqual(QueryStatus.SUCCESS, result3['query']['state'])
         self.assertEqual([], result3['data'])
         self.assertEqual([], result3['columns'])
@@ -226,7 +226,7 @@ class CeleryTestCase(CaravelTestCase):
         # Table and DB exists, async CTA call to the backend.
         sql_where = "SELECT name FROM ab_role WHERE name='Admin'"
         result1 = self.run_sql(
-            1, sql_where, async='true', tmp_table='tmp_async_1', cta='true')
+            1, sql_where, "4", async='true', tmp_table='tmp_async_1', cta='true')
         assert result1['query']['state'] in (
             QueryStatus.PENDING, QueryStatus.RUNNING, QueryStatus.SUCCESS)
 

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -572,7 +572,7 @@ class CoreTests(CaravelTestCase):
         resp = self.client.get('/dashboardmodelview/list/')
         assert "List Dashboard" in resp.data.decode('utf-8')
 
-    def run_sql(self, sql, user_name, client_id='not_used'):
+    def run_sql(self, sql, user_name, client_id):
         self.login(username=user_name)
         dbid = (
             db.session.query(models.Database)
@@ -581,16 +581,17 @@ class CoreTests(CaravelTestCase):
         )
         resp = self.client.post(
             '/caravel/sql_json/',
-            data=dict(database_id=dbid, sql=sql, select_as_create_as=False, client_id=client_id),
+            data=dict(database_id=dbid, sql=sql, select_as_create_as=False,
+                      client_id=client_id),
         )
         self.logout()
         return json.loads(resp.data.decode('utf-8'))
 
     def test_sql_json(self):
-        data = self.run_sql('SELECT * FROM ab_user', 'admin')
+        data = self.run_sql('SELECT * FROM ab_user', 'admin', "1")
         assert len(data['data']) > 0
 
-        data = self.run_sql('SELECT * FROM unexistant_table', 'admin')
+        data = self.run_sql('SELECT * FROM unexistant_table', 'admin', "2")
         assert len(data['error']) > 0
 
     def test_sql_json_has_access(self):
@@ -617,7 +618,7 @@ class CoreTests(CaravelTestCase):
                 'gagarin', 'Iurii', 'Gagarin', 'gagarin@cosmos.ussr',
                 appbuilder.sm.find_role('Astronaut'),
                 password='general')
-        data = self.run_sql('SELECT * FROM ab_user', 'gagarin')
+        data = self.run_sql('SELECT * FROM ab_user', 'gagarin', "3")
         db.session.query(models.Query).delete()
         db.session.commit()
         assert len(data['data']) > 0


### PR DESCRIPTION
Fixes https://github.com/airbnb/caravel/issues/466 and cleans up the result of the `caravel db migrate`.
In addition this change makes client_id unique and updates the tests.

Tested via on MySQL:

```
caravel db history
caravel db upgrade 
caravel db downgrade eca4694defa7
caravel db upgrade 
```

SQL Lite doesn't support most of the operations here.

Reviewers:
- @mistercrunch
- @ascott 
- @vera-liu 
