### PR TITLE
fix x bounds problem for area chart 

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -266,7 +266,7 @@ function nvd3Vis(slice, payload) {
         chart.style(fd.stacked_style);
         chart.xScale(d3.time.scale.utc());
         chart.xAxis
-        .showMaxMin(false)
+        .showMaxMin(fd.x_axis_showminmax)
         .staggerLabels(true);
         break;
 


### PR DESCRIPTION
Because the area chat has "X bounds" as a user input field, it should use the user's choice instead of false.
![bug](https://cloud.githubusercontent.com/assets/10532596/25552738/60a53e46-2c56-11e7-908a-34d1d1e7f91f.png)
