### PR TITLE
Moving the warning message to the navbar

### DIFF
--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -1,5 +1,6 @@
 {% set menu = appbuilder.menu %}
 {% set languages = appbuilder.languages %}
+{% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
 
 <div class="navbar navbar-static-top {{menu.extra_classes}}" role="navigation">
   <div class="container{{ '-fluid' if not navbar_container else '' }}">
@@ -18,9 +19,15 @@
     </div>
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
+        {% if WARNING_MSG %}
+          <li class="alert alert-danger">
+            {{ WARNING_MSG | safe }}
+          </li>
+        {% endif %}
         {% include 'appbuilder/navbar_menu.html' %}
       </ul>
       <ul class="nav navbar-nav navbar-right">
+        {% include 'appbuilder/navbar_right.html' %}
         <li>
           <a href="/static/assets/version_info.json" title="Version info">
             <i class="fa fa-code-fork"></i> &nbsp;
@@ -36,17 +43,8 @@
             <i class="fa fa-book"></i> &nbsp;
           </a>
         </li>
-        {% include 'appbuilder/navbar_right.html' %}
       </ul>
     </div>
   </div>
 </div>
 
-{% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
-{% if WARNING_MSG %}
-  <div class="container">
-    <div id="navbar-warning" class="alert alert-danger">
-      {{ WARNING_MSG | safe }}
-    </div>
-  </div>
-{% endif %}


### PR DESCRIPTION
Before/after
<img width="715" alt="screen shot 2017-04-18 at 3 30 10 pm" src="https://cloud.githubusercontent.com/assets/487433/25155819/f48e7144-244b-11e7-91e6-0fb9d6ea9f1f.png">
<img width="1278" alt="screen shot 2017-04-18 at 3 24 48 pm" src="https://cloud.githubusercontent.com/assets/487433/25155820/f48f04e2-244b-11e7-9a8b-5b9511377b13.png">

At Airbnb we use these WARNING_MSG configuration element to make it
clear that we're in the staging environment.

Before this PR it would render under the navbar and mess up some of the
heights configurations, where you wouldn't be able to scroll all the way
to the bottom of the page. This fixes it.