### PR TITLE
Get world map working in explorev2

### DIFF
--- a/caravel/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/caravel/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -40,12 +40,17 @@ class ChartContainer extends React.Component {
           $(this.state.selector).html(data);
         },
 
-        css: () => {
+        css: (dim, size) => {
           // dimension can be 'height'
           // pixel string can be '300px'
           // should call callback to adjust height of chart
+          $(this.state.selector).css(dim, size);
         },
         height: () => parseInt(this.props.height, 10) - 100,
+
+        show: () => { this.render(); },
+
+        get: (n) => ($(this.state.selector).get(n)),
 
         find: (classname) => ($(this.state.selector).find(classname)),
 


### PR DESCRIPTION
Done:
Use jquery calls for css(), get() and find() inside container

Before:
![world_map](https://cloud.githubusercontent.com/assets/20978302/19754473/b6609aee-9bc2-11e6-8fa5-8f3c9afb0332.png)

After:
![screen shot 2016-10-26 at 2 20 59 pm](https://cloud.githubusercontent.com/assets/20978302/19754469/a5f31b50-9bc2-11e6-8baf-cc0cb2d0fb2e.png)

@ascott 
