### PR TITLE
Add UNIX socket option to runserver

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -48,7 +48,9 @@ def init():
     help="Specify the timeout (seconds) for the gunicorn web server")
 @manager.option(
     '-s', '--socket', default=config.get("SUPERSET_WEBSERVER_SOCKET"),
-    help="Path to a UNIX socket as an alternative to address:port, e.g. /var/run/superset.sock. Will override the address and port values.")
+    help="Path to a UNIX socket as an alternative to address:port, e.g. "
+         "/var/run/superset.sock. "
+         "Will override the address and port values.")
 def runserver(debug, no_reload, address, port, timeout, workers, socket):
     """Starts a Superset web server."""
     debug = debug or config.get("DEBUG")
@@ -60,24 +62,15 @@ def runserver(debug, no_reload, address, port, timeout, workers, socket):
             debug=True,
             use_reloader=no_reload)
     else:
-        if socket:
-            cmd = (
-                "gunicorn "
-                "-w {workers} "
-                "--timeout {timeout} "
-                "-b unix:{socket} "
-                "--limit-request-line 0 "
-                "--limit-request-field_size 0 "
-                "superset:app").format(**locals())
-        else:
-            cmd = (
-                "gunicorn "
-                "-w {workers} "
-                "--timeout {timeout} "
-                "-b {address}:{port} "
-                "--limit-request-line 0 "
-                "--limit-request-field_size 0 "
-                "superset:app").format(**locals())
+        addr_str = " unix:{socket} " if socket else" {address}:{port} "
+        cmd = (
+            "gunicorn "
+            "-w {workers} "
+            "--timeout {timeout} "
+            "-b " + addr_str +
+            "--limit-request-line 0 "
+            "--limit-request-field_size 0 "
+            "superset:app").format(**locals())
         print("Starting server with command: " + cmd)
         Popen(cmd, shell=True).wait()
 


### PR DESCRIPTION
Added an optional parameter to runserver to server from a UNIX socket instead of an address:port. I believe it is fairly common to server from sockets when using a web server like Nginx on the same host.