### PR TITLE
Specify the metric to order by for Series Limit

### DIFF
--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -544,6 +544,11 @@ class FormFactory(object):
                 "description": _(
                     "Limits the number of time series that get displayed")
             }),
+            'timeseries_limit_metric': (SelectField, {
+                "label": _("Sort By"),
+                "choices": datasource.metrics_combo,
+                "description": _("Metric used to define the top series")
+            }),
             'rolling_type': (SelectField, {
                 "label": _("Rolling"),
                 "default": 'None',

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -240,6 +240,7 @@ class BaseViz(object):
             form_data.get("granularity") or form_data.get("granularity_sqla")
         )
         limit = int(form_data.get("limit", 0))
+        timeseries_limit_metric = form_data.get("timeseries_limit_metric")
         row_limit = int(
             form_data.get("row_limit", config.get("ROW_LIMIT")))
         since = (
@@ -275,6 +276,7 @@ class BaseViz(object):
             'filter': self.query_filters(),
             'timeseries_limit': limit,
             'extras': extras,
+            'timeseries_limit_metric': timeseries_limit_metric,
         }
         return d
 
@@ -999,7 +1001,8 @@ class NVD3TimeSeriesViz(NVD3Viz):
         'label': None,
         'fields': (
             'metrics',
-            'groupby', 'limit',
+            'groupby',
+            ('limit', 'timeseries_limit_metric'),
         ),
     }, {
         'label': _('Chart Options'),

--- a/run_specific_test.sh
+++ b/run_specific_test.sh
@@ -5,4 +5,4 @@ export CARAVEL_CONFIG=tests.caravel_test_config
 set -e
 caravel/bin/caravel version -v
 export SOLO_TEST=1
-nosetests tests.core_tests:CoreTests.test_slices
+nosetests tests.core_tests:CoreTests


### PR DESCRIPTION
Used to be based on the first metric from the metric multi-choice, but there's the use case where you don't want to show the metric you are sorting by. It will still default to use the first metric if the new select is empty
