### PR TITLE
[explore-v2] add edit link below datasource select

### DIFF
--- a/superset/assets/javascripts/explorev2/components/SelectField.jsx
+++ b/superset/assets/javascripts/explorev2/components/SelectField.jsx
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react';
 import Select, { Creatable } from 'react-select';
 
-
 const propTypes = {
   choices: PropTypes.array,
   clearable: PropTypes.bool,
   description: PropTypes.string,
+  editUrl: PropTypes.string,
   freeForm: PropTypes.bool,
   label: PropTypes.string,
   multi: PropTypes.bool,
@@ -89,6 +89,9 @@ export default class SelectField extends React.Component {
     return (
       <div>
         {selectWrap}
+        {this.props.editUrl &&
+          <a href={`${this.props.editUrl}/${this.props.value}`}>edit</a>
+        }
       </div>
     );
   }

--- a/superset/assets/javascripts/explorev2/components/SelectField.jsx
+++ b/superset/assets/javascripts/explorev2/components/SelectField.jsx
@@ -18,6 +18,7 @@ const defaultProps = {
   choices: [],
   clearable: true,
   description: null,
+  editUrl: null,
   freeForm: false,
   label: null,
   multi: false,

--- a/superset/assets/javascripts/explorev2/stores/fields.js
+++ b/superset/assets/javascripts/explorev2/stores/fields.js
@@ -31,6 +31,7 @@ export const fields = {
     label: 'Datasource',
     clearable: false,
     default: null,
+    editUrl: '/tablemodelview/edit',
     mapStateToProps: (state) => ({
       choices: state.datasources || [],
     }),


### PR DESCRIPTION
Fix based on feedback from alex: "Working really well so far - one thing I noticed is missing is the ability to edit the data source from the slice view. There are times where I will realize I need to change a column or metric, and previously I could do that from the slice, but not I'll have to search for it in the datasource view. Not a huge issue, but was convenient before!"

I know @mistercrunch had some ideas about how to handle editing/adding columns or metrics for a datasource within the explore view, but for now would like to get this in so it's more convenient for users to edit the datasource. Let me know what you think!

before:
<img width="1437" alt="screenshot 2017-01-06 15 15 43" src="https://cloud.githubusercontent.com/assets/130878/21736128/4a4b6c3c-d423-11e6-9e89-adde2bd34818.png">

after:
<img width="1440" alt="screenshot 2017-01-06 15 15 13" src="https://cloud.githubusercontent.com/assets/130878/21736139/5a8721a4-d423-11e6-9274-9c3b4bf6deef.png">

v1:
<img width="1440" alt="screenshot 2017-01-06 15 16 16" src="https://cloud.githubusercontent.com/assets/130878/21736134/55494eec-d423-11e6-8489-8e7eee063b86.png">

fixes this issue: https://github.com/airbnb/superset/issues/1913

plz review @airbnb/superset-reviewers 