### PR TITLE
updating react-alert dependency to v2.0.1

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -70,7 +70,7 @@
     "react-ace": "^4.1.5",
     "react-addons-css-transition-group": "^15.4.2",
     "react-addons-shallow-compare": "^15.4.2",
-    "react-alert": "^1.0.14",
+    "react-alert": "^2.0.1",
     "react-bootstrap": "^0.30.3",
     "react-bootstrap-table": "^3.1.7",
     "react-dom": "^15.5.1",


### PR DESCRIPTION
The old version used `React.PropTypes` and it was deprecated. This version is compatible with React 15+