### PR TITLE
Fixed bug with cast empty form data and filters

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -33,9 +33,9 @@ def cast_form_data(form_data):
         if ft == 'CheckboxField':
             v = True if v == 'true' else False
         elif ft == 'TextField' and field_config.get('isInt'):
-            v = int(v)
+            v = int(v) if v != '' else None
         elif ft == 'TextField' and field_config.get('isFloat'):
-            v = float(v)
+            v = float(v) if v != '' else None
         d[k] = v
     return d
 

--- a/superset/models.py
+++ b/superset/models.py
@@ -1360,12 +1360,7 @@ class SqlaTable(Model, Queryable, AuditMixinNullable, ImportMixin):
             col_obj = cols[col]
             if op in ('in', 'not in'):
                 splitted = FillterPattern.split(eq)[1::2]
-                values = [types.strip() for types in splitted]
-                # attempt to get the values type if they are not in quotes
-                if not col_obj.is_string:
-                    values = [ast.literal_eval(v) for v in values]
-                else:
-                    values = [v.replace("'", '').strip() for v in values]
+                values = [types.strip("'") for types in splitted]
                 cond = col_obj.sqla_col.in_(values)
                 if op == 'not in':
                     cond = ~cond


### PR DESCRIPTION
Issue:
 - some of our slices in staging were getting errors due to empty strings in integer fields
 - filters were broken in staging due to ast.literal_eval(v)

@mistercrunch 