### PR TITLE
Refactoring out the app creation

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -4,89 +4,17 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import logging
 import os
-from logging.handlers import TimedRotatingFileHandler
 
-from flask import Flask, redirect
-from flask_appbuilder import SQLA, AppBuilder, IndexView
-from flask_appbuilder.baseviews import expose
-from flask_cache import Cache
-from flask_migrate import Migrate
 from superset.source_registry import SourceRegistry
-from werkzeug.contrib.fixers import ProxyFix
-from superset import utils
-
+from superset import config
 
 APP_DIR = os.path.dirname(__file__)
 CONFIG_MODULE = os.environ.get('SUPERSET_CONFIG', 'superset.config')
 
-app = Flask(__name__)
-app.config.from_object(CONFIG_MODULE)
-conf = app.config
-
-if not app.debug:
-    # In production mode, add log handler to sys.stderr.
-    app.logger.addHandler(logging.StreamHandler())
-    app.logger.setLevel(logging.INFO)
-
-db = SQLA(app)
-
-
-utils.pessimistic_connection_handling(db.engine.pool)
-
-cache = Cache(app, config=app.config.get('CACHE_CONFIG'))
-
-migrate = Migrate(app, db, directory=APP_DIR + "/migrations")
-
-# Logging configuration
-logging.basicConfig(format=app.config.get('LOG_FORMAT'))
-logging.getLogger().setLevel(app.config.get('LOG_LEVEL'))
-
-if app.config.get('ENABLE_TIME_ROTATE'):
-    logging.getLogger().setLevel(app.config.get('TIME_ROTATE_LOG_LEVEL'))
-    handler = TimedRotatingFileHandler(app.config.get('FILENAME'),
-                                       when=app.config.get('ROLLOVER'),
-                                       interval=app.config.get('INTERVAL'),
-                                       backupCount=app.config.get('BACKUP_COUNT'))
-    logging.getLogger().addHandler(handler)
-
-if app.config.get('ENABLE_CORS'):
-    from flask_cors import CORS
-    CORS(app, **app.config.get('CORS_OPTIONS'))
-
-if app.config.get('ENABLE_PROXY_FIX'):
-    app.wsgi_app = ProxyFix(app.wsgi_app)
-
-if app.config.get('UPLOAD_FOLDER'):
-    try:
-        os.makedirs(app.config.get('UPLOAD_FOLDER'))
-    except OSError:
-        pass
-
-for middleware in app.config.get('ADDITIONAL_MIDDLEWARE'):
-    app.wsgi_app = middleware(app.wsgi_app)
-
-
-class MyIndexView(IndexView):
-    @expose('/')
-    def index(self):
-        return redirect('/superset/welcome')
-
-appbuilder = AppBuilder(
-    app, db.session,
-    base_template='superset/base.html',
-    indexview=MyIndexView,
-    security_manager_class=app.config.get("CUSTOM_SECURITY_MANAGER"))
-
-sm = appbuilder.sm
-
-get_session = appbuilder.get_session
-results_backend = app.config.get("RESULTS_BACKEND")
+results_backend = config.RESULTS_BACKEND
 
 # Registering sources
-module_datasource_map = app.config.get("DEFAULT_MODULE_DS_MAP")
-module_datasource_map.update(app.config.get("ADDITIONAL_MODULE_DS_MAP"))
+module_datasource_map = config.DEFAULT_MODULE_DS_MAP
+module_datasource_map.update(config.ADDITIONAL_MODULE_DS_MAP)
 SourceRegistry.register_sources(module_datasource_map)
-
-from superset import views, config  # noqa

--- a/superset/app.py
+++ b/superset/app.py
@@ -1,0 +1,92 @@
+"""Used to initialize and store the app"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import os
+from logging.handlers import TimedRotatingFileHandler
+
+from flask import Flask, redirect
+from flask_appbuilder import SQLA, AppBuilder, IndexView
+from flask_appbuilder.baseviews import expose
+from flask_cache import Cache
+from flask_migrate import Migrate
+from werkzeug.contrib.fixers import ProxyFix
+from superset import utils
+
+APP_DIR = os.path.dirname(__file__)
+CONFIG_MODULE = os.environ.get('SUPERSET_CONFIG', 'superset.config')
+
+# the app is cached in this var
+app = None
+
+def get_app():
+    """Returns the app object, inits it if needed"""
+    global app
+    if app:
+        return app
+    app = init_app()
+    return app
+
+def init_app():
+    app = Flask(__name__)
+    app.config.from_object(CONFIG_MODULE)
+
+    if not app.debug:
+        # In production mode, add log handler to sys.stderr.
+        app.logger.addHandler(logging.StreamHandler())
+        app.logger.setLevel(logging.INFO)
+
+    db = SQLA(app)
+
+    utils.pessimistic_connection_handling(db.engine.pool)
+
+    CACHE_CONFIG = app.config.get('CACHE_CONFIG')
+    if CACHE_CONFIG and CACHE_CONFIG.get('CACHE_TYPE') != 'null':
+        Cache(app, config=CACHE_CONFIG)
+
+    Migrate(app, db, directory=APP_DIR + "/migrations")
+
+    # Logging configuration
+    logging.basicConfig(format=app.config.get('LOG_FORMAT'))
+    logging.getLogger().setLevel(app.config.get('LOG_LEVEL'))
+
+    if app.config.get('ENABLE_TIME_ROTATE'):
+        logging.getLogger().setLevel(app.config.get('TIME_ROTATE_LOG_LEVEL'))
+        handler = TimedRotatingFileHandler(app.config.get('FILENAME'),
+                                           when=app.config.get('ROLLOVER'),
+                                           interval=app.config.get('INTERVAL'),
+                                           backupCount=app.config.get('BACKUP_COUNT'))
+        logging.getLogger().addHandler(handler)
+
+    if app.config.get('ENABLE_CORS'):
+        from flask_cors import CORS
+        CORS(app, **app.config.get('CORS_OPTIONS'))
+
+    if app.config.get('ENABLE_PROXY_FIX'):
+        app.wsgi_app = ProxyFix(app.wsgi_app)
+
+    if app.config.get('UPLOAD_FOLDER'):
+        try:
+            os.makedirs(app.config.get('UPLOAD_FOLDER'))
+        except OSError:
+            pass
+
+    for middleware in app.config.get('ADDITIONAL_MIDDLEWARE'):
+        app.wsgi_app = middleware(app.wsgi_app)
+
+
+    class MyIndexView(IndexView):
+        @expose('/')
+        def index(self):
+            return redirect('/superset/welcome')
+
+    AppBuilder(
+        app, db.session,
+        base_template='superset/base.html',
+        indexview=MyIndexView,
+        security_manager_class=app.config.get("CUSTOM_SECURITY_MANAGER"))
+
+    return app

--- a/superset/bin/superset
+++ b/superset/bin/superset
@@ -4,11 +4,28 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
 import warnings
 from flask.exthook import ExtDeprecationWarning
 warnings.simplefilter('ignore', ExtDeprecationWarning)
 
+def set_verbosity(high=True):
+    """Sets the verbosity of the app
+
+    Main goal is to silence overly verbose external libs"""
+
+    if high:
+        # Shushing external lib logging
+        logging.getLogger('flask_appbuilder').setLevel(logging.INFO)
+        logging.getLogger('pyhive.presto').setLevel(logging.INFO)
+    else:
+        # Shushing external lib logging
+        logging.getLogger('flask_appbuilder').setLevel(logging.ERROR)
+        logging.getLogger('pyhive.presto').setLevel(logging.ERROR)
+
+set_verbosity(False)
 from superset.cli import manager
+
 
 if __name__ == "__main__":
     manager.run()

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -13,8 +13,10 @@ from subprocess import Popen
 from flask_migrate import MigrateCommand
 from flask_script import Manager
 
-from superset import app, db, data, security
+from superset.app import get_app
+from superset import data, security, utils
 
+app = get_app()
 config = app.config
 
 manager = Manager(app)
@@ -67,8 +69,9 @@ def runserver(debug, address, port, timeout, workers):
 @manager.option(
     '-v', '--verbose', action='store_true',
     help="Show extra information")
-def version(verbose):
+def version(verbose=False):
     """Prints the current version number"""
+    utils.set_verbosity(verbose)
     s = (
         "\n-----------------------\n"
         "Superset {version}\n"

--- a/superset/config.py
+++ b/superset/config.py
@@ -269,7 +269,7 @@ try:
         imp.load_source('superset_config', os.environ[CONFIG_PATH_ENV_VAR])
 
     from superset_config import *  # noqa
-    print('Loaded your LOCAL configuration')
+    print('Successfully Loaded your local `superset_config` configuration')
 except ImportError:
     pass
 

--- a/superset/data/__init__.py
+++ b/superset/data/__init__.py
@@ -14,8 +14,12 @@ import random
 import pandas as pd
 from sqlalchemy import String, DateTime, Date, Float, BigInteger
 
-from superset import app, db, models, utils
+from superset.app import get_app
+from superset import app, models, utils
 from superset.security import get_or_create_main_db
+
+app = get_app()
+db = app.extensions.get('sqlalchemy')
 
 # Shortcuts
 DB = models.Database

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -15,8 +15,9 @@ from wtforms import (
     BooleanField, IntegerField, HiddenField, DecimalField)
 from wtforms import validators, widgets
 
-from superset import app
+from superset.app import get_app
 
+app = get_app()
 config = app.config
 
 TIMESTAMP_CHOICES = [

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -14,8 +14,10 @@ import textwrap
 import uuid
 import random
 
-from superset import app
+from superset.app import get_app
 from superset.utils import SupersetTemplateException
+
+app = get_app()
 
 config = app.config
 BASE_CONTEXT = {

--- a/superset/security.py
+++ b/superset/security.py
@@ -6,7 +6,14 @@ from __future__ import unicode_literals
 import logging
 from flask_appbuilder.security.sqla import models as ab_models
 
-from superset import conf, db, models, sm, source_registry
+from superset import models, source_registry
+from superset.app import get_app
+
+app = get_app()
+conf = app.config
+db = app.extensions.get('sqlalchemy')
+appbuilder = app.extensions.get('appbuilder')
+sm = appbuilder.sm
 
 
 READ_ONLY_MODEL_VIEWS = {

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -26,12 +26,12 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
 from email.utils import formatdate
 from flask import flash, Markup, render_template, url_for, redirect, request
+from flask_appbuilder._compat import as_unicode
 from flask_appbuilder.const import (
     LOGMSG_ERR_SEC_ACCESS_DENIED,
     FLAMSG_ERR_SEC_ACCESS_DENIED,
     PERMISSION_PREFIX
 )
-from flask_appbuilder._compat import as_unicode
 from flask_babel import gettext as __
 from past.builtins import basestring
 from pydruid.utils.having import Having

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -28,10 +28,13 @@ from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from werkzeug.urls import Href
 from dateutil import relativedelta as rdelta
 
-from superset import app, utils, cache
+from superset.app import get_app
+from superset import utils
 from superset.forms import FormFactory
 from superset.utils import flasher, DTTM_ALIAS
 
+app = get_app()
+cache = app.extensions.get('cache')
 config = app.config
 
 


### PR DESCRIPTION
`superset/__init__.py` was getting crowded, so I moved the app creation to its own module `app.py`.  That gives a bit more control as to initializing the app a little later as the package initializes, allowing me to shoosh the external module logging when running `superset` CLI commands:

After:
```
$ superset
Successfully Loaded your local `superset_config` configuration
usage: superset [-?]

                {shell,version,worker,db,runserver,refresh_druid,init,load_examples}
                ...

positional arguments:
  {shell,version,worker,db,runserver,refresh_druid,init,load_examples}
    shell               Runs a Python shell inside Flask application context.
    load_examples       Loads a set of Slices and Dashboards and a supporting
                        dataset
    worker              Starts a Superset worker for async SQL query
                        execution.
    db                  Perform database migrations
    runserver           Starts a Superset web server
    refresh_druid       Refresh druid datasources
    init                Inits the Superset application
    version             Prints the current version number

optional arguments:
  -?, --help            show this help message and exit
```