### PR TITLE
Override the role with perms for give datasources.

### DIFF
--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -109,10 +109,4 @@ module_datasource_map = app.config.get("DEFAULT_MODULE_DS_MAP")
 module_datasource_map.update(app.config.get("ADDITIONAL_MODULE_DS_MAP"))
 SourceRegistry.register_sources(module_datasource_map)
 
-# Registering databases
-module_db_map = app.config.get("DEFAULT_MODULE_DB_MAP")
-module_db_map.update(app.config.get("ADDITIONAL_MODULE_DB_MAP"))
-SourceRegistry.register_databases(module_db_map)
-
-
 from caravel import views, config  # noqa

--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -109,4 +109,10 @@ module_datasource_map = app.config.get("DEFAULT_MODULE_DS_MAP")
 module_datasource_map.update(app.config.get("ADDITIONAL_MODULE_DS_MAP"))
 SourceRegistry.register_sources(module_datasource_map)
 
+# Registering databases
+module_db_map = app.config.get("DEFAULT_MODULE_DB_MAP")
+module_db_map.update(app.config.get("ADDITIONAL_MODULE_DB_MAP"))
+SourceRegistry.register_databases(module_db_map)
+
+
 from caravel import views, config  # noqa

--- a/caravel/config.py
+++ b/caravel/config.py
@@ -171,9 +171,7 @@ DRUID_DATA_SOURCE_BLACKLIST = []
 # Modules and datasources to be registered
 # --------------------------------------------------
 DEFAULT_MODULE_DS_MAP = {'caravel.models': ['DruidDatasource', 'SqlaTable']}
-DEFAULT_MODULE_DB_MAP = {'caravel.models': ['DruidCluster', 'Database']}
 ADDITIONAL_MODULE_DS_MAP = {}
-ADDITIONAL_MODULE_DB_MAP = {}
 
 """
 1) http://docs.python-guide.org/en/latest/writing/logging/

--- a/caravel/config.py
+++ b/caravel/config.py
@@ -171,8 +171,9 @@ DRUID_DATA_SOURCE_BLACKLIST = []
 # Modules and datasources to be registered
 # --------------------------------------------------
 DEFAULT_MODULE_DS_MAP = {'caravel.models': ['DruidDatasource', 'SqlaTable']}
+DEFAULT_MODULE_DB_MAP = {'caravel.models': ['DruidCluster', 'Database']}
 ADDITIONAL_MODULE_DS_MAP = {}
-
+ADDITIONAL_MODULE_DB_MAP = {}
 
 """
 1) http://docs.python-guide.org/en/latest/writing/logging/

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -583,8 +583,6 @@ class Database(Model, AuditMixinNullable):
 
     __tablename__ = 'dbs'
 
-    type = "table"
-
     id = Column(Integer, primary_key=True)
     database_name = Column(String(250), unique=True)
     sqlalchemy_uri = Column(String(1024))
@@ -1376,8 +1374,6 @@ class DruidCluster(Model, AuditMixinNullable):
     """ORM object referencing the Druid clusters"""
 
     __tablename__ = 'clusters'
-
-    type = "druid"
 
     id = Column(Integer, primary_key=True)
     cluster_name = Column(String(250), unique=True)

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -582,6 +582,9 @@ class Database(Model, AuditMixinNullable):
     """An ORM object that stores Database related information"""
 
     __tablename__ = 'dbs'
+
+    type = "table"
+
     id = Column(Integer, primary_key=True)
     database_name = Column(String(250), unique=True)
     sqlalchemy_uri = Column(String(1024))
@@ -806,7 +809,8 @@ class SqlaTable(Model, Queryable, AuditMixinNullable, ImportMixin):
 
     @property
     def full_name(self):
-        return "[{obj.database}].[{obj.table_name}]".format(obj=self)
+        return utils.get_datasource_full_name(
+            self.database, self.table_name, schema=self.schema)
 
     @property
     def dttm_cols(self):
@@ -1372,6 +1376,9 @@ class DruidCluster(Model, AuditMixinNullable):
     """ORM object referencing the Druid clusters"""
 
     __tablename__ = 'clusters'
+
+    type = "druid"
+
     id = Column(Integer, primary_key=True)
     cluster_name = Column(String(250), unique=True)
     coordinator_host = Column(String(255))
@@ -1484,9 +1491,8 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable):
 
     @property
     def full_name(self):
-        return (
-            "[{obj.cluster_name}]."
-            "[{obj.datasource_name}]").format(obj=self)
+        return utils.get_datasource_full_name(
+            self.cluster_name, self.datasource_name)
 
     @property
     def time_column_grains(self):

--- a/caravel/source_registry.py
+++ b/caravel/source_registry.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import subqueryload
 class SourceRegistry(object):
     """ Central Registry for all available datasource engines"""
 
+    databases = {}
     sources = {}
 
     @classmethod
@@ -15,12 +16,36 @@ class SourceRegistry(object):
                 cls.sources[source_class.type] = source_class
 
     @classmethod
+    def register_databases(cls, database_config):
+        for module_name, class_names in database_config.items():
+            module_obj = __import__(module_name, fromlist=class_names)
+            for class_name in class_names:
+                database_class = getattr(module_obj, class_name)
+                cls.databases[database_class.type] = database_class
+
+    @classmethod
     def get_datasource(cls, datasource_type, datasource_id, session):
         return (
             session.query(cls.sources[datasource_type])
             .filter_by(id=datasource_id)
             .one()
         )
+
+    @classmethod
+    def get_dbs_datasources(cls, datasource_type, database_name, session):
+        database_class = cls.databases[datasource_type]
+        if datasource_type == 'druid':
+            name_field = database_class.cluster_name
+            datasources_field = 'datasources'
+        elif datasource_type == 'table':
+            name_field = database_class.database_name
+            datasources_field = 'tables'
+        else:
+            raise Exception(
+                'Unknown datasources type {}'.format(datasource_type))
+        database = session.query(database_class).filter(
+            name_field == database_name).one()
+        return getattr(database, datasources_field)
 
     @classmethod
     def get_datasource_by_name(cls, session, datasource_type, datasource_name,

--- a/caravel/source_registry.py
+++ b/caravel/source_registry.py
@@ -4,7 +4,6 @@ from sqlalchemy.orm import subqueryload
 class SourceRegistry(object):
     """ Central Registry for all available datasource engines"""
 
-    databases = {}
     sources = {}
 
     @classmethod
@@ -16,14 +15,6 @@ class SourceRegistry(object):
                 cls.sources[source_class.type] = source_class
 
     @classmethod
-    def register_databases(cls, database_config):
-        for module_name, class_names in database_config.items():
-            module_obj = __import__(module_name, fromlist=class_names)
-            for class_name in class_names:
-                database_class = getattr(module_obj, class_name)
-                cls.databases[database_class.type] = database_class
-
-    @classmethod
     def get_datasource(cls, datasource_type, datasource_id, session):
         return (
             session.query(cls.sources[datasource_type])
@@ -32,20 +23,12 @@ class SourceRegistry(object):
         )
 
     @classmethod
-    def get_dbs_datasources(cls, datasource_type, database_name, session):
-        database_class = cls.databases[datasource_type]
-        if datasource_type == 'druid':
-            name_field = database_class.cluster_name
-            datasources_field = 'datasources'
-        elif datasource_type == 'table':
-            name_field = database_class.database_name
-            datasources_field = 'tables'
-        else:
-            raise Exception(
-                'Unknown datasources type {}'.format(datasource_type))
-        database = session.query(database_class).filter(
-            name_field == database_name).one()
-        return getattr(database, datasources_field)
+    def get_all_datasources(cls, session):
+        datasources = []
+        for source_type in SourceRegistry.sources:
+            datasources.extend(
+                session.query(SourceRegistry.sources[source_type]).all())
+        return datasources
 
     @classmethod
     def get_datasource_by_name(cls, session, datasource_type, datasource_name,

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -229,6 +229,7 @@ def init(caravel):
 
     ADMIN_ONLY_PERMISSIONS = set([
         'can_sync_druid_source',
+        'can_override_role_permissions',
         'can_approve',
     ])
 
@@ -441,6 +442,12 @@ def generic_find_constraint_name(table, columns, referenced, db):
                 fk.referred_table.name == referenced and
                 set(fk.column_keys) == columns):
             return fk.name
+
+
+def get_datasource_full_name(database_name, datasource_name, schema=None):
+    if not schema:
+        return "[{}].[{}]".format(database_name, datasource_name)
+    return "[{}].[{}].[{}]".format(database_name, schema, datasource_name)
 
 
 def validate_json(obj):

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1062,6 +1062,55 @@ appbuilder.add_view_no_menu(R)
 
 class Caravel(BaseCaravelView):
     """The base views for Caravel!"""
+    @has_access
+    @expose("/override_role_permissions/", methods=['POST'])
+    def override_role_permissions(self):
+        """Updates the role with the give datasource permissions.
+
+          Permissions not in the request will be revoked. This endpoint should
+          be available to admins only. Expects JSON in the format:
+           {
+            'role_name': '{role_name}',
+            'database': [{
+                'datasource_type': '{table|druid}',
+                'name': '{database_name}',
+                'schema': [{
+                    'name': '{schema_name}',
+                    'datasources': ['{datasource name}, {datasource name}']
+                }]
+            }]
+        }
+        """
+        data = request.get_json(force=True)
+        role_name = data['role_name']
+        databases = data['database']
+
+        datasources = []
+        for dbs in databases:
+            db_ds_names = set()
+            datasource_type = dbs['datasource_type']
+            for schema in dbs['schema']:
+                for ds_name in schema['datasources']:
+                    db_ds_names.add(utils.get_datasource_full_name(
+                        dbs['name'], ds_name, schema=schema['name']))
+            db_datasources = SourceRegistry.get_dbs_datasources(
+                datasource_type, dbs['name'], db.session)
+            datasources.extend(
+                [d for d in db_datasources if d.full_name in db_ds_names])
+
+        role = sm.find_role(role_name)
+        # remove all permissions
+        role.permissions = []
+        # grant permissions to the list of datasources
+        for ds_name in datasources:
+            role.permissions.append(
+                sm.find_permission_view_menu(
+                    view_menu_name=ds_name.perm,
+                    permission_name='datasource_access')
+            )
+        db.session.commit()
+        return Response(status=201)
+
     @log_this
     @has_access
     @expose("/request_access/")

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1085,18 +1085,16 @@ class Caravel(BaseCaravelView):
         role_name = data['role_name']
         databases = data['database']
 
-        datasources = []
+        db_ds_names = set()
         for dbs in databases:
-            db_ds_names = set()
-            datasource_type = dbs['datasource_type']
             for schema in dbs['schema']:
                 for ds_name in schema['datasources']:
                     db_ds_names.add(utils.get_datasource_full_name(
                         dbs['name'], ds_name, schema=schema['name']))
-            db_datasources = SourceRegistry.get_dbs_datasources(
-                datasource_type, dbs['name'], db.session)
-            datasources.extend(
-                [d for d in db_datasources if d.full_name in db_ds_names])
+
+        existing_datasources = SourceRegistry.get_all_datasources(db.session)
+        datasources = [
+            d for d in existing_datasources if d.full_name in db_ds_names]
 
         role = sm.find_role(role_name)
         # remove all permissions

--- a/tests/access_tests.py
+++ b/tests/access_tests.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
 import unittest
 
 from caravel import db, models, sm
@@ -11,16 +12,144 @@ from caravel.source_registry import SourceRegistry
 
 from .base_tests import CaravelTestCase
 
+ROLE_TABLES_PERM_DATA = {
+    'role_name': 'override_me',
+    'database': [{
+        'datasource_type': 'table',
+        'name': 'main',
+        'schema': [{
+            'name': '',
+            'datasources': ['birth_names']
+        }]
+    }]
+}
+
+ROLE_ALL_PERM_DATA = {
+    'role_name': 'override_me',
+    'database': [{
+        'datasource_type': 'table',
+        'name': 'main',
+        'schema': [{
+            'name': '',
+            'datasources': ['birth_names']
+        }]
+    }, {
+        'datasource_type': 'druid',
+        'name': 'druid_test',
+        'schema': [{
+            'name': '',
+            'datasources': ['druid_ds_1', 'druid_ds_2']
+        }]
+    }
+    ]
+}
 
 class RequestAccessTests(CaravelTestCase):
 
-    requires_examples = True
+    requires_examples = False
+
+    @classmethod
+    def setUpClass(cls):
+        sm.add_role('override_me')
+        db.session.commit()
+
+    @classmethod
+    def tearDownClass(cls):
+        override_me = sm.find_role('override_me')
+        db.session.delete(override_me)
+        db.session.commit()
+
+    def setUp(self):
+        self.login('admin')
+
+    def tearDown(self):
+        self.logout()
+        override_me = sm.find_role('override_me')
+        override_me.permissions = []
+        db.session.commit()
+        db.session.close()
+
+    def test_override_role_permissions_is_admin_only(self):
+        self.logout()
+        self.login('alpha')
+        response = self.client.post(
+            '/caravel/override_role_permissions/',
+            data=json.dumps(ROLE_TABLES_PERM_DATA),
+            content_type='application/json',
+            follow_redirects=True)
+        self.assertNotEquals(405, response.status_code)
+
+    def test_override_role_permissions_1_table(self):
+        response = self.client.post(
+            '/caravel/override_role_permissions/',
+            data=json.dumps(ROLE_TABLES_PERM_DATA),
+            content_type='application/json')
+        self.assertEquals(201, response.status_code)
+
+        updated_override_me = sm.find_role('override_me')
+        self.assertEquals(1, len(updated_override_me.permissions))
+        birth_names = self.get_table_by_name('birth_names')
+        self.assertEquals(
+            birth_names.perm,
+            updated_override_me.permissions[0].view_menu.name)
+        self.assertEquals(
+            'datasource_access',
+            updated_override_me.permissions[0].permission.name)
+
+    def test_override_role_permissions_druid_and_table(self):
+        response = self.client.post(
+            '/caravel/override_role_permissions/',
+            data=json.dumps(ROLE_ALL_PERM_DATA),
+            content_type='application/json')
+        self.assertEquals(201, response.status_code)
+
+        updated_role = sm.find_role('override_me')
+        perms = sorted(
+            updated_role.permissions, key=lambda p: p.view_menu.name)
+        self.assertEquals(3, len(perms))
+        druid_ds_1 = self.get_druid_ds_by_name('druid_ds_1')
+        self.assertEquals(druid_ds_1.perm, perms[0].view_menu.name)
+        self.assertEquals('datasource_access', perms[0].permission.name)
+
+        druid_ds_2 = self.get_druid_ds_by_name('druid_ds_2')
+        self.assertEquals(druid_ds_2.perm, perms[1].view_menu.name)
+        self.assertEquals(
+            'datasource_access', updated_role.permissions[1].permission.name)
+
+        birth_names = self.get_table_by_name('birth_names')
+        self.assertEquals(birth_names.perm, perms[2].view_menu.name)
+        self.assertEquals(
+            'datasource_access', updated_role.permissions[2].permission.name)
+
+    def test_override_role_permissions_drops_absent_perms(self):
+        override_me = sm.find_role('override_me')
+        override_me.permissions.append(
+            sm.find_permission_view_menu(
+                view_menu_name=self.get_table_by_name('long_lat').perm,
+                permission_name='datasource_access')
+        )
+        db.session.flush()
+
+        response = self.client.post(
+            '/caravel/override_role_permissions/',
+            data=json.dumps(ROLE_TABLES_PERM_DATA),
+            content_type='application/json')
+        self.assertEquals(201, response.status_code)
+        updated_override_me = sm.find_role('override_me')
+        self.assertEquals(1, len(updated_override_me.permissions))
+        birth_names = self.get_table_by_name('birth_names')
+        self.assertEquals(
+            birth_names.perm,
+            updated_override_me.permissions[0].view_menu.name)
+        self.assertEquals(
+            'datasource_access',
+            updated_override_me.permissions[0].permission.name)
+
 
     def test_approve(self):
         session = db.session
         TEST_ROLE_NAME = 'table_role'
         sm.add_role(TEST_ROLE_NAME)
-        self.login('admin')
 
         def create_access_request(ds_type, ds_name, role_name):
             ds_class = SourceRegistry.sources[ds_type]
@@ -116,6 +245,7 @@ class RequestAccessTests(CaravelTestCase):
 
     def test_request_access(self):
         session = db.session
+        self.logout()
         self.login(username='gamma')
         gamma_user = sm.find_user(username='gamma')
         sm.add_role('dummy_role')

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -20,8 +20,8 @@ cli = imp.load_source('cli', BASE_DIR + "/bin/caravel")
 
 
 class CaravelTestCase(unittest.TestCase):
-    requires_examples = False
-    examples_loaded = False
+    requires_examples = True
+    examples_loaded = True
 
     def __init__(self, *args, **kwargs):
         if (
@@ -118,6 +118,15 @@ class CaravelTestCase(unittest.TestCase):
         )
         session.expunge_all()
         return slc
+
+    def get_table_by_name(self, name):
+        return db.session.query(models.SqlaTable).filter_by(
+            table_name=name).first()
+
+    def get_druid_ds_by_name(self, name):
+        return db.session.query(models.DruidDatasource).filter_by(
+            datasource_name=name).first()
+
 
     def get_resp(self, url):
         """Shortcut to get the parsed results while following redirects"""

--- a/tests/import_export_tests.py
+++ b/tests/import_export_tests.py
@@ -20,6 +20,7 @@ class ImportExportTests(CaravelTestCase):
 
     def __init__(self, *args, **kwargs):
         super(ImportExportTests, self).__init__(*args, **kwargs)
+        db.session.commit()
 
     @classmethod
     def delete_imports(cls):
@@ -108,10 +109,6 @@ class ImportExportTests(CaravelTestCase):
     def get_table(self, table_id):
         return db.session.query(models.SqlaTable).filter_by(
             id=table_id).first()
-
-    def get_table_by_name(self, name):
-        return db.session.query(models.SqlaTable).filter_by(
-            table_name=name).first()
 
     def assert_dash_equals(self, expected_dash, actual_dash):
         self.assertEquals(expected_dash.slug, actual_dash.slug)
@@ -220,7 +217,6 @@ class ImportExportTests(CaravelTestCase):
         self.assertEquals(table_id, imported_slc_1.datasource_id)
         self.assert_slice_equals(slc_1, imported_slc_1)
         self.assertEquals(imported_slc_1.datasource.perm, imported_slc_1.perm)
-
 
         self.assertEquals(table_id, imported_slc_2.datasource_id)
         self.assert_slice_equals(slc_2, imported_slc_2)


### PR DESCRIPTION
Purpose of this PR is to provide ability to have the roles that can by synchronized with the external list of datasources.
Major changes:
- override_role_permissions post endpoint
- added util function get_datasource_full_name to reuse it in views
- added database registry similar to the datasource registry

Reviewers:
- @mistercrunch 

CC:
- @ascott 
- @vera-liu 
- @jefffeng 
