### PR TITLE
a py3 error setup.py causes pip install to fail for 15.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def get_git_sha():
         s = str(subprocess.check_output(['git', 'rev-parse', 'HEAD']))
         return s.strip()
     except:
-        pass
+        return ""
 
 GIT_SHA = get_git_sha()
 version_info = {


### PR DESCRIPTION
since exceptions are "passed" may as well return a blank string instead of nothing

```

pip3 install superset
...

Collecting superset
Downloading superset-0.15.3.tar.gz (32.4MB)
Complete output from command python setup.py egg_info:
fatal: Not a git repository (or any of the parent directories): .git
-==--==--==--==--==--==--==--==--==--==--==--==--==--==--==-
VERSION: 0.15.3
 Traceback (most recent call last):
 File "<string>", line 1, in <module>
 File "/tmp/pip-build-56ww6v0_/superset/setup.py", line 27, in <module>
 print("GIT SHA: " + GIT_SHA)
TypeError: Can't convert 'NoneType' object to str implicitly
```