### PR TITLE
[exploreV2] mapStateToProps for fields

### DIFF
--- a/superset/assets/javascripts/explore/components/EmbedCodeButton.jsx
+++ b/superset/assets/javascripts/explore/components/EmbedCodeButton.jsx
@@ -35,7 +35,8 @@ export default class EmbedCodeButton extends React.Component {
       `  width="${this.state.width}"\n` +
       `  height="${this.state.height}"\n` +
       '  seamless\n' +
-      '  frameBorder="0" scrolling="no"\n' +
+      '  frameBorder="0"\n' +
+      '  scrolling="no"\n' +
       `  src="${srcLink}"\n` +
       '>\n' +
       '</iframe>'

--- a/superset/assets/javascripts/explorev2/actions/exploreActions.js
+++ b/superset/assets/javascripts/explorev2/actions/exploreActions.js
@@ -2,14 +2,14 @@
 const $ = window.$ = require('jquery');
 const FAVESTAR_BASE_URL = '/superset/favstar/slice';
 
-export const SET_FIELD_OPTIONS = 'SET_FIELD_OPTIONS';
-export function setFieldOptions(options) {
-  return { type: SET_FIELD_OPTIONS, options };
-}
-
 export const SET_DATASOURCE_TYPE = 'SET_DATASOURCE_TYPE';
 export function setDatasourceType(datasourceType) {
   return { type: SET_DATASOURCE_TYPE, datasourceType };
+}
+
+export const SET_DATASOURCE = 'SET_DATASOURCE';
+export function setDatasource(datasource) {
+  return { type: SET_DATASOURCE, datasource };
 }
 
 export const FETCH_STARTED = 'FETCH_STARTED';
@@ -27,7 +27,7 @@ export function fetchFailed(error) {
   return { type: FETCH_FAILED, error };
 }
 
-export function fetchFieldOptions(datasourceId, datasourceType) {
+export function fetchDatasourceMetadata(datasourceId, datasourceType) {
   return function (dispatch) {
     dispatch(fetchStarted());
 
@@ -38,7 +38,7 @@ export function fetchFieldOptions(datasourceId, datasourceType) {
         type: 'GET',
         url,
         success: (data) => {
-          dispatch(setFieldOptions(data.field_options));
+          dispatch(setDatasource(data));
           dispatch(fetchSucceeded());
         },
         error(error) {

--- a/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
@@ -22,6 +22,13 @@ const propTypes = {
 };
 
 class ControlPanelsContainer extends React.Component {
+  constructor() {
+    super();
+    this.fieldOverrides = this.fieldOverrides.bind(this);
+    this.getFieldData = this.getFieldData.bind(this);
+    this.removeAlert = this.removeAlert.bind(this);
+    this.onChange = this.onChange.bind(this);
+  }
   componentWillMount() {
     const datasource_id = this.props.form_data.datasource;
     const datasource_type = this.props.datasource_type;
@@ -41,7 +48,7 @@ class ControlPanelsContainer extends React.Component {
     this.props.actions.setFieldValue(this.props.datasource_type, name, value);
   }
   getFieldData(fs) {
-    const fieldOverrides = this.fieldOverrides.bind(this)();
+    const fieldOverrides = this.fieldOverrides();
     if (!this.props.fields) {
       return null;
     }
@@ -79,7 +86,7 @@ class ControlPanelsContainer extends React.Component {
               {this.props.alert}
               <i
                 className="fa fa-close pull-right"
-                onClick={this.removeAlert.bind(this)}
+                onClick={this.removeAlert}
                 style={{ cursor: 'pointer' }}
               />
             </Alert>
@@ -97,7 +104,7 @@ class ControlPanelsContainer extends React.Component {
                     <FieldSet
                       name={field}
                       key={`field-${field}`}
-                      onChange={this.onChange.bind(this)}
+                      onChange={this.onChange}
                       value={this.props.form_data[field]}
                       {...this.getFieldData(field)}
                     />

--- a/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
@@ -7,6 +7,7 @@ import { Panel, Alert } from 'react-bootstrap';
 import visTypes, { sectionsToRender, commonControlPanelSections } from '../stores/visTypes';
 import ControlPanelSection from './ControlPanelSection';
 import FieldSetRow from './FieldSetRow';
+import FieldSet from './FieldSet';
 import Filters from './Filters';
 
 const propTypes = {
@@ -17,6 +18,7 @@ const propTypes = {
   form_data: PropTypes.object.isRequired,
   y_axis_zero: PropTypes.any,
   alert: PropTypes.string,
+  exploreState: PropTypes.object.isRequired,
 };
 
 class ControlPanelsContainer extends React.Component {
@@ -24,41 +26,50 @@ class ControlPanelsContainer extends React.Component {
     const datasource_id = this.props.form_data.datasource;
     const datasource_type = this.props.datasource_type;
     if (datasource_id) {
-      this.props.actions.fetchFieldOptions(datasource_id, datasource_type);
+      this.props.actions.fetchDatasourceMetadata(datasource_id, datasource_type);
     }
   }
-
   componentWillReceiveProps(nextProps) {
     if (nextProps.form_data.datasource !== this.props.form_data.datasource) {
       if (nextProps.form_data.datasource) {
-        this.props.actions.fetchFieldOptions(
+        this.props.actions.fetchDatasourceMetadata(
           nextProps.form_data.datasource, nextProps.datasource_type);
       }
     }
   }
-
-  onChange(name, value, label) {
-    this.props.actions.setFieldValue(this.props.datasource_type, name, value, label);
+  onChange(name, value) {
+    this.props.actions.setFieldValue(this.props.datasource_type, name, value);
   }
-
+  getFieldData(fs) {
+    const fieldOverrides = this.fieldOverrides.bind(this)();
+    if (!this.props.fields) {
+      return null;
+    }
+    let fieldData = this.props.fields[fs] || {};
+    if (fieldOverrides.hasOwnProperty(fs)) {
+      const overrideData = fieldOverrides[fs];
+      fieldData = Object.assign({}, fieldData, overrideData);
+    }
+    if (fieldData.mapStateToProps) {
+      Object.assign(fieldData, fieldData.mapStateToProps(this.props.exploreState));
+    }
+    return fieldData;
+  }
   sectionsToRender() {
     return sectionsToRender(this.props.form_data.viz_type, this.props.datasource_type);
   }
-
   filterSectionsToRender() {
     const filterSections = this.props.datasource_type === 'table' ?
       [commonControlPanelSections.filters[0]] : commonControlPanelSections.filters;
     return filterSections;
   }
-
   fieldOverrides() {
     const viz = visTypes[this.props.form_data.viz_type];
-    return viz.fieldOverrides;
+    return viz.fieldOverrides || {};
   }
   removeAlert() {
     this.props.actions.removeControlPanelAlert();
   }
-
   render() {
     return (
       <div className="scrollbar-container">
@@ -81,12 +92,16 @@ class ControlPanelsContainer extends React.Component {
             >
               {section.fieldSetRows.map((fieldSets, i) => (
                 <FieldSetRow
-                  key={`${section.label}-fieldSetRow-${i}`}
-                  fieldSets={fieldSets}
-                  fieldOverrides={this.fieldOverrides()}
-                  onChange={this.onChange.bind(this)}
-                  fields={this.props.fields}
-                  form_data={this.props.form_data}
+                  key={`fieldsetrow-${i}`}
+                  fields={fieldSets.map(field => (
+                    <FieldSet
+                      name={field}
+                      key={`field-${field}`}
+                      onChange={this.onChange.bind(this)}
+                      value={this.props.form_data[field]}
+                      {...this.getFieldData(field)}
+                    />
+                  ))}
                 />
               ))}
             </ControlPanelSection>
@@ -119,6 +134,7 @@ function mapStateToProps(state) {
     alert: state.controlPanelAlert,
     isDatasourceMetaLoading: state.isDatasourceMetaLoading,
     fields: state.fields,
+    exploreState: state,
   };
 }
 

--- a/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ControlPanelsContainer.jsx
@@ -22,8 +22,8 @@ const propTypes = {
 };
 
 class ControlPanelsContainer extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.fieldOverrides = this.fieldOverrides.bind(this);
     this.getFieldData = this.getFieldData.bind(this);
     this.removeAlert = this.removeAlert.bind(this);

--- a/superset/assets/javascripts/explorev2/components/FieldSetRow.jsx
+++ b/superset/assets/javascripts/explorev2/components/FieldSetRow.jsx
@@ -1,52 +1,23 @@
 import React, { PropTypes } from 'react';
-import FieldSet from './FieldSet';
 
 const NUM_COLUMNS = 12;
 
 const propTypes = {
-  fields: PropTypes.object.isRequired,
-  fieldSets: PropTypes.array.isRequired,
-  fieldOverrides: PropTypes.object,
-  onChange: PropTypes.func,
-  form_data: PropTypes.object.isRequired,
+  fields: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
-const defaultProps = {
-  fieldOverrides: {},
-  onChange: () => {},
-};
-
-export default class FieldSetRow extends React.Component {
-  getFieldData(fs) {
-    const { fields, fieldOverrides } = this.props;
-    let fieldData = fields[fs];
-    if (fieldOverrides.hasOwnProperty(fs)) {
-      const overrideData = fieldOverrides[fs];
-      fieldData = Object.assign({}, fieldData, overrideData);
-    }
-    return fieldData;
-  }
-  render() {
-    const colSize = NUM_COLUMNS / this.props.fieldSets.length;
-    return (
-      <div className="row space-2">
-        {this.props.fieldSets.map((fs) => {
-          const fieldData = this.getFieldData(fs);
-          return (
-            <div className={`col-lg-${colSize} col-xs-12`} key={fs}>
-              <FieldSet
-                name={fs}
-                onChange={this.props.onChange}
-                value={this.props.form_data[fs]}
-                {...fieldData}
-              />
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
+function FieldSetRow(props) {
+  const colSize = NUM_COLUMNS / props.fields.length;
+  return (
+    <div className="row space-2">
+      {props.fields.map((field, i) => (
+        <div className={`col-lg-${colSize} col-xs-12`} key={i} >
+          {field}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 FieldSetRow.propTypes = propTypes;
-FieldSetRow.defaultProps = defaultProps;
+export default FieldSetRow;

--- a/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -39,25 +39,9 @@ export const exploreReducer = function (state, action) {
       return Object.assign({}, state,
         { saveModalAlert: `fetching dashboards failed for ${action.userId}` });
     },
-
-    [actions.SET_FIELD_OPTIONS]() {
-      const newState = Object.assign({}, state);
-      const optionsByFieldName = action.options;
-      const fieldNames = Object.keys(optionsByFieldName);
-
-      fieldNames.forEach((fieldName) => {
-        if (fieldName === 'filterable_cols') {
-          newState.filterColumnOpts = optionsByFieldName[fieldName];
-        } else {
-          newState.fields[fieldName].choices = optionsByFieldName[fieldName];
-          if (fieldName === 'metric' && state.viz.form_data.viz_type === 'dual_line') {
-            newState.fields.metric_2.choices = optionsByFieldName[fieldName];
-          }
-        }
-      });
-      return Object.assign({}, state, newState);
+    [actions.SET_DATASOURCE]() {
+      return Object.assign({}, state, { datasource: action.datasource });
     },
-
     [actions.SET_FILTER_COLUMN_OPTS]() {
       return Object.assign({}, state, { filterColumnOpts: action.filterColumnOpts });
     },

--- a/superset/assets/javascripts/explorev2/stores/fields.js
+++ b/superset/assets/javascripts/explorev2/stores/fields.js
@@ -579,7 +579,7 @@ export const fields = {
     default: null,
     description: 'This define the element to be plotted on the chart',
     mapStateToProps: (state) => ({
-      choices: state.datasource.gb_cols,
+      choices: (state.datasource) ? state.datasource.gb_cols : [],
     }),
   },
 

--- a/superset/assets/javascripts/explorev2/stores/fields.js
+++ b/superset/assets/javascripts/explorev2/stores/fields.js
@@ -31,13 +31,15 @@ export const fields = {
     label: 'Datasource',
     clearable: false,
     default: null,
-    choices: [],
+    mapStateToProps: (state) => ({
+      choices: state.datasources || [],
+    }),
     description: '',
   },
 
   viz_type: {
     type: 'SelectField',
-    label: 'Viz',
+    label: 'Visualization Type',
     clearable: false,
     default: 'table',
     choices: formatSelectOptions(Object.keys(visTypes)),
@@ -47,9 +49,10 @@ export const fields = {
   metrics: {
     type: 'SelectField',
     multi: true,
-    freeForm: false,
     label: 'Metrics',
-    choices: [],
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.metrics_combo : [],
+    }),
     default: [],
     description: 'One or many metrics to display',
   },
@@ -57,19 +60,22 @@ export const fields = {
   order_by_cols: {
     type: 'SelectField',
     multi: true,
-    freeForm: false,
     label: 'Ordering',
-    choices: [],
     default: [],
     description: 'One or many metrics to display',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.order_by_choices : [],
+    }),
   },
 
   metric: {
     type: 'SelectField',
     label: 'Metric',
-    choices: [],
     default: null,
     description: 'Choose the metric',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.metrics_combo : [],
+    }),
   },
 
   metric_2: {
@@ -219,9 +225,11 @@ export const fields = {
   secondary_metric: {
     type: 'SelectField',
     label: 'Color Metric',
-    choices: [],
     default: null,
     description: 'A metric to use for color',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.metrics_combo : [],
+    }),
   },
 
   country_fieldtype: {
@@ -241,17 +249,17 @@ export const fields = {
   groupby: {
     type: 'SelectField',
     multi: true,
-    freeForm: false,
     label: 'Group by',
-    choices: [],
     default: [],
     description: 'One or many fields to group by',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.gb_cols : [],
+    }),
   },
 
   columns: {
     type: 'SelectField',
     multi: true,
-    freeForm: false,
     label: 'Columns',
     choices: [],
     default: [],
@@ -261,32 +269,36 @@ export const fields = {
   all_columns: {
     type: 'SelectField',
     multi: true,
-    freeForm: false,
     label: 'Columns',
-    choices: [],
     default: [],
     description: 'Columns to display',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.all_cols : [],
+    }),
   },
 
   all_columns_x: {
     type: 'SelectField',
     label: 'X',
-    choices: [],
     default: null,
     description: 'Columns to display',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.all_cols : [],
+    }),
   },
 
   all_columns_y: {
     type: 'SelectField',
     label: 'Y',
-    choices: [],
     default: null,
     description: 'Columns to display',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.all_cols : [],
+    }),
   },
 
   druid_time_origin: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Origin',
     choices: [
@@ -300,7 +312,6 @@ export const fields = {
 
   bottom_margin: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Bottom Margin',
     choices: formatSelectOptions(['auto', 50, 75, 100, 125, 150, 200]),
@@ -310,7 +321,6 @@ export const fields = {
 
   granularity: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Time Granularity',
     default: 'one day',
@@ -353,7 +363,6 @@ export const fields = {
 
   link_length: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Link Length',
     default: '200',
@@ -363,7 +372,6 @@ export const fields = {
 
   charge: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Charge',
     default: '-500',
@@ -386,29 +394,32 @@ export const fields = {
     type: 'SelectField',
     label: 'Time Column',
     default: null,
-    choices: [],
     description: 'The time column for the visualization. Note that you ' +
                  'can define arbitrary expression that return a DATETIME ' +
                  'column in the table or. Also note that the ' +
                  'filter below is applied against this column or ' +
                  'expression',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.all_cols : [],
+    }),
   },
 
   time_grain_sqla: {
     type: 'SelectField',
     label: 'Time Grain',
-    choices: [],
     default: 'Time Column',
     description: 'The time granularity for the visualization. This ' +
                  'applies a date transformation to alter ' +
                  'your time column and defines a new time granularity. ' +
                  'The options here are defined on a per database ' +
                  'engine basis in the Superset source code.',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.time_grain_sqla : [],
+    }),
   },
 
   resample_rule: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Resample Rule',
     default: null,
@@ -418,7 +429,6 @@ export const fields = {
 
   resample_how: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Resample How',
     default: null,
@@ -428,7 +438,6 @@ export const fields = {
 
   resample_fillmethod: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Resample Fill Method',
     default: null,
@@ -438,7 +447,6 @@ export const fields = {
 
   since: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Since',
     default: '7 days ago',
@@ -458,7 +466,6 @@ export const fields = {
 
   until: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Until',
     default: 'now',
@@ -474,7 +481,6 @@ export const fields = {
 
   max_bubble_size: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Max Bubble Size',
     default: '25',
@@ -483,7 +489,6 @@ export const fields = {
 
   whisker_options: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Whisker/outlier options',
     default: 'Tukey',
@@ -497,7 +502,7 @@ export const fields = {
   },
 
   treemap_ratio: {
-    type: 'IntegerField',
+    type: 'TextField',
     label: 'Ratio',
     default: 0.5 * (1 + Math.sqrt(5)),  // d3 default, golden ratio
     description: 'Target aspect ratio for treemap tiles.',
@@ -505,7 +510,6 @@ export const fields = {
 
   number_format: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Number format',
     default: D3_TIME_FORMAT_OPTIONS[0],
@@ -515,7 +519,6 @@ export const fields = {
 
   row_limit: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Row limit',
     default: null,
@@ -524,7 +527,6 @@ export const fields = {
 
   limit: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Series limit',
     choices: formatSelectOptions(SERIES_LIMITS),
@@ -535,9 +537,11 @@ export const fields = {
   timeseries_limit_metric: {
     type: 'SelectField',
     label: 'Sort By',
-    choices: [],
     default: null,
     description: 'Metric used to define the top series',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.metrics_combo : [],
+    }),
   },
 
   rolling_type: {
@@ -550,7 +554,7 @@ export const fields = {
   },
 
   rolling_periods: {
-    type: 'IntegerField',
+    type: 'TextField',
     label: 'Periods',
     validators: [],
     description: 'Defines the size of the rolling window function, ' +
@@ -560,42 +564,52 @@ export const fields = {
   series: {
     type: 'SelectField',
     label: 'Series',
-    choices: [],
     default: null,
     description: 'Defines the grouping of entities. ' +
                  'Each series is shown as a specific color on the chart and ' +
                  'has a legend toggle',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.gb_cols : [],
+    }),
   },
 
   entity: {
     type: 'SelectField',
     label: 'Entity',
-    choices: [],
     default: null,
     description: 'This define the element to be plotted on the chart',
+    mapStateToProps: (state) => ({
+      choices: state.datasource.gb_cols,
+    }),
   },
 
   x: {
     type: 'SelectField',
     label: 'X Axis',
-    choices: [],
     default: null,
     description: 'Metric assigned to the [X] axis',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.gb_cols : [],
+    }),
   },
 
   y: {
     type: 'SelectField',
     label: 'Y Axis',
-    choices: [],
     default: null,
     description: 'Metric assigned to the [Y] axis',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.metrics_combo : [],
+    }),
   },
 
   size: {
     type: 'SelectField',
     label: 'Bubble Size',
     default: null,
-    choices: [],
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.metrics_combo : [],
+    }),
   },
 
   url: {
@@ -652,7 +666,6 @@ export const fields = {
 
   table_timestamp_format: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Table Timestamp Format',
     default: 'smart_date',
@@ -662,7 +675,6 @@ export const fields = {
 
   series_height: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Series Height',
     default: '25',
@@ -672,7 +684,6 @@ export const fields = {
 
   page_length: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Page Length',
     default: 0,
@@ -682,7 +693,6 @@ export const fields = {
 
   x_axis_format: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'X axis format',
     default: 'smart_date',
@@ -692,7 +702,6 @@ export const fields = {
 
   y_axis_format: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Y axis format',
     default: '.3s',
@@ -890,7 +899,7 @@ export const fields = {
   },
 
   num_period_compare: {
-    type: 'IntegerField',
+    type: 'TextField',
     label: 'Period Ratio',
     default: '',
     validators: [],
@@ -926,14 +935,15 @@ export const fields = {
   mapbox_label: {
     type: 'SelectField',
     multi: true,
-    freeForm: false,
     label: 'label',
-    choices: [],
     default: [],
     description: '`count` is COUNT(*) if a group by is used. ' +
                  'Numerical columns will be aggregated with the aggregator. ' +
                  'Non-numerical columns will be used to label points. ' +
                  'Leave empty to get a count of points in each cluster.',
+    mapStateToProps: (state) => ({
+      choices: (state.datasource) ? state.datasource.all_cols : [],
+    }),
   },
 
   mapbox_style: {
@@ -953,7 +963,6 @@ export const fields = {
 
   clustering_radius: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'Clustering Radius',
     default: '60',
@@ -977,10 +986,12 @@ export const fields = {
     type: 'SelectField',
     label: 'Point Radius',
     default: null,
-    choices: [],
     description: 'The radius of individual points (ones that are not in a cluster). ' +
                  'Either a numerical column or `Auto`, which scales the point based ' +
                  'on the largest cluster',
+    mapStateToProps: (state) => ({
+      choices: state.fields.point_radius.choices,
+    }),
   },
 
   point_radius_unit: {
@@ -992,7 +1003,7 @@ export const fields = {
   },
 
   global_opacity: {
-    type: 'IntegerField',
+    type: 'TextField',
     label: 'Opacity',
     default: 1,
     description: 'Opacity of all clusters, points, and labels. ' +
@@ -1000,7 +1011,7 @@ export const fields = {
   },
 
   viewport_zoom: {
-    type: 'IntegerField',
+    type: 'TextField',
     label: 'Zoom',
     default: 11,
     validators: [],
@@ -1009,7 +1020,7 @@ export const fields = {
   },
 
   viewport_latitude: {
-    type: 'IntegerField',
+    type: 'TextField',
     label: 'Default latitude',
     default: 37.772123,
     description: 'Latitude of default viewport',
@@ -1017,7 +1028,7 @@ export const fields = {
   },
 
   viewport_longitude: {
-    type: 'IntegerField',
+    type: 'TextField',
     label: 'Default longitude',
     default: -122.405293,
     description: 'Longitude of default viewport',
@@ -1033,7 +1044,6 @@ export const fields = {
 
   mapbox_color: {
     type: 'SelectField',
-    multi: false,
     freeForm: true,
     label: 'RGB Color',
     default: 'rgb(0, 122, 135)',

--- a/superset/assets/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
@@ -31,13 +31,17 @@ describe('EmbedCodeButton', () => {
       width: '2000',
       srcLink: 'http://localhost/endpoint_url',
     });
-    const embedHTML = `
-      <iframe
-        src="nullendpoint_url"
-        width="2000"
-        height="1000"
-        seamless frameBorder="0" scrolling="no">
-      </iframe>`;
+    const embedHTML = (
+      '<iframe\n' +
+      '  width="2000"\n' +
+      '  height="1000"\n' +
+      '  seamless\n' +
+      '  frameBorder="0"\n' +
+      '  scrolling="no"\n' +
+      '  src="nullendpoint_url&height=1000"\n' +
+      '>\n' +
+      '</iframe>'
+    );
     expect(wrapper.instance().generateEmbedHTML()).to.equal(embedHTML);
   });
 });

--- a/superset/assets/spec/javascripts/explorev2/components/FieldSetRow_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/components/FieldSetRow_spec.js
@@ -1,25 +1,18 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import FieldSetRow from '../../../../javascripts/explorev2/components/FieldSetRow';
 
-const defaultProps = {
-  fields: [<a />, <a />],
-};
-
 describe('FieldSetRow', () => {
-  let wrapper;
-
-  beforeEach(() => {
-    wrapper = shallow(<FieldSetRow {...defaultProps} />);
-  });
-
-  it('renders a single row element', () => {
+  it('renders a single row with one element', () => {
+    const wrapper = shallow(<FieldSetRow fields={[<a />]} />);
     expect(wrapper.find('.row')).to.have.lengthOf(1);
+    expect(wrapper.find('.row').find('a')).to.have.lengthOf(1);
   });
-
-  it('renders a FieldSet for each item in fieldSets array', () => {
-    expect(wrapper.find('a')).to.have.lengthOf(2);
+  it('renders a single row with two elements', () => {
+    const wrapper = shallow(<FieldSetRow fields={[<a />, <a />]} />);
+    expect(wrapper.find('.row')).to.have.lengthOf(1);
+    expect(wrapper.find('.row').find('a')).to.have.lengthOf(2);
   });
 });

--- a/superset/assets/spec/javascripts/explorev2/components/FieldSetRow_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/components/FieldSetRow_spec.js
@@ -2,15 +2,10 @@ import React from 'react';
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
-import { fields } from '../../../../javascripts/explorev2/stores/fields';
-import { defaultFormData } from '../../../../javascripts/explorev2/stores/store';
 import FieldSetRow from '../../../../javascripts/explorev2/components/FieldSetRow';
-import FieldSet from '../../../../javascripts/explorev2/components/FieldSet';
 
 const defaultProps = {
-  fields,
-  fieldSets: ['columns', 'metrics'],
-  form_data: defaultFormData(),
+  fields: [<a />, <a />],
 };
 
 describe('FieldSetRow', () => {
@@ -25,7 +20,6 @@ describe('FieldSetRow', () => {
   });
 
   it('renders a FieldSet for each item in fieldSets array', () => {
-    const length = defaultProps.fieldSets.length;
-    expect(wrapper.find(FieldSet)).to.have.lengthOf(length);
+    expect(wrapper.find('a')).to.have.lengthOf(2);
   });
 });

--- a/superset/models.py
+++ b/superset/models.py
@@ -671,6 +671,34 @@ class Queryable(object):
         else:
             return "/superset/explore/{obj.type}/{obj.id}/".format(obj=self)
 
+    @property
+    def data(self):
+        """data representation of the datasource sent to the frontend"""
+        gb_cols = [(col, col) for col in self.groupby_column_names]
+        all_cols = [(c, c) for c in self.column_names]
+        order_by_choices = []
+        for s in sorted(self.column_names):
+            order_by_choices.append((json.dumps([s, True]), s + ' [asc]'))
+            order_by_choices.append((json.dumps([s, False]), s + ' [desc]'))
+
+        d = {
+            'id': self.id,
+            'type': self.type,
+            'name': self.name,
+            'metrics_combo': self.metrics_combo,
+            'order_by_choices': order_by_choices,
+            'gb_cols': gb_cols,
+            'all_cols': all_cols,
+            'filterable_cols': self.filterable_column_names,
+        }
+        if (self.type == 'table'):
+            grains = self.database.grains() or []
+            if grains:
+                grains = [(g.name, g.name) for g in grains]
+            d['granularity_sqla'] = [(c, c) for c in self.dttm_cols]
+            d['time_grain_sqla'] = grains
+        return d
+
 
 class Database(Model, AuditMixinNullable):
 

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -486,10 +486,19 @@ class CoreTests(SupersetTestCase):
 
     def test_fetch_datasource_metadata(self):
         self.login(username='admin')
-        url = '/superset/fetch_datasource_metadata?datasource_type=table&' \
-              'datasource_id=1'
-        resp = json.loads(self.get_resp(url))
-        self.assertEqual(len(resp['field_options']), 21)
+        url = (
+            '/superset/fetch_datasource_metadata?'
+            'datasource_type=table&'
+            'datasource_id=1'
+        )
+        resp = self.get_json_resp(url)
+        keys = [
+            'name', 'filterable_cols', 'gb_cols', 'type', 'all_cols',
+            'order_by_choices', 'metrics_combo', 'granularity_sqla',
+            'time_grain_sqla', 'id',
+        ]
+        for k in keys:
+            self.assertIn(k, resp.keys())
 
     def test_fetch_all_tables(self):
         self.login(username='admin')


### PR DESCRIPTION
This is part of the effort to break down https://github.com/airbnb/superset/pull/1788 and builds up on https://github.com/airbnb/superset/pull/1868 (landed).

* introducing a `mapStateToProps` to field configuration
* making the backend endpoint `fetch_datasource_metadata` do just that, no more backend logic that "broadcasts" field options into the state, instead [more generically] the fields define how they pick from the state to define their props (often `choices` in the current use cases)

Note:
`fetch_datasource_metadata` could be simplified further to expose the raw array of objects of columns and metrics, and more logic to build options could be moved to the js side. It's judged out of scope for this PR.