### PR TITLE
[bugfix] Parse dbid from url to integer

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset/assets/javascripts/SqlLab/components/TabbedSqlEditors.jsx
@@ -44,9 +44,23 @@ class TabbedSqlEditors extends React.PureComponent {
       if (urlId) {
         this.props.actions.popStoredQuery(urlId);
       } else {
+        let dbId = getParamFromQuery(queryString, 'dbid');
+        if (dbId) {
+          dbId = parseInt(dbId, 10);
+        } else {
+          const databases = this.props.databases;
+          const dbName = getParamFromQuery(queryString, 'dbname');
+          if (dbName) {
+            Object.keys(databases).forEach((db) => {
+              if (databases[db].database_name === dbName) {
+                dbId = databases[db].id;
+              }
+            });
+          }
+        }
         const newQueryEditor = {
           title: getParamFromQuery(queryString, 'title'),
-          dbId: getParamFromQuery(queryString, 'dbid'),
+          dbId,
           schema: getParamFromQuery(queryString, 'schema'),
           autorun: getParamFromQuery(queryString, 'autorun'),
           sql: getParamFromQuery(queryString, 'sql'),


### PR DESCRIPTION
Done:
 - dbid in url is a string, need to parse to integer for props
 - allow user to put dbname in url like
 /superset/sqllab?dbname=main&title=Untitled%20Query&sql=SELECT...
which will pop up a new tab, populates db in left panel corresponding to dbname in url:
![screen shot 2017-02-21 at 12 05 35 pm](https://cloud.githubusercontent.com/assets/20978302/23182682/4afe8b08-f82e-11e6-9fb4-8b3fe38519df.png)


