### PR TITLE
Apply appropriate type conversion for viz form_data

### DIFF
--- a/caravel/viz.py
+++ b/caravel/viz.py
@@ -68,7 +68,7 @@ class BaseViz(object):
         if isinstance(form_data, (MultiDict, ImmutableMultiDict)):
             form = form_class(form_data)
         else:
-            form = form_class(**form_data)
+            form = form_class(MultiDict(form_data))
         data = form.data.copy()
 
         if not form.validate():


### PR DESCRIPTION
### Problem

On the Dashboard view, the `form_data` is passed in as a regular dict.  This is then passed as `**kwargs` to WTForms which as the note below describes doesn't do proper type conversion.  `u'false'` becomes `True` which is not what we want.  This is not currently impacting users because slices always pull data from the `json_endpoint` but should still be fixed because the data inside the rendered html is inconsistent.
### Solution

If passing just one parameter as `form_data`, the WTForms constructor will do proper type conversion as if the `form_data` came from a POST.  This is why this bug doesn't surface when using the `json_endpoint` to get slice data, but it does on the dashboard page.  The fix is to pass the `form_data` parameter rather than as `**kwargs`.

Example reproduction steps:
1. Open Genders sample data slice in explore page.
2. Save as a donut chart
3. Save again as a pie chart
4. Go to dashboard page, add Genders slice
5. Inspect `data-dashboard` in the markup.  Note that `form_data.donut` is `true` when it should be `false`.

You have to save as donut and then back to pie to reproduce because initially donut isn't in the params object.  You'll note that the Genders slice still renders as a pie correctly without this fix, but only because internally slices render using data from `json_endpoint` in which `form_data` always follows the `form = form_class(form_data)` code path instead of being used as a `**kwargs`.  This fix is still important because the `form_data` is out of sync with the real values and could be problematic in the future or in the present to people who are extending Caravel to use `form_data` now (which is how I discovered it).

> Note Backing-store objects and kwargs are both expected to be provided with the values being already-coerced datatypes. WTForms does not check the types of incoming object-data or coerce them like it will for formdata as it is expected this data is defaults or data from a backing store which this form represents. See the section on using Forms for more information.

[WTForms docs](https://wtforms.readthedocs.io/en/latest/forms.html)

@mistercrunch
