### PR TITLE
Make QueryTable scrollable in Query Search page

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/QuerySearch.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QuerySearch.jsx
@@ -192,16 +192,22 @@ class QuerySearch extends React.PureComponent {
         {this.state.queriesLoading ?
           (<img className="loading" alt="Loading..." src="/static/assets/images/loading.gif" />)
           :
-          (<QueryTable
-            columns={[
-              'state', 'db', 'user', 'date',
-              'progress', 'rows', 'sql', 'querylink',
-            ]}
-            onUserClicked={this.onUserClicked.bind(this)}
-            onDbClicked={this.onDbClicked.bind(this)}
-            queries={this.state.queriesArray}
-            actions={this.props.actions}
-          />)
+          (
+          <div className="scrollbar-container">
+            <div className="scrollbar-content">
+              <QueryTable
+                columns={[
+                  'state', 'db', 'user', 'date',
+                  'progress', 'rows', 'sql', 'querylink',
+                ]}
+                onUserClicked={this.onUserClicked.bind(this)}
+                onDbClicked={this.onDbClicked.bind(this)}
+                queries={this.state.queriesArray}
+                actions={this.props.actions}
+              />
+            </div>
+          </div>
+          )
         }
       </div>
     );


### PR DESCRIPTION
Issue: After change in [https://github.com/airbnb/superset/pull/1551](url), query search page is not scrollable because overflow is set to hidden for body

Solution: we want QueryTable to scroll but not the search selects
After:
![giphy 9](https://cloud.githubusercontent.com/assets/20978302/20495667/dddf50a6-afd6-11e6-8034-1d63319c3f16.gif)


Note: 
After merging [https://github.com/airbnb/superset/pull/1611](url), we need similar changes in QuerySearch to take height of select-boxes into account

needs-review @ascott @mistercrunch @bkyryliuk 