### PR TITLE
Added action buttons to Chart Container of explore V2

### DIFF
--- a/caravel/assets/javascripts/explore/components/ExploreActionButtons.jsx
+++ b/caravel/assets/javascripts/explore/components/ExploreActionButtons.jsx
@@ -5,7 +5,7 @@ import EmbedCodeButton from './EmbedCodeButton';
 import DisplayQueryButton from './DisplayQueryButton';
 
 const propTypes = {
-  canDownload: PropTypes.string.isRequired,
+  canDownload: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
   slice: PropTypes.object.isRequired,
 };
 

--- a/caravel/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/caravel/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -4,13 +4,18 @@ import { connect } from 'react-redux';
 import { Panel } from 'react-bootstrap';
 import visMap from '../../../visualizations/main';
 import { d3format } from '../../modules/utils';
+import ExploreActionButtons from '../../explore/components/ExploreActionButtons';
 
 const propTypes = {
+  can_download: PropTypes.bool.isRequired,
   slice_name: PropTypes.string.isRequired,
   viz_type: PropTypes.string.isRequired,
   height: PropTypes.string.isRequired,
   containerId: PropTypes.string.isRequired,
   json_endpoint: PropTypes.string.isRequired,
+  csv_endpoint: PropTypes.string.isRequired,
+  standalone_endpoint: PropTypes.string.isRequired,
+  query: PropTypes.string.isRequired,
   column_formats: PropTypes.object,
 };
 
@@ -18,8 +23,13 @@ class ChartContainer extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selector: `#${this.props.containerId}`,
+      selector: `#${props.containerId}`,
+      mockSlice: {},
     };
+  }
+
+  componentWillMount() {
+    this.setState({ mockSlice: this.getMockedSliceObject() });
   }
 
   componentDidMount() {
@@ -32,7 +42,16 @@ class ChartContainer extends React.Component {
 
   getMockedSliceObject() {
     return {
+      viewSqlQuery: this.props.query,
+
+      data: {
+        csv_endpoint: this.props.csv_endpoint,
+        json_endpoint: this.props.json_endpoint,
+        standalone_endpoint: this.props.standalone_endpoint,
+      },
+
       containerId: this.props.containerId,
+
       jsonEndpoint: () => this.props.json_endpoint,
 
       container: {
@@ -110,8 +129,7 @@ class ChartContainer extends React.Component {
   }
 
   renderVis() {
-    const slice = this.getMockedSliceObject();
-    visMap[this.props.viz_type](slice).render();
+    visMap[this.props.viz_type](this.state.mockSlice).render();
   }
 
   render() {
@@ -125,6 +143,12 @@ class ChartContainer extends React.Component {
               className="panel-title"
             >
               {this.props.slice_name}
+              <div className="pull-right">
+                <ExploreActionButtons
+                  slice={this.state.mockSlice}
+                  canDownload={this.props.can_download}
+                />
+              </div>
             </div>
           }
         >
@@ -146,7 +170,11 @@ function mapStateToProps(state) {
     containerId: `slice-container-${state.viz.form_data.slice_id}`,
     slice_name: state.viz.form_data.slice_name,
     viz_type: state.viz.form_data.viz_type,
+    can_download: state.can_download,
+    csv_endpoint: state.viz.csv_endpoint,
     json_endpoint: state.viz.json_endpoint,
+    standalone_endpoint: state.viz.standalone_endpoint,
+    query: state.viz.query,
     column_formats: state.viz.column_formats,
   };
 }

--- a/caravel/assets/javascripts/explorev2/index.jsx
+++ b/caravel/assets/javascripts/explorev2/index.jsx
@@ -13,6 +13,7 @@ const bootstrapData = JSON.parse(exploreViewContainer.getAttribute('data-bootstr
 import { exploreReducer } from './reducers/exploreReducer';
 
 const bootstrappedState = Object.assign(initialState, {
+  can_download: bootstrapData.can_download,
   datasources: bootstrapData.datasources,
   datasource_id: parseInt(bootstrapData.datasource_id, 10),
   datasource_type: bootstrapData.datasource_type,


### PR DESCRIPTION
Done:
 - added attribute to mock slice in render() of ChartContainer for action buttons, 

<img width="1379" alt="screen shot 2016-11-08 at 11 36 58 am" src="https://cloud.githubusercontent.com/assets/20978302/20114098/e86ed3e0-a5a7-11e6-8a6e-7827c292b923.png">
<img width="1384" alt="screen shot 2016-11-08 at 11 37 10 am" src="https://cloud.githubusercontent.com/assets/20978302/20114109/eeb86e32-a5a7-11e6-9db3-6fb4e75c598c.png">
<img width="1388" alt="screen shot 2016-11-08 at 11 37 24 am" src="https://cloud.githubusercontent.com/assets/20978302/20114115/f43e2e6e-a5a7-11e6-862d-3b0ad3da9ba9.png">


needs-review @ascott 