### PR TITLE
[sqllab] Fixed js error when results are not available

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -47,8 +47,7 @@ class QueryTable extends React.PureComponent {
     this.setState({ showVisualizeModal: false });
   }
   showVisualizeModal(query) {
-    this.setState({ showVisualizeModal: true });
-    this.setState({ activeQuery: query });
+    this.setState({ activeQuery: query, showVisualizeModal: true });
   }
   restoreSql(query) {
     this.props.actions.queryEditorSetSql({ id: query.sqlEditorId }, query.sql);

--- a/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -125,7 +125,7 @@ class VisualizeModal extends React.PureComponent {
     this.setState({ columns }, this.validate);
   }
   render() {
-    if (!(this.props.query) || !(this.props.query.results)) {
+    if (!(this.props.query) || !(this.props.query.results) || !(this.props.query.results.columns)) {
       return (
         <div className="VisualizeModal">
           <Modal show={this.props.show} onHide={this.props.onHide}>

--- a/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -34,21 +34,21 @@ class VisualizeModal extends React.PureComponent {
       hints: [],
     };
   }
-  componentWillMount() {
-    this.setStateFromProps();
-  }
   componentDidMount() {
     this.validate();
   }
-  setStateFromProps() {
+  componentWillReceiveProps(nextProps) {
+    this.setStateFromProps(nextProps);
+  }
+  setStateFromProps(props) {
     if (
-        !this.props.query ||
-        !this.props.query.results ||
-        !this.props.query.results.columns) {
+        !props.query ||
+        !props.query.results ||
+        !props.query.results.columns) {
       return;
     }
     const columns = {};
-    this.props.query.results.columns.forEach((col) => {
+    props.query.results.columns.forEach((col) => {
       columns[col.name] = col;
     });
     this.setState({ columns });

--- a/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -125,8 +125,16 @@ class VisualizeModal extends React.PureComponent {
     this.setState({ columns }, this.validate);
   }
   render() {
-    if (!(this.props.query)) {
-      return <div />;
+    if (!(this.props.query) || !(this.props.query.results)) {
+      return (
+        <div className="VisualizeModal">
+          <Modal show={this.props.show} onHide={this.props.onHide}>
+            <Modal.Body>
+              No results available for this query
+            </Modal.Body>
+          </Modal>
+        </div>
+      );
     }
     const tableData = this.props.query.results.columns.map((col) => ({
       column: col.name,

--- a/superset/assets/javascripts/SqlLab/reducers.js
+++ b/superset/assets/javascripts/SqlLab/reducers.js
@@ -134,7 +134,7 @@ export const sqlLabReducer = function (state, action) {
       let newState = Object.assign({}, state);
       if (action.query.sqlEditorId) {
         const qe = getFromArr(state.queryEditors, action.query.sqlEditorId);
-        if (qe.latestQueryId) {
+        if (qe.latestQueryId && state.queries[qe.latestQueryId]) {
           const newResults = Object.assign(
             {}, state.queries[qe.latestQueryId].results, { data: [], query: null });
           const q = Object.assign({}, state.queries[qe.latestQueryId], { results: newResults });

--- a/superset/assets/javascripts/SqlLab/reducers.js
+++ b/superset/assets/javascripts/SqlLab/reducers.js
@@ -135,7 +135,9 @@ export const sqlLabReducer = function (state, action) {
       if (action.query.sqlEditorId) {
         const qe = getFromArr(state.queryEditors, action.query.sqlEditorId);
         if (qe.latestQueryId) {
-          const q = Object.assign({}, state.queries[qe.latestQueryId], { results: null });
+          const newResults = Object.assign(
+            {}, state.queries[qe.latestQueryId].results, { data: [], query: null });
+          const q = Object.assign({}, state.queries[qe.latestQueryId], { results: newResults });
           const queries = Object.assign({}, state.queries, { [q.id]: q });
           newState = Object.assign({}, state, { queries });
         }


### PR DESCRIPTION
Issue:
 - [https://github.com/airbnb/superset/issues/1646](https://github.com/airbnb/superset/issues/1646)
 - [https://github.com/airbnb/superset/issues/1463](url)


Problem:
 - query results could be null in VisualizeModal, triggering js error
 - defaults were not shown in VisualizeModal for past queries

Solution:
 - add modal message when query results are not available
 - we flush results of latestQuery everytime we start a new query [https://github.com/airbnb/superset/blob/94dde075b3eab41797725e1e02c7f87b6b45471a/superset/assets/javascripts/SqlLab/reducers.js#L138](url). I guess the original incentive was flushing query results in case we have too many data in the store. I changed this to only flushing results.data and results.query, leaving results.columns in store, to be used by VisualizeModal
 - move setState from componentWillMount to componentWillReceiveProps, so that column attributes could be passed in 

Before:
![bug](https://cloud.githubusercontent.com/assets/20978302/20805594/3442cb94-b7ac-11e6-8b23-965a3ea03b13.png)

After:
<img width="721" alt="screen shot 2016-12-01 at 9 55 01 am" src="https://cloud.githubusercontent.com/assets/20978302/20805611/40a5505a-b7ac-11e6-8a69-9e21a175061d.png">

@ascott @bkyryliuk @mistercrunch 