### PR TITLE
Switch order of period compare and rolling periods to enable using both together in Advanced Analytics

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1187,19 +1187,6 @@ class NVD3TimeSeriesViz(NVD3Viz):
             dft = df.T
             df = (dft / dft.sum()).T
 
-        num_period_compare = form_data.get("num_period_compare")
-        if num_period_compare:
-            num_period_compare = int(num_period_compare)
-            prt = form_data.get('period_ratio_type')
-            if prt and prt == 'growth':
-                df = (df / df.shift(num_period_compare)) - 1
-            elif prt and prt == 'value':
-                df = df - df.shift(num_period_compare)
-            else:
-                df = df / df.shift(num_period_compare)
-
-            df = df[num_period_compare:]
-
         rolling_periods = form_data.get("rolling_periods")
         rolling_type = form_data.get("rolling_type")
 
@@ -1212,6 +1199,19 @@ class NVD3TimeSeriesViz(NVD3Viz):
                 df = pd.rolling_sum(df, int(rolling_periods), min_periods=0)
         elif rolling_type == 'cumsum':
             df = df.cumsum()
+
+        num_period_compare = form_data.get("num_period_compare")
+        if num_period_compare:
+            num_period_compare = int(num_period_compare)
+            prt = form_data.get('period_ratio_type')
+            if prt and prt == 'growth':
+                df = (df / df.shift(num_period_compare)) - 1
+            elif prt and prt == 'value':
+                df = df - df.shift(num_period_compare)
+            else:
+                df = df / df.shift(num_period_compare)
+
+            df = df[num_period_compare:]
         return df
 
     def to_series(self, df, classed='', title_suffix=''):


### PR DESCRIPTION
Very small and specific bug around using Advanced Analytics in Line Charts. 

There is unexpected behavior when using both Rolling and Period ratio in conjunction.  Based on the code (https://github.com/airbnb/superset/blob/master/superset/viz.py#L1190-L1215), all we do is compute the period ratio however specified, then do rolling windows thereafter. This is pretty counter-intuitive. Basically, when I select rolling sum of 7 days and period compare of 1, it gives me a time series that sums those factors (it will be ~7, and not anywhere near 1)! Which is not really something anybody would want to do. If we switch the steps for period compare and rolling computations, that would make sense. I want to compare each rolling 7 day window with the previous (1 before) rolling 7 day window. The problem doesn't surface for values, but only for factor and growth modes.

Eventually it may make sense to think about how these operations interact but for now switching order is sufficient.

@mistercrunch 