### PR TITLE
Stop ChartContainer from rendering twice on chartStatus change

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -163,6 +163,7 @@ class ChartContainer extends React.Component {
       this.state.viz.render();
     }
     if (heightChange) {
+      this.state.viz.render();
       this.state.viz.resize();
     }
   }

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -56,7 +56,7 @@ class ChartContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.renderVis();
+    this.renderVisOnChange();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -76,7 +76,7 @@ class ChartContainer extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    this.renderVis(prevProps.height !== this.props.height);
+    this.renderVisOnChange(prevProps.height !== this.props.height);
   }
 
   getMockedSliceObject(props) {
@@ -158,7 +158,7 @@ class ChartContainer extends React.Component {
     this.props.actions.removeChartAlert();
   }
 
-  renderVis(heightChange) {
+  renderVisOnChange(heightChange) {
     if (this.props.chartStatus === 'loading') {
       this.state.viz.render();
     }

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -182,13 +182,21 @@ class ChartContainer extends React.Component {
     return (
       <div>
         {loading &&
-          <img alt="loading" width="25" src="/static/assets/images/loading.gif" />
+          <img
+            alt="loading"
+            width="25"
+            src="/static/assets/images/loading.gif"
+            style={{ position: 'absolute' }}
+          />
         }
         <div
           id={this.props.containerId}
           ref={(ref) => { this.chartContainerRef = ref; }}
           className={this.props.viz_type}
-          style={{ overflowX: 'auto' }}
+          style={{
+            overflowX: 'auto',
+            opacity: loading ? '0.25' : '1',
+          }}
         />
       </div>
     );

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -56,11 +56,11 @@ class ChartContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.renderVisOnChange();
+    this.state.viz.render();
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.chartStatus !== this.props.chartStatus) {
+    if (nextProps.chartStatus === 'loading') {
       const mockSlice = this.getMockedSliceObject(nextProps);
       this.setState({
         mockSlice,
@@ -69,13 +69,13 @@ class ChartContainer extends React.Component {
     }
   }
 
-  shouldComponentUpdate(nextProps) {
-    return (nextProps.chartStatus !== this.props.chartStatus
-      || nextProps.height !== this.props.height);
-  }
-
   componentDidUpdate(prevProps) {
-    this.renderVisOnChange(prevProps.height !== this.props.height);
+    if (this.props.chartStatus === 'loading') {
+      this.state.viz.render();
+    }
+    if (prevProps.height !== this.props.height) {
+      this.state.viz.resize();
+    }
   }
 
   getMockedSliceObject(props) {
@@ -155,15 +155,6 @@ class ChartContainer extends React.Component {
 
   removeAlert() {
     this.props.actions.removeChartAlert();
-  }
-
-  renderVisOnChange(heightChange) {
-    if (this.props.chartStatus === 'loading') {
-      this.state.viz.render();
-    }
-    if (heightChange) {
-      this.state.viz.resize(this.state.chart);
-    }
   }
 
   renderChartTitle() {

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -60,8 +60,7 @@ class ChartContainer extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.chartStatus !== this.props.chartStatus
-      || nextProps.height !== this.props.height) {
+    if (nextProps.chartStatus !== this.props.chartStatus) {
       const mockSlice = this.getMockedSliceObject(nextProps);
       this.setState({
         mockSlice,
@@ -105,7 +104,7 @@ class ChartContainer extends React.Component {
           // should call callback to adjust height of chart
           $(this.state.selector).css(dim, size);
         },
-        height: () => parseInt(props.height, 10) - 100,
+        height: () => parseInt(this.props.height, 10) - 100,
 
         show: () => { this.render(); },
 
@@ -117,7 +116,7 @@ class ChartContainer extends React.Component {
 
       width: () => this.chartContainerRef.getBoundingClientRect().width,
 
-      height: () => parseInt(props.height, 10) - 100,
+      height: () => parseInt(this.props.height, 10) - 100,
 
       selector: this.state.selector,
 
@@ -163,8 +162,7 @@ class ChartContainer extends React.Component {
       this.state.viz.render();
     }
     if (heightChange) {
-      this.state.viz.render();
-      this.state.viz.resize();
+      this.state.viz.resize(this.state.chart);
     }
   }
 

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -66,8 +66,8 @@ class ChartContainer extends React.Component {
       || nextProps.height !== this.props.height);
   }
 
-  componentDidUpdate() {
-    this.renderVis();
+  componentDidUpdate(prevProps) {
+    this.renderVis(prevProps.height !== this.props.height);
   }
 
   getMockedSliceObject(props) {
@@ -149,8 +149,10 @@ class ChartContainer extends React.Component {
     this.props.actions.removeChartAlert();
   }
 
-  renderVis() {
-    visMap[this.props.viz_type](this.state.mockSlice).render();
+  renderVis(heightChange) {
+    if (this.props.chartStatus === 'loading' || heightChange) {
+      visMap[this.props.viz_type](this.state.mockSlice).render();
+    }
   }
 
   renderChartTitle() {

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -43,11 +43,16 @@ class ChartContainer extends React.Component {
     this.state = {
       selector: `#${props.containerId}`,
       mockSlice: {},
+      viz: {},
     };
   }
 
   componentWillMount() {
-    this.setState({ mockSlice: this.getMockedSliceObject(this.props) });
+    const mockSlice = this.getMockedSliceObject(this.props);
+    this.setState({
+      mockSlice,
+      viz: visMap[this.props.viz_type](mockSlice),
+    });
   }
 
   componentDidMount() {
@@ -57,7 +62,11 @@ class ChartContainer extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.chartStatus !== this.props.chartStatus
       || nextProps.height !== this.props.height) {
-      this.setState({ mockSlice: this.getMockedSliceObject(nextProps) });
+      const mockSlice = this.getMockedSliceObject(nextProps);
+      this.setState({
+        mockSlice,
+        viz: visMap[nextProps.viz_type](mockSlice),
+      });
     }
   }
 
@@ -150,8 +159,11 @@ class ChartContainer extends React.Component {
   }
 
   renderVis(heightChange) {
-    if (this.props.chartStatus === 'loading' || heightChange) {
-      visMap[this.props.viz_type](this.state.mockSlice).render();
+    if (this.props.chartStatus === 'loading') {
+      this.state.viz.render();
+    }
+    if (heightChange) {
+      this.state.viz.resize();
     }
   }
 

--- a/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
@@ -28,7 +28,6 @@ class ExploreViewContainer extends React.Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize.bind(this));
-    this.props.actions.updateChartStatus('success');
   }
 
   componentWillReceiveProps(nextProps) {

--- a/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
@@ -63,7 +63,10 @@ class ExploreViewContainer extends React.Component {
   }
 
   handleResize() {
-    this.setState({ height: this.getHeight() });
+    clearTimeout(this.resizeTimer);
+    this.resizeTimer = setTimeout(() => {
+      this.setState({ height: this.getHeight() });
+    }, 250);
   }
 
   toggleModal() {

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -57,10 +57,6 @@ function nvd3Vis(slice) {
   let chart;
   let colorKey = 'key';
 
-  const getChart = function () {
-    return chart;
-  };
-
   const render = function () {
     d3.json(slice.jsonEndpoint(), function (error, payload) {
       slice.container.html('');
@@ -376,6 +372,8 @@ function nvd3Vis(slice) {
 
   const update = function () {
     if (chart && chart.update) {
+      chart.height(slice.height());
+      chart.width(slice.width());
       chart.update();
     }
   };
@@ -384,7 +382,6 @@ function nvd3Vis(slice) {
   return {
     render,
     resize: update,
-    getChart,
   };
 }
 

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -57,6 +57,9 @@ function nvd3Vis(slice) {
   let chart;
   let colorKey = 'key';
 
+  const getChart = function () {
+    return chart;
+  };
 
   const render = function () {
     d3.json(slice.jsonEndpoint(), function (error, payload) {
@@ -381,6 +384,7 @@ function nvd3Vis(slice) {
   return {
     render,
     resize: update,
+    getChart,
   };
 }
 


### PR DESCRIPTION
Before:
 - ChartContainer renders twice for each query, one rendering happened when ChartStatus changed from previous status to loading, another at ChartStatus switching from loading to success
![giphy 25](https://cloud.githubusercontent.com/assets/20978302/21156073/5cc63a3e-c129-11e6-920f-61ba4525e593.gif)

 - spinner position is relative, shifting chart downwards while loading

After:
 - renderVis is only called when ChartStatus is changed to loading (meaning ChartUpdate started), or if there's a height change (at browser window resize)
 - chart is dimmed while loading and spinner is put on top as overlay
 - timeout is added to resize handler to prevent over-triggering

![giphy 26](https://cloud.githubusercontent.com/assets/20978302/21158742/4b0de5ee-c133-11e6-9714-4a5f79ac12d7.gif)
![giphy 27](https://cloud.githubusercontent.com/assets/20978302/21163184/6adef8dc-c146-11e6-8383-09a9b5240976.gif)


needs-review @ascott @mistercrunch 
