### PR TITLE
[ui bug] fix styling so warning msg isn't hidden behind sql-lab

### DIFF
--- a/caravel/assets/javascripts/SqlLab/main.css
+++ b/caravel/assets/javascripts/SqlLab/main.css
@@ -1,10 +1,3 @@
-#app {
-    position: absolute;
-    top: 65;
-    left: 0;
-    right: 0;
-    bottom: 0;
-}
 .inlineBlock {
     display: inline-block;
 }


### PR DESCRIPTION
with:
<img width="1280" alt="screenshot 2016-10-10 18 48 13" src="https://cloud.githubusercontent.com/assets/130878/19256329/c25490da-8f1a-11e6-9925-dd4bc5a4bc25.png">

<img width="1280" alt="screenshot 2016-10-10 18 51 10" src="https://cloud.githubusercontent.com/assets/130878/19256352/13e6ff0a-8f1b-11e6-8a01-fb00a5212acb.png">

without:
<img width="1280" alt="screenshot 2016-10-10 18 48 57" src="https://cloud.githubusercontent.com/assets/130878/19256328/c2526e4a-8f1a-11e6-82f4-4971a97bf88d.png">

@ecesena @mistercrunch @bkyryliuk @vera-liu 
