### PR TITLE
[hotfix]  Remove overwrite option when slice doesn't exist

### DIFF
--- a/superset/assets/javascripts/explorev2/components/SaveModal.js
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.js
@@ -139,13 +139,15 @@ class SaveModal extends React.Component {
               />
             </Alert>
           }
-          <Radio
-            disabled={!this.props.can_overwrite}
-            checked={this.state.action === 'overwrite'}
-            onChange={this.changeAction.bind(this, 'overwrite')}
-          >
-          {`Overwrite slice ${this.props.slice.slice_name}`}
-          </Radio>
+          {this.props.slice &&
+            <Radio
+              disabled={!this.props.can_overwrite}
+              checked={this.state.action === 'overwrite'}
+              onChange={this.changeAction.bind(this, 'overwrite')}
+            >
+            {`Overwrite slice ${this.props.slice.slice_name}`}
+            </Radio>
+          }
 
           <Radio
             inline


### PR DESCRIPTION
Issue: [https://github.com/airbnb/superset/issues/2261](url)
Bug:
 for a new slice, slice is null, slice_name can't be accessed

After:
[https://github.com/airbnb/superset/pull/2265](https://github.com/airbnb/superset/pull/2265)

@ascott 