### PR TITLE
Fix of the explore action button bug without reload

### DIFF
--- a/caravel/assets/javascripts/explore/components/EmbedCodeButton.jsx
+++ b/caravel/assets/javascripts/explore/components/EmbedCodeButton.jsx
@@ -12,7 +12,6 @@ export default class EmbedCodeButton extends React.Component {
     this.state = {
       height: '400',
       width: '600',
-      srcLink: window.location.origin + props.slice.data.standalone_endpoint,
     };
     this.handleInputChange = this.handleInputChange.bind(this);
   }
@@ -26,8 +25,9 @@ export default class EmbedCodeButton extends React.Component {
   }
 
   generateEmbedHTML() {
-    const { width, height, srcLink } = this.state;
+    const { width, height } = this.state;
     /* eslint max-len: 0 */
+    const srcLink = window.location.origin + this.props.slice.data.standalone_endpoint;
     const embedHTML =
       `<iframe src="${srcLink}" width="${width}" height="${height}" seamless frameBorder="0" scrolling="no"></iframe>`;
     return embedHTML;

--- a/caravel/assets/javascripts/explore/explore.jsx
+++ b/caravel/assets/javascripts/explore/explore.jsx
@@ -68,7 +68,6 @@ function query(forceUpdate, pushState) {
   }
   $('#is_cached').hide();
   prepForm();
-
   if (pushState !== false) {
     // update the url after prepForm() fix the field ids
     history.pushState({}, document.title, slice.querystring());
@@ -336,7 +335,7 @@ function initExploreView() {
   prepSaveDialog();
 }
 
-function initComponents() {
+function renderComponents() {
   const queryAndSaveBtnsEl = document.getElementById('js-query-and-save-btns');
   ReactDOM.render(
     <QueryAndSaveBtns
@@ -362,6 +361,7 @@ $(document).ready(function () {
   initExploreView();
 
   slice = px.Slice(data);
+  slice.changedDataCb = renderComponents;
 
   $('.slice').data('slice', slice);
 
@@ -371,5 +371,5 @@ $(document).ready(function () {
 
   slice.bindResizeToWindowResize();
 
-  initComponents();
+  renderComponents();
 });

--- a/caravel/assets/javascripts/modules/caravel.js
+++ b/caravel/assets/javascripts/modules/caravel.js
@@ -162,7 +162,7 @@ const px = function () {
           slice.data.standalone_endpoint = data.standalone_endpoint;
           slice.data.form_data = data.form_data;
           if (slice.changedDataCb !== undefined) {
-            slice.changedDataCb && slice.changedDataCb();
+            slice.changedDataCb();
           }
         }
         $('#timer').removeClass('label-warning label-danger');

--- a/caravel/assets/javascripts/modules/caravel.js
+++ b/caravel/assets/javascripts/modules/caravel.js
@@ -76,6 +76,7 @@ const px = function () {
       container,
       containerId,
       selector,
+      changedDataCb: undefined,
       querystring(params) {
         const newParams = params || {};
         const parser = document.createElement('a');
@@ -156,12 +157,18 @@ const px = function () {
 
         if (data !== undefined) {
           slice.viewSqlQuery = data.query;
+          slice.data.json_endpoint = data.json_endpoint;
+          slice.data.csv_endpoint = data.csv_endpoint;
+          slice.data.standalone_endpoint = data.standalone_endpoint;
+          slice.data.form_data = data.form_data;
+          if (slice.changedDataCb !== undefined) {
+            slice.changedDataCb && slice.changedDataCb();
+          }
         }
-
         $('#timer').removeClass('label-warning label-danger');
         $('#timer').addClass('label-success');
         $('.query-and-save button').removeAttr('disabled');
-        always(data);
+        always();
       },
       getErrorMsg(xhr) {
         if (xhr.statusText === 'timeout') {


### PR DESCRIPTION
*Solves #1189: Download button, share button, and url shortener button stay not in sync with visualization while editing
*Syncs the data from the server response to the data in slice.
*Calls a callback to rerender buttons when data changes.

Current Situation:
- slice.data is the bootstraped data and is never changed. It contains the initial form data.
- slice.jsonEndpoint() calculates the json endpoint from the form, referenced by #("query").
- When the user changes the form, even when he hits query, slice.data.json_endpoint is inconsistent with the form data and slice.jsonEndpoint().
- The slice is passed to the React components for the json/csv/embedd. Currently, they access slice.data.json_endpoint/csv_endpoint/standalone_endpoint. Thus they are inconsistent.

There are two options:
1. Replace in the React components slice.data.json_enpoint by slice.jsonEndpoint() and add a analogous function for csv. The former calculates the the json endpoint from the form data.
Problem: If the user changes the form but has not updated the chart, the chart and the json data is inconsistent.
2. Update slice.data.json_endpoint/csv_endpoint in slice.done() with the data from the server.  Then rerender the React components (,which is the recommened way when the props change (setProps is deprecated)). The json/csv endpoints are consistent with the visualization.

The second option in implemented.  We only update slice.data.json_endpoint/csv.endpoint/form_data/standalone_endpoint. slice.data.token/viz_name might get inconsistent.
