### PR TITLE
Make cell-click filter in table viz optional

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/store.js
+++ b/superset/assets/javascripts/explorev2/stores/store.js
@@ -1465,7 +1465,7 @@ export const fields = {
   table_filter: {
     type: 'CheckboxField',
     label: 'Table Filter',
-    default: true,
+    default: false,
     description: 'Whether to apply filter when table cell is clicked',
   },
 

--- a/superset/assets/javascripts/explorev2/stores/store.js
+++ b/superset/assets/javascripts/explorev2/stores/store.js
@@ -264,7 +264,7 @@ export const visTypes = {
           ['table_timestamp_format'],
           ['row_limit'],
           ['page_length'],
-          ['include_search'],
+          ['include_search', 'table_filter'],
         ],
       },
     ],
@@ -1460,6 +1460,13 @@ export const fields = {
     label: 'Search Box',
     default: false,
     description: 'Whether to include a client side search box',
+  },
+
+  table_filter: {
+    type: 'CheckboxField',
+    label: 'Table Filter',
+    default: true,
+    description: 'Whether to apply filter when table cell is clicked',
   },
 
   show_bubbles: {

--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -106,7 +106,7 @@ function tableVis(slice) {
           return (d.isMetric) ? d.val : null;
         })
         .on('click', function (d) {
-          if (!d.isMetric) {
+          if (!d.isMetric && fd.table_filter) {
             const td = d3.select(this);
             if (td.classed('filtered')) {
               slice.removeFilter(d.col, [d.val]);

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -784,6 +784,11 @@ class FormFactory(object):
                 "description": _(
                     "Whether to include a client side search box")
             }),
+            'table_filter': (BetterBooleanField, {
+                "label": _("Table Filter"),
+                "default": True,
+                "description": _("Whether to apply filter when table cell is clicked")
+            }),
             'show_bubbles': (BetterBooleanField, {
                 "label": _("Show Bubbles"),
                 "default": False,

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -787,7 +787,8 @@ class FormFactory(object):
             'table_filter': (BetterBooleanField, {
                 "label": _("Table Filter"),
                 "default": True,
-                "description": _("Whether to apply filter when table cell is clicked")
+                "description": _(
+                    "Whether to apply filter when table cell is clicked")
             }),
             'show_bubbles': (BetterBooleanField, {
                 "label": _("Show Bubbles"),

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -786,7 +786,7 @@ class FormFactory(object):
             }),
             'table_filter': (BetterBooleanField, {
                 "label": _("Table Filter"),
-                "default": True,
+                "default": False,
                 "description": _(
                     "Whether to apply filter when table cell is clicked")
             }),

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -421,7 +421,7 @@ class TableViz(BaseViz):
             'table_timestamp_format',
             'row_limit',
             'page_length',
-            ('include_search', None),
+            ('include_search', 'table_filter'),
         )
     })
     form_overrides = ({


### PR DESCRIPTION
Issue: [https://github.com/airbnb/superset/issues/1752](https://github.com/airbnb/superset/issues/1752)
 - Currently clicking on a cell in table slice will apply filter to dashboard by default, but some users don't want this feature

Done:
 - Added table_filter checkbox in table viz
 - If set to false, clicking on a cell in table will not apply filter to
   dashboard

needs-review @ascott @mistercrunch @bkyryliuk 