### PR TITLE
[dashboard] fix missing datasource issue

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1629,7 +1629,12 @@ class Superset(BaseSupersetView):
             qry = qry.filter_by(slug=dashboard_id)
 
         dash = qry.one()
-        datasources = {slc.datasource for slc in dash.slices}
+        datasources = set()
+        for slc in dash.slices:
+            datasource = slc.datasource
+            if datasource:
+                datasources.add(datasource)
+
         for datasource in datasources:
             if datasource and not self.datasource_access(datasource):
                 flash(


### PR DESCRIPTION
Addresses a bug that happens when rendering a dashboard for which
a datasource behind one of the slices has been deleted