### PR TITLE
Some polish on query search

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/DatabaseSelect.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/DatabaseSelect.jsx
@@ -11,15 +11,12 @@ class DatabaseSelect extends React.Component {
     this.state = {
       databaseLoading: false,
       databaseOptions: [],
-      databaseId: null,
     };
   }
   componentDidMount() {
     this.fetchDatabaseOptions();
   }
   changeDb(db) {
-    const val = (db) ? db.value : null;
-    this.setState({ databaseId: val });
     this.props.onChange(db);
   }
   fetchDatabaseOptions() {
@@ -38,7 +35,7 @@ class DatabaseSelect extends React.Component {
           name="select-db"
           placeholder={`Select a database (${this.state.databaseOptions.length})`}
           options={this.state.databaseOptions}
-          value={this.state.databaseId}
+          value={this.props.databaseId}
           isLoading={this.state.databaseLoading}
           autosize={false}
           onChange={this.changeDb.bind(this)}
@@ -51,6 +48,12 @@ class DatabaseSelect extends React.Component {
 DatabaseSelect.propTypes = {
   onChange: React.PropTypes.func,
   actions: React.PropTypes.object,
+  databaseId: React.PropTypes.number,
+};
+
+DatabaseSelect.defaultProps = {
+  onChange: () => {},
+  databaseId: null,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/caravel/assets/javascripts/SqlLab/components/QuerySearch.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QuerySearch.jsx
@@ -24,6 +24,9 @@ class QuerySearch extends React.Component {
     this.fetchUsers();
     this.refreshQueries();
   }
+  onUserClicked(userId) {
+    this.setState({ userId }, () => { this.refreshQueries(); });
+  }
   onChange(db) {
     const val = (db) ? db.value : null;
     this.setState({ databaseId: val });
@@ -74,9 +77,6 @@ class QuerySearch extends React.Component {
       }
     });
   }
-  search() {
-    this.refreshQueries(this.props);
-  }
   render() {
     return (
       <div>
@@ -114,15 +114,16 @@ class QuerySearch extends React.Component {
               onChange={this.changeStatus.bind(this)}
             />
           </div>
-          <Button bsSize="small" bsStyle="success" onClick={this.search.bind(this)}>
+          <Button bsSize="small" bsStyle="success" onClick={this.refreshQueries.bind(this)}>
             Search
           </Button>
         </div>
         <QueryTable
           columns={[
             'state', 'dbId', 'userId',
-            'progress', 'rows', 'sql',
+            'progress', 'rows', 'sql', 'querylink',
           ]}
+          onUserClicked={this.onUserClicked.bind(this)}
           queries={this.state.queriesArray}
         />
       </div>

--- a/caravel/assets/javascripts/SqlLab/components/QuerySearch.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QuerySearch.jsx
@@ -27,6 +27,9 @@ class QuerySearch extends React.Component {
   onUserClicked(userId) {
     this.setState({ userId }, () => { this.refreshQueries(); });
   }
+  onDbClicked(dbId) {
+    this.setState({ databaseId: dbId }, () => { this.refreshQueries(); });
+  }
   onChange(db) {
     const val = (db) ? db.value : null;
     this.setState({ databaseId: val });
@@ -93,7 +96,10 @@ class QuerySearch extends React.Component {
             />
           </div>
           <div className="col-sm-2">
-            <DatabaseSelect onChange={this.onChange.bind(this)} />
+            <DatabaseSelect
+              onChange={this.onChange.bind(this)}
+              databaseId={this.state.databaseId}
+            />
           </div>
           <div className="col-sm-4">
             <input
@@ -124,6 +130,7 @@ class QuerySearch extends React.Component {
             'progress', 'rows', 'sql', 'querylink',
           ]}
           onUserClicked={this.onUserClicked.bind(this)}
+          onDbClicked={this.onDbClicked.bind(this)}
           queries={this.state.queriesArray}
         />
       </div>

--- a/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -12,6 +12,7 @@ import VisualizeModal from './VisualizeModal';
 import SqlShrink from './SqlShrink';
 import { STATE_BSSTYLE_MAP } from '../common';
 import { fDuration } from '../../modules/dates';
+import { getLink } from '../../../utils/common';
 
 
 class QueryTable extends React.Component {
@@ -27,10 +28,7 @@ class QueryTable extends React.Component {
   }
   getQueryLink(dbId, sql) {
     const params = ['dbid=' + dbId, 'sql=' + sql, 'title=Untitled Query'];
-    const queryString = params.join('&');
-    const queryLink = this.state.cleanUri + '?' + queryString;
-
-    return queryLink;
+    return getLink(this.state.cleanUri, params);
   }
   hideVisualizeModal() {
     this.setState({ showVisualizeModal: false });
@@ -53,14 +51,25 @@ class QueryTable extends React.Component {
         q.duration = fDuration(q.startDttm, q.endDttm);
       }
       q.userId = (
-        <a onClick={this.props.onUserClicked.bind(this, q.userId)}>
+        <button
+          className="btn btn-link btn-xs"
+          onClick={this.props.onUserClicked.bind(this, q.userId)}
+        >
           {q.userId}
-        </a>
+        </button>
+      );
+      q.dbId = (
+        <button
+          className="btn btn-link btn-xs"
+          onClick={this.props.onDbClicked.bind(this, q.dbId)}
+        >
+          {q.dbId}
+        </button>
       );
       q.started = moment(q.startDttm).format('HH:mm:ss');
       const source = (q.ctas) ? q.executedSql : q.sql;
       q.sql = (
-        <SqlShrink sql={source} />
+        <SqlShrink sql={source} maxWidth={100} />
       );
       q.output = q.tempTable;
       q.progress = (
@@ -114,9 +123,12 @@ class QueryTable extends React.Component {
         </div>
       );
       q.querylink = (
-        <div style={{ width: '75px' }}>
-          <a href={this.getQueryLink(q.dbId, source)} >
-            <i className="fa fa-external-link" /> Open in SQL Editor
+        <div style={{ width: '100px' }}>
+          <a
+            href={this.getQueryLink(q.dbId, source)}
+            className="btn btn-primary btn-xs"
+          >
+            <i className="fa fa-external-link" />Open in SQL Editor
           </a>
         </div>
       );
@@ -143,11 +155,13 @@ QueryTable.propTypes = {
   actions: React.PropTypes.object,
   queries: React.PropTypes.array,
   onUserClicked: React.PropTypes.func,
+  onDbClicked: React.PropTypes.func,
 };
 QueryTable.defaultProps = {
   columns: ['started', 'duration', 'rows'],
   queries: [],
   onUserClicked: () => {},
+  onDbClicked: () => {},
 };
 
 function mapStateToProps() {

--- a/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -17,10 +17,20 @@ import { fDuration } from '../../modules/dates';
 class QueryTable extends React.Component {
   constructor(props) {
     super(props);
+    const uri = window.location.toString();
+    const cleanUri = uri.substring(0, uri.indexOf('#'));
     this.state = {
+      cleanUri,
       showVisualizeModal: false,
       activeQuery: null,
     };
+  }
+  getQueryLink(dbId, sql) {
+    const params = ['dbid=' + dbId, 'sql=' + sql, 'title=Untitled Query'];
+    const queryString = params.join('&');
+    const queryLink = this.state.cleanUri + '?' + queryString;
+
+    return queryLink;
   }
   hideVisualizeModal() {
     this.setState({ showVisualizeModal: false });
@@ -42,6 +52,11 @@ class QueryTable extends React.Component {
       if (q.endDttm) {
         q.duration = fDuration(q.startDttm, q.endDttm);
       }
+      q.userId = (
+        <a onClick={this.props.onUserClicked.bind(this, q.userId)}>
+          {q.userId}
+        </a>
+      );
       q.started = moment(q.startDttm).format('HH:mm:ss');
       const source = (q.ctas) ? q.executedSql : q.sql;
       q.sql = (
@@ -98,7 +113,13 @@ class QueryTable extends React.Component {
           />
         </div>
       );
-
+      q.querylink = (
+        <div style={{ width: '75px' }}>
+          <a href={this.getQueryLink(q.dbId, source)} >
+            <i className="fa fa-external-link" /> Open in SQL Editor
+          </a>
+        </div>
+      );
       return q;
     }).reverse();
     return (
@@ -121,10 +142,12 @@ QueryTable.propTypes = {
   columns: React.PropTypes.array,
   actions: React.PropTypes.object,
   queries: React.PropTypes.array,
+  onUserClicked: React.PropTypes.func,
 };
 QueryTable.defaultProps = {
   columns: ['started', 'duration', 'rows'],
   queries: [],
+  onUserClicked: () => {},
 };
 
 function mapStateToProps() {

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditorTopToolbar.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditorTopToolbar.jsx
@@ -114,7 +114,10 @@ class SqlEditorTopToolbar extends React.Component {
       <div className="clearfix sql-toolbar">
         {networkAlert}
         <div>
-          <DatabaseSelect onChange={this.onChange.bind(this)} />
+          <DatabaseSelect
+            onChange={this.onChange.bind(this)}
+            databaseId={this.props.queryEditor.dbId}
+          />
         </div>
         <div className="m-t-5">
           <Select

--- a/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -7,6 +7,7 @@ import SqlEditor from './SqlEditor';
 import shortid from 'shortid';
 import { getParamFromQuery } from '../../../utils/common';
 import CopyQueryTabUrl from './CopyQueryTabUrl';
+import { getLink } from '../../../utils/common';
 
 let queryCount = 1;
 
@@ -47,10 +48,7 @@ class TabbedSqlEditors extends React.Component {
     if (qe.autorun) params.push('autorun=' + qe.autorun);
     if (qe.sql) params.push('sql=' + qe.sql);
 
-    const queryString = params.join('&');
-    const queryLink = this.state.cleanUri + '?' + queryString;
-
-    return queryLink;
+    return getLink(this.state.cleanUri, params);
   }
   renameTab(qe) {
     /* eslint no-alert: 0 */

--- a/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -5,9 +5,8 @@ import { bindActionCreators } from 'redux';
 import * as Actions from '../actions';
 import SqlEditor from './SqlEditor';
 import shortid from 'shortid';
-import { getParamFromQuery } from '../../../utils/common';
+import { getParamFromQuery, getLink } from '../../../utils/common';
 import CopyQueryTabUrl from './CopyQueryTabUrl';
-import { getLink } from '../../../utils/common';
 
 let queryCount = 1;
 

--- a/caravel/assets/utils/common.js
+++ b/caravel/assets/utils/common.js
@@ -37,3 +37,7 @@ export function getParamFromQuery(query, param) {
   }
   return null;
 }
+
+export function getLink(baseUrl, params) {
+  return baseUrl + '?' + params.join('&');
+}


### PR DESCRIPTION
Done:
- Changed query search icon
  ![screen shot 2016-09-29 at 2 08 56 pm](https://cloud.githubusercontent.com/assets/20978302/18972555/7b3c406e-864e-11e6-9d2c-4fbd34ebef17.png)
- In query search results, added column for redirect to SQL Editor
  ![screen shot 2016-09-29 at 2 09 42 pm](https://cloud.githubusercontent.com/assets/20978302/18972598/ac0792b6-864e-11e6-9815-b3172cba6398.png)
- Make userIds clickable, once a userId is clicked, queries will be refreshed with only queries by that user
  ![screen shot 2016-09-29 at 2 09 04 pm](https://cloud.githubusercontent.com/assets/20978302/18972573/920bbe1e-864e-11e6-9aa2-ff2d2093fe46.png)

Todo:
- Change userId and dbId columns to userName and dbName so that they are more readable, needs to change this in Query model, will issue another PR on this

needs-review @ascott @bkyryliuk @mistercrunch 
