### PR TITLE
[explorev2] cosmetic, smaller size for input text

### DIFF
--- a/superset/assets/javascripts/explorev2/components/TextField.jsx
+++ b/superset/assets/javascripts/explorev2/components/TextField.jsx
@@ -23,7 +23,7 @@ export default class TextField extends React.Component {
   }
   render() {
     return (
-      <FormGroup controlId="formInlineName">
+      <FormGroup controlId="formInlineName" bsSize="small">
         <ControlLabelWithTooltip
           label={this.props.label}
           description={this.props.description}


### PR DESCRIPTION
<img width="403" alt="screen shot 2016-12-02 at 10 19 02 am" src="https://cloud.githubusercontent.com/assets/487433/20845205/ceeb9cda-b878-11e6-9827-65572e9cfef7.png">
<img width="393" alt="screen shot 2016-12-02 at 10 17 17 am" src="https://cloud.githubusercontent.com/assets/487433/20845206/ceebaa18-b878-11e6-93fa-a9652d00b586.png">
