### PR TITLE
[SQLLab] Fix the usage of Redux DevTools Enhancer

### DIFF
--- a/caravel/assets/javascripts/reduxUtils.js
+++ b/caravel/assets/javascripts/reduxUtils.js
@@ -67,7 +67,9 @@ export function addToArr(state, arrKey, obj) {
 export function enhancer() {
   let enhancerWithPersistState = compose(persistState());
   if (process.env.NODE_ENV === 'dev') {
+    /* eslint-disable no-underscore-dangle */
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+    /* eslint-enable */
     enhancerWithPersistState = composeEnhancers(persistState());
   }
   return enhancerWithPersistState;

--- a/caravel/assets/javascripts/reduxUtils.js
+++ b/caravel/assets/javascripts/reduxUtils.js
@@ -67,9 +67,8 @@ export function addToArr(state, arrKey, obj) {
 export function enhancer() {
   let enhancerWithPersistState = compose(persistState());
   if (process.env.NODE_ENV === 'dev') {
-    enhancerWithPersistState = compose(
-      persistState(), window.devToolsExtension && window.devToolsExtension()
-    );
+    const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+    enhancerWithPersistState = composeEnhancers(persistState());
   }
   return enhancerWithPersistState;
 }


### PR DESCRIPTION
The issue caused by not having the extension installed could be solved by using

``` js
enhancerWithPersistState = compose(
      persistState(),
      window.devToolsExtension && window.devToolsExtension() || noop => noop
    );
```

However, it was really confusing. So, [we're deprecating the enhancer](https://github.com/zalmoxisus/redux-devtools-extension/issues/220) in favour of a more clear API.

I'm happy that Airbnb devs found the extension useful. If you have any other suggestions about it, let me know (since we're both building tools for development).

Fixes #1223, #1228, #1238.
