### PR TITLE
Bugfix when there's only date filter in FilterBox

### DIFF
--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -1655,6 +1655,7 @@ class FilterBoxViz(BaseViz):
         'groupby': {
             'label': _('Filter fields'),
             'description': _("The fields you want to filter on"),
+            'default': [],
         },
     }
 


### PR DESCRIPTION
To reproduce the bug
- Create a new slice with Filter Box type
- Turn on 'Date Filter' and leave 'Filter fields' empty
- Save the slice and add it to a dashboard
- Go to that dashboard, and you will get an 500 server error.

The problem is that `groupby` field has a default value to `None`. So when `Filter fields` is empty, It breaks code in `FilterBoxViz.query_obj` and `FilterBoxViz.get_data`, as well as `filterBox.refresh` in filter_box.jsx. Set default value to `[]` solves the problem.
