### PR TITLE
[explore] force control validation before runQuery

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -58,6 +58,7 @@ class ChartContainer extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     if (
+        this.props.queryResponse &&
         (
           prevProps.queryResponse !== this.props.queryResponse ||
           prevProps.height !== this.props.height ||

--- a/superset/assets/javascripts/explorev2/components/Control.jsx
+++ b/superset/assets/javascripts/explorev2/components/Control.jsx
@@ -48,9 +48,12 @@ export default class Control extends React.PureComponent {
     super(props);
     this.validate = this.validate.bind(this);
     this.onChange = this.onChange.bind(this);
-    this.onChange(props.value, []);
+    this.validateAndSetValue(props.value, []);
   }
   onChange(value, errors) {
+    this.validateAndSetValue(value, errors);
+  }
+  validateAndSetValue(value, errors) {
     let validationErrors = this.validate(value);
     if (errors && errors.length > 0) {
       validationErrors = validationErrors.concat(errors);

--- a/superset/assets/javascripts/explorev2/components/Control.jsx
+++ b/superset/assets/javascripts/explorev2/components/Control.jsx
@@ -48,6 +48,7 @@ export default class Control extends React.PureComponent {
     super(props);
     this.validate = this.validate.bind(this);
     this.onChange = this.onChange.bind(this);
+    this.onChange(props.value, []);
   }
   onChange(value, errors) {
     let validationErrors = this.validate(value);

--- a/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
@@ -47,10 +47,8 @@ class ExploreViewContainer extends React.Component {
   }
 
   componentDidUpdate() {
-    if (this.props.triggerQuery) {
-      if (this.hasErrors()) {
-        this.runQuery();
-      }
+    if (this.props.triggerQuery && !this.hasErrors()) {
+      this.runQuery();
     }
   }
 
@@ -99,7 +97,7 @@ class ExploreViewContainer extends React.Component {
   }
   hasErrors() {
     const ctrls = this.props.controls;
-    Object.keys(ctrls).some(k => ctrls[k].validationErrors.length > 0);
+    return Object.keys(ctrls).some(k => ctrls[k].validationErrors.length > 0);
   }
   renderErrorMessage() {
     // Returns an error message as a node if any errors are in the store

--- a/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreViewContainer.jsx
@@ -48,7 +48,9 @@ class ExploreViewContainer extends React.Component {
 
   componentDidUpdate() {
     if (this.props.triggerQuery) {
-      this.runQuery();
+      if (this.hasErrors()) {
+        this.runQuery();
+      }
     }
   }
 
@@ -94,6 +96,10 @@ class ExploreViewContainer extends React.Component {
 
   toggleModal() {
     this.setState({ showModal: !this.state.showModal });
+  }
+  hasErrors() {
+    const ctrls = this.props.controls;
+    Object.keys(ctrls).some(k => ctrls[k].validationErrors.length > 0);
   }
   renderErrorMessage() {
     // Returns an error message as a node if any errors are in the store

--- a/superset/assets/javascripts/explorev2/components/QueryAndSaveBtns.jsx
+++ b/superset/assets/javascripts/explorev2/components/QueryAndSaveBtns.jsx
@@ -9,7 +9,7 @@ const propTypes = {
   onSave: PropTypes.func,
   onStop: PropTypes.func,
   loading: PropTypes.bool,
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.node,
 };
 
 const defaultProps = {
@@ -37,6 +37,7 @@ export default function QueryAndSaveBtns(
       className="query"
       onClick={onQuery}
       bsStyle={qryButtonStyle}
+      disabled={errorMessage}
     >
       <i className="fa fa-bolt" /> Query
     </Button>

--- a/superset/assets/javascripts/explorev2/components/QueryAndSaveBtns.jsx
+++ b/superset/assets/javascripts/explorev2/components/QueryAndSaveBtns.jsx
@@ -37,7 +37,7 @@ export default function QueryAndSaveBtns(
       className="query"
       onClick={onQuery}
       bsStyle={qryButtonStyle}
-      disabled={errorMessage}
+      disabled={!!errorMessage}
     >
       <i className="fa fa-bolt" /> Query
     </Button>

--- a/superset/assets/javascripts/explorev2/index.jsx
+++ b/superset/assets/javascripts/explorev2/index.jsx
@@ -29,7 +29,7 @@ import { exploreReducer } from './reducers/exploreReducer';
 // Initial state
 const bootstrappedState = Object.assign(
   bootstrapData, {
-    chartStatus: 'loading',
+    chartStatus: null,
     chartUpdateEndTime: null,
     chartUpdateStartTime: now(),
     dashboards: [],

--- a/superset/assets/javascripts/explorev2/stores/visTypes.js
+++ b/superset/assets/javascripts/explorev2/stores/visTypes.js
@@ -255,10 +255,6 @@ const visTypes = {
       },
     ],
     controlOverrides: {
-      metrics: {
-        default: null,
-        validators: null,
-      },
       time_grain_sqla: {
         default: null,
       },

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -112,7 +112,7 @@ class BaseViz(object):
         """Building a query object"""
         form_data = self.form_data
         groupby = form_data.get("groupby") or []
-        metrics = form_data.get("metrics") or ['count']
+        metrics = form_data.get("metrics") or []
 
         # extra_filters are temporary/contextual filters that are external
         # to the slice definition. We use those for dynamic interactive


### PR DESCRIPTION
* somehow default metric would not be auto populated for Table viz, but there was backend mechanics to auto-chose a random metric (that had some related edge case bug)
* frontend validation would only occur on field change, not when first loaded, that created edge cases where the validation or default value might have changed

@ascott 