### PR TITLE
Add a new endpoint for listing slice information

### DIFF
--- a/superset/views.py
+++ b/superset/views.py
@@ -1798,6 +1798,46 @@ class Superset(BaseSupersetView):
         md['expanded_slices'] = data['expanded_slices']
         dashboard.json_metadata = json.dumps(md, indent=4)
 
+    @has_access
+    @expose("/slices/list/", methods = ['GET'])
+    def slices_view(self):
+        """Retrieve all slices information"""
+        session = db.session()
+        slices = (session.query(models.Slice))
+        slice_id = request.args.get('slice_id')
+        slice_name = request.args.get('slice_name')
+        datasource_id = request.args.get('datasource_id')
+        datasource_name = request.args.get('datasource_name')
+        viz_type = request.args.get('viz_type')
+        owner = request.args.get('owner')
+
+        if slice_id:
+            slices = slices.filter(models.Slice.id == slice_id)
+        if slice_name:
+            slices = slices.filter( \
+                models.Slice.slice_name.like('%{}%'.format(slice_name)))
+        if datasource_id:
+            slices = slices.filter(models.Slice.datasource_id == datasource_id)
+        if datasource_name:
+            slices = slices.filter( \
+                models.Slice.datasource_name.like('{%{}%}'.format(datasource_name)))
+        if viz_type:
+            slices = slices.filter(models.Slice.viz_type == viz_type)
+        if owner:
+            slices = slices.filter(models.Slice.owners.any(username=owner))
+        payload = [{
+            'id': s.id,
+            'slice_name': s.slice_name,
+            'datasource_id': s.datasource_id,
+            'datasource_name': s.datasource.name,
+            'viz_type': s.viz_type,
+            'owners': [o.username for o in s.owners],
+            'slice_url': s.slice_url,
+            'edit_url': s.edit_url,
+            'slice_id_url': s.slice_id_url,
+        } for s in slices.all()]
+        return Response(json.dumps(payload))
+
     @api
     @has_access_api
     @expose("/add_slices/<dashboard_id>/", methods=['POST'])

--- a/superset/views.py
+++ b/superset/views.py
@@ -1799,7 +1799,7 @@ class Superset(BaseSupersetView):
         dashboard.json_metadata = json.dumps(md, indent=4)
 
     @has_access
-    @expose("/slices/list/", methods = ['GET'])
+    @expose("/slices/list/", methods=['GET'])
     def slices_view(self):
         """Retrieve all slices information"""
         session = db.session()
@@ -1814,13 +1814,15 @@ class Superset(BaseSupersetView):
         if slice_id:
             slices = slices.filter(models.Slice.id == slice_id)
         if slice_name:
-            slices = slices.filter( \
+            slices = slices.filter(
                 models.Slice.slice_name.like('%{}%'.format(slice_name)))
         if datasource_id:
             slices = slices.filter(models.Slice.datasource_id == datasource_id)
         if datasource_name:
-            slices = slices.filter( \
-                models.Slice.datasource_name.like('{%{}%}'.format(datasource_name)))
+            slices = slices.filter(
+                models.Slice.datasource_name
+                .like('{%{}%}'.format(datasource_name))
+            )
         if viz_type:
             slices = slices.filter(models.Slice.viz_type == viz_type)
         if owner:


### PR DESCRIPTION
Background:
 - this is for refactoring our slice model view page

Done:
 - added a new endpoint for retrieving slice data, able to filter on slice_id, slice_name, datasource_id, datasource_name, viz_type and owner based on url params

Screenshots:
![screen shot 2017-01-03 at 3 48 01 pm](https://cloud.githubusercontent.com/assets/20978302/21627363/1e0fd33c-d1cc-11e6-8d64-c44bc6ef03eb.png)

![screen shot 2017-01-03 at 3 48 13 pm](https://cloud.githubusercontent.com/assets/20978302/21627367/2478adf2-d1cc-11e6-9561-3c2c0bd7d489.png)

![screen shot 2017-01-03 at 3 48 23 pm](https://cloud.githubusercontent.com/assets/20978302/21627371/28e93c26-d1cc-11e6-8f8e-ea893699531d.png)


needs-review @ascott @mistercrunch @bkyryliuk 
