### PR TITLE
Return original state for query if query was stopped

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/javascripts/SqlLab/components/ResultSet.jsx
@@ -141,6 +141,10 @@ class ResultSet extends React.PureComponent {
 
     let sql;
 
+    if (query.state === 'stopped') {
+      return <Alert bsStyle="warning">Query was stopped</Alert>;
+    }
+
     if (this.props.showSql) {
       sql = <HighlightedSql sql={query.sql} />;
     }


### PR DESCRIPTION
Issue:
 The stop button in sqllab wasn't working as expected, it doesn't stop the query results from entering the state

Solution:
 Leave state as it is if the query was stopped, set results as zero for stopped queries

@mistercrunch @bkyryliuk @ascott 