### PR TITLE
Avoid fine print.

### DIFF
--- a/superset/assets/javascripts/SqlLab/main.css
+++ b/superset/assets/javascripts/SqlLab/main.css
@@ -160,7 +160,7 @@ div.Workspace {
     padding: 0px !important;
     margin: 0px;
     border: none;
-    font-size: 12px;
+    font-size: 14px;
     line-height: @line-height-base;
     background-color: transparent !important;
 }
@@ -289,7 +289,7 @@ a.Link {
     border: none;
     text-align: left;
     color: white;
-    font-size: 10px;
+    font-size: 14px;
 }
 .tooltip-inner {
     max-width: 500px;

--- a/superset/assets/stylesheets/sql.css
+++ b/superset/assets/stylesheets/sql.css
@@ -32,7 +32,7 @@ div.alert {
 }
 #results {
   overflow: auto;
-  font-size: 12px;
+  font-size: 14px;
   margin-bottom: 5px;
 }
 table tbody tr td {

--- a/superset/assets/stylesheets/superset.css
+++ b/superset/assets/stylesheets/superset.css
@@ -52,7 +52,7 @@ input.form-control {
     border: 1px solid #DDD;
     background-color: #F8F8F8;
     border-radius: 5px;
-    font-size: 12px;
+    font-size: 14px;
 }
 
 .slice_info{
@@ -191,5 +191,5 @@ div.widget .slice_container {
 }
 
 .table-condensed {
-    font-size: 12px;
+    font-size: 14px;
 }


### PR DESCRIPTION
We should not use 12px font size to avoid agism in design. At age 40, eyesight is about half as good as it did at age 20. I changed all font sizes to be at least 14px. 

Loving the new homepage by the way! :tada: 

Reviewers

- @ascott 
- @mistercrunch 
