### PR TITLE
Add all_tables endpoint to allow airpal / superset perm sync.

### DIFF
--- a/superset/views.py
+++ b/superset/views.py
@@ -1515,6 +1515,31 @@ class Superset(BaseSupersetView):
 
     @api
     @has_access_api
+    @expose("/all_tables/<db_id>")
+    def all_tables(self, db_id):
+        """Endpoint that returns all tables and views from the database"""
+        database = (
+            db.session
+            .query(models.Database)
+            .filter_by(id=db_id)
+            .one()
+        )
+        all_tables = []
+        all_views = []
+        schemas = database.all_schema_names()
+        for schema in schemas:
+            all_tables.extend(database.all_table_names(schema=schema))
+            all_views.extend(database.all_view_names(schema=schema))
+        if not schemas:
+            all_tables.extend(database.all_table_names())
+            all_views.extend(database.all_view_names())
+
+        return Response(
+            json.dumps({"tables": all_tables, "views": all_views}),
+            mimetype="application/json")
+
+    @api
+    @has_access_api
     @expose("/tables/<db_id>/<schema>")
     def tables(self, db_id, schema):
         """endpoint to power the calendar heatmap on the welcome page"""

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -389,9 +389,18 @@ class CoreTests(SupersetTestCase):
 
     def test_fetch_datasource_metadata(self):
         self.login(username='admin')
-        url = '/superset/fetch_datasource_metadata?datasource_type=table&datasource_id=1';
+        url = '/superset/fetch_datasource_metadata?datasource_type=table&' \
+              'datasource_id=1'
         resp = json.loads(self.get_resp(url))
         self.assertEqual(len(resp['field_options']), 19)
+
+    def test_fetch_all_tables(self):
+        self.login(username='admin')
+        database = self.get_main_database(db.session)
+        url = '/superset/all_tables/{}'.format(database.id)
+        resp = json.loads(self.get_resp(url))
+        self.assertIn('tables', resp)
+        self.assertIn('views', resp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This endpoint is needed to implement the sync between superset and airpal permission using airflow dag.
I decided to implement is as a separate endpoint and tables/<db_id>/<schema> uses None schema value for default schema.

Reviewers:
* @mistercrunch 
* @ascott 
* @vera-liu 