### PR TITLE
fix name for postgresql

### DIFF
--- a/caravel/db_engine_specs.py
+++ b/caravel/db_engine_specs.py
@@ -65,7 +65,7 @@ class BaseEngineSpec(object):
 
 
 class PostgresEngineSpec(BaseEngineSpec):
-    engine = 'postgres'
+    engine = 'postgresql'
 
     time_grains = (
         Grain("Time Column", _('Time Column'), "{col}"),


### PR DESCRIPTION
The code change in ef2670ca32e8ba0a04f9dc7899db55812e2f9b46 caused tables on a postgres backend to lose the time grain selector in the table explorer (i.e. cannot see/select a time grain after this code change).

The previous code used startswith to match the database driver type (which was looking to match 'postgres' and 'postgresql'). 

https://github.com/airbnb/caravel/blob/8626c80d3a491b842f8262c5807154903c107747/caravel/models.py#L775

The new version requires matching the whole string so a postgresql:// uri will not match postgres.

https://github.com/airbnb/caravel/blob/ef2670ca32e8ba0a04f9dc7899db55812e2f9b46/caravel/models.py#L1365

The fix sets postgresql as the engine name. This corresponds to the sqlalchemy doc as well.
