### PR TITLE
Return alert instead of fetch button when async results has no data

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -198,6 +198,10 @@ class ResultSet extends React.PureComponent {
           </div>
         );
       } else if (query.resultsKey) {
+        if (results && data && data.length === 0) {
+          // if fetched result contains zero rows of data
+          return <Alert bsStyle="warning">The asynchronous query returned no data</Alert>;
+        }
         return (
           <div>
             <Alert bsStyle="warning">This query was run asynchronously &nbsp;


### PR DESCRIPTION
Issues:
 - [https://github.com/airbnb/superset/pull/2055](url) wasn't working because we fetch result through an ajax call, there was a time gap after fetching result when results is None and data length is zero

Solution:
 - only display no data when results has returned with zero rows of data

Tested in staging:
 for a query that returned zero rows of data:
Before:
![giphy 28](https://cloud.githubusercontent.com/assets/20978302/22437118/9751adb4-e6db-11e6-8cfe-0d3982e65f0e.gif)

After:
![screen shot 2017-01-30 at 11 00 51 am](https://cloud.githubusercontent.com/assets/20978302/22437124/a0a3800e-e6db-11e6-867c-ec46d3cdd4d0.png)


@bkyryliuk @mistercrunch @ascott 