### PR TITLE
Fix npm linting error with version string

### DIFF
--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caravel",
-  "version": "0.10.0.dev0",
+  "version": "0.10.0-dev.0",
   "description": "Caravel is a data exploration platform designed to be visual, intuitive, and interactive.",
   "license": "Apache-2.0",
   "directories": {


### PR DESCRIPTION
master was failing because "0.10.0.dev0" was not recognized as valid version string in npm linter, changed this to linter version convention "0.10.0-dev.0"
@mistercrunch @bkyryliuk 
