### PR TITLE
Fix 1325: Slice Cache Timeout Setting Ignored in 0.11.0

### DIFF
--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1172,7 +1172,7 @@ class Caravel(BaseCaravelView):
             datasource_type=None,
             datasource_id=None):
 
-        slice_id = slice_id or request.args.get('slice_id')
+        slice_id = slice_id or args.get('slice_id')
 
         if slice_id:
             slc = db.session.query(models.Slice).filter_by(id=slice_id).one()

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1171,6 +1171,9 @@ class Caravel(BaseCaravelView):
             args=None,
             datasource_type=None,
             datasource_id=None):
+
+        slice_id = slice_id or request.args.get('slice_id')
+
         if slice_id:
             slc = db.session.query(models.Slice).filter_by(id=slice_id).one()
             return slc.get_viz()

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -115,7 +115,7 @@ class CoreTests(CaravelTestCase):
             "datasource_id=1&datasource_type=table&previous_viz_type=sankey")
 
         db.session.commit()
-        resp = self.get_resp(url.format(tbl_id, slice_id, copy_name, 'save'))
+        resp = self.get_resp(url.format(tbl_id, slice_id, copy_name, 'saveas'))
         assert copy_name in resp
         assert 'Energy' in self.get_resp(
             url.format(tbl_id, slice_id, copy_name, 'overwrite'))
@@ -201,7 +201,7 @@ class CoreTests(CaravelTestCase):
         resp = self.get_resp(
             '/caravel/warm_up_cache?table_name=energy_usage&db_name=main')
         data = json.loads(resp)
-        assert len(data) == 3
+        assert len(data) == 4
 
     def test_shortner(self):
         self.login(username='admin')


### PR DESCRIPTION
Fixes #1325 

RE: 308f6da, I _think_ that save test passed because `request.args` contained "Slice Name", but there was no persistence of the Slice to the database; I'm not sure whether this was intended or not. As far as I could tell there was no code in `views.py` to handle the `action=save` query param.

This also caused the Cache Warm Up test to fail, since it's tied to DB state affected by the Slice Save test.
