### PR TITLE
[explore-v2] Fix edit datasource link for druid datasources

### DIFF
--- a/superset/assets/javascripts/explorev2/components/SelectField.jsx
+++ b/superset/assets/javascripts/explorev2/components/SelectField.jsx
@@ -43,15 +43,15 @@ export default class SelectField extends React.Component {
   }
   getOptions() {
     const options = this.props.choices.map((c) => {
-      let label = c[0];
-      if (c.length > 1) {
-        label = c[1];
-      }
-      return {
+      const label = c.length > 1 ? c[1] : c[0];
+      const options = {
         value: c[0],
         label,
-        imgSrc: c[2],
       };
+
+      if (c[2]) { options.imgSrc = c[2]; }
+
+      return options;
     });
     if (this.props.freeForm) {
       // For FreeFormSelect, insert value into options if not exist

--- a/superset/assets/javascripts/explorev2/components/SelectField.jsx
+++ b/superset/assets/javascripts/explorev2/components/SelectField.jsx
@@ -44,14 +44,12 @@ export default class SelectField extends React.Component {
   getOptions() {
     const options = this.props.choices.map((c) => {
       const label = c.length > 1 ? c[1] : c[0];
-      const options = {
+      const newOptions = {
         value: c[0],
         label,
       };
-
-      if (c[2]) { options.imgSrc = c[2]; }
-
-      return options;
+      if (c[2]) newOptions.imgSrc = c[2];
+      return newOptions;
     });
     if (this.props.freeForm) {
       // For FreeFormSelect, insert value into options if not exist

--- a/superset/assets/javascripts/explorev2/stores/fields.js
+++ b/superset/assets/javascripts/explorev2/stores/fields.js
@@ -26,16 +26,23 @@ const TIME_STAMP_OPTIONS = [
   ['%H:%M:%S', '%H:%M:%S | 01:32:10'],
 ];
 
+const MAP_DATASOURCE_TYPE_TO_EDIT_URL = {
+  table: '/tablemodelview/edit',
+  druid: '/druiddatasourcemodelview/edit',
+};
+
 export const fields = {
   datasource: {
     type: 'SelectField',
     label: 'Datasource',
     clearable: false,
     default: null,
-    editUrl: '/tablemodelview/edit',
-    mapStateToProps: (state) => ({
-      choices: state.datasources || [],
-    }),
+    mapStateToProps: (state) => {
+      return {
+        choices: state.datasources || [],
+        editUrl: MAP_DATASOURCE_TYPE_TO_EDIT_URL[state.datasource_type],
+      };
+    },
     description: '',
   },
 

--- a/superset/assets/javascripts/explorev2/stores/fields.js
+++ b/superset/assets/javascripts/explorev2/stores/fields.js
@@ -37,12 +37,10 @@ export const fields = {
     label: 'Datasource',
     clearable: false,
     default: null,
-    mapStateToProps: (state) => {
-      return {
-        choices: state.datasources || [],
-        editUrl: MAP_DATASOURCE_TYPE_TO_EDIT_URL[state.datasource_type],
-      };
-    },
+    mapStateToProps: (state) => ({
+      choices: state.datasources || [],
+      editUrl: MAP_DATASOURCE_TYPE_TO_EDIT_URL[state.datasource_type],
+    }),
     description: '',
   },
 


### PR DESCRIPTION
- use mapStateToProps to generate correct editUrl for datasources depending on datasource type

- also change `getOptions` so `imgSrc` is only added for viz type
before:
<img width="880" alt="screenshot 2017-01-13 16 38 01" src="https://cloud.githubusercontent.com/assets/130878/21951584/575c868c-d9bd-11e6-9302-1da1abbd305f.png">
after:
<img width="884" alt="screenshot 2017-01-13 16 41 21" src="https://cloud.githubusercontent.com/assets/130878/21951585/57629644-d9bd-11e6-8da1-cebf49632ae5.png">
<img width="948" alt="screenshot 2017-01-13 16 41 59" src="https://cloud.githubusercontent.com/assets/130878/21951586/5766b3c8-d9bd-11e6-9b4c-6b08d4b6a155.png">


fixes: https://github.com/airbnb/superset/issues/1972

plz review @airbnb/superset-reviewers 