### PR TITLE
Add missing flask-wtf dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'flask-script==2.0.5',
         'flask-sqlalchemy==2.0',
         'flask-testing==0.6.2',
+        'flask-wtf==0.14.2',
         'future>=0.16.0, <0.17',
         'humanize==0.5.1',
         'gunicorn==19.7.1',


### PR DESCRIPTION
It was an implicit dependency but looks like we need a recent version since 122891c29