### PR TITLE
[explore/dashboard] only call drawGraph once, fixes js error on slices

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -418,8 +418,7 @@ function nvd3Vis(slice, payload) {
   // this will clear them before rendering the chart again.
   hideTooltips();
 
-  const graph = drawGraph();
-  nv.addGraph(graph);
+  nv.addGraph(drawGraph);
 }
 
 module.exports = nvd3Vis;


### PR DESCRIPTION
only call drawGraph once, fixes js error on rendering slices on dashboards and the explore view.
fixes: https://github.com/airbnb/superset/issues/2131

before:
<img width="700" alt="screenshot 2017-02-07 13 57 54" src="https://cloud.githubusercontent.com/assets/130878/22714793/f5d3382c-ed42-11e6-9b93-b43c7b1e8542.png">
after:
<img width="665" alt="screenshot 2017-02-07 13 59 12" src="https://cloud.githubusercontent.com/assets/130878/22714794/f5d6ec4c-ed42-11e6-9d4d-87ddc8baa670.png">

plz review @airbnb/superset-reviewers 