### PR TITLE
Filter immune slices array stores strings.

### DIFF
--- a/caravel/models.py
+++ b/caravel/models.py
@@ -506,11 +506,11 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
             new_slc_id = Slice.import_obj(slc, import_time=import_time)
             old_to_new_slc_id_dict[slc.id] = new_slc_id
             # update json metadata that deals with slice ids
-            if ('filter_immune_slices' in i_params_dict and
-                    slc.id in i_params_dict['filter_immune_slices']):
-                new_filter_immune_slices.append(new_slc_id)
             new_slc_id_str = '{}'.format(new_slc_id)
             old_slc_id_str = '{}'.format(slc.id)
+            if ('filter_immune_slices' in i_params_dict and
+                    old_slc_id_str in i_params_dict['filter_immune_slices']):
+                new_filter_immune_slices.append(new_slc_id_str)
             if ('expanded_slices' in i_params_dict and
                     old_slc_id_str in i_params_dict['expanded_slices']):
                 new_expanded_slices[new_slc_id_str] = (

--- a/tests/import_export_tests.py
+++ b/tests/import_export_tests.py
@@ -291,8 +291,11 @@ class ImportExportTests(CaravelTestCase):
             'dash_with_2_slices', slcs=[e_slc, b_slc], id=10003)
         dash_with_2_slices.json_metadata = json.dumps({
             "remote_id": 10003,
-            "filter_immune_slices": [e_slc.id],
-            "expanded_slices": {e_slc.id: True, b_slc.id: False}
+            "filter_immune_slices": ["{}".format(e_slc.id)],
+            "expanded_slices": {
+                "{}".format(e_slc.id): True,
+                "{}".format(b_slc.id): False
+            }
         })
 
         imported_dash_id = models.Dashboard.import_obj(
@@ -309,7 +312,7 @@ class ImportExportTests(CaravelTestCase):
         expected_json_metadata = {
             "remote_id": 10003,
             "import_time": 1991,
-            "filter_immune_slices": [i_e_slc.id],
+            "filter_immune_slices": ["{}".format(i_e_slc.id)],
             "expanded_slices": {
                 '{}'.format(i_e_slc.id): True,
                 '{}'.format(i_b_slc.id): False


### PR DESCRIPTION
another small fix, I figured out that filter_immune_slices is a list of strings rather than integers.
@mistercrunch  ^^
