### PR TITLE
Stop duplicating datasources

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -599,13 +599,14 @@ class TableModelView(CaravelModelView, DeleteMixin):  # noqa
     }
 
     def pre_add(self, table):
-        existing_tables = db.session.query(models.SqlaTable).filter_by(
-            table_name=table.table_name,
-            schema=table.schema,
-            database_id=table.database.id,
-        ).all()
+        number_of_existing_tables = db.session.query(
+            sqla.func.count('*')).filter(
+            models.SqlaTable.table_name == table.table_name,
+            models.SqlaTable.schema == table.schema,
+            models.SqlaTable.database_id == table.database.id
+        ).scalar()
         # table object is already added to the session
-        if len(existing_tables) > 1:
+        if number_of_existing_tables > 1:
             raise Exception(get_datasource_exist_error_mgs(table.full_name))
 
         # Fail before adding if the table can't be found
@@ -948,15 +949,15 @@ class DruidDatasourceModelView(CaravelModelView, DeleteMixin):  # noqa
     }
 
     def pre_add(self, datasource):
-        existing_datasources = (
-            db.session.query(models.DruidDatasource)
-            .filter_by(
-                datasource_name=datasource.datasource_name,
-                cluster_name=datasource.cluster.cluster_name,
-            ).all()
-        )
+        number_of_existing_datasources = db.session.query(
+            sqla.func.count('*')).filter(
+            models.DruidDatasource.datasource_name ==
+                datasource.datasource_name,
+            models.DruidDatasource.cluster_name == datasource.cluster.id
+        ).scalar()
+
         # table object is already added to the session
-        if len(existing_datasources) > 1:
+        if number_of_existing_datasources > 1:
             raise Exception(get_datasource_exist_error_mgs(
                 datasource.full_name))
 

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -596,15 +596,29 @@ class TableModelView(CaravelModelView, DeleteMixin):  # noqa
 
     def pre_add(self, table):
         # Fail before adding if the table can't be found
+        print("Blabla")
+        # TODO: figure out how to get DB object
+        print(table.to_json())
         try:
             table.get_sqla_table_object()
         except Exception as e:
-            logging.exception(e)
+            logging.exception(str(e))
             raise Exception(
                 "Table [{}] could not be found, "
                 "please double check your "
                 "database connection, schema, and "
                 "table name".format(table.table_name))
+        existing_tables = db.session.query(models.Table).filter_by(
+            table_name=table.table_name,
+            schema=table.schema,
+            database_id=table.database_id,
+        ).all()
+        print("Blabla")
+        print(existing_tables)
+        if existing_tables:
+            raise Exception(
+                "Table [{}.{}] already exists in the database [{}]".format(
+                    table.schema, table.table_name, table.database.table_name))
 
     def post_add(self, table):
         table.fetch_metadata()


### PR DESCRIPTION
There is a constraint on the SQL side, but it was introduces after quite big set of duplicates was created. To make the clean up process manageable - we should prevent users from creating more duplicated definitions of tables and druid datasources.

Partially helps https://github.com/airbnb/caravel/issues/1306.

Reviewers:
- @mistercrunch 
- @ascott 
- @vera-liu 
