### PR TITLE
fix a bug in pie chart

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1085,11 +1085,12 @@ class DistributionPieViz(NVD3Viz):
     is_timeseries = False
 
     def get_data(self, df):
+        df = self.get_df()
         df = df.pivot_table(
             index=self.groupby,
             values=[self.metrics[0]])
         df.sort_values(by=self.metrics[0], ascending=False, inplace=True)
-        df = self.get_df()
+        df = df.reset_index()
         df.columns = ['x', 'y']
         return df.to_dict(orient="records")
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1085,7 +1085,6 @@ class DistributionPieViz(NVD3Viz):
     is_timeseries = False
 
     def get_data(self, df):
-        df = self.get_df()
         df = df.pivot_table(
             index=self.groupby,
             values=[self.metrics[0]])


### PR DESCRIPTION
Previously, line 1092 is cancelling what's done in line 1088 to 1091. 
If 'df.columns' contains more than two items, it will throw an error since pivoting it to two columns was canceled by df = self.get_df() 