### PR TITLE
Fixes filters emitted from table viz

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -111,6 +111,10 @@ class ChartContainer extends React.PureComponent {
         {}
       ),
 
+      addFilter: () => {},
+
+      removeFilter: () => {},
+
       done: () => {},
       clearError: () => {
         // no need to do anything here since Alert is closable

--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -68,18 +68,24 @@ function tableVis(slice, payload) {
     .enter()
     .append('tr')
     .selectAll('td')
-    .data((row) => data.columns.map((c) => {
-      let val = row[c];
+    .data(row => data.columns.map(c => {
+      const val = row[c];
+      let html;
+      const isMetric = metrics.indexOf(c) >= 0;
       if (c === 'timestamp') {
-        val = timestampFormatter(val);
+        html = timestampFormatter(val);
       }
       if (typeof(val) === 'string') {
-        val = `<span class="like-pre">${val}</span>`;
+        html = `<span class="like-pre">${val}</span>`;
+      }
+      if (isMetric) {
+        html = slice.d3format(c, val);
       }
       return {
         col: c,
         val,
-        isMetric: metrics.indexOf(c) >= 0,
+        html,
+        isMetric,
       };
     }))
     .enter()
@@ -118,12 +124,7 @@ function tableVis(slice, payload) {
     .style('cursor', function (d) {
       return (!d.isMetric) ? 'pointer' : '';
     })
-    .html((d) => {
-      if (d.isMetric) {
-        return slice.d3format(d.col, d.val);
-      }
-      return d.val;
-    });
+    .html(d => d.html ? d.html : d.val);
   const height = slice.height();
   let paging = false;
   let pageLength;


### PR DESCRIPTION
The table viz supports emitting filters event when clicking on dimensions (there's a checkbox control to enable that). Since recent changes it was emitting a filter on the mutated html content of the table cell as opposed to this original value.

@ascott 
Fixes https://github.com/airbnb/superset/issues/2327 https://github.com/airbnb/superset/issues/2332