### PR TITLE
Fix separator widget CSS

### DIFF
--- a/superset/assets/javascripts/dashboard/components/GridLayout.jsx
+++ b/superset/assets/javascripts/dashboard/components/GridLayout.jsx
@@ -100,7 +100,7 @@ class GridLayout extends React.Component {
             id={'slice_' + slice.slice_id}
             key={slice.slice_id}
             data-slice-id={slice.slice_id}
-            className="widget"
+            className={`widget ${slice.form_data.viz_type}`}
           >
             <SliceCell
               slice={slice}


### PR DESCRIPTION
before/after
<img width="544" alt="screen shot 2017-04-14 at 10 32 07 am" src="https://cloud.githubusercontent.com/assets/487433/25050696/bc39187c-20fd-11e7-964e-c9ca05f4d875.png">
<img width="544" alt="screen shot 2017-04-14 at 10 31 24 am" src="https://cloud.githubusercontent.com/assets/487433/25050695/bc37a2bc-20fd-11e7-8569-0d93921ee819.png">
