### PR TITLE
Add schema name to output column in query history

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -123,7 +123,15 @@ class QueryTable extends React.PureComponent {
           />
         );
       } else {
-        q.output = q.tempTable;
+        const schema = q.schema ? q.schema : '';
+        const tempTable = q.tempTable ? q.tempTable : '';
+        q.output = (
+          <div>
+            <span>
+              {schema} <br /> {tempTable}
+            </span>
+          </div>
+        );
       }
       q.progress = (
         <ProgressBar

--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -123,15 +123,7 @@ class QueryTable extends React.PureComponent {
           />
         );
       } else {
-        const schema = q.schema ? q.schema : '';
-        const tempTable = q.tempTable ? q.tempTable : '';
-        q.output = (
-          <div>
-            <span>
-              {schema} <br /> {tempTable}
-            </span>
-          </div>
-        );
+        q.output = [q.schema, q.tempTable].filter((v) => (v)).join('.');
       }
       q.progress = (
         <ProgressBar

--- a/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -74,7 +74,7 @@ class SqlEditor extends React.PureComponent {
       sqlEditorId: qe.id,
       tab: qe.title,
       schema: qe.schema,
-      tempTableName: this.state.ctas,
+      tempTableName: ctas ? this.state.ctas : '',
       runAsync,
       ctas,
     };


### PR DESCRIPTION
Issue: 
 - temp table name is shown in output when query is not run using ctas [https://github.com/airbnb/superset/issues/1745](url)
 - schema name is not shown in output [https://github.com/airbnb/superset/issues/1708](url)

Done:
 - when query was not run as ctas, leave output column empty
 - add schema name before temp table name for queries run using ctas

needs-review @ascott @bkyryliuk @mistercrunch 
