### PR TITLE
do not overwrite the stored password with the masked password

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -439,9 +439,12 @@ class Database(Model, AuditMixinNullable):
         return url.get_backend_name()
 
     def set_sqlalchemy_uri(self, uri):
+        password_mask = "X" * 10
         conn = sqla.engine.url.make_url(uri)
-        self.password = conn.password
-        conn.password = "X" * 10 if conn.password else None
+        if conn.password != password_mask:
+            # do not over-write the password with the password mask
+            self.password = conn.password
+        conn.password = password_mask if conn.password else None
         self.sqlalchemy_uri = str(conn)  # hides the password
 
     def get_sqla_engine(self, schema=None):

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -168,7 +168,8 @@ class CoreTests(CaravelTestCase):
         data = {k: database.__getattribute__(k) for k in DatabaseView.add_columns}
         data['sqlalchemy_uri'] = database.safe_sqlalchemy_uri()
         response = self.client.post(url, data=data)
-        assert sqlalchemy_uri_decrypted == database.sqlalchemy_uri_decrypted
+        database = db.session.query(models.Database).filter_by(database_name='main').first()
+        self.assertEqual(sqlalchemy_uri_decrypted, database.sqlalchemy_uri_decrypted)
 
     def test_warm_up_cache(self):
         slice = db.session.query(models.Slice).first()

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -15,7 +15,11 @@ import unittest
 from flask import escape
 from flask_appbuilder.security.sqla import models as ab_models
 
-from caravel import db, models, utils, appbuilder, sm
+import caravel
+from caravel import app, db, models, utils, appbuilder, sm
+from caravel.source_registry import SourceRegistry
+from caravel.models import DruidDatasource
+from caravel.views import DatabaseView
 
 from .base_tests import CaravelTestCase
 
@@ -155,6 +159,16 @@ class CoreTests(CaravelTestCase):
         response = self.client.post('/caravel/testconn', data=data, content_type='application/json')
         assert response.status_code == 200
 
+    def test_databaseview_edit(self, username='admin'):
+        # validate that sending a password-masked uri does not over-write the decrypted uri
+        self.login(username=username)
+        database = db.session.query(models.Database).filter_by(database_name='main').first()
+        sqlalchemy_uri_decrypted = database.sqlalchemy_uri_decrypted
+        url = 'databaseview/edit/{}'.format(database.id)
+        data = {k: database.__getattribute__(k) for k in DatabaseView.add_columns}
+        data['sqlalchemy_uri'] = database.safe_sqlalchemy_uri()
+        response = self.client.post(url, data=data)
+        assert sqlalchemy_uri_decrypted == database.sqlalchemy_uri_decrypted
 
     def test_warm_up_cache(self):
         slice = db.session.query(models.Slice).first()


### PR DESCRIPTION
This addresses #1199 

The fixes a common case of editing a database connection by changing something in the "extra" json but leaving the sqlalchemy uri as-is (and password-masked).  Saving this would result in the password being updated with "XXXXXXXXXX".  This only updates the password if it is not the password mask.

Added a test as well.
