### PR TITLE
Fixed big number issue

### DIFF
--- a/caravel/assets/visualizations/big_number.js
+++ b/caravel/assets/visualizations/big_number.js
@@ -75,7 +75,8 @@ function bigNumberVis(slice) {
       .style('cursor', 'pointer')
       .text(f(v))
       .style('font-size', d3.min([height, width]) / 3.5)
-      .attr('fill', 'white');
+      .style('text-anchor', 'middle')
+      .attr('fill', 'black');
 
       // Printing big number subheader text
       if (json.subheader !== null) {


### PR DESCRIPTION
Done:
- somehow the filling color for big number was white..not sure why it didn't block for v1, changed to black filling color, both v1 and v2 work fine now
- adding text anchor to center for big number

Before:
<img width="873" alt="screen shot 2016-10-14 at 5 27 24 pm" src="https://cloud.githubusercontent.com/assets/20978302/19406030/81503e60-9233-11e6-83a5-6423f5218ca7.png">

After:
<img width="867" alt="screen shot 2016-10-14 at 5 20 49 pm" src="https://cloud.githubusercontent.com/assets/20978302/19405996/1e2ab996-9233-11e6-8091-1a23c5fe1396.png">

@ascott 
