### PR TITLE
Keep order of axis data when storing df

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1354,18 +1354,16 @@ class NVD3DualLineViz(NVD3Viz):
         series = df.to_dict('series')
         chart_data = []
         index_list = df.T.index.tolist()
-        for i in range(0, len(index_list)):
-            name = index_list[i]
-            ys = series[name]
-            if df[name].dtype.kind not in "biufc":
+        metrics = [
+            self.form_data.get('metric'),
+            self.form_data.get('metric_2')
+        ]
+        for i, m in enumerate(metrics):
+            ys = series[m]
+            if df[m].dtype.kind not in "biufc":
                 continue
             df[DTTM_ALIAS] = pd.to_datetime(df.index, utc=False)
-            if isinstance(name, string_types):
-                series_title = name
-            else:
-                name = ["{}".format(s) for s in name]
-                series_title = ", ".join(name[1:])
-
+            series_title = m
             d = {
                 "key": series_title,
                 "classed": classed,


### PR DESCRIPTION
Issue: [https://github.com/airbnb/superset/issues/2088](url)

Problem:
pivot_table will reorder column names alphabetically

Solution:
keep order of metrics passed from frontend in get_data

Before:
<img width="1433" alt="screen shot 2017-02-01 at 5 14 57 pm" src="https://cloud.githubusercontent.com/assets/20978302/22533285/fedd03c6-e8a1-11e6-90f7-a538789cf69a.png">


After:
<img width="1437" alt="screen shot 2017-02-01 at 5 12 25 pm" src="https://cloud.githubusercontent.com/assets/20978302/22533271/dcbff8ca-e8a1-11e6-9387-78179c4226b3.png">

@ascott 