### PR TITLE
Fixed a bug with new dashboard

### DIFF
--- a/superset/assets/javascripts/dashboard/Dashboard.jsx
+++ b/superset/assets/javascripts/dashboard/Dashboard.jsx
@@ -19,9 +19,11 @@ export function getInitialState(dashboardData, context) {
   dashboard.firstLoad = true;
 
   dashboard.posDict = {};
-  dashboard.position_json.forEach(position => {
-    dashboard.posDict[position.slice_id] = position;
-  });
+  if (dashboard.position_json) {
+    dashboard.position_json.forEach(position => {
+      dashboard.posDict[position.slice_id] = position;
+    });
+  }
   dashboard.curUserId = dashboard.context.user_id;
   dashboard.refreshTimer = null;
 


### PR DESCRIPTION
Issue: When position_json of dashboard is passed in as null from bootstrapped data, forEach would fail and slice does not show up

Solution: only iterate when position_json is not null

Before:
<img width="1346" alt="screen shot 2016-11-11 at 2 33 42 pm" src="https://cloud.githubusercontent.com/assets/20978302/20232270/e22fc612-a81b-11e6-93ab-c8a94032c11a.png">

After:
<img width="1109" alt="screen shot 2016-11-11 at 2 33 15 pm" src="https://cloud.githubusercontent.com/assets/20978302/20232276/e9f642fe-a81b-11e6-8de7-19aa9952aa6a.png">


needs-review @mistercrunch 