### PR TITLE
Introducing support for pre-depercate_v1 URL scheme

### DIFF
--- a/superset/views.py
+++ b/superset/views.py
@@ -38,6 +38,7 @@ from superset import (
     appbuilder, cache, db, models, viz, utils, app,
     sm, sql_lab, sql_parse, results_backend, security,
 )
+from superset.legacy import cast_form_data
 from superset.utils import has_access
 from superset.source_registry import SourceRegistry
 from superset.models import DatasourceAccessRequest as DAR
@@ -1466,10 +1467,14 @@ class Superset(BaseSupersetView):
     def get_form_data(self):
         form_data = request.args.get("form_data")
         if not form_data:
+            # Supporting POST as well as get
             form_data = request.form.get("form_data")
-        if not form_data:
-            form_data = '{}'
-        d = json.loads(form_data)
+        if form_data:
+            d = json.loads(form_data)
+        elif request.args.get("viz_type"):
+            # Converting old URLs
+            d = cast_form_data(request.args.to_dict())
+
         extra_filters = request.args.get("extra_filters")
         filters = d.get('filters', [])
         if extra_filters:


### PR DESCRIPTION
For testing: `/superset/explore/table/3/?slice_name=Genders+by+State&row_limit=5000&metric=sum__num&flt_op_1=not+in&viz_type=dist_bar&since=100+years+ago&json=false&until=now&datasource_id=1&metrics=sum__sum_girls&metrics=sum__sum_boys&datasource_name=birth_names&granularity=ds&flt_eq_1=other&flt_col_1=state&slice_id=124&datasource_type=table&compare_lag=10&limit=25&markup_type=markdown&compare_suffix=o10Y&where=&groupby=state&V2=true`