### PR TITLE
[bugfix] saved query restore wouldn't pick the db

### DIFF
--- a/superset/assets/javascripts/SqlLab/actions.js
+++ b/superset/assets/javascripts/SqlLab/actions.js
@@ -356,7 +356,7 @@ export function popSavedQuery(saveQueryId) {
         const sq = data.result;
         const queryEditorProps = {
           title: sq.label,
-          dbId: sq.db_id,
+          dbId: sq.db_id ? parseInt(sq.db_id, 10) : null,
           schema: sq.schema,
           autorun: false,
           sql: sq.sql,


### PR DESCRIPTION
note that the casting would not be necessary if it was for this:
https://github.com/dpgaspar/Flask-AppBuilder/pull/443