### PR TITLE
Allow query to display while slice is loading

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -226,13 +226,12 @@ class ChartContainer extends React.PureComponent {
                   status={CHART_STATUS_MAP[this.props.chartStatus]}
                   style={{ fontSize: '10px', marginRight: '5px' }}
                 />
-                {this.state.mockSlice &&
-                  <ExploreActionButtons
-                    slice={this.state.mockSlice}
-                    canDownload={this.props.can_download}
-                    query={this.props.queryResponse.query}
-                  />
-                }
+                <ExploreActionButtons
+                  slice={this.state.mockSlice}
+                  canDownload={this.props.can_download}
+                  queryEndpoint={getExploreUrl(
+                    this.props.formData, this.props.datasource_type, 'query')}
+                />
               </div>
             </div>
           }

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -31,6 +31,8 @@ const propTypes = {
   slice: PropTypes.object.isRequired,
   table_name: PropTypes.string,
   viz_type: PropTypes.string.isRequired,
+  formData: PropTypes.object,
+  latestQueryFormData: PropTypes.object,
 };
 
 class ChartContainer extends React.PureComponent {
@@ -230,7 +232,7 @@ class ChartContainer extends React.PureComponent {
                   slice={this.state.mockSlice}
                   canDownload={this.props.can_download}
                   queryEndpoint={getExploreUrl(
-                    this.props.formData, this.props.datasource_type, 'query')}
+                    this.props.latestQueryFormData, this.props.datasource_type, 'query')}
                 />
               </div>
             </div>
@@ -255,8 +257,8 @@ function mapStateToProps(state) {
     chartUpdateStartTime: state.chartUpdateStartTime,
     column_formats: state.datasource ? state.datasource.column_formats : null,
     containerId: state.slice ? `slice-container-${state.slice.slice_id}` : 'slice-container',
-    datasource_type: state.datasource_type,
     formData,
+    latestQueryFormData: state.latestQueryFormData,
     isStarred: state.isStarred,
     queryResponse: state.queryResponse,
     slice: state.slice,

--- a/superset/assets/javascripts/explorev2/components/DisplayQueryButton.jsx
+++ b/superset/assets/javascripts/explorev2/components/DisplayQueryButton.jsx
@@ -1,25 +1,49 @@
 import React, { PropTypes } from 'react';
 import ModalTrigger from './../../components/ModalTrigger';
+const $ = window.$ = require('jquery');
 
 const propTypes = {
-  query: PropTypes.string,
+  queryEndpoint: PropTypes.string.isRequired,
 };
 
-const defaultProps = {
-  query: '',
-};
-
-export default function DisplayQueryButton({ query }) {
-  const modalBody = (<pre>{query}</pre>);
-  return (
-    <ModalTrigger
-      isButton
-      triggerNode={<span>Query</span>}
-      modalTitle="Query"
-      modalBody={modalBody}
-    />
-  );
+export default class DisplayQueryButton extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      modalBody: <pre />,
+    };
+  }
+  beforeOpen() {
+    this.setState({
+      modalBody:
+        (<img
+          className="loading"
+          alt="Loading..."
+          src="/static/assets/images/loading.gif"
+        />),
+    });
+    $.ajax({
+      type: 'GET',
+      url: this.props.queryEndpoint,
+      success: (data) => {
+        this.setState({ modalBody: (<pre>{data.query}</pre>) });
+      },
+      error(data) {
+        this.setState({ modalBody: (<pre>{data.error}</pre>) });
+      },
+    });
+  }
+  render() {
+    return (
+      <ModalTrigger
+        isButton
+        triggerNode={<span>Query</span>}
+        modalTitle="Query"
+        beforeOpen={this.beforeOpen.bind(this)}
+        modalBody={this.state.modalBody}
+      />
+    );
+  }
 }
 
 DisplayQueryButton.propTypes = propTypes;
-DisplayQueryButton.defaultProps = defaultProps;

--- a/superset/assets/javascripts/explorev2/components/ExploreActionButtons.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreActionButtons.jsx
@@ -6,40 +6,47 @@ import DisplayQueryButton from './DisplayQueryButton';
 
 const propTypes = {
   canDownload: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
-  slice: PropTypes.object.isRequired,
-  query: PropTypes.string,
+  slice: PropTypes.object,
+  queryEndpoint: PropTypes.string,
 };
 
-export default function ExploreActionButtons({ canDownload, slice, query }) {
+export default function ExploreActionButtons({ canDownload, slice, queryEndpoint }) {
   const exportToCSVClasses = cx('btn btn-default btn-sm', {
     'disabled disabledButton': !canDownload,
   });
+  if (slice) {
+    return (
+      <div className="btn-group results" role="group">
+        <URLShortLinkButton slice={slice} />
+
+        <EmbedCodeButton slice={slice} />
+
+        <a
+          href={slice.data.json_endpoint}
+          className="btn btn-default btn-sm"
+          title="Export to .json"
+          target="_blank"
+        >
+          <i className="fa fa-file-code-o"></i> .json
+        </a>
+
+        <a
+          href={slice.data.csv_endpoint}
+          className={exportToCSVClasses}
+          title="Export to .csv format"
+          target="_blank"
+        >
+          <i className="fa fa-file-text-o"></i> .csv
+        </a>
+
+        <DisplayQueryButton
+          queryEndpoint={queryEndpoint}
+        />
+      </div>
+    );
+  }
   return (
-    <div className="btn-group results" role="group">
-      <URLShortLinkButton slice={slice} />
-
-      <EmbedCodeButton slice={slice} />
-
-      <a
-        href={slice.data.json_endpoint}
-        className="btn btn-default btn-sm"
-        title="Export to .json"
-        target="_blank"
-      >
-        <i className="fa fa-file-code-o"></i> .json
-      </a>
-
-      <a
-        href={slice.data.csv_endpoint}
-        className={exportToCSVClasses}
-        title="Export to .csv format"
-        target="_blank"
-      >
-        <i className="fa fa-file-text-o"></i> .csv
-      </a>
-
-      <DisplayQueryButton query={query} />
-    </div>
+    <DisplayQueryButton queryEndpoint={queryEndpoint} />
   );
 }
 

--- a/superset/assets/javascripts/explorev2/exploreUtils.js
+++ b/superset/assets/javascripts/explorev2/exploreUtils.js
@@ -12,6 +12,8 @@ export function getExploreUrl(form_data, dummy, endpoint = 'base') {
       return `/superset/explore_json/${params}&csv=true`;
     case 'standalone':
       return `/superset/explore/${params}&standalone=true`;
+    case 'query':
+      return `/superset/explore_json/${params}&query=true`;
     default:
       return `/superset/explore/${params}`;
   }

--- a/superset/assets/javascripts/explorev2/index.jsx
+++ b/superset/assets/javascripts/explorev2/index.jsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { now } from '../modules/dates';
 import { initEnhancer } from '../reduxUtils';
-import { getFieldsState } from './stores/store';
+import { getFieldsState, getFormDataFromFields } from './stores/store';
 
 
 // jquery and bootstrap required to make bootstrap dropdown menu's work
@@ -32,6 +32,7 @@ const bootstrappedState = Object.assign(
     chartUpdateStartTime: now(),
     dashboards: [],
     fields,
+    latestQueryFormData: getFormDataFromFields(fields),
     filterColumnOpts: [],
     isDatasourceMetaLoading: false,
     isStarred: false,

--- a/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -88,6 +88,7 @@ export const exploreReducer = function (state, action) {
           chartUpdateStartTime: now(),
           triggerQuery: false,
           queryRequest: action.queryRequest,
+          latestQueryFormData: getFormDataFromFields(state.fields),
         });
     },
     [actions.CHART_UPDATE_STOPPED]() {

--- a/superset/models.py
+++ b/superset/models.py
@@ -1440,7 +1440,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable, ImportMixin):
         except Exception as e:
             status = QueryStatus.FAILED
             error_message = str(e)
-        print(datetime.now() - start_dttm)
+
         return QueryResult(
             status=status,
             df=df,

--- a/superset/views.py
+++ b/superset/views.py
@@ -1486,6 +1486,19 @@ class Superset(BaseSupersetView):
                 headers=generate_download_headers("csv"),
                 mimetype="application/csv")
 
+        if request.args.get("query") == "true":
+            try:
+                query = viz_obj.get_query()
+            except Exception as e:
+                return Response(
+                    json.dumps({'error': e}),
+                    status=404,
+                    mimetype="application/json")
+            return Response(
+                json.dumps({'query': query}),
+                status=200,
+                mimetype="application/json")
+
         payload = {}
         status = 200
         try:

--- a/superset/views.py
+++ b/superset/views.py
@@ -1488,12 +1488,17 @@ class Superset(BaseSupersetView):
 
         if request.args.get("query") == "true":
             try:
-                query = viz_obj.get_query()
+                query_obj = viz_obj.query_obj()
+                engine = viz_obj.datasource.database.get_sqla_engine() \
+                    if datasource_type == 'table' \
+                    else viz_obj.datasource.cluster.get_pydruid_client()
+                if datasource_type == 'druid':
+                    # only retrive first phase query for druid
+                    query_obj['phase'] = 1
+                query = viz_obj.datasource.get_query_str(
+                    engine, datetime.now(), **query_obj)
             except Exception as e:
-                return Response(
-                    json.dumps({'error': e}),
-                    status=404,
-                    mimetype="application/json")
+                return json_error_response(e)
             return Response(
                 json.dumps({'query': query}),
                 status=200,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -106,9 +106,8 @@ class BaseViz(object):
                 timestamp_format = dttm_col.python_date_format
 
         # The datasource here can be different backend but the interface is common
-        query_str, engine, start_dttm = self.datasource.get_query_str(**query_obj)
-        self.query = query_str
-        self.results = self.datasource.query(query_str, engine, start_dttm)
+        self.results = self.datasource.query(query_obj)
+        self.query = self.results.query
         self.status = self.results.status
         self.error_message = self.results.error_message
 
@@ -311,11 +310,6 @@ class BaseViz(object):
         df = self.get_df()
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, encoding="utf-8")
-
-    def get_query(self):
-        query_obj = self.query_obj()
-        query_str, engine, start_dttm = self.datasource.get_query_str(**query_obj)
-        return query_str
 
     def get_values_for_column(self, column):
         """

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -106,10 +106,11 @@ class BaseViz(object):
                 timestamp_format = dttm_col.python_date_format
 
         # The datasource here can be different backend but the interface is common
-        self.results = self.datasource.query(**query_obj)
+        query_str, engine, start_dttm = self.datasource.get_query_str(**query_obj)
+        self.query = query_str
+        self.results = self.datasource.query(query_str, engine, start_dttm)
         self.status = self.results.status
         self.error_message = self.results.error_message
-        self.query = self.results.query
 
         df = self.results.df
         # Transform the timestamp we received from database to pandas supported
@@ -310,6 +311,11 @@ class BaseViz(object):
         df = self.get_df()
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, encoding="utf-8")
+
+    def get_query(self):
+        query_obj = self.query_obj()
+        query_str, engine, start_dttm = self.datasource.get_query_str(**query_obj)
+        return query_str
 
     def get_values_for_column(self, column):
         """


### PR DESCRIPTION
Done:
 - separated get_query_str out from query() interface for sqlalchemy and druid
 - pass in queryEndpoint instead of query to DisplayQueryButton
 - add query=true option for explore_json to fetch query string without doing the query
 - get query_str from explore_json when query button is displayed

After:
user could still see the most updated query str from latest form_data even when slice hasn't done rendering:
![screen shot 2017-02-02 at 3 08 58 pm](https://cloud.githubusercontent.com/assets/20978302/22572670/05a32da8-e95a-11e6-939d-47b865a55d96.png)

Todo:
test in druid

needs-review @mistercrunch 