### PR TITLE
[sql lab] only show single run query button

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/RunQueryActionButton.jsx
+++ b/superset/assets/javascripts/SqlLab/components/RunQueryActionButton.jsx
@@ -2,26 +2,24 @@ import React, { PropTypes } from 'react';
 import Button from '../../components/Button';
 
 const propTypes = {
-  queryEditor: PropTypes.object.isRequired,
-  latestQuery: PropTypes.object.isRequired,
-  database: PropTypes.object.isRequired,
+  allowAsync: PropTypes.bool.isRequired,
+  dbId: PropTypes.number.isRequired,
+  queryState: PropTypes.string.isRequired,
   runQuery: PropTypes.func.isRequired,
+  selectedText: PropTypes.string,
   stopQuery: PropTypes.func.isRequired,
 };
 
 export default function RunQueryActionButton(props) {
-  const isSelected = props.queryEditor.selectedText;
-  const runBtnText = isSelected ? 'Run Selected Query' : 'Run Query';
-  const btnStyle = isSelected ? 'warning' : 'primary';
-  const hasAsync = props.database && props.database.allow_run_async;
-  const shouldShowStopBtn = props.latestQuery &&
-    ['running', 'pending'].indexOf(props.latestQuery.state) > -1;
+  const runBtnText = props.selectedText ? 'Run Selected Query' : 'Run Query';
+  const btnStyle = props.selectedText ? 'warning' : 'primary';
+  const shouldShowStopBtn = ['running', 'pending'].indexOf(props.queryState) > -1;
   const asyncToolTip = 'Run query asynchronously';
 
   const commonBtnProps = {
     bsSize: 'small',
     bsStyle: btnStyle,
-    disabled: !(props.queryEditor.dbId),
+    disabled: !(props.dbId),
   };
 
   const syncBtn = (
@@ -57,7 +55,7 @@ export default function RunQueryActionButton(props) {
   let button;
   if (shouldShowStopBtn) {
     button = stopBtn;
-  } else if (hasAsync) {
+  } else if (props.allowAsync) {
     button = asyncBtn;
   } else {
     button = syncBtn;

--- a/superset/assets/javascripts/SqlLab/components/RunQueryActionButton.jsx
+++ b/superset/assets/javascripts/SqlLab/components/RunQueryActionButton.jsx
@@ -1,0 +1,73 @@
+import React, { PropTypes } from 'react';
+import Button from '../../components/Button';
+
+const propTypes = {
+  queryEditor: PropTypes.object.isRequired,
+  latestQuery: PropTypes.object.isRequired,
+  database: PropTypes.object.isRequired,
+  runQuery: PropTypes.func.isRequired,
+  stopQuery: PropTypes.func.isRequired,
+};
+
+export default function RunQueryActionButton(props) {
+  const isSelected = props.queryEditor.selectedText;
+  const runBtnText = isSelected ? 'Run Selected Query' : 'Run Query';
+  const btnStyle = isSelected ? 'warning' : 'primary';
+  const hasAsync = props.database && props.database.allow_run_async;
+  const shouldShowStopBtn = props.latestQuery &&
+    ['running', 'pending'].indexOf(props.latestQuery.state) > -1;
+  const asyncToolTip = 'Run query asynchronously';
+
+  const commonBtnProps = {
+    bsSize: 'small',
+    bsStyle: btnStyle,
+    disabled: !(props.queryEditor.dbId),
+  };
+
+  const syncBtn = (
+    <Button
+      {...commonBtnProps}
+      onClick={() => props.runQuery(false)}
+      key="run-btn"
+    >
+      <i className="fa fa-table" /> {runBtnText}
+    </Button>
+  );
+
+  const asyncBtn = (
+    <Button
+      {...commonBtnProps}
+      onClick={() => props.runQuery(true)}
+      key="run-async-btn"
+      tooltip={asyncToolTip}
+    >
+      <i className="fa fa-table" /> {runBtnText}
+    </Button>
+  );
+
+  const stopBtn = (
+    <Button
+      {...commonBtnProps}
+      onClick={props.stopQuery}
+    >
+      <i className="fa fa-stop" /> Stop
+    </Button>
+  );
+
+  let button;
+  if (shouldShowStopBtn) {
+    button = stopBtn;
+  } else if (hasAsync) {
+    button = asyncBtn;
+  } else {
+    button = syncBtn;
+  }
+
+  return (
+    <div className="inline m-r-5 pull-left">
+      {button}
+    </div>
+  );
+}
+
+RunQueryActionButton.propTypes = propTypes;

--- a/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import {
-  Button as BootstrapButton,
-  ButtonGroup,
   Col,
   FormGroup,
   InputGroup,
@@ -21,6 +19,7 @@ import Timer from '../../components/Timer';
 import SqlEditorLeftBar from './SqlEditorLeftBar';
 import AceEditorWrapper from './AceEditorWrapper';
 import { STATE_BSSTYLE_MAP } from '../constants.js';
+import RunQueryActionButton from './RunQueryActionButton';
 
 const propTypes = {
   actions: React.PropTypes.object.isRequired,
@@ -104,64 +103,6 @@ class SqlEditor extends React.PureComponent {
   }
 
   render() {
-    let runButtons = [];
-    let runText = 'Run Query';
-    let btnStyle = 'primary';
-    if (this.props.queryEditor.selectedText) {
-      runText = 'Run Selection';
-      btnStyle = 'warning';
-    }
-    if (this.props.database && this.props.database.allow_run_sync) {
-      runButtons.push(
-        <BootstrapButton
-          bsSize="small"
-          bsStyle={btnStyle}
-          style={{ width: '100px' }}
-          onClick={this.runQuery.bind(this, false)}
-          disabled={!(this.props.queryEditor.dbId)}
-          key="run-btn"
-        >
-          <i className="fa fa-table" /> {runText}
-        </BootstrapButton>
-      );
-    }
-    if (this.props.database && this.props.database.allow_run_async) {
-      const asyncToolTip = 'Run query asynchronously';
-      runButtons.push(
-        <Button
-          bsSize="small"
-          bsStyle={btnStyle}
-          style={{ width: '100px' }}
-          onClick={this.runQuery.bind(this, true)}
-          disabled={!(this.props.queryEditor.dbId)}
-          key="run-async-btn"
-          tooltip={asyncToolTip}
-        >
-          <i className="fa fa-table" /> Run Async
-        </Button>
-      );
-    }
-    runButtons = (
-      <ButtonGroup bsSize="small" className="inline m-r-5 pull-left">
-        {runButtons}
-      </ButtonGroup>
-    );
-    if (
-        this.props.latestQuery &&
-        ['running', 'pending'].indexOf(this.props.latestQuery.state) > -1) {
-      runButtons = (
-        <ButtonGroup bsSize="small" className="inline m-r-5 pull-left">
-          <BootstrapButton
-            bsStyle="primary"
-            bsSize="small"
-            style={{ width: '100px' }}
-            onClick={this.stopQuery.bind(this)}
-          >
-            <a className="fa fa-stop" /> Stop
-          </BootstrapButton>
-        </ButtonGroup>
-      );
-    }
     let limitWarning = null;
     if (this.props.latestQuery && this.props.latestQuery.limit_reached) {
       const tooltip = (
@@ -208,7 +149,13 @@ class SqlEditor extends React.PureComponent {
       <div className="sql-toolbar clearfix">
         <div className="pull-left">
           <Form inline>
-            {runButtons}
+            <RunQueryActionButton
+              queryEditor={this.props.queryEditor}
+              latestQuery={this.props.latestQuery}
+              database={this.props.database}
+              runQuery={this.runQuery.bind(this)}
+              stopQuery={this.stopQuery.bind(this)}
+            />
             {ctasControls}
           </Form>
         </div>

--- a/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -150,10 +150,11 @@ class SqlEditor extends React.PureComponent {
         <div className="pull-left">
           <Form inline>
             <RunQueryActionButton
-              queryEditor={this.props.queryEditor}
-              latestQuery={this.props.latestQuery}
-              database={this.props.database}
+              allowAsync={this.props.database && this.props.database.allow_run_async}
+              dbId={this.props.queryEditor.dbId}
+              queryState={this.props.latestQuery && this.props.latestQuery.state}
               runQuery={this.runQuery.bind(this)}
+              selectedText={this.props.queryEditor.selectedText}
               stopQuery={this.stopQuery.bind(this)}
             />
             {ctasControls}

--- a/superset/assets/spec/javascripts/explorev2/components/RunQueryActionButton_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/components/RunQueryActionButton_spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { shallow } from 'enzyme';
+
+import RunQueryActionButton
+  from '../../../../javascripts/SqlLab/components/RunQueryActionButton';
+import Button from '../../../../javascripts/components/Button';
+
+describe('RunQueryActionButton', () => {
+  let wrapper;
+  const defaultProps = {
+    allowAsync: false,
+    dbId: 1,
+    queryState: 'pending',
+    runQuery: () => {},
+    selectedText: null,
+    stopQuery: () => {},
+  };
+
+  beforeEach(() => {
+    wrapper = shallow(<RunQueryActionButton {...defaultProps} />);
+  });
+
+  it('is a valid react element', () => {
+    expect(
+      React.isValidElement(<RunQueryActionButton {...defaultProps} />)
+    ).to.equal(true);
+  });
+
+  it('renders a single Button', () => {
+    expect(wrapper.find(Button)).to.have.lengthOf(1);
+  });
+});
+

--- a/superset/assets/spec/javascripts/explorev2/components/RunQueryActionButton_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/components/RunQueryActionButton_spec.js
@@ -13,9 +13,9 @@ describe('RunQueryActionButton', () => {
     allowAsync: false,
     dbId: 1,
     queryState: 'pending',
-    runQuery: () => {},
+    runQuery: () => {}, // eslint-disable-line
     selectedText: null,
-    stopQuery: () => {},
+    stopQuery: () => {}, // eslint-disable-line
   };
 
   beforeEach(() => {
@@ -32,4 +32,3 @@ describe('RunQueryActionButton', () => {
     expect(wrapper.find(Button)).to.have.lengthOf(1);
   });
 });
-


### PR DESCRIPTION
- show single run button rather than `Run Query` and `Run Async Query`
- if async is possible, run async, otherwise run sync
- move buttons to their own component

fixes this issue: https://github.com/airbnb/superset/issues/1819

**before**
![screenshot 2016-12-16 13 40 52](https://cloud.githubusercontent.com/assets/130878/21279568/a8cf43ee-c395-11e6-9f58-4844bb73120d.png)
![screenshot 2016-12-16 13 41 03](https://cloud.githubusercontent.com/assets/130878/21279583/bf755ac0-c395-11e6-92b8-15ec422e99ee.png)



**after**
![screenshot 2016-12-16 13 28 25](https://cloud.githubusercontent.com/assets/130878/21279534/7ae361cc-c395-11e6-8e53-e8243620f59a.png)
![screenshot 2016-12-16 13 27 54](https://cloud.githubusercontent.com/assets/130878/21279546/8965fd86-c395-11e6-85b9-52798f13e45f.png)
![run-selected](https://cloud.githubusercontent.com/assets/130878/21279562/a01ef316-c395-11e6-8bba-3312545c2432.gif)


plz review @mistercrunch @vera-liu @bkyryliuk 