### PR TITLE
[sqllab] Fix sql expression bug with count distinct metrics

### DIFF
--- a/superset/models.py
+++ b/superset/models.py
@@ -1020,7 +1020,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable, ImportMixin):
                 "Datetime column not provided as part table configuration "
                 "and is required by this type of chart"))
         for m in metrics:
-            if not m in metrics_dict:
+            if m not in metrics_dict:
                 raise Exception(_("Metric '{}' is not valid".format(m)))
         metrics_exprs = [metrics_dict.get(m).sqla_col for m in metrics]
         timeseries_limit_metric = metrics_dict.get(timeseries_limit_metric)

--- a/superset/models.py
+++ b/superset/models.py
@@ -1019,7 +1019,9 @@ class SqlaTable(Model, Queryable, AuditMixinNullable, ImportMixin):
             raise Exception(_(
                 "Datetime column not provided as part table configuration "
                 "and is required by this type of chart"))
-
+        for m in metrics:
+            if not m in metrics_dict:
+                raise Exception(_("Metric '{}' is not valid".format(m)))
         metrics_exprs = [metrics_dict.get(m).sqla_col for m in metrics]
         timeseries_limit_metric = metrics_dict.get(timeseries_limit_metric)
         timeseries_limit_metric_expr = None

--- a/superset/views.py
+++ b/superset/views.py
@@ -2199,10 +2199,16 @@ class Superset(BaseSupersetView):
                 dims.append(col)
             agg = config.get('agg')
             if agg:
-                metrics.append(models.SqlMetric(
-                    metric_name="{agg}__{column_name}".format(**locals()),
-                    expression="{agg}({column_name})".format(**locals()),
-                ))
+                if agg == 'count_distinct':
+                    metrics.append(models.SqlMetric(
+                        metric_name="{agg}__{column_name}".format(**locals()),
+                        expression="COUNT(DISTINCT {column_name})".format(**locals()),
+                    ))
+                else:
+                    metrics.append(models.SqlMetric(
+                        metric_name="{agg}__{column_name}".format(**locals()),
+                        expression="{agg}({column_name})".format(**locals()),
+                    ))
         if not metrics:
             metrics.append(models.SqlMetric(
                 metric_name="count".format(**locals()),

--- a/superset/views.py
+++ b/superset/views.py
@@ -2202,7 +2202,8 @@ class Superset(BaseSupersetView):
                 if agg == 'count_distinct':
                     metrics.append(models.SqlMetric(
                         metric_name="{agg}__{column_name}".format(**locals()),
-                        expression="COUNT(DISTINCT {column_name})".format(**locals()),
+                        expression="COUNT(DISTINCT {column_name})"
+                        .format(**locals()),
                     ))
                 else:
                     metrics.append(models.SqlMetric(


### PR DESCRIPTION
Issues solved:
 - when metrics is not valid in query(), the error message gives 'NoneType' has no attribute sqla_col, which is not very descriptive
 - count_distinct was transfered to count_distinct(col) expression in sqllab_viz

Todo:
 - refactor all metrics_creation PR to a consistent place

needs-review @mistercrunch @bkyryliuk 