### PR TITLE
[bug] add ImmutableMultiDict back to views.py

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -27,6 +27,7 @@ from flask_appbuilder.models.sqla.filters import BaseFilter
 
 from sqlalchemy import create_engine
 from werkzeug.routing import BaseConverter
+from werkzeug.datastructures import ImmutableMultiDict
 from wtforms.validators import ValidationError
 
 import caravel


### PR DESCRIPTION
`ImmutableMultiDict` import was removed with @mistercrunch's explore refactor in views.py: https://github.com/airbnb/caravel/pull/1252

adding back because exploreV2 still needs it.

<img width="1280" alt="screenshot 2016-10-07 18 07 23" src="https://cloud.githubusercontent.com/assets/130878/19209152/6ae95ff0-8cb9-11e6-86e7-e363270b825b.png">

@mistercrunch @vera-liu @bkyryliuk 
