### PR TITLE
Add parenthesis for custom where and having

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -55,7 +55,9 @@ import caravel
 from caravel import app, db, db_engine_specs, get_session, utils, sm
 from caravel.source_registry import SourceRegistry
 from caravel.viz import viz_types
-from caravel.utils import flasher, MetricPermException, DimSelector
+from caravel.utils import (
+    flasher, MetricPermException, DimSelector, wrap_clause_in_parens
+)
 
 config = app.config
 
@@ -1005,9 +1007,9 @@ class SqlaTable(Model, Queryable, AuditMixinNullable, ImportMixin):
                     cond = ~cond
                 where_clause_and.append(cond)
         if extras and 'where' in extras:
-            where_clause_and += [text(extras['where'])]
+            where_clause_and += [wrap_clause_in_parens(extras['where'])]
         if extras and 'having' in extras:
-            having_clause_and += [text(extras['having'])]
+            having_clause_and += [wrap_clause_in_parens(extras['having'])]
         if granularity:
             qry = qry.where(and_(*(time_filter + where_clause_and)))
         else:

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -491,3 +491,10 @@ class timeout(object):
         except ValueError as e:
             logging.warning("timeout can't be used in the current context")
             logging.exception(e)
+
+
+def wrap_clause_in_parens(sql):
+    """Wrap where/having clause with parenthesis if necessary"""
+    if sql.strip():
+        sql = '({})'.format(sql)
+    return sa.text(sql)


### PR DESCRIPTION
Currently, when there's a 'OR' in custom where, it may result an unexpected query.

For example, if a user explore a table having a main dttm field, and he sets custom where as `cond1="xxx" or cond2="yyy"`. The query generated would be

```
select ... from table_name where
dttm > '[since]' and dttm < '[until]' and cond1="xxx" or cond2="yyy"
```

That means any records that met `cond="yyy"` would be counted, even those records are out of user-specified date range. That result might not be what user expected. It would be much more reasonable if the generated query is 

```
select ... from table_name where
dttm > '[since]' and dttm < '[until]' and (cond1="xxx" or cond2="yyy")
```
