### PR TITLE
Make nvd3 refresh smoother on dashboard

### DIFF
--- a/superset/assets/javascripts/explore/explore.jsx
+++ b/superset/assets/javascripts/explore/explore.jsx
@@ -73,6 +73,7 @@ function query(forceUpdate, pushState) {
     // update the url after prepForm() fix the field ids
     history.pushState({}, document.title, slice.querystring());
   }
+  slice.container.html('');
   slice.render(force);
 }
 

--- a/superset/assets/javascripts/modules/superset.js
+++ b/superset/assets/javascripts/modules/superset.js
@@ -177,6 +177,9 @@ const px = function () {
         always(data);
         controller.error(this);
       },
+      clearError() {
+        $(selector + ' div.alert').remove();
+      },
       width() {
         return token.width();
       },

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -60,12 +60,13 @@ function nvd3Vis(slice) {
 
   const render = function () {
     d3.json(slice.jsonEndpoint(), function (error, payload) {
-      slice.container.html('');
       // Check error first, otherwise payload can be null
       if (error) {
         slice.error(error.responseText, error);
         return;
       }
+
+      slice.clearError();
 
       // Calculates the longest label size for stretching bottom margin
       function calculateStretchMargins(payloadData) {


### PR DESCRIPTION
## Issue
Currently, refreshing nvd3 visualizations is not very pleasant to look at especially when set to refresh every 10 seconds:
![old_refresh](https://cloud.githubusercontent.com/assets/1399237/20373435/bd952d1a-ac26-11e6-96f7-ac584318017d.gif)

The problem is that upon render, the entire slice container is emptied which means the whole chart must render from scratch instead of just adjusting to new data.


## Solution
If we leave the chart intact upon refesh, nvd3 will automatically update the entire chart smoothly.

Notice the bars and x-axis shift in this example.
![new_fresh](https://cloud.githubusercontent.com/assets/1399237/20373437/bfcbde8a-ac26-11e6-91c5-a25154e88eed.gif)

@mistercrunch 