### PR TITLE
Do not use persistState for explorev2

### DIFF
--- a/superset/assets/javascripts/SqlLab/index.jsx
+++ b/superset/assets/javascripts/SqlLab/index.jsx
@@ -5,7 +5,7 @@ require('bootstrap');
 import React from 'react';
 import { render } from 'react-dom';
 import { getInitialState, sqlLabReducer } from './reducers';
-import { enhancer } from '../reduxUtils';
+import { initEnhancer } from '../reduxUtils';
 import { createStore, compose, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunkMiddleware from 'redux-thunk';
@@ -20,7 +20,7 @@ const bootstrapData = JSON.parse(appContainer.getAttribute('data-bootstrap'));
 const state = Object.assign({}, getInitialState(bootstrapData.defaultDbId), bootstrapData);
 
 let store = createStore(
-  sqlLabReducer, state, compose(applyMiddleware(thunkMiddleware), enhancer()));
+  sqlLabReducer, state, compose(applyMiddleware(thunkMiddleware), initEnhancer()));
 
 // jquery hack to highlight the navbar menu
 $('a:contains("SQL Lab")').parent().addClass('active');

--- a/superset/assets/javascripts/explorev2/index.jsx
+++ b/superset/assets/javascripts/explorev2/index.jsx
@@ -68,7 +68,7 @@ bootstrappedState.viz.form_data.filters =
   getFilters(bootstrappedState.viz.form_data, bootstrapData.datasource_type);
 
 const store = createStore(exploreReducer, bootstrappedState,
-  compose(applyMiddleware(thunk), enhancer())
+  compose(applyMiddleware(thunk), enhancer(false))
 );
 
 ReactDOM.render(

--- a/superset/assets/javascripts/explorev2/index.jsx
+++ b/superset/assets/javascripts/explorev2/index.jsx
@@ -6,7 +6,7 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { now } from '../modules/dates';
-import { enhancer } from '../reduxUtils';
+import { initEnhancer } from '../reduxUtils';
 
 // jquery and bootstrap required to make bootstrap dropdown menu's work
 const $ = window.$ = require('jquery'); // eslint-disable-line
@@ -68,7 +68,7 @@ bootstrappedState.viz.form_data.filters =
   getFilters(bootstrappedState.viz.form_data, bootstrapData.datasource_type);
 
 const store = createStore(exploreReducer, bootstrappedState,
-  compose(applyMiddleware(thunk), enhancer(false))
+  compose(applyMiddleware(thunk), initEnhancer(false))
 );
 
 ReactDOM.render(

--- a/superset/assets/javascripts/reduxUtils.js
+++ b/superset/assets/javascripts/reduxUtils.js
@@ -64,13 +64,13 @@ export function addToArr(state, arrKey, obj) {
   return Object.assign({}, state, newState);
 }
 
-export function enhancer() {
-  let enhancerWithPersistState = compose(persistState());
+export function enhancer(persist = true) {
+  let enhancerWithPersistState = persist ? compose(persistState()) : compose();
   if (process.env.NODE_ENV === 'dev') {
     /* eslint-disable no-underscore-dangle */
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
     /* eslint-enable */
-    enhancerWithPersistState = composeEnhancers(persistState());
+    enhancerWithPersistState = persist ? composeEnhancers(persistState()) : composeEnhancers();
   }
   return enhancerWithPersistState;
 }

--- a/superset/assets/javascripts/reduxUtils.js
+++ b/superset/assets/javascripts/reduxUtils.js
@@ -64,15 +64,15 @@ export function addToArr(state, arrKey, obj) {
   return Object.assign({}, state, newState);
 }
 
-export function enhancer(persist = true) {
-  let enhancerWithPersistState = persist ? compose(persistState()) : compose();
+export function initEnhancer(persist = true) {
+  let enhancer = persist ? compose(persistState()) : compose();
   if (process.env.NODE_ENV === 'dev') {
     /* eslint-disable no-underscore-dangle */
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
     /* eslint-enable */
-    enhancerWithPersistState = persist ? composeEnhancers(persistState()) : composeEnhancers();
+    enhancer = persist ? composeEnhancers(persistState()) : composeEnhancers();
   }
-  return enhancerWithPersistState;
+  return enhancer;
 }
 
 export function areArraysShallowEqual(arr1, arr2) {


### PR DESCRIPTION
Issue: [https://github.com/airbnb/superset/issues/1860](url)

Solution:
This was caused by persistState used in enhancer, when we add the V2 tag, it doesn't update store because of persistState in enhancer. Since states are all stored in url params for explore view,  we don't need persistState in explorev2, but we do need it in sqllab.

needs-review @ascott @mistercrunch 