### PR TITLE
[doc] Pip Cryptography Install Version

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,7 @@ that the required dependencies are installed: ::
 **OSX**, system python is not recommended. brew's python also ships with pip  ::
 
     brew install pkg-config libffi openssl python
-    env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install cryptography
+    env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install cryptography==1.7.2
 
 **Windows** isn't officially supported at this point, but if you want to
 attempt it, download `get-pip.py <https://bootstrap.pypa.io/get-pip.py>`_, and run ``python get-pip.py`` which may need admin access. Then run the following: ::


### PR DESCRIPTION
Description:
Adding a specific version to the pip install intructions for
cryptography.

Why:
So that it matches the required version in setup.py.
Without this, the latest version is installed with the correct flags and
then when setup.py is ran 1.7.2 is installed with no flags which will
cause other errors.

Changes:
Added specific verion to pip install.