### PR TITLE
polyfill es2015 in older browsers and for phantomjs

### DIFF
--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -37,8 +37,6 @@
   "homepage": "https://github.com/airbnb/caravel#readme",
   "dependencies": {
     "autobind-decorator": "^1.3.3",
-    "babel-cli": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
     "bootstrap": "^3.3.6",
     "bootstrap-datepicker": "^1.6.0",
     "brace": "^0.7.0",
@@ -90,6 +88,9 @@
   },
   "devDependencies": {
     "babel": "^6.3.26",
+    "babel-cli": "^6.14.0",
+    "babel-polyfill": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
     "babel-preset-airbnb": "^2.1.1",

--- a/caravel/assets/webpack.config.js
+++ b/caravel/assets/webpack.config.js
@@ -12,14 +12,14 @@ const VERSION_STRING = JSON.parse(fs.readFileSync('package.json')).version;
 
 const config = {
   entry: {
-    'css-theme': ['babel-polyfill', APP_DIR + '/javascripts/css-theme.js'],
+    'css-theme': APP_DIR + '/javascripts/css-theme.js',
+    common: APP_DIR + '/javascripts/common.js',
     dashboard: ['babel-polyfill', APP_DIR + '/javascripts/dashboard/Dashboard.jsx'],
     explore: ['babel-polyfill', APP_DIR + '/javascripts/explore/explore.jsx'],
     explorev2: ['babel-polyfill', APP_DIR + '/javascripts/explorev2/index.jsx'],
-    welcome: ['babel-polyfill', APP_DIR + '/javascripts/welcome.js'],
-    standalone: ['babel-polyfill', APP_DIR + '/javascripts/standalone.js'],
-    common: ['babel-polyfill', APP_DIR + '/javascripts/common.js'],
     sqllab: ['babel-polyfill', APP_DIR + '/javascripts/SqlLab/index.jsx'],
+    standalone: ['babel-polyfill', APP_DIR + '/javascripts/standalone.js'],
+    welcome: ['babel-polyfill', APP_DIR + '/javascripts/welcome.js'],
   },
   output: {
     path: BUILD_DIR,

--- a/caravel/assets/webpack.config.js
+++ b/caravel/assets/webpack.config.js
@@ -12,14 +12,14 @@ const VERSION_STRING = JSON.parse(fs.readFileSync('package.json')).version;
 
 const config = {
   entry: {
-    'css-theme': APP_DIR + '/javascripts/css-theme.js',
-    dashboard: APP_DIR + '/javascripts/dashboard/Dashboard.jsx',
-    explore: APP_DIR + '/javascripts/explore/explore.jsx',
-    explorev2: APP_DIR + '/javascripts/explorev2/index.jsx',
-    welcome: APP_DIR + '/javascripts/welcome.js',
-    standalone: APP_DIR + '/javascripts/standalone.js',
-    common: APP_DIR + '/javascripts/common.js',
-    sqllab: APP_DIR + '/javascripts/SqlLab/index.jsx',
+    'css-theme': ['babel-polyfill', APP_DIR + '/javascripts/css-theme.js'],
+    dashboard: ['babel-polyfill', APP_DIR + '/javascripts/dashboard/Dashboard.jsx'],
+    explore: ['babel-polyfill', APP_DIR + '/javascripts/explore/explore.jsx'],
+    explorev2: ['babel-polyfill', APP_DIR + '/javascripts/explorev2/index.jsx'],
+    welcome: ['babel-polyfill', APP_DIR + '/javascripts/welcome.js'],
+    standalone: ['babel-polyfill', APP_DIR + '/javascripts/standalone.js'],
+    common: ['babel-polyfill', APP_DIR + '/javascripts/common.js'],
+    sqllab: ['babel-polyfill', APP_DIR + '/javascripts/SqlLab/index.jsx'],
   },
   output: {
     path: BUILD_DIR,


### PR DESCRIPTION
only need to include `babel-polyfill` once per js entry file. since css-theme and common.js are both used with the dashboard, sqllab, etc, they don't need the polyfill since it's already been included in the single page app entry file.

IE11 before: 
<img width="1280" alt="screenshot 2016-10-11 20 02 05" src="https://cloud.githubusercontent.com/assets/130878/19296139/491aa1ee-8fee-11e6-9d85-5fa1621702df.png">

IE 11 after: 
<img width="1280" alt="screenshot 2016-10-11 19 59 30" src="https://cloud.githubusercontent.com/assets/130878/19296142/4d13cb0e-8fee-11e6-95ce-5d4943244ada.png">

@williaster @mistercrunch @bkyryliuk 
