### PR TITLE
Use POST in sqllab_viz instead of url params to avoid error with long queries

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -116,13 +116,6 @@ class VisualizeModal extends React.PureComponent {
       success: (url) => {
         window.open(url);
       },
-      error: (error) => {
-        /* eslint no-console: 0 */
-        if (console && console.warn) {
-          console.warn('Something went wrong...');
-          console.warn(error);
-        }
-      },
     });
   }
   changeDatasourceName(event) {

--- a/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -4,6 +4,7 @@ import { Alert, Button, Col, Modal } from 'react-bootstrap';
 import Select from 'react-select';
 import { Table } from 'reactable';
 import shortid from 'shortid';
+import $ from 'jquery';
 
 const CHART_TYPES = [
   { value: 'dist_bar', label: 'Distribution - Bar Chart', requiresTime: false },
@@ -105,7 +106,24 @@ class VisualizeModal extends React.PureComponent {
       sql: this.props.query.sql,
       dbId: this.props.query.dbId,
     };
-    window.open('/superset/sqllab_viz/?data=' + JSON.stringify(vizOptions));
+    $.ajax({
+      type: 'POST',
+      url: '/superset/sqllab_viz/',
+      async: false,
+      data: {
+        data: JSON.stringify(vizOptions),
+      },
+      success: (url) => {
+        window.open(url);
+      },
+      error: (error) => {
+        /* eslint no-console: 0 */
+        if (console && console.warn) {
+          console.warn('Something went wrong...');
+          console.warn(error);
+        }
+      },
+    });
   }
   changeDatasourceName(event) {
     this.setState({ datasourceName: event.target.value });

--- a/superset/views.py
+++ b/superset/views.py
@@ -2222,10 +2222,10 @@ class Superset(BaseSupersetView):
         return Response(status=201)
 
     @has_access
-    @expose("/sqllab_viz/")
+    @expose("/sqllab_viz/", methods=['POST'])
     @log_this
     def sqllab_viz(self):
-        data = json.loads(request.args.get('data'))
+        data = json.loads(request.form.get('data'))
         table_name = data.get('datasourceName')
         viz_type = data.get('chartType')
         table = (
@@ -2284,7 +2284,7 @@ class Superset(BaseSupersetView):
         }
         params = "&".join([k + '=' + v for k, v in params.items() if v])
         url = '/superset/explore/table/{table.id}/?{params}'.format(**locals())
-        return redirect(url)
+        return(url)
 
     @has_access
     @expose("/table/<database_id>/<table_name>/<schema>/")

--- a/superset/views.py
+++ b/superset/views.py
@@ -2283,8 +2283,7 @@ class Superset(BaseSupersetView):
             'limit': '0',
         }
         params = "&".join([k + '=' + v for k, v in params.items() if v])
-        url = '/superset/explore/table/{table.id}/?{params}'.format(**locals())
-        return(url)
+        return '/superset/explore/table/{table.id}/?{params}'.format(**locals())
 
     @has_access
     @expose("/table/<database_id>/<table_name>/<schema>/")


### PR DESCRIPTION
Issue:
 - we were passing sql query in url params for sqllab_viz, which could break for extremely long queries when url exceeds maximum characters allowed

Solution:
 - pass vizOptions through POST request, return url instead of redirect

needs-review @ascott @mistercrunch @bkyryliuk 