### PR TITLE
Added scroll bar and option to collapse for Sql Editor tool bar

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -11,6 +11,7 @@ import {
   OverlayTrigger,
   Row,
   Tooltip,
+  Collapse,
 } from 'react-bootstrap';
 
 import SouthPane from './SouthPane';
@@ -28,12 +29,14 @@ const propTypes = {
   editorQueries: React.PropTypes.array.isRequired,
   dataPreviewQueries: React.PropTypes.array.isRequired,
   queryEditor: React.PropTypes.object.isRequired,
+  hideLeftBar: React.PropTypes.bool,
 };
 
 const defaultProps = {
   networkOn: true,
   database: null,
   latestQuery: null,
+  hideLeftBar: false,
 };
 
 
@@ -207,15 +210,19 @@ class SqlEditor extends React.PureComponent {
     return (
       <div className="SqlEditor" style={{ minHeight: this.sqlEditorHeight() }}>
         <Row>
-          <Col md={3}>
-            <SqlEditorLeftBar
-              queryEditor={this.props.queryEditor}
-              tables={this.props.tables}
-              networkOn={this.props.networkOn}
-              actions={this.props.actions}
-            />
-          </Col>
-          <Col md={9}>
+          <Collapse
+            in={!this.props.hideLeftBar}
+          >
+            <Col md={3}>
+              <SqlEditorLeftBar
+                queryEditor={this.props.queryEditor}
+                tables={this.props.tables}
+                networkOn={this.props.networkOn}
+                actions={this.props.actions}
+              />
+            </Col>
+          </Collapse>
+          <Col md={this.props.hideLeftBar ? 12 : 9}>
             <AceEditorWrapper
               tables={this.props.tables}
               actions={this.props.actions}

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -223,20 +223,22 @@ class SqlEditor extends React.PureComponent {
             </Col>
           </Collapse>
           <Col md={this.props.hideLeftBar ? 12 : 9}>
-            <AceEditorWrapper
-              tables={this.props.tables}
-              actions={this.props.actions}
-              queryEditor={this.props.queryEditor}
-              sql={this.props.queryEditor.sql}
-              onBlur={this.setQueryEditorSql.bind(this)}
-            />
-            {editorBottomBar}
-            <br />
-            <SouthPane
-              editorQueries={this.props.editorQueries}
-              dataPreviewQueries={this.props.dataPreviewQueries}
-              actions={this.props.actions}
-            />
+            <div className="scrollbar">
+              <AceEditorWrapper
+                tables={this.props.tables}
+                actions={this.props.actions}
+                queryEditor={this.props.queryEditor}
+                sql={this.props.queryEditor.sql}
+                onBlur={this.setQueryEditorSql.bind(this)}
+              />
+              {editorBottomBar}
+              <br />
+              <SouthPane
+                editorQueries={this.props.editorQueries}
+                dataPreviewQueries={this.props.dataPreviewQueries}
+                actions={this.props.actions}
+              />
+            </div>
           </Col>
         </Row>
       </div>

--- a/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
@@ -99,7 +99,7 @@ class SqlEditorLeftBar extends React.PureComponent {
     }
     const shouldShowReset = window.location.search === '?reset=1';
     return (
-      <div className="clearfix sql-toolbar">
+      <div className="clearfix sql-toolbar scrollbar">
         {networkAlert}
         <div>
           <DatabaseSelect

--- a/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -36,6 +36,7 @@ class TabbedSqlEditors extends React.PureComponent {
       cleanUri,
       query,
       queriesArray: [],
+      hideLeftBar: false,
     };
   }
   componentWillMount() {
@@ -105,6 +106,9 @@ class TabbedSqlEditors extends React.PureComponent {
   removeQueryEditor(qe) {
     this.props.actions.removeQueryEditor(qe);
   }
+  toggleLeftBar() {
+    this.setState({ hideLeftBar: !this.state.hideLeftBar });
+  }
   render() {
     const editors = this.props.queryEditors.map((qe, i) => {
       const isSelected = (qe.id === this.activeQueryEditor().id);
@@ -146,6 +150,10 @@ class TabbedSqlEditors extends React.PureComponent {
                 <i className="fa fa-clipboard" /> <CopyQueryTabUrl queryEditor={qe} />
               </MenuItem>
             }
+            <MenuItem eventKey="4" onClick={this.toggleLeftBar.bind(this)}>
+              <i className="fa fa-cogs" />
+                {this.state.hideLeftBar ? 'expand tool bar' : 'hide tool bar'}
+            </MenuItem>
           </DropdownButton>
         </div>
       );
@@ -167,6 +175,7 @@ class TabbedSqlEditors extends React.PureComponent {
                   database={database}
                   actions={this.props.actions}
                   networkOn={this.props.networkOn}
+                  hideLeftBar={this.state.hideLeftBar}
                 />
               }
             </div>

--- a/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -152,7 +152,8 @@ class TabbedSqlEditors extends React.PureComponent {
             }
             <MenuItem eventKey="4" onClick={this.toggleLeftBar.bind(this)}>
               <i className="fa fa-cogs" />
-                {this.state.hideLeftBar ? 'expand tool bar' : 'hide tool bar'}
+              &nbsp;
+              {this.state.hideLeftBar ? 'expand tool bar' : 'hide tool bar'}
             </MenuItem>
           </DropdownButton>
         </div>

--- a/caravel/assets/javascripts/SqlLab/main.css
+++ b/caravel/assets/javascripts/SqlLab/main.css
@@ -28,6 +28,14 @@
     padding-top: 5px;
     padding-bottom: 5px;
 }
+
+.scrollbar {
+    position: relative;
+    width: 100%;
+    overflow-y: auto;
+    height: 100%;
+}
+
 .Workspace .btn-sm {
     box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
     margin-top: 2px;
@@ -231,6 +239,10 @@ div.tablePopover:hover {
 
 .SouthPane .tab-content {
     padding-top: 10px;
+}
+
+.TableElement {
+    margin-right: 5px;
 }
 
 .TableElement .well {

--- a/caravel/assets/javascripts/SqlLab/main.css
+++ b/caravel/assets/javascripts/SqlLab/main.css
@@ -242,7 +242,7 @@ div.tablePopover:hover {
 }
 
 .TableElement {
-    margin-right: 5px;
+    margin-right: 10px;
 }
 
 .TableElement .well {


### PR DESCRIPTION
Done:
 - Added scroll-bar to Sql Editor tool bar and right panel in SqlEditor
 - Added hide/expand tool bar option to dropdown menu of tab

After:
 - scroll bar
![giphy 3](https://cloud.githubusercontent.com/assets/20978302/20022833/a068461e-a299-11e6-904b-57824884d39b.gif)



 - hide tool bar option
<img width="236" alt="screen shot 2016-11-03 at 4 52 57 pm" src="https://cloud.githubusercontent.com/assets/20978302/19989765/08adfc96-a1e6-11e6-8eef-fa83519bb4b4.png">


 - after hiding tool bar
<img width="1413" alt="screen shot 2016-11-02 at 5 51 43 pm" src="https://cloud.githubusercontent.com/assets/20978302/19952894/c3c093e8-a125-11e6-8db4-31b189438df8.png">
![Uploading Screen Shot 2016-11-03 at 4.53.40 PM.png…]()


 - after expanding
<img width="1411" alt="screen shot 2016-11-02 at 5 51 58 pm" src="https://cloud.githubusercontent.com/assets/20978302/19952903/dbbb837c-a125-11e6-913e-4236bee12a7d.png">


Note: 
I put hideLeftBar in state TabbedSqlEditor component, once it's clicked in the menu, tool bar will be hided for all the tabs. The other option would be add hideLeftBar to one of QueryEditor's attribute, then the option for hiding/expanding tool bar will be per-queryEditor-tab-ish. Let me know which you prefer 😃 
needs-review @mistercrunch @ascott @bkyryliuk 


