### PR TITLE
Moved queriesArray from render() to local state

### DIFF
--- a/caravel/assets/javascripts/reduxUtils.js
+++ b/caravel/assets/javascripts/reduxUtils.js
@@ -94,3 +94,18 @@ export function areArraysShallowEqual(arr1, arr2) {
   }
   return true;
 }
+
+export function areObjectsEqual(obj1, obj2) {
+  if (!obj1 || !obj2) {
+    return false;
+  }
+  for (const id in obj1) {
+    if (!obj2.hasOwnProperty(id)) {
+      return false;
+    }
+    if (obj1[id] !== obj2[id]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/caravel/assets/javascripts/reduxUtils.js
+++ b/caravel/assets/javascripts/reduxUtils.js
@@ -99,6 +99,9 @@ export function areObjectsEqual(obj1, obj2) {
   if (!obj1 || !obj2) {
     return false;
   }
+  if (! Object.keys(obj1).length !== Object.keys(obj2).length) {
+    return false;
+  }
   for (const id in obj1) {
     if (!obj2.hasOwnProperty(id)) {
       return false;


### PR DESCRIPTION
Before:
 - queriesArray is reloaded during each render, but for some re-rendering caused by prop-change like tables, queriesArray doesn't change.

After:
 - queriesArray is moved to local state of TabbedSqlEditors, and is only reloaded during switching tabs or queries object is updated.

needs-review @mistercrunch 