### PR TITLE
Fix ordered dictionary bug.

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -372,7 +372,8 @@ class SliceModelView(SupersetModelView, DeleteMixin):  # noqa
     @expose('/add', methods=['GET', 'POST'])
     @has_access
     def add(self):
-        datasources = ConnectorRegistry.get_all_datasources(db.session)
+        datasources = sorted(ConnectorRegistry.get_all_datasources(db.session),
+                             key=lambda x: x.name)
         datasources = [
             {'value': str(d.id) + '__' + d.type, 'label': repr(d)}
             for d in datasources
@@ -380,7 +381,7 @@ class SliceModelView(SupersetModelView, DeleteMixin):  # noqa
         return self.render_template(
             "superset/add_slice.html",
             bootstrap_data=json.dumps({
-                'datasources': sorted(datasources),
+                'datasources': datasources,
             }),
         )
 

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -219,13 +219,21 @@ class CoreTests(SupersetTestCase):
     def test_add_slice(self):
         self.login(username='admin')
 
-        # Click on the + to add a slice
         url = '/tablemodelview/list/'
         resp = self.get_resp(url)
 
         table = db.session.query(SqlaTable).first()
         assert table.name in resp
         assert '/superset/explore/table/{}'.format(table.id) in resp
+
+        url = '/slicemodelview/add'
+        resp = self.client.get(url)
+        assert resp.status == '200 OK'
+
+        resp = resp.data.decode('utf-8')
+        tables = db.session.query(SqlaTable).all()
+        for table in tables:
+            assert table.name in resp
 
     def test_slices_V2(self):
         # Add explore-v2-beta role to admin user


### PR DESCRIPTION
The add slice page fails to load because it tries to execute `ordered(datasources)` where `datasources` is a list of dictionaries. This PR fixes that bug and also adds to some tests that I wrote earlier that should have caught the page failing to load. My bad!

@ascott, this is the PR for the error I mentioned [here](https://github.com/airbnb/superset/commit/24292dbc1159ba5dd807e56f4d268cda8f16f474).