### PR TITLE
Reimplement has_access decorator.

### DIFF
--- a/superset/views.py
+++ b/superset/views.py
@@ -21,7 +21,7 @@ from flask import (
 from flask_appbuilder import ModelView, CompactCRUDMixin, BaseView, expose
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_appbuilder.security.decorators import has_access, has_access_api
+from flask_appbuilder.security.decorators import has_access_api
 from flask_appbuilder.widgets import ListWidget
 from flask_appbuilder.models.sqla.filters import BaseFilter
 from flask_appbuilder.security.sqla import models as ab_models
@@ -38,6 +38,7 @@ from superset import (
     app, appbuilder, cache, db, models, sm, sql_lab, sql_parse,
     results_backend, security, viz, utils,
 )
+from superset.utils import has_access
 from superset.source_registry import SourceRegistry
 from superset.models import DatasourceAccessRequest as DAR
 from superset.sql_parse import SupersetQuery


### PR DESCRIPTION
I moved has_access to utils and extended the redirect upon successful login to provide next arg that can be used by the login implementation to redirect user back to the original path.

I plan to contribute it back to the FAB later on.

Partially solves: https://github.com/airbnb/superset/issues/1303

It can be used then in the login implementation
```
from flask import request, url_for

def redirect_url():
    return request.args.get('next') or request.referrer or url_for('index')


class AuthRemoteUserView(AuthRemoteUserView):
    @expose('/login/')
    def login(self):
      .....
      if success:
         return redirect(self.redirect_url())
```

Additional links:
* http://flask.pocoo.org/docs/0.12/reqcontext/
*  http://flask.pocoo.org/docs/0.12/api/#flask.Request.path


Reviewers:
* @mistercrunch 
* @vera-liu 
* @ascott 