### PR TITLE
[hotfix] 'filter box from and to date filter #2649'

### DIFF
--- a/superset/assets/javascripts/dashboard/Dashboard.jsx
+++ b/superset/assets/javascripts/dashboard/Dashboard.jsx
@@ -196,8 +196,13 @@ export function dashboardContainer(dashboard, datasources, userid) {
       }
       if (!(col in this.filters[sliceId]) || !merge) {
         this.filters[sliceId][col] = vals;
-      } else {
+
+        // d3.merge pass in array of arrays while some value form filter components
+        // from and to filter box require string to be process and return
+      } else if (this.filters[sliceId][col] instanceof Array) {
         this.filters[sliceId][col] = d3.merge([this.filters[sliceId][col], vals]);
+      } else {
+        this.filters[sliceId][col] = d3.merge([[this.filters[sliceId][col]], vals])[0] || '';
       }
       if (refresh) {
         this.refreshExcept(sliceId);


### PR DESCRIPTION
Filter Box return a string and passes through d3.merge (which accept an array).
This fix allow the date in filter box (ie '3 years ago') to be able to be used correctly