### PR TITLE
Make it possible to import caravel.bin.caravel script

### DIFF
--- a/caravel/bin/caravel.py
+++ b/caravel/bin/caravel.py
@@ -151,5 +151,9 @@ def worker():
     c_worker.run(**options)
 
 
-if __name__ == "__main__":
+def main():
     manager.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/run_specific_test.sh
+++ b/run_specific_test.sh
@@ -3,7 +3,7 @@ echo $DB
 rm -f .coverage
 export CARAVEL_CONFIG=tests.caravel_test_config
 set -e
-caravel/bin/caravel version -v
+caravel version -v
 export SOLO_TEST=1
 # e.g. tests.core_tests:CoreTests.test_templated_sql_json
 nosetests $1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,8 +6,8 @@ rm ~/.caravel/celery_results.sqlite
 rm -f .coverage
 export CARAVEL_CONFIG=tests.caravel_test_config
 set -e
-caravel/bin/caravel db upgrade
-caravel/bin/caravel db upgrade  # running twice on purpose as a test
-caravel/bin/caravel version -v
+caravel db upgrade
+caravel db upgrade  # running twice on purpose as a test
+caravel version -v
 python setup.py nosetests
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    scripts=['caravel/bin/caravel'],
     install_requires=[
         'celery==3.1.23',
         'cryptography==1.4',
@@ -65,4 +64,9 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
+    entry_points={
+        'console_scripts': [
+            'caravel=caravel.bin.caravel:main',
+        ]
+    },
 )


### PR DESCRIPTION
It's sometimes convenient to be able to import functionality
from script for example in caravel case I wanted to do:

```
from caravel.bin.caravel import manager
manager.do_something()
```

But because caravel/bin/caravel does not end with '.py' it is not possible to import it.

I suggest to move

`caravel/bin/caravel -> caravel/bin/caravel.py`

So it is possible to import and use functionality available in the script

Also I replaced `setup.py` `scripts=[...]` with entrypoints as it is described in: https://packaging.python.org/distributing/#console-scripts
to automatically create script named `caravel` in `$VIRTUAL_ENV/bin`