### PR TITLE
Handle filters with integer values

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -23,7 +23,7 @@ from flask import request
 from flask_babel import lazy_gettext as _
 from markdown import markdown
 import simplejson as json
-from six import string_types, PY3
+from six import string_types, text_type, PY3
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from werkzeug.urls import Href
 from dateutil import relativedelta as rdelta
@@ -260,15 +260,9 @@ class BaseViz(object):
             if not (col and vals):
                 continue
             elif col in self.datasource.filterable_column_names:
-                eq = []
-                for x in vals:
-                    x = str(x)  # cast to string to handle integer values
-                    if "," in x:
-                        # Quote values with comma to avoid conflict
-                        eq.append("'{}'".format(x))
-                    else:
-                        eq.append(x)
-                filters += [(col, 'in', ",".join(eq))]
+                vals = map(text_type, vals)
+                vals = [u"'{}'".format(x) if "," in x else x for x in vals]
+                filters += [(col, 'in', ",".join(vals))]
         return filters
 
     def query_obj(self):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -260,9 +260,15 @@ class BaseViz(object):
             if not (col and vals):
                 continue
             elif col in self.datasource.filterable_column_names:
-                # Quote values with comma to avoid conflict
-                vals = ["'{}'".format(x) if "," in x else x for x in vals]
-                filters += [(col, 'in', ",".join(vals))]
+                eq = []
+                for x in vals:
+                    x = str(x)  # cast to string to handle integer values
+                    if "," in x:
+                        # Quote values with comma to avoid conflict
+                        eq.append("'{}'".format(x))
+                    else:
+                        eq.append(x)
+                filters += [(col, 'in', ",".join(eq))]
         return filters
 
     def query_obj(self):


### PR DESCRIPTION
Fixing https://github.com/airbnb/superset/issues/1640

`query_filters` was surrounding filter value with quotes if the value contains `,`. Leading that if the value was an integer it fails on `if "," in x`.
Casting value to string fixes both UI problems listed in the issue.

PS: I tried to not cast the value from integer to string, but then DB request wasn't working. So this fix seems to be more appropriate.
PS: This part doesn't seem to be tested, am I wrong?