### PR TITLE
Fix epoch time calculation if provided datetime has timezone

### DIFF
--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -10,6 +10,7 @@ import decimal
 import functools
 import json
 import logging
+import pytz
 import numpy
 import signal
 import uuid
@@ -363,6 +364,9 @@ def json_iso_dttm_ser(obj):
 
 
 def datetime_to_epoch(dttm):
+    if dttm.tzinfo:
+        epoch_with_tz = pytz.utc.localize(EPOCH)
+        return (dttm - epoch_with_tz).total_seconds() * 1000
     return (dttm - EPOCH).total_seconds() * 1000
 
 


### PR DESCRIPTION
I was hitting the following bug:

```
2016-10-07 13:26:36,709:ERROR:root:Timestamp subtraction must have the same timezones or no timezones
Traceback (most recent call last):
  File "/Users/lmwangi/venvs/caravel/lib/python2.7/site-packages/caravel/viz.py", line 328, in get_json
    data = self.json_dumps(payload)
  File "/Users/lmwangi/venvs/caravel/lib/python2.7/site-packages/caravel/viz.py", line 346, in json_dumps
    return json.dumps(obj, default=utils.json_int_dttm_ser, ignore_nan=True)
  File "/Users/lmwangi/venvs/caravel/lib/python2.7/site-packages/simplejson/__init__.py", line 397, in dumps
    **kw).encode(obj)
  File "/Users/lmwangi/venvs/caravel/lib/python2.7/site-packages/simplejson/encoder.py", line 275, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/lmwangi/venvs/caravel/lib/python2.7/site-packages/simplejson/encoder.py", line 357, in iterencode
    return _iterencode(o, 0)
  File "/Users/lmwangi/venvs/caravel/lib/python2.7/site-packages/caravel/utils.py", line 380, in json_int_dttm_ser
    obj = datetime_to_epoch(obj)
  File "/Users/lmwangi/venvs/caravel/lib/python2.7/site-packages/caravel/utils.py", line 367, in datetime_to_epoch
    return (dttm - EPOCH).total_seconds() * 1000
  File "pandas/tslib.pyx", line 1071, in pandas.tslib._Timestamp.__sub__ (pandas/tslib.c:21031)
TypeError: Timestamp subtraction must have the same timezones or no timezones

```

This PR fixes this issue.
