### PR TITLE
make chart margin consistent in dashboard

### DIFF
--- a/superset/assets/visualizations/directed_force.js
+++ b/superset/assets/visualizations/directed_force.js
@@ -7,7 +7,7 @@ require('./directed_force.css');
 const directedForceVis = function (slice, json) {
   const div = d3.select(slice.selector);
   const width = slice.width();
-  const height = slice.height() - 25;
+  const height = slice.height();
   const fd = slice.formData;
   const linkLength = fd.link_length || 200;
   const charge = fd.charge || -500;

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -299,7 +299,7 @@ function nvd3Vis(slice, payload) {
       }
     }
 
-    let height = slice.height() - 15;
+    let height = slice.height();
     if (vizType === 'bullet') {
       height = Math.min(height, 50);
     }


### PR DESCRIPTION
nvd3 related visualization and directed force visualization have some additional margin in the dashboard as shown in the screenshots. Other visualizations don't have them. The additional margin kind of wastes some space in the dashboard and does not look consistent with other chart types.
![margin_bug1](https://cloud.githubusercontent.com/assets/10532596/25978287/113e5bc4-3676-11e7-9f87-84ceefa1b894.png)
![margin_bug2](https://cloud.githubusercontent.com/assets/10532596/25978291/16a61020-3676-11e7-8318-5c6750083db5.png)



After fix:
<img width="609" alt="fix1" src="https://cloud.githubusercontent.com/assets/10532596/25978379/8b1c5acc-3676-11e7-97e4-d51a004e98ea.png">
<img width="695" alt="fix2" src="https://cloud.githubusercontent.com/assets/10532596/25978386/930b8910-3676-11e7-97a8-b6c59a84688a.png">

