### PR TITLE
[deprecate_v1] Change filter endpoint to match with new url format

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1134,11 +1134,12 @@ class Superset(BaseSupersetView):
         :return:
         """
         # TODO: Cache endpoint by user, datasource and column
+        form_data = self.get_form_data()
+        viz_type = form_data.get('viz_type', 'table')
+        datasource = ConnectorRegistry.get_datasource(
+            datasource_type, datasource_id, db.session)
         error_redirect = '/slicemodelview/list/'
         datasource_class = ConnectorRegistry.sources[datasource_type]
-
-        datasource = db.session.query(
-            datasource_class).filter_by(id=datasource_id).first()
 
         if not datasource:
             flash(DATASOURCE_MISSING_ERR, "alert")
@@ -1147,7 +1148,6 @@ class Superset(BaseSupersetView):
             flash(get_datasource_access_error_msg(datasource.name), "danger")
             return json_error_response(DATASOURCE_ACCESS_ERR)
 
-        viz_type = request.args.get("viz_type")
         if not viz_type and datasource.default_endpoint:
             return redirect(datasource.default_endpoint)
         if not viz_type:
@@ -1155,11 +1155,10 @@ class Superset(BaseSupersetView):
         try:
             obj = viz.viz_types[viz_type](
                 datasource,
-                form_data=request.args,
-                slice_=None)
+                form_data=form_data,
+            )
         except Exception as e:
-            flash(str(e), "danger")
-            return redirect(error_redirect)
+            return json_error_response(utils.error_msg_from_exception(e))
         return json_success(obj.get_values_for_column(column))
 
     def save_or_overwrite_slice(

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -63,34 +63,6 @@ class BaseViz(object):
         self.status = None
         self.error_message = None
 
-    def get_filter_url(self):
-        """Returns the URL to retrieve column values used in the filter"""
-        data = self.orig_form_data.copy()
-        # Remove unchecked checkboxes because HTML is weird like that
-        ordered_data = MultiDict()
-        for key in sorted(data.keys()):
-            # if MultiDict is initialized with MD({key:[emptyarray]}),
-            # key is included in d.keys() but accessing it throws
-            try:
-                if data[key] is False:
-                    del data[key]
-                    continue
-            except IndexError:
-                pass
-
-            if isinstance(data, (MultiDict, ImmutableMultiDict)):
-                v = data.getlist(key)
-            else:
-                v = data.get(key)
-            if not isinstance(v, list):
-                v = [v]
-            for item in v:
-                ordered_data.add(key, item)
-        href = Href(
-            '/superset/filter/{self.datasource.type}/'
-            '{self.datasource.id}/'.format(**locals()))
-        return href(ordered_data)
-
     def get_df(self, query_obj=None):
         """Returns a pandas dataframe based on the query object"""
         if not query_obj:
@@ -268,7 +240,6 @@ class BaseViz(object):
                 'cache_timeout': cache_timeout,
                 'data': data,
                 'error': self.error_message,
-                'filter_endpoint': self.filter_endpoint,
                 'form_data': self.form_data,
                 'query': self.query,
                 'status': self.status,
@@ -303,7 +274,6 @@ class BaseViz(object):
         """This is the data object serialized to the js layer"""
         content = {
             'form_data': self.form_data,
-            'filter_endpoint': self.filter_endpoint,
             'token': self.token,
             'viz_name': self.viz_type,
             'filter_select_enabled': self.datasource.filter_select_enabled,
@@ -344,10 +314,6 @@ class BaseViz(object):
 
     def get_data(self, df):
         return []
-
-    @property
-    def filter_endpoint(self):
-        return self.get_filter_url()
 
     @property
     def json_data(self):

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -190,14 +190,19 @@ class CoreTests(SupersetTestCase):
         tbl_id = self.table_ids.get('energy_usage')
         table = db.session.query(SqlaTable).filter(SqlaTable.id == tbl_id)
         table.filter_select_enabled = True
+        form_data = {
+            'viz_type': 'sankey',
+            'groupby': 'source',
+            'groupby': 'target',
+            'metric': 'sum__value',
+            'row_limit': 5000,
+            'slice_id': slice_id,
+        }
         url = (
-            "/superset/filter/table/{}/target/?viz_type=sankey&groupby=source"
-            "&metric=sum__value&flt_col_0=source&flt_op_0=in&flt_eq_0=&"
-            "slice_id={}&datasource_name=energy_usage&"
-            "datasource_id=1&datasource_type=table")
+            "/superset/filter/table/{}/target/?form_data={}")
 
         # Changing name
-        resp = self.get_resp(url.format(tbl_id, slice_id))
+        resp = self.get_resp(url.format(tbl_id, json.dumps(form_data)))
         assert len(resp) > 0
         assert 'Carbon Dioxide' in resp
 


### PR DESCRIPTION
Changes:
 - change filter endpoint to match with new url format
 - delete filter endpoint from viz since front-end knows the endpoint (no need to pass it through viz.data)

@mistercrunch 