### PR TITLE
Adding a way to see the git SHA from the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ app.db
 node_modules
 npm-debug.log
 yarn.lock
+superset/assets/version_info.json

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ with open(PACKAGE_FILE) as package_file:
 
 def get_git_sha():
     try:
-         return subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip()
+        s = str(subprocess.check_output(['git', 'rev-parse', 'HEAD']))
+        return s.strip()
     except:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-import imp
 import os
+import subprocess
 import json
 from setuptools import setup, find_packages
 
@@ -8,6 +8,27 @@ PACKAGE_DIR = os.path.join(BASE_DIR, 'superset', 'static', 'assets')
 PACKAGE_FILE = os.path.join(PACKAGE_DIR, 'package.json')
 with open(PACKAGE_FILE) as package_file:
     version_string = json.load(package_file)['version']
+
+
+def get_git_sha():
+    try:
+         return subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip()
+    except:
+        pass
+
+GIT_SHA = get_git_sha()
+version_info = {
+    'GIT_SHA': GIT_SHA,
+    'version': version_string,
+}
+print("-==-" * 15)
+print("VERSION: " + version_string)
+print("GIT SHA: " + GIT_SHA)
+print("-==-" * 15)
+
+with open(os.path.join(PACKAGE_DIR, 'version_info.json'), 'w') as version_file:
+    json.dump(version_info, version_file)
+
 
 setup(
     name='superset',

--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -22,6 +22,11 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li>
+          <a href="/static/assets/version_info.json" title="Version info">
+            <i class="fa fa-code-fork"></i> &nbsp;
+          </a>
+        </li>
+        <li>
           <a href="https://github.com/airbnb/superset" title="Superset's Github">
             <i class="fa fa-github"></i> &nbsp;
           </a>


### PR DESCRIPTION
The SHA is stored in a static file whenever `setup.py` is run. I added a link to the static json file to the navbar.


![screen shot 2017-01-11 at 5 54 24 pm](https://cloud.githubusercontent.com/assets/487433/21873992/0808d082-d827-11e6-8cc9-438e323848b5.png)
![screen shot 2017-01-11 at 5 54 17 pm](https://cloud.githubusercontent.com/assets/487433/21873993/0808f4e0-d827-11e6-83a1-599eb228bee1.png)
![screen shot 2017-01-11 at 5 53 54 pm](https://cloud.githubusercontent.com/assets/487433/21873994/080c22aa-d827-11e6-9064-e3e3ce4d49f2.png)
