### PR TITLE
Only allow owners to overwrite slice

### DIFF
--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -6,7 +6,7 @@ import Select from 'react-select';
 import { connect } from 'react-redux';
 
 const propTypes = {
-  can_edit: PropTypes.bool,
+  can_overwrite: PropTypes.bool,
   onHide: PropTypes.func.isRequired,
   actions: PropTypes.object.isRequired,
   form_data: PropTypes.object,
@@ -26,7 +26,7 @@ class SaveModal extends React.Component {
       newSliceName: '',
       dashboards: [],
       alert: null,
-      action: 'overwrite',
+      action: 'saveas',
       addToDash: 'noSave',
     };
   }
@@ -140,7 +140,7 @@ class SaveModal extends React.Component {
             </Alert>
           }
           <Radio
-            disabled={!this.props.can_edit}
+            disabled={!this.props.can_overwrite}
             checked={this.state.action === 'overwrite'}
             onChange={this.changeAction.bind(this, 'overwrite')}
           >
@@ -229,7 +229,7 @@ function mapStateToProps(state) {
   return {
     datasource: state.datasource,
     slice: state.slice,
-    can_edit: state.can_edit,
+    can_overwrite: state.can_overwrite,
     user_id: state.user_id,
     dashboards: state.dashboards,
     alert: state.saveModalAlert,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -163,8 +163,7 @@ class BaseViz(object):
         until = extra_filters.get('__to') or form_data.get("until", "now")
         to_dttm = utils.parse_human_datetime(until)
         if from_dttm > to_dttm:
-            flasher("The date range doesn't seem right.", "danger")
-            from_dttm = to_dttm  # Making them identical to not raise
+            raise Exception("From date cannot be larger than to date")
 
         # extras are used to query elements specific to a datasource type
         # for instance the extra where clause that applies only to Tables
@@ -329,8 +328,7 @@ class BaseViz(object):
         until = form_data.get("until", "now")
         to_dttm = utils.parse_human_datetime(until)
         if from_dttm > to_dttm:
-            flasher("The date range doesn't seem right.", "danger")
-            from_dttm = to_dttm  # Making them identical to not raise
+            raise Exception("From date cannot be larger than to date")
 
         kwargs = dict(
             column_name=column,


### PR DESCRIPTION
Issue: [https://github.com/airbnb/superset/issues/2122](url)

Before:
 - Allow Admin users or slice_creator to overwrite any slice
 - Save Modal action is set to overwrite by default, but it's disabled when user doesn't have permission

After:
 - Only allow owners to overwrite slice
 - Save Modal set saveas instead of overwrite as default action

<img width="1282" alt="screen shot 2017-02-08 at 5 13 46 pm" src="https://cloud.githubusercontent.com/assets/20978302/22764922/61982e52-ee22-11e6-8824-8533d3c701b8.png">



@mistercrunch 

