### PR TITLE
Leave metrics empty if not specified

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -269,7 +269,7 @@ class BaseViz(object):
         """Building a query object"""
         form_data = self.form_data
         groupby = form_data.get("groupby") or []
-        metrics = form_data.get("metrics") or ['count']
+        metrics = form_data.get("metrics") or []
         extra_filters = self.get_extra_filters()
         granularity = (
             form_data.get("granularity") or form_data.get("granularity_sqla")


### PR DESCRIPTION
Issue:
 - we had a bug when user tries to explore a table generated from sqllab visualization flow, when columns are selected for table viz, count metrics is applied by default. 

Solution:
 - since we support column-only table viz, there's no need to add count metrics by default

needs-review @mistercrunch 