### PR TITLE
Remove fetch results button for async queries

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -46,6 +46,10 @@ class ResultSet extends React.PureComponent {
         this.clearQueryResults(nextProps.query)
       );
     }
+    if (nextProps.query.resultsKey
+      && nextProps.query.resultsKey !== this.props.query.resultsKey) {
+      this.fetchResults(nextProps.query);
+    }
   }
   getControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
@@ -195,20 +199,6 @@ class ResultSet extends React.PureComponent {
                 hideFilterInput
               />
             </div>
-          </div>
-        );
-      } else if (query.resultsKey) {
-        if (results && data && data.length === 0) {
-          // if fetched result contains zero rows of data
-          return <Alert bsStyle="warning">The asynchronous query returned no data</Alert>;
-        }
-        return (
-          <div>
-            <Alert bsStyle="warning">This query was run asynchronously &nbsp;
-              <Button bsSize="sm" onClick={this.fetchResults.bind(this, query)}>
-                Fetch results
-              </Button>
-            </Alert>
           </div>
         );
       }


### PR DESCRIPTION
Issue:
https://github.com/airbnb/superset/issues/2078

Before:
![screen shot 2017-01-31 at 4 27 38 pm](https://cloud.githubusercontent.com/assets/20978302/22490444/35896b06-e7d2-11e6-824b-536e822f8cc8.png)


After:
results are directly shown when fetching results finishes

Tested in staging

@mistercrunch @ascott @bkyryliuk 