### PR TITLE
hack to dynamically adjust y axis left margin

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -407,49 +407,42 @@ function nvd3Vis(slice, payload) {
       .style('fill-opacity', 1);
     }
 
-    // Hack to adjust margins to accommodate long axis tick labels.
-    // - has to be done only after the chart has been rendered once
-    // - measure the width or height of the labels
-    // ---- (x axis labels are rotated 45 degrees so we use height),
-    // - adjust margins based on these measures and render again
-    const marginPad = isExplore ? width * 0.01 : width * 0.03;
-    if (isTimeSeries && vizType !== 'bar') {
-      const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x');
-      const chartMargins = {
-        bottom: maxXAxisLabelHeight + marginPad,
-        right: maxXAxisLabelHeight + marginPad,
-      };
-
-      if (vizType === 'dual_line') {
-        const maxYAxis2LabelWidth = getMaxLabelSize(slice.container, 'nv-y2');
-        // use y axis width if it's wider than axis width/height
-        if (maxYAxis2LabelWidth > maxXAxisLabelHeight) {
-          chartMargins.right = maxYAxis2LabelWidth + marginPad;
-        }
-      }
-
-      // apply margins
-      chart.margin(chartMargins);
-
-      // render chart
-      svg
-      .datum(payload.data)
-      .transition().duration(500)
-      .attr('height', height)
-      .attr('width', width)
-      .call(chart);
-    }
-
-    // Hack to adjust y axis left margin to accormadate long y axis numbers
     if (chart.yAxis !== undefined) {
+      // Hack to adjust y axis left margin to accommodate long numbers
+      const marginPad = isExplore ? width * 0.01 : width * 0.03;
       const maxYAxisLabelWidth = getMaxLabelSize(slice.container, 'nv-y');
       chart.margin({ left: maxYAxisLabelWidth + marginPad });
-      svg
-      .datum(payload.data)
-      .transition().duration(500)
-      .attr('height', height)
-      .attr('width', width)
-      .call(chart);
+      // Hack to adjust margins to accommodate long axis tick labels.
+      // - has to be done only after the chart has been rendered once
+      // - measure the width or height of the labels
+      // ---- (x axis labels are rotated 45 degrees so we use height),
+      // - adjust margins based on these measures and render again
+      if (isTimeSeries && vizType !== 'bar') {
+        const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x');
+        const chartMargins = {
+          bottom: maxXAxisLabelHeight + marginPad,
+          right: maxXAxisLabelHeight + marginPad,
+        };
+
+        if (vizType === 'dual_line') {
+          const maxYAxis2LabelWidth = getMaxLabelSize(slice.container, 'nv-y2');
+          // use y axis width if it's wider than axis width/height
+          if (maxYAxis2LabelWidth > maxXAxisLabelHeight) {
+            chartMargins.right = maxYAxis2LabelWidth + marginPad;
+          }
+        }
+
+        // apply margins
+        chart.margin(chartMargins);
+
+        // render chart
+        svg
+        .datum(payload.data)
+        .transition().duration(500)
+        .attr('height', height)
+        .attr('width', width)
+        .call(chart);
+      }
     }
 
     // on scroll, hide tooltips. throttle to only 4x/second.

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -434,15 +434,15 @@ function nvd3Vis(slice, payload) {
 
         // apply margins
         chart.margin(chartMargins);
-
-        // render chart
-        svg
-        .datum(payload.data)
-        .transition().duration(500)
-        .attr('height', height)
-        .attr('width', width)
-        .call(chart);
       }
+
+      // render chart
+      svg
+      .datum(payload.data)
+      .transition().duration(500)
+      .attr('height', height)
+      .attr('width', width)
+      .call(chart);
     }
 
     // on scroll, hide tooltips. throttle to only 4x/second.

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -412,9 +412,9 @@ function nvd3Vis(slice, payload) {
     // - measure the width or height of the labels
     // ---- (x axis labels are rotated 45 degrees so we use height),
     // - adjust margins based on these measures and render again
+    const marginPad = isExplore ? width * 0.01 : width * 0.03;
     if (isTimeSeries && vizType !== 'bar') {
       const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x');
-      const marginPad = isExplore ? width * 0.01 : width * 0.03;
       const chartMargins = {
         bottom: maxXAxisLabelHeight + marginPad,
         right: maxXAxisLabelHeight + marginPad,
@@ -432,6 +432,18 @@ function nvd3Vis(slice, payload) {
       chart.margin(chartMargins);
 
       // render chart
+      svg
+      .datum(payload.data)
+      .transition().duration(500)
+      .attr('height', height)
+      .attr('width', width)
+      .call(chart);
+    }
+
+    // Hack to adjust y axis left margin to accormadate long y axis numbers
+    if (chart.yAxis !== undefined) {
+      const maxYAxisLabelWidth = getMaxLabelSize(slice.container, 'nv-y');
+      chart.margin({ left: maxYAxisLabelWidth + marginPad });
       svg
       .datum(payload.data)
       .transition().duration(500)


### PR DESCRIPTION
Before, y axis has cutoff when number is too long. Sometimes, people want to see the long raw number instead of '.3s' formatted number. 
<img width="935" alt="y axis number cutoff" src="https://cloud.githubusercontent.com/assets/10532596/25513181/1eb3ffdc-2b88-11e7-9b9e-31f427f13d24.png">

Added into @ascott 's hack code to get y axis left margin always accommodate the number's length.
After fix, it looks like follows:
<img width="942" alt="after fix" src="https://cloud.githubusercontent.com/assets/10532596/25513255/cfd2e6fc-2b88-11e7-9e16-6afefe81b533.png">

