### PR TITLE
[slices axis] fix axis spacing on dashboard and explore slices

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -66,6 +66,7 @@ function hideTooltips() {
 function nvd3Vis(slice, payload) {
   let chart;
   let colorKey = 'key';
+  const isExplore = $('#explore-container').length === 1;
 
   slice.container.html('');
   slice.clearError();
@@ -387,7 +388,7 @@ function nvd3Vis(slice, payload) {
     // - adjust margins based on these measures and render again
     if (isTimeSeries && vizType !== 'bar') {
       const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x', 'height')
-      const marginPad = width * .05;
+      const marginPad = isExplore ? width * .01 : width * .03;
       const chartMargins = {
         bottom: maxXAxisLabelHeight + marginPad,
         right: maxXAxisLabelHeight + marginPad,

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -367,7 +367,6 @@ function nvd3Vis(slice, payload) {
       chart.yAxis2.tickFormat(yAxisFormatter2);
       customizeToolTip(chart, xAxisFormatter, [yAxisFormatter1, yAxisFormatter2]);
       chart.showLegend(true);
-      chart.margin({ right: 50 });
     }
     svg
     .datum(payload.data)

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -386,7 +386,7 @@ function nvd3Vis(slice, payload) {
     // - has to be done only after the chart has been rendered once
     // - measure the width or height of the labels (x axis labels are rotated 45 degrees so we use height),
     // - adjust margins based on these measures and render again
-    if (isTimeSeries) {
+    if (isTimeSeries && vizType !== 'bar') {
       const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x', 'height')
       const marginPad = width * .05;
       const chartMargins = {

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -63,6 +63,15 @@ function hideTooltips() {
   $('.nvtooltip').css({ opacity: 0 });
 }
 
+function getMaxLabelSize(container, axisClass, widthOrHeight) {
+  // axis class = .nv-y2  // second y axis on dual line chart
+  // axis class = .nv-x  // x axis on time series line chart
+  const labelEls = container.find(`.${axisClass} .tick text`);
+  const labelDimensions = labelEls.map(i => labelEls[i].getBoundingClientRect()[widthOrHeight]);
+  const max = Math.max.apply(Math, labelDimensions);
+  return max;
+}
+
 function nvd3Vis(slice, payload) {
   let chart;
   let colorKey = 'key';
@@ -384,11 +393,12 @@ function nvd3Vis(slice, payload) {
 
     // Hack to adjust margins to accommodate long axis tick labels.
     // - has to be done only after the chart has been rendered once
-    // - measure the width or height of the labels (x axis labels are rotated 45 degrees so we use height),
+    // - measure the width or height of the labels
+    // ---- (x axis labels are rotated 45 degrees so we use height),
     // - adjust margins based on these measures and render again
     if (isTimeSeries && vizType !== 'bar') {
-      const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x', 'height')
-      const marginPad = isExplore ? width * .01 : width * .03;
+      const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x', 'height');
+      const marginPad = isExplore ? width * 0.01 : width * 0.03;
       const chartMargins = {
         bottom: maxXAxisLabelHeight + marginPad,
         right: maxXAxisLabelHeight + marginPad,
@@ -398,7 +408,7 @@ function nvd3Vis(slice, payload) {
         const maxYAxis2LabelWidth = getMaxLabelSize(slice.container, 'nv-y2', 'width');
         // use y axis width if it's wider than axis width/height
         if (maxYAxis2LabelWidth > maxXAxisLabelHeight) {
-          axis.right = maxYAxis2LabelWidth + marginPad;
+          chartMargins.right = maxYAxis2LabelWidth + marginPad;
         }
       }
 
@@ -427,15 +437,6 @@ function nvd3Vis(slice, payload) {
 
   const graph = drawGraph();
   nv.addGraph(graph);
-}
-
-function getMaxLabelSize(container, axisClass, widthOrHeight) {
-  // axis class = .nv-y2  // second y axis on dual line chart
-  // axis class = .nv-x  // x axis on time series line chart
-  const labelEls = container.find(`.${axisClass} .tick text`);
-  const labelDimensions = labelEls.map(i => labelEls[i].getBoundingClientRect()[widthOrHeight]);
-  const max = Math.max.apply(Math, labelDimensions);
-  return max;
 }
 
 module.exports = nvd3Vis;


### PR DESCRIPTION
- fixes bug where we weren't finding the axis labels for that slice, but for all slices on the page. fixed my constraining to look inside the slice container only.

- adjusted additional padding based on if it's the explore view or dashboard view

- i created an NVD3 Dashboard locally to test this, but will also test with a number of dashboards and slices on staging to make sure things are looking good.

before:
<img width="1437" alt="screenshot 2017-02-09 09 56 53" src="https://cloud.githubusercontent.com/assets/130878/22796388/f02bccbe-eeae-11e6-99b3-5f33690a18b5.png">

after:
<img width="1439" alt="screenshot 2017-02-09 09 55 06" src="https://cloud.githubusercontent.com/assets/130878/22796389/f02f2490-eeae-11e6-8aa2-09f585c5e84f.png">

plz review @airbnb/superset-reviewers 