### PR TITLE
[sqllab] proper, quoted, select * on the server side

### DIFF
--- a/caravel/assets/javascripts/SqlLab/common.js
+++ b/caravel/assets/javascripts/SqlLab/common.js
@@ -7,6 +7,4 @@ export const STATE_BSSTYLE_MAP = {
   success: 'success',
 };
 
-export const DATA_PREVIEW_ROW_COUNT = 100;
-
 export const STATUS_OPTIONS = ['success', 'failed', 'running'];

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
@@ -82,15 +82,12 @@ class SqlEditorLeftBar extends React.Component {
 
     this.setState({ tableLoading: true });
     $.get(url, (data) => {
-      this.props.actions.mergeTable({
+      this.props.actions.mergeTable(Object.assign(data, {
         dbId: this.props.queryEditor.dbId,
         queryEditorId: this.props.queryEditor.id,
-        name: data.name,
-        indexes: data.indexes,
         schema: qe.schema,
-        columns: data.columns,
         expanded: true,
-      });
+      }));
       this.setState({ tableLoading: false });
     })
     .fail(() => {

--- a/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
@@ -6,7 +6,6 @@ import * as Actions from '../actions';
 import { ButtonGroup, Well } from 'react-bootstrap';
 import shortid from 'shortid';
 
-import { DATA_PREVIEW_ROW_COUNT } from '../common';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import Link from './Link';
 import ModalTrigger from '../../components/ModalTrigger';
@@ -23,33 +22,6 @@ const defaultProps = {
 };
 
 class TableElement extends React.Component {
-  setSelectStar() {
-    this.props.actions.queryEditorSetSql(this.props.queryEditor, this.selectStar());
-  }
-
-  selectStar(useStar = false, limit = 0) {
-    let cols = '';
-    this.props.table.columns.forEach((col, i) => {
-      cols += col.name;
-      if (i < this.props.table.columns.length - 1) {
-        cols += ', ';
-      }
-    });
-    let tableName = this.props.table.name;
-    if (this.props.table.schema) {
-      tableName = this.props.table.schema + '.' + tableName;
-    }
-    let sql;
-    if (useStar) {
-      sql = `SELECT * FROM ${tableName}`;
-    } else {
-      sql = `SELECT ${cols}\nFROM ${tableName}`;
-    }
-    if (limit > 0) {
-      sql += `\nLIMIT ${limit}`;
-    }
-    return sql;
-  }
 
   popSelectStar() {
     const qe = {
@@ -57,7 +29,7 @@ class TableElement extends React.Component {
       title: this.props.table.name,
       dbId: this.props.table.dbId,
       autorun: true,
-      sql: this.selectStar(),
+      sql: this.props.table.selectStar,
     };
     this.props.actions.addQueryEditor(qe);
   }
@@ -78,7 +50,7 @@ class TableElement extends React.Component {
   dataPreviewModal() {
     const query = {
       dbId: this.props.queryEditor.dbId,
-      sql: this.selectStar(true, DATA_PREVIEW_ROW_COUNT),
+      sql: this.props.table.selectStar,
       tableName: this.props.table.name,
       sqlEditorId: null,
       tab: '',
@@ -208,7 +180,7 @@ class TableElement extends React.Component {
                 copyNode={
                   <a className="fa fa-clipboard pull-left m-l-2" />
                 }
-                text={this.selectStar()}
+                text={table.selectStar}
                 shouldShowText={false}
                 tooltipText="Copy SELECT statement to clipboard"
               />

--- a/caravel/views.py
+++ b/caravel/views.py
@@ -1962,6 +1962,8 @@ class Caravel(BaseCaravelView):
         tbl = {
             'name': table_name,
             'columns': cols,
+            'selectStar': mydb.select_star(
+                table_name, schema=schema, show_cols=True, indent=True),
             'indexes': indexes,
         }
         return Response(json.dumps(tbl), mimetype="application/json")
@@ -1982,6 +1984,7 @@ class Caravel(BaseCaravelView):
     def select_star(self, database_id, table_name):
         mydb = db.session.query(
             models.Database).filter_by(id=database_id).first()
+        quote = mydb.get_quoter()
         t = mydb.get_table(table_name)
 
         # Prevent exposing column fields to users that cannot access DB.
@@ -1990,7 +1993,7 @@ class Caravel(BaseCaravelView):
             return redirect("/tablemodelview/list/")
 
         fields = ", ".join(
-            [c.name for c in t.columns] or "*")
+            [quote(c.name) for c in t.columns] or "*")
         s = "SELECT\n{}\nFROM {}".format(fields, table_name)
         return self.render_template(
             "caravel/ajah.html",


### PR DESCRIPTION
Reserved words should be properly quoted now, indent is arguably better than before
<img width="441" alt="screen shot 2016-10-21 at 12 29 32 am" src="https://cloud.githubusercontent.com/assets/487433/19590207/7c6ffa56-9725-11e6-8b0b-d82d6789bad9.png">
