### PR TITLE
Aggregate data outside of topN into a single category

### DIFF
--- a/superset/forms.py
+++ b/superset/forms.py
@@ -575,9 +575,11 @@ class FormFactory(object):
                 "description": _(
                     "Limits the number of time series that get displayed")
             }),
-            'others_category': (BetterBooleanField, {
-                "label": _("Others category"),
-                "default": True,
+            'others_category': (FreeFormSelectField, {
+                "label": _('Others category'),
+                "default": None,
+                "choices": self.choicify(
+                    [None, 5, 10, 50, 100, 250, 500, 1000, 5000]),
                 "description": _("Aggregate data outside of topN into a single category")
             }),
             'timeseries_limit_metric': (SelectField, {

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -575,6 +575,11 @@ class FormFactory(object):
                 "description": _(
                     "Limits the number of time series that get displayed")
             }),
+            'others_category': (BetterBooleanField, {
+                "label": _("Others category"),
+                "default": True,
+                "description": _("Aggregate data outside of topN into a single category")
+            }),
             'timeseries_limit_metric': (SelectField, {
                 "label": _("Sort By"),
                 "choices": [('', '')] + datasource.metrics_combo,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1454,6 +1454,8 @@ class DistributionPieViz(NVD3Viz):
             'pie_label_type',
             ('donut', 'show_legend'),
             'labels_outside',
+            'row_limit',
+            'others_category',
         )
     },)
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -224,7 +224,8 @@ class BaseViz(object):
                     df[DTTM_ALIAS] += timedelta(hours=self.datasource.offset)
             df.replace([np.inf, -np.inf], np.nan)
             df = df.fillna(0)
-            if (self.others_category is not None) & (self.others_category != 'None'):
+            if (self.others_category is not None) & \
+                    (self.others_category != 'None'):
                 top_n = int(self.others_category)
                 if (top_n > 0) & (len(df) > top_n):
                     df_head = df.head(top_n)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1465,7 +1465,6 @@ class DistributionPieViz(NVD3Viz):
             'pie_label_type',
             ('donut', 'show_legend'),
             'labels_outside',
-            'row_limit',
             'others_category',
         )
     },)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -92,6 +92,7 @@ class BaseViz(object):
 
         self.status = None
         self.error_message = None
+        self.others_category = self.form_data.get('others_category') or None
 
     @classmethod
     def flat_form_fields(cls):
@@ -223,6 +224,16 @@ class BaseViz(object):
                     df[DTTM_ALIAS] += timedelta(hours=self.datasource.offset)
             df.replace([np.inf, -np.inf], np.nan)
             df = df.fillna(0)
+            if (self.others_category is not None) & (self.others_category != 'None'):
+                top_n = int(self.others_category)
+                if (top_n > 0) & (len(df) > top_n):
+                    df_head = df.head(top_n)
+                    df_tail = df.tail(len(df) - top_n)
+                    other_metrics_sum = ['Others']
+                    for metric in query_obj['metrics']:
+                        other_metrics_sum.append(df_tail[metric].sum())
+                    df_other = pd.DataFrame([other_metrics_sum], columns=df.columns)
+                    df = df_head.append(df_other, ignore_index=True)
         return df
 
     @property

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -224,7 +224,8 @@ class BaseViz(object):
                     df[DTTM_ALIAS] += timedelta(hours=self.datasource.offset)
             df.replace([np.inf, -np.inf], np.nan)
             df = df.fillna(0)
-            if self.others_category is not None and self.others_category != 'None':
+            if self.others_category is not None \
+                    and self.others_category != 'None':
                 top_n = int(self.others_category)
                 if 0 < top_n < len(df):
                     df_head = df.head(top_n)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -224,10 +224,9 @@ class BaseViz(object):
                     df[DTTM_ALIAS] += timedelta(hours=self.datasource.offset)
             df.replace([np.inf, -np.inf], np.nan)
             df = df.fillna(0)
-            if (self.others_category is not None) & \
-                    (self.others_category != 'None'):
+            if self.others_category is not None and self.others_category != 'None':
                 top_n = int(self.others_category)
-                if (top_n > 0) & (len(df) > top_n):
+                if 0 < top_n < len(df):
                     df_head = df.head(top_n)
                     df_tail = df.tail(len(df) - top_n)
                     other_metrics_sum = ['Others']

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -143,6 +143,22 @@ class DruidTests(SupersetTestCase):
         resp = self.get_json_resp(url)
         self.assertEqual("Canada", resp['data']['records'][0]['dim1'])
 
+        # others category
+        url = (
+            '/superset/explore_json/druid/{}/?viz_type=table&granularity=one+day&'
+            'druid_time_origin=&since=7+days+ago&until=now&row_limit=5000&'
+            'include_search=false&metrics=count&groupby=dim1&'
+            'flt_col_0=dim1&groupby=dim2d&'
+            'flt_op_0=in&flt_eq_0=&slice_id=&slice_name=&collapsed_fieldsets=&'
+            'action=&datasource_name=test_datasource&datasource_id={}&'
+            'datasource_type=druid&previous_viz_type=table&'
+            'force=true&others_category=1'.format(datasource_id, datasource_id))
+        resp = self.get_json_resp(url)
+        self.assertEqual("Canada", resp['data']['records'][0]['dim1'])
+        self.assertEqual(12345678, resp['data']['records'][0]['metric1'])
+        self.assertEqual("Others", resp['data']['records'][1]['dim1'])
+        self.assertEqual(12345678 / 2, resp['data']['records'][1]['metric1'])
+
     def test_druid_sync_from_config(self):
         CLUSTER_NAME = 'new_druid'
         self.login()

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -147,17 +147,17 @@ class DruidTests(SupersetTestCase):
         url = (
             '/superset/explore_json/druid/{}/?viz_type=table&granularity=one+day&'
             'druid_time_origin=&since=7+days+ago&until=now&row_limit=5000&'
-            'include_search=false&metrics=count&groupby=dim1&'
-            'flt_col_0=dim1&groupby=dim2d&'
+            'include_search=false&metrics=count&groupby=dim1&flt_col_0=dim1&'
             'flt_op_0=in&flt_eq_0=&slice_id=&slice_name=&collapsed_fieldsets=&'
             'action=&datasource_name=test_datasource&datasource_id={}&'
             'datasource_type=druid&previous_viz_type=table&'
             'force=true&others_category=1'.format(datasource_id, datasource_id))
         resp = self.get_json_resp(url)
-        self.assertEqual("Canada", resp['data']['records'][0]['dim1'])
-        self.assertEqual(12345678, resp['data']['records'][0]['metric1'])
-        self.assertEqual("Others", resp['data']['records'][1]['dim1'])
-        self.assertEqual(12345678 / 2, resp['data']['records'][1]['metric1'])
+        records = resp['data']['records']
+        self.assertEqual("Canada", records[0]['dim1'])
+        self.assertEqual(12345678, records[0]['metric1'])
+        self.assertEqual("Others", records[1]['dim1'])
+        self.assertEqual(12345678 / 2, records[1]['metric1'])
 
     def test_druid_sync_from_config(self):
         CLUSTER_NAME = 'new_druid'


### PR DESCRIPTION
Aggregate data outside of topN into a single category

There is a problem that those category icons will fill up the whole chart, when i have tens of thousands metrics need to be display. So we should aggregate those category outside of topN into a single category named `Others Category.`

![image](https://cloud.githubusercontent.com/assets/8108788/22957716/28f44aca-f365-11e6-9303-109ce75c14ea.png)

![image](https://cloud.githubusercontent.com/assets/8108788/22958015/51a5a75a-f367-11e6-9cab-512a3c8382e6.png)
