### PR TITLE
[sqllab] add support for results backends

### DIFF
--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -103,6 +103,7 @@ appbuilder = AppBuilder(
 sm = appbuilder.sm
 
 get_session = appbuilder.get_session
+results_backend = app.config.get("RESULTS_BACKEND")
 
 # Registering sources
 module_datasource_map = app.config.get("DEFAULT_MODULE_DS_MAP")

--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -31,7 +31,7 @@ if not app.debug:
 db = SQLA(app)
 
 
-utils.pessimistic_connection_handling()
+utils.pessimistic_connection_handling(db.engine)
 
 
 cache = Cache(app, config=app.config.get('CACHE_CONFIG'))

--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -31,8 +31,7 @@ if not app.debug:
 db = SQLA(app)
 
 
-utils.pessimistic_connection_handling(db.engine)
-
+utils.pessimistic_connection_handling(db.engine.pool)
 
 cache = Cache(app, config=app.config.get('CACHE_CONFIG'))
 

--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -10,12 +10,12 @@ from logging.handlers import TimedRotatingFileHandler
 
 from flask import Flask, redirect
 from flask_appbuilder import SQLA, AppBuilder, IndexView
-from sqlalchemy import event, exc
 from flask_appbuilder.baseviews import expose
 from flask_cache import Cache
 from flask_migrate import Migrate
 from caravel.source_registry import SourceRegistry
 from werkzeug.contrib.fixers import ProxyFix
+from caravel import utils
 
 
 APP_DIR = os.path.dirname(__file__)
@@ -31,32 +31,7 @@ if not app.debug:
 db = SQLA(app)
 
 
-@event.listens_for(db.engine, 'checkout')
-def checkout(dbapi_con, con_record, con_proxy):
-    """
-    Making sure the connection is live, and preventing against:
-    'MySQL server has gone away'
-
-    Copied from:
-    http://stackoverflow.com/questions/30630120/mysql-keeps-losing-connection-during-celery-tasks
-    """
-    try:
-        try:
-            if hasattr(dbapi_con, 'ping'):
-                dbapi_con.ping(False)
-            else:
-                cursor = dbapi_con.cursor()
-                cursor.execute("SELECT 1")
-        except TypeError:
-            app.logger.debug('MySQL connection died. Restoring...')
-            dbapi_con.ping()
-    except dbapi_con.OperationalError as e:
-        app.logger.warning(e)
-        if e.args[0] in (2006, 2013, 2014, 2045, 2055):
-            raise exc.DisconnectionError()
-        else:
-            raise
-    return db
+utils.pessimistic_connection_handling()
 
 
 cache = Cache(app, config=app.config.get('CACHE_CONFIG'))

--- a/caravel/assets/javascripts/SqlLab/actions.js
+++ b/caravel/assets/javascripts/SqlLab/actions.js
@@ -81,11 +81,9 @@ export function fetchQueryResults(query) {
       dataType: 'json',
       url: sqlJsonUrl,
       success(results) {
-        // console.log(results);
         dispatch(querySuccess(query, results));
       },
       error() {
-        // console.log(err);
         dispatch(queryFailed(query, 'Failed at retrieving results from the results backend'));
       },
     });
@@ -105,7 +103,7 @@ export function runQuery(query) {
       sql: query.sql,
       sql_editor_id: query.sqlEditorId,
       tab: query.tab,
-      // tmp_table_name: this.state.ctas,
+      tmp_table_name: query.tempTableName,
       select_as_cta: query.ctas,
     };
     $.ajax({

--- a/caravel/assets/javascripts/SqlLab/common.js
+++ b/caravel/assets/javascripts/SqlLab/common.js
@@ -1,7 +1,9 @@
 export const STATE_BSSTYLE_MAP = {
   failed: 'danger',
   pending: 'info',
+  fetching: 'info',
   running: 'warning',
+  stopped: 'danger',
   success: 'success',
 };
 

--- a/caravel/assets/javascripts/SqlLab/common.js
+++ b/caravel/assets/javascripts/SqlLab/common.js
@@ -7,4 +7,6 @@ export const STATE_BSSTYLE_MAP = {
   success: 'success',
 };
 
+export const DATA_PREVIEW_ROW_COUNT = 100;
+
 export const STATUS_OPTIONS = ['success', 'failed', 'running'];

--- a/caravel/assets/javascripts/SqlLab/components/App.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/App.jsx
@@ -5,6 +5,7 @@ import TabbedSqlEditors from './TabbedSqlEditors';
 import QueryAutoRefresh from './QueryAutoRefresh';
 import QuerySearch from './QuerySearch';
 import Alerts from './Alerts';
+import DataPreviewModal from './DataPreviewModal';
 
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -26,8 +27,9 @@ class App extends React.Component {
     this.setState({ hash: window.location.hash });
   }
   render() {
+    let content;
     if (this.state.hash) {
-      return (
+      content = (
         <div className="container-fluid">
           <div className="row">
             <div className="col-md-12">
@@ -37,16 +39,18 @@ class App extends React.Component {
         </div>
       );
     }
+    content = (
+      <div>
+        <QueryAutoRefresh />
+        <TabbedSqlEditors />
+      </div>
+    );
     return (
       <div className="App SqlLab">
+        <Alerts alerts={this.props.alerts} />
+        <DataPreviewModal />
         <div className="container-fluid">
-          <QueryAutoRefresh />
-          <Alerts alerts={this.props.alerts} />
-          <div className="row">
-            <div className="col-md-12">
-              <TabbedSqlEditors />
-            </div>
-          </div>
+          {content}
         </div>
       </div>
     );

--- a/caravel/assets/javascripts/SqlLab/components/DataPreviewModal.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/DataPreviewModal.jsx
@@ -1,0 +1,58 @@
+import * as Actions from '../actions';
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { Modal } from 'react-bootstrap';
+
+import ResultSet from './ResultSet';
+
+const propTypes = {
+  queries: React.PropTypes.array,
+  actions: React.PropTypes.object,
+  showDataPreviewModal: React.PropTypes.bool,
+  dataPreviewQueryId: React.PropTypes.string,
+};
+
+class DataPreviewModal extends React.Component {
+  hide() {
+    this.props.actions.hideDataPreview();
+  }
+  render() {
+    if (this.props.showDataPreviewModal && this.props.dataPreviewQueryId) {
+      const query = this.props.queries[this.props.dataPreviewQueryId];
+      return (
+        <Modal
+          show={this.props.showDataPreviewModal}
+          onHide={this.hide.bind(this)}
+          bsStyle="lg"
+        >
+          <Modal.Header closeButton>
+            <Modal.Title>
+              Data preview for <strong>{query.tableName}</strong>
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <ResultSet query={query} visualize={false} csv={false} />
+          </Modal.Body>
+        </Modal>
+      );
+    }
+    return null;
+  }
+}
+DataPreviewModal.propTypes = propTypes;
+
+function mapStateToProps(state) {
+  return {
+    queries: state.queries,
+    showDataPreviewModal: state.showDataPreviewModal,
+    dataPreviewQueryId: state.dataPreviewQueryId,
+  };
+}
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: bindActionCreators(Actions, dispatch),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DataPreviewModal);

--- a/caravel/assets/javascripts/SqlLab/components/DataPreviewModal.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/DataPreviewModal.jsx
@@ -7,7 +7,7 @@ import { Modal } from 'react-bootstrap';
 import ResultSet from './ResultSet';
 
 const propTypes = {
-  queries: React.PropTypes.array,
+  queries: React.PropTypes.object,
   actions: React.PropTypes.object,
   showDataPreviewModal: React.PropTypes.bool,
   dataPreviewQueryId: React.PropTypes.string,

--- a/caravel/assets/javascripts/SqlLab/components/HighlightedSql.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/HighlightedSql.jsx
@@ -2,38 +2,43 @@ import React from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { github } from 'react-syntax-highlighter/dist/styles';
 
-const SqlShrink = (props) => {
+const HighlightedSql = (props) => {
   const sql = props.sql || '';
   let lines = sql.split('\n');
   if (lines.length >= props.maxLines) {
     lines = lines.slice(0, props.maxLines);
     lines.push('{...}');
   }
-  const shrunk = lines.map((line) => {
-    if (line.length > props.maxWidth) {
-      return line.slice(0, props.maxWidth) + '{...}';
-    }
-    return line;
-  })
-  .join('\n');
+  let shownSql = sql;
+  if (props.shrink) {
+    shownSql = lines.map((line) => {
+      if (line.length > props.maxWidth) {
+        return line.slice(0, props.maxWidth) + '{...}';
+      }
+      return line;
+    })
+    .join('\n');
+  }
   return (
     <div>
       <SyntaxHighlighter language="sql" style={github}>
-        {shrunk}
+        {shownSql}
       </SyntaxHighlighter>
     </div>
   );
 };
 
-SqlShrink.defaultProps = {
+HighlightedSql.defaultProps = {
   maxWidth: 60,
   maxLines: 6,
+  shrink: false,
 };
 
-SqlShrink.propTypes = {
+HighlightedSql.propTypes = {
   sql: React.PropTypes.string,
   maxWidth: React.PropTypes.number,
   maxLines: React.PropTypes.number,
+  shrink: React.PropTypes.bool,
 };
 
-export default SqlShrink;
+export default HighlightedSql;

--- a/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -6,13 +6,29 @@ import * as Actions from '../actions';
 
 import moment from 'moment';
 import { Table } from 'reactable';
-import { ProgressBar } from 'react-bootstrap';
+import { Label, ProgressBar } from 'react-bootstrap';
 import Link from './Link';
 import VisualizeModal from './VisualizeModal';
-import SqlShrink from './SqlShrink';
+import ResultSet from './ResultSet';
+import ModalTrigger from '../../components/ModalTrigger';
+import HighlightedSql from './HighlightedSql';
 import { STATE_BSSTYLE_MAP } from '../common';
 import { fDuration } from '../../modules/dates';
 import { getLink } from '../../../utils/common';
+
+const propTypes = {
+  columns: React.PropTypes.array,
+  actions: React.PropTypes.object,
+  queries: React.PropTypes.array,
+  onUserClicked: React.PropTypes.func,
+  onDbClicked: React.PropTypes.func,
+};
+const defaultProps = {
+  columns: ['started', 'duration', 'rows'],
+  queries: [],
+  onUserClicked: () => {},
+  onDbClicked: () => {},
+};
 
 
 class QueryTable extends React.Component {
@@ -45,6 +61,12 @@ class QueryTable extends React.Component {
   openQueryInNewTab(query) {
     this.props.actions.cloneQueryToNewTab(query);
   }
+  openAsyncResults(query) {
+    this.props.actions.fetchQueryResults(query);
+  }
+  clearQueryResults(query) {
+    this.props.actions.clearQueryResults(query);
+  }
 
   render() {
     const data = this.props.queries.map((query) => {
@@ -71,9 +93,30 @@ class QueryTable extends React.Component {
       q.started = moment(q.startDttm).format('HH:mm:ss');
       const source = (q.ctas) ? q.executedSql : q.sql;
       q.sql = (
-        <SqlShrink sql={source} maxWidth={100} />
+        <HighlightedSql sql={source} shrink maxWidth={100} />
       );
-      q.output = q.tempTable;
+      if (q.resultsKey) {
+        q.output = (
+          <ModalTrigger
+            bsSize="large"
+            className="ResultsModal"
+            triggerNode={(
+              <Label
+                bsStyle="info"
+                style={{ cursor: 'pointer' }}
+              >
+                view results
+              </Label>
+            )}
+            modalTitle={'Data preview'}
+            beforeOpen={this.openAsyncResults.bind(this, query)}
+            onExit={this.clearQueryResults.bind(this, query)}
+            modalBody={<ResultSet showSql query={query} />}
+          />
+        );
+      } else {
+        q.output = q.tempTable;
+      }
       q.progress = (
         <ProgressBar
           style={{ width: '75px' }}
@@ -137,7 +180,7 @@ class QueryTable extends React.Component {
       return q;
     }).reverse();
     return (
-      <div>
+      <div className="QueryTable">
         <VisualizeModal
           show={this.state.showVisualizeModal}
           query={this.state.activeQuery}
@@ -152,19 +195,8 @@ class QueryTable extends React.Component {
     );
   }
 }
-QueryTable.propTypes = {
-  columns: React.PropTypes.array,
-  actions: React.PropTypes.object,
-  queries: React.PropTypes.array,
-  onUserClicked: React.PropTypes.func,
-  onDbClicked: React.PropTypes.func,
-};
-QueryTable.defaultProps = {
-  columns: ['started', 'duration', 'rows'],
-  queries: [],
-  onUserClicked: () => {},
-  onDbClicked: () => {},
-};
+QueryTable.propTypes = propTypes;
+QueryTable.defaultProps = defaultProps;
 
 function mapStateToProps() {
   return {};

--- a/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -206,4 +206,5 @@ function mapDispatchToProps(dispatch) {
     actions: bindActionCreators(Actions, dispatch),
   };
 }
+export { QueryTable };
 export default connect(mapStateToProps, mapDispatchToProps)(QueryTable);

--- a/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -1,8 +1,31 @@
 import React from 'react';
-import { Alert, Button, ButtonGroup } from 'react-bootstrap';
+import { Alert, Button, ButtonGroup, ProgressBar } from 'react-bootstrap';
 import { Table } from 'reactable';
 
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as Actions from '../actions';
+
 import VisualizeModal from './VisualizeModal';
+import HighlightedSql from './HighlightedSql';
+
+const propTypes = {
+  actions: React.PropTypes.object,
+  csv: React.PropTypes.bool,
+  query: React.PropTypes.object,
+  search: React.PropTypes.bool,
+  searchText: React.PropTypes.string,
+  showSql: React.PropTypes.bool,
+  visualize: React.PropTypes.bool,
+};
+const defaultProps = {
+  search: true,
+  visualize: true,
+  showSql: false,
+  csv: true,
+  searchText: '',
+  actions: {},
+};
 
 
 class ResultSet extends React.Component {
@@ -13,8 +36,55 @@ class ResultSet extends React.Component {
       showModal: false,
     };
   }
-  changeSearch(event) {
-    this.setState({ searchText: event.target.value });
+  getControls() {
+    if (this.props.search || this.props.visualize || this.props.csv) {
+      let csvButton;
+      if (this.props.csv) {
+        csvButton = (
+          <Button bsSize="small" href={'/caravel/csv/' + this.props.query.id}>
+            <i className="fa fa-file-text-o" /> .CSV
+          </Button>
+        );
+      }
+      let visualizeButton;
+      if (this.props.visualize) {
+        visualizeButton = (
+          <Button
+            bsSize="small"
+            onClick={this.showModal.bind(this)}
+          >
+            <i className="fa fa-line-chart m-l-1" /> Visualize
+          </Button>
+        );
+      }
+      let searchBox;
+      if (this.props.search) {
+        searchBox = (
+          <input
+            type="text"
+            onChange={this.changeSearch.bind(this)}
+            className="form-control input-sm"
+            placeholder="Search Results"
+          />
+        );
+      }
+      return (
+        <div className="ResultSetControls">
+          <div className="clearfix">
+            <div className="pull-left">
+              <ButtonGroup>
+                {visualizeButton}
+                {csvButton}
+              </ButtonGroup>
+            </div>
+            <div className="pull-right">
+              {searchBox}
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return <div className="noControls" />;
   }
   showModal() {
     this.setState({ showModal: true });
@@ -22,74 +92,101 @@ class ResultSet extends React.Component {
   hideModal() {
     this.setState({ showModal: false });
   }
+  changeSearch(event) {
+    this.setState({ searchText: event.target.value });
+  }
+  fetchResults(query) {
+    this.props.actions.fetchQueryResults(query);
+  }
   render() {
-    const results = this.props.query.results;
-    let controls = <div className="noControls" />;
-    if (this.props.showControls) {
-      controls = (
-        <div className="ResultSetControls">
-          <div className="clearfix">
-            <div className="pull-left">
-              <ButtonGroup>
-                <Button
-                  bsSize="small"
-                  onClick={this.showModal.bind(this)}
-                >
-                  <i className="fa fa-line-chart m-l-1" /> Visualize
-                </Button>
-                <Button bsSize="small" href={'/caravel/csv/' + this.props.query.id}>
-                  <i className="fa fa-file-text-o" /> .CSV
-                </Button>
-              </ButtonGroup>
-            </div>
-            <div className="pull-right">
-              <input
-                type="text"
-                onChange={this.changeSearch.bind(this)}
-                className="form-control input-sm"
-                placeholder="Search Results"
+    const query = this.props.query;
+    const results = query.results;
+    let sql;
+    if (this.props.showSql) {
+      sql = <HighlightedSql sql={query.sql} />;
+    }
+    if (['running', 'pending', 'fetching'].includes(query.state)) {
+      let progressBar;
+      if (query.progress > 0 && query.state === 'running') {
+        progressBar = (
+          <ProgressBar
+            striped
+            now={query.progress}
+            label={`${query.progress}%`}
+          />);
+      }
+      return (
+        <div>
+          <img className="loading" alt="Loading..." src="/static/assets/images/loading.gif" />
+          {progressBar}
+        </div>
+      );
+    } else if (query.state === 'failed') {
+      return <Alert bsStyle="danger">{query.errorMessage}</Alert>;
+    } else if (query.state === 'success' && query.ctas) {
+      return (
+        <div>
+          <Alert bsStyle="info">
+            Table [<strong>{query.tempTable}</strong>] was created
+          </Alert>
+          <p>
+            <Button
+              bsSize="small"
+              className="m-r-5"
+              onClick={this.popSelectStar.bind(this)}
+            >
+              Query in a new tab
+            </Button>
+            <Button bsSize="small">Visualize</Button>
+          </p>
+        </div>);
+    } else if (query.state === 'success') {
+      if (results && results.data && results.data.length > 0) {
+        return (
+          <div>
+            <VisualizeModal
+              show={this.state.showModal}
+              query={this.props.query}
+              onHide={this.hideModal.bind(this)}
+            />
+            {this.getControls.bind(this)()}
+            {sql}
+            <div className="ResultSet">
+              <Table
+                data={results.data}
+                columns={results.columns.map((col) => col.name)}
+                sortable
+                className="table table-condensed table-bordered"
+                filterBy={this.state.searchText}
+                filterable={results.columns.map((c) => c.name)}
+                hideFilterInput
               />
             </div>
           </div>
-        </div>
-      );
-    }
-    if (results && results.data && results.data.length > 0) {
-      return (
-        <div>
-          <VisualizeModal
-            show={this.state.showModal}
-            query={this.props.query}
-            onHide={this.hideModal.bind(this)}
-          />
-          {controls}
-          <div className="ResultSet">
-            <Table
-              data={results.data}
-              columns={results.columns.map((col) => col.name)}
-              sortable
-              className="table table-condensed table-bordered"
-              filterBy={this.state.searchText}
-              filterable={results.columns}
-              hideFilterInput
-            />
+        );
+      } else if (query.resultsKey) {
+        return (
+          <div>
+            <Alert bsStyle="warning">This query was run asynchronously</Alert>
+            <Button bsSize="sm" bsStyle="primary" onClick={this.fetchResults.bind(this, query)}>
+              Fetch results
+            </Button>
           </div>
-        </div>
-      );
+        );
+      }
     }
     return (<Alert bsStyle="warning">The query returned no data</Alert>);
   }
 }
-ResultSet.propTypes = {
-  query: React.PropTypes.object,
-  showControls: React.PropTypes.bool,
-  search: React.PropTypes.bool,
-  searchText: React.PropTypes.string,
-};
-ResultSet.defaultProps = {
-  showControls: true,
-  search: true,
-  searchText: '',
-};
+ResultSet.propTypes = propTypes;
+ResultSet.defaultProps = defaultProps;
 
-export default ResultSet;
+function mapStateToProps() {
+  return {};
+}
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: bindActionCreators(Actions, dispatch),
+  };
+}
+export default connect(mapStateToProps, mapDispatchToProps)(ResultSet);

--- a/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Alert, Button, ButtonGroup, ProgressBar } from 'react-bootstrap';
 import { Table } from 'reactable';
+import shortid from 'shortid';
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -86,6 +87,16 @@ class ResultSet extends React.Component {
     }
     return <div className="noControls" />;
   }
+  popSelectStar() {
+    const qe = {
+      id: shortid.generate(),
+      title: this.props.query.tempTable,
+      autorun: false,
+      dbId: this.props.query.dbId,
+      sql: `SELECT * FROM ${this.props.query.tempTable}`,
+    };
+    this.props.actions.addQueryEditor(qe);
+  }
   showModal() {
     this.setState({ showModal: true });
   }
@@ -127,9 +138,8 @@ class ResultSet extends React.Component {
       return (
         <div>
           <Alert bsStyle="info">
-            Table [<strong>{query.tempTable}</strong>] was created
-          </Alert>
-          <p>
+            Table [<strong>{query.tempTable}</strong>] was
+            created &nbsp;
             <Button
               bsSize="small"
               className="m-r-5"
@@ -137,8 +147,7 @@ class ResultSet extends React.Component {
             >
               Query in a new tab
             </Button>
-            <Button bsSize="small">Visualize</Button>
-          </p>
+          </Alert>
         </div>);
     } else if (query.state === 'success') {
       if (results && results.data && results.data.length > 0) {
@@ -167,10 +176,11 @@ class ResultSet extends React.Component {
       } else if (query.resultsKey) {
         return (
           <div>
-            <Alert bsStyle="warning">This query was run asynchronously</Alert>
-            <Button bsSize="sm" bsStyle="primary" onClick={this.fetchResults.bind(this, query)}>
-              Fetch results
-            </Button>
+            <Alert bsStyle="warning">This query was run asynchronously &nbsp;
+              <Button bsSize="sm" onClick={this.fetchResults.bind(this, query)}>
+                Fetch results
+              </Button>
+            </Alert>
           </div>
         );
       }

--- a/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
@@ -25,7 +25,7 @@ class SouthPane extends React.Component {
     if (latestQuery) {
       if (['running', 'pending'].includes(latestQuery.state)) {
         results = (
-          <img className="loading" alt="Loading.." src="/static/assets/images/loading.gif" />
+          <img className="loading" alt="Loading..." src="/static/assets/images/loading.gif" />
         );
       } else if (latestQuery.state === 'failed') {
         results = <Alert bsStyle="danger">{latestQuery.errorMessage}</Alert>;

--- a/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Tab, Tabs } from 'react-bootstrap';
+import { Alert, Tab, Tabs } from 'react-bootstrap';
 import QueryHistory from './QueryHistory';
 import ResultSet from './ResultSet';
 import React from 'react';
@@ -8,66 +8,29 @@ import { bindActionCreators } from 'redux';
 import * as Actions from '../actions';
 import shortid from 'shortid';
 
-class SouthPane extends React.Component {
-  popSelectStar() {
-    const qe = {
-      id: shortid.generate(),
-      title: this.props.latestQuery.tempTable,
-      autorun: false,
-      dbId: this.props.latestQuery.dbId,
-      sql: `SELECT * FROM ${this.props.latestQuery.tempTable}`,
-    };
-    this.props.actions.addQueryEditor(qe);
+const SouthPane = function (props) {
+  let results = <div />;
+  const latestQuery = props.latestQuery;
+  if (latestQuery) {
+    results = <ResultSet showControls search query={latestQuery} />;
+  } else {
+    results = <Alert bsStyle="info">Run a query to display results here</Alert>;
   }
-  render() {
-    let results = <div />;
-    const latestQuery = this.props.latestQuery;
-    if (latestQuery) {
-      if (['running', 'pending'].includes(latestQuery.state)) {
-        results = (
-          <img className="loading" alt="Loading..." src="/static/assets/images/loading.gif" />
-        );
-      } else if (latestQuery.state === 'failed') {
-        results = <Alert bsStyle="danger">{latestQuery.errorMessage}</Alert>;
-      } else if (latestQuery.state === 'success' && latestQuery.ctas) {
-        results = (
-          <div>
-            <Alert bsStyle="info">
-              Table [<strong>{latestQuery.tempTable}</strong>] was created
-            </Alert>
-            <p>
-              <Button
-                bsSize="small"
-                className="m-r-5"
-                onClick={this.popSelectStar.bind(this)}
-              >
-                Query in a new tab
-              </Button>
-              <Button bsSize="small">Visualize</Button>
-            </p>
-          </div>);
-      } else if (latestQuery.state === 'success') {
-        results = <ResultSet showControls search query={latestQuery} />;
-      }
-    } else {
-      results = <Alert bsStyle="info">Run a query to display results here</Alert>;
-    }
-    return (
-      <div className="SouthPane">
-        <Tabs bsStyle="tabs" id={shortid.generate()}>
-          <Tab title="Results" eventKey={1}>
-            <div style={{ overflow: 'auto' }}>
-              {results}
-            </div>
-          </Tab>
-          <Tab title="Query History" eventKey={2}>
-            <QueryHistory />
-          </Tab>
-        </Tabs>
-      </div>
-    );
-  }
-}
+  return (
+    <div className="SouthPane">
+      <Tabs bsStyle="tabs" id={shortid.generate()}>
+        <Tab title="Results" eventKey={1}>
+          <div style={{ overflow: 'auto' }}>
+            {results}
+          </div>
+        </Tab>
+        <Tab title="Query History" eventKey={2}>
+          <QueryHistory />
+        </Tab>
+      </Tabs>
+    </div>
+  );
+};
 
 SouthPane.propTypes = {
   latestQuery: React.PropTypes.object,

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -1,5 +1,3 @@
-const $ = require('jquery');
-import { now } from '../../modules/dates';
 import React from 'react';
 import {
   Button,
@@ -53,64 +51,15 @@ class SqlEditor extends React.Component {
     this.startQuery(runAsync);
   }
   startQuery(runAsync = false, ctas = false) {
-    const that = this;
     const query = {
       dbId: this.props.queryEditor.dbId,
-      id: shortid.generate(),
-      progress: 0,
       sql: this.props.queryEditor.sql,
       sqlEditorId: this.props.queryEditor.id,
-      startDttm: now(),
-      state: 'running',
       tab: this.props.queryEditor.title,
-    };
-    if (runAsync) {
-      query.state = 'pending';
-    }
-
-    // Execute the Query
-    that.props.actions.startQuery(query);
-
-    const sqlJsonUrl = '/caravel/sql_json/';
-    const sqlJsonRequest = {
-      client_id: query.id,
-      database_id: this.props.queryEditor.dbId,
-      json: true,
       runAsync,
-      schema: this.props.queryEditor.schema,
-      select_as_cta: ctas,
-      sql: this.props.queryEditor.sql,
-      sql_editor_id: this.props.queryEditor.id,
-      tab: this.props.queryEditor.title,
-      tmp_table_name: this.state.ctas,
+      ctas,
     };
-    $.ajax({
-      type: 'POST',
-      dataType: 'json',
-      url: sqlJsonUrl,
-      data: sqlJsonRequest,
-      success(results) {
-        if (!runAsync) {
-          that.props.actions.querySuccess(query, results);
-        }
-      },
-      error(err, textStatus, errorThrown) {
-        let msg;
-        try {
-          msg = err.responseJSON.error;
-        } catch (e) {
-          if (err.responseText !== undefined) {
-            msg = err.responseText;
-          }
-        }
-        if (textStatus === 'error' && errorThrown === '') {
-          msg = 'Could not connect to server';
-        } else if (msg === null) {
-          msg = `[${textStatus}] ${errorThrown}`;
-        }
-        that.props.actions.queryFailed(query, msg);
-      },
-    });
+    this.props.actions.runQuery(query);
   }
   stopQuery() {
     this.props.actions.stopQuery(this.props.latestQuery);

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -130,7 +130,7 @@ class SqlEditor extends React.Component {
         {runButtons}
       </ButtonGroup>
     );
-    if (this.props.latestQuery && this.props.latestQuery.state === 'running') {
+    if (this.props.latestQuery && ['running', 'pending'].includes(this.props.latestQuery.state)) {
       runButtons = (
         <ButtonGroup bsSize="small" className="inline m-r-5 pull-left">
           <Button

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -56,6 +56,7 @@ class SqlEditor extends React.Component {
       sql: this.props.queryEditor.sql,
       sqlEditorId: this.props.queryEditor.id,
       tab: this.props.queryEditor.title,
+      tempTableName: this.state.ctas,
       runAsync,
       ctas,
     };

--- a/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -8,6 +8,18 @@ import shortid from 'shortid';
 import { getParamFromQuery, getLink } from '../../../utils/common';
 import CopyQueryTabUrl from './CopyQueryTabUrl';
 
+const propTypes = {
+  actions: React.PropTypes.object,
+  databases: React.PropTypes.object,
+  queries: React.PropTypes.object,
+  queryEditors: React.PropTypes.array,
+  tabHistory: React.PropTypes.array,
+};
+const defaultProps = {
+  tabHistory: [],
+  queryEditors: [],
+};
+
 let queryCount = 1;
 
 class TabbedSqlEditors extends React.Component {
@@ -141,17 +153,8 @@ class TabbedSqlEditors extends React.Component {
     );
   }
 }
-TabbedSqlEditors.propTypes = {
-  actions: React.PropTypes.object,
-  databases: React.PropTypes.object,
-  queries: React.PropTypes.object,
-  queryEditors: React.PropTypes.array,
-  tabHistory: React.PropTypes.array,
-};
-TabbedSqlEditors.defaultProps = {
-  tabHistory: [],
-  queryEditors: [],
-};
+TabbedSqlEditors.propTypes = propTypes;
+TabbedSqlEditors.defaultProps = defaultProps;
 
 function mapStateToProps(state) {
   return {

--- a/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { ButtonGroup, Well } from 'react-bootstrap';
-import Link from './Link';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as Actions from '../actions';
+
+import { ButtonGroup, Well } from 'react-bootstrap';
 import shortid from 'shortid';
-import ModalTrigger from '../../components/ModalTrigger';
+
 import CopyToClipboard from '../../components/CopyToClipboard';
+import Link from './Link';
+import ModalTrigger from '../../components/ModalTrigger';
 
 const propTypes = {
   table: React.PropTypes.object,
@@ -24,7 +26,7 @@ class TableElement extends React.Component {
     this.props.actions.queryEditorSetSql(this.props.queryEditor, this.selectStar());
   }
 
-  selectStar() {
+  selectStar(useStar = false, limit = 0) {
     let cols = '';
     this.props.table.columns.forEach((col, i) => {
       cols += col.name;
@@ -36,7 +38,16 @@ class TableElement extends React.Component {
     if (this.props.table.schema) {
       tableName = this.props.table.schema + '.' + tableName;
     }
-    return `SELECT ${cols}\nFROM ${tableName}`;
+    let sql;
+    if (useStar) {
+      sql = `SELECT * FROM ${tableName}`;
+    } else {
+      sql = `SELECT ${cols}\nFROM ${tableName}`;
+    }
+    if (limit > 0) {
+      sql += `\nLIMIT ${limit}`;
+    }
+    return sql;
   }
 
   popSelectStar() {
@@ -62,6 +73,18 @@ class TableElement extends React.Component {
 
   removeTable() {
     this.props.actions.removeTable(this.props.table);
+  }
+  dataPreviewModal() {
+    const query = {
+      dbId: this.props.queryEditor.dbId,
+      sql: this.selectStar(true, 100),
+      tableName: this.props.table.name,
+      sqlEditorId: null,
+      tab: '',
+      runAsync: false,
+      ctas: false,
+    };
+    this.props.actions.runQuery(query);
   }
 
   render() {
@@ -175,16 +198,18 @@ class TableElement extends React.Component {
             <ButtonGroup className="ws-el-controls pull-right">
               {keyLink}
               <Link
-                className="fa fa-pencil pull-left m-l-2"
-                onClick={this.setSelectStar.bind(this)}
-                tooltip="Run query in this tab"
+                className="fa fa-search-plus pull-left m-l-2"
+                onClick={this.dataPreviewModal.bind(this)}
+                tooltip="Data preview"
                 href="#"
               />
-              <Link
-                className="fa fa-plus-circle pull-left  m-l-2"
-                onClick={this.popSelectStar.bind(this)}
-                tooltip="Run query in a new tab"
-                href="#"
+              <CopyToClipboard
+                copyNode={
+                  <a className="fa fa-clipboard pull-left m-l-2" />
+                }
+                text={this.selectStar()}
+                shouldShowText={false}
+                tooltipText="Copy SELECT statement to clipboard"
               />
               <Link
                 className="fa fa-trash pull-left m-l-2"

--- a/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
@@ -6,6 +6,7 @@ import * as Actions from '../actions';
 import { ButtonGroup, Well } from 'react-bootstrap';
 import shortid from 'shortid';
 
+import { DATA_PREVIEW_ROW_COUNT } from '../common';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import Link from './Link';
 import ModalTrigger from '../../components/ModalTrigger';
@@ -77,7 +78,7 @@ class TableElement extends React.Component {
   dataPreviewModal() {
     const query = {
       dbId: this.props.queryEditor.dbId,
-      sql: this.selectStar(true, 100),
+      sql: this.selectStar(true, DATA_PREVIEW_ROW_COUNT),
       tableName: this.props.table.name,
       sqlEditorId: null,
       tab: '',

--- a/caravel/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -26,8 +26,6 @@ class VisualizeModal extends React.Component {
       columns: {},
       hints: [],
     };
-    // update columns if possible
-    this.setStateFromProps();
   }
   componentWillMount() {
     this.setStateFromProps();

--- a/caravel/assets/javascripts/SqlLab/index.jsx
+++ b/caravel/assets/javascripts/SqlLab/index.jsx
@@ -6,15 +6,17 @@ import React from 'react';
 import { render } from 'react-dom';
 import { initialState, sqlLabReducer } from './reducers';
 import { enhancer } from '../reduxUtils';
-import { createStore } from 'redux';
+import { createStore, compose, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
+import thunkMiddleware from 'redux-thunk';
 
 import App from './components/App';
 
 
 require('./main.css');
 
-let store = createStore(sqlLabReducer, initialState, enhancer());
+let store = createStore(
+  sqlLabReducer, initialState, compose(applyMiddleware(thunkMiddleware), enhancer()));
 
 // jquery hack to highlight the navbar menu
 $('a:contains("SQL Lab")').parent().addClass('active');

--- a/caravel/assets/javascripts/SqlLab/main.css
+++ b/caravel/assets/javascripts/SqlLab/main.css
@@ -238,3 +238,19 @@ div.tablePopover:hover {
     margin-bottom: 5px;
     padding: 5px 10px;
 }
+
+.QueryTable .label {
+    margin-top: 5px;
+}
+
+.ResultsModal .modal-body {
+    min-height: 600px;
+}
+
+.modal-body {
+    overflow: auto;
+}
+
+a.Link {
+    cursor: pointer;
+}

--- a/caravel/assets/javascripts/components/CopyToClipboard.jsx
+++ b/caravel/assets/javascripts/components/CopyToClipboard.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { Button, Tooltip, OverlayTrigger } from 'react-bootstrap';
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 
 const propTypes = {
   copyNode: PropTypes.node,
@@ -81,14 +81,16 @@ export default class CopyToClipboard extends React.Component {
             &nbsp;&nbsp;&nbsp;&nbsp;
           </span>
         }
-        <OverlayTrigger placement="top" overlay={this.renderTooltip()} trigger={['hover']}>
-          <Button
-            bsStyle="link"
-            onClick={this.copyToClipboard}
-            onMouseOut={this.onMouseOut}
-          >
+        <OverlayTrigger
+          placement="top"
+          style={{ cursor: 'pointer' }}
+          overlay={this.renderTooltip()}
+          trigger={['hover']}
+          bsStyle="link"
+          onClick={this.copyToClipboard}
+          onMouseOut={this.onMouseOut}
+        >
             {this.props.copyNode}
-          </Button>
         </OverlayTrigger>
       </span>
     );

--- a/caravel/assets/javascripts/components/ModalTrigger.jsx
+++ b/caravel/assets/javascripts/components/ModalTrigger.jsx
@@ -7,12 +7,18 @@ const propTypes = {
   modalTitle: PropTypes.node.isRequired,
   modalBody: PropTypes.node.isRequired,
   beforeOpen: PropTypes.func,
+  onExit: PropTypes.func,
   isButton: PropTypes.bool,
+  bsSize: PropTypes.string,
+  className: PropTypes.string,
 };
 
 const defaultProps = {
   beforeOpen: () => {},
+  onExit: () => {},
   isButton: false,
+  bsSize: null,
+  className: '',
 };
 
 export default class ModalTrigger extends React.Component {
@@ -42,7 +48,13 @@ export default class ModalTrigger extends React.Component {
     return (
       <a href="#" className={classNames} onClick={this.open}>
         {this.props.triggerNode}
-        <Modal show={this.state.showModal} onHide={this.close}>
+        <Modal
+          show={this.state.showModal}
+          onHide={this.close}
+          onExit={this.props.onExit}
+          bsSize={this.props.bsSize}
+          className={this.props.className}
+        >
           <Modal.Header closeButton>
             <Modal.Title>{this.props.modalTitle}</Modal.Title>
           </Modal.Header>

--- a/caravel/assets/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/caravel/assets/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -149,7 +149,7 @@ describe('TableElement', () => {
   });
   it('has 3 Link elements', () => {
     const wrapper = shallow(<TableElement {...mockedProps} />);
-    expect(wrapper.find(Link)).to.have.length(3);
+    expect(wrapper.find(Link)).to.have.length(2);
   });
   it('has 14 columns', () => {
     const wrapper = shallow(<TableElement {...mockedProps} />);

--- a/caravel/config.py
+++ b/caravel/config.py
@@ -234,6 +234,11 @@ DEFAULT_DB_ID = None
 # Timeout duration for SQL Lab synchronous queries
 SQLLAB_TIMEOUT = 30
 
+# An instantiated derivative of werkzeug.contrib.cache.BaseCache
+# if enabled, it can be used to store the results of long-running queries
+# in SQL Lab by using the "Run Async" button/feature
+RESULTS_BACKEND = None
+
 try:
     from caravel_config import *  # noqa
 except ImportError:

--- a/caravel/db_engine_specs.py
+++ b/caravel/db_engine_specs.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 from collections import namedtuple
 import inspect
 import textwrap
+import time
 
 from flask_babel import lazy_gettext as _
 
@@ -45,6 +46,15 @@ class BaseEngineSpec(object):
     @classmethod
     def convert_dttm(cls, target_type, dttm):
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
+
+    @classmethod
+    def handle_cursor(cls, cursor, query):
+        """Handle a live cursor between the execute and fetchall calls
+
+        The flow works without this method doing anything, but it allows
+        for handling the cursor and updating progress information in the
+        query object"""
+        pass
 
 
 class PostgresEngineSpec(BaseEngineSpec):
@@ -200,6 +210,28 @@ class PrestoEngineSpec(BaseEngineSpec):
                 'partitionQuery': partition_query,
             }
         }
+
+    @classmethod
+    def handle_cursor(cls, cursor, query, session):
+        """Updates progress information"""
+        polled = cursor.poll()
+        # poll returns dict -- JSON status information or ``None``
+        # if the query is done
+        # https://github.com/dropbox/PyHive/blob/
+        # b34bdbf51378b3979eaf5eca9e956f06ddc36ca0/pyhive/presto.py#L178
+        while polled:
+            # Update the object and wait for the kill signal.
+            stats = polled.get('stats', {})
+            if stats:
+                completed_splits = float(stats.get('completedSplits'))
+                total_splits = float(stats.get('totalSplits'))
+                if total_splits and completed_splits:
+                    progress = 100 * (completed_splits / total_splits)
+                    if progress > query.progress:
+                        query.progress = progress
+                    session.commit()
+            time.sleep(1)
+            polled = cursor.poll()
 
 
 class MssqlEngineSpec(BaseEngineSpec):

--- a/caravel/db_engine_specs.py
+++ b/caravel/db_engine_specs.py
@@ -26,9 +26,16 @@ from flask_babel import lazy_gettext as _
 Grain = namedtuple('Grain', 'name label function')
 
 
+class LimitMethod(object):
+    """Enum the ways that limits can be applied"""
+    FETCH_MANY = 'fetch_many'
+    WRAP_SQL = 'wrap_sql'
+
+
 class BaseEngineSpec(object):
     engine = 'base'  # str as defined in sqlalchemy.engine.engine
     time_grains = tuple()
+    limit_method = LimitMethod.FETCH_MANY
 
     @classmethod
     def epoch_to_dttm(cls):

--- a/caravel/migrations/versions/7e3ddad2a00b_results_key_to_query.py
+++ b/caravel/migrations/versions/7e3ddad2a00b_results_key_to_query.py
@@ -1,0 +1,22 @@
+"""results_key to query
+
+Revision ID: 7e3ddad2a00b
+Revises: b46fa1b0b39e
+Create Date: 2016-10-14 11:17:54.995156
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '7e3ddad2a00b'
+down_revision = 'b46fa1b0b39e'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('query', sa.Column('results_key', sa.String(length=64), nullable=True))
+
+
+def downgrade():
+    op.drop_column('query', 'results_key')

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -2272,6 +2272,8 @@ class Query(Model):
     # # of rows in the result set or rows modified.
     rows = Column(Integer)
     error_message = Column(Text)
+    # key used to store the results in the results backend
+    results_key = Column(String(64))
 
     # Using Numeric in place of DateTime for sub-second precision
     # stored as seconds since epoch, allowing for milliseconds
@@ -2320,6 +2322,7 @@ class Query(Model):
             'userId': self.user_id,
             'user': self.user.username,
             'limit_reached': self.limit_reached,
+            'resultsKey': self.results_key,
         }
 
     @property

--- a/caravel/results_backends.py
+++ b/caravel/results_backends.py
@@ -1,0 +1,49 @@
+"""Results backends are used to store long-running query results
+
+The Abstraction is flask-cache, which uses the BaseCache class from werkzeug
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from werkzeug.contrib.cache import BaseCache
+
+
+class S3Cache(BaseCache):
+
+    """S3 cache"""
+
+    def __init__(self, default_timeout=300):
+        self.default_timeout = default_timeout
+
+    def get(self, key):
+        return None
+
+    def delete(self, key):
+        return True
+
+    def set(self, key, value, timeout=None):
+        return True
+
+    def add(self, key, value, timeout=None):
+        """Works like :meth:`set` but does not overwrite the values of already
+        existing keys.
+        :param key: the key to set
+        :param value: the value for the key
+        :param timeout: the cache timeout for the key in seconds (if not
+                        specified, it uses the default timeout). A timeout of
+                        0 idicates that the cache never expires.
+        :returns: Same as :meth:`set`, but also ``False`` for already
+                  existing keys.
+        :rtype: boolean
+        """
+        return True
+
+    def clear(self):
+        """Clears the cache.  Keep in mind that not all caches support
+        completely clearing the cache.
+        :returns: Whether the cache has been cleared.
+        :rtype: boolean
+        """
+        return True

--- a/caravel/sql_lab.py
+++ b/caravel/sql_lab.py
@@ -126,14 +126,8 @@ def get_sql_results(query_id, return_results=True, store_results=False):
         'status': query.status,
         'data': [],
     }
-    if query.status == models.QueryStatus.SUCCESS:
-        payload['data'] = cdf.data if cdf else []
-        payload['columns'] = cdf.columns_dict if cdf else []
-        query.state = 'success'
-    else:
-        payload['error'] = query.error_message
-        query.state = 'error'
-
+    payload['data'] = cdf.data if cdf else []
+    payload['columns'] = cdf.columns_dict if cdf else []
     payload['query'] = query.to_dict()
     payload = json.dumps(payload, default=utils.json_iso_dttm_ser)
 

--- a/caravel/sql_lab.py
+++ b/caravel/sql_lab.py
@@ -98,7 +98,6 @@ def get_sql_results(query_id, return_results=True, store_results=False):
     cursor = result_proxy.cursor
     query.status = QueryStatus.RUNNING
     session.flush()
-    print('here1')
     db_engine_spec.handle_cursor(cursor, query)
 
     cdf = None
@@ -132,15 +131,14 @@ def get_sql_results(query_id, return_results=True, store_results=False):
     payload['columns'] = cdf.columns_dict if cdf else []
     payload['query'] = query.to_dict()
     payload = json.dumps(payload, default=utils.json_iso_dttm_ser)
-    logging.info([store_results, results_backend])
 
     if store_results and results_backend:
         key = '{}'.format(uuid.uuid4())
         logging.info("Storing results in results backend, key: {}".format(key))
         results_backend.set(key, zlib.compress(payload))
         query.results_key = key
-        session.flush()
 
+    session.flush()
     session.commit()
 
     if return_results:

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -15,6 +15,8 @@ import numpy
 import signal
 import uuid
 
+import pandas as pd
+import numpy as np
 import parsedatetime
 import sqlalchemy as sa
 from dateutil.parser import parse

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -15,8 +15,8 @@ import numpy
 import signal
 import uuid
 
-import pandas as pd
-import numpy as np
+from sqlalchemy import event, exc
+from sqlalchemy.pool import Pool
 import parsedatetime
 import sqlalchemy as sa
 from dateutil.parser import parse
@@ -507,3 +507,18 @@ def wrap_clause_in_parens(sql):
     if sql.strip():
         sql = '({})'.format(sql)
     return sa.text(sql)
+
+
+def pessimistic_connection_handling():
+    @event.listens_for(Pool, "checkout")
+    def ping_connection(dbapi_connection, connection_record, connection_proxy):
+        """
+        Disconnect Handling - Pessimistic, taken from:
+        http://docs.sqlalchemy.org/en/rel_0_9/core/pooling.html
+        """
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("SELECT 1")
+        except:
+            raise exc.DisconnectionError()
+        cursor.close()

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -509,8 +509,8 @@ def wrap_clause_in_parens(sql):
     return sa.text(sql)
 
 
-def pessimistic_connection_handling():
-    @event.listens_for(Pool, "checkout")
+def pessimistic_connection_handling(target):
+    @event.listens_for(target, "checkout")
     def ping_connection(dbapi_connection, connection_record, connection_proxy):
         """
         Disconnect Handling - Pessimistic, taken from:

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -76,6 +76,7 @@ DATASOURCE_MISSING_ERR = __("The datasource seems to have been deleted")
 ACCESS_REQUEST_MISSING_ERR = __(
     "The access requests seem to have been deleted")
 USER_MISSING_ERR = __("The user seems to have been deleted")
+DATASOURCE_ACCESS_ERR = __("You don't have access to this datasource")
 
 
 def get_database_access_error_msg(database_name):
@@ -1248,7 +1249,7 @@ class Caravel(BaseCaravelView):
         if not self.datasource_access(viz_obj.datasource):
             return Response(
                 json.dumps(
-                    {'error': _("You don't have access to this datasource")}),
+                    {'error': DATASOURCE_ACCESS_ERR}),
                 status=404,
                 mimetype="application/json")
 
@@ -2085,7 +2086,7 @@ class Caravel(BaseCaravelView):
         if async:
             # Ignore the celery future object and the request may time out.
             sql_lab.get_sql_results.delay(
-                query_id, return_results=False, store_results=True)
+                query_id, return_results=False, store_results=not query.select_as_cta)
             return Response(
                 json.dumps({'query': query.to_dict()},
                            default=utils.json_int_dttm_ser,

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -2021,7 +2021,7 @@ class Caravel(BaseCaravelView):
             obj = json.loads(json_payload)
             db_id = obj['query']['dbId']
             session = db.session()
-            mydb = session.query(models.Database).filter_by(id=db_id).first()
+            mydb = session.query(models.Database).filter_by(id=db_id).one()
 
             if not self.database_access(mydb):
                 json_error_response(
@@ -2029,7 +2029,7 @@ class Caravel(BaseCaravelView):
 
             return Response(
                 json_payload,
-                status=202,
+                status=200,
                 mimetype="application/json")
         else:
             return Response(
@@ -2039,7 +2039,7 @@ class Caravel(BaseCaravelView):
                         "re-run the query."
                     )
                 }),
-                status=202,
+                status=410,
                 mimetype="application/json")
 
     @has_access_api


### PR DESCRIPTION
@ascott @vera-liu @bkyryliuk 
Long running SQL queries (beyond the scope of a web request) can now use
a k/v store to hold their result sets.

![img](http://g.recordit.co/CEUP1pCvTT.gif)

Side missions:
- Use redux-thunk for async query processing
- Added a data preview option for queries that ran async
- Data preview for any table element in the left panel
- Make a bunch of components more flexible to satisfy the use-cases here
