### PR TITLE
Redirect to explore view when saving a table

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -9,7 +9,6 @@ import logging
 import pandas as pd
 import pickle
 import re
-import sys
 import time
 import traceback
 import zlib


### PR DESCRIPTION
The redirect flow is pretty unpredictable at the moment when saving a table. In most cases, when people go to alter a table, they are interested in seeing the result in the explore view right after they save.

@ascott 