### PR TITLE
Database has no schema, hotfix.

### DIFF
--- a/caravel/jinja_context.py
+++ b/caravel/jinja_context.py
@@ -43,8 +43,6 @@ class BaseContext(object):
         self.schema = None
         if query and query.schema:
             self.schema = query.schema
-        elif database:
-            self.schema = database.schema
 
 
 class PrestoContext(BaseContext):


### PR DESCRIPTION
@mistercrunch ^^ please
Database has no schema, we may need to parse the SQL URI to retrieve it, other way could be to force all to user database connection string without schema name.

Resolves: https://github.com/airbnb/caravel/issues/1501