### PR TITLE
Moved fetching table metadata from SqlEditorLeftBar to actions

### DIFF
--- a/caravel/assets/javascripts/SqlLab/actions.js
+++ b/caravel/assets/javascripts/SqlLab/actions.js
@@ -197,6 +197,42 @@ export function mergeTable(table) {
   return { type: MERGE_TABLE, table };
 }
 
+export function addTable(query, tableName) {
+  return function (dispatch) {
+    let url = `/caravel/table/${query.dbId}/${tableName}/${query.schema}/`;
+    $.get(url, (data) => {
+      dispatch(
+        mergeTable(Object.assign(data, {
+          dbId: query.dbId,
+          queryEditorId: query.id,
+          schema: query.schema,
+          expanded: true,
+        }))
+      );
+    })
+    .fail(() => {
+      dispatch(
+        addAlert({
+          msg: 'Error occurred while fetching metadata',
+          bsStyle: 'danger',
+        })
+      );
+    });
+
+    url = `/caravel/extra_table_metadata/${query.dbId}/${tableName}/${query.schema}/`;
+    $.get(url, (data) => {
+      const table = {
+        dbId: query.dbId,
+        queryEditorId: query.id,
+        schema: query.schema,
+        name: tableName,
+      };
+      Object.assign(table, data);
+      dispatch(mergeTable(table));
+    });
+  };
+}
+
 export function expandTable(table) {
   return { type: EXPAND_TABLE, table };
 }

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
@@ -87,37 +87,10 @@ class SqlEditorLeftBar extends React.PureComponent {
   changeTable(tableOpt) {
     const tableName = tableOpt.value;
     const qe = this.props.queryEditor;
-    let url = `/caravel/table/${qe.dbId}/${tableName}/${qe.schema}/`;
 
     this.setState({ tableLoading: true });
-    $.get(url, (data) => {
-      this.props.actions.mergeTable(Object.assign(data, {
-        dbId: qe.dbId,
-        queryEditorId: qe.id,
-        schema: qe.schema,
-        expanded: true,
-      }));
-      this.setState({ tableLoading: false });
-    })
-    .fail(() => {
-      this.props.actions.addAlert({
-        msg: 'Error occurred while fetching metadata',
-        bsStyle: 'danger',
-      });
-      this.setState({ tableLoading: false });
-    });
-
-    url = `/caravel/extra_table_metadata/${qe.dbId}/${tableName}/${qe.schema}/`;
-    $.get(url, (data) => {
-      const table = {
-        dbId: this.props.queryEditor.dbId,
-        queryEditorId: this.props.queryEditor.id,
-        schema: qe.schema,
-        name: tableName,
-      };
-      Object.assign(table, data);
-      this.props.actions.mergeTable(table);
-    });
+    this.props.actions.addTable(qe, tableName);
+    this.setState({ tableLoading: false });
   }
   render() {
     let networkAlert = null;


### PR DESCRIPTION
Before:
 - ajax call for fetching table and metadata were in changeTable() of SqlEditorLeft

After:
 - moved ajax call to action creators and dispatch actions from there

This doesn't change any UI.

needs-review @mistercrunch 