### PR TITLE
[bug] fix explore action buttons bug

### DIFF
--- a/caravel/assets/javascripts/explore/explore.jsx
+++ b/caravel/assets/javascripts/explore/explore.jsx
@@ -65,6 +65,7 @@ function query(forceUpdate, pushState) {
   $('.query-and-save button').attr('disabled', 'disabled');
   if (force) {  // Don't hide the alert message when the page is just loaded
     $('div.alert').remove();
+    updateUI();
   }
   $('#is_cached').hide();
   prepForm();
@@ -354,6 +355,10 @@ function initComponents() {
     />,
     exploreActionsEl
   );
+}
+
+function updateUI() {
+  window.location.reload();
 }
 
 $(document).ready(function () {


### PR DESCRIPTION
a quick hack to fix the issue with the explore button action buttons not getting the updated slice properties once query is clicked. now when query is clicked, we will also reload the page so the components get the updated slice.

i tried to just re-render the components after query click, but the slice object doesn't get updated on query, only the url params get updated.

i spent some time trying to do this in a better way, but since we are rebuilding the explore view, decided to spend less time on a real solution and opted for this hack instead. 

@mistercrunch if you know of a better way to handle this in the interim, plz let me know!

@vera-liu @bkyryliuk 
