### PR TITLE
Sort searched queries by recency

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/App.jsx
+++ b/superset/assets/javascripts/SqlLab/components/App.jsx
@@ -49,7 +49,7 @@ class App extends React.PureComponent {
         <div className="container-fluid">
           <div className="row">
             <div className="col-md-12">
-              <QuerySearch height={this.state.contentHeight} />
+              <QuerySearch height={this.state.contentHeight} actions={this.props.actions} />
             </div>
           </div>
         </div>

--- a/superset/assets/javascripts/SqlLab/components/QuerySearch.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QuerySearch.jsx
@@ -116,11 +116,7 @@ class QuerySearch extends React.PureComponent {
     const url = this.insertParams('/superset/search_queries', params);
     $.getJSON(url, (data, status) => {
       if (status === 'success') {
-        const newQueriesArray = [];
-        for (const id in data) {
-          newQueriesArray.push(data[id]);
-        }
-        this.setState({ queriesArray: newQueriesArray, queriesLoading: false });
+        this.setState({ queriesArray: data, queriesLoading: false });
       }
     });
   }
@@ -143,6 +139,7 @@ class QuerySearch extends React.PureComponent {
             <DatabaseSelect
               onChange={this.onChange.bind(this)}
               databaseId={this.state.databaseId}
+              actions={this.props.actions}
             />
           </div>
           <div className="col-sm-4">
@@ -200,7 +197,7 @@ class QuerySearch extends React.PureComponent {
             <div className="scrollbar-content">
               <QueryTable
                 columns={[
-                  'state', 'db', 'user', 'date',
+                  'state', 'db', 'user', 'time',
                   'progress', 'rows', 'sql', 'querylink',
                 ]}
                 onUserClicked={this.onUserClicked.bind(this)}

--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -66,14 +66,20 @@ class QueryTable extends React.PureComponent {
   removeQuery(query) {
     this.props.actions.removeQuery(query);
   }
-
   render() {
     const data = this.props.queries.map((query) => {
       const q = Object.assign({}, query);
       if (q.endDttm) {
         q.duration = fDuration(q.startDttm, q.endDttm);
       }
-      q.date = moment(q.startDttm).format('MMM Do YYYY');
+      const time = moment(q.startDttm).format().split('T');
+      q.time = (
+        <div>
+          <span>
+            {time[0]} <br /> {time[1]}
+          </span>
+        </div>
+      );
       q.user = (
         <button
           className="btn btn-link btn-xs"
@@ -189,6 +195,7 @@ class QueryTable extends React.PureComponent {
           columns={this.props.columns}
           className="table table-condensed"
           data={data}
+          itemsPerPage={50}
         />
       </div>
     );

--- a/superset/assets/spec/javascripts/sqllab/QueryTable_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QueryTable_spec.jsx
@@ -21,6 +21,6 @@ describe('QueryTable', () => {
   it('renders a proper table', () => {
     const wrapper = mount(<QueryTable {...mockedProps} />);
     expect(wrapper.find('table')).to.have.length(1);
-    expect(wrapper.find('tr')).to.have.length(3);
+    expect(wrapper.find('tr')).to.have.length(4);
   });
 });

--- a/superset/views.py
+++ b/superset/views.py
@@ -2557,7 +2557,7 @@ class Superset(BaseSupersetView):
 
         query_limit = config.get('QUERY_SEARCH_LIMIT', 1000)
         sql_queries = (
-            query.order_by(models.Query.start_time.desc())
+            query.order_by(models.Query.start_time.asc())
             .limit(query_limit)
             .all()
         )

--- a/superset/views.py
+++ b/superset/views.py
@@ -2555,9 +2555,14 @@ class Superset(BaseSupersetView):
         if to_time:
             query = query.filter(models.Query.start_time < int(to_time))
 
-        query_limit = config.get('QUERY_SEARCH_LIMIT', 5000)
-        sql_queries = query.limit(query_limit).all()
-        dict_queries = {q.client_id: q.to_dict() for q in sql_queries}
+        query_limit = config.get('QUERY_SEARCH_LIMIT', 1000)
+        sql_queries = (
+            query.order_by(models.Query.start_time.desc())
+            .limit(query_limit)
+            .all()
+        )
+
+        dict_queries = [q.to_dict() for q in sql_queries]
 
         return Response(
             json.dumps(dict_queries, default=utils.json_int_dttm_ser),

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -121,7 +121,7 @@ class SqlLabTests(SupersetTestCase):
         resp = self.get_resp('/superset/search_queries?database_id=1')
         data = json.loads(resp)
         self.assertEquals(3, len(data))
-        db_ids = [data[k]['dbId'] for k in data]
+        db_ids = [k['dbId'] for k in data]
         self.assertEquals([1, 1, 1], db_ids)
 
         resp = self.get_resp('/superset/search_queries?database_id=-1')
@@ -137,14 +137,14 @@ class SqlLabTests(SupersetTestCase):
         data = self.get_json_resp(
             '/superset/search_queries?user_id={}'.format(user.id))
         self.assertEquals(2, len(data))
-        user_ids = {data[k]['userId'] for k in data}
+        user_ids = {k['userId'] for k in data}
         self.assertEquals(set([user.id]), user_ids)
 
         user = appbuilder.sm.find_user('gamma_sqllab')
         resp = self.get_resp('/superset/search_queries?user_id={}'.format(user.id))
         data = json.loads(resp)
         self.assertEquals(1, len(data))
-        self.assertEquals(list(data.values())[0]['userId'] , user.id)
+        self.assertEquals(data[0]['userId'] , user.id)
 
     def test_search_query_on_status(self):
         self.run_some_queries()
@@ -153,13 +153,13 @@ class SqlLabTests(SupersetTestCase):
         resp = self.get_resp('/superset/search_queries?status=success')
         data = json.loads(resp)
         self.assertEquals(2, len(data))
-        states = [data[k]['state'] for k in data]
+        states = [k['state'] for k in data]
         self.assertEquals(['success', 'success'], states)
 
         resp = self.get_resp('/superset/search_queries?status=failed')
         data = json.loads(resp)
         self.assertEquals(1, len(data))
-        self.assertEquals(list(data.values())[0]['state'], 'failed')
+        self.assertEquals(data[0]['state'], 'failed')
 
     def test_search_query_on_text(self):
         self.run_some_queries()
@@ -167,7 +167,7 @@ class SqlLabTests(SupersetTestCase):
         resp = self.get_resp('/superset/search_queries?search_text=permission')
         data = json.loads(resp)
         self.assertEquals(1, len(data))
-        self.assertIn('permission', list(data.values())[0]['sql'])
+        self.assertIn('permission', data[0]['sql'])
 
     def test_search_query_on_time(self):
         self.run_some_queries()
@@ -187,9 +187,9 @@ class SqlLabTests(SupersetTestCase):
         resp = self.get_resp('/superset/search_queries?'+'&'.join(params))
         data = json.loads(resp)
         self.assertEquals(2, len(data))
-        for _, v in data.items():
-            self.assertLess(int(first_query_time), v['startDttm'])
-            self.assertLess(v['startDttm'], int(second_query_time))
+        for k in data:
+            self.assertLess(int(first_query_time), k['startDttm'])
+            self.assertLess(k['startDttm'], int(second_query_time))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#Issue: [https://github.com/airbnb/superset/issues/1630](url)
Done:
 - Order searched queries by query start time
 - pass in actions to solve js errors on QuerySearch page
 - add pagination to queries

Before:
<img width="1414" alt="screen shot 2016-12-01 at 5 51 29 pm" src="https://cloud.githubusercontent.com/assets/20978302/20820274/dbab83c0-b7ee-11e6-9367-3b96072b284f.png">

After:
<img width="720" alt="screen shot 2016-12-01 at 5 50 59 pm" src="https://cloud.githubusercontent.com/assets/20978302/20820277/e6f3308e-b7ee-11e6-8bf6-1b0e04f75c5c.png">

@mistercrunch @ascott @bkyryliuk 
Todo:
 -  I spent a long time trying to get column in reactable sortable by customized sort function, but it seems that even when passed in data is in the right order, reactable does not render data in order...seems like a bug in reactable