### PR TITLE
Display no data alert when async result has zero rows

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -197,7 +197,7 @@ class ResultSet extends React.PureComponent {
             </div>
           </div>
         );
-      } else if (query.resultsKey) {
+      } else if (query.resultsKey && !(data && data.length === 0)) {
         return (
           <div>
             <Alert bsStyle="warning">This query was run asynchronously &nbsp;


### PR DESCRIPTION
Before:
 - when query was run asynchronously and result returned with zero rows, fetch result button is always displayed, clicking on it doesn't do anything, which causes confusion

After:
 - if query already returned with empty data, display 'no data' alert

Tested in staging:
![screen shot 2017-01-27 at 11 06 33 am](https://cloud.githubusercontent.com/assets/20978302/22383886/b159a674-e480-11e6-9daf-02b3316da827.png)


@mistercrunch 