### PR TITLE
Replace stack trace with error message in explorev2

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/store.js
+++ b/superset/assets/javascripts/explorev2/stores/store.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { sectionsToRender } from './visTypes';
 import fields from './fields';
+import { getExploreUrl } from '../exploreUtils';
 
 export function defaultFormData(vizType = 'table', datasourceType = 'table') {
   const data = {
@@ -13,7 +14,11 @@ export function defaultFormData(vizType = 'table', datasourceType = 'table') {
   sections.forEach((section) => {
     section.fieldSetRows.forEach((fieldSetRow) => {
       fieldSetRow.forEach((k) => {
-        data[k] = fields[k].default;
+        if (k === 'viz_type') {
+          data[k] = vizType;
+        } else {
+          data[k] = fields[k].default;
+        }
       });
     });
   });
@@ -21,18 +26,19 @@ export function defaultFormData(vizType = 'table', datasourceType = 'table') {
 }
 
 export function defaultViz(vizType, datasourceType = 'table') {
+  const form_data = defaultFormData(vizType, datasourceType);
   return {
     cached_key: null,
     cached_timeout: null,
     cached_dttm: null,
     column_formats: null,
-    csv_endpoint: null,
+    csv_endpoint: getExploreUrl(form_data, datasourceType, 'csv'),
     is_cached: false,
     data: [],
-    form_data: defaultFormData(vizType, datasourceType),
-    json_endpoint: null,
+    form_data,
+    json_endpoint: getExploreUrl(form_data, datasourceType, 'json'),
     query: null,
-    standalone_endpoint: null,
+    standalone_endpoint: getExploreUrl(form_data, datasourceType, 'standalone'),
   };
 }
 

--- a/superset/views.py
+++ b/superset/views.py
@@ -1486,13 +1486,16 @@ class Superset(BaseSupersetView):
                 "datasource_name": viz_obj.datasource.name,
                 "datasource_type": datasource_type,
                 "user_id": g.user.get_id() if g.user else None,
-                "viz": json.loads(viz_obj.get_json())
             }
             table_name = viz_obj.datasource.table_name \
                 if datasource_type == 'table' \
                 else viz_obj.datasource.datasource_name
-            return self.render_template(
-                "superset/explorev2.html",
+            try:
+                viz_json = json.loads(viz_obj.get_json())
+                bootstrap_data["viz"] = viz_json
+            except Exception as e:
+                bootstrap_data["error"] = str(e)
+            return self.render_template("superset/explorev2.html",
                 bootstrap_data=json.dumps(bootstrap_data),
                 slice=slc,
                 table_name=table_name)


### PR DESCRIPTION
Before:
 - when there are errors in viz.get_json, bootstrap_data is not loaded, stack trace is shown (this happens when user refreshes the page with wrong form_data)
![screen shot 2016-12-12 at 5 25 14 pm](https://cloud.githubusercontent.com/assets/20978302/21123837/02d26f0a-c090-11e6-86e7-940519c46694.png)


After:
 - actual error message is shown in ChartContainer when user refresh the page with wrong form_data, and viz_type is set back to 'table'

needs-review @ascott @mistercrunch 

