### PR TITLE
Add analysisTypes to refresh druid

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -77,6 +77,7 @@ APP_ICON = "/static/assets/images/superset-logo@2x.png"
 # other tz can be overridden by providing a local_config
 DRUID_IS_ACTIVE = True
 DRUID_TZ = tz.tzutc()
+DRUID_ANALYSIS_TYPES = ['cardinality']
 
 # ----------------------------------------------------
 # AUTHENTICATION CONFIG

--- a/superset/models.py
+++ b/superset/models.py
@@ -2018,7 +2018,8 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable, ImportMixin):
             segment_metadata = client.segment_metadata(
                 datasource=self.datasource_name,
                 intervals=lbound + '/' + rbound,
-                merge=self.merge_flag)
+                merge=self.merge_flag,
+                analysisTypes=config.get('DRUID_ANALYSIS_TYPES'))
         except Exception as e:
             logging.warning("Failed first attempt to get latest segment")
             logging.exception(e)
@@ -2032,7 +2033,8 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable, ImportMixin):
                 segment_metadata = client.segment_metadata(
                     datasource=self.datasource_name,
                     intervals=lbound + '/' + rbound,
-                    merge=self.merge_flag)
+                    merge=self.merge_flag,
+                    analysisTypes=config.get('DRUID_ANALYSIS_TYPES'))
             except Exception as e:
                 logging.warning("Failed 2nd attempt to get latest segment")
                 logging.exception(e)


### PR DESCRIPTION
To add `analysisTypes` to refresh druid so that the query to get the metadata faster.