### PR TITLE
[sql lab] fix responsivity of grid

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -193,7 +193,12 @@ class SqlEditor extends React.PureComponent {
           <Collapse
             in={!this.props.hideLeftBar}
           >
-            <Col md={3}>
+            <Col
+              xs={6}
+              sm={5}
+              md={4}
+              lg={3}
+            >
               <SqlEditorLeftBar
                 height={this.sqlEditorHeight()}
                 queryEditor={this.props.queryEditor}
@@ -202,7 +207,12 @@ class SqlEditor extends React.PureComponent {
               />
             </Col>
           </Collapse>
-          <Col md={this.props.hideLeftBar ? 12 : 9}>
+          <Col
+              xs={this.props.hideLeftBar ? 12 : 6}
+              sm={this.props.hideLeftBar ? 12 : 7}
+              md={this.props.hideLeftBar ? 12 : 8}
+              lg={this.props.hideLeftBar ? 12 : 9}
+          >
             <AceEditorWrapper
               actions={this.props.actions}
               onBlur={this.setQueryEditorSql.bind(this)}

--- a/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -208,10 +208,10 @@ class SqlEditor extends React.PureComponent {
             </Col>
           </Collapse>
           <Col
-              xs={this.props.hideLeftBar ? 12 : 6}
-              sm={this.props.hideLeftBar ? 12 : 7}
-              md={this.props.hideLeftBar ? 12 : 8}
-              lg={this.props.hideLeftBar ? 12 : 9}
+            xs={this.props.hideLeftBar ? 12 : 6}
+            sm={this.props.hideLeftBar ? 12 : 7}
+            md={this.props.hideLeftBar ? 12 : 8}
+            lg={this.props.hideLeftBar ? 12 : 9}
           >
             <AceEditorWrapper
               actions={this.props.actions}


### PR DESCRIPTION
Currently resizing the window under `md` size makes SQL Lab show only the left panel since the height is set to fit the window's viewport.

This addresses it.

<img width="608" alt="screen shot 2017-05-09 at 12 57 07 am" src="http://g.recordit.co/8rXi6dXwMe.gif">
