### PR TITLE
Preprocess the where clauses.

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -509,6 +509,7 @@ class SqlaTable(Model, BaseDatasource):
         )
         logging.info(sql)
         sql = sqlparse.format(sql, reindent=True)
+        sql = self.database.db_engine_spec.sql_preprocessor(sql)
         return sql
 
     def query(self, query_obj):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -115,9 +115,9 @@ class BaseEngineSpec(object):
     def sql_preprocessor(cls, sql):
         """If the SQL needs to be altered prior to running it
 
-        For example Presto needs to double `%` characters
+        For example db api needs to double `%` characters
         """
-        return sql
+        return sql.replace('%', '%%')
 
     @classmethod
     def patch(cls):
@@ -278,10 +278,6 @@ class PrestoEngineSpec(BaseEngineSpec):
         from pyhive import presto
         from superset.db_engines import presto as patched_presto
         presto.Cursor.cancel = patched_presto.cancel
-
-    @classmethod
-    def sql_preprocessor(cls, sql):
-        return sql.replace('%', '%%')
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):


### PR DESCRIPTION
Preprocess the where clauses in explore view.
After this change user will be able do:
`WHERE ds LIKE '%2016%'` and `WHERE ds LIKE '%%2016%%'`

@mistercrunch @ascott @vera-liu  - please review