### PR TITLE
Updates to the time handling.

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -280,7 +280,7 @@ class PrestoEngineSpec(BaseEngineSpec):
     def convert_dttm(cls, target_type, dttm):
         tt = target_type.upper()
         if tt == 'DATE':
-            return "from_iso8601_date('{}')".format(dttm.isoformat()[:10])
+            return "from_iso8601_date('{}')".format(dttm.strftime('%Y-%m-%d'))
         if tt == 'TIMESTAMP':
             return "from_iso8601_timestamp('{}')".format(dttm.isoformat())
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))


### PR DESCRIPTION
Let's start a discussion here.
The way we handle time leads to confusion sometimes, especially when time is represented as YYYY-MM-DD string.
Default expectation is start <= time_displayed < end.
Our behavior is start<= time_displayed <= end

@mistercrunch @ascott 