### PR TITLE
when adding a new database use Database.set_sqlalchemy_uri

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -521,6 +521,7 @@ class DatabaseView(CaravelModelView, DeleteMixin):  # noqa
     }
 
     def pre_add(self, db):
+        db.set_sqlalchemy_uri(db.sqlalchemy_uri)
         utils.merge_perm(sm, 'database_access', db.perm)
 
     def pre_update(self, db):


### PR DESCRIPTION
When adding a new database in the UI, call `Database.set_sqlalchemy_uri` in `DatabaseView.pre_add`.

This fixes a regression I introduced with PR #1137

The issue is #1176 
