### PR TITLE
[explorev2] making Datasource an Viz controls not clearable

### DIFF
--- a/superset/assets/javascripts/explorev2/components/SelectField.jsx
+++ b/superset/assets/javascripts/explorev2/components/SelectField.jsx
@@ -7,12 +7,13 @@ import Select, { Creatable } from 'react-select';
 const propTypes = {
   name: PropTypes.string.isRequired,
   choices: PropTypes.array,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]).isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
   label: PropTypes.string,
   description: PropTypes.string,
   onChange: PropTypes.func,
   multi: PropTypes.bool,
   freeForm: PropTypes.bool,
+  clearable: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -22,6 +23,7 @@ const defaultProps = {
   label: null,
   description: null,
   onChange: () => {},
+  clearable: true,
 };
 
 export default class SelectField extends React.Component {
@@ -50,10 +52,11 @@ export default class SelectField extends React.Component {
     return opt.label;
   }
   render() {
-    const options = this.props.choices.map((c) => ({ value: c[0], label: c[1] }));
+    const choices = this.props.choices || [];
+    const options = choices.map((c) => ({ value: c[0], label: c[1] }));
     if (this.props.freeForm) {
       // For FreeFormSelect, insert value into options if not exist
-      const values = this.props.choices.map((c) => c[0]);
+      const values = choices.map((c) => c[0]);
       if (values.indexOf(this.props.value) === -1) {
         options.push({ value: this.props.value, label: this.props.value });
       }
@@ -62,10 +65,11 @@ export default class SelectField extends React.Component {
     const selectProps = {
       multi: this.props.multi,
       name: `select-${this.props.name}`,
-      placeholder: `Select (${this.props.choices.length})`,
+      placeholder: `Select (${choices.length})`,
       options,
       value: this.props.value,
       autosize: false,
+      clearable: this.props.clearable,
       onChange: this.onChange.bind(this),
       optionRenderer: this.renderOption.bind(this),
     };

--- a/superset/assets/javascripts/explorev2/components/SelectField.jsx
+++ b/superset/assets/javascripts/explorev2/components/SelectField.jsx
@@ -5,25 +5,26 @@ import Select, { Creatable } from 'react-select';
 
 
 const propTypes = {
-  name: PropTypes.string.isRequired,
   choices: PropTypes.array,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
-  label: PropTypes.string,
-  description: PropTypes.string,
-  onChange: PropTypes.func,
-  multi: PropTypes.bool,
-  freeForm: PropTypes.bool,
   clearable: PropTypes.bool,
+  description: PropTypes.string,
+  freeForm: PropTypes.bool,
+  label: PropTypes.string,
+  multi: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
 };
 
 const defaultProps = {
-  multi: false,
-  freeForm: false,
-  value: '',
-  label: null,
-  description: null,
-  onChange: () => {},
+  choices: [],
   clearable: true,
+  description: null,
+  freeForm: false,
+  label: null,
+  multi: false,
+  onChange: () => {},
+  value: '',
 };
 
 export default class SelectField extends React.Component {
@@ -52,7 +53,7 @@ export default class SelectField extends React.Component {
     return opt.label;
   }
   render() {
-    const choices = this.props.choices || [];
+    const choices = this.props.choices;
     const options = choices.map((c) => ({ value: c[0], label: c[1] }));
     if (this.props.freeForm) {
       // For FreeFormSelect, insert value into options if not exist

--- a/superset/assets/javascripts/explorev2/stores/fields.js
+++ b/superset/assets/javascripts/explorev2/stores/fields.js
@@ -39,6 +39,7 @@ export const fields = {
   datasource: {
     type: 'SelectField',
     label: 'Datasource',
+    clearable: false,
     default: null,
     choices: [],
     description: '',
@@ -47,6 +48,7 @@ export const fields = {
   viz_type: {
     type: 'SelectField',
     label: 'Viz',
+    clearable: false,
     default: 'table',
     choices: formatSelectOptions(Object.keys(visTypes)),
     description: 'The type of visualization to display',


### PR DESCRIPTION
<img width="409" alt="screen shot 2016-12-14 at 4 16 08 pm" src="https://cloud.githubusercontent.com/assets/487433/21206715/a94fafa8-c218-11e6-8e80-d45efd1df2f8.png">
<img width="391" alt="screen shot 2016-12-14 at 4 13 23 pm" src="https://cloud.githubusercontent.com/assets/487433/21206716/a953294e-c218-11e6-9586-f294092cd27c.png">

Other SelectField and new ones can now be set as non-clearable for places where null isn't right.