### PR TITLE
[sqllab] optimizing React

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/AceEditorWrapper.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/AceEditorWrapper.jsx
@@ -10,7 +10,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  sql: '',
   onBlur: () => {},
 };
 

--- a/caravel/assets/javascripts/SqlLab/components/AceEditorWrapper.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/AceEditorWrapper.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import AceEditor from 'react-ace';
+import 'brace/mode/sql';
+import 'brace/theme/github';
+import 'brace/ext/language_tools';
+
+const propTypes = {
+  sql: React.PropTypes.string.isRequired,
+  onBlur: React.PropTypes.func,
+};
+
+const defaultProps = {
+  sql: '',
+  onBlur: () => {},
+};
+
+class AceEditorWrapper extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      sql: props.sql,
+    };
+  }
+  textChange(text) {
+    this.setState({ sql: text });
+  }
+  onBlur() {
+    this.props.onBlur(this.state.sql);
+  }
+
+  render() {
+    return (
+      <AceEditor
+        mode="sql"
+        theme="github"
+        onBlur={this.onBlur.bind(this)}
+        minLines={8}
+        maxLines={30}
+        onChange={this.textChange.bind(this)}
+        height="200px"
+        width="100%"
+        editorProps={{ $blockScrolling: true }}
+        enableBasicAutocompletion
+        value={this.state.sql}
+      />
+    );
+  }
+}
+AceEditorWrapper.defaultProps = defaultProps;
+AceEditorWrapper.propTypes = propTypes;
+
+export default AceEditorWrapper;

--- a/caravel/assets/javascripts/SqlLab/components/Alerts.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/Alerts.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-class Alerts extends React.Component {
+class Alerts extends React.PureComponent {
   removeAlert(alert) {
     this.props.actions.removeAlert(alert);
   }

--- a/caravel/assets/javascripts/SqlLab/components/App.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/App.jsx
@@ -10,7 +10,7 @@ import DataPreviewModal from './DataPreviewModal';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-class App extends React.Component {
+class App extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/caravel/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
@@ -10,7 +10,7 @@ const defaultProps = {
   queryEditor: null,
 };
 
-export default class CopyQueryTabUrl extends React.Component {
+export default class CopyQueryTabUrl extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/caravel/assets/javascripts/SqlLab/components/DataPreviewModal.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/DataPreviewModal.jsx
@@ -13,7 +13,7 @@ const propTypes = {
   dataPreviewQueryId: React.PropTypes.string,
 };
 
-class DataPreviewModal extends React.Component {
+class DataPreviewModal extends React.PureComponent {
   hide() {
     this.props.actions.hideDataPreview();
   }

--- a/caravel/assets/javascripts/SqlLab/components/DatabaseSelect.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/DatabaseSelect.jsx
@@ -2,7 +2,7 @@ const $ = window.$ = require('jquery');
 import React from 'react';
 import Select from 'react-select';
 
-class DatabaseSelect extends React.Component {
+class DatabaseSelect extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/caravel/assets/javascripts/SqlLab/components/Link.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/Link.jsx
@@ -20,7 +20,7 @@ const defaultProps = {
 };
 
 
-class Link extends React.Component {
+class Link extends React.PureComponent {
   render() {
     let tooltip = (
       <Tooltip id="tooltip">

--- a/caravel/assets/javascripts/SqlLab/components/QueryAutoRefresh.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QueryAutoRefresh.jsx
@@ -7,7 +7,7 @@ const $ = require('jquery');
 const QUERY_UPDATE_FREQ = 1000;
 const QUERY_UPDATE_BUFFER_MS = 5000;
 
-class QueryAutoRefresh extends React.Component {
+class QueryAutoRefresh extends React.PureComponent {
   componentWillMount() {
     this.startTimer();
   }

--- a/caravel/assets/javascripts/SqlLab/components/QuerySearch.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QuerySearch.jsx
@@ -11,7 +11,7 @@ const propTypes = {
   actions: React.PropTypes.object.isRequired,
 };
 
-class QuerySearch extends React.Component {
+class QuerySearch extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -27,7 +27,7 @@ const defaultProps = {
 };
 
 
-class QueryTable extends React.Component {
+class QueryTable extends React.PureComponent {
   constructor(props) {
     super(props);
     const uri = window.location.toString();

--- a/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -25,7 +25,7 @@ const defaultProps = {
 };
 
 
-class ResultSet extends React.Component {
+class ResultSet extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
@@ -1,6 +1,7 @@
 import { Alert, Tab, Tabs } from 'react-bootstrap';
 import QueryHistory from './QueryHistory';
 import ResultSet from './ResultSet';
+import { areArrayDifferent } from '../../reduxUtils';
 import React from 'react';
 
 import shortid from 'shortid';
@@ -10,32 +11,40 @@ const propTypes = {
   actions: React.PropTypes.object.isRequired,
 };
 
-const SouthPane = function (props) {
-  let latestQuery;
-  if (props.queries.length > 0) {
-    latestQuery = props.queries[props.queries.length - 1];
+class SouthPane extends React.PureComponent {
+  shouldComponentUpdate(nextProps) {
+    return areArrayDifferent(this.props.queries, nextProps.queries);
   }
-  let results;
-  if (latestQuery) {
-    results = <ResultSet showControls search query={latestQuery} actions={props.actions} />;
-  } else {
-    results = <Alert bsStyle="info">Run a query to display results here</Alert>;
+  render() {
+    let latestQuery;
+    const props = this.props;
+    if (props.queries.length > 0) {
+      latestQuery = props.queries[props.queries.length - 1];
+    }
+    let results;
+    if (latestQuery) {
+      results = (
+        <ResultSet showControls search query={latestQuery} actions={props.actions} />
+      );
+    } else {
+      results = <Alert bsStyle="info">Run a query to display results here</Alert>;
+    }
+    return (
+      <div className="SouthPane">
+        <Tabs bsStyle="tabs" id={shortid.generate()}>
+          <Tab title="Results" eventKey={1}>
+            <div style={{ overflow: 'auto' }}>
+              {results}
+            </div>
+          </Tab>
+          <Tab title="Query History" eventKey={2}>
+            <QueryHistory queries={props.queries} actions={props.actions} />
+          </Tab>
+        </Tabs>
+      </div>
+    );
   }
-  return (
-    <div className="SouthPane">
-      <Tabs bsStyle="tabs" id={shortid.generate()}>
-        <Tab title="Results" eventKey={1}>
-          <div style={{ overflow: 'auto' }}>
-            {results}
-          </div>
-        </Tab>
-        <Tab title="Query History" eventKey={2}>
-          <QueryHistory queries={props.queries} actions={props.actions} />
-        </Tab>
-      </Tabs>
-    </div>
-  );
-};
+}
 SouthPane.propTypes = propTypes;
 
 export default SouthPane;

--- a/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
@@ -1,7 +1,7 @@
 import { Alert, Tab, Tabs } from 'react-bootstrap';
 import QueryHistory from './QueryHistory';
 import ResultSet from './ResultSet';
-import { areArrayDifferent } from '../../reduxUtils';
+import { areArraysShallowEqual } from '../../reduxUtils';
 import React from 'react';
 
 import shortid from 'shortid';
@@ -13,7 +13,7 @@ const propTypes = {
 
 class SouthPane extends React.PureComponent {
   shouldComponentUpdate(nextProps) {
-    return areArrayDifferent(this.props.queries, nextProps.queries);
+    return !areArraysShallowEqual(this.props.queries, nextProps.queries);
   }
   render() {
     let latestQuery;

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -13,16 +13,11 @@ import {
   Tooltip,
 } from 'react-bootstrap';
 
-import AceEditor from 'react-ace';
-import 'brace/mode/sql';
-import 'brace/theme/github';
-import 'brace/ext/language_tools';
-
-import shortid from 'shortid';
 import SouthPane from './SouthPane';
 import Timer from './Timer';
 
 import SqlEditorLeftBar from './SqlEditorLeftBar';
+import AceEditorWrapper from './AceEditorWrapper';
 
 const propTypes = {
   actions: React.PropTypes.object.isRequired,
@@ -41,12 +36,11 @@ const defaultProps = {
 };
 
 
-class SqlEditor extends React.Component {
+class SqlEditor extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
       autorun: props.queryEditor.autorun,
-      sql: props.queryEditor.sql,
       ctas: '',
     };
   }
@@ -82,16 +76,12 @@ class SqlEditor extends React.Component {
   createTableAs() {
     this.startQuery(true, true);
   }
-  textChange(text) {
-    this.setState({ sql: text });
-    this.props.actions.queryEditorSetSql(this.props.queryEditor, text);
+  sqlToStore(sql) {
+    this.props.actions.queryEditorSetSql(this.props.queryEditor, sql);
   }
-  ctasChange() {}
-  visualize() {}
   ctasChanged(event) {
     this.setState({ ctas: event.target.value });
   }
-
   sqlEditorHeight() {
     // quick hack to make the white bg of the tab stretch full height.
     const tabNavHeight = 40;
@@ -110,7 +100,7 @@ class SqlEditor extends React.Component {
           style={{ width: '100px' }}
           onClick={this.runQuery.bind(this, false)}
           disabled={!(this.props.queryEditor.dbId)}
-          key={shortid.generate()}
+          key="run-btn"
         >
           <i className="fa fa-table" /> Run Query
         </Button>
@@ -124,7 +114,7 @@ class SqlEditor extends React.Component {
           style={{ width: '100px' }}
           onClick={this.runQuery.bind(this, true)}
           disabled={!(this.props.queryEditor.dbId)}
-          key={shortid.generate()}
+          key="run-async-btn"
         >
           <i className="fa fa-table" /> Run Async
         </Button>
@@ -217,18 +207,9 @@ class SqlEditor extends React.Component {
             />
           </Col>
           <Col md={9}>
-            <AceEditor
-              mode="sql"
-              name={this.props.queryEditor.id}
-              theme="github"
-              minLines={7}
-              maxLines={30}
-              onChange={this.textChange.bind(this)}
-              height="200px"
-              width="100%"
-              editorProps={{ $blockScrolling: true }}
-              enableBasicAutocompletion
-              value={this.props.queryEditor.sql}
+            <AceEditorWrapper
+              sql={this.props.queryEditor.sql}
+              onBlur={this.sqlToStore.bind(this)}
             />
             {editorBottomBar}
             <br />

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -76,7 +76,7 @@ class SqlEditor extends React.PureComponent {
   createTableAs() {
     this.startQuery(true, true);
   }
-  sqlToStore(sql) {
+  setQueryEditorSql(sql) {
     this.props.actions.queryEditorSetSql(this.props.queryEditor, sql);
   }
   ctasChanged(event) {
@@ -209,7 +209,7 @@ class SqlEditor extends React.PureComponent {
           <Col md={9}>
             <AceEditorWrapper
               sql={this.props.queryEditor.sql}
-              onBlur={this.sqlToStore.bind(this)}
+              onBlur={this.setQueryEditorSql.bind(this)}
             />
             {editorBottomBar}
             <br />

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
@@ -1,6 +1,5 @@
 const $ = window.$ = require('jquery');
 import React from 'react';
-
 import Select from 'react-select';
 import { Label, Button } from 'react-bootstrap';
 import TableElement from './TableElement';
@@ -19,7 +18,7 @@ const defaultProps = {
   actions: {},
 };
 
-class SqlEditorLeftBar extends React.Component {
+class SqlEditorLeftBar extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -27,6 +26,7 @@ class SqlEditorLeftBar extends React.Component {
       schemaOptions: [],
       tableLoading: false,
       tableOptions: [],
+      networkOn: true,
     };
   }
   componentWillMount() {
@@ -92,8 +92,8 @@ class SqlEditorLeftBar extends React.Component {
     this.setState({ tableLoading: true });
     $.get(url, (data) => {
       this.props.actions.mergeTable(Object.assign(data, {
-        dbId: this.props.queryEditor.dbId,
-        queryEditorId: this.props.queryEditor.id,
+        dbId: qe.dbId,
+        queryEditorId: qe.id,
         schema: qe.schema,
         expanded: true,
       }));
@@ -163,7 +163,6 @@ class SqlEditorLeftBar extends React.Component {
             isLoading={this.state.tableLoading}
             placeholder={`Add a table (${this.state.tableOptions.length})`}
             autosize={false}
-            value={this.state.tableName}
             onChange={this.changeTable.bind(this)}
             options={this.state.tableOptions}
           />
@@ -173,7 +172,6 @@ class SqlEditorLeftBar extends React.Component {
           {this.props.tables.map((table) => (
             <TableElement
               table={table}
-              queryEditor={this.props.queryEditor}
               key={table.id}
               actions={this.props.actions}
             />

--- a/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -23,7 +23,7 @@ const defaultProps = {
 
 let queryCount = 1;
 
-class TabbedSqlEditors extends React.Component {
+class TabbedSqlEditors extends React.PureComponent {
   constructor(props) {
     super(props);
     const uri = window.location.toString();

--- a/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TableElement.jsx
@@ -9,7 +9,6 @@ import ModalTrigger from '../../components/ModalTrigger';
 
 const propTypes = {
   table: React.PropTypes.object,
-  queryEditor: React.PropTypes.object,
   actions: React.PropTypes.object,
 };
 
@@ -18,7 +17,7 @@ const defaultProps = {
   actions: {},
 };
 
-class TableElement extends React.Component {
+class TableElement extends React.PureComponent {
 
   popSelectStar() {
     const qe = {
@@ -46,7 +45,7 @@ class TableElement extends React.Component {
   }
   dataPreviewModal() {
     const query = {
-      dbId: this.props.queryEditor.dbId,
+      dbId: this.props.table.dbId,
       sql: this.props.table.selectStar,
       tableName: this.props.table.name,
       sqlEditorId: null,

--- a/caravel/assets/javascripts/SqlLab/components/Timer.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/Timer.jsx
@@ -3,7 +3,7 @@ import { now, fDuration } from '../../modules/dates';
 
 import { STATE_BSSTYLE_MAP } from '../common.js';
 
-class Timer extends React.Component {
+class Timer extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/caravel/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -23,7 +23,7 @@ const defaultProps = {
   onHide: () => {},
 };
 
-class VisualizeModal extends React.Component {
+class VisualizeModal extends React.PureComponent {
   constructor(props) {
     super(props);
     const uniqueId = shortid.generate();

--- a/caravel/assets/javascripts/reduxUtils.js
+++ b/caravel/assets/javascripts/reduxUtils.js
@@ -75,21 +75,22 @@ export function enhancer() {
   return enhancerWithPersistState;
 }
 
-export function areArrayDifferent(arr1, arr2) {
+export function areArraysShallowEqual(arr1, arr2) {
+  // returns whether 2 arrays are shallow equal
   // used in shouldComponentUpdate when denormalizing arrays
   // where the array object is different every time, but the content might
   // be the same
   if (!arr1 || !arr2) {
-    return true;
+    return false;
   }
   if (arr1.length !== arr2.length) {
-    return true;
+    return false;
   }
   const length = arr1.length;
   for (let i = 0; i < length; i++) {
     if (arr1[i] !== arr2[i]) {
-      return true;
+      return false;
     }
   }
-  return false;
+  return true;
 }

--- a/caravel/assets/javascripts/reduxUtils.js
+++ b/caravel/assets/javascripts/reduxUtils.js
@@ -74,3 +74,22 @@ export function enhancer() {
   }
   return enhancerWithPersistState;
 }
+
+export function areArrayDifferent(arr1, arr2) {
+  // used in shouldComponentUpdate when denormalizing arrays
+  // where the array object is different every time, but the content might
+  // be the same
+  if (!arr1 || !arr2) {
+    return true;
+  }
+  if (arr1.length !== arr2.length) {
+    return true;
+  }
+  const length = arr1.length;
+  for (let i = 0; i < length; i++) {
+    if (arr1[i] !== arr2[i]) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/caravel/assets/package.json
+++ b/caravel/assets/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "mocha --compilers js:babel-core/register --require spec/helpers/browser.js --recursive spec/**/*_spec.*",
     "cover": "babel-node ./node_modules/.bin/istanbul cover _mocha -- --require spec/helpers/browser.js --recursive spec/**/*_spec.*",
-    "dev": "NODE_ENV=dev webpack -d --watch --colors --progress",
+    "dev": "NODE_ENV=dev webpack --watch --colors --progress --debug --devtool cheap-eval-source-map --output-pathinfo",
     "prod": "NODE_ENV=production node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js -p --colors --progress",
     "build": "NODE_ENV=production webpack --colors --progress",
     "lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx ."


### PR DESCRIPTION
@ascott  @vera-liu @bkyryliuk 
The UI is much more snappy after these changes. I noticed keystrokes in the editor were getting quite laggy, incrementally as the query history would grow or when the result set was large. 

The big win is to not re-render the whole page at each keystroke in the AceEditor by wrapping it in its own component and managing local state there: affecting the store only onBlur events.

I also made pretty much every component a PureComponent which reduces the amount of rendering dramatically.

@ascott I'm doing this trick with `shouldComponentUpdate` to work around the fact that denormalizing the query array in the "controller"'s rendering method (to go from a global object in the store, to editor-specific array of queries) always creates a new array object. I made this function `areArraysDifferent` which looks inside the array for comparison. Any cleaner way to do this? It seems like it would be a common problem when denormalizing. Maybe keeping the array in the controller's state and handling the mutation there only if necessary?
