### PR TITLE
Fix js warnings

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ExploreActionButtons.jsx
+++ b/superset/assets/javascripts/explorev2/components/ExploreActionButtons.jsx
@@ -8,7 +8,7 @@ import DisplayQueryButton from './DisplayQueryButton';
 const propTypes = {
   canDownload: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
   slice: PropTypes.object,
-  queryEndpoint: PropTypes.string,
+  queryEndpoint: PropTypes.string.isRequired,
   queryResponse: PropTypes.object,
   chartStatus: PropTypes.string,
 };

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -97,7 +97,6 @@
     "viewport-mercator-project": "^2.1.0"
   },
   "devDependencies": {
-    "babel": "^6.3.26",
     "babel-cli": "^6.14.0",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -62,7 +62,6 @@
     "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^0.26.0",
     "moment": "^2.14.1",
-    "moments": "0.0.2",
     "mustache": "^2.2.1",
     "nvd3": "1.8.5",
     "prop-types": "^15.5.8",

--- a/superset/assets/spec/javascripts/dashboard/SliceCell_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/SliceCell_spec.jsx
@@ -10,7 +10,7 @@ describe('SliceCell', () => {
   const mockedProps = {
     slice,
     removeSlice: () => {},
-    expandedSlices: () => {},
+    expandedSlices: {},
   };
   it('is valid', () => {
     expect(

--- a/superset/assets/spec/javascripts/explorev2/components/ExploreActionButtons_spec.jsx
+++ b/superset/assets/spec/javascripts/explorev2/components/ExploreActionButtons_spec.jsx
@@ -14,6 +14,7 @@ describe('ExploreActionButtons', () => {
         json_endpoint: '',
       },
     },
+    queryEndpoint: 'localhost',
   };
 
   it('renders', () => {

--- a/superset/assets/spec/javascripts/sqllab/SqlEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditor_spec.jsx
@@ -15,6 +15,9 @@ describe('SqlEditor', () => {
     latestQuery: queries[0],
     tables: [table],
     queries,
+    height: '',
+    editorQueries: [],
+    dataPreviewQueries: [],
   };
   it('is valid', () => {
     expect(

--- a/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
@@ -15,6 +15,7 @@ describe('TabbedSqlEditors', () => {
     queries: {},
     queryEditors: initialState.queryEditors,
     tabHistory: initialState.tabHistory,
+    editorHeight: '',
   };
   it('is valid', () => {
     expect(

--- a/superset/assets/visualizations/filter_box.jsx
+++ b/superset/assets/visualizations/filter_box.jsx
@@ -1,6 +1,7 @@
 // JS
 import d3 from 'd3';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Select from 'react-select';
 import { Button } from 'react-bootstrap';
@@ -10,11 +11,11 @@ import { TIME_CHOICES } from './constants';
 import './filter_box.css';
 
 const propTypes = {
-  origSelectedValues: React.PropTypes.object,
-  instantFiltering: React.PropTypes.bool,
-  filtersChoices: React.PropTypes.object,
-  onChange: React.PropTypes.func,
-  showDateFilter: React.PropTypes.bool,
+  origSelectedValues: PropTypes.object,
+  instantFiltering: PropTypes.bool,
+  filtersChoices: PropTypes.object,
+  onChange: PropTypes.func,
+  showDateFilter: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/superset/assets/visualizations/mapbox.jsx
+++ b/superset/assets/visualizations/mapbox.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import d3 from 'd3';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import MapGL from 'react-map-gl';
 import ScatterPlotOverlay from 'react-map-gl/dist/overlays/scatterplot.react';
@@ -256,20 +257,20 @@ class MapboxViz extends React.Component {
   }
 }
 MapboxViz.propTypes = {
-  aggregatorName: React.PropTypes.string,
-  clusterer: React.PropTypes.object,
-  globalOpacity: React.PropTypes.number,
-  mapStyle: React.PropTypes.string,
-  mapboxApiKey: React.PropTypes.string,
-  pointRadius: React.PropTypes.number,
-  pointRadiusUnit: React.PropTypes.string,
-  renderWhileDragging: React.PropTypes.bool,
-  rgb: React.PropTypes.array,
-  sliceHeight: React.PropTypes.number,
-  sliceWidth: React.PropTypes.number,
-  viewportLatitude: React.PropTypes.number,
-  viewportLongitude: React.PropTypes.number,
-  viewportZoom: React.PropTypes.number,
+  aggregatorName: PropTypes.string,
+  clusterer: PropTypes.object,
+  globalOpacity: PropTypes.number,
+  mapStyle: PropTypes.string,
+  mapboxApiKey: PropTypes.string,
+  pointRadius: PropTypes.number,
+  pointRadiusUnit: PropTypes.string,
+  renderWhileDragging: PropTypes.bool,
+  rgb: PropTypes.array,
+  sliceHeight: PropTypes.number,
+  sliceWidth: PropTypes.number,
+  viewportLatitude: PropTypes.number,
+  viewportLongitude: PropTypes.number,
+  viewportZoom: PropTypes.number,
 };
 
 function mapbox(slice, json) {


### PR DESCRIPTION
- removing babel devDependency because has been deprecated in favor of babel-cli

    this fixes a warning during `npm install`:
    ```
    npm WARN deprecated babel@6.23.0:
    In 6.x, the babel package has been deprecated in favor of babel-cli.
    Check https://opencollective.com/babel to support the Babel maintainers
    ```

- react: using prop-types package to fix deprecated React.PropTypes property warning

    https://facebook.github.io/react/warnings/dont-call-proptypes.html

- js: setting ExploreActionButtons.queryEndpoint PropType as required

    because it's required in the child component DisplayQueryButton

- js(tests): using object in expandedSlices prop type of SliceCell tests

- js(tests): adding required props to SqlEditor mockedProps

- js(tests): adding required prop editorHeight to TabbedSqlEditors mockedProps

- js: removing unused moments dependency