### PR TITLE
[SQLLab] Fix updating the database state.

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/DatabaseSelect.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/DatabaseSelect.jsx
@@ -1,6 +1,9 @@
 const $ = window.$ = require('jquery');
 import React from 'react';
+import { bindActionCreators } from 'redux';
 import Select from 'react-select';
+import { connect } from 'react-redux';
+import * as Actions from '../actions';
 
 class DatabaseSelect extends React.Component {
   constructor(props) {
@@ -11,7 +14,7 @@ class DatabaseSelect extends React.Component {
       databaseId: null,
     };
   }
-  componentWillMount() {
+  componentDidMount() {
     this.fetchDatabaseOptions();
   }
   changeDb(db) {
@@ -25,6 +28,7 @@ class DatabaseSelect extends React.Component {
     $.get(url, (data) => {
       const options = data.result.map((db) => ({ value: db.id, label: db.database_name }));
       this.setState({ databaseOptions: options, databaseLoading: false });
+      this.props.actions.setDatabases(data.result);
     });
   }
   render() {
@@ -46,6 +50,13 @@ class DatabaseSelect extends React.Component {
 
 DatabaseSelect.propTypes = {
   onChange: React.PropTypes.func,
+  actions: React.PropTypes.object,
 };
 
-export default DatabaseSelect;
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: bindActionCreators(Actions, dispatch),
+  };
+}
+
+export default connect(null, mapDispatchToProps)(DatabaseSelect);


### PR DESCRIPTION
Resolves: https://github.com/airbnb/caravel/issues/1220
Database changes were not propagated to the redux state, it caused client inability to show the run query button for the activated dbs and also to display newly added databases.

In addition, looks like `componentDidMount` is sufficient and may be better than `componentWillMount`as the latter is supposed to be synchronous and called on the server:
http://stackoverflow.com/questions/29899116/what-is-the-difference-between-componentwillmount-and-componentdidmount-in-react

Reviewers:
- @mistercrunch 
- @ascott 
- @vera-liu 
