### PR TITLE
Using the time zone with specific name for querying Druid

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -76,9 +76,12 @@ APP_ICON = "/static/assets/images/superset-logo@2x.png"
 # Druid query timezone
 # tz.tzutc() : Using utc timezone
 # tz.tzlocal() : Using local timezone
+# tz.gettz('Asia/Shanghai') : Using the time zone with specific name
+# [TimeZone List]
+# See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # other tz can be overridden by providing a local_config
 DRUID_IS_ACTIVE = True
-DRUID_TZ = tz.tzutc()
+DRUID_TZ = tz.gettz('Africa/Abidjan')
 DRUID_ANALYSIS_TYPES = ['cardinality']
 
 # ----------------------------------------------------

--- a/superset/config.py
+++ b/superset/config.py
@@ -81,7 +81,7 @@ APP_ICON = "/static/assets/images/superset-logo@2x.png"
 # See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # other tz can be overridden by providing a local_config
 DRUID_IS_ACTIVE = True
-DRUID_TZ = tz.gettz('Africa/Abidjan')
+DRUID_TZ = tz.tzutc()
 DRUID_ANALYSIS_TYPES = ['cardinality']
 
 # ----------------------------------------------------


### PR DESCRIPTION
Using the time zone with specific name for querying Druid.

Just use `DRUID_TZ = tz.gettz('Africa/Abidjan')` to test, and then it will be modified into `tz.tzutc()`.

By the way, sorry for creating so many PRs. I just figure out that i should create the new branch `time_zone` to contribute codes. :)