### PR TITLE
[bugfix] save slice not workin for slice without slice_id

### DIFF
--- a/superset/views.py
+++ b/superset/views.py
@@ -1646,7 +1646,8 @@ class Superset(BaseSupersetView):
         datasource_id = args.get('datasource_id')
 
         if action in ('saveas'):
-            d.pop('slice_id')  # don't save old slice_id
+            if 'slice_id' in d:
+                d.pop('slice_id')  # don't save old slice_id
             slc = models.Slice(owners=[g.user] if g.user else [])
 
         slc.params = json.dumps(d, indent=4, sort_keys=True)


### PR DESCRIPTION
Problem:
 - For some slices generated from sqllab, they don't have slice_id in the url, save_or_overwrite slice will fail when popping old slice_id from url params dict

Solution:
 - only pop slice_id when it exists in url

@ascott 