### PR TITLE
use full name in SqlaTable repr

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -190,7 +190,7 @@ class SqlaTable(Model, BaseDatasource):
             name='_customer_location_uc'),)
 
     def __repr__(self):
-        return self.name
+        return self.full_name
 
     @property
     def description_markeddown(self):


### PR DESCRIPTION
this more closely matches the old caravel behavior. The problem arises when you have the same table come from different databases. in the "explore" view you'd have something like this

![image](https://cloud.githubusercontent.com/assets/697647/25141672/33c9927c-2432-11e7-997f-9e93070f06b5.png)

which is rather confusing. Alternatives to this would be to add a verbose_name like the one used in the [Database model](https://github.com/airbnb/superset/blob/db02b33e09dd6391fb1d8f777b19d5c16a511abe/superset/models/core.py#L536)

After the feedback, I'll make sure to add tests :)