### PR TITLE
[explore] fix height in embed mode

### DIFF
--- a/superset/assets/javascripts/explore/components/EmbedCodeButton.jsx
+++ b/superset/assets/javascripts/explore/components/EmbedCodeButton.jsx
@@ -25,15 +25,21 @@ export default class EmbedCodeButton extends React.Component {
   }
 
   generateEmbedHTML() {
-    const srcLink = window.location.origin + this.props.slice.data.standalone_endpoint;
-    /* eslint max-len: 0 */
-    return `
-      <iframe
-        src="${srcLink}"
-        width="${this.state.width}"
-        height="${this.state.height}"
-        seamless frameBorder="0" scrolling="no">
-      </iframe>`;
+    const srcLink = (
+      window.location.origin +
+      this.props.slice.data.standalone_endpoint +
+      `&height=${this.state.height}`
+    );
+    return (
+      '<iframe\n' +
+      `  width="${this.state.width}"\n` +
+      `  height="${this.state.height}"\n` +
+      '  seamless\n' +
+      '  frameBorder="0" scrolling="no"\n' +
+      `  src="${srcLink}"\n` +
+      '>\n' +
+      '</iframe>'
+    );
   }
 
   renderPopover() {

--- a/superset/assets/javascripts/explore/components/EmbedCodeButton.jsx
+++ b/superset/assets/javascripts/explore/components/EmbedCodeButton.jsx
@@ -49,7 +49,14 @@ export default class EmbedCodeButton extends React.Component {
         <div>
           <div className="row">
             <div className="col-sm-10">
-              <textarea name="embedCode" value={html} rows="4" readOnly className="form-control input-sm"></textarea>
+              <textarea
+                name="embedCode"
+                value={html}
+                rows="4"
+                readOnly
+                className="form-control input-sm"
+              >
+              </textarea>
             </div>
             <div className="col-sm-2">
               <CopyToClipboard


### PR DESCRIPTION
Currently the `height` param in the embed modal only affect the height of the iframe itself, not the height of the chart contained in the iframe. This PR addresses this issue by adding a height parameter to the querystring in the url.

fixes https://github.com/airbnb/superset/issues/1624