### PR TITLE
[WiP] making doubling '%' not required

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -722,7 +722,7 @@ class DruidDatasource(Model, BaseDatasource):
         return [row[0] for row in df.to_records(index=False)]
 
     def get_query_str(  # noqa / druid
-            self, client, qry_start_dttm,
+            self,
             groupby, metrics,
             granularity,
             from_dttm, to_dttm,
@@ -741,6 +741,7 @@ class DruidDatasource(Model, BaseDatasource):
         This query interface is common to SqlAlchemy and Druid
         """
         # TODO refactor into using a TBD Query object
+        client = self.cluster.get_pydruid_client()
         if not is_timeseries:
             granularity = 'all'
         inner_from_dttm = inner_from_dttm or from_dttm

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -942,7 +942,7 @@ class DruidDatasource(Model, BaseDatasource):
     def query(self, query_obj):
         qry_start_dttm = datetime.now()
         client = self.cluster.get_pydruid_client()
-        query_str = self.get_query_str(client, qry_start_dttm, **query_obj)
+        query_str = self.get_query_str(**query_obj)
         df = client.export_pandas()
 
         if df is None or df.size == 0:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -322,8 +322,16 @@ class SqlaTable(Model, BaseDatasource):
         return get_template_processor(
             table=self, database=self.database, **kwargs)
 
-    def get_query_str(  # sqla
-            self, engine, qry_start_dttm,
+    def get_query_str(self, **kwargs):
+        qry = self.get_sqla_query(**kwargs)
+        sql = str(qry.compile(kwargs['engine']))
+        logging.info(sql)
+        sql = sqlparse.format(sql, reindent=True)
+        sql = self.database.db_engine_spec.sql_preprocessor(sql)
+        return sql
+
+    def get_sqla_query(  # sqla
+            self,
             groupby, metrics,
             granularity,
             from_dttm, to_dttm,
@@ -472,8 +480,7 @@ class SqlaTable(Model, BaseDatasource):
                 elif op == '<=':
                     where_clause_and.append(col_obj.sqla_col <= eq)
                 elif op == 'LIKE':
-                    where_clause_and.append(
-                        col_obj.sqla_col.like(eq.replace('%', '%%')))
+                    where_clause_and.append(col_obj.sqla_col.like(eq))
         if extras:
             where = extras.get('where')
             if where:
@@ -523,25 +530,18 @@ class SqlaTable(Model, BaseDatasource):
 
             tbl = tbl.join(subq.alias(), and_(*on_clause))
 
-        qry = qry.select_from(tbl)
-
-        sql = "{}".format(
-            qry.compile(
-                engine, compile_kwargs={"literal_binds": True},),
-        )
-        logging.info(sql)
-        sql = sqlparse.format(sql, reindent=True)
-        return sql
+        return qry.select_from(tbl)
 
     def query(self, query_obj):
         qry_start_dttm = datetime.now()
         engine = self.database.get_sqla_engine()
-        sql = self.get_query_str(engine, qry_start_dttm, **query_obj)
+        qry = self.get_sqla_query(**query_obj)
+        sql = str(qry)
         status = QueryStatus.SUCCESS
         error_message = None
         df = None
         try:
-            df = pd.read_sql_query(sql, con=engine)
+            df = pd.read_sql_query(qry, con=engine)
         except Exception as e:
             status = QueryStatus.FAILED
             error_message = str(e)

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -117,7 +117,7 @@ class BaseEngineSpec(object):
 
         For example Presto needs to double `%` characters
         """
-        return sql#.replace('%', '%')
+        return sql
 
     @classmethod
     def patch(cls):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -117,7 +117,7 @@ class BaseEngineSpec(object):
 
         For example Presto needs to double `%` characters
         """
-        return sql
+        return sql#.replace('%', '%')
 
     @classmethod
     def patch(cls):
@@ -278,10 +278,6 @@ class PrestoEngineSpec(BaseEngineSpec):
         from pyhive import presto
         from superset.db_engines import presto as patched_presto
         presto.Cursor.cancel = patched_presto.cancel
-
-    @classmethod
-    def sql_preprocessor(cls, sql):
-        return sql.replace('%', '%%')
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -983,14 +983,11 @@ class Superset(BaseSupersetView):
         if request.args.get("query") == "true":
             try:
                 query_obj = viz_obj.query_obj()
-                engine = viz_obj.datasource.database.get_sqla_engine() \
-                    if datasource_type == 'table' \
-                    else viz_obj.datasource.cluster.get_pydruid_client()
                 if datasource_type == 'druid':
                     # only retrive first phase query for druid
                     query_obj['phase'] = 1
                 query = viz_obj.datasource.get_query_str(
-                    engine, datetime.now(), **query_obj)
+                    datetime.now(), **query_obj)
             except Exception as e:
                 return json_error_response(e)
             return Response(


### PR DESCRIPTION
Now passing the sqlalchemy query object to pandas's read_sql_query.

Also some simplification, removing engine and start time from the query_obj