### PR TITLE
Improve Druid metadata fetching resilience

### DIFF
--- a/superset/bin/superset
+++ b/superset/bin/superset
@@ -112,14 +112,18 @@ def load_examples(load_test_data):
         print("Loading [Unicode test data]")
         data.load_unicode_test_data()
 
-@manager.command
-def refresh_druid():
-    """Refresh all druid datasources"""
+@manager.option(
+    '-d', '--datasource',
+    help=(
+        "Specify which datasource name to load, if omitted, all "
+        "datasources will be refreshed"))
+def refresh_druid(datasource):
+    """Refresh druid datasources"""
     session = db.session()
     from superset import models
     for cluster in session.query(models.DruidCluster).all():
         try:
-            cluster.refresh_datasources()
+            cluster.refresh_datasources(datasource_name=datasource)
         except Exception as e:
             print(
                 "Error while processing cluster '{}'\n{}".format(


### PR DESCRIPTION
Can target a specific datasource when using the CLI's `refresh_druid`.

Added logic around finding segments for any given datasource while handling the `0.8.2` segment metadata bug.