### PR TITLE
Add the missing argument

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -187,7 +187,7 @@ def create_missing_metrics_perm(view_menu_set):
     for metric in metrics:
         if (metric.is_restricted and metric.perm and
                 metric.perm not in view_menu_set):
-            merge_perm('metric_access', metric.perm)
+            merge_perm(sm, 'metric_access', metric.perm)
 
 
 def sync_role_definitions():


### PR DESCRIPTION
miss the first argument in line 190 in security.py

so that when executing command superset init,

![1](https://cloud.githubusercontent.com/assets/2179241/21931603/46441864-d9d7-11e6-9b56-43e02b497f2b.png)
