### PR TITLE
fix auto select override pre-selected value bug

### DIFF
--- a/superset/assets/javascripts/components/AsyncSelect.jsx
+++ b/superset/assets/javascripts/components/AsyncSelect.jsx
@@ -41,7 +41,7 @@ class AsyncSelect extends React.PureComponent {
     $.get(this.props.dataEndpoint, (data) => {
       this.setState({ options: mutator ? mutator(data) : data, isLoading: false });
 
-      if (this.props.autoSelect && this.state.options.length) {
+      if (!this.props.value && this.props.autoSelect && this.state.options.length) {
         this.onChange(this.state.options[0]);
       }
     })

--- a/superset/assets/spec/javascripts/components/AsyncSelect_spec.jsx
+++ b/superset/assets/spec/javascripts/components/AsyncSelect_spec.jsx
@@ -66,5 +66,17 @@ describe('AsyncSelect', () => {
       expect(spy.callCount).to.equal(1);
       expect(spy.calledWith(wrapper.instance().state.options[0])).to.equal(true);
     });
+    it('should not auto select when value prop is set', () => {
+      const wrapper = mount(
+        <AsyncSelect {...mockedProps} value={2} autoSelect />,
+      );
+      const spy = sinon.spy(wrapper.instance(), 'onChange');
+
+      server.respond();
+
+      expect(spy.callCount).to.equal(0);
+      expect(wrapper.find(Select)).to.have.length(1);
+      expect(wrapper.find('.Select-value-label').children().first().text()).to.equal('another');
+    });
   });
 });


### PR DESCRIPTION
auto select should only apply to cases where select control doesn't have pre-selected value prop. If select control has pre-selected value (passed in from value prop), auto select first avaliable options should not apply.