### PR TITLE
Show clear and actionable query timeout error message

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/SaveQuery.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SaveQuery.jsx
@@ -1,4 +1,3 @@
-/* global notify */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormControl, FormGroup, Overlay, Popover, Row, Col } from 'react-bootstrap';

--- a/superset/assets/javascripts/SqlLab/index.jsx
+++ b/superset/assets/javascripts/SqlLab/index.jsx
@@ -6,7 +6,7 @@ import thunkMiddleware from 'redux-thunk';
 
 import { getInitialState, sqlLabReducer } from './reducers';
 import { initEnhancer } from '../reduxUtils';
-import { initJQueryAjaxCSRF } from '../modules/utils';
+import { initJQueryAjax } from '../modules/utils';
 import App from './components/App';
 import { appSetup } from '../common';
 
@@ -15,7 +15,7 @@ import './reactable-pagination.css';
 import '../components/FilterableTable/FilterableTableStyles.css';
 
 appSetup();
-initJQueryAjaxCSRF();
+initJQueryAjax();
 
 const appContainer = document.getElementById('app');
 const bootstrapData = JSON.parse(appContainer.getAttribute('data-bootstrap'));

--- a/superset/assets/javascripts/constants.js
+++ b/superset/assets/javascripts/constants.js
@@ -1,0 +1,1 @@
+export const QUERY_TIMEOUT_THRESHOLD = 60000;

--- a/superset/assets/javascripts/dashboard/Dashboard.jsx
+++ b/superset/assets/javascripts/dashboard/Dashboard.jsx
@@ -337,7 +337,7 @@ export function dashboardContainer(dashboard, datasources, userid) {
 
 $(document).ready(() => {
   // Getting bootstrapped data from the DOM
-  utils.initJQueryAjaxCSRF();
+  utils.initJQueryAjax();
   const dashboardData = $('.dashboard').data('bootstrap');
 
   const state = getInitialState(dashboardData);

--- a/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explorev2/components/ChartContainer.jsx
@@ -169,11 +169,13 @@ class ChartContainer extends React.PureComponent {
   renderAlert() {
     const msg = (
       <div>
-        {this.props.alert}
         <i
           className="fa fa-close pull-right"
           onClick={this.removeAlert.bind(this)}
           style={{ cursor: 'pointer' }}
+        />
+        <p
+          dangerouslySetInnerHTML={{ __html: this.props.alert }}
         />
       </div>);
     return (

--- a/superset/assets/javascripts/explorev2/index.jsx
+++ b/superset/assets/javascripts/explorev2/index.jsx
@@ -9,14 +9,14 @@ import { now } from '../modules/dates';
 import { initEnhancer } from '../reduxUtils';
 import AlertsWrapper from '../components/AlertsWrapper';
 import { getControlsState, getFormDataFromControls } from './stores/store';
-import { initJQueryAjaxCSRF } from '../modules/utils';
+import { initJQueryAjax } from '../modules/utils';
 import ExploreViewContainer from './components/ExploreViewContainer';
 import { exploreReducer } from './reducers/exploreReducer';
 import { appSetup } from '../common';
 import './main.css';
 
 appSetup();
-initJQueryAjaxCSRF();
+initJQueryAjax();
 
 const exploreViewContainer = document.getElementById('js-explore-view-container');
 const bootstrapData = JSON.parse(exploreViewContainer.getAttribute('data-bootstrap'));

--- a/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
+++ b/superset/assets/javascripts/explorev2/reducers/exploreReducer.js
@@ -2,6 +2,7 @@
 import { getControlsState, getFormDataFromControls } from '../stores/store';
 import * as actions from '../actions/exploreActions';
 import { now } from '../../modules/dates';
+import { QUERY_TIMEOUT_THRESHOLD } from '../../constants';
 
 export const exploreReducer = function (state, action) {
   const actionHandlers = {
@@ -107,6 +108,16 @@ export const exploreReducer = function (state, action) {
     [actions.TRIGGER_QUERY]() {
       return Object.assign({}, state, {
         triggerQuery: true,
+      });
+    },
+    [actions.CHART_UPDATE_TIMEOUT]() {
+      return Object.assign({}, state, {
+        chartStatus: 'failed',
+        chartAlert: '<strong>Query timeout</strong> - visualization query are set to timeout at ' +
+        `${QUERY_TIMEOUT_THRESHOLD / 1000} seconds. ` +
+        'Perhaps your data has grown, your database is under unusual load, ' +
+        'or you are simply querying a data source that is to large to be processed within the timeout range. ' +
+        'If that is the case, we recommend that you summarize your data further.',
       });
     },
     [actions.CHART_UPDATE_FAILED]() {

--- a/superset/assets/javascripts/modules/utils.js
+++ b/superset/assets/javascripts/modules/utils.js
@@ -189,7 +189,7 @@ export function customizeToolTip(chart, xAxisFormatter, yAxisFormatters) {
   });
 }
 
-export function initJQueryAjaxCSRF() {
+export function initJQueryAjax() {
   // Works in conjunction with a Flask-WTF token as described here:
   // http://flask-wtf.readthedocs.io/en/stable/csrf.html#javascript-requests
   const token = $('input#csrf_token').val();

--- a/superset/assets/spec/javascripts/explorev2/actions_spec.js
+++ b/superset/assets/spec/javascripts/explorev2/actions_spec.js
@@ -1,6 +1,9 @@
 import { it, describe } from 'mocha';
 import { expect } from 'chai';
+import sinon from 'sinon';
+import $ from 'jquery';
 import * as actions from '../../../javascripts/explorev2/actions/exploreActions';
+import * as exploreUtils from '../../../javascripts/explorev2/exploreUtils';
 import { defaultState } from '../../../javascripts/explorev2/stores/store';
 import { exploreReducer } from '../../../javascripts/explorev2/reducers/exploreReducer';
 
@@ -14,5 +17,23 @@ describe('reducers', () => {
     const newState = exploreReducer(defaultState,
       actions.setControlValue('show_legend', true, []));
     expect(newState.controls.show_legend.value).to.equal(true);
+  });
+});
+
+describe('runQuery', () => {
+  it('should handle query timeout', () => {
+    const dispatch = sinon.spy();
+    const urlStub = sinon.stub(exploreUtils, 'getExploreUrl', () => ('mockURL'));
+    const ajaxStub = sinon.stub($, 'ajax');
+    ajaxStub.yieldsTo('error', { statusText: 'timeout' });
+
+    const request = actions.runQuery({});
+    request(dispatch);
+
+    expect(dispatch.callCount).to.equal(2);
+    expect(dispatch.args[0][0].type).to.equal(actions.CHART_UPDATE_TIMEOUT);
+
+    urlStub.restore();
+    ajaxStub.restore();
   });
 });


### PR DESCRIPTION
1. Instead of waiting for a long time or server-side response 504 Gateway timeout, explore view now add a query timeout threshold. After timeout it will show specific query timeout warning.
2. fix alert box close button position.

https://github.com/airbnb/superset/issues/2734

before
![before](https://cloud.githubusercontent.com/assets/27990562/26085451/4518c76a-3999-11e7-8205-ea29a3207458.png)

after
![after](https://cloud.githubusercontent.com/assets/27990562/26085452/4520cd70-3999-11e7-8d0b-458660a3b361.png)

