### PR TITLE
[explorev2] fix textfield and druid bug

### DIFF
--- a/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -96,7 +96,8 @@ export const exploreReducer = function (state, action) {
       if (action.key === 'viz_type') {
         newFormData.previous_viz_type = state.viz.form_data.viz_type;
       }
-      newFormData[action.key] = action.value ? action.value : (!state.viz.form_data[action.key]);
+      newFormData[action.key] = (action.value !== undefined)
+        ? action.value : (!state.viz.form_data[action.key]);
       return Object.assign(
         {},
         state,

--- a/superset/views.py
+++ b/superset/views.py
@@ -2455,10 +2455,7 @@ class Superset(BaseSupersetView):
         for s in sorted(datasource.column_names):
             order_by_choices.append((json.dumps([s, True]), s + ' [asc]'))
             order_by_choices.append((json.dumps([s, False]), s + ' [desc]'))
-        grains = datasource.database.grains()
-        grain_choices = []
-        if grains:
-            grain_choices = [(grain.name, grain.name) for grain in grains]
+
         field_options = {
             'datasource': [(d.id, d.full_name) for d in datasources],
             'metrics': datasource.metrics_combo,
@@ -2470,8 +2467,6 @@ class Superset(BaseSupersetView):
             'all_columns': all_cols,
             'all_columns_x': all_cols,
             'all_columns_y': all_cols,
-            'granularity_sqla': [(c, c) for c in datasource.dttm_cols],
-            'time_grain_sqla': grain_choices,
             'timeseries_limit_metric': [('', '')] + datasource.metrics_combo,
             'series': gb_cols,
             'entity': gb_cols,
@@ -2482,6 +2477,15 @@ class Superset(BaseSupersetView):
             'point_radius': [(c, c) for c in (["Auto"] + datasource.column_names)],
             'filterable_cols': datasource.filterable_column_names,
         }
+
+        if (datasource_type == 'table'):
+            grains = datasource.database.grains()
+            grain_choices = []
+            if grains:
+                grain_choices = [(grain.name, grain.name) for grain in grains]
+            field_options['granularity_sqla'] = \
+                [(c, c) for c in datasource.dttm_cols]
+            field_options['time_grain_sqla'] = grain_choices
 
         return Response(
             json.dumps({'field_options': field_options}),


### PR DESCRIPTION
Bug: 
 1. when textfield is empty, it is set to true/false in reducers
 2. fetch_datasource_metadata was broken for druid 
<img width="717" alt="screen shot 2016-12-01 at 12 20 08 pm" src="https://cloud.githubusercontent.com/assets/20978302/20811328/0fac60e0-b7c2-11e6-9328-9acf6797c951.png">


Solution: 
 1. differentiate checkbox with text/select by identifying undefined action.value
 2. remove time_grains for druid when fetching metadata

Tested in staging:
<img width="1427" alt="screen shot 2016-12-01 at 1 45 21 pm" src="https://cloud.githubusercontent.com/assets/20978302/20813942/79a15410-b7cc-11e6-82e3-8f9325f94461.png">


@ascott 