### PR TITLE
[WiP] Breaking down ChartContainer in more components

### DIFF
--- a/superset/assets/javascripts/explorev2/components/Chart.jsx
+++ b/superset/assets/javascripts/explorev2/components/Chart.jsx
@@ -1,0 +1,177 @@
+import $ from 'jquery';
+import React, { PropTypes } from 'react';
+import { Alert, Collapse } from 'react-bootstrap';
+import visMap from '../../../visualizations/main';
+import { d3format } from '../../modules/utils';
+import { getExploreUrl } from '../exploreUtils';
+import shortid from 'shortid';
+
+const propTypes = {
+  actions: PropTypes.object.isRequired,
+  alert: PropTypes.string,
+  chartStatus: PropTypes.string,
+  datasource: PropTypes.object.isRequired,
+  height: PropTypes.string.isRequired,
+  formData: PropTypes.object,
+  triggerRender: PropTypes.bool,
+};
+
+class Chart extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    const containerId = shortid.generate();
+    this.state = {
+      containerId,
+      selector: `#${containerId}`,
+      showStackTrace: false,
+    };
+  }
+  componentDidUpdate(prevProps) {
+    if (
+        (
+          prevProps.queryResponse !== this.props.queryResponse ||
+          prevProps.height !== this.props.height || (
+              !prevProps.triggerRender &&
+              this.props.triggerRender
+          )
+        ) && !this.props.queryResponse.error
+        && this.props.chartStatus !== 'failed'
+        && this.props.chartStatus !== 'stopped'
+      ) {
+      this.renderViz();
+    }
+  }
+
+  renderViz() {
+    this.props.actions.renderTriggered();
+    const mockSlice = this.getMockedSliceObject();
+
+    this.setState({ mockSlice });
+    try {
+      visMap[this.props.formData.viz_type](mockSlice, this.props.queryResponse);
+    } catch (e) {
+      this.props.actions.chartRenderingFailed(e);
+    }
+  }
+
+  getMockedSliceObject() {
+    const props = this.props;
+    const getHeight = () => {
+      const headerHeight = this.props.standalone ? 0 : 100;
+      return parseInt(props.height, 10) - headerHeight;
+    };
+    return {
+      viewSqlQuery: this.props.queryResponse.query,
+      containerId: this.state.containerId,
+      selector: this.state.selector,
+      formData: this.props.formData,
+      container: {
+        html: (data) => {
+          // this should be a callback to clear the contents of the slice container
+          $(this.state.selector).html(data);
+        },
+        css: (dim, size) => {
+          // dimension can be 'height'
+          // pixel string can be '300px'
+          // should call callback to adjust height of chart
+          $(this.state.selector).css(dim, size);
+        },
+        height: getHeight,
+        show: () => { },
+        get: (n) => ($(this.state.selector).get(n)),
+        find: (classname) => ($(this.state.selector).find(classname)),
+      },
+
+      width: () => this.chartContainerRef.getBoundingClientRect().width,
+
+      height: getHeight,
+
+      setFilter: () => {
+        // set filter according to data in store
+        // used in FilterBox.onChange()
+      },
+
+      getFilters: () => (
+        // return filter objects from viz.formData
+        {}
+      ),
+
+      done: () => {},
+      clearError: () => {
+        // no need to do anything here since Alert is closable
+        // query button will also remove Alert
+      },
+      error() {},
+
+      d3format: (col, number) => {
+        // mock d3format function in Slice object in superset.js
+        const format = props.column_formats[col];
+        return d3format(format, number);
+      },
+
+      data: {
+        csv_endpoint: getExploreUrl(this.props.formData, 'csv'),
+        json_endpoint: getExploreUrl(this.props.formData, 'json'),
+        standalone_endpoint: getExploreUrl(this.props.formData, 'standalone'),
+      },
+
+    };
+  }
+
+  renderAlert() {
+    const msg = (
+      <div>
+        {this.props.alert}
+        <i
+          className="fa fa-close pull-right"
+          style={{ cursor: 'pointer' }}
+        />
+      </div>);
+    return (
+      <div>
+        <Alert
+          bsStyle="warning"
+          onClick={() => this.setState({ showStackTrace: !this.state.showStackTrace })}
+        >
+          {msg}
+        </Alert>
+        {this.props.queryResponse && this.props.queryResponse.stacktrace &&
+          <Collapse in={this.state.showStackTrace}>
+            <pre>
+              {this.props.queryResponse.stacktrace}
+            </pre>
+          </Collapse>
+        }
+      </div>);
+  }
+
+  render() {
+    if (this.props.alert) {
+      return this.renderAlert();
+    }
+    const loading = this.props.chartStatus === 'loading';
+    return (
+      <div>
+        {loading &&
+          <img
+            alt="loading"
+            width="25"
+            src="/static/assets/images/loading.gif"
+            style={{ position: 'absolute' }}
+          />
+        }
+        <div
+          id={this.state.containerId}
+          ref={ref => { this.chartContainerRef = ref; }}
+          className={this.props.formData.viz_type}
+          style={{
+            opacity: loading ? '0.25' : '1',
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+Chart.propTypes = propTypes;
+export default Chart;

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -1,18 +1,9 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { Label, Panel } from 'react-bootstrap';
-import ExploreActionButtons from './ExploreActionButtons';
-import FaveStar from '../../components/FaveStar';
-import TooltipWrapper from '../../components/TooltipWrapper';
-import Timer from '../../components/Timer';
+import { Panel } from 'react-bootstrap';
 import { getFormDataFromControls } from '../stores/store';
 import Chart from './Chart';
-
-const CHART_STATUS_MAP = {
-  failed: 'danger',
-  loading: 'warning',
-  success: 'success',
-};
+import ChartHeader from './ChartHeader';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -31,126 +22,6 @@ const propTypes = {
 };
 
 class ChartContainer extends React.PureComponent {
-<<<<<<< 8042ac876e80c08d72489287777cb1e9672b177a
-  constructor(props) {
-    super(props);
-    this.state = {
-      selector: `#${props.containerId}`,
-      showStackTrace: false,
-    };
-  }
-
-  renderViz() {
-    this.props.actions.renderTriggered();
-    const mockSlice = this.getMockedSliceObject();
-    this.setState({ mockSlice });
-    try {
-      visMap[this.props.viz_type](mockSlice, this.props.queryResponse);
-    } catch (e) {
-      this.props.actions.chartRenderingFailed(e);
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-        (
-          prevProps.queryResponse !== this.props.queryResponse ||
-          prevProps.height !== this.props.height ||
-          this.props.triggerRender
-        ) && !this.props.queryResponse.error
-        && this.props.chartStatus !== 'failed'
-        && this.props.chartStatus !== 'stopped'
-      ) {
-      this.renderViz();
-    }
-  }
-
-  getMockedSliceObject() {
-    const props = this.props;
-    const getHeight = () => {
-      const headerHeight = this.props.standalone ? 0 : 100;
-      return parseInt(props.height, 10) - headerHeight;
-    };
-    return {
-      viewSqlQuery: this.props.queryResponse.query,
-      containerId: props.containerId,
-      selector: this.state.selector,
-      formData: this.props.formData,
-      container: {
-        html: (data) => {
-          // this should be a callback to clear the contents of the slice container
-          $(this.state.selector).html(data);
-        },
-        css: (dim, size) => {
-          // dimension can be 'height'
-          // pixel string can be '300px'
-          // should call callback to adjust height of chart
-          $(this.state.selector).css(dim, size);
-        },
-        height: getHeight,
-        show: () => { },
-        get: (n) => ($(this.state.selector).get(n)),
-        find: (classname) => ($(this.state.selector).find(classname)),
-      },
-
-      width: () => this.chartContainerRef.getBoundingClientRect().width,
-
-      height: getHeight,
-
-      setFilter: () => {},
-
-      getFilters: () => (
-        // return filter objects from viz.formData
-        {}
-      ),
-
-      addFilter: () => {},
-
-      removeFilter: () => {},
-
-      done: () => {},
-      clearError: () => {
-        // no need to do anything here since Alert is closable
-        // query button will also remove Alert
-      },
-      error() {},
-
-      d3format: (col, number) => {
-        // mock d3format function in Slice object in superset.js
-        const format = props.column_formats[col];
-        return d3format(format, number);
-      },
-
-      data: {
-        csv_endpoint: getExploreUrl(this.props.formData, 'csv'),
-        json_endpoint: getExploreUrl(this.props.formData, 'json'),
-        standalone_endpoint: getExploreUrl(
-          this.props.formData, 'standalone'),
-      },
-
-    };
-  }
-
-  removeAlert() {
-    this.props.actions.removeChartAlert();
-  }
-=======
->>>>>>> Refactoring Chart in more components to allow for Dashboard embedding
-
-  renderChartTitle() {
-    let title;
-    if (this.props.slice) {
-      title = this.props.slice.slice_name;
-    } else {
-      title = `[${this.props.table_name}] - untitled`;
-    }
-    return title;
-  }
-
-  runQuery() {
-    this.props.actions.runQuery(this.props.formData, true);
-  }
-
   render() {
     if (this.props.standalone) {
       return this.renderChart();
@@ -161,65 +32,7 @@ class ChartContainer extends React.PureComponent {
       <div className="chart-container">
         <Panel
           style={{ height: this.props.height }}
-          header={
-            <div
-              id="slice-header"
-              className="clearfix panel-title-large"
-            >
-              {this.renderChartTitle()}
-
-              {this.props.slice &&
-                <span>
-                  <FaveStar
-                    sliceId={this.props.slice.slice_id}
-                    actions={this.props.actions}
-                    isStarred={this.props.isStarred}
-                  />
-
-                  <TooltipWrapper
-                    label="edit-desc"
-                    tooltip="Edit Description"
-                  >
-                    <a
-                      className="edit-desc-icon"
-                      href={`/slicemodelview/edit/${this.props.slice.slice_id}`}
-                    >
-                      <i className="fa fa-edit" />
-                    </a>
-                  </TooltipWrapper>
-                </span>
-              }
-
-              <div className="pull-right">
-                {this.props.chartStatus === 'success' &&
-                 this.props.queryResponse &&
-                 this.props.queryResponse.is_cached &&
-                  <TooltipWrapper
-                    tooltip="Loaded from cache. Click to force refresh"
-                    label="cache-desc"
-                  >
-                    <Label
-                      style={{ fontSize: '10px', marginRight: '5px', cursor: 'pointer' }}
-                      onClick={this.runQuery.bind(this)}
-                    >
-                      cached
-                    </Label>
-                  </TooltipWrapper>
-                }
-                <Timer
-                  startTime={this.props.chartUpdateStartTime}
-                  endTime={this.props.chartUpdateEndTime}
-                  isRunning={this.props.chartStatus === 'loading'}
-                  status={CHART_STATUS_MAP[this.props.chartStatus]}
-                  style={{ fontSize: '10px', marginRight: '5px' }}
-                />
-                <ExploreActionButtons
-                  formData={this.props.latestQueryFormData}
-                  canDownload={this.props.can_download}
-                />
-              </div>
-            </div>
-          }
+          header={<ChartHeader />}
         >
         {this.props.datasource &&
           <Chart

--- a/superset/assets/javascripts/explorev2/components/ChartHeader.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartHeader.jsx
@@ -1,14 +1,10 @@
-import $ from 'jquery';
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { Alert, Collapse, Label, Panel } from 'react-bootstrap';
-import visMap from '../../../visualizations/main';
-import { d3format } from '../../modules/utils';
+import { Label } from 'react-bootstrap';
 import ExploreActionButtons from './ExploreActionButtons';
 import FaveStar from '../../components/FaveStar';
 import TooltipWrapper from '../../components/TooltipWrapper';
 import Timer from '../../components/Timer';
-import { getExploreUrl } from '../exploreUtils';
 import { getFormDataFromControls } from '../stores/store';
 
 const CHART_STATUS_MAP = {
@@ -24,119 +20,13 @@ const propTypes = {
   chartStatus: PropTypes.string,
   chartUpdateEndTime: PropTypes.number,
   chartUpdateStartTime: PropTypes.number.isRequired,
-  column_formats: PropTypes.object,
-  containerId: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired,
   isStarred: PropTypes.bool.isRequired,
   slice: PropTypes.object,
   table_name: PropTypes.string,
-  viz_type: PropTypes.string.isRequired,
   formData: PropTypes.object,
-  latestQueryFormData: PropTypes.object,
 };
 
-class ChartContainer extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selector: `#${props.containerId}`,
-      showStackTrace: false,
-    };
-  }
-
-  renderViz() {
-    this.props.actions.renderTriggered();
-    const mockSlice = this.getMockedSliceObject();
-    this.setState({ mockSlice });
-    try {
-      visMap[this.props.viz_type](mockSlice, this.props.queryResponse);
-    } catch (e) {
-      this.props.actions.chartRenderingFailed(e);
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-        (
-          prevProps.queryResponse !== this.props.queryResponse ||
-          prevProps.height !== this.props.height ||
-          this.props.triggerRender
-        ) && !this.props.queryResponse.error
-        && this.props.chartStatus !== 'failed'
-        && this.props.chartStatus !== 'stopped'
-      ) {
-      this.renderViz();
-    }
-  }
-
-  getMockedSliceObject() {
-    const props = this.props;
-    const getHeight = () => {
-      const headerHeight = this.props.standalone ? 0 : 100;
-      return parseInt(props.height, 10) - headerHeight;
-    };
-    return {
-      viewSqlQuery: this.props.queryResponse.query,
-      containerId: props.containerId,
-      selector: this.state.selector,
-      formData: this.props.formData,
-      container: {
-        html: (data) => {
-          // this should be a callback to clear the contents of the slice container
-          $(this.state.selector).html(data);
-        },
-        css: (dim, size) => {
-          // dimension can be 'height'
-          // pixel string can be '300px'
-          // should call callback to adjust height of chart
-          $(this.state.selector).css(dim, size);
-        },
-        height: getHeight,
-        show: () => { },
-        get: (n) => ($(this.state.selector).get(n)),
-        find: (classname) => ($(this.state.selector).find(classname)),
-      },
-
-      width: () => this.chartContainerRef.getBoundingClientRect().width,
-
-      height: getHeight,
-
-      setFilter: () => {
-        // set filter according to data in store
-        // used in FilterBox.onChange()
-      },
-
-      getFilters: () => (
-        // return filter objects from viz.formData
-        {}
-      ),
-
-      done: () => {},
-      clearError: () => {
-        // no need to do anything here since Alert is closable
-        // query button will also remove Alert
-      },
-      error() {},
-
-      d3format: (col, number) => {
-        // mock d3format function in Slice object in superset.js
-        const format = props.column_formats[col];
-        return d3format(format, number);
-      },
-
-      data: {
-        csv_endpoint: getExploreUrl(this.props.formData, 'csv'),
-        json_endpoint: getExploreUrl(this.props.formData, 'json'),
-        standalone_endpoint: getExploreUrl(
-          this.props.formData, 'standalone'),
-      },
-
-    };
-  }
-
-  removeAlert() {
-    this.props.actions.removeChartAlert();
-  }
+class ChartHeader extends React.PureComponent {
 
   renderChartTitle() {
     let title;
@@ -148,163 +38,67 @@ class ChartContainer extends React.PureComponent {
     return title;
   }
 
-  renderAlert() {
-    const msg = (
-      <div>
-        {this.props.alert}
-        <i
-          className="fa fa-close pull-right"
-          onClick={this.removeAlert.bind(this)}
-          style={{ cursor: 'pointer' }}
-        />
-      </div>);
-    return (
-      <div>
-        <Alert
-          bsStyle="warning"
-          onClick={() => this.setState({ showStackTrace: !this.state.showStackTrace })}
-        >
-          {msg}
-        </Alert>
-        {this.props.queryResponse && this.props.queryResponse.stacktrace &&
-          <Collapse in={this.state.showStackTrace}>
-            <pre>
-              {this.props.queryResponse.stacktrace}
-            </pre>
-          </Collapse>
-        }
-      </div>);
-  }
-
-  renderChart() {
-    if (this.props.alert) {
-      return this.renderAlert();
-    }
-    const loading = this.props.chartStatus === 'loading';
-    return (
-      <div>
-        {loading &&
-          <img
-            alt="loading"
-            width="25"
-            src="/static/assets/images/loading.gif"
-            style={{ position: 'absolute' }}
-          />
-        }
-        <div
-          id={this.props.containerId}
-          ref={ref => { this.chartContainerRef = ref; }}
-          className={this.props.viz_type}
-          style={{
-            opacity: loading ? '0.25' : '1',
-          }}
-        />
-      </div>
-    );
-  }
-  runQuery() {
-    this.props.actions.runQuery(this.props.formData, true);
-  }
-
   render() {
-    if (this.props.standalone) {
-      return this.renderChart();
-    }
     return (
-      <div className="chart-container">
-        <Panel
-          style={{ height: this.props.height }}
-          header={
-            <div
-              id="slice-header"
-              className="clearfix panel-title-large"
+      <div
+        id="slice-header"
+        className="clearfix panel-title-large"
+      >
+        {this.renderChartTitle()}
+
+        {this.props.slice &&
+          <span>
+            <FaveStar
+              sliceId={this.props.slice.slice_id}
+              actions={this.props.actions}
+              isStarred={this.props.isStarred}
+            />
+            <TooltipWrapper
+              label="edit-desc"
+              tooltip="Edit Description"
             >
-              {this.renderChartTitle()}
+              <a
+                className="edit-desc-icon"
+                href={`/slicemodelview/edit/${this.props.slice.slice_id}`}
+              >
+                <i className="fa fa-edit" />
+              </a>
+            </TooltipWrapper>
+          </span>
+        }
 
-              {this.props.slice &&
-                <span>
-                  <FaveStar
-                    sliceId={this.props.slice.slice_id}
-                    actions={this.props.actions}
-                    isStarred={this.props.isStarred}
-                  />
-
-                  <TooltipWrapper
-                    label="edit-desc"
-                    tooltip="Edit Description"
-                  >
-                    <a
-                      className="edit-desc-icon"
-                      href={`/slicemodelview/edit/${this.props.slice.slice_id}`}
-                    >
-                      <i className="fa fa-edit" />
-                    </a>
-                  </TooltipWrapper>
-                </span>
-              }
-
-              <div className="pull-right">
-                {this.props.chartStatus === 'success' &&
-                 this.props.queryResponse &&
-                 this.props.queryResponse.is_cached &&
-                  <TooltipWrapper
-                    tooltip="Loaded from cache. Click to force refresh"
-                    label="cache-desc"
-                  >
-                    <Label
-                      style={{ fontSize: '10px', marginRight: '5px', cursor: 'pointer' }}
-                      onClick={this.runQuery.bind(this)}
-                    >
-                      cached
-                    </Label>
-                  </TooltipWrapper>
-                }
-                <Timer
-                  startTime={this.props.chartUpdateStartTime}
-                  endTime={this.props.chartUpdateEndTime}
-                  isRunning={this.props.chartStatus === 'loading'}
-                  status={CHART_STATUS_MAP[this.props.chartStatus]}
-                  style={{ fontSize: '10px', marginRight: '5px' }}
-                />
-                <ExploreActionButtons
-                  slice={this.state.mockSlice}
-                  canDownload={this.props.can_download}
-                  queryEndpoint={getExploreUrl(this.props.latestQueryFormData, 'query')}
-                />
-              </div>
-            </div>
+        <div className="pull-right">
+          {this.props.chartStatus === 'success' &&
+           this.props.queryResponse &&
+           this.props.queryResponse.is_cached &&
+            <TooltipWrapper
+              tooltip="Loaded from cache. Click to force refresh"
+              label="cache-desc"
+            >
+              <Label
+                style={{ fontSize: '10px', marginRight: '5px', cursor: 'pointer' }}
+                onClick={this.runQuery.bind(this)}
+              >
+                cached
+              </Label>
+            </TooltipWrapper>
           }
-        >
-          {this.renderChart()}
-        </Panel>
+          <Timer
+            startTime={this.props.chartUpdateStartTime}
+            endTime={this.props.chartUpdateEndTime}
+            isRunning={this.props.chartStatus === 'loading'}
+            status={CHART_STATUS_MAP[this.props.chartStatus]}
+            style={{ fontSize: '10px', marginRight: '5px' }}
+          />
+          <ExploreActionButtons
+            formData={this.props.formData}
+            canDownload={this.props.can_download}
+          />
+        </div>
       </div>
     );
   }
 }
 
-ChartContainer.propTypes = propTypes;
-
-function mapStateToProps(state) {
-  const formData = getFormDataFromControls(state.controls);
-  return {
-    alert: state.chartAlert,
-    can_download: state.can_download,
-    chartStatus: state.chartStatus,
-    chartUpdateEndTime: state.chartUpdateEndTime,
-    chartUpdateStartTime: state.chartUpdateStartTime,
-    column_formats: state.datasource ? state.datasource.column_formats : null,
-    containerId: state.slice ? `slice-container-${state.slice.slice_id}` : 'slice-container',
-    formData,
-    latestQueryFormData: state.latestQueryFormData,
-    isStarred: state.isStarred,
-    queryResponse: state.queryResponse,
-    slice: state.slice,
-    standalone: state.standalone,
-    table_name: formData.datasource_name,
-    viz_type: formData.viz_type,
-    triggerRender: state.triggerRender,
-    datasourceType: state.datasource ? state.datasource.type : null,
-  };
-}
-
-export default connect(mapStateToProps, () => ({}))(ChartContainer);
+ChartHeader.propTypes = propTypes;
+export default ChartHeader;

--- a/superset/assets/javascripts/explorev2/components/EmbedCodeButton.jsx
+++ b/superset/assets/javascripts/explorev2/components/EmbedCodeButton.jsx
@@ -3,7 +3,7 @@ import CopyToClipboard from './../../components/CopyToClipboard';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
 
 const propTypes = {
-  slice: PropTypes.object.isRequired,
+  standaloneEndpoint: PropTypes.string.isRequired,
 };
 
 export default class EmbedCodeButton extends React.Component {
@@ -27,7 +27,7 @@ export default class EmbedCodeButton extends React.Component {
   generateEmbedHTML() {
     const srcLink = (
       window.location.origin +
-      this.props.slice.data.standalone_endpoint +
+      this.props.standaloneEndpoint +
       `&height=${this.state.height}`
     );
     return (

--- a/superset/assets/javascripts/explorev2/components/ExploreActionButtons.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreActionButtons.jsx
@@ -3,52 +3,45 @@ import cx from 'classnames';
 import URLShortLinkButton from './URLShortLinkButton';
 import EmbedCodeButton from './EmbedCodeButton';
 import DisplayQueryButton from './DisplayQueryButton';
+import { getExploreUrl } from '../exploreUtils';
 
 const propTypes = {
   canDownload: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
-  slice: PropTypes.object,
-  queryEndpoint: PropTypes.string,
-  query: PropTypes.string,
+  formData: PropTypes.object,
 };
 
-export default function ExploreActionButtons({ canDownload, slice, query, queryEndpoint }) {
+export default function ExploreActionButtons({ canDownload, formData }) {
   const exportToCSVClasses = cx('btn btn-default btn-sm', {
     'disabled disabledButton': !canDownload,
   });
-  if (slice) {
-    return (
-      <div className="btn-group results" role="group">
-        <URLShortLinkButton slice={slice} />
-
-        <EmbedCodeButton slice={slice} />
-
-        <a
-          href={slice.data.json_endpoint}
-          className="btn btn-default btn-sm"
-          title="Export to .json"
-          target="_blank"
-        >
-          <i className="fa fa-file-code-o"></i> .json
-        </a>
-
-        <a
-          href={slice.data.csv_endpoint}
-          className={exportToCSVClasses}
-          title="Export to .csv format"
-          target="_blank"
-        >
-          <i className="fa fa-file-text-o"></i> .csv
-        </a>
-
-        <DisplayQueryButton
-          query={query}
-          queryEndpoint={queryEndpoint}
-        />
-      </div>
-    );
-  }
   return (
-    <DisplayQueryButton queryEndpoint={queryEndpoint} />
+    <div className="btn-group results" role="group">
+      <URLShortLinkButton />
+
+      <EmbedCodeButton standaloneEndpoint={getExploreUrl(formData, 'standalone')} />
+
+      <a
+        href={getExploreUrl(formData, 'json')}
+        className="btn btn-default btn-sm"
+        title="Export to .json"
+        target="_blank"
+      >
+        <i className="fa fa-file-code-o"></i> .json
+      </a>
+
+      <a
+        href={getExploreUrl(formData, 'csv')}
+        className={exportToCSVClasses}
+        title="Export to .csv format"
+        target="_blank"
+      >
+        <i className="fa fa-file-text-o"></i> .csv
+      </a>
+
+      <DisplayQueryButton
+        queryEndpoint={getExploreUrl(formData, 'query')}
+      />
+    </div>
   );
 }
 

--- a/superset/assets/javascripts/explorev2/components/URLShortLinkButton.jsx
+++ b/superset/assets/javascripts/explorev2/components/URLShortLinkButton.jsx
@@ -1,11 +1,7 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
 import CopyToClipboard from './../../components/CopyToClipboard';
 import { getShortUrl } from '../../../utils/common';
-
-const propTypes = {
-  slice: PropTypes.object.isRequired,
-};
 
 export default class URLShortLinkButton extends React.Component {
   constructor(props) {
@@ -58,5 +54,3 @@ export default class URLShortLinkButton extends React.Component {
     );
   }
 }
-
-URLShortLinkButton.propTypes = propTypes;

--- a/superset/assets/spec/javascripts/explorev2/components/EmbedCodeButton_spec.jsx
+++ b/superset/assets/spec/javascripts/explorev2/components/EmbedCodeButton_spec.jsx
@@ -38,7 +38,7 @@ describe('EmbedCodeButton', () => {
       '  seamless\n' +
       '  frameBorder="0"\n' +
       '  scrolling="no"\n' +
-      '  src="nullendpoint_url&height=1000"\n' +
+      '  src="nullundefined&height=1000"\n' +
       '>\n' +
       '</iframe>'
     );

--- a/superset/assets/spec/javascripts/explorev2/components/ExploreActionButtons_spec.jsx
+++ b/superset/assets/spec/javascripts/explorev2/components/ExploreActionButtons_spec.jsx
@@ -9,7 +9,7 @@ describe('ExploreActionButtons', () => {
   const defaultProps = {
     canDownload: 'True',
     formData: {
-      datasource: '1__table'
+      datasource: '1__table',
     },
   };
 

--- a/superset/assets/spec/javascripts/explorev2/components/ExploreActionButtons_spec.jsx
+++ b/superset/assets/spec/javascripts/explorev2/components/ExploreActionButtons_spec.jsx
@@ -8,11 +8,8 @@ import ExploreActionButtons from
 describe('ExploreActionButtons', () => {
   const defaultProps = {
     canDownload: 'True',
-    slice: {
-      data: {
-        csv_endpoint: '',
-        json_endpoint: '',
-      },
+    formData: {
+      datasource: '1__table'
     },
   };
 


### PR DESCRIPTION
... to allow for embedding `<Chart/>` into the dashboard view

Some important thoughts here that open a discussion:

Some of the logic that makes the `Chart` defined here in the first commit live outside the component in the actions & reducer (aka the Redux layer). This is problematic as we want to share this component in the Dashboard view AND in an eventual API where users can just embed charts in their application.  To make this possible, we'd have to either refactor some of the Redux logic to be reusable in other stores, ship the component with its own store, or much more simply, handle all of that logic in the component itself.

My vote goes towards handling all of this in the component itself. The component would receive `formData`, and do the proper thing as it changes over time (running queries & re-rendering the chart). In theory this allows for a self contained component that isn't bound to a store or anything complex. 

The component has a hook to trigger a refresh and it's a bit messy. Moving forward I'd like to change this to have the component reflect directly what is passed in formData, meaning the explore controller would have to handle the logic around holding and releasing formData based when the Query button is pushed.