### PR TITLE
[big num] make sure scatterplot dots align properly

### DIFF
--- a/superset/assets/visualizations/big_number.js
+++ b/superset/assets/visualizations/big_number.js
@@ -63,7 +63,7 @@ function bigNumberVis(slice, payload) {
   const line = d3.svg.line()
     .x(d => scaleX(d[0]))
     .y(d => scaleY(d[1]))
-    .interpolate('basis');
+    .interpolate('cardinal');
 
   let y = height / 2;
   let g = svg.append('g');

--- a/superset/assets/visualizations/big_number.js
+++ b/superset/assets/visualizations/big_number.js
@@ -50,8 +50,9 @@ function bigNumberVis(slice, payload) {
   const valueExt = d3.extent(data, (d) => d[1]);
   const yAxisLabelWidths = valueExt.map(value => getTextWidth(f(value), '10px Roboto'));
   const yAxisMaxWidth = Math.max(...yAxisLabelWidths);
-  const margin = yAxisMaxWidth + (yAxisMaxWidth / 2);
-
+  let margin = yAxisMaxWidth + (yAxisMaxWidth / 2);
+  // make sure margin is minimum 30px, for the case when the y axix label is very small.
+  if (margin < 30) margin = 30;
   const scaleX = d3.time.scale.utc().domain(dateExt).range([margin, width - margin]);
   const scaleY = d3.scale.linear().domain(valueExt).range([height - (margin), margin]);
   const colorRange = [d3.hsl(0, 1, 0.3), d3.hsl(120, 1, 0.3)];


### PR DESCRIPTION
showing scatterplot dots to show how they were not aligning. the scatterplot dots are the triggers for the tooltips.

before: 
![screenshot 2017-04-05 12 07 03](https://cloud.githubusercontent.com/assets/130878/24722787/f0415932-19f9-11e7-9d6c-12023433be3a.png)

after:
![screenshot 2017-04-05 12 07 56](https://cloud.githubusercontent.com/assets/130878/24722793/f3ed97b2-19f9-11e7-8704-39ec80b3675f.png)
![screenshot 2017-04-05 12 08 44](https://cloud.githubusercontent.com/assets/130878/24722859/20f406ec-19fa-11e7-8abe-d25bfc3dcc25.png)
 @mistercrunch 
