### PR TITLE
Fix a type error in rst' sub list.

### DIFF
--- a/docs/sqllab.rst
+++ b/docs/sqllab.rst
@@ -13,9 +13,11 @@ Feature Overview
   visualization capabilities
 - Browse database metadata: tables, columns, indexes, partitions
 - Support for long-running queries
+
   - uses the `Celery distributed queue <http://www.python.org/>`_
     to dispatch query handling to workers
   - supports defining a "results backend" to persist query results
+
 - A search engine to find queries executed in the past
 - Supports templating using the
   `Jinja templating language <http://jinja.pocoo.org/docs/dev/>`_


### PR DESCRIPTION
Sub list in rst requires a blank line above and below.

Ref:
- http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#bullet-lists

Original HTML before fix:

![image](https://cloud.githubusercontent.com/assets/1164623/26664195/3e6ce76c-46c2-11e7-88cd-db3567e292fa.png)
