### PR TITLE
Added cache prop to ResultSet

### DIFF
--- a/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -128,7 +128,7 @@ class ResultSet extends React.PureComponent {
   render() {
     const query = this.props.query;
     const results =
-      (this.props.cache && this.props.query.cached) ? this.state.results : query.results;
+      (this.props.cache && query.cached) ? this.state.results : query.results;
     let sql;
 
     if (this.props.showSql) {

--- a/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -33,7 +33,7 @@ class ResultSet extends React.PureComponent {
     this.state = {
       searchText: '',
       showModal: false,
-      results: null,
+      data: [],
     };
   }
   componentWillReceiveProps(nextProps) {
@@ -42,7 +42,7 @@ class ResultSet extends React.PureComponent {
       && nextProps.query.results
       && nextProps.query.results.data.length > 0) {
       this.setState(
-        { results: nextProps.query.results },
+        { data: nextProps.query.results.data },
         this.clearQueryResults(nextProps.query)
       );
     }
@@ -127,8 +127,14 @@ class ResultSet extends React.PureComponent {
   }
   render() {
     const query = this.props.query;
-    const results =
-      (this.props.cache && query.cached) ? this.state.results : query.results;
+    const results = query.results;
+    let data;
+    if (this.props.cache && query.cached) {
+      data = this.state.data;
+    } else {
+      data = results ? results.data : [];
+    }
+
     let sql;
 
     if (this.props.showSql) {
@@ -168,7 +174,7 @@ class ResultSet extends React.PureComponent {
           </Alert>
         </div>);
     } else if (query.state === 'success') {
-      if (results && results.data && results.data.length > 0) {
+      if (results && data && data.length > 0) {
         return (
           <div>
             <VisualizeModal
@@ -180,7 +186,7 @@ class ResultSet extends React.PureComponent {
             {sql}
             <div className="ResultSet">
               <Table
-                data={results.data}
+                data={data}
                 columns={results.columns.map((col) => col.name)}
                 sortable
                 className="table table-condensed table-bordered"

--- a/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -14,6 +14,7 @@ const propTypes = {
   searchText: React.PropTypes.string,
   showSql: React.PropTypes.bool,
   visualize: React.PropTypes.bool,
+  cache: React.PropTypes.bool,
 };
 const defaultProps = {
   search: true,
@@ -22,6 +23,7 @@ const defaultProps = {
   csv: true,
   searchText: '',
   actions: {},
+  cache: false,
 };
 
 
@@ -36,7 +38,7 @@ class ResultSet extends React.PureComponent {
   }
   componentWillReceiveProps(nextProps) {
     // when new results comes in, save them locally and clear in store
-    if ((!nextProps.query.cached)
+    if (this.props.cache && (!nextProps.query.cached)
       && nextProps.query.results
       && nextProps.query.results.data.length > 0) {
       this.setState(
@@ -125,7 +127,8 @@ class ResultSet extends React.PureComponent {
   }
   render() {
     const query = this.props.query;
-    const results = (this.props.query.cached) ? this.state.results : query.results;
+    const results =
+      (this.props.cache && this.props.query.cached) ? this.state.results : query.results;
     let sql;
 
     if (this.props.showSql) {

--- a/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
+++ b/caravel/assets/javascripts/SqlLab/components/SouthPane.jsx
@@ -54,7 +54,7 @@ class SouthPane extends React.PureComponent {
         eventKey={query.id}
         key={query.id}
       >
-        <ResultSet query={query} visualize={false} csv={false} actions={props.actions} />
+        <ResultSet query={query} visualize={false} csv={false} actions={props.actions} cache />
       </Tab>
     ));
 

--- a/caravel/assets/javascripts/SqlLab/reducers.js
+++ b/caravel/assets/javascripts/SqlLab/reducers.js
@@ -150,7 +150,9 @@ export const sqlLabReducer = function (state, action) {
       return alterInObject(state, 'queries', action.query, { state: 'stopped' });
     },
     [actions.CLEAR_QUERY_RESULTS]() {
-      return alterInObject(state, 'queries', action.query, { results: [], cached: true });
+      const newResults = Object.assign({}, action.query.results);
+      newResults.data = [];
+      return alterInObject(state, 'queries', action.query, { results: newResults, cached: true });
     },
     [actions.REQUEST_QUERY_RESULTS]() {
       return alterInObject(state, 'queries', action.query, { state: 'fetching' });


### PR DESCRIPTION
Bug/Issue: 
 - We don't want user to lose query results when they refresh the page
 - and VisualizeModal needs query results

Done:
 - Added cache prop to ResultSet
 - Results from query run by user are not flushed from global state, when user refreshes the page, results stay the same
 - Preview results of selected tables are stored in local component's state, it will go away when user refreshes.

needs-review @mistercrunch 