### PR TITLE
travis: no need to install python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: python
 addons:
   code_climate:
     repo_token: 5f3a06c425eef7be4b43627d7d07a3e46c45bdc07155217825ff7c49cb6a470c
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
 cache:
   directories:
     - $HOME/.wheelhouse/


### PR DESCRIPTION
As we are testing on 3.4 and 2.7.