### PR TITLE
Add parsing for nested json objects in resultset

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -190,7 +190,18 @@ class ResultSet extends React.PureComponent {
             {sql}
             <div className="ResultSet">
               <Table
-                data={data}
+                data={data.map(function (row) {
+                  const newRow = {};
+                  for (const k in row) {
+                    const val = row[k];
+                    if (typeof(val) === 'string') {
+                      newRow[k] = val;
+                    } else {
+                      newRow[k] = JSON.stringify(val);
+                    }
+                  }
+                  return newRow;
+                })}
                 columns={results.columns.map((col) => col.name)}
                 sortable
                 className="table table-condensed table-bordered"


### PR DESCRIPTION
Issue:
 When results return with nested data, reactable doesn't parse it. While the csv would have the right strings. the UI shows [object Object] in rows

![screen shot 2017-02-13 at 3 27 42 pm](https://cloud.githubusercontent.com/assets/20978302/22908026/11356852-f201-11e6-9cd4-b52b2cdcfe00.png)


Solution:
 parse nested object before passing data to reactable

@mistercrunch @ascott @bkyryliuk 