### PR TITLE
[explore-v2] increase space between field set rows 

### DIFF
--- a/superset/assets/javascripts/explorev2/components/FieldSetRow.jsx
+++ b/superset/assets/javascripts/explorev2/components/FieldSetRow.jsx
@@ -29,7 +29,7 @@ export default class FieldSetRow extends React.Component {
   render() {
     const colSize = NUM_COLUMNS / this.props.fieldSets.length;
     return (
-      <div className="row">
+      <div className="row space-2">
         {this.props.fieldSets.map((fs) => {
           const fieldData = this.getFieldData(fs);
           return (

--- a/superset/assets/stylesheets/less/cosmo/bootswatch.less
+++ b/superset/assets/stylesheets/less/cosmo/bootswatch.less
@@ -412,3 +412,12 @@ a.list-group-item {
 hr {
   margin: 10px 0;
 }
+
+// generate space-n classes for vertical spacing
+.space-loop(@counter) when (@counter > 0) {
+  .space-loop((@counter - 1));    // next iteration
+  .space-@{counter} {
+    margin-bottom: (10px * @counter); // code for each iteration
+  }
+}
+.space-loop(6);


### PR DESCRIPTION
i think we could improve this further, but it's more readable with more space between rows.


before:
![screenshot 2016-11-17 14 02 25](https://cloud.githubusercontent.com/assets/130878/20409548/ece61342-acce-11e6-8e07-929bef7fc2de.png)


after:
![screenshot 2016-11-17 14 01 59](https://cloud.githubusercontent.com/assets/130878/20409559/f624262e-acce-11e6-81e3-592afeb15aab.png)

plz review @vera-liu @mistercrunch @bkyryliuk 