### PR TITLE
filter_box: allow creatable entries

### DIFF
--- a/superset/assets/visualizations/filter_box.jsx
+++ b/superset/assets/visualizations/filter_box.jsx
@@ -82,7 +82,7 @@ class FilterBox extends React.Component {
       return (
         <div key={filter} className="m-b-5">
           {filter}
-          <Select
+          <Select.Creatable
             placeholder={`Select [${filter}]`}
             key={filter}
             multi


### PR DESCRIPTION
The reason is that it should be able to create arbitrary filters
over attributes with very high cardinality, where loading all
possible combinations into the filter box is infeasible,
e.g. IPv6 addresses.