### PR TITLE
fix 'Time Series - Percentage Change' viz

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/visTypes.js
+++ b/superset/assets/javascripts/explorev2/stores/visTypes.js
@@ -203,6 +203,12 @@ const visTypes = {
     requiresTime: true,
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
+      {
+        label: 'Chart Options',
+        controlSetRows: [
+          ['x_axis_format', 'y_axis_format'],
+        ],
+      },
       sections.NVD3TimeSeries[1],
     ],
   },

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -237,6 +237,7 @@ function nvd3Vis(slice, payload) {
       case 'compare':
         chart = nv.models.cumulativeLineChart();
         chart.xScale(d3.time.scale.utc());
+        chart.useInteractiveGuideline(true);
         chart.xAxis
         .showMaxMin(false)
         .staggerLabels(true);


### PR DESCRIPTION
The 'Time Series - Percentage Change' type previously has stacked x axis labels. Also see #2506 
<img width="1373" alt="bug" src="https://cloud.githubusercontent.com/assets/10532596/26018096/cd5f51e0-3721-11e7-86c7-a53c470e6ca5.png">


After fix:
<img width="1350" alt="fix" src="https://cloud.githubusercontent.com/assets/10532596/26018160/10aa57d8-3722-11e7-8620-574198e2314a.png">
