### PR TITLE
Remove metrics control non-null validator in Table context

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/visTypes.js
+++ b/superset/assets/javascripts/explorev2/stores/visTypes.js
@@ -242,7 +242,8 @@ const visTypes = {
         label: 'NOT GROUPED BY',
         description: 'Use this section if you want to query atomic rows',
         controlSetRows: [
-          ['all_columns', 'order_by_cols'],
+          ['all_columns'],
+          ['order_by_cols'],
         ],
       },
       {
@@ -255,6 +256,9 @@ const visTypes = {
       },
     ],
     controlOverrides: {
+      metrics: {
+        validators: [],
+      },
       time_grain_sqla: {
         default: null,
       },


### PR DESCRIPTION
We generally require non-null for the `metrics` control, but it can't apply in the Table visualization context where there's a not-grouped-by way to use it.

I also moved `all_columns` to have its own row as opposed to sharing it with the `ordering` control.