### PR TITLE
Fix for merge string as array

### DIFF
--- a/superset/assets/javascripts/dashboard/Dashboard.jsx
+++ b/superset/assets/javascripts/dashboard/Dashboard.jsx
@@ -193,10 +193,12 @@ export function dashboardContainer(dashboard) {
       if (!(sliceId in this.filters)) {
         this.filters[sliceId] = {};
       }
-      if (!(col in this.filters[sliceId]) || !merge) {
-        this.filters[sliceId][col] = vals;
-      } else {
-        this.filters[sliceId][col] = d3.merge([this.filters[sliceId][col], vals]);
+      if (!(col in this.filters[sliceId])) {
+        if (!merge) {
+          this.filters[sliceId][col] = vals;
+        } else {
+          this.filters[sliceId][col] = d3.merge([this.filters[sliceId][col], vals]);
+        }
       }
       if (refresh) {
         this.refreshExcept(sliceId);


### PR DESCRIPTION
Fixed for the issue where string is being treated as array.

Situation:
When user select a date from filter box, it passes `merge=true` and the selectedValues of filter_box is correct but when apply button is clicked, it passes `merge=false` and the string(for example `1 day ago`) is treated as array and become `['1', ' ', 'd', 'a', 'y', ' ', 'a', 'g', 'o']`