### PR TITLE
Fix werkzeug instance was created twice in Debug Mode (#2135)

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -31,7 +31,8 @@ def init():
     '-d', '--debug', action='store_true',
     help="Start the web server in debug mode")
 @manager.option(
-    '-n', '--no-reload', action='store_false', dest='no_reload', default=config.get("FLASK_USE_RELOAD"),
+    '-n', '--no-reload', action='store_false', dest='no_reload',
+    default=config.get("FLASK_USE_RELOAD"),
     help="Don't use the reloader in debug mode")
 @manager.option(
     '-a', '--address', default=config.get("SUPERSET_WEBSERVER_ADDRESS"),

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -50,7 +50,8 @@ def runserver(debug, address, port, timeout, workers):
             host='0.0.0.0',
             port=int(port),
             threaded=True,
-            debug=True)
+            debug=True,
+            use_reloader=False)
     else:
         cmd = (
             "gunicorn "

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -31,8 +31,8 @@ def init():
     '-d', '--debug', action='store_true',
     help="Start the web server in debug mode")
 @manager.option(
-    '-r', '--reloader', default=config.get("FLASK_USE_RELOAD"),
-    help="Specify the flask whether to use the auto-reloader")
+    '-n', '--no-reload', action='store_false', dest='no_reload', default=config.get("FLASK_USE_RELOAD"),
+    help="Don't use the reloader in debug mode")
 @manager.option(
     '-a', '--address', default=config.get("SUPERSET_WEBSERVER_ADDRESS"),
     help="Specify the address to which to bind the web server")
@@ -45,7 +45,7 @@ def init():
 @manager.option(
     '-t', '--timeout', default=config.get("SUPERSET_WEBSERVER_TIMEOUT"),
     help="Specify the timeout (seconds) for the gunicorn web server")
-def runserver(debug, reloader, address, port, timeout, workers):
+def runserver(debug, no_reload, address, port, timeout, workers):
     """Starts a Superset web server"""
     debug = debug or config.get("DEBUG")
     if debug:
@@ -54,7 +54,7 @@ def runserver(debug, reloader, address, port, timeout, workers):
             port=int(port),
             threaded=True,
             debug=True,
-            use_reloader=(str(reloader) == 'True'))
+            use_reloader=no_reload)
     else:
         cmd = (
             "gunicorn "
@@ -121,13 +121,13 @@ def load_examples(load_test_data):
 @manager.option(
     '-d', '--datasource',
     help=(
-        "Specify which datasource name to load, if omitted, all "
-        "datasources will be refreshed"))
+            "Specify which datasource name to load, if omitted, all "
+            "datasources will be refreshed"))
 @manager.option(
     '-m', '--merge',
     help=(
-        "Specify using 'merge' property during operation. "
-        "Default value is False "))
+            "Specify using 'merge' property during operation. "
+            "Default value is False "))
 def refresh_druid(datasource, merge):
     """Refresh druid datasources"""
     session = db.session()

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -31,6 +31,9 @@ def init():
     '-d', '--debug', action='store_true',
     help="Start the web server in debug mode")
 @manager.option(
+    '-r', '--reloader', default=config.get("FLASK_USE_RELOAD"),
+    help="Specify the flask whether to use the auto-reloader")
+@manager.option(
     '-a', '--address', default=config.get("SUPERSET_WEBSERVER_ADDRESS"),
     help="Specify the address to which to bind the web server")
 @manager.option(
@@ -42,7 +45,7 @@ def init():
 @manager.option(
     '-t', '--timeout', default=config.get("SUPERSET_WEBSERVER_TIMEOUT"),
     help="Specify the timeout (seconds) for the gunicorn web server")
-def runserver(debug, address, port, timeout, workers):
+def runserver(debug, reloader, address, port, timeout, workers):
     """Starts a Superset web server"""
     debug = debug or config.get("DEBUG")
     if debug:
@@ -51,7 +54,7 @@ def runserver(debug, address, port, timeout, workers):
             port=int(port),
             threaded=True,
             debug=True,
-            use_reloader=False)
+            use_reloader=(str(reloader) == 'True'))
     else:
         cmd = (
             "gunicorn "

--- a/superset/config.py
+++ b/superset/config.py
@@ -57,6 +57,7 @@ CSRF_ENABLED = True
 
 # Whether to run the web server in debug mode or not
 DEBUG = False
+FLASK_USE_RELOAD = True
 
 # Whether to show the stacktrace on 500 error
 SHOW_STACKTRACE = True


### PR DESCRIPTION
Fix werkzeug instance was created twice in Debug Mode (#2135)
```
(superset) [root@edeppreapp01 superset-0.15.4]# ./bin/python ./lib/python2.7/site-packages/superset/cli.py runserver -d -p 8888
/root/superset-0.15.4/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.script is deprecated, use flask_script instead.
  .format(x=modname), ExtDeprecationWarning
/root/superset-0.15.4/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.sqlalchemy is deprecated, use flask_sqlalchemy instead.
  .format(x=modname), ExtDeprecationWarning
/root/superset-0.15.4/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.sqlalchemy._compat is deprecated, use flask_sqlalchemy._compat instead.
  .format(x=modname), ExtDeprecationWarning
/root/superset-0.15.4/lib/python2.7/site-packages/flask_cache/__init__.py:152: UserWarning: Flask-Cache: CACHE_TYPE is set to null, caching is effectively disabled.
  warnings.warn("Flask-Cache: CACHE_TYPE is set to null, "
/root/superset-0.15.4/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.cache is deprecated, use flask_cache instead.
  .format(x=modname), ExtDeprecationWarning
2017-02-08 15:40:07,200:INFO:flask_appbuilder.base:Registering class MyIndexView on menu 
2017-02-08 15:40:07,205:INFO:flask_appbuilder.base:Registering class UtilView on menu 
2017-02-08 15:40:07,209:INFO:flask_appbuilder.base:Registering class LocaleView on menu 
2017-02-08 15:40:07,213:INFO:flask_appbuilder.base:Registering class ResetPasswordView on menu 
2017-02-08 15:40:07,230:INFO:flask_appbuilder.base:Registering class ResetMyPasswordView on menu 
2017-02-08 15:40:07,244:INFO:flask_appbuilder.base:Registering class UserInfoEditView on menu 
2017-02-08 15:40:07,258:INFO:flask_appbuilder.base:Registering class AuthDBView on menu 
2017-02-08 15:40:07,267:INFO:flask_appbuilder.base:Registering class UserDBModelView on menu List Users
2017-02-08 15:40:07,313:INFO:flask_appbuilder.base:Registering class RoleModelView on menu List Roles
2017-02-08 15:40:07,355:INFO:flask_appbuilder.base:Registering class UserStatsChartView on menu User's Statistics
2017-02-08 15:40:07,383:INFO:flask_appbuilder.base:Registering class PermissionModelView on menu Base Permissions
2017-02-08 15:40:07,418:INFO:flask_appbuilder.base:Registering class ViewMenuModelView on menu Views/Menus
2017-02-08 15:40:07,452:INFO:flask_appbuilder.base:Registering class PermissionViewModelView on menu Permission on Views/Menus
2017-02-08 15:40:08,112:INFO:flask_appbuilder.base:Registering class TableColumnInlineView on menu 
2017-02-08 15:40:08,158:INFO:flask_appbuilder.base:Registering class DruidColumnInlineView on menu 
2017-02-08 15:40:08,193:INFO:flask_appbuilder.base:Registering class SqlMetricInlineView on menu 
2017-02-08 15:40:08,223:INFO:flask_appbuilder.base:Registering class DruidMetricInlineView on menu 
2017-02-08 15:40:08,265:WARNING:flask_appbuilder.models.filters:Filter type not supported for column: password
2017-02-08 15:40:08,269:INFO:flask_appbuilder.base:Registering class DatabaseView on menu Databases
2017-02-08 15:40:08,308:WARNING:flask_appbuilder.models.filters:Filter type not supported for column: password
2017-02-08 15:40:08,311:INFO:flask_appbuilder.base:Registering class DatabaseAsync on menu 
2017-02-08 15:40:08,337:WARNING:flask_appbuilder.models.filters:Filter type not supported for column: password
2017-02-08 15:40:08,340:INFO:flask_appbuilder.base:Registering class DatabaseTablesAsync on menu 
2017-02-08 15:40:08,374:INFO:flask_appbuilder.base:Registering class TableModelView on menu Tables
2017-02-08 15:40:08,421:INFO:flask_appbuilder.base:Registering class AccessRequestsModelView on menu Access requests
2017-02-08 15:40:08,472:INFO:flask_appbuilder.base:Registering class DruidClusterModelView on menu Druid Clusters
2017-02-08 15:40:08,605:INFO:flask_appbuilder.base:Registering class SliceModelView on menu Slices
2017-02-08 15:40:08,640:INFO:flask_appbuilder.base:Registering class SliceAsync on menu 
2017-02-08 15:40:08,670:INFO:flask_appbuilder.base:Registering class SliceAddView on menu 
2017-02-08 15:40:08,699:INFO:flask_appbuilder.base:Registering class DashboardModelView on menu Dashboards
2017-02-08 15:40:08,737:INFO:flask_appbuilder.base:Registering class DashboardModelViewAsync on menu 
2017-02-08 15:40:08,767:INFO:flask_appbuilder.base:Registering class LogModelView on menu Action Log
2017-02-08 15:40:08,809:INFO:flask_appbuilder.base:Registering class QueryView on menu Queries
2017-02-08 15:40:08,851:INFO:flask_appbuilder.base:Registering class DruidDatasourceModelView on menu Druid Datasources
2017-02-08 15:40:08,891:INFO:flask_appbuilder.base:Registering class R on menu 
2017-02-08 15:40:08,896:INFO:flask_appbuilder.base:Registering class Superset on menu 
2017-02-08 15:40:08,986:INFO:flask_appbuilder.base:Registering class CssTemplateModelView on menu CSS Templates
2017-02-08 15:40:09,026:INFO:flask_appbuilder.base:Registering class CssTemplateAsyncModelView on menu 
2017-02-08 15:40:09,121:INFO:werkzeug: * Running on http://0.0.0.0:8888/ (Press CTRL+C to quit)

```
(superset) [root@edeppreapp01 superset-0.15.4]# ps -ef | grep superset | grep -v grep
root     31522  1632 28 15:40 pts/0    00:00:03 ./bin/python ./lib/python2.7/site-packages/superset/cli.py runserver -d -p 8888