### PR TITLE
[vis] fix axis labels display

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/fields.js
+++ b/superset/assets/javascripts/explorev2/stores/fields.js
@@ -18,7 +18,7 @@ const ROW_LIMIT_OPTIONS = [10, 50, 100, 250, 500, 1000, 5000, 10000, 50000];
 
 const SERIES_LIMITS = [0, 5, 10, 25, 50, 100, 500];
 
-const TIME_STAMP_OPTIONS = [
+export const TIME_STAMP_OPTIONS = [
   ['smart_date', 'Adaptative formating'],
   ['%m/%d/%Y', '%m/%d/%Y | 01/14/2019'],
   ['%Y-%m-%d', '%Y-%m-%d | 2019-01-14'],

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -292,6 +292,7 @@ function nvd3Vis(slice, payload) {
       chart.xAxis.tickFormat(xAxisFormatter);
     }
 
+    const isTimeSeries = timeStampFormats.indexOf(fd.x_axis_format) > -1;
     // if x axis format is a date format, rotate label 90 degrees
     if (isTimeSeries) {
       chart.xAxis.rotateLabels(90);

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -296,7 +296,7 @@ function nvd3Vis(slice, payload) {
     const isTimeSeries = timeStampFormats.indexOf(fd.x_axis_format) > -1;
     // if x axis format is a date format, rotate label 90 degrees
     if (isTimeSeries) {
-      chart.xAxis.rotateLabels(90);
+      chart.xAxis.rotateLabels(45);
     }
 
     if (chart.hasOwnProperty('x2Axis')) {
@@ -383,7 +383,10 @@ function nvd3Vis(slice, payload) {
       const xAxisHeight = Math.max.apply(Math, labelHeights);
 
       // set new bottom margin to accomodate labels
-      chart.margin({ bottom: xAxisHeight + 40 });
+      chart.margin({
+        bottom: xAxisHeight + 40,
+        right: xAxisHeight,
+      });
 
       // render chart
       svg

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -1,4 +1,5 @@
 // JS
+import $ from 'jquery';
 import { category21 } from '../javascripts/modules/colors';
 import { timeFormatFactory, formatDate } from '../javascripts/modules/dates';
 const d3 = require('d3');
@@ -377,7 +378,7 @@ function nvd3Vis(slice, payload) {
     // then we adjust the bottom margin and render again.
     if (isTimeSeries) {
       // get height of formatted axis labels
-      const labelEls = document.getElementsByClassName('.nv-x.nv-axis .tick text');
+      const labelEls = $('.nv-x.nv-axis .tick text');
       const labelHeights = labelEls.map(i => labelEls[i].getBoundingClientRect().height);
       const xAxisHeight = Math.max.apply(Math, labelHeights);
 

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -3,11 +3,13 @@ import { category21 } from '../javascripts/modules/colors';
 import { timeFormatFactory, formatDate } from '../javascripts/modules/dates';
 const d3 = require('d3');
 const nv = require('nvd3');
+import { TIME_STAMP_OPTIONS } from '../javascripts/explorev2/stores/fields';
 
 // CSS
 require('../node_modules/nvd3/build/nv.d3.min.css');
 require('./nvd3_vis.css');
 
+const timeStampFormats = TIME_STAMP_OPTIONS.map(opt => opt[0]);
 const minBarWidth = 15;
 const animationTime = 1000;
 
@@ -290,6 +292,11 @@ function nvd3Vis(slice, payload) {
       chart.xAxis.tickFormat(xAxisFormatter);
     }
 
+    // if x axis format is a date format, rotate label 90 degrees
+    if (isTimeSeries) {
+      chart.xAxis.rotateLabels(90);
+    }
+
     if (chart.hasOwnProperty('x2Axis')) {
       chart.x2Axis.tickFormat(xAxisFormatter);
       height += 30;
@@ -362,6 +369,22 @@ function nvd3Vis(slice, payload) {
       .style('stroke-opacity', 1)
       .style('fill-opacity', 1);
     }
+
+    // Hack to adjust margins to accomodate long x axis tick labels,
+    // has to be done only after the chart has been rendered once,
+    // then we adjust the bottom margin and render again.
+    if (isTimeSeries) {
+      // get height of formatted axis label
+      const xAxisHeight = $('.nv-x.nv-axis .tick text')[0].getBoundingClientRect().height;
+      chart.margin({ bottom: xAxisHeight + 40 });
+      svg
+      .datum(payload.data)
+      .transition().duration(500)
+      .attr('height', height)
+      .attr('width', width)
+      .call(chart);
+    }
+
     return chart;
   };
 

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -372,11 +372,20 @@ function nvd3Vis(slice, payload) {
 
     // Hack to adjust margins to accomodate long x axis tick labels,
     // has to be done only after the chart has been rendered once,
+    // then we measure the height of the labels (they are rotated 90 degrees),
     // then we adjust the bottom margin and render again.
     if (isTimeSeries) {
-      // get height of formatted axis label
-      const xAxisHeight = $('.nv-x.nv-axis .tick text')[0].getBoundingClientRect().height;
+      //get height of formatted axis labels
+      const labelEls = $('.nv-x.nv-axis .tick text');
+      const labelHeights = labelEls.map((i) => {
+        return labelEls[i].getBoundingClientRect().height;
+      });
+      const xAxisHeight = Math.max.apply(Math, labelHeights);
+
+      // set new bottom margin to accomodate labels
       chart.margin({ bottom: xAxisHeight + 40 });
+
+      //render chart
       svg
       .datum(payload.data)
       .transition().duration(500)

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -376,17 +376,15 @@ function nvd3Vis(slice, payload) {
     // then we measure the height of the labels (they are rotated 90 degrees),
     // then we adjust the bottom margin and render again.
     if (isTimeSeries) {
-      //get height of formatted axis labels
-      const labelEls = $('.nv-x.nv-axis .tick text');
-      const labelHeights = labelEls.map((i) => {
-        return labelEls[i].getBoundingClientRect().height;
-      });
+      // get height of formatted axis labels
+      const labelEls = document.getElementsByClassName('.nv-x.nv-axis .tick text');
+      const labelHeights = labelEls.map(i => labelEls[i].getBoundingClientRect().height);
       const xAxisHeight = Math.max.apply(Math, labelHeights);
 
       // set new bottom margin to accomodate labels
       chart.margin({ bottom: xAxisHeight + 40 });
 
-      //render chart
+      // render chart
       svg
       .datum(payload.data)
       .transition().duration(500)


### PR DESCRIPTION
- if it's a time series, rotate labels 90 (we may want to do this for all x axis labels in the future for consistency)
- once rendered measure the length of the formatted label text and adjust margins to accommodate

fixes: https://github.com/airbnb/superset/issues/1971

before
![screenshot 2017-01-26 21 23 34](https://cloud.githubusercontent.com/assets/130878/22383365/55204040-e47e-11e6-8c89-86ecc88e056a.png)

after
![screenshot 2017-01-26 21 14 14](https://cloud.githubusercontent.com/assets/130878/22383371/5dab917e-e47e-11e6-8f68-7b27222f3d30.png)

before
![screenshot 2017-01-26 21 22 58](https://cloud.githubusercontent.com/assets/130878/22383387/6dcc7dde-e47e-11e6-88db-d3117deff319.png)

after
![screenshot 2017-01-26 21 13 24](https://cloud.githubusercontent.com/assets/130878/22383413/8488f8c2-e47e-11e6-94e3-5bca925a4792.png)

plz review @airbnb/superset-reviewers 