### PR TITLE
Handle issue 2649 by catching wrong string input in parse_human_date

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -198,13 +198,22 @@ def parse_human_datetime(s):
     """
     try:
         dttm = parse(s)
-    except Exception:
+    except Exception e0:
         try:
             cal = parsedatetime.Calendar()
             dttm = dttm_from_timtuple(cal.parse(s)[0])
-        except Exception as e:
-            logging.exception(e)
-            raise ValueError("Couldn't parse date string [{}]".format(s))
+        except Exception as e1:
+            try:
+		## When using a dashborad filter, somehow, splitted version of the string
+		## is raised to the parser. This code should handle it
+                if type(s) == list && len(s) == 1:
+                  s1 = ''.join(s[0])
+                  dttm = parse(s1)
+		else:
+		  raise e1
+            except Exception as e2:    
+                logging.exception(e0)
+                raise ValueError("Couldn't parse date string [{}]".format(s))
     return dttm
 
 

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -204,13 +204,13 @@ def parse_human_datetime(s):
             dttm = dttm_from_timtuple(cal.parse(s)[0])
         except Exception as e1:
             try:
-## When using a dashborad filter, somehow, splitted version of the string
-## is raised to the parser. This code should handle it
-                if type(s) == list && len(s) == 1:
+                # When using a dashborad filter, somehow, splitted version of the string
+                # is raised to the parser. This code should handle it
+                if (type(s) == list and len(s) == 1):
                   s1 = ''.join(s[0])
                   dttm = parse(s1)
-		else:
-		  raise e1
+                else:
+                  raise e1
             except Exception as e2:    
                 logging.exception(e0)
                 raise ValueError("Couldn't parse date string [{}]".format(s))

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -198,7 +198,7 @@ def parse_human_datetime(s):
     """
     try:
         dttm = parse(s)
-    except Exception e0:
+    except Exception as e0:
         try:
             cal = parsedatetime.Calendar()
             dttm = dttm_from_timtuple(cal.parse(s)[0])

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -204,8 +204,8 @@ def parse_human_datetime(s):
             dttm = dttm_from_timtuple(cal.parse(s)[0])
         except Exception as e1:
             try:
-		## When using a dashborad filter, somehow, splitted version of the string
-		## is raised to the parser. This code should handle it
+## When using a dashborad filter, somehow, splitted version of the string
+## is raised to the parser. This code should handle it
                 if type(s) == list && len(s) == 1:
                   s1 = ''.join(s[0])
                   dttm = parse(s1)

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -204,14 +204,14 @@ def parse_human_datetime(s):
             dttm = dttm_from_timtuple(cal.parse(s)[0])
         except Exception as e1:
             try:
-                # When using a dashborad filter, somehow, splitted version of the string
-                # is raised to the parser. This code should handle it
+                # When using a dashborad filter, somehow, splitted version of
+                # the string is raised to the parser.
                 if (type(s) == list and len(s) == 1):
-                  s1 = ''.join(s[0])
-                  dttm = parse(s1)
+                    s1 = ''.join(s[0])
+                    dttm = parse(s1)
                 else:
-                  raise e1
-            except Exception as e2:    
+                    raise e1
+            except Exception as e2:
                 logging.exception(e0)
                 raise ValueError("Couldn't parse date string [{}]".format(s))
     return dttm


### PR DESCRIPTION
try catch the error in parse_human_date() & handle input like 
[[u'1', u' ', u'h', u'o', u'u', u'r', u' ', u'a', u'g', u'o']]
(https://github.com/airbnb/superset/issues/2649)