### PR TITLE
[bugfix] only filterable columns should show up in FilterBox list

### DIFF
--- a/superset/assets/javascripts/explore/components/ControlPanelsContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ControlPanelsContainer.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Alert } from 'react-bootstrap';
-import { sectionsToRender } from '../stores/visTypes';
+import { sectionsToRender, visTypes } from '../stores/visTypes';
 import ControlPanelSection from './ControlPanelSection';
 import ControlRow from './ControlRow';
 import Control from './Control';
@@ -28,7 +28,15 @@ class ControlPanelsContainer extends React.Component {
     this.getControlData = this.getControlData.bind(this);
   }
   getControlData(controlName) {
-    const mapF = controls[controlName].mapStateToProps;
+    // Identifying mapStateToProps function to apply (logic can't be in store)
+    let mapF = controls[controlName].mapStateToProps;
+
+    // Looking to find mapStateToProps override for this viz type
+    const controlOverrides = visTypes[this.props.controls.viz_type.value].controlOverrides || {};
+    if (controlOverrides[controlName] && controlOverrides[controlName].mapStateToProps) {
+      mapF = controlOverrides[controlName].mapStateToProps;
+    }
+    // Applying mapStateToProps if needed
     if (mapF) {
       return Object.assign({}, this.props.controls[controlName], mapF(this.props.exploreState));
     }

--- a/superset/assets/javascripts/explore/components/controls/SelectControl.jsx
+++ b/superset/assets/javascripts/explore/components/controls/SelectControl.jsx
@@ -43,7 +43,8 @@ export default class SelectControl extends React.PureComponent {
     this.onChange = this.onChange.bind(this);
   }
   componentWillReceiveProps(nextProps) {
-    if (nextProps.choices !== this.props.choices) {
+    if (nextProps.choices !== this.props.choices ||
+        nextProps.options !== this.props.options) {
       const options = this.getOptions(nextProps);
       this.setState({ options });
     }

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -326,7 +326,7 @@ export const controls = {
     valueRenderer: c => <ColumnOption column={c} />,
     valueKey: 'column_name',
     mapStateToProps: state => ({
-      options: (state.datasource) ? state.datasource.columns : [],
+      options: (state.datasource) ? state.datasource.columns.filter(c => c.groupby) : [],
     }),
   },
 

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -75,7 +75,7 @@ export const sections = {
   ],
 };
 
-const visTypes = {
+export const visTypes = {
   dist_bar: {
     label: 'Distribution - Bar Chart',
     controlPanelSections: [
@@ -742,8 +742,13 @@ const visTypes = {
     controlOverrides: {
       groupby: {
         label: 'Filter controls',
-        description: 'The controls you want to filter on',
-        default: [],
+        description: (
+          'The controls you want to filter on. Note that only columns ' +
+          'checked as "filterable" will show up on this list.'
+        ),
+        mapStateToProps: state => ({
+          options: (state.datasource) ? state.datasource.columns.filter(c => c.filterable) : [],
+        }),
       },
     },
   },

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -224,7 +224,7 @@ class BaseColumn(AuditMixinNullable, ImportMixin):
     def data(self):
         attrs = (
             'column_name', 'verbose_name', 'description', 'expression',
-            'filterable')
+            'filterable', 'groupby')
         return {s: getattr(self, s) for s in attrs}
 
 

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -222,7 +222,9 @@ class BaseColumn(AuditMixinNullable, ImportMixin):
 
     @property
     def data(self):
-        attrs = ('column_name', 'verbose_name', 'description', 'expression')
+        attrs = (
+            'column_name', 'verbose_name', 'description', 'expression',
+            'filterable')
         return {s: getattr(self, s) for s in attrs}
 
 


### PR DESCRIPTION
Also fixing issue where controls override for `mapStateToProps` would not be applied