### PR TITLE
[vis] render line breaks in TableViz

### DIFF
--- a/superset/assets/visualizations/table.css
+++ b/superset/assets/visualizations/table.css
@@ -23,3 +23,7 @@
 table.table thead th.sorting:after, table.table thead th.sorting_asc:after, table.table thead th.sorting_desc:after {
     top: 0px;
 }
+
+.like-pre {
+  white-space: pre;
+}

--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -10,6 +10,12 @@ import 'datatables.net';
 import dt from 'datatables.net-bs';
 dt(window, $);
 
+function textFormatter(text) {
+  // The first replace turns the sequence \r\n into <br />.
+  // The second replace replaces any \r or \n characters found on their own within the string.
+  return text.replace(/\r\n/g, '<br />').replace(/[\r\n]/g, '<br />');
+}
+
 function tableVis(slice, payload) {
   const container = $(slice.selector);
   const fC = d3.format('0,000');
@@ -71,6 +77,9 @@ function tableVis(slice, payload) {
       let val = row[c];
       if (c === 'timestamp') {
         val = timestampFormatter(val);
+      }
+      if (typeof(val) === 'string') {
+        val = textFormatter(val);
       }
       return {
         col: c,

--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -10,12 +10,6 @@ import 'datatables.net';
 import dt from 'datatables.net-bs';
 dt(window, $);
 
-function textFormatter(text) {
-  // The first replace turns the sequence \r\n into <br />.
-  // The second replace replaces any \r or \n characters found on their own within the string.
-  return text.replace(/\r\n/g, '<br />').replace(/[\r\n]/g, '<br />');
-}
-
 function tableVis(slice, payload) {
   const container = $(slice.selector);
   const fC = d3.format('0,000');
@@ -79,7 +73,7 @@ function tableVis(slice, payload) {
         val = timestampFormatter(val);
       }
       if (typeof(val) === 'string') {
-        val = textFormatter(val);
+        val = `<span class="like-pre">${val}</span>`;
       }
       return {
         col: c,


### PR DESCRIPTION
wrap values in a class that uses `white-space: pre`, to honor line breaks, tabs, spaces.
http://stackoverflow.com/questions/219219/how-to-change-a-span-to-look-like-a-pre-with-css

fixes: https://github.com/airbnb/superset/issues/1785

before:
<img width="1436" alt="screenshot 2017-02-10 09 34 21" src="https://cloud.githubusercontent.com/assets/130878/22837128/1ec5a4f8-ef74-11e6-8573-146829dffe87.png">

after:
<img width="1440" alt="screenshot 2017-02-10 09 30 25" src="https://cloud.githubusercontent.com/assets/130878/22837031/b98c1888-ef73-11e6-9922-f71a8f386038.png">

plz review @airbnb/superset-reviewers 
