### PR TITLE
[hotfix] Js helper for wrongly migrated filter values

### DIFF
--- a/superset/assets/javascripts/explorev2/components/controls/Filter.jsx
+++ b/superset/assets/javascripts/explorev2/components/controls/Filter.jsx
@@ -97,8 +97,12 @@ export default class Filter extends React.Component {
         this.fetchFilterValues(filter.col);
       }
     }
+    // switching filter value between array/string when needed
     if (strFilterOps.indexOf(filter.op) !== -1) {
       // druid having filter or regex/==/!= filters
+      if (typeof filter.val !== 'string') {
+        this.props.changeFilter('val', filter.val.length > 0 ? filter.val[0] : '');
+      }
       return (
         <input
           type="text"
@@ -108,6 +112,9 @@ export default class Filter extends React.Component {
           placeholder="Filter value"
         />
       );
+    }
+    if (typeof filter.val === 'string') {
+      this.props.changeFilter('val', filter.val === '' ? [] : [filter.val]);
     }
     return (
       <SelectControl


### PR DESCRIPTION
We migrated all filter values from string to arrays, which broke the regex/==/!= filter values for druid, this frontend patch will remap the type of filter values when necessary

@ascott 