### PR TITLE
Workaround for slices "Not Found" issue in IE <= 11

### DIFF
--- a/superset/assets/javascripts/modules/superset.js
+++ b/superset/assets/javascripts/modules/superset.js
@@ -107,6 +107,11 @@ const px = function () {
         const parser = document.createElement('a');
         parser.href = data.json_endpoint;
         let endpoint = parser.pathname + this.querystring();
+        if (endpoint.charAt(0) !== '/') {
+          // Known issue for IE <= 11:
+          // https://connect.microsoft.com/IE/feedbackdetail/view/1002846/pathname-incorrect-for-out-of-document-elements
+          endpoint = '/' + endpoint;
+        }
         endpoint += '&json=true';
         endpoint += '&force=' + this.force;
         return endpoint;


### PR DESCRIPTION
This should fix issue #1339.

IE 11 and lower have a long standing issue: out-of-document element's
pathname has no leading '/'. See [Pathname incorrect for out-of-document elements](https://connect.microsoft.com/IE/feedbackdetail/view/1002846/pathname-incorrect-for-out-of-document-elements) at Microsoft side (it's marked as fixed but apparently not...).

And Superset's `Slice.jsonEndpoint()` method relies on `pathname()` to build
JSON API URL for slices:

```javascript
      jsonEndpoint() {
        const parser = document.createElement('a');
        parser.href = data.json_endpoint;
        let endpoint = parser.pathname + this.querystring();
        endpoint += '&json=true';
        endpoint += '&force=' + this.force;
        return endpoint;
      },
```

`parser` above is exactly an out-of-document element. Therefore when
running in IE <= 11, Superset would build wrong JSON endpoint URLs,
hence the 404 errors for loading data for slices.

This commit adds a simple workaround when leading '/' is missing in the
value returned by pathname().