### PR TITLE
Save modal component for explore v2

### DIFF
--- a/superset/assets/javascripts/explore/components/QueryAndSaveBtns.jsx
+++ b/superset/assets/javascripts/explore/components/QueryAndSaveBtns.jsx
@@ -4,9 +4,14 @@ import classnames from 'classnames';
 const propTypes = {
   canAdd: PropTypes.string.isRequired,
   onQuery: PropTypes.func.isRequired,
+  onSave: PropTypes.func,
 };
 
-export default function QueryAndSaveBtns({ canAdd, onQuery }) {
+const defaultProps = {
+  onSave: () => {},
+};
+
+export default function QueryAndSaveBtns({ canAdd, onQuery, onSave }) {
   const saveClasses = classnames('btn btn-default btn-sm', {
     'disabled disabledButton': canAdd !== 'True',
   });
@@ -21,6 +26,7 @@ export default function QueryAndSaveBtns({ canAdd, onQuery }) {
         className={saveClasses}
         data-target="#save_modal"
         data-toggle="modal"
+        onClick={onSave}
       >
         <i className="fa fa-plus-circle"></i> Save as
       </button>
@@ -29,3 +35,4 @@ export default function QueryAndSaveBtns({ canAdd, onQuery }) {
 }
 
 QueryAndSaveBtns.propTypes = propTypes;
+QueryAndSaveBtns.defaultProps = defaultProps;

--- a/superset/assets/javascripts/explorev2/actions/exploreActions.js
+++ b/superset/assets/javascripts/explorev2/actions/exploreActions.js
@@ -183,21 +183,20 @@ export function fetchDashboards(userId) {
   };
 }
 
-export const SAVE_SLICE_SUCCEEDED = 'SAVE_SLICE_SUCCEEDED';
-export function saveSliceSucceeded() {
-  return { type: SAVE_SLICE_SUCCEEDED };
-}
-
 export const SAVE_SLICE_FAILED = 'SAVE_SLICE_FAILED';
 export function saveSliceFailed() {
   return { type: SAVE_SLICE_FAILED };
+}
+
+export const REMOVE_SAVE_MODAL_ALERT = 'REMOVE_SAVE_MODAL_ALERT';
+export function removeSaveModalAlert() {
+  return { type: REMOVE_SAVE_MODAL_ALERT };
 }
 
 export function saveSlice(url) {
   return function (dispatch) {
     $.get(url, (data, status) => {
       if (status === 'success') {
-        dispatch(saveSliceSucceeded());
         // Go to new slice url or dashboard url
         window.location = data;
       } else {

--- a/superset/assets/javascripts/explorev2/actions/exploreActions.js
+++ b/superset/assets/javascripts/explorev2/actions/exploreActions.js
@@ -155,3 +155,54 @@ export const REMOVE_CHART_ALERT = 'REMOVE_CHART_ALERT';
 export function removeChartAlert() {
   return { type: REMOVE_CHART_ALERT };
 }
+
+export const FETCH_DASHBOARDS_SUCCEEDED = 'FETCH_DASHBOARDS_SUCCEEDED';
+export function fetchDashboardsSucceeded(choices) {
+  return { type: FETCH_DASHBOARDS_SUCCEEDED, choices };
+}
+
+export const FETCH_DASHBOARDS_FAILED = 'FETCH_DASHBOARDS_FAILED';
+export function fetchDashboardsFailed(userId) {
+  return { type: FETCH_FAILED, userId };
+}
+
+export function fetchDashboards(userId) {
+  return function (dispatch) {
+    const url = '/dashboardmodelviewasync/api/read?_flt_0_owners=' + userId;
+    $.get(url, function (data, status) {
+      if (status === 'success') {
+        const choices = [];
+        for (let i = 0; i < data.pks.length; i++) {
+          choices.push({ value: data.pks[i], label: data.result[i].dashboard_title });
+        }
+        dispatch(fetchDashboardsSucceeded(choices));
+      } else {
+        dispatch(fetchDashboardsFailed(userId));
+      }
+    });
+  };
+}
+
+export const SAVE_SLICE_SUCCEEDED = 'SAVE_SLICE_SUCCEEDED';
+export function saveSliceSucceeded() {
+  return { type: SAVE_SLICE_SUCCEEDED };
+}
+
+export const SAVE_SLICE_FAILED = 'SAVE_SLICE_FAILED';
+export function saveSliceFailed() {
+  return { type: SAVE_SLICE_FAILED };
+}
+
+export function saveSlice(url) {
+  return function (dispatch) {
+    $.get(url, (data, status) => {
+      if (status === 'success') {
+        dispatch(saveSliceSucceeded());
+        // Go to new slice url or dashboard url
+        window.location = data;
+      } else {
+        dispatch(saveSliceFailed());
+      }
+    });
+  };
+}

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -231,4 +231,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, () => {})(ChartContainer);
+export default connect(mapStateToProps, () => ({}))(ChartContainer);

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -231,8 +231,4 @@ function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps() {
-  return {};
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ChartContainer);
+export default connect(mapStateToProps, () => {})(ChartContainer);

--- a/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
@@ -108,8 +108,6 @@ function mapStateToProps(state) {
     alert: state.controlPanelAlert,
     isDatasourceMetaLoading: state.isDatasourceMetaLoading,
     fields: state.fields,
-    datasource_type: state.datasource_type,
-    form_data: state.viz.form_data,
   };
 }
 

--- a/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
@@ -112,6 +112,5 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export { ControlPanelsContainer };
-
+export { ExploreViewContainer };
 export default connect(mapStateToProps, mapDispatchToProps)(ExploreViewContainer);

--- a/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
@@ -5,6 +5,7 @@ import * as actions from '../actions/exploreActions';
 import { connect } from 'react-redux';
 import ChartContainer from './ChartContainer';
 import ControlPanelsContainer from './ControlPanelsContainer';
+import SaveModal from './SaveModal';
 import QueryAndSaveBtns from '../../explore/components/QueryAndSaveBtns';
 const $ = require('jquery');
 
@@ -20,6 +21,7 @@ class ExploreViewContainer extends React.Component {
     super(props);
     this.state = {
       height: this.getHeight(),
+      showModal: false,
     };
   }
 
@@ -63,6 +65,10 @@ class ExploreViewContainer extends React.Component {
       this.props.datasource_type, this.props.form_data.datasource, data);
   }
 
+  toggleModal() {
+    this.setState({ showModal: !this.state.showModal });
+  }
+
   render() {
     return (
       <div
@@ -72,16 +78,26 @@ class ExploreViewContainer extends React.Component {
           overflow: 'hidden',
         }}
       >
+      {this.state.showModal &&
+        <SaveModal
+          onHide={this.toggleModal.bind(this)}
+          actions={this.props.actions}
+          form_data={this.props.form_data}
+          datasource_type={this.props.datasource_type}
+        />
+      }
         <div className="row">
           <div className="col-sm-4">
             <QueryAndSaveBtns
               canAdd="True"
               onQuery={this.onQuery.bind(this)}
+              onSave={this.toggleModal.bind(this)}
             />
             <br /><br />
             <ControlPanelsContainer
               actions={this.props.actions}
               form_data={this.props.form_data}
+              datasource_type={this.props.datasource_type}
             />
           </div>
           <div className="col-sm-8">

--- a/superset/assets/javascripts/explorev2/components/FieldSet.jsx
+++ b/superset/assets/javascripts/explorev2/components/FieldSet.jsx
@@ -14,7 +14,11 @@ const propTypes = {
   places: PropTypes.number,
   validators: PropTypes.any,
   onChange: React.PropTypes.func,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.array]).isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+    PropTypes.array]).isRequired,
 };
 
 const defaultProps = {

--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -10,8 +10,6 @@ const propTypes = {
   onHide: PropTypes.func.isRequired,
   actions: PropTypes.object.isRequired,
   form_data: PropTypes.object,
-  datasource_id: PropTypes.number.isRequired,
-  datasource_name: PropTypes.string.isRequired,
   datasource_type: PropTypes.string.isRequired,
   user_id: PropTypes.string.isRequired,
 };
@@ -51,9 +49,9 @@ class SaveModal extends React.Component {
     this.setState({ alert: null });
     const params = {};
     const sliceParams = {};
-    params.datasource_id = this.props.datasource_id;
+    params.datasource_id = this.props.form_data.datasource;
     params.datasource_type = this.props.datasource_type;
-    params.datasource_name = this.props.datasource_name;
+    params.datasource_name = this.props.form_data.datasource_name;
 
     const action = $('input[name=rdo_save]:checked').val();
     let sliceName = null;
@@ -100,7 +98,8 @@ class SaveModal extends React.Component {
     }
     params.V2 = true;
     sliceParams.goto_dash = gotodash;
-    const baseUrl = `/superset/explore/${this.props.datasource_type}/${this.props.datasource_id}/`;
+    const baseUrl = '/superset/explore/' +
+      `${this.props.datasource_type}/${this.props.form_data.datasource}/`;
     const saveUrl = `${baseUrl}?${$.param(params, true)}&${$.param(sliceParams, true)}`;
     this.props.actions.saveSlice(saveUrl);
     this.props.onHide();
@@ -237,8 +236,6 @@ function mapStateToProps(state) {
   return {
     can_edit: state.can_edit,
     form_data: state.viz.form_data,
-    datasource_id: state.datasource_id,
-    datasource_name: state.datasource_name,
     datasource_type: state.datasource_type,
     user_id: state.user_id,
   };

--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -1,7 +1,7 @@
 /* eslint camel-case: 0 */
 import React, { PropTypes } from 'react';
 import $ from 'jquery';
-import { Modal, Alert } from 'react-bootstrap';
+import { Modal, Alert, Button, Radio } from 'react-bootstrap';
 import Select from 'react-select';
 import { connect } from 'react-redux';
 
@@ -142,84 +142,76 @@ class SaveModal extends React.Component {
               />
             </Alert>
           }
-          <form>
-            <input
-              type="radio"
-              disabled={!this.props.can_edit}
-              checked={this.state.action === 'overwrite'}
-              onChange={this.changeAction.bind(this, 'overwrite')}
-            />
-            {`Overwrite slice ${this.props.form_data.slice_name}`}
-            <br />
+          <Radio
+            disabled={!this.props.can_edit}
+            checked={this.state.action === 'overwrite'}
+            onChange={this.changeAction.bind(this, 'overwrite')}
+          >
+          {`Overwrite slice ${this.props.form_data.slice_name}`}
+          </Radio>
 
-            <input
-              type="radio"
-              checked={this.state.action === 'saveas'}
-              onChange={this.changeAction.bind(this, 'saveas')}
-            /> Save as &nbsp;
-            <input
-              type="text"
-              name="new_slice_name"
-              placeholder="[slice name]"
-              onChange={this.onChange.bind(this, 'newSliceName')}
-              onFocus={this.changeAction.bind(this, 'saveas')}
-            />
+          <Radio
+            inline
+            checked={this.state.action === 'saveas'}
+            onChange={this.changeAction.bind(this, 'saveas')}
+          > Save as &nbsp;
+          </Radio>
+          <input
+            name="new_slice_name"
+            placeholder="[slice name]"
+            onChange={this.onChange.bind(this, 'newSliceName')}
+            onFocus={this.changeAction.bind(this, 'saveas')}
+          />
 
-            <br />
-            <hr />
 
-            <input
-              type="radio"
-              checked={this.state.addToDash === 'noSave'}
-              onChange={this.changeDash.bind(this, 'noSave')}
-            />
-            Do not add to a dashboard
-            <br />
+          <br />
+          <hr />
 
-            <div
-              id="save_to_dashboard_id"
-            >
-              <input
-                type="radio"
-                checked={this.state.addToDash === 'existing'}
-                onChange={this.changeDash.bind(this, 'existing')}
-              />
-              Add slice to existing dashboard
-              <Select
-                options={this.props.dashboards}
-                onChange={this.onChange.bind(this, 'saveToDashboardId')}
-                autoSize={false}
-                value={this.state.saveToDashboardId}
-              />
-            </div>
-            <br />
+          <Radio
+            checked={this.state.addToDash === 'noSave'}
+            onChange={this.changeDash.bind(this, 'noSave')}
+          >
+          Do not add to a dashboard
+          </Radio>
 
-            <input
-              type="radio"
-              checked={this.state.addToDash === 'new'}
-              onChange={this.changeDash.bind(this, 'new')}
-            />
-            Add to new dashboard &nbsp;
-            <input
-              type="text"
-              onChange={this.onChange.bind(this, 'newDashboardName')}
-              onFocus={this.changeDash.bind(this, 'new')}
-              placeholder="[dashboard name]"
-            />
-            <br />
-          </form>
+          <Radio
+            inline
+            checked={this.state.addToDash === 'existing'}
+            onChange={this.changeDash.bind(this, 'existing')}
+          >
+          Add slice to existing dashboard
+          </Radio>
+          <Select
+            options={this.props.dashboards}
+            onChange={this.onChange.bind(this, 'saveToDashboardId')}
+            autoSize={false}
+            value={this.state.saveToDashboardId}
+          />
+
+          <Radio
+            inline
+            checked={this.state.addToDash === 'new'}
+            onChange={this.changeDash.bind(this, 'new')}
+          >
+          Add to new dashboard &nbsp;
+          </Radio>
+          <input
+            onChange={this.onChange.bind(this, 'newDashboardName')}
+            onFocus={this.changeDash.bind(this, 'new')}
+            placeholder="[dashboard name]"
+          />
         </Modal.Body>
 
         <Modal.Footer>
-          <button
+          <Button
             type="button"
             id="btn_modal_save"
             className="btn pull-left"
             onClick={this.saveOrOverwrite.bind(this)}
           >
             Save
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             id="btn_modal_save_goto_dash"
             className="btn btn-primary pull-left gotodash"
@@ -227,7 +219,7 @@ class SaveModal extends React.Component {
             onClick={this.saveOrOverwrite.bind(this, true)}
           >
             Save & go to dashboard
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
     );

--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -1,6 +1,6 @@
 /* eslint camel-case: 0 */
 import React, { PropTypes } from 'react';
-const $ = window.$ = require('jquery');
+import $ from 'jquery';
 import { Modal, Alert } from 'react-bootstrap';
 import Select from 'react-select';
 import { connect } from 'react-redux';

--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -34,17 +34,6 @@ class SaveModal extends React.Component {
     $('.gotodash').removeAttr('disabled');
   }
 
-  fetchDashboards() {
-    const url = '/dashboardmodelviewasync/api/read?_flt_0_owners=' + this.props.user_id;
-    $.get(url, function (data) {
-      const choices = [];
-      for (let i = 0; i < data.pks.length; i++) {
-        choices.push({ value: data.pks[i], label: data.result[i].dashboard_title });
-      }
-      this.setState({ dashboards: choices });
-    }.bind(this));
-  }
-
   saveOrOverwrite(gotodash) {
     this.setState({ alert: null });
     const params = {};

--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -241,9 +241,5 @@ function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps() {
-  return {};
-}
-
 export { SaveModal };
-export default connect(mapStateToProps, mapDispatchToProps)(SaveModal);
+export default connect(mapStateToProps, () => {})(SaveModal);

--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -13,6 +13,7 @@ const propTypes = {
   datasource_type: PropTypes.string.isRequired,
   user_id: PropTypes.string.isRequired,
   dashboards: PropTypes.array.isRequired,
+  alert: PropTypes.string,
 };
 
 class SaveModal extends React.Component {
@@ -55,6 +56,7 @@ class SaveModal extends React.Component {
   }
   saveOrOverwrite(gotodash) {
     this.setState({ alert: null });
+    this.props.actions.removeSaveModalAlert();
     const params = {};
     const sliceParams = {};
     params.datasource_id = this.props.form_data.datasource;
@@ -112,6 +114,9 @@ class SaveModal extends React.Component {
     this.props.onHide();
   }
   removeAlert() {
+    if (this.props.alert) {
+      this.props.actions.removeSaveModalAlert();
+    }
     this.setState({ alert: null });
   }
   render() {
@@ -127,9 +132,9 @@ class SaveModal extends React.Component {
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {this.state.alert &&
+          {(this.state.alert || this.props.alert) &&
             <Alert>
-              {this.state.alert}
+              {this.state.alert ? this.state.alert : this.props.alert}
               <i
                 className="fa fa-close pull-right"
                 onClick={this.removeAlert.bind(this)}
@@ -236,6 +241,7 @@ function mapStateToProps(state) {
     can_edit: state.can_edit,
     user_id: state.user_id,
     dashboards: state.dashboards,
+    alert: state.saveModalAlert,
   };
 }
 

--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -1,0 +1,252 @@
+/* eslint camel-case: 0 */
+import React, { PropTypes } from 'react';
+const $ = window.$ = require('jquery');
+import { Modal, Alert } from 'react-bootstrap';
+import Select from 'react-select';
+import { connect } from 'react-redux';
+
+const propTypes = {
+  can_edit: PropTypes.bool,
+  onHide: PropTypes.func.isRequired,
+  actions: PropTypes.object.isRequired,
+  form_data: PropTypes.object,
+  datasource_id: PropTypes.number.isRequired,
+  datasource_name: PropTypes.string.isRequired,
+  datasource_type: PropTypes.string.isRequired,
+  user_id: PropTypes.string.isRequired,
+};
+
+class SaveModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      save_to_dashboard_id: null,
+      dashboards: [],
+      alert: null,
+    };
+  }
+
+  componentDidMount() {
+    this.prepSaveDialog();
+  }
+
+  setSaveDashboard(opt) {
+    this.setState({ save_to_dashboard_id: opt.value });
+    $('#add_to_dash_existing').prop('checked', true);
+    $('.gotodash').removeAttr('disabled');
+  }
+
+  fetchDashboards() {
+    const url = '/dashboardmodelviewasync/api/read?_flt_0_owners=' + this.props.user_id;
+    $.get(url, function (data) {
+      const choices = [];
+      for (let i = 0; i < data.pks.length; i++) {
+        choices.push({ value: data.pks[i], label: data.result[i].dashboard_title });
+      }
+      this.setState({ dashboards: choices });
+    }.bind(this));
+  }
+
+  saveOrOverwrite(gotodash) {
+    this.setState({ alert: null });
+    const params = {};
+    const sliceParams = {};
+    params.datasource_id = this.props.datasource_id;
+    params.datasource_type = this.props.datasource_type;
+    params.datasource_name = this.props.datasource_name;
+
+    const action = $('input[name=rdo_save]:checked').val();
+    let sliceName = null;
+    sliceParams.action = action;
+    if (action === 'saveas') {
+      sliceName = $('input[name=new_slice_name]').val();
+      if (sliceName === '') {
+        this.setState({ alert: 'Please enter a slice name' });
+        return;
+      }
+      sliceParams.slice_name = sliceName;
+    } else {
+      sliceParams.slice_name = this.props.form_data.slice_name;
+    }
+
+    Object.keys(this.props.form_data).forEach((field) => {
+      if (this.props.form_data[field] !== null && field !== 'slice_name') {
+        params[field] = this.props.form_data[field];
+      }
+    });
+
+    const addToDash = $('input[name=add_to_dash]:checked').val();
+    sliceParams.add_to_dash = addToDash;
+    let dashboard = null;
+    switch (addToDash) {
+      case ('existing'):
+        dashboard = this.state.save_to_dashboard_id;
+        if (!dashboard) {
+          this.setState({ alert: 'Please select a dashboard' });
+          return;
+        }
+        sliceParams.save_to_dashboard_id = dashboard;
+        break;
+      case ('new'):
+        dashboard = $('input[name=new_dashboard_name]').val();
+        if (dashboard === '') {
+          this.setState({ alert: 'Please enter a dashboard name' });
+          return;
+        }
+        sliceParams.new_dashboard_name = dashboard;
+        break;
+      default:
+        dashboard = null;
+    }
+    params.V2 = true;
+    sliceParams.goto_dash = gotodash;
+    const baseUrl = `/superset/explore/${this.props.datasource_type}/${this.props.datasource_id}/`;
+    const saveUrl = `${baseUrl}?${$.param(params, true)}&${$.param(sliceParams, true)}`;
+    this.props.actions.saveSlice(saveUrl);
+    this.props.onHide();
+  }
+
+  prepSaveDialog() {
+    const setButtonsState = function () {
+      const addToDash = $('input[name=add_to_dash]:checked').val();
+      if (addToDash === 'existing' || addToDash === 'new') {
+        $('.gotodash').removeAttr('disabled');
+      } else {
+        $('.gotodash').prop('disabled', true);
+      }
+    };
+    setButtonsState();
+    const url = '/dashboardmodelviewasync/api/read?_flt_0_owners=' + this.props.user_id;
+    $.get(url, function (data) {
+      const choices = [];
+      for (let i = 0; i < data.pks.length; i++) {
+        choices.push({ value: data.pks[i], label: data.result[i].dashboard_title });
+      }
+      this.setState({ dashboards: choices });
+    }.bind(this));
+    $('input[name=add_to_dash]').change(setButtonsState);
+    $("input[name='new_dashboard_name']").on('focus', function () {
+      $('#add_to_new_dash').prop('checked', true);
+      setButtonsState();
+    });
+    $("input[name='new_slice_name']").on('focus', function () {
+      $('#save_as_new').prop('checked', true);
+      setButtonsState();
+    });
+  }
+
+  removeAlert() {
+    this.setState({ alert: null });
+  }
+
+  render() {
+    return (
+      <Modal
+        show
+        onHide={this.props.onHide}
+        bsStyle="large"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>
+            Save A Slice
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {this.state.alert &&
+            <Alert>
+              {this.state.alert}
+              <i
+                className="fa fa-close pull-right"
+                onClick={this.removeAlert.bind(this)}
+                style={{ cursor: 'pointer' }}
+              />
+            </Alert>
+          }
+          <form>
+            <input
+              type="radio"
+              name="rdo_save"
+              value="overwrite"
+              disabled={!this.props.can_edit}
+            />
+            {`Overwrite slice ${this.props.form_data.slice_name}`}
+            <br />
+
+            <input
+              id="save_as_new"
+              type="radio"
+              name="rdo_save"
+              value="saveas"
+            /> Save as &nbsp;
+            <input type="text" name="new_slice_name" placeholder="[slice name]" />
+
+            <br />
+            <hr />
+
+            <input type="radio" name="add_to_dash" value="false" />
+            Do not add to a dashboard
+            <br />
+
+            <div
+              id="save_to_dashboard_id"
+            >
+              <input id="add_to_dash_existing" type="radio" name="add_to_dash" value="existing" />
+              Add slice to existing dashboard
+              <Select
+                options={this.state.dashboards}
+                onChange={this.setSaveDashboard.bind(this)}
+                autoSize={false}
+                value={this.state.save_to_dashboard_id}
+              />
+            </div>
+            <br />
+
+            <input type="radio" id="add_to_new_dash" name="add_to_dash" value="new" />
+            Add to new dashboard &nbsp;
+            <input type="text" name="new_dashboard_name" placeholder="[dashboard name]" />
+            <br />
+          </form>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <button
+            type="button"
+            id="btn_modal_save"
+            className="btn pull-left"
+            onClick={this.saveOrOverwrite.bind(this)}
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            id="btn_modal_save_goto_dash"
+            className="btn btn-primary pull-left gotodash"
+            onClick={this.saveOrOverwrite.bind(this, true)}
+          >
+            Save & go to dashboard
+          </button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+SaveModal.propTypes = propTypes;
+
+function mapStateToProps(state) {
+  return {
+    can_edit: state.can_edit,
+    form_data: state.viz.form_data,
+    datasource_id: state.datasource_id,
+    datasource_name: state.datasource_name,
+    datasource_type: state.datasource_type,
+    user_id: state.user_id,
+  };
+}
+
+function mapDispatchToProps() {
+  return {};
+}
+
+export { SaveModal };
+export default connect(mapStateToProps, mapDispatchToProps)(SaveModal);

--- a/superset/assets/javascripts/explorev2/index.jsx
+++ b/superset/assets/javascripts/explorev2/index.jsx
@@ -13,10 +13,12 @@ const bootstrapData = JSON.parse(exploreViewContainer.getAttribute('data-bootstr
 import { exploreReducer } from './reducers/exploreReducer';
 
 const bootstrappedState = Object.assign(initialState(bootstrapData.viz.form_data.viz_type), {
+  can_edit: bootstrapData.can_edit,
   can_download: bootstrapData.can_download,
   datasources: bootstrapData.datasources,
   datasource_type: bootstrapData.datasource_type,
   viz: bootstrapData.viz,
+  user_id: bootstrapData.user_id,
 });
 bootstrappedState.viz.form_data.datasource = parseInt(bootstrapData.datasource_id, 10);
 bootstrappedState.viz.form_data.datasource_name = bootstrapData.datasource_name;

--- a/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -27,6 +27,16 @@ export const exploreReducer = function (state, action) {
     [actions.REMOVE_CONTROL_PANEL_ALERT]() {
       return Object.assign({}, state, { controlPanelAlert: null });
     },
+
+    [actions.FETCH_DASHBOARDS_SUCCEEDED]() {
+      return Object.assign({}, state, { dashboards: action.choices });
+    },
+
+    [actions.FETCH_DASHBOARDS_FAILED]() {
+      return Object.assign({}, state,
+        { alert: `fetching dashboards failed for ${action.userId}` });
+    },
+
     [actions.SET_FIELD_OPTIONS]() {
       const newState = Object.assign({}, state);
       const optionsByFieldName = action.options;

--- a/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -34,7 +34,7 @@ export const exploreReducer = function (state, action) {
 
     [actions.FETCH_DASHBOARDS_FAILED]() {
       return Object.assign({}, state,
-        { alert: `fetching dashboards failed for ${action.userId}` });
+        { saveModalAlert: `fetching dashboards failed for ${action.userId}` });
     },
 
     [actions.SET_FIELD_OPTIONS]() {
@@ -112,12 +112,11 @@ export const exploreReducer = function (state, action) {
     [actions.REMOVE_CHART_ALERT]() {
       return Object.assign({}, state, { chartAlert: null });
     },
-    [actions.SAVE_SLICE_SUCCEEDED]() {
-      // todo: vera: add Alert to exploreV2 for all ajax calls
-      return Object.assign({}, state, { alert: 'Successfully saved slice' });
-    },
     [actions.SAVE_SLICE_FAILED]() {
-      return Object.assign({}, state, { alert: 'Failed to save slice' });
+      return Object.assign({}, state, { saveModalAlert: 'Failed to save slice' });
+    },
+    [actions.REMOVE_SAVE_MODAL_ALERT]() {
+      return Object.assign({}, state, { saveModalAlert: null });
     },
   };
   if (action.type in actionHandlers) {

--- a/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -66,6 +66,9 @@ export const exploreReducer = function (state, action) {
         newFormData.slice_name = state.viz.form_data.slice_name;
         newFormData.viz_type = state.viz.form_data.viz_type;
       }
+      if (action.key === 'viz_type') {
+        newFormData.previous_viz_type = state.viz.form_data.viz_type;
+      }
       newFormData[action.key] = action.value ? action.value : (!state.viz.form_data[action.key]);
       return Object.assign(
         {},

--- a/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -102,6 +102,13 @@ export const exploreReducer = function (state, action) {
     [actions.REMOVE_CHART_ALERT]() {
       return Object.assign({}, state, { chartAlert: null });
     },
+    [actions.SAVE_SLICE_SUCCEEDED]() {
+      // todo: vera: add Alert to exploreV2 for all ajax calls
+      return Object.assign({}, state, { alert: 'Successfully saved slice' });
+    },
+    [actions.SAVE_SLICE_FAILED]() {
+      return Object.assign({}, state, { alert: 'Failed to save slice' });
+    },
   };
   if (action.type in actionHandlers) {
     return actionHandlers[action.type]();

--- a/superset/assets/javascripts/explorev2/stores/store.js
+++ b/superset/assets/javascripts/explorev2/stores/store.js
@@ -750,7 +750,7 @@ export const fields = {
     type: 'SelectMultipleSortableField',
     label: 'Metrics',
     choices: [],
-    default: null,
+    default: [],
     description: 'One or many metrics to display',
   },
 
@@ -758,6 +758,7 @@ export const fields = {
     type: 'SelectMultipleSortableField',
     label: 'Ordering',
     choices: [],
+    default: [],
     description: 'One or many metrics to display',
   },
 
@@ -931,6 +932,7 @@ export const fields = {
     type: 'SelectMultipleSortableField',
     label: 'Group by',
     choices: [],
+    default: [],
     description: 'One or many fields to group by',
   },
 
@@ -938,6 +940,7 @@ export const fields = {
     type: 'SelectMultipleSortableField',
     label: 'Columns',
     choices: [],
+    default: [],
     description: 'One or many fields to pivot as columns',
   },
 
@@ -945,6 +948,7 @@ export const fields = {
     type: 'SelectMultipleSortableField',
     label: 'Columns',
     choices: [],
+    default: [],
     description: 'Columns to display',
   },
 
@@ -1552,6 +1556,7 @@ export const fields = {
     type: 'SelectMultipleSortableField',
     label: 'label',
     choices: [],
+    default: [],
     description: '`count` is COUNT(*) if a group by is used. ' +
                  'Numerical columns will be aggregated with the aggregator. ' +
                  'Non-numerical columns will be used to label points. ' +
@@ -1704,6 +1709,7 @@ export function defaultViz(vizType) {
 
 export function initialState(vizType = 'table') {
   return {
+    dashboards: [],
     isDatasourceMetaLoading: false,
     datasources: null,
     datasource_type: null,

--- a/superset/assets/spec/javascripts/explorev2/components/SaveModal_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/components/SaveModal_spec.js
@@ -32,5 +32,4 @@ describe('SaveModal', () => {
     expect(wrapper.find('input')).to.have.lengthOf(7);
     expect(wrapper.find('button')).to.have.lengthOf(2);
   });
-
 });

--- a/superset/assets/spec/javascripts/explorev2/components/SaveModal_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/components/SaveModal_spec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { shallow } from 'enzyme';
+import { defaultFormData } from '../../../../javascripts/explorev2/stores/store';
+import { SaveModal } from '../../../../javascripts/explorev2/components/SaveModal';
+import { Modal } from 'react-bootstrap';
+import sinon from 'sinon';
+
+const defaultProps = {
+  can_edit: true,
+  onHide: () => {},
+  actions: {
+    saveSlice: sinon.spy(),
+  },
+  form_data: defaultFormData,
+  datasource_id: 1,
+  datasource_name: 'birth_names',
+  datasource_type: 'table',
+  user_id: 1,
+};
+
+describe('SaveModal', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<SaveModal {...defaultProps} />);
+  });
+
+  it('renders a Modal with 7 inputs and 2 buttons', () => {
+    expect(wrapper.find(Modal)).to.have.lengthOf(1);
+    expect(wrapper.find('input')).to.have.lengthOf(7);
+    expect(wrapper.find('button')).to.have.lengthOf(2);
+  });
+
+});

--- a/superset/assets/spec/javascripts/explorev2/components/SaveModal_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/components/SaveModal_spec.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 const defaultProps = {
   can_edit: true,
-  onHide: () => {},
+  onHide: () => ({}),
   actions: {
     saveSlice: sinon.spy(),
   },

--- a/superset/assets/spec/javascripts/explorev2/components/SaveModal_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/components/SaveModal_spec.js
@@ -4,7 +4,7 @@ import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import { defaultFormData } from '../../../../javascripts/explorev2/stores/store';
 import { SaveModal } from '../../../../javascripts/explorev2/components/SaveModal';
-import { Modal } from 'react-bootstrap';
+import { Modal, Button, Radio } from 'react-bootstrap';
 import sinon from 'sinon';
 
 const defaultProps = {
@@ -29,7 +29,8 @@ describe('SaveModal', () => {
 
   it('renders a Modal with 7 inputs and 2 buttons', () => {
     expect(wrapper.find(Modal)).to.have.lengthOf(1);
-    expect(wrapper.find('input')).to.have.lengthOf(7);
-    expect(wrapper.find('button')).to.have.lengthOf(2);
+    expect(wrapper.find('input')).to.have.lengthOf(2);
+    expect(wrapper.find(Button)).to.have.lengthOf(2);
+    expect(wrapper.find(Radio)).to.have.lengthOf(5);
   });
 });

--- a/superset/views.py
+++ b/superset/views.py
@@ -1456,7 +1456,8 @@ class Superset(BaseSupersetView):
         # TODO use form processing form wtforms
         d = args.to_dict(flat=False)
         del d['action']
-        del d['previous_viz_type']
+        if 'previous_viz_type' in d:
+            del d['previous_viz_type']
 
         as_list = ('metrics', 'groupby', 'columns', 'all_columns',
                    'mapbox_label', 'order_by_cols')

--- a/superset/views.py
+++ b/superset/views.py
@@ -1515,8 +1515,12 @@ class Superset(BaseSupersetView):
             db.session.commit()
 
         if request.args.get('goto_dash') == 'true':
+            if request.args.get('V2') == 'true':
+                return dash.url
             return redirect(dash.url)
         else:
+            if request.args.get('V2') == 'true':
+                return slc.slice_url
             return redirect(slc.slice_url)
 
     def save_slice(self, slc):


### PR DESCRIPTION
Done:
 - Added a SaveModal component, triggered by save button in QueryAndSaveButton
 - url params for saveOrOverwriteSlice stay the same as in v1 
 - when user updates control panel and save the slice, new form_data will be saved into the slice
 - Added specs for SaveModal
 - This PR includes changes from [https://github.com/airbnb/superset/pull/1610](url) since datasource_name is required in saveOrOverwriteSlice url
<img width="1345" alt="screen shot 2016-11-16 at 9 22 14 am" src="https://cloud.githubusercontent.com/assets/20978302/20357793/35b6fe52-abde-11e6-841d-0871325e1287.png">


Todo:
 - add Alert to explore v2 for all ajax calls and exception handling

needs-review @mistercrunch @ascott 