### PR TITLE
[table] metric ordering is wrong in some cases

### DIFF
--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -17,15 +17,10 @@ function tableVis(slice, payload) {
 
   const data = payload.data;
   const fd = slice.formData;
+
   // Removing metrics (aggregates) that are strings
-  const realMetrics = [];
   let metrics = fd.metrics || [];
-  for (const k in data.records[0]) {
-    if (metrics.indexOf(k) > -1 && !isNaN(data.records[0][k])) {
-      realMetrics.push(k);
-    }
-  }
-  metrics = realMetrics;
+  metrics = metrics.filter(m => !isNaN(data.records[0][m]));
 
   function col(c) {
     const arr = [];


### PR DESCRIPTION
I'm not sure why the condition was there in the first place, but it reordered the metrics which breaks ordering. The outcome should be the same now, it's denser and won't reorder the metrics