### PR TITLE
[bugfix] Datasource -> Slice relationship

### DIFF
--- a/superset/connectors/base.py
+++ b/superset/connectors/base.py
@@ -1,15 +1,19 @@
 import json
 
 from sqlalchemy import (
-    Column, Integer, String, Text, Boolean,
+    and_, Column, Integer, String, Text, Boolean,
 )
+from sqlalchemy.orm import foreign, relationship
+from sqlalchemy.ext.declarative import declared_attr
+
 from superset import utils
+from superset.models.core import Slice
 from superset.models.helpers import AuditMixinNullable, ImportMixin
 
 
 class BaseDatasource(AuditMixinNullable, ImportMixin):
-
-    """A common interface to objects that are queryable (tables and datasources)"""
+    """A common interface to objects that are queryable
+    (tables and datasources)"""
 
     # ---------------------------------------------------------------
     # class attributes to define when deriving BaseDatasource
@@ -17,7 +21,6 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
     __tablename__ = None  # {connector_name}_datasource
     type = None  # datasoure type, str to be defined when deriving this class
     baselink = None  # url portion pointing to ModelView endpoint
-
     column_class = None  # link to derivative of BaseColumn
     metric_class = None  # link to derivative of BaseMetric
 
@@ -38,6 +41,14 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
     cache_timeout = Column(Integer)
     params = Column(String(1000))
     perm = Column(String(1000))
+
+    @declared_attr
+    def slices(self):
+        return relationship(
+            'Slice',
+            primaryjoin=lambda: and_(
+              foreign(Slice.datasource_id) == self.id,
+              foreign(Slice.datasource_type) == self.type))
 
     # placeholder for a relationship to a derivative of BaseColumn
     columns = []

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -342,11 +342,6 @@ class DruidDatasource(Model, BaseDatasource):
         'datasource_name', 'is_hidden', 'description', 'default_endpoint',
         'cluster_name', 'offset', 'cache_timeout', 'params'
     )
-    slices = relationship(
-        'Slice',
-        primaryjoin=(
-            "DruidDatasource.id == foreign(Slice.datasource_id) and "
-            "Slice.datasource_type == 'druid'"))
 
     @property
     def database(self):

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -178,11 +178,6 @@ class SqlaTable(Model, BaseDatasource):
         foreign_keys=[database_id])
     schema = Column(String(255))
     sql = Column(Text)
-    slices = relationship(
-        'Slice',
-        primaryjoin=(
-            "SqlaTable.id == foreign(Slice.datasource_id) and "
-            "Slice.datasource_type == 'table'"))
 
     baselink = "tablemodelview"
     export_fields = (


### PR DESCRIPTION
The existing slices relationship does not filter correctly on the `datasource_type`.

Currently, if you delete a druid datasource, it will set `datasource_id` on all slices to `NULL` where the druid datasource id matches that `datasource_id`, even if the slice was referencing a sql table id.