### PR TITLE
Revert "Preprocess the where clauses."

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -517,7 +517,6 @@ class SqlaTable(Model, BaseDatasource):
         )
         logging.info(sql)
         sql = sqlparse.format(sql, reindent=True)
-        sql = self.database.db_engine_spec.sql_preprocessor(sql)
         return sql
 
     def query(self, query_obj):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -115,9 +115,9 @@ class BaseEngineSpec(object):
     def sql_preprocessor(cls, sql):
         """If the SQL needs to be altered prior to running it
 
-        For example db api needs to double `%` characters
+        For example Presto needs to double `%` characters
         """
-        return sql.replace('%', '%%')
+        return sql
 
     @classmethod
     def patch(cls):
@@ -278,6 +278,10 @@ class PrestoEngineSpec(BaseEngineSpec):
         from pyhive import presto
         from superset.db_engines import presto as patched_presto
         presto.Cursor.cancel = patched_presto.cancel
+
+    @classmethod
+    def sql_preprocessor(cls, sql):
+        return sql.replace('%', '%%')
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):


### PR DESCRIPTION
Reverts airbnb/superset#2405
This commit breaks date formatting:
<img width="1043" alt="screen shot 2017-03-14 at 3 59 32 pm" src="https://cloud.githubusercontent.com/assets/5727938/23926048/5668f36e-08cf-11e7-9aac-9d6c8f3a77f1.png">
