### PR TITLE
Make show query button work for v1

### DIFF
--- a/superset/assets/javascripts/explore/explore.jsx
+++ b/superset/assets/javascripts/explore/explore.jsx
@@ -343,6 +343,7 @@ function renderExploreActions() {
     <ExploreActionButtons
       canDownload={exploreActionsEl.getAttribute('data-can-download')}
       slice={slice}
+      query={slice.viewSqlQuery}
     />,
     exploreActionsEl
   );


### PR DESCRIPTION
Problem:
 - we replaced query in state with queryResponse in [https://github.com/airbnb/superset/pull/2005](url), then pass query instead of slice to DisplayQueryButton in [https://github.com/airbnb/superset/pull/1948](url). (The reason was that query was sent back to ChartContainer after slice rendering is done, by the time we don't want to change mock slice object but want to change query) However in v1 the query is still stored in the slice object

Solution:
this is a temporary hack to get query button working for v1, the bug should be automatically resolved after v1 deprecation.

Before:
![screen shot 2017-01-31 at 1 40 30 pm](https://cloud.githubusercontent.com/assets/20978302/22486174/533052ba-e7bd-11e6-826c-3ac35d5bf4e3.png)

After:
![screen shot 2017-01-31 at 1 39 36 pm](https://cloud.githubusercontent.com/assets/20978302/22486185/59f826d6-e7bd-11e6-9de3-f77a50a87de8.png)

@ascott 