### PR TITLE
Fixed a bug with switching viz_type in exploreV2

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/store.js
+++ b/superset/assets/javascripts/explorev2/stores/store.js
@@ -1112,6 +1112,7 @@ export const fields = {
       '28 days ago',
       '90 days ago',
       '1 year ago',
+      '100 year ago',
     ]),
     description: 'Timestamp from filter. This supports free form typing and ' +
                  'natural language as in `1 day ago`, `28 days` or `3 years`',

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -103,7 +103,8 @@ function nvd3Vis(slice) {
       const reduceXTicks = fd.reduce_x_ticks || false;
       let stacked = false;
       let row;
-      nv.addGraph(function () {
+
+      const drawGraph = function () {
         switch (vizType) {
           case 'line':
             if (fd.show_brush) {
@@ -351,8 +352,10 @@ function nvd3Vis(slice) {
         }
 
         return chart;
-      });
+      };
 
+      const graph = drawGraph();
+      nv.addGraph(graph);
       slice.done(payload);
     });
   };


### PR DESCRIPTION
 - Bug: when switching from a viz_type outside nvd3 to a viz_type in
 nvd3, (for instance, switching from table to dist_bar) the Chart Container doesn't draw new graph
 - Fix: The reason was somehow the function inside nv.addGraph() wasn't
   called, extract the function outside and explicitly calling it solve
   the problem

Before:
![giphy 6](https://cloud.githubusercontent.com/assets/20978302/20415570/02d26506-acee-11e6-968d-ca4456c32521.gif)

After:
![giphy 7](https://cloud.githubusercontent.com/assets/20978302/20415632/6336f290-acee-11e6-8169-34b7f394ba9f.gif)


needs-review @ascott @mistercrunch 