### PR TITLE
Temperary fix of a slice bug in explore V2

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -109,16 +109,17 @@ class ChartContainer extends React.Component {
       },
 
       clearError: () => {
-        this.props.actions.removeChartAlert();
+        // no need to do anything here since Alert is closable
+        // query button will also remove Alert
       },
 
       error(msg) {
-        this.props.actions.chartUpdateFailed(msg);
+        props.actions.chartUpdateFailed(msg);
       },
 
       d3format: (col, number) => {
         // mock d3format function in Slice object in superset.js
-        const format = this.props.column_formats[col];
+        const format = props.column_formats[col];
         return d3format(format, number);
       },
     };

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -60,6 +60,7 @@ function nvd3Vis(slice) {
 
   const render = function () {
     d3.json(slice.jsonEndpoint(), function (error, payload) {
+      slice.container.html('');
       // Check error first, otherwise payload can be null
       if (error) {
         slice.error(error.responseText, error);


### PR DESCRIPTION
Issue:
 - Changes in [https://github.com/airbnb/superset/pull/1618](url) were not working in exploreV2, causing the Chart Container not cleaning up graphs at re-rendering, 
e.g. after switching viz_type, previous graph is still shown
![screen shot 2016-11-18 at 5 50 40 pm](https://cloud.githubusercontent.com/assets/20978302/20452156/31aff40e-adb8-11e6-8c6f-604d3c01ed18.png)

Fix:
 - Added back the html cleaning in nvd3
 - Cleaned up some left over typos in mock slice

needs-review @ascott 
