### PR TITLE
utils: teach our json serializer to handle more types

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from builtins import object
-from datetime import date, datetime
+from datetime import date, datetime, time
 import decimal
 import functools
 import json
@@ -216,6 +216,8 @@ def base_json_conv(obj):
 
     if isinstance(obj, numpy.int64):
         return int(obj)
+    elif isinstance(obj, numpy.bool_):
+        return bool(obj)
     elif isinstance(obj, set):
         return list(obj)
     elif isinstance(obj, decimal.Decimal):
@@ -238,6 +240,8 @@ def json_iso_dttm_ser(obj):
     if isinstance(obj, datetime):
         obj = obj.isoformat()
     elif isinstance(obj, date):
+        obj = obj.isoformat()
+    elif isinstance(obj, time):
         obj = obj.isoformat()
     else:
         raise TypeError(

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,14 +1,19 @@
-from datetime import datetime, date, timedelta
-from superset import utils
+from datetime import datetime, date, timedelta, time
+from decimal import Decimal
+from superset.utils import (
+    json_int_dttm_ser, json_iso_dttm_ser, base_json_conv
+)
 import unittest
+import uuid
 
 from mock import Mock, patch
+import numpy
+
 
 class UtilsTestCase(unittest.TestCase):
     def test_json_int_dttm_ser(self):
         dttm = datetime(2020, 1, 1)
         ts = 1577836800000.0
-        json_int_dttm_ser = utils.json_int_dttm_ser
         assert json_int_dttm_ser(dttm) == ts
         assert json_int_dttm_ser(date(2020, 1, 1)) == ts
         assert json_int_dttm_ser(datetime(1970, 1, 1)) == 0
@@ -17,6 +22,24 @@ class UtilsTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             utils.json_int_dttm_ser("this is not a date")
+
+    def test_json_iso_dttm_ser(self):
+        dttm = datetime(2020, 1, 1)
+        dt = date(2020, 1, 1)
+        t = time()
+        assert json_iso_dttm_ser(dttm) == dttm.isoformat()
+        assert json_iso_dttm_ser(dt) == dt.isoformat()
+        assert json_iso_dttm_ser(t) == t.isoformat()
+
+        with self.assertRaises(TypeError):
+            utils.json_int_dttm_ser("this is not a date")
+
+    def test_base_json_conv(self):
+        assert isinstance(base_json_conv(numpy.bool(1)), bool)
+        assert isinstance(base_json_conv(numpy.int64(1)), int)
+        assert isinstance(base_json_conv(set(1)), list)
+        assert isinstance(base_json_conv(Decimal('1.0')), float)
+        assert isinstance(base_json_conv(uuid.uuid4()), str)
 
     @patch('superset.utils.datetime')
     def test_parse_human_timedelta(self, mock_now):


### PR DESCRIPTION
Namely datetime.time and numpy.bool_. While at it add tests. The big diff on the tests are because i've run dos2unix on them