### PR TITLE
Bug Fix: Handling pandas ExtensionDtypes

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -14,6 +14,8 @@ from datetime import datetime, date
 from past.builtins import basestring
 
 import pandas as pd
+from pandas.core.dtypes.dtypes import ExtensionDtype
+
 import numpy as np
 
 
@@ -52,6 +54,8 @@ class SupersetDataFrame(object):
     @classmethod
     def db_type(cls, dtype):
         """Given a numpy dtype, Returns a generic database type"""
+        if isinstance(dtype, ExtensionDtype):
+            return cls.type_map.get(dtype.kind)
         return cls.type_map.get(dtype.char)
 
     @classmethod
@@ -87,8 +91,10 @@ class SupersetDataFrame(object):
         # consider checking for key substring too.
         if cls.is_id(column_name):
             return 'count_distinct'
-        if np.issubdtype(dtype, np.number):
+        if (issubclass(dtype.type, np.generic) and
+                np.issubdtype(dtype, np.number)):
             return 'sum'
+        return None
 
     @property
     def columns(self):


### PR DESCRIPTION
Pandas ExtensionDtypes are not handled correctly in SQL Lab.

![image](https://user-images.githubusercontent.com/3138343/26982760-641902fc-4d07-11e7-8aeb-9741ba8b846f.png)

If a SQL column is of type TIMESTAMP and supports timezones, pandas returns an object of type `DatetimeTZDtype` https://github.com/pandas-dev/pandas/blob/v0.20.2/pandas/io/sql.py#L911

`DatetimeTZDtype` is a np.dtype duck-typed class but not a real numpy dtype. 