### PR TITLE
Use metrics and columns "Verbose Name" in visualization

### DIFF
--- a/superset/assets/visualizations/filter_box.jsx
+++ b/superset/assets/visualizations/filter_box.jsx
@@ -14,6 +14,7 @@ const propTypes = {
   origSelectedValues: PropTypes.object,
   instantFiltering: PropTypes.bool,
   filtersChoices: PropTypes.object,
+  verboseFiltersChoices: PropTypes.object,
   onChange: PropTypes.func,
   showDateFilter: PropTypes.bool,
 };
@@ -139,7 +140,7 @@ function filterBox(slice, payload) {
   fd.groupby.forEach((f) => {
     filtersChoices[f] = payload.data[f];
   });
-  const verboseFiltersChoices = payload.verbose_filters
+  const verboseFiltersChoices = payload.verbose_filters;
   ReactDOM.render(
     <FilterBox
       filtersChoices={filtersChoices}

--- a/superset/assets/visualizations/filter_box.jsx
+++ b/superset/assets/visualizations/filter_box.jsx
@@ -75,15 +75,16 @@ class FilterBox extends React.Component {
     }
     const filters = Object.keys(this.props.filtersChoices).map((filter) => {
       const data = this.props.filtersChoices[filter];
+      const verboseFilterName = this.props.verboseFiltersChoices[filter];
       const maxes = {};
       maxes[filter] = d3.max(data, function (d) {
         return d.metric;
       });
       return (
         <div key={filter} className="m-b-5">
-          {filter}
+          {verboseFilterName}
           <Select.Creatable
-            placeholder={`Select [${filter}]`}
+            placeholder={`Select [${verboseFilterName}]`}
             key={filter}
             multi
             value={this.state.selectedValues[filter]}
@@ -138,9 +139,11 @@ function filterBox(slice, payload) {
   fd.groupby.forEach((f) => {
     filtersChoices[f] = payload.data[f];
   });
+  const verboseFiltersChoices = payload.verbose_filters
   ReactDOM.render(
     <FilterBox
       filtersChoices={filtersChoices}
+      verboseFiltersChoices={verboseFiltersChoices}
       onChange={slice.addFilter}
       showDateFilter={fd.date_filter}
       origSelectedValues={slice.getFilters() || {}}

--- a/superset/connectors/base.py
+++ b/superset/connectors/base.py
@@ -90,11 +90,17 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
 
     @property
     def verbose_column_names(self):
-        return {c.column_name: c.verbose_name or c.column_name for c in self.columns}
+        return {
+            c.column_name: c.verbose_name or c.column_name
+            for c in self.columns
+        }
 
     @property
     def verbose_metrics_names(self):
-        return {m.metric_name: m.verbose_name or m.metric_name for m in self.metrics}
+        return {
+            m.metric_name: m.verbose_name or m.metric_name
+            for m in self.metrics
+        }
 
     @property
     def metrics_combo(self):

--- a/superset/connectors/base.py
+++ b/superset/connectors/base.py
@@ -121,11 +121,11 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
             order_by_choices.append((json.dumps([s, False]), s + ' [desc]'))
 
         d = {
-            'all_cols': utils.choicify(self.column_names),
+            'all_cols': self.columns_combo,
             'column_formats': self.column_formats,
             'edit_url': self.url,
             'filter_select': self.filter_select_enabled,
-            'filterable_cols': utils.choicify(self.filterable_column_names),
+            'filterable_cols': self.columns_combo,
             'gb_cols': self.columns_combo,
             'id': self.id,
             'metrics_combo': self.metrics_combo,

--- a/superset/connectors/base.py
+++ b/superset/connectors/base.py
@@ -145,12 +145,12 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
     def get_verbose_column_names(self, columns):
         if columns is None:
             return []
-        return [self.verbose_column_names[c] for c in columns]
+        return [self.verbose_column_names.get(c) for c in columns]
 
     def get_verbose_metrics_names(self, metrics):
         if metrics is None:
             return []
-        return [self.verbose_metrics_names[m] for m in metrics]
+        return [self.verbose_metrics_names.get(m) for m in metrics]
 
     def get_verbose_values(self, values):
         return {

--- a/superset/connectors/base.py
+++ b/superset/connectors/base.py
@@ -89,11 +89,27 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
         }
 
     @property
+    def verbose_column_names(self):
+        return {c.column_name: c.verbose_name or c.column_name for c in self.columns}
+
+    @property
+    def verbose_metrics_names(self):
+        return {m.metric_name: m.verbose_name or m.metric_name for m in self.metrics}
+
+    @property
     def metrics_combo(self):
         return sorted(
             [
                 (m.metric_name, m.verbose_name or m.metric_name)
                 for m in self.metrics],
+            key=lambda x: x[1])
+
+    @property
+    def columns_combo(self):
+        return sorted(
+            [
+                (m.column_name, m.verbose_name or m.column_name)
+                for m in self.columns],
             key=lambda x: x[1])
 
     @property
@@ -110,7 +126,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
             'edit_url': self.url,
             'filter_select': self.filter_select_enabled,
             'filterable_cols': utils.choicify(self.filterable_column_names),
-            'gb_cols': utils.choicify(self.groupby_column_names),
+            'gb_cols': self.columns_combo,
             'id': self.id,
             'metrics_combo': self.metrics_combo,
             'name': self.name,
@@ -119,6 +135,25 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
         }
 
         return d
+
+    def get_verbose_column_names(self, columns):
+        if columns is None:
+            return []
+        return [self.verbose_column_names[c] for c in columns]
+
+    def get_verbose_metrics_names(self, metrics):
+        if metrics is None:
+            return []
+        return [self.verbose_metrics_names[m] for m in metrics]
+
+    def get_verbose_values(self, values):
+        return {
+            df_value:
+                self.verbose_column_names.get(df_value) or
+                self.verbose_metrics_names.get(df_value) or
+                df_value
+            for df_value in values
+        }
 
     def get_query_str(self, query_obj):
         """Returns a query as a string

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -69,8 +69,14 @@ class BaseViz(object):
             'column': self.datasource.get_verbose_column_names
         }
         attributes = {
-            'metric': ['metrics', 'metric', 'secondary_metric', 'x', 'y', 'size', 'metric_2'],
-            'column': ['columns', 'groupby', 'granularity_sqla', 'series', 'all_columns_x', 'all_columns_y']
+            'metric': [
+                'metrics', 'metric', 'secondary_metric',
+                'x', 'y', 'size', 'metric_2'
+            ],
+            'column': [
+                'columns', 'groupby', 'granularity_sqla',
+                'series', 'all_columns_x', 'all_columns_y'
+            ]
         }
 
         existing_attributes = {}
@@ -498,7 +504,10 @@ class WordCloudViz(BaseViz):
 
     def get_data(self, df):
         # Ordering the columns
-        df = df[[self.verbose_form_data.get('series')[0], self.verbose_form_data.get('metric')[0]]]
+        df = df[[
+            self.verbose_form_data.get('series')[0],
+            self.verbose_form_data.get('metric')[0]
+        ]]
         # Labeling the columns for uniform json schema
         df.columns = ['text', 'size']
         return df.to_dict(orient="records")

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -68,6 +68,7 @@ class BaseViz(object):
             'metric': self.datasource.get_verbose_metrics_names,
             'column': self.datasource.get_verbose_column_names
         }
+
         attributes = {
             'metric': [
                 'metrics', 'metric', 'secondary_metric',

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -342,7 +342,7 @@ class BaseViz(object):
         return df.to_csv(index=include_index, encoding="utf-8")
 
     def get_data(self, df):
-        return []
+        return dict()
 
     @property
     def json_data(self):


### PR DESCRIPTION
Instead of metric and column names, verbose names are shown for all visualization objects. The metric or column name is only shown if there is no verbose name. Also, verbose names are used for drop-down options on the explore page.