### PR TITLE
Enable "Run Query in New Tab" in SQL Lab

### DIFF
--- a/caravel/assets/javascripts/SqlLab/actions.js
+++ b/caravel/assets/javascripts/SqlLab/actions.js
@@ -1,5 +1,6 @@
 export const RESET_STATE = 'RESET_STATE';
 export const ADD_QUERY_EDITOR = 'ADD_QUERY_EDITOR';
+export const CLONE_QUERY_TO_NEW_TAB = 'CLONE_QUERY_TO_NEW_TAB';
 export const REMOVE_QUERY_EDITOR = 'REMOVE_QUERY_EDITOR';
 export const ADD_TABLE = 'ADD_TABLE';
 export const REMOVE_TABLE = 'REMOVE_TABLE';
@@ -35,6 +36,10 @@ export function setDatabases(databases) {
 
 export function addQueryEditor(queryEditor) {
   return { type: ADD_QUERY_EDITOR, queryEditor };
+}
+
+export function cloneQueryToNewTab(query) {
+  return { type: CLONE_QUERY_TO_NEW_TAB, query };
 }
 
 export function setNetworkStatus(networkOn) {

--- a/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -9,7 +9,6 @@ import { Table } from 'reactable';
 import { ProgressBar } from 'react-bootstrap';
 import Link from './Link';
 import VisualizeModal from './VisualizeModal';
-import shortid from 'shortid';
 import SqlShrink from './SqlShrink';
 import { STATE_BSSTYLE_MAP } from '../common';
 import { fDuration } from '../../modules/dates';
@@ -44,16 +43,7 @@ class QueryTable extends React.Component {
   }
 
   openQueryInNewTab(query) {
-    const qe = {
-      id: shortid.generate(),
-      title: `${query.title}`,
-      dbId: (query.dbId) ? query.dbId : null,
-      schema: (query.schema) ? query.schema : null,
-      autorun: true,
-      sql: `${query.sql}`,
-    };
-    this.props.actions.addQueryEditor(qe);
-    this.props.actions.setActiveQueryEditor(qe);
+    this.props.actions.cloneQueryToNewTab(query);
   }
 
   render() {

--- a/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -9,6 +9,7 @@ import { Table } from 'reactable';
 import { ProgressBar } from 'react-bootstrap';
 import Link from './Link';
 import VisualizeModal from './VisualizeModal';
+import shortid from 'shortid';
 import SqlShrink from './SqlShrink';
 import { STATE_BSSTYLE_MAP } from '../common';
 import { fDuration } from '../../modules/dates';
@@ -41,10 +42,20 @@ class QueryTable extends React.Component {
   restoreSql(query) {
     this.props.actions.queryEditorSetSql({ id: query.sqlEditorId }, query.sql);
   }
-  notImplemented() {
-    /* eslint no-alert: 0 */
-    alert('Not implemented yet!');
+
+  openQueryInNewTab(query) {
+    const qe = {
+      id: shortid.generate(),
+      title: `${query.title}`,
+      dbId: (query.dbId) ? query.dbId : null,
+      schema: (query.schema) ? query.schema : null,
+      autorun: true,
+      sql: `${query.sql}`,
+    };
+    this.props.actions.addQueryEditor(qe);
+    this.props.actions.setActiveQueryEditor(qe);
   }
+
   render() {
     const data = this.props.queries.map((query) => {
       const q = Object.assign({}, query);
@@ -112,7 +123,7 @@ class QueryTable extends React.Component {
           />
           <Link
             className="fa fa-plus-circle m-r-3"
-            onClick={self.notImplemented}
+            onClick={this.openQueryInNewTab.bind(this, query)}
             tooltip="Run query in a new tab"
             placement="top"
           />

--- a/caravel/assets/javascripts/SqlLab/reducers.js
+++ b/caravel/assets/javascripts/SqlLab/reducers.js
@@ -36,20 +36,17 @@ export const sqlLabReducer = function (state, action) {
     },
     [actions.CLONE_QUERY_TO_NEW_TAB]() {
       const progenitor = state.queryEditors.find((qe) =>
-          qe.latestQueryId === action.query.id);
+          qe.id === state.tabHistory[state.tabHistory.length - 1]);
       const qe = {
         id: shortid.generate(),
         title: `Copy of ${progenitor.title}`,
         dbId: (action.query.dbId) ? action.query.dbId : null,
         schema: (action.query.schema) ? action.query.schema : null,
         autorun: true,
-        sql: action.query.sql
+        sql: action.query.sql,
       };
 
-      const tabHistory = state.tabHistory.slice();
-      tabHistory.push(qe.id);
-      const newState = Object.assign({}, state, { tabHistory });
-      return addToArr(newState, 'queryEditors', qe);
+      return sqlLabReducer(state, actions.addQueryEditor(qe));
     },
     [actions.REMOVE_QUERY_EDITOR]() {
       let newState = removeFromArr(state, 'queryEditors', action.queryEditor);

--- a/caravel/assets/javascripts/SqlLab/reducers.js
+++ b/caravel/assets/javascripts/SqlLab/reducers.js
@@ -34,6 +34,23 @@ export const sqlLabReducer = function (state, action) {
       const newState = Object.assign({}, state, { tabHistory });
       return addToArr(newState, 'queryEditors', action.queryEditor);
     },
+    [actions.CLONE_QUERY_TO_NEW_TAB]() {
+      const progenitor = state.queryEditors.find((qe) =>
+          qe.latestQueryId === action.query.id);
+      const qe = {
+        id: shortid.generate(),
+        title: `Copy of ${progenitor.title}`,
+        dbId: (action.query.dbId) ? action.query.dbId : null,
+        schema: (action.query.schema) ? action.query.schema : null,
+        autorun: true,
+        sql: `${action.query.sql}`,
+      };
+
+      const tabHistory = state.tabHistory.slice();
+      tabHistory.push(qe.id);
+      const newState = Object.assign({}, state, { tabHistory });
+      return addToArr(newState, 'queryEditors', qe);
+    },
     [actions.REMOVE_QUERY_EDITOR]() {
       let newState = removeFromArr(state, 'queryEditors', action.queryEditor);
       // List of remaining queryEditor ids

--- a/caravel/assets/javascripts/SqlLab/reducers.js
+++ b/caravel/assets/javascripts/SqlLab/reducers.js
@@ -43,7 +43,7 @@ export const sqlLabReducer = function (state, action) {
         dbId: (action.query.dbId) ? action.query.dbId : null,
         schema: (action.query.schema) ? action.query.schema : null,
         autorun: true,
-        sql: `${action.query.sql}`,
+        sql: action.query.sql
       };
 
       const tabHistory = state.tabHistory.slice();

--- a/caravel/assets/spec/javascripts/sqllab/reducers_spec.js
+++ b/caravel/assets/spec/javascripts/sqllab/reducers_spec.js
@@ -1,18 +1,16 @@
-import React from 'react';
-import * as r from '../../../javascripts/SqlLab/reducers'
+import * as r from '../../../javascripts/SqlLab/reducers';
 import * as actions from '../../../javascripts/SqlLab/actions';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 describe('sqlLabReducer', () => {
   describe('CLONE_QUERY_TO_NEW_TAB', () => {
-    const testQuery = { sql: "SELECT * FROM...", dbId: 1, id: 1 };
-    const state = Object.assign(r.initialState, { queries: [ testQuery ] });
-    const newState = r.sqlLabReducer(state, actions.cloneQueryToNewTab(testQuery))
+    const testQuery = { sql: 'SELECT * FROM...', dbId: 1, id: 1 };
+    const state = Object.assign(r.initialState, { queries: [testQuery] });
+    const newState = r.sqlLabReducer(state, actions.cloneQueryToNewTab(testQuery));
 
     it('should have at most one more tab', () => {
       expect(newState.queryEditors).have.length(2);
-      //expect(newState.queryEditors.filter((qe) => qe.sql == testQuery.SQL).length).to.equal(2)
     });
   
     it('should have the same SQL as the cloned query', () => {
@@ -20,7 +18,7 @@ describe('sqlLabReducer', () => {
     });
 
     it('should prefix the new tab title with "Copy of"', () => {
-      expect(newState.queryEditors[1].title).to.include("Copy of");
+      expect(newState.queryEditors[1].title).to.include('Copy of');
     });
 
     it('should push the cloned tab onto tab history stack', () => {

--- a/caravel/assets/spec/javascripts/sqllab/reducers_spec.js
+++ b/caravel/assets/spec/javascripts/sqllab/reducers_spec.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import * as r from '../../../javascripts/SqlLab/reducers'
+import * as actions from '../../../javascripts/SqlLab/actions';
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+describe('sqlLabReducer', () => {
+  describe('CLONE_QUERY_TO_NEW_TAB', () => {
+    const testQuery = { sql: "SELECT * FROM...", dbId: 1, id: 1 };
+    const state = Object.assign(r.initialState, { queries: [ testQuery ] });
+    const newState = r.sqlLabReducer(state, actions.cloneQueryToNewTab(testQuery))
+
+    it('should have at most one more tab', () => {
+      expect(newState.queryEditors).have.length(2);
+      //expect(newState.queryEditors.filter((qe) => qe.sql == testQuery.SQL).length).to.equal(2)
+    });
+  
+    it('should have the same SQL as the cloned query', () => {
+      expect(newState.queryEditors[1].sql).to.equal(testQuery.sql);
+    });
+
+    it('should prefix the new tab title with "Copy of"', () => {
+      expect(newState.queryEditors[1].title).to.include("Copy of");
+    });
+
+    it('should push the cloned tab onto tab history stack', () => {
+      expect(newState.tabHistory[1]).to.eq(newState.queryEditors[1].id);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1147 – saw this was on the roadmap but it's important for the workflow I personally use so worst case I'll abandon this patch if there's already a fix in mainline.

Commit 7d33c8f shows the first approach I took, before reading a bit more about Redux; I can rebase it away and add tests if the approach in f3326a3 looks good.

n.b. This was my first time working with React/Redux, apologies in advance if this isn't idiomatic; I tried my best to base it on the rest of the codebase.
