### PR TITLE
Fix for Dashboard Filters for Mysql datasource

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -462,7 +462,7 @@ class SqlaTable(Model, BaseDatasource):
             col_obj = cols.get(col)
             if col_obj:
                 if op in ('in', 'not in'):
-                    values = [types.strip("'").strip('"') for types in eq]
+                    values = [str(types).strip("'").strip('"') for types in eq]
                     if col_obj.is_num:
                         values = [utils.js_string_to_num(s) for s in values]
                     cond = col_obj.sqla_col.in_(values)


### PR DESCRIPTION
Dashboard filters are throwing the following error on filtering on any integer fields. 
``'int' object has no attribute 'strip'``
Converting all the fields to integers before calling strip method. 

Addresses: https://github.com/airbnb/superset/issues/2615
