### PR TITLE
Ignore pyenv files in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ app.db
 .idea
 *.sqllite
 .vscode
+.python-version
 
 # Node.js, webpack artifacts
 *.entry.js
@@ -33,3 +34,4 @@ node_modules
 npm-debug.log
 yarn.lock
 superset/assets/version_info.json
+


### PR DESCRIPTION
Some python developers use Python version manager to create and switch Python
enviroments, pyenv (http://github.com/yyuu/pyenv) is one of the version managers.

When you use `pyenv local x.x.x`, `pyenv` will put a `.python-version` file in
project directory, which, in general, should not be commited to git.