### PR TITLE
Sankey Tooltip fix (#1748)

### DIFF
--- a/superset/assets/visualizations/sankey.js
+++ b/superset/assets/visualizations/sankey.js
@@ -89,8 +89,8 @@ function sankeyVis(slice) {
           .html(function () { return getTooltipHtml(d); })
          .transition()
           .duration(200)
-          .style('left', (d3.event.layerX + 10) + 'px')
-          .style('top', (d3.event.layerY + 10) + 'px')
+          .style('left', (d3.event.offsetX + 10) + 'px')
+          .style('top', (d3.event.offsetY + 10) + 'px')
           .style('opacity', 0.95);
       }
 


### PR DESCRIPTION
@bkyryliuk @mistercrunch 

Issue #1748 

The [.layer{X,Y} property](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/layerX) returns the position relative to the whole document.  However, this is being applied relative to the slice container. As such, the tooltip is not aligned to the mouse position, and can move out of the viewport:

![screen shot 2016-12-02 at 11 54 11](https://cloud.githubusercontent.com/assets/445312/20848952/3683535a-b889-11e6-8c57-34fb3d0c415d.png)


The [.offset{X,Y}](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/offsetX) provides the position relative to the target node. This gives an accurate positioning of the tooltip relative to the mouse:

![screen shot 2016-12-02 at 12 07 49](https://cloud.githubusercontent.com/assets/445312/20848955/39b99322-b889-11e6-947d-100e1579b99b.png)

Simple fix, tested locally.