### PR TITLE
Add ADDITIONAL_MIDDLEWARE option to config

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -304,6 +304,30 @@ The following keys in `superset_config.py` can be specified to configure CORS:
 * ``ENABLE_CORS``: Must be set to True in order to enable CORS
 * ``CORS_OPTIONS``: options passed to Flask-CORS (`documentation <http://flask-cors.corydolphin.com/en/latest/api.html#extension>`)
 
+
+MIDDLEWARE
+----------
+
+Superset allows you to add your own middleware. To add your own middleware, update the ``ADDITIONAL_MIDDLEWARE`` key in
+your `superset_config.py`. ``ADDITIONAL_MIDDLEWARE`` should be a list of your additional middleware classes.
+
+For example, to use AUTH_REMOTE_USER from behind a proxy server like nginx, you have to add a simple middleware class to
+add the value of ``HTTP_X_PROXY_REMOTE_USER`` (or any other custom header from the proxy) to Gunicorn's ``REMOTE_USER``
+environment variable: ::
+
+    class RemoteUserMiddleware(object):
+        def __init__(self, app):
+            self.app = app
+        def __call__(self, environ, start_response):
+            user = environ.pop('HTTP_X_PROXY_REMOTE_USER', None)
+            environ['REMOTE_USER'] = user
+            return self.app(environ, start_response)
+
+    ADDITIONAL_MIDDLEWARE = [RemoteUserMiddleware, ]
+
+*Adapted from http://flask.pocoo.org/snippets/69/*
+
+
 Upgrading
 ---------
 

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -64,6 +64,9 @@ if app.config.get('UPLOAD_FOLDER'):
     except OSError:
         pass
 
+for middleware in app.config.get('ADDITIONAL_MIDDLEWARE'):
+    app.wsgi_app = middleware(app.wsgi_app)
+
 
 class MyIndexView(IndexView):
     @expose('/')

--- a/superset/config.py
+++ b/superset/config.py
@@ -168,10 +168,11 @@ VIZ_TYPE_BLACKLIST = []
 DRUID_DATA_SOURCE_BLACKLIST = []
 
 # --------------------------------------------------
-# Modules and datasources to be registered
+# Modules, datasources and middleware to be registered
 # --------------------------------------------------
 DEFAULT_MODULE_DS_MAP = {'superset.models': ['DruidDatasource', 'SqlaTable']}
 ADDITIONAL_MODULE_DS_MAP = {}
+ADDITIONAL_MIDDLEWARE = []
 
 """
 1) http://docs.python-guide.org/en/latest/writing/logging/


### PR DESCRIPTION
Expose `ADDITIONAL_MIDDLEWARE` key in config to allow users to specify their own middleware to be added to Superset. My use case for this is to get `AUTH_REMOTE_USER` working from behind an nginx proxy without needing to make my own build.

For example, with this pull request, I can now use `AUTH_REMOTE_USER` by adding a simple middleware class to the ``ADDITIONAL_MIDDLEWARE`` key in `superset_config.py`. This middleware simply copies the value of `HTTP_X_PROXY_REMOTE_USER` (or any other custom header from the proxy) to Gunicorn's `REMOTE_USER` environment variable: 

```python
# superset_config.py

class RemoteUserMiddleware(object):
    def __init__(self, app):
        self.app = app
    def __call__(self, environ, start_response):
        user = environ.pop('HTTP_X_PROXY_REMOTE_USER', None)
        environ['REMOTE_USER'] = user
        return self.app(environ, start_response)

ADDITIONAL_MIDDLEWARE = [RemoteUserMiddleware, ]

```

* Example adapted from from http://flask.pocoo.org/snippets/69/*.