### PR TITLE
[sqllab] use encodeURIComponent for copy query URL

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
@@ -27,10 +27,10 @@ export default class CopyQueryTabUrl extends React.Component {
     const params = [];
     const qe = this.props.qe;
     if (qe.dbId) params.push('dbid=' + qe.dbId);
-    if (qe.title) params.push('title=' + qe.title);
-    if (qe.schema) params.push('schema=' + qe.schema);
+    if (qe.title) params.push('title=' + encodeURIComponent(qe.title));
+    if (qe.schema) params.push('schema=' + encodeURIComponent(qe.schema));
     if (qe.autorun) params.push('autorun=' + qe.autorun);
-    if (qe.sql) params.push('sql=' + qe.sql);
+    if (qe.sql) params.push('sql=' + encodeURIComponent(qe.sql));
 
     const queryString = params.join('&');
     const queryLink = this.state.cleanUri + '?' + queryString;
@@ -43,7 +43,8 @@ export default class CopyQueryTabUrl extends React.Component {
       <CopyToClipboard
         inMenu
         text={this.getQueryLink()}
-        copyNode={<span>copy query</span>}
+        copyNode={<span>share query</span>}
+        tooltipText="copy URL to clipboard"
         shouldShowText={false}
       />
     );

--- a/caravel/assets/javascripts/components/CopyToClipboard.jsx
+++ b/caravel/assets/javascripts/components/CopyToClipboard.jsx
@@ -7,6 +7,7 @@ const propTypes = {
   shouldShowText: PropTypes.bool,
   text: PropTypes.string.isRequired,
   inMenu: PropTypes.bool,
+  tooltipText: PropTypes.string,
 };
 
 const defaultProps = {
@@ -14,6 +15,7 @@ const defaultProps = {
   onCopyEnd: () => {},
   shouldShowText: true,
   inMenu: false,
+  tooltipText: 'Copy to clipboard',
 };
 
 export default class CopyToClipboard extends React.Component {
@@ -64,13 +66,10 @@ export default class CopyToClipboard extends React.Component {
   }
 
   tooltipText() {
-    let tooltipText;
     if (this.state.hasCopied) {
-      tooltipText = 'Copied!';
-    } else {
-      tooltipText = 'Copy text';
+      return 'Copied!';
     }
-    return tooltipText;
+    return this.props.tooltipText;
   }
 
   renderLink() {

--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -92,7 +92,7 @@
     "babel": "^6.3.26",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
-    "babel-preset-airbnb": "^2.0.0",
+    "babel-preset-airbnb": "^2.1.1",
     "babel-preset-react": "^6.11.1",
     "chai": "^3.5.0",
     "codeclimate-test-reporter": "^0.3.3",


### PR DESCRIPTION
had to bump babel-preset-airbnb for object-rest-spread to work in my env. Also changed the menu text and tooltip for clarity

@ascott @vera-liu 
