### PR TITLE
[vis] bar values should match y axis format

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -23,8 +23,8 @@ const BREAKPOINTS = {
   small: 340,
 };
 
-const addTotalBarValues = function (svg, chart, data, stacked) {
-  const format = d3.format('.3s');
+const addTotalBarValues = function (svg, chart, data, stacked, axisFormat) {
+  const format = d3.format(axisFormat || '.3s');
   const countSeriesDisplayed = data.length;
 
   const totalStackedValues = stacked && data.length !== 0 ?
@@ -169,7 +169,7 @@ function nvd3Vis(slice, payload) {
 
         if (fd.show_bar_value) {
           setTimeout(function () {
-            addTotalBarValues(svg, chart, payload.data, stacked);
+            addTotalBarValues(svg, chart, payload.data, stacked, fd.y_axis_format);
           }, animationTime);
         }
         break;
@@ -199,7 +199,7 @@ function nvd3Vis(slice, payload) {
         }
         if (fd.show_bar_value) {
           setTimeout(function () {
-            addTotalBarValues(svg, chart, payload.data, stacked);
+            addTotalBarValues(svg, chart, payload.data, stacked, fd.y_axis_format);
           }, animationTime);
         }
         if (!reduceXTicks) {


### PR DESCRIPTION
It passes the user yAxis format value to the totalValue function to render the label text accordingly

* Screenshot
<img width="1214" alt="screen shot 2017-04-30 at 6 09 10 pm" src="https://cloud.githubusercontent.com/assets/1392866/25569657/47acf6b0-2dd0-11e7-9c41-8c04c9a78627.png">
<img width="1018" alt="screen shot 2017-04-30 at 6 09 32 pm" src="https://cloud.githubusercontent.com/assets/1392866/25569658/47addb84-2dd0-11e7-94f1-a2eac93c74e2.png">

* Issue
It resolves the issue #2319 