### PR TITLE
Fix hardcoded urls in python and template files.

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -8,7 +8,7 @@ import logging
 import os
 from logging.handlers import TimedRotatingFileHandler
 
-from flask import Flask, redirect
+from flask import Flask, redirect, url_for
 from flask_appbuilder import SQLA, AppBuilder, IndexView
 from flask_appbuilder.baseviews import expose
 from flask_cache import Cache
@@ -71,7 +71,7 @@ for middleware in app.config.get('ADDITIONAL_MIDDLEWARE'):
 class MyIndexView(IndexView):
     @expose('/')
     def index(self):
-        return redirect('/superset/welcome')
+        return redirect(url_for('Superset.welcome'))
 
 appbuilder = AppBuilder(
     app, db.session,

--- a/superset/config.py
+++ b/superset/config.py
@@ -13,6 +13,8 @@ import imp
 import json
 import os
 
+from flask import url_for
+
 from dateutil import tz
 from flask_appbuilder.security.manager import AUTH_DB
 
@@ -68,8 +70,12 @@ ENABLE_PROXY_FIX = False
 # Uncomment to setup Your App name
 APP_NAME = "Superset"
 
-# Uncomment to setup an App icon
-APP_ICON = "/static/assets/images/superset-logo@2x.png"
+
+# Uncomment to setup Setup an App icon. The APP_ICON can both be an executable
+# or a string to enable dynamic resolving of the path.
+def get_app_icon():
+    return url_for('static', filename="assets/images/superset-logo@2x.png")
+APP_ICON = get_app_icon
 
 # Druid query timezone
 # tz.tzutc() : Using utc timezone

--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -9,9 +9,9 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/superset/profile/{{ current_user.username }}/">
+      <a class="navbar-brand" href="{{ url_for('Superset.profile', username=current_user.username) }}">
         <img
-          width="126" src="{{ appbuilder.app_icon }}"
+          width="126" src="{% if appbuilder.app_icon is callable %}{{ appbuilder.app_icon() }}{% else %}{{ appbuilder.app_icon }}{% endif %}"
           alt="{{ appbuilder.app_name }}"
         />
       </a>

--- a/superset/templates/index.html
+++ b/superset/templates/index.html
@@ -81,7 +81,7 @@
       <img class="img-circle" src="{{ url_for('static', filename='img/cardash.jpg') }}" width="140" height="140">
       <h2>Dashboards</h2>
       <p>Browse the dashboards list</p>
-      <p><a class="btn btn-default" href="/dashboardmodelview/list/" role="button">
+      <p><a class="btn btn-default" href="{{ url_for('DashboardModelView.list') }}" role="button">
         <i class="fa fa-dashboard"></i>
       </a></p>
     </div><!-- /.col-lg-4 -->
@@ -89,7 +89,7 @@
       <img class="img-circle" src="{{ url_for('static', filename='img/slice.jpg') }}" width="140" height="140">
       <h2>Slices</h2>
       <p>"Slices" are individual views into a single dataset</p>
-      <p><a class="btn btn-default" href="/slicemodelview/list/" role="button">
+      <p><a class="btn btn-default" href="{{ url_for("SliceModelView.list")}}" role="button">
         <i class="fa fa-line-chart"></i>
       </a></p>
     </div><!-- /.col-lg-4 -->

--- a/superset/templates/superset/base.html
+++ b/superset/templates/superset/base.html
@@ -1,8 +1,8 @@
 {% extends "appbuilder/baselayout.html" %}
 
   {% block head_css %}
-    <link rel="icon" type="image/png" href="/static/assets/images/favicon.png">
-    <link rel="stylesheet" type="text/css" href="/static/assets/stylesheets/superset.css" />
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='assets/images/favicon.png')}}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='assets/stylesheets/superset.css')}}" />
     {{super()}}
   {% endblock %}
 

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -11,10 +11,10 @@
     </title>
     {% block head_meta %}{% endblock %}
     {% block head_css %}
-      <link rel="stylesheet" type="text/css" href="/static/assets/node_modules/font-awesome/css/font-awesome.min.css" />
-      <link rel="stylesheet" type="text/css" href="/static/assets/stylesheets/superset.css" />
-      <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/flags/flags16.css" />
-      <link rel="icon" type="image/png" href="/static/assets/images/favicon.png">
+      <link rel="stylesheet" type="text/css" href="{{url_for("static", filename="assets/node_modules/font-awesome/css/font-awesome.min.css")}}" />
+      <link rel="stylesheet" type="text/css" href="{{url_for("static", filename="assets/stylesheets/superset.css")}}" />
+      <link rel="stylesheet" type="text/css" href="{{url_for("static", filename="appbuilder/css/flags/flags16.css")}}" />
+      <link rel="icon" type="image/png" href="{{url_for("static", filename="assets/images/favicon.png")}}" >
     {% endblock %}
     {% block head_js %}
       {% with filename="css-theme" %}
@@ -35,7 +35,7 @@
     {% block body %}
       {% include 'superset/flash_wrapper.html' %}
       <div id="app" data-bootstrap="{{ bootstrap_data }}" >
-        <img src="/static/assets/images/loading.gif" style="width: 50px; margin: 10px;">
+        <img src="{{url_for("static", filename="assets/images/loading.gif")}}" style="width: 50px; margin: 10px;">
       </div>
     {% endblock %}
 

--- a/superset/templates/superset/explorev2.html
+++ b/superset/templates/superset/explorev2.html
@@ -9,6 +9,7 @@
 {% endblock %}
 
 {% block body %}
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='assets/stylesheets/exploreV2/exploreV2.css')}}">
   <div
     id="js-explore-view-container"
     data-bootstrap="{{ bootstrap_data }}"

--- a/superset/templates/superset/fab_overrides/list_with_checkboxes.html
+++ b/superset/templates/superset/fab_overrides/list_with_checkboxes.html
@@ -64,7 +64,7 @@
                           {{'checked' if item[value] }}
                           name="{{ '{}__{}'.format(pk, value) }}"
                           id="{{ '{}__{}'.format(pk, value) }}"
-                          data-checkbox-api-prefix="/superset/checkbox/{{ modelview_name }}/{{ pk }}/{{ value }}/">
+                          data-checkbox-api-prefix="{{ url_for('Superset.checkbox', model_view=modeview_name, id_=pk, attr=value, value='') }}">
                     {% else %}
                       {{ item[value] }}
                     {% endif %}

--- a/superset/templates/superset/index.html
+++ b/superset/templates/superset/index.html
@@ -2,5 +2,5 @@
 
 {% block tail_js %}
   {{ super() }}
-  <script src="/static/assets/dist/index.entry.js"></script>
+  <script src="{{ url_for('static', filename='assets/dist/index.entry.js')}}"></script>
 {% endblock %}

--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -4,7 +4,7 @@
       .append('<button id="testconn" class="btn">{{ _("Test Connection") }}</button>');
     $("#testconn").click(function(e) {
       e.preventDefault();
-      var url = "/superset/testconn";
+      var url = "{{ url_for('Superset.testconn') }}";
 
       var data = {};
       try{
@@ -33,7 +33,7 @@
           $.each(data, function(i, d){
             var id = 'tbl_' + d;
             div.append('<span id="' + id + '" style="margin: 0px 10px 10px 0px;" class="btn btn-default">' + d + '</span>')
-            $('#' + id).click(function(){window.location = '/tablemodelview/add';})
+            $('#' + id).click(function(){window.location = '{{ url_for('TableModelView.add') }}';})
           });
       }).fail(function(error) {
           var respJSON = error.responseJSON;

--- a/superset/templates/superset/partials/_explore_title.html
+++ b/superset/templates/superset/partials/_explore_title.html
@@ -6,7 +6,7 @@
         <span class="favstar" class_name="Slice" obj_id="{{ slice.id }}"></span>
         <span>
           <a
-            href="/slicemodelview/edit/{{ slice.id }}"
+            href="{{ url_for('SliceModelView.edit', pk=slice.id) }}"
             data-toggle="tooltip"
             title="Edit Description"
             class="edit-slice-description-icon"

--- a/superset/templates/superset/partials/_script_tag.html
+++ b/superset/templates/superset/partials/_script_tag.html
@@ -1,4 +1,4 @@
 {% set VERSION_STRING = appbuilder.get_app.config.get("VERSION_STRING") %}
 {% block tail_js %}
-  <script src="/static/assets/dist/{{filename}}.{{VERSION_STRING}}.entry.js"></script>
+  <script src="{{url_for("static", filename="assets/dist/"+filename+"."+VERSION_STRING+".entry.js")}}" ></script>
 {% endblock %}

--- a/superset/templates/superset/request_access.html
+++ b/superset/templates/superset/request_access.html
@@ -12,7 +12,7 @@
       <button  onclick="window.location += '&action=go';">
         {{ _("Request Permissions") }}
       </button>
-      <button onclick="window.location.href = '/slicemodelview/list/';">
+      <button onclick="window.location.href = '{{ url_for("SliceModelView.list") }}';">
         {{ _("Cancel") }}
       </button>
     </div>

--- a/superset/templates/superset/standalone.html
+++ b/superset/templates/superset/standalone.html
@@ -1,10 +1,10 @@
 <html>
   <head>
     <title>{{ viz.token }}</title>
-    <link rel="stylesheet" type="text/css" href="/static/assets/node_modules/font-awesome/css/font-awesome.min.css" />
-    <link rel="stylesheet" type="text/css" href="/static/assets/stylesheets/superset.css" />
-    <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/flags/flags16.css" />
-    <link rel="icon" type="image/png" href="/static/assets/images/favicon.png">
+    <link rel="stylesheet" type="text/css" href={{ url_for('static', filename='assets/node_modules/font-awesome/css/font-awesome.min.css') }}"/>
+    <link rel="stylesheet" type="text/css" href={{ url_for('static', filename='assets/stylesheets/superset.css') }}"/>
+    <link rel="stylesheet" type="text/css" href={{ url_for('static', filename='appbuilder/css/flags/flags16.css') }}"/>
+    <link rel="icon" type="image/png" href={{ url_for('static', filename='assets/images/favicon.png') }}">
     {% set CSS_THEME = appbuilder.get_app.config.get("CSS_THEME") %}
     {% set height = request.args.get("height", 700) %}
     {% if CSS_THEME %}

--- a/superset/templates/superset/theme.html
+++ b/superset/templates/superset/theme.html
@@ -1324,5 +1324,5 @@
   {{ super() }}
   <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <script src="/static/assets/stylesheets/less/cosmo/cosmoTheme.js"></script>
+  <script src="{{ url_for('static', filename='assets/stylesheets/less/cosmo/cosmoTheme.js'}}"></script>
 {% endblock %}

--- a/superset/templates/superset/welcome.html
+++ b/superset/templates/superset/welcome.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="panel-body">
-      <img class="loading" src="/static/assets/images/loading.gif"/>
+      <img class="loading" src="{{url_for("static", filename="assets/images/loading.gif")}}"/>
       <table id="dash_table" class="table" width="100%"></table>
     </div>
   </div>

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 import numpy as np
-from flask import request
+from flask import request, url_for
 from flask_babel import lazy_gettext as _
 from markdown import markdown
 import simplejson as json
@@ -140,13 +140,17 @@ class BaseViz(object):
             for item in v:
                 od.add(key, item)
 
-        base_endpoint = '/superset/explore'
-        if json_endpoint:
-            base_endpoint = '/superset/explore_json'
+        endpoint_kwargs = {
+            "datasource_id": self.datasource.id,
+            "datasource_type": self.datasource.type
+        }
 
-        href = Href(
-            '{base_endpoint}/{self.datasource.type}/'
-            '{self.datasource.id}/'.format(**locals()))
+        if json_endpoint:
+            url = url_for('Superset.explore_json', **endpoint_kwargs)
+        else:
+            url = url_for('Superset.explore', **endpoint_kwargs)
+
+        href = Href(url)
         if for_cache_key and 'force' in od:
             del od['force']
         return href(od)
@@ -174,9 +178,12 @@ class BaseViz(object):
                 v = [v]
             for item in v:
                 ordered_data.add(key, item)
-        href = Href(
-            '/caravel/filter/{self.datasource.type}/'
-            '{self.datasource.id}/'.format(**locals()))
+        href = Href(url_for(
+            'Superset.filter',
+            datasource_type=self.datasource.type,
+            datasource_id=self.datasource.id,
+            column=''
+        ))
         return href(ordered_data)
 
     def get_df(self, query_obj=None):

--- a/tests/access_tests.py
+++ b/tests/access_tests.py
@@ -301,8 +301,9 @@ class RequestAccessTests(SupersetTestCase):
         approve_link_3 = ROLE_GRANT_LINK.format(
             'table', table_3_id, 'gamma', 'energy_usage_role',
             'energy_usage_role')
-        self.assertEqual(access_request3.roles_with_datasource,
-                         '<ul><li>{}</li></ul>'.format(approve_link_3))
+        with self.client.application.test_request_context():
+            self.assertEqual(access_request3.roles_with_datasource,
+                             '<ul><li>{}</li></ul>'.format(approve_link_3))
 
         # Request druid access, there are no roles have this table.
         druid_ds_4 = session.query(models.DruidDatasource).filter_by(
@@ -340,8 +341,9 @@ class RequestAccessTests(SupersetTestCase):
         approve_link_5 = ROLE_GRANT_LINK.format(
             'druid', druid_ds_5_id, 'gamma', 'druid_ds_2_role',
             'druid_ds_2_role')
-        self.assertEqual(access_request5.roles_with_datasource,
-                         '<ul><li>{}</li></ul>'.format(approve_link_5))
+        with self.client.application.test_request_context():
+            self.assertEqual(access_request5.roles_with_datasource,
+                             '<ul><li>{}</li></ul>'.format(approve_link_5))
 
         # cleanup
         gamma_user = sm.find_user(username='gamma')

--- a/tests/url_tests.py
+++ b/tests/url_tests.py
@@ -1,0 +1,107 @@
+"""Unit tests for Superset"""
+from __future__ import unicode_literals
+
+from wsgiref.util import shift_path_info
+
+from .base_tests import SupersetTestCase, app
+
+
+class TestProxyMiddleWare(object):
+    """ Simple prefix Middleware to test urls when running
+        superset under a prefix
+    """
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        script_name = shift_path_info(environ)
+
+        if script_name != 'test':
+            start_response('404 Not Found',
+                           [('Content-Type', 'text/plain')])
+            return ["This url does not belong to the app.".encode()]
+
+        return self.app(environ, start_response)
+
+
+class UrlTestCase(SupersetTestCase):
+    """TestCase for making sure that the most bookmarked urls are working.
+
+       This class can be derived with a new url_prefix to test that the same
+       urls also work when using a prefix.
+    """
+    requires_examples = True
+    url_prefix = ''
+
+    @classmethod
+    def setUpClass(cls):
+        if cls.url_prefix:
+            app.wsgi_app = TestProxyMiddleWare(app.wsgi_app)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.url_prefix:
+            app.wsgi_app = app.wsgi_app.app
+
+    def prefix_get(self, url):
+        return self.client.get(self.url_prefix + url)
+
+    def prefix_post(self, url, data):
+        return self.client.post(self.url_prefix + url, data=data)
+
+    @property
+    def http_prefix(self):
+        return 'http://localhost' + self.url_prefix
+
+    def login(self, username='admin', password='general'):
+        resp = self.prefix_post(
+            '/login/',
+            data=dict(username=username, password=password)
+        )
+        assert resp.status_code == 302
+        assert resp.location == self.http_prefix + '/'
+
+    def logout(self):
+        self.prefix_get('/logout')
+
+    def test_welcome_url(self):
+        self.login()
+        resp = self.prefix_get('/superset/welcome')
+        assert resp.status_code == 200
+
+    def test_sqllab_url(self):
+        self.login()
+        resp = self.prefix_get('/superset/sqllab')
+        assert resp.status_code == 200
+
+    def test_user_profile_url(self):
+        self.login()
+        resp = self.prefix_get('/superset/profile/admin/')
+        assert resp.status_code == 200
+
+    def test_shortener_url(self):
+        self.login()
+        url_to_shorten = (
+            "/superset/explore/table/1/?viz_type=sankey&groupby=source&"
+            "groupby=target&metric=sum__value&row_limit=5000&where=&having=&"
+            "flt_col_0=source&flt_op_0=in&flt_eq_0=&slice_id=78&slice_name="
+            "Energy+Sankey&collapsed_fieldsets=&action=&datasource_name="
+            "energy_usage&datasource_id=1&datasource_type=table&"
+            "previous_viz_type=sankey"
+        )
+        # Test that it generates a shortened url.
+        data = {"data": "/" + self.url_prefix + url_to_shorten}
+        resp = self.prefix_post('/r/shortner/', data=data)
+        url = resp.data.decode('utf-8')
+        assert url.startswith(self.url_prefix + '/r/')
+
+        # Make sure it redirects to the correct url.
+        # Also make sure to use the client directly as the url we get back
+        # should already be prefixed.
+        resp = self.client.get(url)
+        assert resp.status_code == 302
+        assert resp.location == self.http_prefix + url_to_shorten
+
+
+class PrefixUrlTests(UrlTestCase):
+    url_prefix = '/test'


### PR DESCRIPTION
This PR is in relation to issue #985.

The first commit basically converts all existing hard coded urls in superset to use the Flask `url_for` method to generate urls. 

The second commit adds a middleware that runs all tests under the prefix `/test` to make sure that future contributions will not add in hard coded urls again. It also fixes current tests that wouldn't work with the new prefix. 

I need to clean some of this up a bit, but wanted to create the PR now to get some feedback before I do much more with it.

If you want to go with running tests under a prefix, there are a some complications due to the fact that `url_for` needs the application context in order to resolve the urls. And it needs to be prepared with the right prefix to give the right urls. In addition, any test code that runs app code which generates urls need to wrap this code in an app context as well (exceptions being `self.client.get/post`). I have added a number of help methods to the `SupersetTestCase` class that should help people out (`self.url_for`, `self.get_app_context`. It still requires a bit more from the test code though since app context mishaps give very confusing errors.

Anything I missed, should change, etc., Please let me know