### PR TITLE
[WIP] Add http to copied url and move function to componentWillReceiveProps

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
+++ b/superset/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
@@ -14,8 +14,8 @@ export default class CopyQueryTabUrl extends React.PureComponent {
     };
   }
 
-  componentWillMount() {
-    const qe = this.props.queryEditor;
+  componentWillReceiveProps(nextProps) {
+    const qe = nextProps.queryEditor;
     const params = [];
     if (qe.dbId) params.push('dbid=' + qe.dbId);
     if (qe.title) params.push('title=' + encodeURIComponent(qe.title));

--- a/superset/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
+++ b/superset/assets/javascripts/SqlLab/components/CopyQueryTabUrl.jsx
@@ -7,15 +7,8 @@ const propTypes = {
 };
 
 export default class CopyQueryTabUrl extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      shortUrl: '',
-    };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const qe = nextProps.queryEditor;
+  getUrl(callback) {
+    const qe = this.props.queryEditor;
     const params = [];
     if (qe.dbId) params.push('dbid=' + qe.dbId);
     if (qe.title) params.push('title=' + encodeURIComponent(qe.title));
@@ -25,20 +18,13 @@ export default class CopyQueryTabUrl extends React.PureComponent {
 
     const queryString = params.join('&');
     const queryLink = window.location.pathname + '?' + queryString;
-    getShortUrl(queryLink, this.onShortUrlSuccess.bind(this));
-  }
-
-  onShortUrlSuccess(data) {
-    this.setState({
-      shortUrl: data,
-    });
+    getShortUrl(queryLink, callback);
   }
 
   render() {
     return (
       <CopyToClipboard
         inMenu
-        text={this.state.shortUrl}
         copyNode={(
           <div>
             <i className="fa fa-clipboard" /> <span>share query</span>
@@ -46,6 +32,7 @@ export default class CopyQueryTabUrl extends React.PureComponent {
         )}
         tooltipText="copy URL to clipboard"
         shouldShowText={false}
+        getText={this.getUrl.bind(this)}
       />
     );
   }

--- a/superset/assets/javascripts/components/CopyToClipboard.jsx
+++ b/superset/assets/javascripts/components/CopyToClipboard.jsx
@@ -3,9 +3,10 @@ import { Tooltip, OverlayTrigger, MenuItem } from 'react-bootstrap';
 
 const propTypes = {
   copyNode: PropTypes.node,
+  getText: PropTypes.func,
   onCopyEnd: PropTypes.func,
   shouldShowText: PropTypes.bool,
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
   inMenu: PropTypes.bool,
   tooltipText: PropTypes.string,
 };
@@ -36,12 +37,19 @@ export default class CopyToClipboard extends React.Component {
     setTimeout(this.resetTooltipText, 200);
   }
 
+  onClick() {
+    if (this.props.getText) {
+      this.props.getText((d) => { this.copyToClipboard(d); });
+    } else {
+      this.copyToClipboard(this.props.text);
+    }
+  }
+
   resetTooltipText() {
     this.setState({ hasCopied: false });
   }
 
-  copyToClipboard() {
-    const textToCopy = this.props.text;
+  copyToClipboard(textToCopy) {
     const textArea = document.createElement('textarea');
 
     textArea.style.position = 'fixed';
@@ -50,7 +58,6 @@ export default class CopyToClipboard extends React.Component {
 
     document.body.appendChild(textArea);
     textArea.select();
-
     try {
       if (!document.execCommand('copy')) {
         throw new Error('Not successful');
@@ -87,7 +94,7 @@ export default class CopyToClipboard extends React.Component {
           overlay={this.renderTooltip()}
           trigger={['hover']}
           bsStyle="link"
-          onClick={this.copyToClipboard}
+          onClick={this.onClick.bind(this)}
           onMouseOut={this.onMouseOut}
         >
             {this.props.copyNode}
@@ -101,7 +108,7 @@ export default class CopyToClipboard extends React.Component {
       <OverlayTrigger placement="top" overlay={this.renderTooltip()} trigger={['hover']}>
         <MenuItem>
           <span
-            onClick={this.copyToClipboard}
+            onClick={this.onClick.bind(this)}
             onMouseOut={this.onMouseOut}
           >
             {this.props.copyNode}

--- a/superset/assets/utils/common.js
+++ b/superset/assets/utils/common.js
@@ -59,6 +59,7 @@ export function getShortUrl(longUrl, callback) {
   $.ajax({
     type: 'POST',
     url: '/r/shortner/',
+    async: false,
     data: {
       data: '/' + longUrl,
     },

--- a/superset/assets/utils/common.js
+++ b/superset/assets/utils/common.js
@@ -55,7 +55,7 @@ export function getParamsFromUrl() {
   return newParams;
 }
 
-export function getShortUrl(longUrl, callBack) {
+export function getShortUrl(longUrl, callback) {
   $.ajax({
     type: 'POST',
     url: '/r/shortner/',
@@ -63,7 +63,7 @@ export function getShortUrl(longUrl, callBack) {
       data: '/' + longUrl,
     },
     success: (data) => {
-      callBack(data);
+      callback(data);
     },
     error: (error) => {
       /* eslint no-console: 0 */
@@ -71,6 +71,7 @@ export function getShortUrl(longUrl, callBack) {
         console.warn('Something went wrong...');
         console.warn(error);
       }
+      callback(longUrl);
     },
   });
 }

--- a/superset/views.py
+++ b/superset/views.py
@@ -1115,7 +1115,7 @@ class R(BaseSupersetView):
         obj = models.Url(url=url)
         db.session.add(obj)
         db.session.commit()
-        return("{request.headers[Host]}/r/{obj.id}".format(
+        return("http://{request.headers[Host]}/r/{obj.id}".format(
             request=request, obj=obj))
 
     @expose("/msg/")


### PR DESCRIPTION
Issue:
 - http was returned in url shortener, some editor like jira cannot parse url directly as a link
 - after CopyQueryTabUrl was changed to a pure component, componentWillMount was not called when props update, share-url always takes the old sql
Before
![giphy 19](https://cloud.githubusercontent.com/assets/20978302/20944237/7bd3ff46-bbb7-11e6-866a-e0e32f54af62.gif)

Done:
 - added http to returned url in shortner
 - add a getText function with callback in CopyToClipboard component, once clicked, getText function is called to retrieve text to be copied to clipboard

After:
![giphy 20](https://cloud.githubusercontent.com/assets/20978302/20944396/1c464380-bbb8-11e6-8197-e6ceb09925bd.gif)


needs-review @ascott @mistercrunch @bkyryliuk 

