### PR TITLE
Fixing confusion when selecting schema across engines

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -117,6 +117,27 @@ class BaseEngineSpec(object):
         return utils.error_msg_from_exception(e)
 
     @classmethod
+    def adjust_database_uri(cls, uri, selected_schema):
+        """Based on a URI and selected schema, return a new URI
+
+        The URI here represents the URI as entered when saving the database,
+        ``selected_schema`` is the schema currently active presumably in
+        the SQL Lab dropdown. Based on that, for some database engine,
+        we can return a new altered URI that connects straight to the
+        active schema, meaning the users won't have to prefix the object
+        names by the schema name.
+
+        Some databases engines have 2 level of namespacing: database and
+        schema (postgres, oracle, mssql, ...)
+        For those it's probably better to not alter the database
+        component of the URI with the schema name, it won't work.
+
+        Some database drivers like presto accept "{catalog}/{schema}" in
+        the database component of the URL, that can be handled here.
+        """
+        return uri
+
+    @classmethod
     def sql_preprocessor(cls, sql):
         """If the SQL needs to be altered prior to running it
 
@@ -291,6 +312,12 @@ class MySQLEngineSpec(BaseEngineSpec):
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
     @classmethod
+    def adjust_database_uri(cls, uri, selected_schema=None):
+        if selected_schema:
+            uri.database = selected_schema
+        return uri
+
+    @classmethod
     def epoch_to_dttm(cls):
         return "from_unixtime({col})"
 
@@ -327,6 +354,17 @@ class PrestoEngineSpec(BaseEngineSpec):
         from pyhive import presto
         from superset.db_engines import presto as patched_presto
         presto.Cursor.cancel = patched_presto.cancel
+
+    @classmethod
+    def adjust_database_uri(cls, uri, selected_schema=None):
+        database = uri.database
+        if selected_schema:
+            if '/' in database:
+                database = database.split('/')[0] + '/' + selected_schema
+            else:
+                database += '/' + selected_schema
+            uri.database = database
+        return uri
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -169,8 +169,8 @@ def generate_download_headers(extension):
 class DatabaseView(SupersetModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.Database)
     list_columns = [
-        'verbose_name', 'backend', 'allow_run_sync', 'allow_run_async',
-        'allow_dml', 'creator', 'changed_on_', 'database_name']
+        'database_name', 'backend', 'allow_run_sync', 'allow_run_async',
+        'allow_dml', 'creator', 'modified']
     add_columns = [
         'database_name', 'sqlalchemy_uri', 'cache_timeout', 'extra',
         'expose_in_sqllab', 'allow_run_sync', 'allow_run_async',
@@ -1351,6 +1351,7 @@ class Superset(BaseSupersetView):
             engine.connect()
             return json.dumps(engine.table_names(), indent=4)
         except Exception as e:
+            logging.exception(e)
             return json_error_response((
                 "Connection failed!\n\n"
                 "The error message returned was:\n{}").format(e))


### PR DESCRIPTION
Different engines have different semantics around what a `database` and `schema` are. This PR moves that logic to where it should be in `db_engine_spec`, and sets a more predicable default.