### PR TITLE
[cosmetics] making CRUD buttons non-primary

### DIFF
--- a/superset/templates/appbuilder/baselayout.html
+++ b/superset/templates/appbuilder/baselayout.html
@@ -13,7 +13,7 @@
 
     {% block uncontained %}{% endblock %}
 
-    <div class="container">
+    <div class="container" style="display: none;">
       <div class="row">
           {% block messages %}
             {% include 'superset/flash_wrapper.html' %}

--- a/superset/templates/superset/base.html
+++ b/superset/templates/superset/base.html
@@ -18,4 +18,16 @@
     {% with filename="common" %}
       {% include "superset/partials/_script_tag.html" %}
     {% endwith %}
+    <script>
+      // FAB hacks
+
+      $(document).ready( function() {
+        // Making the buttons not primary
+        $('.btn-primary').addClass('btn-default').removeClass('btn-primary');
+        // Setting the `+` button as primary
+        $('.fa-plus').parent().addClass('btn-primary').removeClass('btn-default');
+
+        $('.container').fadeIn();
+      });
+    </script>
   {% endblock %}


### PR DESCRIPTION
Not all buttons should be `btn-primary`! I'll send a PR to fix this in FAB itself, in the meantime I'm adding this jQuery hack. We could do more FAB hacks in that location if needed.

@elibrumbaugh @ascott 

Before:
<img width="876" alt="screen shot 2016-12-16 at 8 51 22 am" src="https://cloud.githubusercontent.com/assets/487433/21270788/f4fb907a-c36c-11e6-9658-389ac905379a.png">
After:
<img width="874" alt="screen shot 2016-12-16 at 8 49 41 am" src="https://cloud.githubusercontent.com/assets/487433/21270785/f18661e0-c36c-11e6-8a78-b8ca6b53c1fa.png">