### PR TITLE
[hotfix] Fix filter for sqlalchemy and druid

### DIFF
--- a/superset/assets/javascripts/explorev2/components/controls/Filter.jsx
+++ b/superset/assets/javascripts/explorev2/components/controls/Filter.jsx
@@ -4,6 +4,9 @@ import Select from 'react-select';
 import { Button, Row, Col } from 'react-bootstrap';
 import SelectControl from './SelectControl';
 
+const arrayFilterOps = ['in', 'not in'];
+const strFilterOps = ['==', '!=', '>', '<', '>=', '<=', 'regex'];
+
 const propTypes = {
   choices: PropTypes.array,
   changeFilter: PropTypes.func,
@@ -55,6 +58,15 @@ export default class Filter extends React.Component {
     if (event && event.value) {
       value = event.value;
     }
+    if (control === 'op') {
+      if (arrayFilterOps.indexOf(this.props.filter.op) !== -1
+        && strFilterOps.indexOf(value) !== -1) {
+        this.props.changeFilter('val', this.props.filter.val[0]);
+      } else if (strFilterOps.indexOf(this.props.filter.op) !== -1
+        && arrayFilterOps.indexOf(value) !== -1) {
+        this.props.changeFilter('val', [this.props.filter.val]);
+      }
+    }
     this.props.changeFilter(control, value);
     if (control === 'col' && value !== null && this.props.datasource.filter_select) {
       this.fetchFilterValues(value);
@@ -70,13 +82,13 @@ export default class Filter extends React.Component {
         this.fetchFilterValues(filter.col);
       }
     }
-    if (this.props.having) {
-      // druid having filter
+    if (this.props.having || strFilterOps.indexOf(filter.op) !== -1) {
+      // druid having filter or regex/==/!= filters
       return (
         <input
           type="text"
           onChange={this.changeFilter.bind(this, 'val')}
-          value={filter.value}
+          value={filter.val}
           className="form-control input-sm"
           placeholder="Filter value"
         />

--- a/superset/assets/javascripts/explorev2/components/controls/Filter.jsx
+++ b/superset/assets/javascripts/explorev2/components/controls/Filter.jsx
@@ -50,6 +50,21 @@ export default class Filter extends React.Component {
       });
     }
   }
+  switchFilterValue(prevFilter, nextOp) {
+    const prevOp = prevFilter.op;
+    let newVal = null;
+    if (arrayFilterOps.indexOf(prevOp) !== -1
+        && strFilterOps.indexOf(nextOp) !== -1) {
+      // switch from array to string
+      newVal = this.props.filter.val.length > 0 ? this.props.filter.val[0] : '';
+    }
+    if (strFilterOps.indexOf(prevOp) !== -1
+        && arrayFilterOps.indexOf(nextOp) !== -1) {
+      // switch from string to array
+      newVal = this.props.filter.val === '' ? [] : [this.props.filter.val];
+    }
+    return newVal;
+  }
   changeFilter(control, event) {
     let value = event;
     if (event && event.target) {
@@ -59,15 +74,15 @@ export default class Filter extends React.Component {
       value = event.value;
     }
     if (control === 'op') {
-      if (arrayFilterOps.indexOf(this.props.filter.op) !== -1
-        && strFilterOps.indexOf(value) !== -1) {
-        this.props.changeFilter('val', this.props.filter.val[0]);
-      } else if (strFilterOps.indexOf(this.props.filter.op) !== -1
-        && arrayFilterOps.indexOf(value) !== -1) {
-        this.props.changeFilter('val', [this.props.filter.val]);
+      const newVal = this.switchFilterValue(this.props.filter, value);
+      if (newVal) {
+        this.props.changeFilter(['op', 'val'], [value, newVal]);
+      } else {
+        this.props.changeFilter(control, value);
       }
+    } else {
+      this.props.changeFilter(control, value);
     }
-    this.props.changeFilter(control, value);
     if (control === 'col' && value !== null && this.props.datasource.filter_select) {
       this.fetchFilterValues(value);
     }
@@ -82,7 +97,7 @@ export default class Filter extends React.Component {
         this.fetchFilterValues(filter.col);
       }
     }
-    if (this.props.having || strFilterOps.indexOf(filter.op) !== -1) {
+    if (strFilterOps.indexOf(filter.op) !== -1) {
       // druid having filter or regex/==/!= filters
       return (
         <input

--- a/superset/assets/javascripts/explorev2/components/controls/FilterControl.jsx
+++ b/superset/assets/javascripts/explorev2/components/controls/FilterControl.jsx
@@ -29,7 +29,13 @@ export default class FilterControl extends React.Component {
   changeFilter(index, control, value) {
     const newFilters = Object.assign([], this.props.value);
     const modifiedFilter = Object.assign({}, newFilters[index]);
-    modifiedFilter[control] = value;
+    if (typeof control === 'string') {
+      modifiedFilter[control] = value;
+    } else {
+      control.forEach((c, i) => {
+        modifiedFilter[c] = value[i];
+      });
+    }
     newFilters.splice(index, 1, modifiedFilter);
     this.props.onChange(newFilters);
   }

--- a/superset/models.py
+++ b/superset/models.py
@@ -1403,7 +1403,8 @@ class SqlaTable(Model, Datasource, AuditMixinNullable, ImportMixin):
             col_obj = cols.get(col)
             if col_obj and op in ('in', 'not in'):
                 values = [types.strip("'").strip('"') for types in eq]
-                values = [utils.js_string_to_num(s) for s in values]
+                if col_obj.is_num:
+                    values = [utils.js_string_to_num(s) for s in values]
                 cond = col_obj.sqla_col.in_(values)
                 if op == 'not in':
                     cond = ~cond
@@ -2567,8 +2568,7 @@ class DruidDatasource(Model, AuditMixinNullable, Datasource, ImportMixin):
             query=query_str,
             duration=datetime.now() - qry_start_dttm)
 
-    @staticmethod
-    def get_filters(raw_filters):
+    def get_filters(self, raw_filters):
         filters = None
         for flt in raw_filters:
             if not all(f in flt for f in ['col', 'op', 'val']):
@@ -2577,21 +2577,24 @@ class DruidDatasource(Model, AuditMixinNullable, Datasource, ImportMixin):
             op = flt['op']
             eq = flt['val']
             cond = None
+            if op in ('in', 'not in'):
+                eq = [types.replace("'", '').strip() for types in eq]
+            if col in self.num_cols:
+                if op in ('in', 'not in'):
+                    eq = [utils.js_string_to_num(v) for v in eq]
+                else:
+                    eq = utils.js_string_to_num(eq)
             if op == '==':
                 cond = Dimension(col) == eq
             elif op == '!=':
                 cond = ~(Dimension(col) == eq)
             elif op in ('in', 'not in'):
                 fields = []
-                # Distinguish quoted values with regular value types
-                values = [types.replace("'", '') for types in eq]
-                values = [utils.js_string_to_num(s) for s in values]
-                if len(values) > 1:
-                    for s in values:
-                        s = s.strip()
+                if len(eq) > 1:
+                    for s in eq:
                         fields.append(Dimension(col) == s)
                     cond = Filter(type="or", fields=fields)
-                elif len(values) == 1:
+                elif len(eq) == 1:
                     cond = Dimension(col) == eq[0]
                 if op == 'not in':
                     cond = ~cond


### PR DESCRIPTION
Reopen the fix:
 - cast filter value to integer when column type is numeric
 - use string instead of array, input instead of SelectField when filter op is 'regex', '==', '!=', '>' or '<', fixing problems with regex filters in druid

@mistercrunch @ascott 