### PR TITLE
[table] Allowing to show the time grain in table view

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/controls.jsx
+++ b/superset/assets/javascripts/explorev2/stores/controls.jsx
@@ -188,6 +188,13 @@ export const controls = {
                  'displaying the Y scale',
   },
 
+  include_time: {
+    type: 'CheckboxControl',
+    label: 'Include Time',
+    description: 'Whether to include the time granularity as defined in the time section',
+    default: false,
+  },
+
   bar_stacked: {
     type: 'CheckboxControl',
     label: 'Stacked Bars',

--- a/superset/assets/javascripts/explorev2/stores/visTypes.js
+++ b/superset/assets/javascripts/explorev2/stores/visTypes.js
@@ -236,6 +236,7 @@ const visTypes = {
         description: 'Use this section if you want a query that aggregates',
         controlSetRows: [
           ['groupby', 'metrics'],
+          ['include_time'],
         ],
       },
       {
@@ -258,6 +259,9 @@ const visTypes = {
       metrics: {
         default: null,
         validators: null,
+      },
+      time_grain_sqla: {
+        default: null,
       },
     },
   },

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -366,10 +366,15 @@ class TableViz(BaseViz):
     def should_be_timeseries(self):
         fd = self.form_data
         # TODO handle datasource-type-specific code in datasource
-        return (
+        conditions_met = (
             (fd.get('granularity') and fd.get('granularity') != 'all') or
             (fd.get('granularity_sqla') and fd.get('time_grain_sqla'))
         )
+        if fd.get('include_time') and not conditions_met:
+            raise Exception(
+                "Pick a granularity in the Time section or "
+                "uncheck 'Include Time'")
+        return fd.get('include_time')
 
     def query_obj(self):
         d = super(TableViz, self).query_obj()


### PR DESCRIPTION
Explicitely request to show the time grain in the table view as a checkbox
![img](http://g.recordit.co/hQG6ix1O33.gif)

This prevents a change in behavior from a recent PR where groupby table views that used to not show time granularity may do it on the recent release.