### PR TITLE
Implement feature for user to favourite(save) queries

### DIFF
--- a/superset/assets/javascripts/SqlLab/actions.js
+++ b/superset/assets/javascripts/SqlLab/actions.js
@@ -186,16 +186,16 @@ export function removeQuery(query) {
 }
 
 export const FAVE_QUERY_SUCCESS = 'FAVE_QUERY_SUCCESS';
-export function faveQuerySuccess(query) {
-  return { type: FAVE_QUERY_SUCCESS, query };
+export function faveQuerySuccess(query, fave) {
+  return { type: FAVE_QUERY_SUCCESS, query, fave };
 }
 
 const FAVEQUERY_BASE_URL = '/superset/favstar/query';
-export function favouriteQuery(query) {
+export function favouriteQuery(query, fave) {
   return function (dispatch) {
-    const favAction = query.faved ? 'unselect' : 'select';
+    const favAction = fave ? 'select' : 'unselect';
     $.get(`${FAVEQUERY_BASE_URL}/${query.id}/${favAction}/`);
-    dispatch(faveQuerySuccess(query));
+    dispatch(faveQuerySuccess(query, fave));
   };
 }
 

--- a/superset/assets/javascripts/SqlLab/actions.js
+++ b/superset/assets/javascripts/SqlLab/actions.js
@@ -185,6 +185,20 @@ export function removeQuery(query) {
   return { type: REMOVE_QUERY, query };
 }
 
+export const FAVE_QUERY_SUCCESS = 'FAVE_QUERY_SUCCESS';
+export function faveQuerySuccess(query) {
+  return { type: FAVE_QUERY_SUCCESS, query };
+}
+
+const FAVEQUERY_BASE_URL = '/superset/favstar/query';
+export function favouriteQuery(query) {
+  return function (dispatch) {
+    const favAction = query.faved ? 'unselect' : 'select';
+    $.get(`${FAVEQUERY_BASE_URL}/${query.id}/${favAction}/`);
+    dispatch(faveQuerySuccess(query));
+  };
+}
+
 export function queryEditorSetDb(queryEditor, dbId) {
   return { type: QUERY_EDITOR_SETDB, queryEditor, dbId };
 }

--- a/superset/assets/javascripts/SqlLab/components/App.jsx
+++ b/superset/assets/javascripts/SqlLab/components/App.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import TabbedSqlEditors from './TabbedSqlEditors';
 import QueryAutoRefresh from './QueryAutoRefresh';
 import QuerySearch from './QuerySearch';
+import FaveQueries from './FaveQueries';
 import Alerts from './Alerts';
 
 import { bindActionCreators } from 'redux';
@@ -44,7 +45,7 @@ class App extends React.PureComponent {
   }
   render() {
     let content;
-    if (this.state.hash) {
+    if (this.state.hash === '#search') {
       content = (
         <div className="container-fluid">
           <div className="row">
@@ -52,6 +53,12 @@ class App extends React.PureComponent {
               <QuerySearch height={this.state.contentHeight} actions={this.props.actions} />
             </div>
           </div>
+        </div>
+      );
+    } else if (this.state.hash === '#faved') {
+      content = (
+        <div className="container-fluid">
+          <FaveQueries height={this.state.contentHeight} actions={this.props.actions} />
         </div>
       );
     } else {

--- a/superset/assets/javascripts/SqlLab/components/FaveQueries.jsx
+++ b/superset/assets/javascripts/SqlLab/components/FaveQueries.jsx
@@ -16,13 +16,8 @@ class FaveQueries extends React.PureComponent {
   }
 
   deleteQuery(query) {
-    $.ajax({
-      type: 'GET',
-      url: `/superset/favstar/query/${query.id}/unselect/`,
-      success: () => {
-        this.fetchFaveQueries();
-      },
-    });
+    this.props.actions.favouriteQuery(query, false);
+    this.fetchFaveQueries();
   }
   fetchFaveQueries() {
     this.setState({ fetching: true });

--- a/superset/assets/javascripts/SqlLab/components/FaveQueries.jsx
+++ b/superset/assets/javascripts/SqlLab/components/FaveQueries.jsx
@@ -1,0 +1,73 @@
+const $ = window.$ = require('jquery');
+import QueryTable from './QueryTable';
+import React from 'react';
+
+const propTypes = {
+  actions: React.PropTypes.object.isRequired,
+};
+
+class FaveQueries extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      favedQueries: [],
+      fetching: false,
+    };
+  }
+
+  deleteQuery(query) {
+    $.ajax({
+      type: 'GET',
+      url: `/superset/favstar/query/${query.id}/unselect/`,
+      success: () => {
+        this.fetchFaveQueries();
+      },
+    });
+  }
+  fetchFaveQueries() {
+    this.setState({ fetching: true });
+    $.ajax({
+      type: 'GET',
+      url: '/superset/fave_queries/',
+      success: (data) => {
+        this.setState({ favedQueries: data });
+        this.setState({ fetching: false });
+      },
+    });
+  }
+  componentDidMount() {
+    this.fetchFaveQueries();
+  }
+  render() {
+    if (this.state.fetching) {
+      return (
+        <img
+          className="loading"
+          alt="Loading..."
+          src="/static/assets/images/loading.gif"
+        />
+      );
+    }
+    return (
+      <div
+        style={{ height: this.props.height }}
+        className="scrollbar-container"
+      >
+        <div className="scrollbar-content">
+          <QueryTable
+            columns={[
+              'db', 'schema', 'sql', 'querylink', 'delete',
+            ]}
+            queries={this.state.favedQueries}
+            actions={this.props.actions}
+            onDelete={this.deleteQuery.bind(this)}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+FaveQueries.propTypes = propTypes;
+
+export default FaveQueries;

--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -18,12 +18,14 @@ const propTypes = {
   queries: React.PropTypes.array,
   onUserClicked: React.PropTypes.func,
   onDbClicked: React.PropTypes.func,
+  onDelete: React.PropTypes.func,
 };
 const defaultProps = {
   columns: ['started', 'duration', 'rows'],
   queries: [],
   onUserClicked: () => {},
   onDbClicked: () => {},
+  onDelete: () => {},
 };
 
 
@@ -71,6 +73,9 @@ class QueryTable extends React.PureComponent {
   }
   removeQuery(query) {
     this.props.actions.removeQuery(query);
+  }
+  favQuery(query) {
+    this.props.actions.favouriteQuery(query);
   }
   render() {
     const data = this.props.queries.map((query) => {
@@ -167,6 +172,15 @@ class QueryTable extends React.PureComponent {
           {errorTooltip}
         </div>
       );
+      q.delete = (
+        <button
+          className="btn btn-link btn-xs"
+          onClick={this.props.onDelete.bind(this, query)}
+        >
+          <i className="fa fa-trash" />Delete
+        </button>
+      );
+      const faveIcon = query.faved ? 'fa fa-heart' : 'fa fa-heart-o';
       q.actions = (
         <div style={{ width: '75px' }}>
           <Link
@@ -190,6 +204,11 @@ class QueryTable extends React.PureComponent {
             className="fa fa-trash m-r-3"
             tooltip="Remove query from log"
             onClick={this.removeQuery.bind(this, query)}
+          />
+          <Link
+            className={`${faveIcon} m-r-3`}
+            tooltip="Save query"
+            onClick={this.favQuery.bind(this, query)}
           />
         </div>
       );

--- a/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryTable.jsx
@@ -75,7 +75,7 @@ class QueryTable extends React.PureComponent {
     this.props.actions.removeQuery(query);
   }
   favQuery(query) {
-    this.props.actions.favouriteQuery(query);
+    this.props.actions.favouriteQuery(query, !query.faved);
   }
   render() {
     const data = this.props.queries.map((query) => {

--- a/superset/assets/javascripts/SqlLab/reducers.js
+++ b/superset/assets/javascripts/SqlLab/reducers.js
@@ -71,6 +71,13 @@ export const sqlLabReducer = function (state, action) {
       delete newQueries[action.query.id];
       return Object.assign({}, state, { queries: newQueries });
     },
+    [actions.FAVE_QUERY_SUCCESS]() {
+      let faved = false;
+      if (!state.queries[action.query.id].faved) {
+        faved = true;
+      }
+      return alterInObject(state, 'queries', action.query, { faved });
+    },
     [actions.RESET_STATE]() {
       return Object.assign({}, getInitialState());
     },

--- a/superset/assets/javascripts/SqlLab/reducers.js
+++ b/superset/assets/javascripts/SqlLab/reducers.js
@@ -72,11 +72,7 @@ export const sqlLabReducer = function (state, action) {
       return Object.assign({}, state, { queries: newQueries });
     },
     [actions.FAVE_QUERY_SUCCESS]() {
-      let faved = false;
-      if (!state.queries[action.query.id].faved) {
-        faved = true;
-      }
-      return alterInObject(state, 'queries', action.query, { faved });
+      return alterInObject(state, 'queries', action.query, { faved: action.fave });
     },
     [actions.RESET_STATE]() {
       return Object.assign({}, getInitialState());

--- a/superset/assets/spec/javascripts/sqllab/FaveQueries_spec.js
+++ b/superset/assets/spec/javascripts/sqllab/FaveQueries_spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Select from 'react-select';
+import FaveQueries from '../../../javascripts/SqlLab/components/FaveQueries';
+import { shallow } from 'enzyme';
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+describe('QuerySearch', () => {
+  const mockedProps = {
+    actions: {},
+  };
+  it('is valid', () => {
+    expect(
+      React.isValidElement(<FaveQueries {...mockedProps} />)
+    ).to.equal(true);
+  });
+});

--- a/superset/assets/spec/javascripts/sqllab/FaveQueries_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/FaveQueries_spec.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
-import Select from 'react-select';
 import FaveQueries from '../../../javascripts/SqlLab/components/FaveQueries';
-import { shallow } from 'enzyme';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
-describe('QuerySearch', () => {
+describe('FaveQueries', () => {
   const mockedProps = {
     actions: {},
   };

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1509,10 +1509,14 @@ class Superset(BaseSupersetView):
         return json_success(
             json.dumps(payload, default=utils.json_int_dttm_ser))
 
-    @api
-    @has_access_api
+    @has_access
     @expose("/fave_queries/", methods=['GET'])
     def fave_queries(self):
+        if not g.user.get_id():
+            return Response(
+                json.dumps({'error': "Please login to access the queries."}),
+                status=403,
+                mimetype="application/json")
         qry = (
             db.session.query(
                 models.Query,
@@ -1526,9 +1530,10 @@ class Superset(BaseSupersetView):
                 )
             )
             .order_by(
-                models.FavStar.dttm.desc()
+                models.FavStar.dttm.asc()
             )
         )
+
         queries = [q.to_dict() for q in qry.all()]
         payload = []
         for q in queries:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1526,7 +1526,7 @@ class Superset(BaseSupersetView):
                 sqla.and_(
                     models.FavStar.user_id == int(g.user.id),
                     models.FavStar.class_name == 'query',
-                    models.Query.client_id == models.FavStar.obj_id,
+                    models.Query.id == models.FavStar.obj_id,
                 )
             )
             .order_by(
@@ -1696,6 +1696,13 @@ class Superset(BaseSupersetView):
         session = db.session()
         FavStar = models.FavStar  # noqa
         count = 0
+        if class_name == 'query':
+            query = session.query(models.Query).filter_by(
+                client_id=obj_id).first()
+            if not query:
+                return json_error_response(
+                    json.dumps({'error': 'No query was found!'}))
+            obj_id = query.id
         favs = session.query(FavStar).filter_by(
             class_name=class_name, obj_id=obj_id,
             user_id=g.user.get_id()).all()

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -194,6 +194,27 @@ class SqlLabTests(SupersetTestCase):
             self.assertLess(int(first_query_time), k['startDttm'])
             self.assertLess(k['startDttm'], int(second_query_time))
 
+    def test_fave_queries(self):
+        self.logout()
+        self.run_some_queries()
+        # Favourite a query
+        self.login('admin')
+        query = db.session.query(models.Query).first()
+        client_id = query.client_id
+        url = '/superset/favstar/query/{}/select/'.format(client_id)
+        resp = self.get_json_resp(url)
+        self.assertEqual(resp['count'], 1)
+
+        self.login('admin')
+        data = self.get_json_resp('/superset/fave_queries/')
+        self.assertEqual(len(data), 1)
+        url = '/superset/favstar/query/{}/unselect/'.format(client_id)
+        resp = self.get_resp(url)
+
+        data = self.get_json_resp('/superset/fave_queries/')
+        self.assertEqual(len(data), 0)
+
+
     def test_alias_duplicate(self):
         self.run_sql(
             "SELECT username as col, id as col, username FROM ab_user",


### PR DESCRIPTION
Done: 
**User can favourite/unfavourite a query in query history
 **User can view favourited queries under SQL Lab - Saved queries

Favourite queries:
![screen shot 2017-02-14 at 4 33 12 pm](https://cloud.githubusercontent.com/assets/20978302/22955859/6aade3e6-f2d3-11e6-97fa-682c93804b57.png)

Access saved queries:
![screen shot 2017-02-14 at 4 33 25 pm](https://cloud.githubusercontent.com/assets/20978302/22955867/72d5d9d4-f2d3-11e6-84a4-2c867cd8ecc0.png)

Saved queries:
![screen shot 2017-02-14 at 4 33 39 pm](https://cloud.githubusercontent.com/assets/20978302/22955877/7f5f03ce-f2d3-11e6-83e7-9572fcaed137.png)

Todo:
 - [ ] Pass whether query is faved at /queries/ endpoint

needs-review @ascott @mistercrunch @bkyryliuk 
