### PR TITLE
Allow 'refresh_immune_slices'

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -107,7 +107,8 @@ never be affected by any dashboard level filtering.
         "filter_immune_slice_fields": {
             "177": ["country_name", "__from", "__to"],
             "32": ["__from", "__to"]
-        }
+        },
+        "timed_refresh_immune_slices": [324]
     }
 
 In the json blob above, slices 324, 65 and 92 won't be affected by any
@@ -123,6 +124,24 @@ for dealing with the time boundary filtering mentioned above.
 But what happens with filtering when dealing with slices coming from
 different tables or databases? If the column name is shared, the filter will
 be applied, it's as simple as that.
+
+
+How to limit the timed refresh on a dashboard?
+----------------------------------------------
+By default, the dashboard timed refresh feature allows you to automatically requery every slice on a dashboard according to a set schedule. Sometimes, however, you won't want all of the slices to be refreshed - especially if some data is slow moving, or run heavy queries.
+To exclude specific slices from the timed refresh process, add the ``timed_refresh_immune_slices`` key to the dashboard ``JSON Metadata`` field:
+
+..code::
+
+    {
+       "filter_immune_slices": [],
+        "expanded_slices": {},
+        "filter_immune_slice_fields": {},
+        "timed_refresh_immune_slices": [324]
+    }
+
+In the example above, if a timed refresh is set for the dashboard, then every slice except 324 will be automatically requeried on schedule.
+
 
 Why does fabmanager or superset freezed/hung/not responding when started (my home directory is NFS mounted)?
 -----------------------------------------------------------------------------------------

--- a/superset/assets/javascripts/dashboard/Dashboard.jsx
+++ b/superset/assets/javascripts/dashboard/Dashboard.jsx
@@ -245,15 +245,18 @@ export function dashboardContainer(dashboard, datasources, userid) {
     startPeriodicRender(interval) {
       this.stopPeriodicRender();
       const dash = this;
+      const immune = this.metadata.refresh_immune_slices || [];
       const maxRandomDelay = Math.max(interval * 0.2, 5000);
       const refreshAll = () => {
         dash.sliceObjects.forEach((slice) => {
           const force = !dash.firstLoad;
-          setTimeout(() => {
-            slice.render(force);
-          },
-          // Randomize to prevent all widgets refreshing at the same time
-          maxRandomDelay * Math.random());
+          if (immune.indexOf(slice.data.slice_id) === -1) {
+              setTimeout(() => {
+                slice.render(force);
+              },
+              // Randomize to prevent all widgets refreshing at the same time
+              maxRandomDelay * Math.random());
+              };
         });
         dash.firstLoad = false;
       };

--- a/superset/assets/javascripts/dashboard/Dashboard.jsx
+++ b/superset/assets/javascripts/dashboard/Dashboard.jsx
@@ -251,12 +251,12 @@ export function dashboardContainer(dashboard, datasources, userid) {
         dash.sliceObjects.forEach((slice) => {
           const force = !dash.firstLoad;
           if (immune.indexOf(slice.data.slice_id) === -1) {
-              setTimeout(() => {
-                slice.render(force);
-              },
-              // Randomize to prevent all widgets refreshing at the same time
-              maxRandomDelay * Math.random());
-              };
+            setTimeout(() => {
+              slice.render(force);
+            },
+            // Randomize to prevent all widgets refreshing at the same time
+            maxRandomDelay * Math.random());
+          }
         });
         dash.firstLoad = false;
       };

--- a/superset/assets/javascripts/dashboard/Dashboard.jsx
+++ b/superset/assets/javascripts/dashboard/Dashboard.jsx
@@ -245,7 +245,7 @@ export function dashboardContainer(dashboard, datasources, userid) {
     startPeriodicRender(interval) {
       this.stopPeriodicRender();
       const dash = this;
-      const immune = this.metadata.refresh_immune_slices || [];
+      const immune = this.metadata.timed_refresh_immune_slices || [];
       const maxRandomDelay = Math.max(interval * 0.2, 5000);
       const refreshAll = () => {
         dash.sliceObjects.forEach((slice) => {

--- a/superset/assets/spec/javascripts/dashboard/fixtures.jsx
+++ b/superset/assets/spec/javascripts/dashboard/fixtures.jsx
@@ -43,7 +43,7 @@ export const dashboardData = {
   css: '',
   metadata: {
     filter_immune_slices: [],
-    refresh_immune_slices: [],
+    timed_refresh_immune_slices: [],
     filter_immune_slice_fields: {},
     expanded_slices: {},
   },

--- a/superset/assets/spec/javascripts/dashboard/fixtures.jsx
+++ b/superset/assets/spec/javascripts/dashboard/fixtures.jsx
@@ -43,6 +43,7 @@ export const dashboardData = {
   css: '',
   metadata: {
     filter_immune_slices: [],
+    refresh_immune_slices: [],
     filter_immune_slice_fields: {},
     expanded_slices: {},
   },

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -411,7 +411,7 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         slices = copy(dashboard_to_import.slices)
         old_to_new_slc_id_dict = {}
         new_filter_immune_slices = []
-        new_refresh_immune_slices = []
+        new_timed_refresh_immune_slices = []
         new_expanded_slices = {}
         i_params_dict = dashboard_to_import.params_dict
         for slc in slices:
@@ -425,9 +425,9 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
             if ('filter_immune_slices' in i_params_dict and
                     old_slc_id_str in i_params_dict['filter_immune_slices']):
                 new_filter_immune_slices.append(new_slc_id_str)
-            if ('refresh_immune_slices' in i_params_dict and
-                    old_slc_id_str in i_params_dict['refresh_immune_slices']):
-                new_refresh_immune_slices.append(new_slc_id_str)
+            if ('timed_refresh_immune_slices' in i_params_dict and
+                    old_slc_id_str in i_params_dict['timed_refresh_immune_slices']):
+                new_timed_refresh_immune_slices.append(new_slc_id_str)
             if ('expanded_slices' in i_params_dict and
                     old_slc_id_str in i_params_dict['expanded_slices']):
                 new_expanded_slices[new_slc_id_str] = (
@@ -450,9 +450,9 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         if new_filter_immune_slices:
             dashboard_to_import.alter_params(
                 filter_immune_slices=new_filter_immune_slices)
-        if new_refresh_immune_slices:
+        if new_timed_refresh_immune_slices:
             dashboard_to_import.alter_params(
-                refresh_immune_slices=new_refresh_immune_slices)
+                timed_refresh_immune_slices=new_timed_refresh_immune_slices)
 
         new_slices = session.query(Slice).filter(
             Slice.id.in_(old_to_new_slc_id_dict.values())).all()

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -426,7 +426,8 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
                     old_slc_id_str in i_params_dict['filter_immune_slices']):
                 new_filter_immune_slices.append(new_slc_id_str)
             if ('timed_refresh_immune_slices' in i_params_dict and
-                    old_slc_id_str in i_params_dict['timed_refresh_immune_slices']):
+                    old_slc_id_str in
+                        i_params_dict['timed_refresh_immune_slices']):
                 new_timed_refresh_immune_slices.append(new_slc_id_str)
             if ('expanded_slices' in i_params_dict and
                     old_slc_id_str in i_params_dict['expanded_slices']):

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -411,6 +411,7 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         slices = copy(dashboard_to_import.slices)
         old_to_new_slc_id_dict = {}
         new_filter_immune_slices = []
+        new_refresh_immune_slices = []
         new_expanded_slices = {}
         i_params_dict = dashboard_to_import.params_dict
         for slc in slices:
@@ -424,6 +425,9 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
             if ('filter_immune_slices' in i_params_dict and
                     old_slc_id_str in i_params_dict['filter_immune_slices']):
                 new_filter_immune_slices.append(new_slc_id_str)
+            if ('refresh_immune_slices' in i_params_dict and
+                    old_slc_id_str in i_params_dict['refresh_immune_slices']):
+                new_refresh_immune_slices.append(new_slc_id_str)
             if ('expanded_slices' in i_params_dict and
                     old_slc_id_str in i_params_dict['expanded_slices']):
                 new_expanded_slices[new_slc_id_str] = (
@@ -446,6 +450,9 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         if new_filter_immune_slices:
             dashboard_to_import.alter_params(
                 filter_immune_slices=new_filter_immune_slices)
+        if new_refresh_immune_slices:
+            dashboard_to_import.alter_params(
+                refresh_immune_slices=new_refresh_immune_slices)
 
         new_slices = session.query(Slice).filter(
             Slice.id.in_(old_to_new_slc_id_dict.values())).all()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1343,6 +1343,8 @@ class Superset(BaseSupersetView):
 
         if 'filter_immune_slices' not in md:
             md['filter_immune_slices'] = []
+        if 'refresh_immune_slices' not in md:
+            md['refresh_immune_slices'] = []
         if 'filter_immune_slice_fields' not in md:
             md['filter_immune_slice_fields'] = {}
         md['expanded_slices'] = data['expanded_slices']

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1343,8 +1343,8 @@ class Superset(BaseSupersetView):
 
         if 'filter_immune_slices' not in md:
             md['filter_immune_slices'] = []
-        if 'refresh_immune_slices' not in md:
-            md['refresh_immune_slices'] = []
+        if 'timed_refresh_immune_slices' not in md:
+            md['timed_refresh_immune_slices'] = []
         if 'filter_immune_slice_fields' not in md:
             md['filter_immune_slice_fields'] = {}
         md['expanded_slices'] = data['expanded_slices']


### PR DESCRIPTION
Ref #2958 , add a 'refresh_immune_slices' property to dashboards. Any slice ids listed will not be included in an automatic dashboard refresh.
I chose to exclude rather than include to be consist with filter_immune_slices.