### PR TITLE
Update REMOTE_USER docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -353,6 +353,8 @@ environment variable: ::
 
 *Adapted from http://flask.pocoo.org/snippets/69/*
 
+*Requires you to set ``X-Proxy-REMOTE-USER`` (in all caps) request header*
+
 
 Upgrading
 ---------


### PR DESCRIPTION
I couldn't get this to work using the middleware example without making sure the `REMOTE_USER` part of the header variable was in all caps: https://github.com/airbnb/superset/blob/master/docs/installation.rst#middleware