### PR TITLE
Add six into tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ find_links =
 
 [testenv]
 deps =
+    six
     wheel
     coveralls
 passenv =


### PR DESCRIPTION
to: @mistercrunch 
cc: @airbnb/superset-reviewers 

#### Summary
Add `six` dependency into `tox.ini` to fix Travis builds on master (e.g., https://travis-ci.org/airbnb/superset/jobs/238201232). 