### PR TITLE
Change validator of timeshift to allow for strings

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/fields.js
+++ b/superset/assets/javascripts/explorev2/stores/fields.js
@@ -939,7 +939,6 @@ export const fields = {
   time_compare: {
     type: 'TextField',
     label: 'Time Shift',
-    isInt: true,
     default: null,
     description: 'Overlay a timeseries from a ' +
                  'relative time period. Expects relative time delta ' +


### PR DESCRIPTION
Before:
![screen shot 2017-01-25 at 12 56 26 pm 2](https://cloud.githubusercontent.com/assets/20978302/22342467/5ea35646-e3a9-11e6-9e23-93f4818b861b.png)

Query button is disabled when time shift is a string instead of integer

After:
![screen shot 2017-01-26 at 9 29 37 am](https://cloud.githubusercontent.com/assets/20978302/22342703/2268a234-e3aa-11e6-87eb-b25bdb98f3b1.png)

@mistercrunch 

