### PR TITLE
Fix monthly time grain in sqllite

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -193,7 +193,7 @@ class SqliteEngineSpec(BaseEngineSpec):
         Grain("week", _('week'),
               "DATE({col}, -strftime('%w', {col}) || ' days')"),
         Grain("month", _('month'),
-              "DATE({col}, -strftime('%d', {col}) || ' days')"),
+              "DATE({col}, -strftime('%d', {col}) || ' days', '+1 day')"),
     )
 
     @classmethod


### PR DESCRIPTION
Fixes: https://github.com/airbnb/superset/issues/1234
```
sqlite> SELECT date('2017-02-02', -strftime('%d','2017-02-02') || ' days');
2017-01-31

but

sqlite> SELECT date('2017-02-02', -strftime('%d','2017-02-02')   || ' days', '+1 day');
2017-02-01
```

@mistercrunch @ascott ^^