### PR TITLE
[hotfix] delete DAR when datasource requested does not exist anymore

### DIFF
--- a/superset/source_registry.py
+++ b/superset/source_registry.py
@@ -20,7 +20,7 @@ class SourceRegistry(object):
         return (
             session.query(cls.sources[datasource_type])
             .filter_by(id=datasource_id)
-            .one()
+            .first()
         )
 
     @classmethod

--- a/superset/views.py
+++ b/superset/views.py
@@ -1295,7 +1295,9 @@ class Superset(BaseSupersetView):
                 datasource = SourceRegistry.get_datasource(
                     r.datasource_type, r.datasource_id, session)
                 user = sm.get_user_by_id(r.created_by_fk)
-                if self.datasource_access(datasource, user):
+                if not datasource or \
+                   self.datasource_access(datasource, user):
+                    # datasource doesnot exist anymore
                     session.delete(r)
             session.commit()
         datasource_type = request.args.get('datasource_type')


### PR DESCRIPTION
Problem:
We had datasource access requests with datasources that do not exist anymore

Fix:
Drop the request access when datasource cannot retrieved

needs-review @bkyryliuk 