### PR TITLE
[explore] 'Save as' -> 'Save' as it can be used to overwrite

### DIFF
--- a/superset/assets/javascripts/explore/components/QueryAndSaveBtns.jsx
+++ b/superset/assets/javascripts/explore/components/QueryAndSaveBtns.jsx
@@ -56,7 +56,7 @@ export default function QueryAndSaveBtns(
           disabled={saveButtonDisabled}
           onClick={onSave}
         >
-          <i className="fa fa-plus-circle" /> Save as
+          <i className="fa fa-plus-circle" /> Save
         </Button>
       </ButtonGroup>
       {errorMessage &&

--- a/superset/assets/spec/javascripts/explore/components/QueryAndSaveBtns_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/QueryAndSaveBtns_spec.jsx
@@ -32,7 +32,7 @@ describe('QueryAndSaveButtons', () => {
 
     it('renders buttons with correct text', () => {
       expect(wrapper.find(Button).contains(' Query')).to.eql(true);
-      expect(wrapper.find(Button).contains(' Save as')).to.eql(true);
+      expect(wrapper.find(Button).contains(' Save')).to.eql(true);
     });
 
     it('calls onQuery when query button is clicked', () => {


### PR DESCRIPTION
![screen shot 2017-05-30 at 2 26 11 pm](https://cloud.githubusercontent.com/assets/487433/26605732/f85721f4-4543-11e7-91a4-864782becf25.png)
