### PR TITLE
Vliu explorev2 bugs

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -204,7 +204,7 @@ class ChartContainer extends React.Component {
               id={this.props.containerId}
               ref={(ref) => { this.chartContainerRef = ref; }}
               className={this.props.viz_type}
-              style={{ overflow: 'scroll' }}
+              style={{ 'overflow-x': 'scroll' }}
             />)
           }
         </Panel>

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -204,6 +204,7 @@ class ChartContainer extends React.Component {
               id={this.props.containerId}
               ref={(ref) => { this.chartContainerRef = ref; }}
               className={this.props.viz_type}
+              style={{ overflow: 'scroll' }}
             />)
           }
         </Panel>

--- a/superset/assets/visualizations/heatmap.js
+++ b/superset/assets/visualizations/heatmap.js
@@ -12,9 +12,9 @@ function heatmapVis(slice) {
   function refresh() {
     // Header for panel in explore v2
     const header = document.getElementById('slice-header');
-    const headerHeight = header ? header.getBoundingClientRect().height : 0;
+    const headerHeight = header ? 30 + header.getBoundingClientRect().height : 0;
     const margin = {
-      top: 20 + headerHeight,
+      top: headerHeight,
       right: 10,
       bottom: 35,
       left: 35,
@@ -101,14 +101,14 @@ function heatmapVis(slice) {
         .style('height', hmHeight + 'px')
         .style('image-rendering', fd.canvas_image_rendering)
         .style('left', margin.left + 'px')
-        .style('top', margin.top + 'px')
+        .style('top', margin.top + headerHeight + 'px')
         .style('position', 'absolute');
 
       const svg = container.append('svg')
         .attr('width', width)
         .attr('height', height)
         .style('left', '0px')
-        .style('top', '0px')
+        .style('top', headerHeight + 'px')
         .style('position', 'absolute');
 
       const rect = svg.append('g')

--- a/superset/views.py
+++ b/superset/views.py
@@ -1451,11 +1451,13 @@ class Superset(BaseSupersetView):
                 "user_id": g.user.get_id() if g.user else None,
                 "viz": json.loads(viz_obj.get_json())
             }
+            table_name = viz_obj.datasource.table_name \
+                if datasource_type == 'table' else viz_obj.datasource.datasource_name
             return self.render_template(
                 "superset/explorev2.html",
                 bootstrap_data=json.dumps(bootstrap_data),
                 slice=slc,
-                table_name=viz_obj.datasource.table_name)
+                table_name=table_name)
         else:
             return self.render_template(
                 "superset/explore.html",

--- a/superset/views.py
+++ b/superset/views.py
@@ -1452,7 +1452,8 @@ class Superset(BaseSupersetView):
                 "viz": json.loads(viz_obj.get_json())
             }
             table_name = viz_obj.datasource.table_name \
-                if datasource_type == 'table' else viz_obj.datasource.datasource_name
+                if datasource_type == 'table' \
+                else viz_obj.datasource.datasource_name
             return self.render_template(
                 "superset/explorev2.html",
                 bootstrap_data=json.dumps(bootstrap_data),


### PR DESCRIPTION
Issues:
 - [x] Chart Container can't accomodate large chart [https://github.com/airbnb/superset/issues/1676](url) 
Solution: I was afraid wrapping entire chart within the container would cause it to be squashed/look bad. So I made chart container scrollable. 
![giphy 14](https://cloud.githubusercontent.com/assets/20978302/20693675/cceb2d1a-b594-11e6-91b6-94f979d9976a.gif)


 - [x] Druid datasource pops errors in views.py
![screen shot 2016-11-28 at 4 16 25 pm](https://cloud.githubusercontent.com/assets/20978302/20693578/2e59e24a-b594-11e6-8b55-b978e18cb1b0.png)
Solution: use datasource_name for druid instead of table_name

 - [x] action buttons are not clickable in heatmap-v2
Solution: svg was not shifted downward in Chart Container, so it blocks the action button. Adding headerHeight to svg solved the problem.

needs-review @ascott 
