### PR TITLE
Time grain config

### DIFF
--- a/caravel/config.py
+++ b/caravel/config.py
@@ -240,7 +240,7 @@ SQLLAB_TIMEOUT = 30
 # ---------------------------------------------------
 
 # DB_CUSTOM_GRAIN = (
-#     ('vertica', (
+#     ('postgresql', (
 #         ("Time Column", 'Time Column', "{col}"),
 #         ("second", 'second', "DATE_TRUNC('second', {col})"),
 #         ("minute", 'minute', "DATE_TRUNC('minute', {col})"),

--- a/caravel/config.py
+++ b/caravel/config.py
@@ -235,6 +235,25 @@ DEFAULT_DB_ID = None
 # Timeout duration for SQL Lab synchronous queries
 SQLLAB_TIMEOUT = 30
 
+# ---------------------------------------------------
+# Configure Caravel to use a custom Time Grain for Databases
+# ---------------------------------------------------
+
+# DB_CUSTOM_GRAIN = (
+#     ('vertica', (
+#         ("Time Column", 'Time Column', "{col}"),
+#         ("second", 'second', "DATE_TRUNC('second', {col})"),
+#         ("minute", 'minute', "DATE_TRUNC('minute', {col})"),
+#         ("hour", 'hour', "DATE_TRUNC('hour', {col})"),
+#         ("day", 'day', "DATE_TRUNC('day', {col})"),
+#         ("week", 'week', "DATE({col}) - DAYOFWEEK(DATE({col})) + 1"),
+#         ("month", 'month', "DATE_TRUNC('month', {col})"),
+#         ("year", 'year', "DATE_TRUNC('year', {col})"),
+#     )),
+#     )
+
+DB_CUSTOM_GRAIN = None
+
 try:
     from caravel_config import *  # noqa
 except ImportError:

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -594,6 +594,13 @@ class Database(Model, AuditMixinNullable):
         }
         db_time_grains['redshift'] = db_time_grains['postgresql']
         db_time_grains['vertica'] = db_time_grains['postgresql']
+        custom_grain = config.get('DB_CUSTOM_GRAIN')
+        if custom_grain:
+            for db, grains in custom_grain:
+                db_time_grains[db] = tuple(
+                    Grain(name, label, function)
+                    for name, label, function in grains)
+
         for db_type, grains in db_time_grains.items():
             if self.sqlalchemy_uri.startswith(db_type):
                 return grains


### PR DESCRIPTION
Allow the user to configure the Time Grain for the Database.

This should make solving issues like #971 easier without having to fork
