### PR TITLE
Week beginning Monday time grain for MySQL

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -139,6 +139,9 @@ class MySQLEngineSpec(BaseEngineSpec):
               "+ INTERVAL QUARTER({col}) QUARTER - INTERVAL 1 QUARTER"),
         Grain("year", _('year'), "DATE(DATE_SUB({col}, "
               "INTERVAL DAYOFYEAR({col}) - 1 DAY))"),
+        Grain("week_start_monday", _('week_start_monday'),
+              "DATE(DATE_SUB({col}, "
+              "INTERVAL DAYOFWEEK(DATE_SUB({col}, INTERVAL 1 DAY)) - 1 DAY))"),
     )
 
     @classmethod


### PR DESCRIPTION
Related to #1188 - adding it as default for now until config is in place.

In Europe, having a default week which starts on Sunday has been really confusing for new users. This PR adds an additional time grain for MySQL to specify a weekly time grain starting on Monday. The naming of the fields is chosen to be consistent with similarly named fields in the PrestoEngineSpec.

This could feasibly be moved to a region specific config at a later date if we introduce a plugins model  