### PR TITLE
Slice level cache_timeout isn't taken into consideration

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/controls.jsx
+++ b/superset/assets/javascripts/explorev2/stores/controls.jsx
@@ -1199,5 +1199,12 @@ export const controls = {
     hidden: true,
     description: 'The id of the active slice',
   },
+
+  cache_timeout: {
+    type: 'HiddenControl',
+    label: 'Cache Timeout (seconds)',
+    hidden: true,
+    description: 'The number of seconds before expiring the cache',
+  },
 };
 export default controls;

--- a/superset/assets/javascripts/explorev2/stores/visTypes.js
+++ b/superset/assets/javascripts/explorev2/stores/visTypes.js
@@ -12,7 +12,7 @@ export const sections = {
     controlSetRows: [
       ['datasource'],
       ['viz_type'],
-      ['slice_id'],
+      ['slice_id', 'cache_timeout'],
     ],
   },
   sqlaTimeSeries: {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -33,7 +33,7 @@ from superset import (
     sm, sql_lab, results_backend, security,
 )
 from superset.legacy import cast_form_data
-from superset.utils import has_access
+from superset.utils import has_access, QueryStatus
 from superset.connectors.connector_registry import ConnectorRegistry
 import superset.models.core as models
 from superset.models.sql_lab import Query
@@ -47,7 +47,6 @@ from .base import (
 config = app.config
 log_this = models.Log.log_this
 can_access = utils.can_access
-QueryStatus = models.QueryStatus
 DAR = models.DatasourceAccessRequest
 
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -42,13 +42,12 @@ class BaseViz(object):
     credits = ""
     is_timeseries = False
 
-    def __init__(self, datasource, form_data, slice_=None):
+    def __init__(self, datasource, form_data):
         if not datasource:
             raise Exception("Viz is missing a datasource")
         self.datasource = datasource
         self.request = request
         self.viz_type = form_data.get("viz_type")
-        self.slice = slice_
         self.form_data = form_data
 
         self.query = ""
@@ -184,9 +183,8 @@ class BaseViz(object):
 
     @property
     def cache_timeout(self):
-
-        if self.slice and self.slice.cache_timeout:
-            return self.slice.cache_timeout
+        if self.form_data.get('cache_timeout'):
+            return int(self.form_data.get('cache_timeout'))
         if self.datasource.cache_timeout:
             return self.datasource.cache_timeout
         if (


### PR DESCRIPTION
I decided to make `cache_timeout` a `form_data` parameter to add extra flexibility, and avoid doing a DB round trip to get the slice's timeout in the `explore_json` view.