### PR TITLE
Bump cryptography dependecy to 1.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     scripts=['caravel/bin/caravel'],
     install_requires=[
         'celery==3.1.23',
-        'cryptography==1.4',
+        'cryptography==1.5.3',
         'flask-appbuilder==1.8.1',
         'flask-cache==0.13.1',
         'flask-migrate==1.5.1',


### PR DESCRIPTION
As the 1.5 release branch builds with OpenSSL 1.1.x