### PR TITLE
Basic integration with ClickHouse

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -211,6 +211,9 @@ Here's a list of some of the recommended packages.
 |  Vertica      | ``pip install                       |  ``vertica+vertica_python://``                  |
 |               | sqlalchemy-vertica-python``         |                                                 |
 +---------------+-------------------------------------+-------------------------------------------------+
+|  ClickHouse   | ``pip install                       | ``clickhouse://``                               |
+|               | sqlalchemy-clickhouse``             |                                                 |
++---------------+-------------------------------------+-------------------------------------------------+
 
 Note that many other database are supported, the main criteria being the
 existence of a functional SqlAlchemy dialect and Python driver. Googling

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -632,8 +632,7 @@ class SqlaTable(Model, BaseDatasource):
             if not any_date_col and dbcol.is_time:
                 any_date_col = col.name
 
-            quoted = "{}".format(
-                column(dbcol.column_name).compile(dialect=db_dialect))
+            quoted = "{}".format(col.compile(dialect=db_dialect))
             if dbcol.sum:
                 metrics.append(M(
                     metric_name='sum__' + dbcol.column_name,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -370,6 +370,9 @@ class SqlaTable(Model, BaseDatasource):
         if granularity not in self.dttm_cols:
             granularity = self.main_dttm_col
 
+        # Database spec supports join-free timeslot grouping
+        time_groupby_inline = self.database.db_engine_spec.time_groupby_inline
+
         cols = {col.column_name: col for col in self.columns}
         metrics_dict = {m.metric_name: m for m in self.metrics}
 
@@ -522,7 +525,7 @@ class SqlaTable(Model, BaseDatasource):
 
         qry = qry.limit(row_limit)
 
-        if is_timeseries and timeseries_limit and groupby:
+        if is_timeseries and timeseries_limit and groupby and not time_groupby_inline:
             # some sql dialects require for order by expressions
             # to also be in the select clause -- others, e.g. vertica,
             # require a unique inner alias

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -50,6 +50,7 @@ class BaseEngineSpec(object):
     engine = 'base'  # str as defined in sqlalchemy.engine.engine
     cursor_execute_kwargs = {}
     time_grains = tuple()
+    time_groupby_inline = False
     limit_method = LimitMethod.FETCH_MANY
 
     @classmethod

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -865,6 +865,40 @@ class AthenaEngineSpec(BaseEngineSpec):
     def epoch_to_dttm(cls):
         return "from_unixtime({col})"
 
+class ClickHouseEngineSpec(BaseEngineSpec):
+
+    """Dialect for ClickHouse analytical DB."""
+
+    engine = 'clickhouse'
+
+    time_groupby_inline = True
+    time_grains = (
+        Grain('Time Column', _('Time Column'), '{col}'),
+        Grain('minute', _('minute'),
+              "toStartOfMinute(toDateTime({col}))"),
+        Grain('5 minute', _('5 minute'),
+              "toDateTime(intDiv(toUInt32(toDateTime({col})), 300)*300)"),
+        Grain('10 minute', _('10 minute'),
+              "toDateTime(intDiv(toUInt32(toDateTime({col})), 600)*600)"),
+        Grain('hour', _('hour'),
+              "toStartOfHour(toDateTime({col}))"),
+        Grain('month', _('month'),
+              "toStartOfMonth(toDateTime({col}))"),
+        Grain('quarter', _('quarter'),
+              "toStartOfQuarter(toDateTime({col}))"),
+        Grain('year', _('year'),
+              "toStartOfYear(toDateTime({col}))"),
+    )
+
+    @classmethod
+    def convert_dttm(cls, target_type, dttm):
+        tt = target_type.upper()
+        if tt == 'DATE':
+            return "toDate('{}')".format(dttm.strftime('%Y-%m-%d'))
+        if tt == 'DATETIME':
+            return "toDateTime('{}')".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
+        return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
+
 engines = {
     o.engine: o for o in globals().values()
     if inspect.isclass(o) and issubclass(o, BaseEngineSpec)}

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -867,8 +867,8 @@ class AthenaEngineSpec(BaseEngineSpec):
     def epoch_to_dttm(cls):
         return "from_unixtime({col})"
 
-class ClickHouseEngineSpec(BaseEngineSpec):
 
+class ClickHouseEngineSpec(BaseEngineSpec):
     """Dialect for ClickHouse analytical DB."""
 
     engine = 'clickhouse'
@@ -901,7 +901,8 @@ class ClickHouseEngineSpec(BaseEngineSpec):
         if tt == 'DATE':
             return "toDate('{}')".format(dttm.strftime('%Y-%m-%d'))
         if tt == 'DATETIME':
-            return "toDateTime('{}')".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
+            return "toDateTime('{}')".format(
+                dttm.strftime('%Y-%m-%d %H:%M:%S'))
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
 engines = {

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -52,6 +52,7 @@ class BaseEngineSpec(object):
     time_grains = tuple()
     time_groupby_inline = False
     limit_method = LimitMethod.FETCH_MANY
+    time_secondary_columns = False
 
     @classmethod
     def fetch_data(cls, cursor, limit):
@@ -872,6 +873,7 @@ class ClickHouseEngineSpec(BaseEngineSpec):
 
     engine = 'clickhouse'
 
+    time_secondary_columns = True
     time_groupby_inline = True
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}'),
@@ -883,6 +885,8 @@ class ClickHouseEngineSpec(BaseEngineSpec):
               "toDateTime(intDiv(toUInt32(toDateTime({col})), 600)*600)"),
         Grain('hour', _('hour'),
               "toStartOfHour(toDateTime({col}))"),
+        Grain('day', _('day'),
+              "toStartOfDay(toDateTime({col}))"),
         Grain('month', _('month'),
               "toStartOfMonth(toDateTime({col}))"),
         Grain('quarter', _('quarter'),

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -130,7 +130,9 @@ class BaseViz(object):
         # [column_name in list_of_values]. `__` prefix is there to avoid
         # potential conflicts with column that would be named `from` or `to`
         since = (
-            extra_filters.get('__from') or form_data.get("since") or config.get("SUPERSET_DEFAULT_SINCE", "1 year ago")
+            extra_filters.get('__from') or
+            form_data.get("since") or
+            config.get("SUPERSET_DEFAULT_SINCE", "1 year ago")
         )
 
         from_dttm = utils.parse_human_datetime(since)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -130,7 +130,7 @@ class BaseViz(object):
         # [column_name in list_of_values]. `__` prefix is there to avoid
         # potential conflicts with column that would be named `from` or `to`
         since = (
-            extra_filters.get('__from') or form_data.get("since", "1 year ago")
+            extra_filters.get('__from') or form_data.get("since") or config.get("SUPERSET_DEFAULT_SINCE", "1 year ago")
         )
 
         from_dttm = utils.parse_human_datetime(since)


### PR DESCRIPTION
This PR adds integration with ClickHouse SQLAlchemy engine spec.

* [x] Adding database and tables works
* [x] Adding views works
* [x] Table, timeseries, group by, group by + timeseries works
* [x] Using secondary dttm columns (ClickHouse has often `date` + `datetime`, so timeseries needs to reference both)
* [x] Superset makes quoted (e.g. `AVG("column")`) metrics by default when it shouldn't, don't know why
* [x] Filter on INTEGER fields creates `column IN ("1", "2", ...)` SQL where values are quoted, this is wrong
* [x] Superset launches a query as soon as I create slice, this is bad as it potentially full-scans the whole database