### PR TITLE
Taking out object spread operator

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,7 @@ engines:
     enabled: true
     config:
       config: caravel/assets/.eslintrc
+    channel: "eslint-2"
   pep8:
     enabled: true
   fixme:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,7 +7,6 @@ engines:
     enabled: true
     config:
       config: caravel/assets/.eslintrc
-    channel: "eslint-2"
   pep8:
     enabled: true
   fixme:

--- a/caravel/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/caravel/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -11,10 +11,11 @@ const setFormInViz = function (state, action) {
 const setVizInState = function (state, action) {
   switch (action.type) {
     case actions.SET_FORM_DATA:
-      return {
-        ...state,
-        formData: setFormInViz(state.formData, action),
-      };
+      return Object.assign(
+        {},
+        state,
+        { formData: setFormInViz(state.formData, action) }
+        );
     default:
       return state;
   }
@@ -74,10 +75,11 @@ export const exploreReducer = function (state, action) {
       return Object.assign({}, state, { datasourceType: action.datasourceType });
     },
     [actions.SET_FORM_DATA]() {
-      return {
-        ...state,
-        viz: setVizInState(state.viz, action),
-      };
+      return Object.assign(
+        {},
+        state,
+        { viz: setVizInState(state.viz, action) }
+      );
     },
   };
   if (action.type in actionHandlers) {


### PR DESCRIPTION
Previously codeclimate check was failing on [https://github.com/airbnb/caravel/pull/1281](url)
Upon talking to codeclimate support regarding the issue with using object spread operator, they suggested on using eslint-2 channel in codeclimate.yml.
