### PR TITLE
reduce chunk size for countries table

### DIFF
--- a/caravel/data/__init__.py
+++ b/caravel/data/__init__.py
@@ -178,7 +178,7 @@ def load_world_bank_health_n_pop():
         tbl_name,
         db.engine,
         if_exists='replace',
-        chunksize=500,
+        chunksize=50,
         dtype={
             'year': DateTime(),
             'country_code': String(3),


### PR DESCRIPTION
FROM https://trello.com/c/3JWvIC8T/8-aggiungere-una-faq-per-grandezza-pacchetti-mysql

May I suggest to change the chunk size of the countries query?
While this slow the initial load from 17 to 18 seconds on this machine (for the sqlite db) it should be a non issue.

With a chunk size of 50 instead of 500 the packet size should be less than 500KB instead than the actual more than 4MB

The committer has not checked other tables
