### PR TITLE
[sql-lab] make datasource name in visualize flow more descriptive

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -58,7 +58,8 @@ class VisualizeModal extends React.PureComponent {
     const uniqueId = shortid.generate();
     let datasourceName = uniqueId;
     if (query) {
-      datasourceName = query.db ? `${query.db}-` : '';
+      datasourceName = query.user ? `${query.user}-` : '';
+      datasourceName += query.db ? `${query.db}-` : '';
       datasourceName += `${query.tab}-${uniqueId}`;
     }
     return datasourceName;

--- a/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -27,10 +27,9 @@ const defaultProps = {
 class VisualizeModal extends React.PureComponent {
   constructor(props) {
     super(props);
-    const uniqueId = shortid.generate();
     this.state = {
       chartType: CHART_TYPES[0],
-      datasourceName: uniqueId,
+      datasourceName: this.datasourceName(),
       columns: {},
       hints: [],
     };
@@ -53,6 +52,16 @@ class VisualizeModal extends React.PureComponent {
       columns[col.name] = col;
     });
     this.setState({ columns });
+  }
+  datasourceName() {
+    const { query } = this.props;
+    const uniqueId = shortid.generate();
+    let datasourceName = uniqueId;
+    if (query) {
+      datasourceName = query.db ? `${query.db}-` : '';
+      datasourceName += `${query.tab}-${uniqueId}`;
+    }
+    return datasourceName;
   }
   validate() {
     const hints = [];


### PR DESCRIPTION
Rather than only using a unique id for the datasource name, let's use the db name, if we have it, and the name of the tab plus the unique id.

fixes this issue: https://github.com/airbnb/superset/issues/1851

before:
<img width="1431" alt="screenshot 2017-02-02 20 13 24" src="https://cloud.githubusercontent.com/assets/130878/22579384/91de40f8-e984-11e6-91f6-56e7aade55df.png">
<img width="1039" alt="screenshot 2017-02-02 20 17 44" src="https://cloud.githubusercontent.com/assets/130878/22579398/ba07d562-e984-11e6-8fa7-8a28be639cfc.png">
<img width="1042" alt="screenshot 2017-02-02 20 17 59" src="https://cloud.githubusercontent.com/assets/130878/22579399/ba136c92-e984-11e6-80a3-6c8fb15f0ba4.png">

after:
<img width="1435" alt="screenshot 2017-02-02 20 08 38" src="https://cloud.githubusercontent.com/assets/130878/22579422/e13af10a-e984-11e6-843b-a8e1c3861f71.png">
<img width="1043" alt="screenshot 2017-02-02 20 07 11" src="https://cloud.githubusercontent.com/assets/130878/22579428/ea10048c-e984-11e6-86bf-d22096078585.png">
<img width="1043" alt="screenshot 2017-02-02 20 07 28" src="https://cloud.githubusercontent.com/assets/130878/22579429/ea18d4fe-e984-11e6-9690-a73a3b1b2c23.png">

plz review @airbnb/superset-reviewers 
