### PR TITLE
[explore-v2] chart header styling

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -141,27 +141,29 @@ class ChartContainer extends React.Component {
           header={
             <div
               id="slice-header"
-              className="panel-title"
+              className="clearfix panel-title-large"
             >
-              {this.props.slice_name}
+              <div className="pull-left">
+                {this.props.slice_name}
 
-              <FaveStar
-                sliceId={this.props.slice_id}
-                actions={this.props.actions}
-                isStarred={this.props.isStarred}
-              />
+                <FaveStar
+                  sliceId={this.props.slice_id}
+                  actions={this.props.actions}
+                  isStarred={this.props.isStarred}
+                />
 
-              <TooltipWrapper
-                label="edit-desc"
-                tooltip="Edit Description"
-              >
-                <a
-                  className="edit-desc-icon"
-                  href={`/slicemodelview/edit/${this.props.slice_id}`}
+                <TooltipWrapper
+                  label="edit-desc"
+                  tooltip="Edit Description"
                 >
-                  <i className="fa fa-edit" />
-                </a>
-              </TooltipWrapper>
+                  <a
+                    className="edit-desc-icon"
+                    href={`/slicemodelview/edit/${this.props.slice_id}`}
+                  >
+                    <i className="fa fa-edit" />
+                  </a>
+                </TooltipWrapper>
+              </div>
 
               <div className="pull-right">
                 <ExploreActionButtons

--- a/superset/assets/stylesheets/less/cosmo/bootswatch.less
+++ b/superset/assets/stylesheets/less/cosmo/bootswatch.less
@@ -337,6 +337,10 @@ label {
   }
 }
 
+.panel-title-large {
+  font-size: 24px;
+}
+
 a.list-group-item {
 
   &-success {


### PR DESCRIPTION
- make chart title larger
- fix explore actions btn spacing

before:
![screenshot 2016-11-23 12 08 30](https://cloud.githubusercontent.com/assets/130878/20577051/730bb6de-b175-11e6-8325-0755a10b3ad5.png)


after:
![screenshot 2016-11-23 11 48 21](https://cloud.githubusercontent.com/assets/130878/20577037/5f237e0e-b175-11e6-94d8-3601ce3cd913.png)

plz review @airbnb/superset-reviewers @elibrumbaugh 
