### PR TITLE
Support week_ending_saturday for Druid.

### DIFF
--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -359,6 +359,7 @@ class FormFactory(object):
                     ('week', _('week')),
                     ('week_starting_sunday', _('week_starting_sunday')),
                     ('week_ending_saturday', _('week_ending_saturday')),
+                    ('month', _('month')),
                 ),
                 "description": _(
                     "The time granularity for the visualization. Note that you "

--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -356,6 +356,8 @@ class FormFactory(object):
                     ('6 hour', _('6 hour')),
                     ('1 day', _('1 day')),
                     ('7 days', _('7 days')),
+                    ('week', _('week')),
+                    ('week_starting_sunday', _('week_starting_sunday')),
                     ('week_ending_saturday', _('week_ending_saturday')),
                 ),
                 "description": _(

--- a/caravel/forms.py
+++ b/caravel/forms.py
@@ -356,6 +356,7 @@ class FormFactory(object):
                     ('6 hour', _('6 hour')),
                     ('1 day', _('1 day')),
                     ('7 days', _('7 days')),
+                    ('week_ending_saturday', _('week_ending_saturday')),
                 ),
                 "description": _(
                     "The time granularity for the visualization. Note that you "

--- a/caravel/models.py
+++ b/caravel/models.py
@@ -1808,6 +1808,7 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable):
             '5 minutes': 'PT5M',
             '1 hour': 'PT1H',
             '6 hour': 'PT6H',
+            'one day': 'P1D',
             '1 day': 'P1D',
             '7 days': 'P7D',
             'week': 'P1W',

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -128,7 +128,6 @@ class CaravelTestCase(unittest.TestCase):
         return db.session.query(models.DruidDatasource).filter_by(
             datasource_name=name).first()
 
-
     def get_resp(self, url):
         """Shortcut to get the parsed results while following redirects"""
         resp = self.client.get(url, follow_redirects=True)

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -155,8 +155,6 @@ class DruidTests(CaravelTestCase):
         resp = self.get_json_resp(url)
         self.assertEqual(
             "2012-01-01T00:00:00", resp['data']['records'][0]['timestamp'])
-        resp = self.get_resp(url)
-        self.assertIn("Canada", resp)
 
     def test_druid_sync_from_config(self):
         CLUSTER_NAME = 'new_druid'

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -115,7 +115,7 @@ class DruidTests(CaravelTestCase):
 
         resp = self.get_resp('/caravel/explore/druid/{}/'.format(
             datasource_id))
-        assert "[test_cluster].[test_datasource]" in resp
+        self.assertIn("[test_cluster].[test_datasource]", resp)
 
         # One groupby
         url = (
@@ -155,6 +155,8 @@ class DruidTests(CaravelTestCase):
         resp = self.get_json_resp(url)
         self.assertEqual(
             "2012-01-01T00:00:00", resp['data']['records'][0]['timestamp'])
+        resp = self.get_resp(url)
+        self.assertIn("Canada", resp)
 
     def test_druid_sync_from_config(self):
         CLUSTER_NAME = 'new_druid'


### PR DESCRIPTION
Implements: https://github.com/airbnb/caravel/issues/1495

In this change:

- refactored the granularity calculation to use `period` instead of `duration`
- added `week`, `week_starting_sunday`, `week_ending_saturday`, `month` granularities
- week_ending_saturday requires result post processing to offset the time to display the end of the week.

Tested:

- I've ran druid timeseries queries on couple examples for all data granularities - result look the same on dev and prod instances.

Reviewers:
* @mistercrunch 
* @ascott 
* @vera-liu 


