### PR TITLE
Change slice ids in the position json during dashboard import.

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -497,11 +497,24 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         # and will remove the existing dashboard - slice association
         slices = copy(dashboard_to_import.slices)
         old_to_new_slc_id_dict = {}
+        new_filter_immune_slices = []
+        new_expanded_slices = {}
+        i_params_dict = dashboard_to_import.params_dict
         for slc in slices:
             logging.info('Importing slice {} from the dashboard: {}'.format(
                 slc.to_json(), dashboard_to_import.dashboard_title))
-            old_to_new_slc_id_dict[slc.id] = (
-                Slice.import_obj(slc, import_time=import_time))
+            new_slc_id = Slice.import_obj(slc, import_time=import_time)
+            old_to_new_slc_id_dict[slc.id] = new_slc_id
+            # update json metadata that deals with slice ids
+            if ('filter_immune_slices' in i_params_dict and
+                    slc.id in i_params_dict['filter_immune_slices']):
+                new_filter_immune_slices.append(new_slc_id)
+            new_slc_id_str = '{}'.format(new_slc_id)
+            old_slc_id_str = '{}'.format(slc.id)
+            if ('expanded_slices' in i_params_dict and
+                    old_slc_id_str in i_params_dict['expanded_slices']):
+                new_expanded_slices[new_slc_id_str] = (
+                    i_params_dict['expanded_slices'][old_slc_id_str])
 
         # override the dashboard
         existing_dashboard = None
@@ -514,6 +527,13 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         dashboard_to_import.id = None
         alter_positions(dashboard_to_import, old_to_new_slc_id_dict)
         dashboard_to_import.alter_params(import_time=import_time)
+        if new_expanded_slices:
+            dashboard_to_import.alter_params(
+                expanded_slices=new_expanded_slices)
+        if new_filter_immune_slices:
+            dashboard_to_import.alter_params(
+                filter_immune_slices=new_filter_immune_slices)
+
         new_slices = session.query(Slice).filter(
             Slice.id.in_(old_to_new_slc_id_dict.values())).all()
 

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -449,6 +449,12 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
     def params(self, value):
         self.json_metadata = value
 
+    @property
+    def position_array(self):
+        if self.position_json:
+            return json.loads(self.position_json)
+        return []
+
     @classmethod
     def import_obj(cls, dashboard_to_import, import_time=None):
         """Imports the dashboard from the object to the database.
@@ -460,6 +466,28 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
          to import/export dashboards between multiple caravel instances.
          Audit metadata isn't copies over.
         """
+        def alter_positions(dashboard, old_to_new_slc_id_dict):
+            """ Updates slice_ids in the position json.
+
+            Sample position json:
+            [{
+                "col": 5,
+                "row": 10,
+                "size_x": 4,
+                "size_y": 2,
+                "slice_id": "3610"
+            }]
+            """
+            position_array = dashboard.position_array
+            for position in position_array:
+                if 'slice_id' not in position:
+                    continue
+                old_slice_id = int(position['slice_id'])
+                if old_slice_id in old_to_new_slc_id_dict:
+                    position['slice_id'] = '{}'.format(
+                        old_to_new_slc_id_dict[old_slice_id])
+            dashboard.position_json = json.dumps(position_array)
+
         logging.info('Started import of the dashboard: {}'
                      .format(dashboard_to_import.to_json()))
         session = db.session
@@ -468,11 +496,12 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         # copy slices object as Slice.import_slice will mutate the slice
         # and will remove the existing dashboard - slice association
         slices = copy(dashboard_to_import.slices)
-        slice_ids = set()
+        old_to_new_slc_id_dict = {}
         for slc in slices:
             logging.info('Importing slice {} from the dashboard: {}'.format(
                 slc.to_json(), dashboard_to_import.dashboard_title))
-            slice_ids.add(Slice.import_obj(slc, import_time=import_time))
+            old_to_new_slc_id_dict[slc.id] = (
+                Slice.import_obj(slc, import_time=import_time))
 
         # override the dashboard
         existing_dashboard = None
@@ -483,8 +512,10 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
                 existing_dashboard = dash
 
         dashboard_to_import.id = None
+        alter_positions(dashboard_to_import, old_to_new_slc_id_dict)
         dashboard_to_import.alter_params(import_time=import_time)
-        new_slices = session.query(Slice).filter(Slice.id.in_(slice_ids)).all()
+        new_slices = session.query(Slice).filter(
+            Slice.id.in_(old_to_new_slc_id_dict.values())).all()
 
         if existing_dashboard:
             existing_dashboard.override(dashboard_to_import)


### PR DESCRIPTION
Position config is tied to the slice ids.
In order to preserve the dashboard config and appearances we have to update the slice ids in the position_json attr in the dashboard.

Reviewers:
- @mistercrunch 
  CC:
- @ascott 
- @vera-liu 
