### PR TITLE
Fetch schemas separately.

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SqlEditorLeftBar.jsx
@@ -112,10 +112,9 @@ ${this.props.queryEditor.schema}/${input}`;
     const actualDbId = dbId || this.props.queryEditor.dbId;
     if (actualDbId) {
       this.setState({ schemaLoading: true });
-      const url = `/databasetablesasync/api/read?_flt_0_id=${actualDbId}`;
+      const url = `/superset/schemas/${actualDbId}/`;
       $.get(url, (data) => {
-        const schemas = data.result[0].all_schema_names;
-        const schemaOptions = schemas.map((s) => ({ value: s, label: s }));
+        const schemaOptions = data.schemas.map((s) => ({ value: s, label: s }));
         this.setState({ schemaOptions });
         this.setState({ schemaLoading: false });
       });

--- a/superset/views.py
+++ b/superset/views.py
@@ -1846,7 +1846,7 @@ class Superset(BaseSupersetView):
     @has_access_api
     @expose("/tables/<db_id>/<schema>/<substr>/")
     def tables(self, db_id, schema, substr):
-        """endpoint to power the calendar heatmap on the welcome page"""
+        """Endpoint to fetch the list of tables for given database"""
         schema = utils.js_string_to_python(schema)
         substr = utils.js_string_to_python(substr)
         database = db.session.query(models.Database).filter_by(id=db_id).one()


### PR DESCRIPTION
`/databasetablesasync/api/read?_flt_0_id=${actualDbId}` - fetches all tables and schemas for the database, that is quite heave request for presto / hive databases.

@mistercrunch @vera-liu @ascott ^^ please