### PR TITLE
Fix for Python 2/3 compatibility

### DIFF
--- a/superset/legacy.py
+++ b/superset/legacy.py
@@ -74,7 +74,7 @@ def cast_form_data(form_data):
         d[k] = v
     if 'filters' not in d:
         d = cast_filter_data(d)
-    for k in d.keys():
+    for k in list(d):
         if k not in FORM_DATA_KEY_WHITELIST:
             del d[k]
     return d


### PR DESCRIPTION
In Python 2 calling keys makes a copy of the key that you can iterate over while modifying the dict.
This doesn't work in Python 3, because keys returns an iterator instead of a list.
To make it work in both Python 2 and 3, use `list(d)` instead of d.keys() to force a copy.

Source: http://stackoverflow.com/a/11941855