### PR TITLE
Allow user to extend shrunken sql text in Query Table

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/HighlightedSql.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/HighlightedSql.jsx
@@ -2,43 +2,61 @@ import React from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { github } from 'react-syntax-highlighter/dist/styles';
 
-const HighlightedSql = (props) => {
-  const sql = props.sql || '';
-  let lines = sql.split('\n');
-  if (lines.length >= props.maxLines) {
-    lines = lines.slice(0, props.maxLines);
-    lines.push('{...}');
-  }
-  let shownSql = sql;
-  if (props.shrink) {
-    shownSql = lines.map((line) => {
-      if (line.length > props.maxWidth) {
-        return line.slice(0, props.maxWidth) + '{...}';
-      }
-      return line;
-    })
-    .join('\n');
-  }
-  return (
-    <div>
-      <SyntaxHighlighter language="sql" style={github}>
-        {shownSql}
-      </SyntaxHighlighter>
-    </div>
-  );
-};
-
-HighlightedSql.defaultProps = {
+const defaultProps = {
   maxWidth: 60,
   maxLines: 6,
   shrink: false,
 };
 
-HighlightedSql.propTypes = {
+const propTypes = {
   sql: React.PropTypes.string,
   maxWidth: React.PropTypes.number,
   maxLines: React.PropTypes.number,
   shrink: React.PropTypes.bool,
 };
 
-export default HighlightedSql;
+export default class HighlightedSql extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      extend: false,
+    };
+  }
+  extendSql() {
+    this.setState({ extend: !this.state.extend });
+  }
+  render() {
+    const sql = this.props.sql || '';
+    let lines = sql.split('\n');
+    if (lines.length >= this.props.maxLines && !this.state.extend) {
+      lines = lines.slice(0, this.props.maxLines);
+      lines.push('{...}');
+    }
+    let shownSql = sql;
+    if (this.props.shrink && !this.state.extend) {
+      shownSql = lines.map((line) => {
+        if (line.length > this.props.maxWidth) {
+          return line.slice(0, this.props.maxWidth) + '{...}';
+        }
+        return line;
+      })
+      .join('\n');
+    }
+    const icon = this.state.extend ? 'minus' : 'plus';
+    return (
+      <div>
+        <SyntaxHighlighter language="sql" style={github}>
+          {shownSql}
+        </SyntaxHighlighter>
+        {this.props.shrink &&
+          <span onClick={this.extendSql.bind(this)}>
+            <i className={`fa fa-${icon}-circle`} />
+          </span>
+        }
+      </div>
+    );
+  }
+}
+
+HighlightedSql.propTypes = propTypes;
+HighlightedSql.defaultProps = defaultProps;


### PR DESCRIPTION
Issue: https://github.com/airbnb/caravel/issues/1218
User case: currently the sql text in query table is default to be shrunken, but users might want to view full sql in some cases.

Done:
- Added state 'extend' to HighlightedSql component
- Added button at the end of each sql for extending/shrinking sql text, user can click on the button to extend/shrink the sql on each row
- I kept the original shrink prop so that this component could still be used for cases where we don't shrink any sql text

before clicking on plus sign at end of sql text:
![screen shot 2016-10-25 at 2 20 23 pm](https://cloud.githubusercontent.com/assets/20978302/19705540/ea01106a-9ac1-11e6-9540-edbb189a57b1.png)

after:
![screen shot 2016-10-25 at 2 20 32 pm](https://cloud.githubusercontent.com/assets/20978302/19705560/06314106-9ac2-11e6-9b06-1b8d50681735.png)

needs-review @mistercrunch @ascott @bkyryliuk 
