### PR TITLE
Deprecate is_featured as a datasource attribute

### DIFF
--- a/superset/connectors/base.py
+++ b/superset/connectors/base.py
@@ -23,7 +23,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
     id = Column(Integer, primary_key=True)
     description = Column(Text)
     default_endpoint = Column(Text)
-    is_featured = Column(Boolean, default=False)
+    is_featured = Column(Boolean, default=False)  # TODO deprecating
     filter_select_enabled = Column(Boolean, default=False)
     offset = Column(Integer, default=0)
     cache_timeout = Column(Integer)

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -338,7 +338,7 @@ class DruidDatasource(Model, BaseDatasource):
 
     export_fields = (
         'datasource_name', 'is_hidden', 'description', 'default_endpoint',
-        'cluster_name', 'is_featured', 'offset', 'cache_timeout', 'params'
+        'cluster_name', 'offset', 'cache_timeout', 'params'
     )
 
     @property

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -152,7 +152,7 @@ class DruidDatasourceModelView(SupersetModelView, DeleteMixin):  # noqa
     related_views = [DruidColumnInlineView, DruidMetricInlineView]
     edit_columns = [
         'datasource_name', 'cluster', 'description', 'owner',
-        'is_featured', 'is_hidden',
+        'is_hidden',
         'filter_select_enabled', 'fetch_values_from',
         'default_endpoint', 'offset', 'cache_timeout']
     add_columns = edit_columns
@@ -174,7 +174,6 @@ class DruidDatasourceModelView(SupersetModelView, DeleteMixin):  # noqa
         'cluster': _("Cluster"),
         'description': _("Description"),
         'owner': _("Owner"),
-        'is_featured': _("Is Featured"),
         'is_hidden': _("Is Hidden"),
         'filter_select_enabled': _("Enable Filter Select"),
         'default_endpoint': _("Default Endpoint"),

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -184,7 +184,7 @@ class SqlaTable(Model, BaseDatasource):
     baselink = "tablemodelview"
     export_fields = (
         'table_name', 'main_dttm_col', 'description', 'default_endpoint',
-        'database_id', 'is_featured', 'offset', 'cache_timeout', 'schema',
+        'database_id', 'offset', 'cache_timeout', 'schema',
         'sql', 'params')
 
     __table_args__ = (

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -129,13 +129,13 @@ appbuilder.add_view_no_menu(SqlMetricInlineView)
 class TableModelView(SupersetModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.SqlaTable)
     list_columns = [
-        'link', 'database', 'is_featured',
+        'link', 'database',
         'changed_by_', 'changed_on_']
     order_columns = [
-        'link', 'database', 'is_featured', 'changed_on_']
+        'link', 'database', 'changed_on_']
     add_columns = ['database', 'schema', 'table_name']
     edit_columns = [
-        'table_name', 'sql', 'is_featured', 'filter_select_enabled',
+        'table_name', 'sql', 'filter_select_enabled',
         'fetch_values_predicate', 'database', 'schema',
         'description', 'owner',
         'main_dttm_col', 'default_endpoint', 'offset', 'cache_timeout']
@@ -168,7 +168,6 @@ class TableModelView(SupersetModelView, DeleteMixin):  # noqa
         'changed_by_': _("Changed By"),
         'database': _("Database"),
         'changed_on_': _("Last Changed"),
-        'is_featured': _("Is Featured"),
         'filter_select_enabled': _("Enable Filter Select"),
         'schema': _("Schema"),
         'default_endpoint': _("Default Endpoint"),

--- a/superset/data/__init__.py
+++ b/superset/data/__init__.py
@@ -70,7 +70,6 @@ def load_energy():
     if not tbl:
         tbl = TBL(table_name=tbl_name)
     tbl.description = "Energy consumption"
-    tbl.is_featured = True
     tbl.database = get_or_create_main_db()
     db.session.merge(tbl)
     db.session.commit()
@@ -179,7 +178,6 @@ def load_world_bank_health_n_pop():
         tbl = TBL(table_name=tbl_name)
     tbl.description = utils.readfile(os.path.join(DATA_FOLDER, 'countries.md'))
     tbl.main_dttm_col = 'year'
-    tbl.is_featured = True
     tbl.database = get_or_create_main_db()
     db.session.merge(tbl)
     db.session.commit()
@@ -574,7 +572,6 @@ def load_birth_names():
         obj = TBL(table_name='birth_names')
     obj.main_dttm_col = 'ds'
     obj.database = get_or_create_main_db()
-    obj.is_featured = True
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -843,7 +840,6 @@ def load_unicode_test_data():
         obj = TBL(table_name='unicode_test')
     obj.main_dttm_col = 'date'
     obj.database = get_or_create_main_db()
-    obj.is_featured = False
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -922,7 +918,6 @@ def load_random_time_series_data():
         obj = TBL(table_name='random_time_series')
     obj.main_dttm_col = 'ds'
     obj.database = get_or_create_main_db()
-    obj.is_featured = False
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -988,7 +983,6 @@ def load_long_lat_data():
         obj = TBL(table_name='long_lat')
     obj.main_dttm_col = 'date'
     obj.database = get_or_create_main_db()
-    obj.is_featured = False
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -1050,7 +1044,6 @@ def load_multiformat_time_series_data():
         obj = TBL(table_name='multiformat_time_series')
     obj.main_dttm_col = 'ds'
     obj.database = get_or_create_main_db()
-    obj.is_featured = False
     dttm_and_expr_dict = {
         'ds': [None, None],
         'ds2': [None, None],


### PR DESCRIPTION
`is_featured` was legacy from a previous Welcome page where you could define which datasource would show up.
fixes https://github.com/airbnb/superset/issues/2403

The vision for the welcome page is to replace it with the profile page.