### PR TITLE
Celery uses separate db engine with NullPool.

### DIFF
--- a/caravel/sql_lab.py
+++ b/caravel/sql_lab.py
@@ -1,15 +1,20 @@
 import celery
 from datetime import datetime
-import pandas as pd
-import logging
 import json
+import logging
+import pandas as pd
+import sqlalchemy
 import uuid
 import zlib
+
+from sqlalchemy.pool import NullPool
+from sqlalchemy.orm import sessionmaker
 
 from caravel import (
     app, db, models, utils, dataframe, results_backend)
 from caravel.db_engine_specs import LimitMethod
 from caravel.jinja_context import process_template
+
 QueryStatus = models.QueryStatus
 
 celery_app = celery.Celery(config_source=app.config.get('CELERY_CONFIG'))
@@ -46,10 +51,17 @@ def create_table_as(sql, table_name, schema=None, override=False):
     return exec_sql.format(**locals())
 
 
-@celery_app.task
-def get_sql_results(query_id, return_results=True, store_results=False):
+@celery_app.task(bind=True)
+def get_sql_results(self, query_id, return_results=True, store_results=False):
     """Executes the sql query returns the results."""
-    session = db.session()
+    if not self.request.called_directly:
+        engine = sqlalchemy.create_engine(
+            app.config.get('SQLALCHEMY_DATABASE_URI'), poolclass=NullPool)
+        session_class = sessionmaker()
+        session_class.configure(bind=engine)
+        session = session_class()
+    else:
+        session = db.session()
     session.commit()  # HACK
     query = session.query(models.Query).filter_by(id=query_id).one()
     database = query.database

--- a/caravel/sql_lab.py
+++ b/caravel/sql_lab.py
@@ -62,7 +62,7 @@ def get_sql_results(self, query_id, return_results=True, store_results=False):
         session = session_class()
     else:
         session = db.session()
-    session.commit()  # HACK
+        session.commit()  # HACK
     query = session.query(models.Query).filter_by(id=query_id).one()
     database = query.database
     executed_sql = query.sql.strip().strip(';')


### PR DESCRIPTION
attempt to resolve: https://github.com/airbnb/caravel/issues/1473
@mistercrunch ^^

Testing:
```
-- set global vars:
SET @@GLOBAL.interactive_timeout=10
SET @@GLOBAL.wait_timeout=10
-- reset the connection and check them:
SHOW GLOBAL VARIABLES LIKE "interactive_timeout";
SHOW GLOBAL VARIABLES LIKE "wait_timeout";
SHOW session VARIABLES LIKE "interactive_timeout";
SHOW session VARIABLES LIKE "wait_timeout";

-- all of them are 10 sec:
+---------------+-------+
| Variable_name | Value |
+---------------+-------+
| wait_timeout  | 10    |
+---------------+-------+
```

* Ran presto queries on celery worker locally and connection isn't dying.

![screen shot 2016-10-31 at 11 25 55 am](https://cloud.githubusercontent.com/assets/5727938/19866292/d6b8d9b2-9f5c-11e6-9e96-c10881fa3c07.png)
