### PR TITLE
viz: hotfix for saving in cache

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -379,10 +379,13 @@ class BaseViz(object):
             payload['cached_dttm'] = datetime.now().isoformat().split('.')[0]
             logging.info("Caching for the next {} seconds".format(
                 cache_timeout))
+            data = json.dumps(
+                payload,
+                default=utils.json_int_dttm_ser, ignore_nan=True
+            )
+            if PY3:
+                data = bytes(data, 'utf-8')
             try:
-                data = self.json_dumps(payload)
-                if PY3:
-                    data = bytes(data, 'utf-8')
                 cache.set(
                     cache_key,
                     zlib.compress(data),


### PR DESCRIPTION
Fix cache set after c14c7ed update json serializer behaviour
but forget to update one call site.

While at it move payload serialization outside of catch all try
block since we want to see explosions if any.

Fix #1910