### PR TITLE
[ui] adjust header nav links so they are all aligned on the base line

### DIFF
--- a/superset/assets/stylesheets/less/cosmo/bootswatch.less
+++ b/superset/assets/stylesheets/less/cosmo/bootswatch.less
@@ -40,6 +40,10 @@
   background: transparent;
 }
 
+.navbar-nav > li > a {
+  padding-top: 18px;
+}
+
 // Buttons ====================================================================
 
 .btn-default:hover {

--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -21,11 +21,15 @@
         {% include 'appbuilder/navbar_menu.html' %}
       </ul>
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://github.com/airbnb/superset" title="Superset's Github">
-          <i class="fa fa-github fa-lg"></i></a>
+        <li>
+          <a href="https://github.com/airbnb/superset" title="Superset's Github">
+            <i class="fa fa-github"></i> &nbsp;
+          </a>
         </li>
-        <li><a href="http://airbnb.io/superset" title="Documentation">
-          <i class="fa fa-book fa-lg"></i> </a>
+        <li>
+          <a href="http://airbnb.io/superset" title="Documentation">
+            <i class="fa fa-book"></i> &nbsp;
+          </a>
         </li>
         {% include 'appbuilder/navbar_right.html' %}
       </ul>

--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -29,8 +29,13 @@
 
 {% if not current_user.is_anonymous() %}
     <li class="dropdown">
-      <a class="dropdown-toggle" data-toggle="dropdown" title="{{g.user.get_full_name()}}" href="#">
-        <span class="fa fa-user fa-lg" title=""></span><b class="caret"></b>
+      <a
+        class="dropdown-toggle"
+        data-toggle="dropdown"
+        title="{{g.user.get_full_name()}}"
+        href="javascript:void(0)"
+      >
+        <i class="fa fa-user"></i>&nbsp;<b class="caret"></b>
       </a>
         <ul class="dropdown-menu">
             <li><a href="{{appbuilder.get_url_for_userinfo}}"><span class="fa fa-fw fa-user"></span>{{_("Profile")}}</a></li>


### PR DESCRIPTION
- makes logo and nav items all aligned on the same base line
- use smaller icons for git/doc/login items for consistency

<img width="1280" alt="screenshot 2016-12-06 21 22 17" src="https://cloud.githubusercontent.com/assets/130878/20955704/19d4dad4-bbfa-11e6-863e-a433d14efb8f.png">


plz review @elibrumbaugh @airbnb/superset-reviewers 