### PR TITLE
[explore] fix empty chart when changing viz type

### DIFF
--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -60,6 +60,7 @@ class ChartContainer extends React.PureComponent {
         ) && !this.props.queryResponse.error
         && this.props.chartStatus !== 'failed'
         && this.props.chartStatus !== 'stopped'
+        && this.props.chartStatus !== 'loading'
       ) {
       this.renderViz();
     }

--- a/superset/assets/javascripts/explorev2/components/Control.jsx
+++ b/superset/assets/javascripts/explorev2/components/Control.jsx
@@ -51,17 +51,26 @@ export default class Control extends React.PureComponent {
     super(props);
     this.validate = this.validate.bind(this);
     this.onChange = this.onChange.bind(this);
-    this.validateAndSetValue(props.value, []);
+  }
+  componentDidMount() {
+    this.validateAndSetValue(this.props.value, []);
   }
   onChange(value, errors) {
     this.validateAndSetValue(value, errors);
   }
   validateAndSetValue(value, errors) {
-    let validationErrors = this.validate(value);
+    let validationErrors = this.props.validationErrors;
+    let currentErrors = this.validate(value);
     if (errors && errors.length > 0) {
-      validationErrors = validationErrors.concat(errors);
+      currentErrors = validationErrors.concat(errors);
     }
-    this.props.actions.setControlValue(this.props.name, value, validationErrors);
+    if (validationErrors.length + currentErrors.length > 0) {
+      validationErrors = currentErrors;
+    }
+
+    if (value !== this.props.value || validationErrors != this.props.validationErrors) {
+      this.props.actions.setControlValue(this.props.name, value, validationErrors);
+    }
   }
   validate(value) {
     const validators = this.props.validators;

--- a/superset/assets/javascripts/explorev2/components/Control.jsx
+++ b/superset/assets/javascripts/explorev2/components/Control.jsx
@@ -68,7 +68,7 @@ export default class Control extends React.PureComponent {
       validationErrors = currentErrors;
     }
 
-    if (value !== this.props.value || validationErrors != this.props.validationErrors) {
+    if (value !== this.props.value || validationErrors !== this.props.validationErrors) {
       this.props.actions.setControlValue(this.props.name, value, validationErrors);
     }
   }

--- a/superset/assets/javascripts/explorev2/index.jsx
+++ b/superset/assets/javascripts/explorev2/index.jsx
@@ -39,6 +39,7 @@ const bootstrappedState = Object.assign(
     queryResponse: null,
     triggerQuery: true,
     triggerRender: false,
+    alert: null,
   },
 );
 

--- a/superset/assets/javascripts/explorev2/stores/store.js
+++ b/superset/assets/javascripts/explorev2/stores/store.js
@@ -65,6 +65,7 @@ export function getControlsState(state, form_data) {
     if (typeof control.default === 'function') {
       control.default = control.default(control);
     }
+    control.validationErrors = [];
     control.value = formData[k] !== undefined ? formData[k] : control.default;
     controlsState[k] = control;
   });


### PR DESCRIPTION
* avoid re-render while `loading`
* avoiding calling `setControlValue` action when not necessary to avoid unnecessary redux interactions