### PR TITLE
read anon user role from config, remove reference to public role

### DIFF
--- a/superset/views.py
+++ b/superset/views.py
@@ -205,8 +205,8 @@ def check_ownership(obj, raise_if_false=True):
 
 def get_user_roles():
     if g.user.is_anonymous():
-        public_role = config.get('AUTH_ROLE_PUBLIC', None)
-        return [appbuilder.sm.find_role(public_role)] if public_role is not None else []
+        public_role = config.get('AUTH_ROLE_PUBLIC')
+        return [appbuilder.sm.find_role(public_role)] if public_role else []
     return g.user.roles
 
 

--- a/superset/views.py
+++ b/superset/views.py
@@ -205,7 +205,8 @@ def check_ownership(obj, raise_if_false=True):
 
 def get_user_roles():
     if g.user.is_anonymous():
-        return [appbuilder.sm.find_role('Public')]
+        public_role = config.get('AUTH_ROLE_PUBLIC', None)
+        return [appbuilder.sm.find_role(public_role)] if public_role is not None else []
     return g.user.roles
 
 

--- a/tests/superset_test_config.py
+++ b/tests/superset_test_config.py
@@ -20,7 +20,7 @@ CSRF_ENABLED = False
 SECRET_KEY = 'thisismyscretkey'
 WTF_CSRF_ENABLED = False
 PUBLIC_ROLE_LIKE_GAMMA = True
-
+AUTH_ROLE_PUBLIC = 'Public'
 
 class CeleryConfig(object):
     BROKER_URL = 'sqla+sqlite:///' + SQL_CELERY_DB_FILE_PATH


### PR DESCRIPTION
This PR replaces #1483 and rebases those changes on the current master.

The get_user_roles should get the role specified for the anon user in the config.py at the key AUTH_ROLE_PUBLIC. Without this fix, the list of tables the anon user can see is limited to the tables visible to the "Public" role.