### PR TITLE
Parse filter values for possible integers and floats

### DIFF
--- a/superset/models.py
+++ b/superset/models.py
@@ -1391,6 +1391,7 @@ class SqlaTable(Model, Datasource, AuditMixinNullable, ImportMixin):
             col_obj = cols[col]
             if op in ('in', 'not in'):
                 values = [types.strip("'").strip('"') for types in eq]
+                values = [utils.js_string_to_num(s) for s in values]
                 cond = col_obj.sqla_col.in_(values)
                 if op == 'not in':
                     cond = ~cond
@@ -2551,6 +2552,7 @@ class DruidDatasource(Model, AuditMixinNullable, Datasource, ImportMixin):
                 fields = []
                 # Distinguish quoted values with regular value types
                 values = [types.replace("'", '') for types in eq]
+                values = [utils.js_string_to_num(s) for s in values]
                 if len(values) > 1:
                     for s in values:
                         s = s.strip()

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -126,6 +126,14 @@ class memoized(object):  # noqa
 def js_string_to_python(item):
     return None if item in ('null', 'undefined') else item
 
+def js_string_to_num(item):
+    if item.isdigit():
+        return int(item)
+    s = item
+    try:
+        s = float(item)
+    except ValueError:
+        return s
 
 class DimSelector(Having):
     def __init__(self, **args):


### PR DESCRIPTION
With the new explore view filter values are passed from frontend as strings, we want to parse them into integers when needed.
@ascott @mistercrunch @bkyryliuk 