### PR TITLE
[explore] fix save as bug for markup/html slices

### DIFF
--- a/superset/assets/javascripts/explorev2/actions/exploreActions.js
+++ b/superset/assets/javascripts/explorev2/actions/exploreActions.js
@@ -1,3 +1,4 @@
+/* global notify */
 /* eslint camelcase: 0 */
 import { getExploreUrl } from '../exploreUtils';
 import { QUERY_TIMEOUT_THRESHOLD } from '../../constants';
@@ -218,14 +219,23 @@ export function removeSaveModalAlert() {
   return { type: REMOVE_SAVE_MODAL_ALERT };
 }
 
-export function saveSlice(url) {
+export function saveSlice(url, formData) {
   return function (dispatch) {
-    $.get(url, (data, status) => {
-      if (status === 'success') {
-        // Go to new slice url or dashboard url
-        window.location = data;
-      } else {
-        dispatch(saveSliceFailed());
+    $.ajax({
+      type: 'POST',
+      url,
+      data: JSON.stringify({ form_data: formData }),
+      contentType: 'application/json',
+      success: (data, status) => {
+        if (status === 'success') {
+          if (data.dash_url) {
+            window.location = data.dash_url;
+          } else {
+            notify.success('Your slice was saved')
+          }
+        } else {
+          dispatch(saveSliceFailed());
+        }
       }
     });
   };

--- a/superset/assets/javascripts/explorev2/actions/exploreActions.js
+++ b/superset/assets/javascripts/explorev2/actions/exploreActions.js
@@ -231,12 +231,12 @@ export function saveSlice(url, formData) {
           if (data.dash_url) {
             window.location = data.dash_url;
           } else {
-            notify.success('Your slice was saved')
+            notify.success('Your slice was saved');
           }
         } else {
           dispatch(saveSliceFailed());
         }
-      }
+      },
     });
   };
 }

--- a/superset/assets/javascripts/explorev2/actions/exploreActions.js
+++ b/superset/assets/javascripts/explorev2/actions/exploreActions.js
@@ -1,4 +1,3 @@
-/* global notify */
 /* eslint camelcase: 0 */
 import { getExploreUrl } from '../exploreUtils';
 import { QUERY_TIMEOUT_THRESHOLD } from '../../constants';
@@ -228,11 +227,7 @@ export function saveSlice(url, formData) {
       contentType: 'application/json',
       success: (data, status) => {
         if (status === 'success') {
-          if (data.dash_url) {
-            window.location = data.dash_url;
-          } else {
-            notify.success('Your slice was saved');
-          }
+          window.location = data.url;
         } else {
           dispatch(saveSliceFailed());
         }

--- a/superset/assets/javascripts/explorev2/actions/exploreActions.js
+++ b/superset/assets/javascripts/explorev2/actions/exploreActions.js
@@ -227,7 +227,7 @@ export function saveSlice(url, formData) {
       contentType: 'application/json',
       success: (data, status) => {
         if (status === 'success') {
-          window.location = data.url;
+          window.location = data;
         } else {
           dispatch(saveSliceFailed());
         }

--- a/superset/assets/javascripts/explorev2/components/SaveModal.jsx
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.jsx
@@ -1,7 +1,6 @@
 /* eslint camelcase: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
-import $ from 'jquery';
 import { Modal, Alert, Button, Radio } from 'react-bootstrap';
 import Select from 'react-select';
 import { connect } from 'react-redux';

--- a/superset/assets/javascripts/explorev2/components/SaveModal.jsx
+++ b/superset/assets/javascripts/explorev2/components/SaveModal.jsx
@@ -105,10 +105,8 @@ class SaveModal extends React.Component {
     const baseUrl = `/superset/explore/${this.props.datasource.type}/${this.props.datasource.id}/`;
     sliceParams.datasource_name = this.props.datasource.name;
 
-    const saveUrl = `${baseUrl}?form_data=` +
-      `${encodeURIComponent(JSON.stringify(this.props.form_data))}` +
-      `&${$.param(sliceParams, true)}`;
-    this.props.actions.saveSlice(saveUrl);
+    const dataToSave = Object.assign(this.props.form_data, sliceParams);
+    this.props.actions.saveSlice(baseUrl, dataToSave);
     this.props.onHide();
   }
   removeAlert() {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -120,6 +120,14 @@ def check_ownership(obj, raise_if_false=True):
     else:
         return False
 
+def get_short_url(url):
+    obj = models.Url(url=url)
+    session = db.session()
+    session.add(obj)
+    session.commit()
+    return("http://{request.headers[Host]}/r/{obj.id}".format(
+        request=request, obj=obj))
+
 
 class SliceFilter(SupersetFilter):
     def apply(self, query, func):  # noqa
@@ -593,11 +601,7 @@ class R(BaseSupersetView):
     @expose("/shortner/", methods=['POST', 'GET'])
     def shortner(self):
         url = request.form.get('data')
-        obj = models.Url(url=url)
-        db.session.add(obj)
-        db.session.commit()
-        return("http://{request.headers[Host]}/r/{obj.id}".format(
-            request=request, obj=obj))
+        return get_short_url(url)
 
     @expose("/msg/")
     def msg(self):
@@ -1146,7 +1150,7 @@ class Superset(BaseSupersetView):
         if request.args.get('goto_dash') == 'true':
             return dash.url
         else:
-            return slc.slice_url
+            return get_short_url('/' + slc.slice_url)
 
     def save_slice(self, slc):
         session = db.session()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1152,13 +1152,11 @@ class Superset(BaseSupersetView):
             db.session.commit()
 
         if goto_dash:
-            return_data = {
-                'dash_url': dash.url
-            }
+            url = dash.url
         else:
-            return_data = {}
+            url = slc.slice_url
 
-        return json_success(json.dumps(return_data))
+        return json_success(json.dumps({ 'url': url }))
 
     def save_slice(self, slc):
         session = db.session()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -120,14 +120,6 @@ def check_ownership(obj, raise_if_false=True):
     else:
         return False
 
-def get_short_url(url):
-    obj = models.Url(url=url)
-    session = db.session()
-    session.add(obj)
-    session.commit()
-    return("http://{request.headers[Host]}/r/{obj.id}".format(
-        request=request, obj=obj))
-
 
 class SliceFilter(SupersetFilter):
     def apply(self, query, func):  # noqa
@@ -601,7 +593,11 @@ class R(BaseSupersetView):
     @expose("/shortner/", methods=['POST', 'GET'])
     def shortner(self):
         url = request.form.get('data')
-        return get_short_url(url)
+        obj = models.Url(url=url)
+        db.session.add(obj)
+        db.session.commit()
+        return("http://{request.headers[Host]}/r/{obj.id}".format(
+            request=request, obj=obj))
 
     @expose("/msg/")
     def msg(self):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1100,16 +1100,13 @@ class Superset(BaseSupersetView):
         slice_name = form_data.get('slice_name')
         action = form_data.get('action')
         goto_dash = form_data.get('goto_dash')
+        form_data.pop('goto_dash')  # don't save this param
         add_to_dash = form_data.get('add_to_dash')
 
         if action in ('saveas'):
             if 'slice_id' in form_data:
                 form_data.pop('slice_id')  # don't save old slice_id
             slc = models.Slice(owners=[g.user] if g.user else [])
-
-        form_data.pop('goto_dash')  # don't save this param
-        form_data.pop('add_to_dash')  # don't save this param
-        form_data.pop('action')  # don't save this param
 
         slc.params = json.dumps(form_data)
         slc.datasource_name = form_data.get('datasource_name')
@@ -1151,7 +1148,7 @@ class Superset(BaseSupersetView):
             dash.slices.append(slc)
             db.session.commit()
 
-        if goto_dash:
+        if goto_dash == 'true':
             return dash.url
         else:
             return slc.slice_url

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -984,7 +984,8 @@ class Superset(BaseSupersetView):
 
     @log_this
     @has_access
-    @expose("/explore/<datasource_type>/<datasource_id>/", methods=["GET", "POST"])
+    @expose("/explore/<datasource_type>/<datasource_id>/",
+        methods=["GET", "POST"])
     def explore(self, datasource_type, datasource_id):
         form_data = self.get_form_data()
 
@@ -1106,9 +1107,9 @@ class Superset(BaseSupersetView):
                 form_data.pop('slice_id')  # don't save old slice_id
             slc = models.Slice(owners=[g.user] if g.user else [])
 
-        form_data.pop('goto_dash') # don't save this param
-        form_data.pop('add_to_dash') # don't save this param
-        form_data.pop('action') # don't save this param
+        form_data.pop('goto_dash')  # don't save this param
+        form_data.pop('add_to_dash')  # don't save this param
+        form_data.pop('action')  # don't save this param
 
         slc.params = json.dumps(form_data)
         slc.datasource_name = form_data.get('datasource_name')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1039,7 +1039,7 @@ class Superset(BaseSupersetView):
                 datasource_type)
 
         form_data['datasource'] = str(datasource_id) + '__' + datasource_type
-        standalone = form_data.get("standalone") == "true"
+        standalone = request.args.get("standalone") == "true"
         bootstrap_data = {
             "can_add": slice_add_perm,
             "can_download": slice_download_perm,
@@ -1052,7 +1052,7 @@ class Superset(BaseSupersetView):
             "slice": slc.data if slc else None,
             "standalone": standalone,
             "user_id": user_id,
-            "forced_height": form_data.get('height'),
+            "forced_height": request.args.get('height'),
         }
         table_name = datasource.table_name \
             if datasource_type == 'table' \

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1156,7 +1156,6 @@ class Superset(BaseSupersetView):
         else:
             return slc.slice_url
 
-
     def save_slice(self, slc):
         session = db.session()
         msg = "Slice [{}] has been saved".format(slc.slice_name)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -985,7 +985,7 @@ class Superset(BaseSupersetView):
     @log_this
     @has_access
     @expose("/explore/<datasource_type>/<datasource_id>/",
-        methods=["GET", "POST"])
+            methods=["GET", "POST"])
     def explore(self, datasource_type, datasource_id):
         form_data = self.get_form_data()
 
@@ -1152,11 +1152,10 @@ class Superset(BaseSupersetView):
             db.session.commit()
 
         if goto_dash:
-            url = dash.url
+            return dash.url
         else:
-            url = slc.slice_url
+            return slc.slice_url
 
-        return json_success(json.dumps({ 'url': url }))
 
     def save_slice(self, slc):
         session = db.session()

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -135,9 +135,7 @@ class CoreTests(SupersetTestCase):
         tbl_id = self.table_ids.get('energy_usage')
         new_slice_name = "Test Sankey Overwirte"
 
-        url = (
-            "/superset/explore/table/{}/?slice_name={}&"
-            "action={}&datasource_name=energy_usage&form_data={}")
+        url = "/superset/explore/table/{}/"
 
         form_data = {
             'viz_type': 'sankey',
@@ -145,39 +143,28 @@ class CoreTests(SupersetTestCase):
             'groupby': 'target',
             'metric': 'sum__value',
             'row_limit': 5000,
-            'slice_id': slice_id,
         }
+
         # Changing name and save as a new slice
-        resp = self.get_resp(
-            url.format(
-                tbl_id,
-                copy_name,
-                'saveas',
-                json.dumps(form_data)
-            )
-        )
+        form_data['action'] = 'saveas'
+        form_data['slice_name'] = copy_name
+        form_data['slice_id'] = slice_id
+
+        resp = self.get_resp(url.format(tbl_id), data=form_data)
+
         slices = db.session.query(models.Slice) \
             .filter_by(slice_name=copy_name).all()
         assert len(slices) == 1
+
         new_slice_id = slices[0].id
 
-        form_data = {
-            'viz_type': 'sankey',
-            'groupby': 'source',
-            'groupby': 'target',
-            'metric': 'sum__value',
-            'row_limit': 5000,
-            'slice_id': new_slice_id,
-        }
         # Setting the name back to its original name by overwriting new slice
-        resp = self.get_resp(
-            url.format(
-                tbl_id,
-                new_slice_name,
-                'overwrite',
-                json.dumps(form_data)
-            )
-        )
+        form_data['action'] = 'overwrite'
+        form_data['slice_name'] = new_slice_name
+        form_data['slice_id'] = new_slice_id
+
+        resp = self.get_resp(url.format(tbl_id), data=form_data)
+
         slc = db.session.query(models.Slice).filter_by(id=new_slice_id).first()
         assert slc.slice_name == new_slice_name
         db.session.delete(slc)


### PR DESCRIPTION
when we make an xhr get request with a really long url, the server throws a 400. 
markup slices can have really long url's if there is a lot of markdown/html for the slice.

this PR allows the /explore endpoint to accept post requests, and makes the saveSlice method in exploreActions pass the data as params rather than in the url.

@mistercrunch 