### PR TITLE
Fixing filter_box css padding

### DIFF
--- a/superset/assets/visualizations/filter_box.css
+++ b/superset/assets/visualizations/filter_box.css
@@ -20,7 +20,7 @@ ul.select2-results div.filter_box{
     border-width: 1px;
     border-color: transparent;
 }
-.filter_box .slice_container {
+.filter_box.slice_container {
     padding: 10px;
     overflow: visible !important;
 }


### PR DESCRIPTION
Before:
<img width="417" alt="screen shot 2017-03-27 at 11 03 15 pm" src="https://cloud.githubusercontent.com/assets/487433/24391075/b6231bbe-1341-11e7-83fe-406f2eb16a3c.png">

After
<img width="414" alt="screen shot 2017-03-27 at 11 03 08 pm" src="https://cloud.githubusercontent.com/assets/487433/24391076/b63abbac-1341-11e7-9dbf-0bb743dd7bfb.png">
