### PR TITLE
[table] fixing CSS glitches on table view

### DIFF
--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -89,9 +89,11 @@ function tableVis(slice, payload) {
     .style('background-image', function (d) {
       if (d.isMetric) {
         const perc = Math.round((d.val / maxes[d.col]) * 100);
+        // The 0.01 to 0.001 is a workaround for what appears to be a
+        // CSS rendering bug on flat, transparent colors
         return (
-          `linear-gradient(to right, lightgrey, lightgrey ${perc}%, ` +
-          `rgba(0,0,0,0) ${perc}%)`
+          `linear-gradient(to right, rgba(0,0,0,0.2), rgba(0,0,0,0.2) ${perc}%, ` +
+          `rgba(0,0,0,0.01) ${perc}%, rgba(0,0,0,0.001) 100%)`
         );
       }
       return null;


### PR DESCRIPTION
Somehow the CSS trick we use to display histogram-type visual elements
in table views started showing some odd glitches since
what I believe was a not-so-recent version of webkit.

The bug is around the `linear-gradient` call under `background-image`
prop being used to show non-gradient or "hard" colors, while using
transparency.

I was able to find a workaround that addresses things in chrome by using
a fake [minimal] gradient instead of a flat color.

Before with glitches:
![screen shot 2017-05-08 at 4 17 59 pm](https://cloud.githubusercontent.com/assets/487433/25829287/0abc9914-340a-11e7-9e1c-267cf2b413c2.png)
After, sans-glitches:
![screen shot 2017-05-08 at 4 17 32 pm](https://cloud.githubusercontent.com/assets/487433/25829288/0abff5a0-340a-11e7-9857-1906f728bcff.png)
