### PR TITLE
Add force_ctas_schema to query model when enabled

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -123,7 +123,10 @@ class QueryTable extends React.PureComponent {
           />
         );
       } else {
-        q.output = [q.schema, q.tempTable].filter((v) => (v)).join('.');
+        // if query was run using ctas and force_ctas_schema was set
+        // tempTable will have the schema
+        const schemaUsed = q.ctas && q.tempTable.includes('.') ? '' : q.schema;
+        q.output = [schemaUsed, q.tempTable].filter((v) => (v)).join('.');
       }
       q.progress = (
         <ProgressBar

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -55,8 +55,6 @@ def create_table_as(sql, table_name, schema=None, override=False):
     # TODO(bkyryliuk): drop table if allowed, check the namespace and
     #                  the permissions.
     # TODO raise if multi-statement
-    if schema:
-        table_name = schema + '.' + table_name
     exec_sql = ''
     if override:
         exec_sql = 'DROP TABLE IF EXISTS {table_name};\n'

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -40,7 +40,7 @@ def dedup(l, suffix='__'):
     return new_l
 
 
-def create_table_as(sql, table_name, schema=None, override=False):
+def create_table_as(sql, table_name, override=False):
     """Reformats the query into the create table as query.
 
     Works only for the single select SQL statements, in all other cases
@@ -103,7 +103,7 @@ def get_sql_results(self, query_id, return_results=True, store_results=False):
                 query.user_id,
                 start_dttm.strftime('%Y_%m_%d_%H_%M_%S'))
         executed_sql = create_table_as(
-            executed_sql, query.tmp_table_name, database.force_ctas_schema)
+            executed_sql, query.tmp_table_name)
         query.select_as_cta_used = True
     elif (
             query.limit and superset_query.is_select() and

--- a/superset/views.py
+++ b/superset/views.py
@@ -2384,20 +2384,24 @@ class Superset(BaseSupersetView):
         session.commit()
 
         select_as_cta = request.form.get('select_as_cta') == 'true'
+        tmp_table_name = request.form.get('tmp_table_name')
         if select_as_cta and mydb.force_ctas_schema:
-            schema = mydb.force_ctas_schema
+            tmp_table_name = '{}.{}'.format(
+                mydb.force_ctas_schema,
+                tmp_table_name
+            )
 
         query = models.Query(
             database_id=int(database_id),
             limit=int(app.config.get('SQL_MAX_ROW', None)),
             sql=sql,
             schema=schema,
-            select_as_cta=select_as_cta,
+            select_as_cta=request.form.get('select_as_cta') == 'true',
             start_time=utils.now_as_float(),
             tab_name=request.form.get('tab'),
             status=QueryStatus.PENDING if async else QueryStatus.RUNNING,
             sql_editor_id=request.form.get('sql_editor_id'),
-            tmp_table_name=request.form.get('tmp_table_name'),
+            tmp_table_name=tmp_table_name,
             user_id=int(g.user.get_id()),
             client_id=request.form.get('client_id'),
         )

--- a/superset/views.py
+++ b/superset/views.py
@@ -2383,12 +2383,16 @@ class Superset(BaseSupersetView):
                 get_datasource_access_error_msg('{}'.format(rejected_tables)))
         session.commit()
 
+        select_as_cta = request.form.get('select_as_cta') == 'true'
+        if select_as_cta and mydb.force_ctas_schema:
+            schema = mydb.force_ctas_schema
+
         query = models.Query(
             database_id=int(database_id),
             limit=int(app.config.get('SQL_MAX_ROW', None)),
             sql=sql,
             schema=schema,
-            select_as_cta=request.form.get('select_as_cta') == 'true',
+            select_as_cta=select_as_cta,
             start_time=utils.now_as_float(),
             tab_name=request.form.get('tab'),
             status=QueryStatus.PENDING if async else QueryStatus.RUNNING,


### PR DESCRIPTION
Before:
 - force_ctas_schema is not passed to Query model when enabled, the output column of Query Table  does not receive schema from backend unless it is set in query editor

After:
 - when force_ctas_schema is set, it gets stored in query, and will be displayed in output column of QueryHistory if the query was run using ctas

Tested in staging: 
 - Use case one: run query with selected schema in left pane
1. set schema in sql editor left pane
2. run a query
3. schema is shown in output column of Query History

 - Use case two: run query with ctas on a database with force_ctas_schema
 1. set schema in database view
 2. run a query using ctas
 3. schema.table_name is shown in output column of Query History

 - Use case three: run query with selected schema and ctas 
1. set schema in sql editor left pane
2. run a query using ctas
3. schema.table_name is shown in output column of Query History

Todo:
 - [https://github.com/airbnb/superset/issues/1850](url)
needs-review @bkyryliuk @mistercrunch 
