### PR TITLE
check if tempTable exists for ctas queries

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -133,7 +133,7 @@ class QueryTable extends React.PureComponent {
       } else {
         // if query was run using ctas and force_ctas_schema was set
         // tempTable will have the schema
-        const schemaUsed = q.ctas && q.tempTable.includes('.') ? '' : q.schema;
+        const schemaUsed = q.ctas && q.tempTable && q.tempTable.includes('.') ? '' : q.schema;
         q.output = [schemaUsed, q.tempTable].filter((v) => (v)).join('.');
       }
       q.progress = (


### PR DESCRIPTION
Problem:
 - Seems like we had queries that was run using ctas but didn't have tempTable names (those queries most likely were run before we implement the feature of disabling ctas query when tempTable name is empty). This was was causing failures of loading failed queries in query search page

Quickfix:
 - check if tempTable exists

@ascott @mistercrunch 