### PR TITLE
[explorev2] improving the scrolling/scrollbars placement

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -196,7 +196,6 @@ class ChartContainer extends React.Component {
           ref={(ref) => { this.chartContainerRef = ref; }}
           className={this.props.viz_type}
           style={{
-            overflowX: 'auto',
             opacity: loading ? '0.25' : '1',
           }}
         />

--- a/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
@@ -61,56 +61,52 @@ class ControlPanelsContainer extends React.Component {
 
   render() {
     return (
-      <Panel>
-        {this.props.alert &&
-          <Alert bsStyle="warning">
-            {this.props.alert}
-            <i
-              className="fa fa-close pull-right"
-              onClick={this.removeAlert.bind(this)}
-              style={{ cursor: 'pointer' }}
-            />
-          </Alert>
-        }
-        {!this.props.isDatasourceMetaLoading &&
-          <div className="scrollbar-container">
-            <div className="scrollbar-content">
-              {this.sectionsToRender().map((section) => (
-                <ControlPanelSection
-                  key={section.label}
-                  label={section.label}
-                  tooltip={section.description}
-                >
-                  {section.fieldSetRows.map((fieldSets, i) => (
-                    <FieldSetRow
-                      key={`${section.label}-fieldSetRow-${i}`}
-                      fieldSets={fieldSets}
-                      fieldOverrides={this.fieldOverrides()}
-                      onChange={this.onChange.bind(this)}
-                      fields={this.props.fields}
-                      form_data={this.props.form_data}
-                    />
-                  ))}
-                </ControlPanelSection>
+      <div className="scrollbar-container">
+        <Panel className="scrollbar-content">
+          {this.props.alert &&
+            <Alert bsStyle="warning">
+              {this.props.alert}
+              <i
+                className="fa fa-close pull-right"
+                onClick={this.removeAlert.bind(this)}
+                style={{ cursor: 'pointer' }}
+              />
+            </Alert>
+          }
+          {!this.props.isDatasourceMetaLoading && this.sectionsToRender().map((section) => (
+            <ControlPanelSection
+              key={section.label}
+              label={section.label}
+              tooltip={section.description}
+            >
+              {section.fieldSetRows.map((fieldSets, i) => (
+                <FieldSetRow
+                  key={`${section.label}-fieldSetRow-${i}`}
+                  fieldSets={fieldSets}
+                  fieldOverrides={this.fieldOverrides()}
+                  onChange={this.onChange.bind(this)}
+                  fields={this.props.fields}
+                  form_data={this.props.form_data}
+                />
               ))}
-              {this.filterSectionsToRender().map((section) => (
-                <ControlPanelSection
-                  key={section.label}
-                  label={section.label}
-                  tooltip={section.description}
-                >
-                  <Filters
-                    filterColumnOpts={[]}
-                    filters={this.props.form_data.filters}
-                    actions={this.props.actions}
-                    prefix={section.prefix}
-                  />
-                </ControlPanelSection>
-              ))}
-            </div>
-          </div>
-        }
-      </Panel>
+            </ControlPanelSection>
+          ))}
+          {this.filterSectionsToRender().map((section) => (
+            <ControlPanelSection
+              key={section.label}
+              label={section.label}
+              tooltip={section.description}
+            >
+              <Filters
+                filterColumnOpts={[]}
+                filters={this.props.form_data.filters}
+                actions={this.props.actions}
+                prefix={section.prefix}
+              />
+            </ControlPanelSection>
+          ))}
+        </Panel>
+      </div>
     );
   }
 }

--- a/superset/assets/javascripts/explorev2/main.css
+++ b/superset/assets/javascripts/explorev2/main.css
@@ -11,9 +11,8 @@
   left: 0px;
   right: 0px;
   bottom: 0px;
-  overflow: scroll;
+  overflow-y: auto;
   margin-right: 0px;
-  margin-bottom: 100px;
 }
 
 .fave-unfave-icon, .edit-desc-icon {


### PR DESCRIPTION
For the controls, moving the scrollbar outside the panel as opposed to inside the panel.
Before:
<img width="409" alt="screen shot 2016-12-14 at 3 08 57 pm" src="https://cloud.githubusercontent.com/assets/487433/21205343/936dee14-c210-11e6-9692-c208529d066d.png">
After:
<img width="408" alt="screen shot 2016-12-14 at 3 18 03 pm" src="https://cloud.githubusercontent.com/assets/487433/21205342/936b89a8-c210-11e6-8a68-4400b22d380b.png">

Also, in v1, the chart container doesn't allow to overflow-x, unless the viz's CSS override that. Matching this behavior here so that the table view doesn't show an X axis scrollbar.