### PR TITLE
fixed 500 error when export dashboard

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -472,6 +472,8 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
 
     @action("mulexport", __("Export"), __("Export dashboards?"), "fa-database")
     def mulexport(self, items):
+        if not isinstance(items, list):
+            items = [items]
         ids = ''.join('&id={}'.format(d.id) for d in items)
         return redirect(
             '/dashboardmodelview/export_dashboards_form?{}'.format(ids[1:]))


### PR DESCRIPTION
https://github.com/airbnb/superset/blob/master/superset/views/core.py#L474

http://flask-appbuilder.readthedocs.io/en/latest/actions.html?highlight=action

```python
@action("mulexport", __("Export"), __("Export dashboards?"), "fa-database")
    def mulexport(self, items):
        ids = ''.join('&id={}'.format(d.id) for d in items)
```
change to 
```python
@action("mulexport", __("Export"), __("Export dashboards?"), "fa-database")
    def mulexport(self, items):
        if not isinstance(items, list):
            items = [items]
        ids = ''.join('&id={}'.format(d.id) for d in items)
```

fixed:
#2184
#2667