### PR TITLE
[Easy] Remove duplicate code for property name of SqlaTable

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -744,10 +744,6 @@ class SqlaTable(Model, Queryable, AuditMixinNullable):
                 "table-condensed"))
 
     @property
-    def name(self):
-        return self.table_name
-
-    @property
     def metrics_combo(self):
         return sorted(
             [


### PR DESCRIPTION
The code 
`@property
    def name(self):
        return self.table_name
`

is duplicated in the class SqlaTable. 

First simple pull request to test the water in this project.
