### PR TITLE
[explore-v2] make control panel sections and fields more dense

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ControlPanelSection.jsx
+++ b/superset/assets/javascripts/explorev2/components/ControlPanelSection.jsx
@@ -32,9 +32,16 @@ export default class ControlPanelSection extends React.Component {
 
   render() {
     return (
-      <Panel header={this.renderHeader()}>
-        {this.props.children}
-      </Panel>
+      <div className="panel panel-default control-panel-section">
+        <div className="panel-header">
+          <div className="panel-title">
+            {this.renderHeader()}
+          </div>
+        </div>
+        <div className="panel-body">
+          {this.props.children}
+        </div>
+      </div>
     );
   }
 }

--- a/superset/assets/javascripts/explorev2/components/ControlPanelSection.jsx
+++ b/superset/assets/javascripts/explorev2/components/ControlPanelSection.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { Panel } from 'react-bootstrap';
 import InfoTooltipWithTrigger from '../../components/InfoTooltipWithTrigger';
 
 const propTypes = {
@@ -31,16 +32,12 @@ export default class ControlPanelSection extends React.Component {
 
   render() {
     return (
-      <div className="panel panel-default control-panel-section">
-        <div className="panel-header">
-          <div className="panel-title">
-            {this.renderHeader()}
-          </div>
-        </div>
-        <div className="panel-body">
-          {this.props.children}
-        </div>
-      </div>
+      <Panel
+        className="control-panel-section"
+        header={this.renderHeader()}
+      >
+        {this.props.children}
+      </Panel>
     );
   }
 }

--- a/superset/assets/javascripts/explorev2/components/ControlPanelSection.jsx
+++ b/superset/assets/javascripts/explorev2/components/ControlPanelSection.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { Panel } from 'react-bootstrap';
 import InfoTooltipWithTrigger from '../../components/InfoTooltipWithTrigger';
 
 const propTypes = {

--- a/superset/assets/javascripts/explorev2/components/FieldSetRow.jsx
+++ b/superset/assets/javascripts/explorev2/components/FieldSetRow.jsx
@@ -9,7 +9,7 @@ const propTypes = {
 function FieldSetRow(props) {
   const colSize = NUM_COLUMNS / props.fields.length;
   return (
-    <div className="row space-2">
+    <div className="row space-1">
       {props.fields.map((field, i) => (
         <div className={`col-lg-${colSize} col-xs-12`} key={i} >
           {field}

--- a/superset/assets/javascripts/explorev2/main.css
+++ b/superset/assets/javascripts/explorev2/main.css
@@ -25,3 +25,8 @@
     margin-top: 0px;
     margin-right: 3px;
 }
+
+.control-panel-section {
+  margin-bottom: 0px;
+  box-shadow: none;
+}


### PR DESCRIPTION
fixes: https://github.com/airbnb/superset/issues/1941

before:
<img width="1440" alt="screenshot 2017-01-11 14 33 26" src="https://cloud.githubusercontent.com/assets/130878/21869785/139405fc-d80e-11e6-8c59-8ed3aa9d8007.png">


after:
<img width="1440" alt="screenshot 2017-01-11 14 52 17" src="https://cloud.githubusercontent.com/assets/130878/21869792/1dda4832-d80e-11e6-9771-ac29eb88d849.png">


plz review @airbnb/superset-reviewers @elibrumbaugh 