### PR TITLE
Fixed dashboard controls for standalone bug

### DIFF
--- a/superset/assets/javascripts/dashboard/components/Header.jsx
+++ b/superset/assets/javascripts/dashboard/components/Header.jsx
@@ -22,7 +22,7 @@ class Header extends React.PureComponent {
           <h1>{dashboard.dashboard_title}</h1>
         </div>
         <div className="pull-right">
-        {this.props.dashboard.standalone_mode &&
+        {!this.props.dashboard.context.standalone_mode &&
           <Controls dashboard={dashboard} />
         }
         </div>


### PR DESCRIPTION
Issue: a bug was introduced by me in [https://github.com/airbnb/superset/pull/1596](url), causing controls not rendered on dashboard page.

Before:
<img width="1089" alt="screen shot 2016-11-16 at 5 51 02 pm" src="https://cloud.githubusercontent.com/assets/20978302/20373168/49c3d6e4-ac25-11e6-8927-5531e9d1c98b.png">


After:
<img width="1128" alt="screen shot 2016-11-16 at 5 49 50 pm" src="https://cloud.githubusercontent.com/assets/20978302/20373156/2b1d132c-ac25-11e6-97fb-2a2c08797770.png">

<img width="1131" alt="screen shot 2016-11-16 at 5 50 04 pm" src="https://cloud.githubusercontent.com/assets/20978302/20373158/32eefcb4-ac25-11e6-97ae-a7d8b7c187fc.png">


Fix: get standalone_mode from context object instead of dashboard

needs-review @mistercrunch 