### PR TITLE
explorev2/stores/controls: use default time range

### DIFF
--- a/superset/assets/javascripts/explorev2/stores/controls.jsx
+++ b/superset/assets/javascripts/explorev2/stores/controls.jsx
@@ -508,7 +508,8 @@ export const controls = {
     type: 'SelectControl',
     freeForm: true,
     label: 'Since',
-    default: '7 days ago',
+    default: control =>
+      control.choices && control.choices.length > 0 ? [control.choices[0][0]] : null,
     choices: formatSelectOptions([
       '1 hour ago',
       '12 hours ago',


### PR DESCRIPTION
The reasoning is that most of the controls use first available value.
7 days is really impractical for huge datasets where it can easily be
petabytes of data, so it makes initial load slow.