### PR TITLE
run_specific_test: take the test as parameter

### DIFF
--- a/run_specific_test.sh
+++ b/run_specific_test.sh
@@ -5,4 +5,5 @@ export CARAVEL_CONFIG=tests.caravel_test_config
 set -e
 caravel/bin/caravel version -v
 export SOLO_TEST=1
-nosetests tests.core_tests:CoreTests.test_templated_sql_json
+# e.g. tests.core_tests:CoreTests.test_templated_sql_json
+nosetests $1


### PR DESCRIPTION
Instead of hardcoding it, e.g.:
./run_specific_test.sh tests.core_tests:CoreTests.test_templated_sql_json
