### PR TITLE
[dashboard] fix css padding for markup viz

### DIFF
--- a/superset/assets/visualizations/markup.css
+++ b/superset/assets/visualizations/markup.css
@@ -1,4 +1,4 @@
-.markup .slice_container {
+.markup.slice_container {
     padding: 10px;
     overflow: auto;
 }


### PR DESCRIPTION
before/after

<img width="457" alt="screen shot 2017-04-12 at 9 13 38 am" src="https://cloud.githubusercontent.com/assets/487433/24968009/b2979f8a-1f60-11e7-9fd3-42d4b94c2666.png">
<img width="475" alt="screen shot 2017-04-12 at 9 15 06 am" src="https://cloud.githubusercontent.com/assets/487433/24968008/b28c5c74-1f60-11e7-883c-b1cdbf4ab6e7.png">