### PR TITLE
Get table viz work in explore v2: Added d3 format to mock slice

### DIFF
--- a/caravel/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/caravel/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -10,7 +10,7 @@ const propTypes = {
   height: PropTypes.string.isRequired,
   sliceContainerId: PropTypes.string.isRequired,
   jsonEndpoint: PropTypes.string.isRequired,
-  column_formats: PropTypes.object,
+  columnFormats: PropTypes.object,
 };
 
 class ChartContainer extends React.Component {
@@ -50,7 +50,7 @@ class ChartContainer extends React.Component {
       },
       d3format: (col, number) => {
         // mock d3format function in Slice object in caravel.js
-        const format = this.props.column_formats[col];
+        const format = this.props.columnFormats[col];
         return d3format(format, number);
       },
     };
@@ -88,7 +88,7 @@ function mapStateToProps(state) {
     vizType: state.viz.formData.vizType,
     sliceContainerId: `slice-container-${state.viz.formData.sliceId}`,
     jsonEndpoint: state.viz.jsonEndPoint,
-    column_formats: state.viz.column_formats,
+    columnFormats: state.viz.columnFormats,
   };
 }
 

--- a/caravel/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/caravel/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { Panel } from 'react-bootstrap';
 import visMap from '../../../visualizations/main';
+import { d3format } from '../../modules/utils';
 
 const propTypes = {
   sliceName: PropTypes.string.isRequired,
@@ -9,6 +10,7 @@ const propTypes = {
   height: PropTypes.string.isRequired,
   sliceContainerId: PropTypes.string.isRequired,
   jsonEndpoint: PropTypes.string.isRequired,
+  column_formats: PropTypes.object,
 };
 
 class ChartContainer extends React.Component {
@@ -34,6 +36,7 @@ class ChartContainer extends React.Component {
           // pixel string can be '300px'
           // should call callback to adjust height of chart
         },
+        height: () => parseInt(this.props.height, 10) - 100,
       },
 
       width: () => this.chartContainerRef.getBoundingClientRect().width,
@@ -44,6 +47,11 @@ class ChartContainer extends React.Component {
 
       done: () => {
         // finished rendering callback
+      },
+      d3format: (col, number) => {
+        // mock d3format function in Slice object in caravel.js
+        const format = this.props.column_formats[col];
+        return d3format(format, number);
       },
     };
   }
@@ -80,6 +88,7 @@ function mapStateToProps(state) {
     vizType: state.viz.formData.vizType,
     sliceContainerId: `slice-container-${state.viz.formData.sliceId}`,
     jsonEndpoint: state.viz.jsonEndPoint,
+    column_formats: state.viz.column_formats,
   };
 }
 

--- a/caravel/assets/javascripts/explorev2/index.jsx
+++ b/caravel/assets/javascripts/explorev2/index.jsx
@@ -20,6 +20,7 @@ const bootstrappedState = Object.assign(initialState, {
   viz: {
     jsonEndPoint: bootstrapData.viz.json_endpoint,
     data: bootstrapData.viz.data,
+    column_formats: bootstrapData.viz.column_formats,
     formData: {
       sliceId: bootstrapData.viz.form_data.slice_id,
       vizType: bootstrapData.viz.form_data.viz_type,

--- a/caravel/assets/javascripts/explorev2/index.jsx
+++ b/caravel/assets/javascripts/explorev2/index.jsx
@@ -20,7 +20,7 @@ const bootstrappedState = Object.assign(initialState, {
   viz: {
     jsonEndPoint: bootstrapData.viz.json_endpoint,
     data: bootstrapData.viz.data,
-    column_formats: bootstrapData.viz.column_formats,
+    columnFormats: bootstrapData.viz.column_formats,
     formData: {
       sliceId: bootstrapData.viz.form_data.slice_id,
       vizType: bootstrapData.viz.form_data.viz_type,

--- a/caravel/assets/javascripts/explorev2/stores/store.js
+++ b/caravel/assets/javascripts/explorev2/stores/store.js
@@ -37,7 +37,7 @@ export const initialState = {
   filters: [],
   filterColumnOpts: [],
   viz: {
-    column_formats: {},
+    columnFormats: {},
     formData: defaultFormData,
   },
 };

--- a/caravel/assets/javascripts/explorev2/stores/store.js
+++ b/caravel/assets/javascripts/explorev2/stores/store.js
@@ -37,6 +37,7 @@ export const initialState = {
   filters: [],
   filterColumnOpts: [],
   viz: {
+    column_formats: {},
     formData: defaultFormData,
   },
 };

--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -326,6 +326,7 @@ class BaseViz(object):
                 'json_endpoint': self.json_endpoint,
                 'query': self.query,
                 'standalone_endpoint': self.standalone_endpoint,
+                'column_formats': self.data['column_formats'],
             }
             payload['cached_dttm'] = datetime.now().isoformat().split('.')[0]
             logging.info("Caching for the next {} seconds".format(


### PR DESCRIPTION
Done:
 added d3format function to Slice mock in ChartContainer

Before:
![before](https://cloud.githubusercontent.com/assets/20978302/19405953/e1f8d818-9232-11e6-80b1-b68369803410.png)

After:
<img width="940" alt="screen shot 2016-10-14 at 3 32 49 pm" src="https://cloud.githubusercontent.com/assets/20978302/19404553/9a35138e-9223-11e6-89a6-3cca07eb805a.png">

The Slice (in caravel.js) properties that are used by table viz:
- [x] .selector 
- [ ] .removeFilter() --leaving for Control panel components to handle
- [ ] .addFilter() --leaving for Control panel components to handle
- [x] .d3format()
- [x] .container.height() --same as height of mock slice
- [ ] .container.parents('.widget').find('.tooltip').remove() --leaving for Control panel components to handle
- [ ] .container.find('.dataTable').DataTable
- [ ] .container.find('.dataTables_wrapper'), height) --I'm not sure how should we mock container in slice for find() calls since we don't currently have dataTable and dataTables_wrapper? @ascott 
