### PR TITLE
Make up the user link string

### DIFF
--- a/superset/models.py
+++ b/superset/models.py
@@ -169,7 +169,7 @@ class AuditMixinNullable(AuditMixin):
         if not user:
             return ''
         url = '/superset/profile/{}/'.format(user.username)
-        return '<a href="{}">{}</a>'.format(url, escape(user) or '')
+        return Markup('<a href="{}">{}</a>'.format(url, escape(user) or ''))
 
     @renders('created_by')
     def creator(self):  # noqa


### PR DESCRIPTION
the return value of _user_link function in class AuditMixinNullable is not wrapped in a Makeup object, and as a result in DruidDatasourcesModelView the user link will be escaped.

![1](https://cloud.githubusercontent.com/assets/2179241/21835648/9d918b90-d7f9-11e6-9e48-03700ef56dcb.png)
