### PR TITLE
Make entire menuitem clickable for copy query

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
+++ b/superset/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
@@ -39,7 +39,11 @@ export default class CopyQueryTabUrl extends React.PureComponent {
       <CopyToClipboard
         inMenu
         text={this.state.shortUrl}
-        copyNode={<span>share query</span>}
+        copyNode={(
+          <div>
+            <i className="fa fa-clipboard" /> <span>share query</span>
+          </div>
+        )}
         tooltipText="copy URL to clipboard"
         shouldShowText={false}
       />

--- a/superset/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -150,9 +150,7 @@ class TabbedSqlEditors extends React.PureComponent {
               <i className="fa fa-i-cursor" /> rename tab
             </MenuItem>
             {qe &&
-              <MenuItem eventKey="3">
-                <i className="fa fa-clipboard" /> <CopyQueryTabUrl queryEditor={qe} />
-              </MenuItem>
+              <CopyQueryTabUrl queryEditor={qe} />
             }
             <MenuItem eventKey="4" onClick={this.toggleLeftBar.bind(this)}>
               <i className="fa fa-cogs" />

--- a/superset/assets/javascripts/components/CopyToClipboard.jsx
+++ b/superset/assets/javascripts/components/CopyToClipboard.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { Tooltip, OverlayTrigger } from 'react-bootstrap';
+import { Tooltip, OverlayTrigger, MenuItem } from 'react-bootstrap';
 
 const propTypes = {
   copyNode: PropTypes.node,
@@ -99,12 +99,14 @@ export default class CopyToClipboard extends React.Component {
   renderInMenu() {
     return (
       <OverlayTrigger placement="top" overlay={this.renderTooltip()} trigger={['hover']}>
-        <span
-          onClick={this.copyToClipboard}
-          onMouseOut={this.onMouseOut}
-        >
-          {this.props.copyNode}
-        </span>
+        <MenuItem>
+          <span
+            onClick={this.copyToClipboard}
+            onMouseOut={this.onMouseOut}
+          >
+            {this.props.copyNode}
+          </span>
+        </MenuItem>
       </OverlayTrigger>
     );
   }


### PR DESCRIPTION
Issue:
 - only span is specified in CopyToClipboard component, the user had to click on the text to copy a url, clicking on blank spaces or icon doesn't work

Solution:
 - move MenuItem to CopyToClipboard, make entire MenuItem clickable for copying query when rendering in menu

needs-review @mistercrunch @ascott 