### PR TITLE
[explorev2] no bootstrap data, just metadata in exploreV2

### DIFF
--- a/superset/views.py
+++ b/superset/views.py
@@ -1492,7 +1492,7 @@ class Superset(BaseSupersetView):
                 "datasource_name": viz_obj.datasource.name,
                 "datasource_type": datasource_type,
                 "user_id": user_id,
-                "viz": json.loads(viz_obj.get_json())
+                "viz": json.loads(viz_obj.json_data)
             }
             table_name = viz_obj.datasource.table_name \
                 if datasource_type == 'table' \


### PR DESCRIPTION
json_data really just returns the *metadata* for the slice, where
get_json returns both the metadata and the data