### PR TITLE
Fix issues around % signs and Presto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'pandas==0.19.2',
         'parsedatetime==2.0.0',
         'pydruid==0.3.1',
-        'PyHive>=0.2.1',
+        'PyHive>=0.3.0',
         'python-dateutil==2.6.0',
         'requests==2.13.0',
         'simplejson==3.10.0',

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -542,14 +542,12 @@ class SqlaTable(Model, BaseDatasource):
 
     def query(self, query_obj):
         qry_start_dttm = datetime.now()
-        engine = self.database.get_sqla_engine()
-        qry = self.get_sqla_query(**query_obj)
         sql = self.get_query_str(query_obj)
         status = QueryStatus.SUCCESS
         error_message = None
         df = None
         try:
-            df = pd.read_sql_query(qry, con=engine)
+            df = self.database.get_df(sql, self.schema)
         except Exception as e:
             status = QueryStatus.FAILED
             logging.exception(e)

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -312,6 +312,7 @@ class SqliteEngineSpec(BaseEngineSpec):
 
 class MySQLEngineSpec(BaseEngineSpec):
     engine = 'mysql'
+    cursor_execute_kwargs = {'args': {}}
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}'),
         Grain("second", _('second'), "DATE_ADD(DATE({col}), "

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -355,6 +355,7 @@ class MySQLEngineSpec(BaseEngineSpec):
 
 class PrestoEngineSpec(BaseEngineSpec):
     engine = 'presto'
+    cursor_execute_kwargs = {'parameters': None}
 
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}'),


### PR DESCRIPTION
We've been having to double `%` in WHERE clauses and expressions against Presto. This removes the need for doing that.