### PR TITLE
Fixed bug with querylink passing sql object instead of string

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -91,6 +91,16 @@ class QueryTable extends React.PureComponent {
         </button>
       );
       q.started = moment(q.startDttm).format('HH:mm:ss');
+      q.querylink = (
+        <div style={{ width: '100px' }}>
+          <a
+            href={this.getQueryLink(q.dbId, q.sql)}
+            className="btn btn-primary btn-xs"
+          >
+            <i className="fa fa-external-link" />Open in SQL Editor
+          </a>
+        </div>
+      );
       q.sql = (
         <HighlightedSql sql={q.sql} rawSql={q.executedSql} shrink maxWidth={60} />
       );
@@ -164,16 +174,6 @@ class QueryTable extends React.PureComponent {
             tooltip="Remove query from log"
             onClick={this.removeQuery.bind(this, query)}
           />
-        </div>
-      );
-      q.querylink = (
-        <div style={{ width: '100px' }}>
-          <a
-            href={this.getQueryLink(q.dbId, q.sql)}
-            className="btn btn-primary btn-xs"
-          >
-            <i className="fa fa-external-link" />Open in SQL Editor
-          </a>
         </div>
       );
       return q;


### PR DESCRIPTION
Issue:
 q.sql was changed from string to HighlightedSql component in [https://github.com/airbnb/superset/blob/bd6a439e0b2a3a76f8aece91f11a7eee2ebf6d29/superset/assets/javascripts/SqlLab/components/QueryTable.jsx#L94](url)

Solution:
since querylink uses the sql query string, I moved its definition before q.sql is altered so that right sql query is passed to open in Sql Editor


Before:
when opening a query from Query Search page in SqlEditor:
![giphy 12](https://cloud.githubusercontent.com/assets/20978302/20502238/13af7812-aff2-11e6-8c64-dfc27f493577.gif)

After:
![giphy 13](https://cloud.githubusercontent.com/assets/20978302/20502265/32b6a456-aff2-11e6-8de9-489cef2d497f.gif)

needs-review @ascott @bkyryliuk @mistercrunch 
