### PR TITLE
Speed up all CRUD list views

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -119,6 +119,7 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin):  # noqa
     ]
     edit_columns = add_columns
     list_columns = ['cluster_name', 'metadata_last_refreshed']
+    search_columns = ('cluster_name',)
     label_columns = {
         'cluster_name': _("Cluster"),
         'coordinator_host': _("Coordinator Host"),
@@ -150,7 +151,7 @@ class DruidDatasourceModelView(SupersetModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.DruidDatasource)
     list_widget = ListWidgetWithCheckboxes
     list_columns = [
-        'datasource_link', 'cluster', 'changed_by_', 'changed_on_', 'offset']
+        'datasource_link', 'cluster', 'changed_by_', 'modified']
     order_columns = [
         'datasource_link', 'changed_on_', 'offset']
     related_views = [DruidColumnInlineView, DruidMetricInlineView]
@@ -159,6 +160,9 @@ class DruidDatasourceModelView(SupersetModelView, DeleteMixin):  # noqa
         'is_hidden',
         'filter_select_enabled', 'fetch_values_from',
         'default_endpoint', 'offset', 'cache_timeout']
+    search_columns = (
+        'datasource_name', 'cluster', 'description', 'owner'
+    )
     add_columns = edit_columns
     show_columns = add_columns + ['perm']
     page_size = 500

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -137,7 +137,7 @@ class TableModelView(SupersetModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.SqlaTable)
     list_columns = [
         'link', 'database',
-        'changed_by_', 'changed_on_']
+        'changed_by_', 'modified']
     order_columns = [
         'link', 'database', 'changed_on_']
     add_columns = ['database', 'schema', 'table_name']
@@ -149,6 +149,9 @@ class TableModelView(SupersetModelView, DeleteMixin):  # noqa
     show_columns = edit_columns + ['perm']
     related_views = [TableColumnInlineView, SqlMetricInlineView]
     base_order = ('changed_on', 'desc')
+    search_columns = (
+        'database', 'schema', 'table_name', 'owner',
+    )
     description_columns = {
         'slices': _(
             "The list of slices associated with this table. By "

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -188,7 +188,7 @@ class BaseSupersetView(BaseView):
 
 
 class SupersetModelView(ModelView):
-    page_size = 500
+    page_size = 100
 
 
 class ListWidgetWithCheckboxes(ListWidget):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -175,7 +175,9 @@ class DatabaseView(SupersetModelView, DeleteMixin):  # noqa
         'database_name', 'sqlalchemy_uri', 'cache_timeout', 'extra',
         'expose_in_sqllab', 'allow_run_sync', 'allow_run_async',
         'allow_ctas', 'allow_dml', 'force_ctas_schema']
-    search_exclude_columns = ('password',)
+    search_exclude_columns = (
+        'password', 'tables', 'created_by', 'changed_by', 'queries',
+        'saved_queries', )
     edit_columns = add_columns
     show_columns = [
         'tables',
@@ -317,6 +319,9 @@ class SliceModelView(SupersetModelView, DeleteMixin):  # noqa
     label_columns = {
         'datasource_link': 'Datasource',
     }
+    search_columns = (
+        'slice_name', 'description', 'viz_type', 'owners',
+    )
     list_columns = [
         'slice_link', 'viz_type', 'datasource_link', 'creator', 'modified']
     edit_columns = [
@@ -405,6 +410,7 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
         'dashboard_title', 'slug', 'slices', 'owners', 'position_json', 'css',
         'json_metadata']
     show_columns = edit_columns + ['table_names']
+    search_columns = ('dashboard_title', 'slug', 'owners')
     add_columns = edit_columns
     base_order = ('changed_on', 'desc')
     description_columns = {

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -31,6 +31,7 @@ class SavedQueryView(SupersetModelView, DeleteMixin):
     show_columns = [
         'id', 'label', 'user', 'database',
         'description', 'sql', 'pop_tab_link']
+    search_columns = ('label', 'user', 'database', 'schema', 'changed_on')
     add_columns = ['label', 'database', 'description', 'sql']
     edit_columns = add_columns
     base_order = ('changed_on', 'desc')


### PR DESCRIPTION
Load times on list view pages like Slices, Dashboards, Tables and Database
have grown to be terrible over time.

After a bit of digging, I found that the not specifying `search_columns`
in ModelViews actually means "all columns" and that for each filter,
Flask App Builder (our beloved web framework) goes and fetches a
list of all values to prepopulate the
filter dropdowns. That means that for each page load, we'd fetch the
entire list of related objects. For example, when loading the 
tables list view, it would fetch the list of all of the
slices, users and dashboards upfront and sequentially which takes time
and generates quite a bit of data to send over. In the worst case the database list
would also fetch all of the related SQL Lab queries with is insane.

This PR picks a sane subset of columns for search/filters and changes the
default configuration for list views to show only 100 elements per page
instead of 500