### PR TITLE
[hotfix] Fix druid filters

### DIFF
--- a/superset/assets/javascripts/explorev2/components/controls/Filter.jsx
+++ b/superset/assets/javascripts/explorev2/components/controls/Filter.jsx
@@ -4,6 +4,9 @@ import Select from 'react-select';
 import { Button, Row, Col } from 'react-bootstrap';
 import SelectControl from './SelectControl';
 
+const arrayFilterOps = ['in', 'not in'];
+const strFilterOps = ['==', '!=', '>', '<', '>=', '<=', 'regex'];
+
 const propTypes = {
   choices: PropTypes.array,
   changeFilter: PropTypes.func,
@@ -55,6 +58,15 @@ export default class Filter extends React.Component {
     if (event && event.value) {
       value = event.value;
     }
+    if (control === 'op') {
+      if (arrayFilterOps.indexOf(this.props.filter.op) !== -1
+        && strFilterOps.indexOf(value) !== -1) {
+        this.props.changeFilter('val', this.props.filter.val[0]);
+      } else if (strFilterOps.indexOf(this.props.filter.op) !== -1
+        && arrayFilterOps.indexOf(value) !== -1) {
+        this.props.changeFilter('val', [this.props.filter.val]);
+      }
+    }
     this.props.changeFilter(control, value);
     if (control === 'col' && value !== null && this.props.datasource.filter_select) {
       this.fetchFilterValues(value);
@@ -70,13 +82,13 @@ export default class Filter extends React.Component {
         this.fetchFilterValues(filter.col);
       }
     }
-    if (this.props.having) {
-      // druid having filter
+    if (this.props.having || StrFilterOps.indexOf(filter.op) !== -1) {
+      // druid having filter or regex/==/!= filters
       return (
         <input
           type="text"
           onChange={this.changeFilter.bind(this, 'val')}
-          value={filter.value}
+          value={filter.val}
           className="form-control input-sm"
           placeholder="Filter value"
         />

--- a/superset/models.py
+++ b/superset/models.py
@@ -1403,7 +1403,8 @@ class SqlaTable(Model, Datasource, AuditMixinNullable, ImportMixin):
             col_obj = cols.get(col)
             if col_obj and op in ('in', 'not in'):
                 values = [types.strip("'").strip('"') for types in eq]
-                values = [utils.js_string_to_num(s) for s in values]
+                if col_obj.is_num:
+                    values = [utils.js_string_to_num(s) for s in values]
                 cond = col_obj.sqla_col.in_(values)
                 if op == 'not in':
                     cond = ~cond
@@ -2567,8 +2568,7 @@ class DruidDatasource(Model, AuditMixinNullable, Datasource, ImportMixin):
             query=query_str,
             duration=datetime.now() - qry_start_dttm)
 
-    @staticmethod
-    def get_filters(raw_filters):
+    def get_filters(self, raw_filters):
         filters = None
         for flt in raw_filters:
             if not all(f in flt for f in ['col', 'op', 'val']):
@@ -2577,6 +2577,11 @@ class DruidDatasource(Model, AuditMixinNullable, Datasource, ImportMixin):
             op = flt['op']
             eq = flt['val']
             cond = None
+            if col in self.num_cols:
+                if op in ('in', 'not in'):
+                    eq = [utils.js_string_to_num(v) for v in eq]
+                else:
+                    eq = utils.js_string_to_num(eq)
             if op == '==':
                 cond = Dimension(col) == eq
             elif op == '!=':
@@ -2585,7 +2590,9 @@ class DruidDatasource(Model, AuditMixinNullable, Datasource, ImportMixin):
                 fields = []
                 # Distinguish quoted values with regular value types
                 values = [types.replace("'", '') for types in eq]
-                values = [utils.js_string_to_num(s) for s in values]
+                for val in eq:
+                    if col in self.num_cols:
+                        val = utils.js_string_to_num(val)
                 if len(values) > 1:
                     for s in values:
                         s = s.strip()


### PR DESCRIPTION
Fixed:
 - cast filter value to integer when column type is numeric
 - use string instead of array, input instead of SelectField when filter op is 'regex', '==', '!=', '>' or '<', fixing problems with regex filters in druid

@mistercrunch @ascott 