### PR TITLE
Bug Fix: Converting filter argument to number if column is number

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -477,7 +477,9 @@ class SqlaTable(Model, BaseDatasource):
                     if op == 'not in':
                         cond = ~cond
                     where_clause_and.append(cond)
-                elif op == '==':
+                if col_obj.is_num:
+                    eq = utils.string_to_num(flt['val'])
+                if op == '==':
                     where_clause_and.append(col_obj.sqla_col == eq)
                 elif op == '!=':
                     where_clause_and.append(col_obj.sqla_col != eq)


### PR DESCRIPTION
Not all SQL dialects automatically cast strings to numbers. Therefore filtering on numeric values using the filter control on the explore/slice page does not work. 

E.g. a table with a numeric (int, bigint, numeric, etc) `id` column. Filtering on the id generates this SQL expression:  
```
SELECT COUNT(*)
FROM `table`
WHERE `id` = '123'
LIMIT 50000
```
However the expression should be:
```
SELECT COUNT(*)
FROM `table`
WHERE `id` = 123
LIMIT 50000
```
