### PR TITLE
Speeding up polling by not checking access

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2087,7 +2087,6 @@ class Superset(BaseSupersetView):
             return json_error_response(DATASOURCE_ACCESS_ERR)
         return json_success(json.dumps(datasource.data))
 
-    @has_access
     @expose("/queries/<last_updated_ms>")
     def queries(self, last_updated_ms):
         """Get the updated queries."""

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -63,7 +63,6 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(('can_slice', 'Superset'), perm_set)
         self.assertIn(('can_explore', 'Superset'), perm_set)
         self.assertIn(('can_explore_json', 'Superset'), perm_set)
-        self.assertIn(('can_queries', 'Superset'), perm_set)
 
     def assert_can_alpha(self, perm_set):
         self.assert_can_all('SqlMetricInlineView', perm_set)


### PR DESCRIPTION
Here's the difference locally, on AWS this should matter more as networks pings can't be expected to be as good as locally.

Before
<img width="62" alt="screen shot 2017-03-23 at 5 43 19 pm" src="https://cloud.githubusercontent.com/assets/487433/24275952/94a5db88-0ff0-11e7-848e-f8cd2471d769.png">

After
<img width="60" alt="screen shot 2017-03-23 at 5 43 28 pm" src="https://cloud.githubusercontent.com/assets/487433/24275949/91af0c42-0ff0-11e7-817e-3f4defdf9d4d.png">