### PR TITLE
[bugfix] Query fails for druid datasource with one groupby column and having_filters

### DIFF
--- a/superset/models.py
+++ b/superset/models.py
@@ -2376,7 +2376,7 @@ class DruidDatasource(Model, AuditMixinNullable, Queryable, ImportMixin):
         if len(groupby) == 0:
             del qry['dimensions']
             client.timeseries(**qry)
-        if len(groupby) == 1:
+        if not having_filters and len(groupby) == 1:
             qry['threshold'] = timeseries_limit or 1000
             if row_limit and granularity == 'all':
                 qry['threshold'] = row_limit


### PR DESCRIPTION
A small bugfix for:
when having filter exists and there's only one groupby, topn query will fail on pydruid due to validation error
according to 
[https://github.com/druid-io/pydruid/blob/8dd11ef412c85339086871489e8c9e946c1e53ff/pydruid/query.py#L266](url)

@mistercrunch @ascott 