### PR TITLE
Updated eslinter for object rest spread

### DIFF
--- a/caravel/assets/.eslintrc
+++ b/caravel/assets/.eslintrc
@@ -1,5 +1,10 @@
 {
   "extends": "airbnb",
+  "parserOptions":{
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
+  },
   "rules": {
     "prefer-template": 0,
     "new-cap": 0,


### PR DESCRIPTION
To accomodate object spread used here: [https://github.com/airbnb/caravel/pull/1281/files#diff-6bd901888ac91dd4a3477a842551aa2bR30](url)
Using the suggestions from: [https://github.com/eslint/eslint/issues/2532](url) , update eslinter to include object spread operator

needs-review @bkyryliuk @ascott @mistercrunch 
