### PR TITLE
[sqllab-presto] adding partition information

### DIFF
--- a/caravel/assets/javascripts/SqlLab/actions.js
+++ b/caravel/assets/javascripts/SqlLab/actions.js
@@ -2,7 +2,7 @@ export const RESET_STATE = 'RESET_STATE';
 export const ADD_QUERY_EDITOR = 'ADD_QUERY_EDITOR';
 export const CLONE_QUERY_TO_NEW_TAB = 'CLONE_QUERY_TO_NEW_TAB';
 export const REMOVE_QUERY_EDITOR = 'REMOVE_QUERY_EDITOR';
-export const ADD_TABLE = 'ADD_TABLE';
+export const MERGE_TABLE = 'MERGE_TABLE';
 export const REMOVE_TABLE = 'REMOVE_TABLE';
 export const START_QUERY = 'START_QUERY';
 export const STOP_QUERY = 'STOP_QUERY';
@@ -86,8 +86,8 @@ export function queryEditorSetSql(queryEditor, sql) {
   return { type: QUERY_EDITOR_SET_SQL, queryEditor, sql };
 }
 
-export function addTable(table) {
-  return { type: ADD_TABLE, table };
+export function mergeTable(table) {
+  return { type: MERGE_TABLE, table };
 }
 
 export function expandTable(table) {

--- a/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
@@ -55,7 +55,7 @@ class SouthPane extends React.Component {
     return (
       <div className="SouthPane">
         <Tabs bsStyle="tabs" id={shortid.generate()}>
-          <Tab title="Results" eventKey={1} id={shortid.generate()}>
+          <Tab title="Results" eventKey={1}>
             <div style={{ overflow: 'auto' }}>
               {results}
             </div>

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -28,7 +28,7 @@ import shortid from 'shortid';
 import SouthPane from './SouthPane';
 import Timer from './Timer';
 
-import SqlEditorTopToolbar from './SqlEditorTopToolbar';
+import SqlEditorLeftBar from './SqlEditorLeftBar';
 
 class SqlEditor extends React.Component {
   constructor(props) {
@@ -252,7 +252,7 @@ class SqlEditor extends React.Component {
       <div className="SqlEditor" style={{ minHeight: this.sqlEditorHeight() }}>
         <Row>
           <Col md={3}>
-            <SqlEditorTopToolbar queryEditor={this.props.queryEditor} />
+            <SqlEditorLeftBar queryEditor={this.props.queryEditor} />
           </Col>
           <Col md={9}>
             <AceEditor

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
@@ -4,14 +4,13 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as Actions from '../actions';
-import shortid from 'shortid';
 import Select from 'react-select';
 import { Label, Button } from 'react-bootstrap';
 import TableElement from './TableElement';
 import DatabaseSelect from './DatabaseSelect';
 
 
-class SqlEditorTopToolbar extends React.Component {
+class SqlEditorLeftBar extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -79,12 +78,11 @@ class SqlEditorTopToolbar extends React.Component {
   changeTable(tableOpt) {
     const tableName = tableOpt.value;
     const qe = this.props.queryEditor;
-    const url = `/caravel/table/${qe.dbId}/${tableName}/${qe.schema}/`;
+    let url = `/caravel/table/${qe.dbId}/${tableName}/${qe.schema}/`;
 
     this.setState({ tableLoading: true });
     $.get(url, (data) => {
-      this.props.actions.addTable({
-        id: shortid.generate(),
+      this.props.actions.mergeTable({
         dbId: this.props.queryEditor.dbId,
         queryEditorId: this.props.queryEditor.id,
         name: data.name,
@@ -101,6 +99,18 @@ class SqlEditorTopToolbar extends React.Component {
         bsStyle: 'danger',
       });
       this.setState({ tableLoading: false });
+    });
+
+    url = `/caravel/extra_table_metadata/${qe.dbId}/${tableName}/${qe.schema}/`;
+    $.get(url, (data) => {
+      const table = {
+        dbId: this.props.queryEditor.dbId,
+        queryEditorId: this.props.queryEditor.id,
+        schema: qe.schema,
+        name: tableName,
+      };
+      Object.assign(table, data);
+      this.props.actions.mergeTable(table);
     });
   }
   render() {
@@ -158,14 +168,14 @@ class SqlEditorTopToolbar extends React.Component {
   }
 }
 
-SqlEditorTopToolbar.propTypes = {
+SqlEditorLeftBar.propTypes = {
   queryEditor: React.PropTypes.object,
   tables: React.PropTypes.array,
   actions: React.PropTypes.object,
   networkOn: React.PropTypes.bool,
 };
 
-SqlEditorTopToolbar.defaultProps = {
+SqlEditorLeftBar.defaultProps = {
   tables: [],
 };
 
@@ -182,4 +192,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SqlEditorTopToolbar);
+export default connect(mapStateToProps, mapDispatchToProps)(SqlEditorLeftBar);

--- a/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -116,7 +116,6 @@ class TabbedSqlEditors extends React.Component {
           key={qe.id}
           title={tabTitle}
           eventKey={qe.id}
-          id={`a11y-query-editor-${qe.id}`}
         >
           <div className="panel panel-default">
             <div className="panel-body">

--- a/caravel/assets/javascripts/SqlLab/main.css
+++ b/caravel/assets/javascripts/SqlLab/main.css
@@ -232,3 +232,9 @@ div.tablePopover:hover {
 .SouthPane .tab-content {
     padding-top: 10px;
 }
+
+.TableElement .well {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    padding: 5px 10px;
+}

--- a/caravel/assets/javascripts/SqlLab/reducers.js
+++ b/caravel/assets/javascripts/SqlLab/reducers.js
@@ -72,8 +72,23 @@ export const sqlLabReducer = function (state, action) {
     [actions.RESET_STATE]() {
       return Object.assign({}, initialState);
     },
-    [actions.ADD_TABLE]() {
-      return addToArr(state, 'tables', action.table);
+    [actions.MERGE_TABLE]() {
+      const at = Object.assign({}, action.table);
+      let existingTable;
+      state.tables.forEach((t) => {
+        if (
+            t.dbId === at.dbId &&
+            t.queryEditorId === at.queryEditorId &&
+            t.schema === at.schema &&
+            t.name === at.name) {
+          existingTable = t;
+        }
+      });
+      if (existingTable) {
+        return alterInArr(state, 'tables', existingTable, at);
+      }
+      at.id = shortid.generate();
+      return addToArr(state, 'tables', at);
     },
     [actions.EXPAND_TABLE]() {
       return alterInArr(state, 'tables', action.table, { expanded: true });

--- a/caravel/assets/javascripts/components/CopyToClipboard.jsx
+++ b/caravel/assets/javascripts/components/CopyToClipboard.jsx
@@ -76,9 +76,11 @@ export default class CopyToClipboard extends React.Component {
     return (
       <span>
         {this.props.shouldShowText &&
-          <span>{this.props.text}</span>
+          <span>
+            {this.props.text}
+            &nbsp;&nbsp;&nbsp;&nbsp;
+          </span>
         }
-        &nbsp;&nbsp;&nbsp;&nbsp;
         <OverlayTrigger placement="top" overlay={this.renderTooltip()} trigger={['hover']}>
           <Button
             bsStyle="link"

--- a/caravel/assets/javascripts/components/ModalTrigger.jsx
+++ b/caravel/assets/javascripts/components/ModalTrigger.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 
 const propTypes = {
   triggerNode: PropTypes.node.isRequired,
-  modalTitle: PropTypes.string.isRequired,
+  modalTitle: PropTypes.node.isRequired,
   modalBody: PropTypes.node.isRequired,
   beforeOpen: PropTypes.func,
   isButton: PropTypes.bool,

--- a/caravel/assets/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/caravel/assets/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import Link from '../../../javascripts/SqlLab/components/Link';
+import { Button } from 'react-bootstrap';
+import { TableElement } from '../../../javascripts/SqlLab/components/TableElement';
+import { shallow } from 'enzyme';
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+
+describe('TableElement', () => {
+
+  const mockedProps = {
+    'table': {
+      "dbId": 1,
+      "queryEditorId": "rJ-KP47a",
+      "schema": "caravel",
+      "name": "ab_user",
+      "id": "r11Vgt60",
+      "indexes": [
+        {
+          "unique": true,
+          "column_names": [
+            "username"
+          ],
+          "type": "UNIQUE",
+          "name": "username"
+        },
+        {
+          "unique": true,
+          "column_names": [
+            "email"
+          ],
+          "type": "UNIQUE",
+          "name": "email"
+        },
+        {
+          "unique": false,
+          "column_names": [
+            "created_by_fk"
+          ],
+          "name": "created_by_fk"
+        },
+        {
+          "unique": false,
+          "column_names": [
+            "changed_by_fk"
+          ],
+          "name": "changed_by_fk"
+        }
+      ],
+      "columns": [
+        {
+          "indexed": false,
+          "longType": "INTEGER(11)",
+          "type": "INTEGER",
+          "name": "id"
+        },
+        {
+          "indexed": false,
+          "longType": "VARCHAR(64)",
+          "type": "VARCHAR",
+          "name": "first_name"
+        },
+        {
+          "indexed": false,
+          "longType": "VARCHAR(64)",
+          "type": "VARCHAR",
+          "name": "last_name"
+        },
+        {
+          "indexed": true,
+          "longType": "VARCHAR(64)",
+          "type": "VARCHAR",
+          "name": "username"
+        },
+        {
+          "indexed": false,
+          "longType": "VARCHAR(256)",
+          "type": "VARCHAR",
+          "name": "password"
+        },
+        {
+          "indexed": false,
+          "longType": "TINYINT(1)",
+          "type": "TINYINT",
+          "name": "active"
+        },
+        {
+          "indexed": true,
+          "longType": "VARCHAR(64)",
+          "type": "VARCHAR",
+          "name": "email"
+        },
+        {
+          "indexed": false,
+          "longType": "DATETIME",
+          "type": "DATETIME",
+          "name": "last_login"
+        },
+        {
+          "indexed": false,
+          "longType": "INTEGER(11)",
+          "type": "INTEGER",
+          "name": "login_count"
+        },
+        {
+          "indexed": false,
+          "longType": "INTEGER(11)",
+          "type": "INTEGER",
+          "name": "fail_login_count"
+        },
+        {
+          "indexed": false,
+          "longType": "DATETIME",
+          "type": "DATETIME",
+          "name": "created_on"
+        },
+        {
+          "indexed": false,
+          "longType": "DATETIME",
+          "type": "DATETIME",
+          "name": "changed_on"
+        },
+        {
+          "indexed": true,
+          "longType": "INTEGER(11)",
+          "type": "INTEGER",
+          "name": "created_by_fk"
+        },
+        {
+          "indexed": true,
+          "longType": "INTEGER(11)",
+          "type": "INTEGER",
+          "name": "changed_by_fk"
+        }
+      ],
+      "expanded": true
+    }
+  }
+  it('should just render', () => {
+    expect(
+      React.isValidElement(<TableElement />)
+    ).to.equal(true);
+  });
+  it('should render with props', () => {
+    expect(
+      React.isValidElement(<TableElement {...mockedProps} />)
+    ).to.equal(true);
+  });
+  it('has 3 Link elements', () => {
+    const wrapper = shallow(<TableElement {...mockedProps} />);
+    expect(wrapper.find(Link)).to.have.length(3);
+  });
+  it('has 14 columns', () => {
+    const wrapper = shallow(<TableElement {...mockedProps} />);
+    expect(wrapper.find('div.table-column')).to.have.length(14);
+  });
+});

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import imp
+import json
 import os
 import unittest
 
@@ -123,6 +124,18 @@ class CaravelTestCase(unittest.TestCase):
         """Shortcut to get the parsed results while following redirects"""
         resp = self.client.get(url, follow_redirects=True)
         return resp.data.decode('utf-8')
+
+    def get_json_resp(self, url):
+        """Shortcut to get the parsed results while following redirects"""
+        resp = self.get_resp(url)
+        return json.loads(resp)
+
+    def get_main_database(self, session):
+        return (
+            db.session.query(models.Database)
+            .filter_by(database_name='main')
+            .first()
+        )
 
     def get_access_requests(self, username, ds_type, ds_id):
             DAR = models.DatasourceAccessRequest


### PR DESCRIPTION
Showing latest partition information as a header in the TableElement component, plus a "copy to cilpboard" icon to get a query to get detailed information about existing partitions.

Side-missions:
- a new abstraction to provide per-database-engine extra table metadata, this runs async and independently from the common table metadata endpoint to avoid slowing down showing the column/type info to users
- my first mochajs unit tests, I had to play some small tricks here to decouple my component from react-redux for the react tests to run
- overdue rename of `SqlEditorTopToolbar` to `SqlEditorLeftBar`
- a bit of refactoring in the python tests
- a very basic python test, just making sure the endpoint works, no Presto mocking or anything fancy there
- minor cosmetic touchup of `CopyToClipboard` component to allow a node in the tooltip and removing unwanted `&nbsp;`
  <img width="339" alt="screen shot 2016-10-13 at 5 58 38 pm" src="https://cloud.githubusercontent.com/assets/487433/19372215/b5ae6f80-916e-11e6-8ef0-99dfbdb06f4c.png">
  <img width="384" alt="screen shot 2016-10-13 at 5 58 23 pm" src="https://cloud.githubusercontent.com/assets/487433/19372216/b5b3d0f6-916e-11e6-932b-3bef47d99000.png">

@bkyryliuk @ascott 
