### PR TITLE
Showing slices on datasource edit form

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -331,6 +331,11 @@ class DruidDatasource(Model, BaseDatasource):
         'datasource_name', 'is_hidden', 'description', 'default_endpoint',
         'cluster_name', 'offset', 'cache_timeout', 'params'
     )
+    slices = relationship(
+        'Slice',
+        primaryjoin=(
+            "DruidDatasource.id == foreign(Slice.datasource_id) and "
+            "Slice.datasource_type == 'druid'"))
 
     @property
     def database(self):

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -155,7 +155,7 @@ class DruidDatasourceModelView(SupersetModelView, DeleteMixin):  # noqa
         'datasource_link', 'changed_on_', 'offset']
     related_views = [DruidColumnInlineView, DruidMetricInlineView]
     edit_columns = [
-        'datasource_name', 'cluster', 'description', 'owner',
+        'datasource_name', 'cluster', 'slices', 'description', 'owner',
         'is_hidden',
         'filter_select_enabled', 'fetch_values_from',
         'default_endpoint', 'offset', 'cache_timeout']
@@ -164,6 +164,14 @@ class DruidDatasourceModelView(SupersetModelView, DeleteMixin):  # noqa
     page_size = 500
     base_order = ('datasource_name', 'asc')
     description_columns = {
+        'slices': _(
+            "The list of slices associated with this table. By "
+            "altering this datasource, you may change how these associated "
+            "slices behave. "
+            "Also note that slices need to point to a datasource, so "
+            "this form will fail at saving if removing slices from a "
+            "datasource. If you want to change the datasource for a slice, "
+            "overwrite the slice from the 'explore view'"),
         'offset': _("Timezone offset (in hours) for this datasource"),
         'description': Markup(
             "Supports <a href='"
@@ -185,6 +193,7 @@ class DruidDatasourceModelView(SupersetModelView, DeleteMixin):  # noqa
     }
     base_filters = [['id', DatasourceFilter, lambda: []]]
     label_columns = {
+        'slices': _("Associated Slices"),
         'datasource_link': _("Data Source"),
         'cluster': _("Cluster"),
         'description': _("Description"),

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -177,6 +177,11 @@ class SqlaTable(Model, BaseDatasource):
         foreign_keys=[database_id])
     schema = Column(String(255))
     sql = Column(Text)
+    slices = relationship(
+        'Slice',
+        primaryjoin=(
+            "SqlaTable.id == foreign(Slice.datasource_id) and "
+            "Slice.datasource_type == 'table'"))
 
     baselink = "tablemodelview"
     export_fields = (

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -142,7 +142,7 @@ class TableModelView(SupersetModelView, DeleteMixin):  # noqa
         'link', 'database', 'changed_on_']
     add_columns = ['database', 'schema', 'table_name']
     edit_columns = [
-        'table_name', 'sql', 'filter_select_enabled',
+        'table_name', 'sql', 'filter_select_enabled', 'slices',
         'fetch_values_predicate', 'database', 'schema',
         'description', 'owner',
         'main_dttm_col', 'default_endpoint', 'offset', 'cache_timeout']
@@ -150,6 +150,14 @@ class TableModelView(SupersetModelView, DeleteMixin):  # noqa
     related_views = [TableColumnInlineView, SqlMetricInlineView]
     base_order = ('changed_on', 'desc')
     description_columns = {
+        'slices': _(
+            "The list of slices associated with this table. By "
+            "altering this datasource, you may change how these associated "
+            "slices behave. "
+            "Also note that slices need to point to a datasource, so "
+            "this form will fail at saving if removing slices from a "
+            "datasource. If you want to change the datasource for a slice, "
+            "overwrite the slice from the 'explore view'"),
         'offset': _("Timezone offset (in hours) for this datasource"),
         'table_name': _(
             "Name of the table that exists in the source database"),
@@ -179,6 +187,7 @@ class TableModelView(SupersetModelView, DeleteMixin):  # noqa
     }
     base_filters = [['id', DatasourceFilter, lambda: []]]
     label_columns = {
+        'slices': _("Associated Slices"),
         'link': _("Table"),
         'changed_by_': _("Changed By"),
         'database': _("Database"),

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -48,9 +48,10 @@ metadata = Model.metadata  # pylint: disable=no-member
 def set_related_perm(mapper, connection, target):  # noqa
     src_class = target.cls_model
     id_ = target.datasource_id
-    ds = db.session.query(src_class).filter_by(id=int(id_)).first()
-    if ds:
-        target.perm = ds.perm
+    if id_:
+        ds = db.session.query(src_class).filter_by(id=int(id_)).first()
+        if ds:
+            target.perm = ds.perm
 
 
 class Url(Model, AuditMixinNullable):


### PR DESCRIPTION
Sometimes users get confused and re-point a datasource to a totally unrelated table and it breaks the associated slices. They may be thinking that only the slice they care about will be affected by the change in datasource, without thinking all other slices using this datasource may be affected.

This PR adds an "Associated Slices" form entry to the datasources edit form. Hopefully that makes it more clear that this datasource (table) object is linked to many slices and that those may break if you rewire this object.

Note that this will also prevent from deleting datasources that have slices associated with them, which is a good thing, though the related error message is cryptic. Still a lesser evil than "orphaning" the slices.

<img width="856" alt="screen shot 2017-04-19 at 2 12 42 pm" src="https://cloud.githubusercontent.com/assets/487433/25202459/53e3d83c-250a-11e7-9f48-2a5b7a247e98.png">
