### PR TITLE
Use dist instead of src in mapbox

### DIFF
--- a/superset/assets/visualizations/mapbox.jsx
+++ b/superset/assets/visualizations/mapbox.jsx
@@ -4,7 +4,7 @@ import d3 from 'd3';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import MapGL from 'react-map-gl';
-import ScatterPlotOverlay from 'react-map-gl/src/overlays/scatterplot.react.js';
+import ScatterPlotOverlay from 'react-map-gl/dist/overlays/scatterplot.react.js';
 import Immutable from 'immutable';
 import supercluster from 'supercluster';
 import ViewportMercator from 'viewport-mercator-project';


### PR DESCRIPTION
I had issues compiling the src, I think it's because the syntax is different than the one used here?
With the dist it works fine.

I also saw there were other related issues in the past, so I'm suggesting to switch to the dist file.