### PR TITLE
Fixed error of inserializable json for druid test

### DIFF
--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -102,19 +102,20 @@ class DruidTests(CaravelTestCase):
         datasource_id = cluster.datasources[0].id
         db.session.commit()
 
-        resp = self.client.get('/caravel/explore/druid/{}/'.format(
-            datasource_id))
-        assert "[test_cluster].[test_datasource]" in resp.data.decode('utf-8')
-
         nres = [
-            list(v['event'].items()) + [('timestamp', v['timestamp'])]
-            for v in GB_RESULT_SET]
+        list(v['event'].items()) + [('timestamp', v['timestamp'])]
+        for v in GB_RESULT_SET]
         nres = [dict(v) for v in nres]
         import pandas as pd
         df = pd.DataFrame(nres)
         instance.export_pandas.return_value = df
         instance.query_dict = {}
         instance.query_builder.last_query.query_dict = {}
+
+        resp = self.client.get('/caravel/explore/druid/{}/'.format(
+            datasource_id))
+        assert "[test_cluster].[test_datasource]" in resp.data.decode('utf-8')
+
         resp = self.client.get(
             '/caravel/explore/druid/{}/?viz_type=table&granularity=one+day&'
             'druid_time_origin=&since=7+days+ago&until=now&row_limit=5000&'

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -103,8 +103,8 @@ class DruidTests(CaravelTestCase):
         db.session.commit()
 
         nres = [
-        list(v['event'].items()) + [('timestamp', v['timestamp'])]
-        for v in GB_RESULT_SET]
+            list(v['event'].items()) + [('timestamp', v['timestamp'])]
+            for v in GB_RESULT_SET]
         nres = [dict(v) for v in nres]
         import pandas as pd
         df = pd.DataFrame(nres)


### PR DESCRIPTION
Problem:
Previously druid tests were failing on alanna-explore-v2-main, this was because we load the json of viz_obj and pass it to refactored explore view: [https://github.com/airbnb/caravel/pull/1205/files#diff-e9b1e371eebef6df66bd8cde507e5931R1217](url)

In Druid test, the return value of export_pandas is defined after endpoint test, causing the test to fail when json.loads(viz_obj.get_json()) is called

Flow: get_json() calls -> get_data() calls -> get_df() calls -> query() calls ->export_pandas() -> returns a mock object instead of df

Solution (credits to Bogdan):
moving export_pandas mock definition before endpoint test

needs-review @ascott @bkyryliuk @mistercrunch 
