### PR TITLE
Add implementation of S3Cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     zip_safe=False,
     scripts=['superset/bin/superset'],
     install_requires=[
+        'boto3==1.4.4',
         'celery==3.1.23',
         'cryptography==1.5.3',
         'flask-appbuilder==1.8.1',

--- a/superset/assets/version_info.json
+++ b/superset/assets/version_info.json
@@ -1,1 +1,1 @@
-{"GIT_SHA": "2d08e240285288b71df98747ddd4b6cca3220c5a", "version": "0.15.2"}
+{"GIT_SHA": "0f7189b859f4a782fd43af694012029645f81b44", "version": "0.15.4"}

--- a/superset/assets/version_info.json
+++ b/superset/assets/version_info.json
@@ -1,1 +1,0 @@
-{"GIT_SHA": "1e94498d9d548cbea6466a45dafa3b919c65bd1f", "version": "0.15.4"}

--- a/superset/assets/version_info.json
+++ b/superset/assets/version_info.json
@@ -1,1 +1,1 @@
-{"GIT_SHA": "0f7189b859f4a782fd43af694012029645f81b44", "version": "0.15.4"}
+{"GIT_SHA": "1e94498d9d548cbea6466a45dafa3b919c65bd1f", "version": "0.15.4"}

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -35,7 +35,7 @@ class S3Cache(BaseCache):
         self.default_timeout = default_timeout
 
         self.s3_client = boto3.client('s3')
-        self.bucket = self.s3_resource.Bucket(config.get('S3_CACHE_BUCKET'))
+        self.bucket = config.get('S3_CACHE_BUCKET')
         self.key_prefix = config.get('S3_CACHE_KEY_PREFIX')
 
     def get(self, key):
@@ -140,7 +140,7 @@ class S3Cache(BaseCache):
     def _key_exists(self, key):
         """Determine whether the given key exists in the bucket."""
         try:
-            response = self.s3_client.head_object(
+            self.s3_client.head_object(
                 Bucket=self.bucket,
                 Key=self._full_s3_key(key)
             )

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -41,6 +41,7 @@ class S3Cache(BaseCache):
 
     def get(self, key):
         """Look up key in the cache and return the value for it.
+
         :param key: the key to be looked up.
         :returns: The value if it exists and is readable, else ``None``.
         """
@@ -64,6 +65,7 @@ class S3Cache(BaseCache):
 
     def delete(self, key):
         """Delete `key` from the cache.
+
         :param key: the key to delete.
         :returns: Whether the key existed and has been deleted.
         :rtype: boolean
@@ -72,7 +74,7 @@ class S3Cache(BaseCache):
             return False
         else:
             try:
-                response = self.s3_client.delete_objects(
+                self.s3_client.delete_objects(
                     Bucket=self.bucket,
                     Delete={
                         'Objects': [
@@ -89,8 +91,10 @@ class S3Cache(BaseCache):
                 return True
 
     def set(self, key, value, timeout=None):
-        """Add a new key/value to the cache (overwrites value, if key already
-        exists in the cache).
+        """Add a new key/value to the cache.
+
+        If the key already exists, the existing value is overwritten.
+
         :param key: the key to set
         :param value: the value for the key
         :param timeout: the cache timeout for the key in seconds (if not
@@ -118,8 +122,8 @@ class S3Cache(BaseCache):
             return True
 
     def add(self, key, value, timeout=None):
-        """Works like :meth:`set` but does not overwrite the values of already
-        existing keys.
+        """Works like :meth:`set` but does not overwrite existing values.
+
         :param key: the key to set
         :param value: the value for the key
         :param timeout: the cache timeout for the key in seconds (if not
@@ -135,8 +139,9 @@ class S3Cache(BaseCache):
             return self.set(key, value, timeout=timeout)
 
     def clear(self):
-        """Clears the cache.  Keep in mind that not all caches support
-        completely clearing the cache.
+        """Clears the cache.
+
+        Keep in mind that not all caches support completely clearing the cache.
         :returns: Whether the cache has been cleared.
         :rtype: boolean
         """
@@ -153,7 +158,7 @@ class S3Cache(BaseCache):
                 Bucket=self.bucket,
                 Key=self._full_s3_key(key)
             )
-        except Exception as e:
+        except Exception:
             # head_object throws an exception when object doesn't exist
             return False
         else:

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 try:
     import cPickle as pickle
-except:
+except ImportError:
     import pickle
 
 import logging

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -7,24 +7,106 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import cPickle
+import logging
+import StringIO
+
+import boto3
 from werkzeug.contrib.cache import BaseCache
+
+from superset import app
+
+config = app.config
 
 
 class S3Cache(BaseCache):
 
-    """S3 cache"""
+    """S3 cache implementation.
+
+    Adapted from examples in
+    https://github.com/pallets/werkzeug/blob/master/werkzeug/contrib/cache.py.
+
+    Timeout parameters are ignored as S3 doesn't support key-level expiration. To expire
+    keys, set up an expiration policy as described in
+    https://aws.amazon.com/blogs/aws/amazon-s3-object-expiration/.
+    """
 
     def __init__(self, default_timeout=300):
         self.default_timeout = default_timeout
 
+        self.s3_client = boto3.client('s3')
+        self.bucket = self.s3_resource.Bucket(config.get('S3_CACHE_BUCKET'))
+        self.key_prefix = config.get('S3_CACHE_KEY_PREFIX')
+
     def get(self, key):
-        return None
+        """Look up key in the cache and return the value for it.
+        :param key: the key to be looked up.
+        :returns: The value if it exists and is readable, else ``None``.
+        """
+        if not self._key_exists(key):
+            return None
+        else:
+            value_file = StringIO.StringIO()
+
+            try:
+                self.s3_client.download_fileobj(self.bucket, self._full_s3_key(key), value_file)
+            except Exception as e:
+                logging.warn('Exception while trying to get %s: %s', key, e)
+                return None
+            else:
+                value_file.seek(0)
+                return cPickle.load(value_file)
 
     def delete(self, key):
-        return True
+        """Delete `key` from the cache.
+        :param key: the key to delete.
+        :returns: Whether the key existed and has been deleted.
+        :rtype: boolean
+        """
+        if not self._key_exists(key):
+            return False
+        else:
+            try:
+                response = self.s3_client.delete_objects(
+                    Bucket=self.bucket,
+                    Delete={
+                        'Objects': [
+                            {
+                                'Key': self._full_s3_key(key)
+                            }
+                        ]
+                    }
+                )
+            except Exception as e:
+                logging.warn('Exception while trying to delete %s: %s', key, e)
+                return False
+            else:
+                return True
 
     def set(self, key, value, timeout=None):
-        return True
+        """Add a new key/value to the cache (overwrites value, if key already
+        exists in the cache).
+        :param key: the key to set
+        :param value: the value for the key
+        :param timeout: the cache timeout for the key in seconds (if not
+                        specified, it uses the default timeout). A timeout of
+                        0 idicates that the cache never expires.
+        :returns: ``True`` if key has been updated, ``False`` for backend
+                  errors. Pickling errors, however, will raise a subclass of
+                  ``pickle.PickleError``.
+        :rtype: boolean
+        """
+        value_file = StringIO.StringIO()
+        cPickle.dump(value, value_file)
+
+        try:
+            value_file.seek(0)
+            self.s3_client.upload_fileobj(value_file, self.bucket, self._full_s3_key(key))
+        except Exception as e:
+            logging.warn('Exception while trying to set %s: %s', key, e)
+            return False
+        else:
+            return True
 
     def add(self, key, value, timeout=None):
         """Works like :meth:`set` but does not overwrite the values of already
@@ -38,7 +120,10 @@ class S3Cache(BaseCache):
                   existing keys.
         :rtype: boolean
         """
-        return True
+        if self._key_exists(key):
+            return False
+        else:
+            return self.set(key, value, timeout=timeout)
 
     def clear(self):
         """Clears the cache.  Keep in mind that not all caches support
@@ -46,4 +131,21 @@ class S3Cache(BaseCache):
         :returns: Whether the cache has been cleared.
         :rtype: boolean
         """
-        return True
+        return False
+
+    def _full_s3_key(self, key):
+        """Convert a cache key to a full S3 key, including the key prefix."""
+        return '%s%s' % (self.key_prefix, key)
+
+    def _key_exists(self, key):
+        """Determine whether the given key exists in the bucket."""
+        try:
+            response = self.s3_client.head_object(
+                Bucket=self.bucket,
+                Key=self._full_s3_key(key)
+            )
+        except Exception as e:
+            # head_object throws an exception when object doesn't exist
+            return False
+        else:
+            return True

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -8,9 +8,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 try:
-   import cPickle as pickle
+    import cPickle as pickle
 except:
-   import pickle
+    import pickle
 
 import logging
 import StringIO

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -35,6 +35,7 @@ class S3Cache(BaseCache):
         self.default_timeout = default_timeout
 
         self.s3_client = boto3.client('s3')
+
         self.bucket = config.get('S3_CACHE_BUCKET')
         self.key_prefix = config.get('S3_CACHE_KEY_PREFIX')
 

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -13,7 +13,11 @@ except:
     import pickle
 
 import logging
-import StringIO
+
+try:
+    import StringIO
+except ImportError:
+    import io as StringIO
 
 import boto3
 from werkzeug.contrib.cache import BaseCache

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -26,8 +26,8 @@ class S3Cache(BaseCache):
     Adapted from examples in
     https://github.com/pallets/werkzeug/blob/master/werkzeug/contrib/cache.py.
 
-    Timeout parameters are ignored as S3 doesn't support key-level expiration. To expire
-    keys, set up an expiration policy as described in
+    Timeout parameters are ignored as S3 doesn't support key-level expiration.
+    To expire keys, set up an expiration policy as described in
     https://aws.amazon.com/blogs/aws/amazon-s3-object-expiration/.
     """
 
@@ -50,7 +50,11 @@ class S3Cache(BaseCache):
             value_file = StringIO.StringIO()
 
             try:
-                self.s3_client.download_fileobj(self.bucket, self._full_s3_key(key), value_file)
+                self.s3_client.download_fileobj(
+                    self.bucket,
+                    self._full_s3_key(key),
+                    value_file
+                )
             except Exception as e:
                 logging.warn('Exception while trying to get %s: %s', key, e)
                 return None
@@ -102,7 +106,11 @@ class S3Cache(BaseCache):
 
         try:
             value_file.seek(0)
-            self.s3_client.upload_fileobj(value_file, self.bucket, self._full_s3_key(key))
+            self.s3_client.upload_fileobj(
+                value_file,
+                self.bucket,
+                self._full_s3_key(key)
+            )
         except Exception as e:
             logging.warn('Exception while trying to set %s: %s', key, e)
             return False

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -12,12 +12,8 @@ try:
 except ImportError:
     import pickle
 
+import io
 import logging
-
-try:
-    import StringIO
-except ImportError:
-    import io as StringIO
 
 import boto3
 from werkzeug.contrib.cache import BaseCache
@@ -56,7 +52,7 @@ class S3Cache(BaseCache):
         if not self._key_exists(key):
             return None
         else:
-            value_file = StringIO.StringIO()
+            value_file = io.BytesIO()
 
             try:
                 self.s3_client.download_fileobj(
@@ -117,7 +113,7 @@ class S3Cache(BaseCache):
                   ``pickle.PickleError``.
         :rtype: boolean
         """
-        value_file = StringIO.StringIO()
+        value_file = io.BytesIO()
         pickle.dump(value, value_file)
 
         try:

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -57,7 +57,9 @@ class S3Cache(BaseCache):
                     value_file
                 )
             except Exception as e:
-                logging.warn('Exception while trying to get %s: %s', key, e)
+                logging.warn('Error while trying to get key %s', key)
+                logging.exception(e)
+
                 return None
             else:
                 value_file.seek(0)
@@ -85,7 +87,9 @@ class S3Cache(BaseCache):
                     }
                 )
             except Exception as e:
-                logging.warn('Exception while trying to delete %s: %s', key, e)
+                logging.warn('Error while trying to delete key %s', key)
+                logging.exception(e)
+
                 return False
             else:
                 return True
@@ -116,7 +120,9 @@ class S3Cache(BaseCache):
                 self._full_s3_key(key)
             )
         except Exception as e:
-            logging.warn('Exception while trying to set %s: %s', key, e)
+            logging.warn('Error while trying to set key %s', key)
+            logging.exception(e)
+
             return False
         else:
             return True

--- a/superset/results_backends.py
+++ b/superset/results_backends.py
@@ -7,7 +7,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import cPickle
+try:
+   import cPickle as pickle
+except:
+   import pickle
+
 import logging
 import StringIO
 
@@ -63,7 +67,7 @@ class S3Cache(BaseCache):
                 return None
             else:
                 value_file.seek(0)
-                return cPickle.load(value_file)
+                return pickle.load(value_file)
 
     def delete(self, key):
         """Delete `key` from the cache.
@@ -110,7 +114,7 @@ class S3Cache(BaseCache):
         :rtype: boolean
         """
         value_file = StringIO.StringIO()
-        cPickle.dump(value, value_file)
+        pickle.dump(value, value_file)
 
         try:
             value_file.seek(0)

--- a/tests/results_backends_tests.py
+++ b/tests/results_backends_tests.py
@@ -1,6 +1,6 @@
 try:
     import cPickle as pickle
-except:
+except ImportError:
     import pickle
 
 import mock

--- a/tests/results_backends_tests.py
+++ b/tests/results_backends_tests.py
@@ -66,7 +66,7 @@ class ResultsBackendsTests(SupersetTestCase):
         self.assertEquals(result, None)
         self.assertFalse(self.mock_s3_client.download_fileobj.called)
 
-    def test_s3_cache_get_s3_exception(self):
+    def test_s3_cache_get_exception(self):
         self.mock_s3_client.download_fileobj.side_effect = Exception('Something bad happened')
         result = self.s3_cache.get('test-key')
 

--- a/tests/results_backends_tests.py
+++ b/tests/results_backends_tests.py
@@ -1,4 +1,7 @@
-import cPickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 
 import mock
 
@@ -24,7 +27,7 @@ class ResultsBackendsTests(SupersetTestCase):
 
     @staticmethod
     def _mock_download_fileobj(bucket, key, value_file):
-        value_file.write(cPickle.dumps('%s:%s' % (bucket, key)))
+        value_file.write(pickle.dumps('%s:%s' % (bucket, key)))
 
     @staticmethod
     def _mock_key_exists(key):
@@ -41,7 +44,7 @@ class ResultsBackendsTests(SupersetTestCase):
 
         call_args = self.mock_s3_client.upload_fileobj.call_args_list[0][0]
 
-        self.assertEquals(cPickle.loads(call_args[0].getvalue()), 'test-value')
+        self.assertEquals(pickle.loads(call_args[0].getvalue()), 'test-value')
         self.assertEquals(call_args[1], 'test-bucket')
         self.assertEquals(call_args[2], 'test-prefix/test-key')
 
@@ -109,7 +112,7 @@ class ResultsBackendsTests(SupersetTestCase):
 
         call_args = self.mock_s3_client.upload_fileobj.call_args_list[0][0]
 
-        self.assertEquals(cPickle.loads(call_args[0].getvalue()), 'test-value')
+        self.assertEquals(pickle.loads(call_args[0].getvalue()), 'test-value')
         self.assertEquals(call_args[1], 'test-bucket')
         self.assertEquals(call_args[2], 'test-prefix/test-key2')
 

--- a/tests/results_backends_tests.py
+++ b/tests/results_backends_tests.py
@@ -1,0 +1,120 @@
+import cPickle
+import mock
+
+from superset import app, results_backends
+from .base_tests import SupersetTestCase
+
+app.config['S3_CACHE_BUCKET'] = 'test-bucket'
+app.config['S3_CACHE_KEY_PREFIX'] = 'test-prefix/'
+
+
+class ResultsBackendsTests(SupersetTestCase):
+    requires_examples = False
+
+    @mock.patch('boto3.client')
+    def setUp(self, mock_boto3_client):
+        self.mock_boto3_client = mock_boto3_client
+        self.mock_s3_client = mock.MagicMock()
+
+        self.mock_boto3_client.return_value = self.mock_s3_client
+
+        self.s3_cache = results_backends.S3Cache()
+        self.s3_cache._key_exists = ResultsBackendsTests._mock_key_exists
+
+    @staticmethod
+    def _mock_download_fileobj(bucket, key, value_file):
+        value_file.write(cPickle.dumps('%s:%s' % (bucket, key)))
+
+    @staticmethod
+    def _mock_key_exists(key):
+        return key == 'test-key'
+
+    def test_s3_cache_initilization(self):
+        self.mock_boto3_client.assert_called_with('s3')
+
+    def test_s3_cache_set(self):
+        result = self.s3_cache.set('test-key', 'test-value')
+
+        self.assertTrue(result)
+        self.mock_s3_client.upload_fileobj.assert_called_once()
+
+        call_args = self.mock_s3_client.upload_fileobj.call_args_list[0][0]
+
+        self.assertEquals(cPickle.loads(call_args[0].getvalue()), 'test-value')
+        self.assertEquals(call_args[1], 'test-bucket')
+        self.assertEquals(call_args[2], 'test-prefix/test-key')
+
+    def test_s3_cache_exception(self):
+        self.mock_s3_client.upload_fileobj.side_effect = Exception('Something bad happened!')
+        result = self.s3_cache.set('test-key', 'test-value')
+
+        self.assertFalse(result)
+        self.mock_s3_client.upload_fileobj.assert_called_once()
+
+    def test_s3_cache_get_exists(self):
+        self.mock_s3_client.download_fileobj.side_effect = (
+            ResultsBackendsTests._mock_download_fileobj)
+        result = self.s3_cache.get('test-key')
+
+        self.assertEquals(result, 'test-bucket:test-prefix/test-key')
+        self.mock_s3_client.download_fileobj.assert_called_once()
+
+    def test_s3_cache_get_does_not_exist(self):
+        result = self.s3_cache.get('test-key2')
+
+        self.assertEquals(result, None)
+        self.assertFalse(self.mock_s3_client.download_fileobj.called)
+
+    def test_s3_cache_get_s3_exception(self):
+        self.mock_s3_client.download_fileobj.side_effect = Exception('Something bad happened')
+        result = self.s3_cache.get('test-key')
+
+        self.assertEquals(result, None)
+        self.mock_s3_client.download_fileobj.assert_called_once()
+
+    def test_s3_cache_delete_exists(self):
+        result = self.s3_cache.delete('test-key')
+
+        self.assertTrue(result)
+        self.mock_s3_client.delete_objects.assert_called_once_with(
+            Bucket='test-bucket',
+            Delete={'Objects': [{'Key': 'test-prefix/test-key'}]}
+        )
+
+    def test_s3_cache_delete_does_not_exist(self):
+        result = self.s3_cache.delete('test-key2')
+
+        self.assertFalse(result)
+        self.assertFalse(self.mock_s3_client.delete_objects.called)
+
+    def test_s3_cache_delete_exception(self):
+        self.mock_s3_client.delete_objects.side_effect = Exception('Something bad happened')
+        result = self.s3_cache.delete('test-key')
+
+        self.assertFalse(result)
+        self.mock_s3_client.delete_objects.assert_called_once()
+
+    def test_s3_cache_add_exists(self):
+        result = self.s3_cache.add('test-key', 'test-value')
+
+        self.assertFalse(result)
+        self.assertFalse(self.mock_s3_client.upload_fileobj.called)
+
+    def test_s3_cache_add_does_not_exist(self):
+        result = self.s3_cache.add('test-key2', 'test-value')
+
+        self.assertTrue(result)
+        self.mock_s3_client.upload_fileobj.assert_called_once()
+
+        call_args = self.mock_s3_client.upload_fileobj.call_args_list[0][0]
+
+        self.assertEquals(cPickle.loads(call_args[0].getvalue()), 'test-value')
+        self.assertEquals(call_args[1], 'test-bucket')
+        self.assertEquals(call_args[2], 'test-prefix/test-key2')
+
+    def test_s3_cache_add_exception(self):
+        self.mock_s3_client.upload_fileobj.side_effect = Exception('Something bad happened')
+        result = self.s3_cache.add('test-key2', 'test-value')
+
+        self.assertFalse(result)
+        self.mock_s3_client.upload_fileobj.assert_called_once()

--- a/tests/results_backends_tests.py
+++ b/tests/results_backends_tests.py
@@ -1,4 +1,5 @@
 import cPickle
+
 import mock
 
 from superset import app, results_backends
@@ -44,7 +45,7 @@ class ResultsBackendsTests(SupersetTestCase):
         self.assertEquals(call_args[1], 'test-bucket')
         self.assertEquals(call_args[2], 'test-prefix/test-key')
 
-    def test_s3_cache_exception(self):
+    def test_s3_cache_set_exception(self):
         self.mock_s3_client.upload_fileobj.side_effect = Exception('Something bad happened!')
         result = self.s3_cache.set('test-key', 'test-value')
 


### PR DESCRIPTION
to: @mistercrunch 

#### Content

This change implements an `S3Cache` which extends from `werkzeug.contrib.cache.BaseCache`. All S3 calls are made using the `boto3` library.