### PR TITLE
Fix bad d3.format metric setting and/or value === Infinity

### DIFF
--- a/superset/assets/javascripts/modules/utils.js
+++ b/superset/assets/javascripts/modules/utils.js
@@ -109,7 +109,11 @@ export function d3format(format, number) {
   if (!(format in formatters)) {
     formatters[format] = d3.format(format);
   }
-  return formatters[format](number);
+  try {
+    return formatters[format](number);
+  } catch (e) {
+    return 'ERR';
+  }
 }
 
 // Slice objects interact with their context through objects that implement


### PR DESCRIPTION
@vera-liu @ascott @bkyryliuk 
Fixes <img width="810" alt="screen shot 2017-03-13 at 9 08 02 pm" src="https://cloud.githubusercontent.com/assets/487433/23885562/2db81948-0831-11e7-96cc-c1558a27f0b8.png">

on dash #777 reported on our slack channel today