### PR TITLE
Highlight affected slices for filter change in dashboard view

### DIFF
--- a/caravel/assets/javascripts/dashboard/Dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard/Dashboard.jsx
@@ -205,7 +205,7 @@ function dashboardContainer(dashboardData) {
           sliceSeletor.addClass('slice-highlight');
           setTimeout(function () {
             sliceSeletor.removeClass('slice-highlight');
-          }, 2000);
+          }, 1200);
         }
       });
     },

--- a/caravel/assets/javascripts/dashboard/Dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard/Dashboard.jsx
@@ -201,9 +201,10 @@ function dashboardContainer(dashboardData) {
       this.slices.forEach(function (slice) {
         if (slice.data.slice_id !== sliceId && immune.indexOf(slice.data.slice_id) === -1) {
           slice.render();
-          $(`#${slice.data.token}-header`).addClass('slice-highlight');
+          const sliceSeletor = $(`#${slice.data.token}-cell`);
+          sliceSeletor.addClass('slice-highlight');
           setTimeout(function () {
-            $(`#${slice.data.token}-header`).removeClass('slice-highlight');
+            sliceSeletor.removeClass('slice-highlight');
           }, 2000);
         }
       });

--- a/caravel/assets/javascripts/dashboard/Dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard/Dashboard.jsx
@@ -201,6 +201,10 @@ function dashboardContainer(dashboardData) {
       this.slices.forEach(function (slice) {
         if (slice.data.slice_id !== sliceId && immune.indexOf(slice.data.slice_id) === -1) {
           slice.render();
+          $(`#${slice.data.token}-header`).addClass('slice-highlight');
+          setTimeout(function () {
+            $(`#${slice.data.token}-header`).removeClass('slice-highlight');
+          }, 2000);
         }
       });
     },

--- a/caravel/assets/javascripts/dashboard/Dashboard.jsx
+++ b/caravel/assets/javascripts/dashboard/Dashboard.jsx
@@ -202,9 +202,9 @@ function dashboardContainer(dashboardData) {
         if (slice.data.slice_id !== sliceId && immune.indexOf(slice.data.slice_id) === -1) {
           slice.render();
           const sliceSeletor = $(`#${slice.data.token}-cell`);
-          sliceSeletor.addClass('slice-highlight');
+          sliceSeletor.addClass('slice-cell-highlight');
           setTimeout(function () {
-            sliceSeletor.removeClass('slice-highlight');
+            sliceSeletor.removeClass('slice-cell-highlight');
           }, 1200);
         }
       });

--- a/caravel/assets/javascripts/dashboard/components/SliceCell.js
+++ b/caravel/assets/javascripts/dashboard/components/SliceCell.js
@@ -9,7 +9,7 @@ const propTypes = {
 function SliceCell({ expandedSlices, removeSlice, slice }) {
   return (
     <div>
-      <div className="chart-header">
+      <div className="chart-header" id={`${slice.token}-header`}>
         <div className="row">
           <div className="col-md-12 header">
             <span>{slice.slice_name}</span>

--- a/caravel/assets/javascripts/dashboard/components/SliceCell.js
+++ b/caravel/assets/javascripts/dashboard/components/SliceCell.js
@@ -8,7 +8,7 @@ const propTypes = {
 
 function SliceCell({ expandedSlices, removeSlice, slice }) {
   return (
-    <div id={`${slice.token}-cell`}>
+    <div className="slice-cell" id={`${slice.token}-cell`}>
       <div className="chart-header">
         <div className="row">
           <div className="col-md-12 header">

--- a/caravel/assets/javascripts/dashboard/components/SliceCell.js
+++ b/caravel/assets/javascripts/dashboard/components/SliceCell.js
@@ -8,8 +8,8 @@ const propTypes = {
 
 function SliceCell({ expandedSlices, removeSlice, slice }) {
   return (
-    <div>
-      <div className="chart-header" id={`${slice.token}-header`}>
+    <div id={`${slice.token}-cell`}>
+      <div className="chart-header">
         <div className="row">
           <div className="col-md-12 header">
             <span>{slice.slice_name}</span>

--- a/caravel/assets/stylesheets/dashboard.css
+++ b/caravel/assets/stylesheets/dashboard.css
@@ -87,7 +87,7 @@ div.widget .chart-controls {
   transition: box-shadow 1s ease-in;
 }
 
-.slice-highlight {
+.slice-cell-highlight {
   box-shadow: 0px 0px 20px 5px rgba(0,0,0,0.2);
 }
 

--- a/caravel/assets/stylesheets/dashboard.css
+++ b/caravel/assets/stylesheets/dashboard.css
@@ -81,6 +81,11 @@ div.widget .chart-controls {
 .slice-grid div.separator.widget h1,h2,h3,h4 {
   margin-top: 0px;
 }
+
+.slice-highlight {
+  background-color:  #FFFF00 !important;
+}
+
 .dashboard .separator.widget .slice_container {
   padding: 0px;
   overflow: visible;

--- a/caravel/assets/stylesheets/dashboard.css
+++ b/caravel/assets/stylesheets/dashboard.css
@@ -82,8 +82,13 @@ div.widget .chart-controls {
   margin-top: 0px;
 }
 
+.slice-cell {
+  box-shadow: 0px 0px 20px 5px rgba(0,0,0,0);
+  transition: box-shadow 1s ease-in;
+}
+
 .slice-highlight {
-  box-shadow: 0px 0px 20px 5px rgba(0,0,0,0.2) !important;
+  box-shadow: 0px 0px 20px 5px rgba(0,0,0,0.2);
 }
 
 .dashboard .separator.widget .slice_container {

--- a/caravel/assets/stylesheets/dashboard.css
+++ b/caravel/assets/stylesheets/dashboard.css
@@ -83,7 +83,7 @@ div.widget .chart-controls {
 }
 
 .slice-highlight {
-  background-color:  #FFFF00 !important;
+  box-shadow: 0px 0px 20px 5px rgba(0,0,0,0.2) !important;
 }
 
 .dashboard .separator.widget .slice_container {


### PR DESCRIPTION
Issue: [https://github.com/airbnb/caravel/issues/659](url)
Done:
- When user adds/deletes a filter in dashboard, affected slices will
  have their header highlighted for 2 seconds

![giphy 2](https://cloud.githubusercontent.com/assets/20978302/19747973/ce0487c0-9b93-11e6-81a8-a5180cabc43f.gif)

needs-review @ascott @mistercrunch 
