### PR TITLE
Long running queries are set to timeout (#2926)

### DIFF
--- a/superset/assets/javascripts/SqlLab/actions.js
+++ b/superset/assets/javascripts/SqlLab/actions.js
@@ -27,6 +27,7 @@ export const ADD_ALERT = 'ADD_ALERT';
 export const REMOVE_ALERT = 'REMOVE_ALERT';
 export const REFRESH_QUERIES = 'REFRESH_QUERIES';
 export const RUN_QUERY = 'RUN_QUERY';
+export const QUERY_TIMEOUT = 'QUERY_TIMEOUT';
 export const START_QUERY = 'START_QUERY';
 export const STOP_QUERY = 'STOP_QUERY';
 export const REQUEST_QUERY_RESULTS = 'REQUEST_QUERY_RESULTS';
@@ -115,6 +116,10 @@ export function fetchQueryResults(query) {
   };
 }
 
+export function queryTimeout(query) {
+  return { type: QUERY_TIMEOUT, query };
+}
+
 export function runQuery(query) {
   return function (dispatch) {
     dispatch(startQuery(query));
@@ -179,6 +184,26 @@ export function postStopQuery(query) {
       },
       error() {
         notify.error('Failed at stopping query.');
+      },
+    });
+  };
+}
+
+export function timeOutQuery(query) {
+  return function (dispatch) {
+    const timeoutQueryUrl = '/superset/timeout_query/';
+    const timeoutQueryRequestData = { client_id: query.id };
+    dispatch(queryTimeout(query));
+    $.ajax({
+      type: 'POST',
+      dataType: 'json',
+      url: timeoutQueryUrl,
+      data: timeoutQueryRequestData,
+      success() {
+        notify.success('Query was timedout.');
+      },
+      error() {
+        notify.error('Failed at timeing out query.');
       },
     });
   };

--- a/superset/assets/javascripts/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryAutoRefresh.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { now, addXHours } from '../../modules/dates';
 import * as Actions from '../actions';
 
 const $ = require('jquery');
@@ -16,11 +17,18 @@ class QueryAutoRefresh extends React.PureComponent {
   componentWillUnmount() {
     this.stopTimer();
   }
+  setPotentialTimeout(query) {
+    // if a running query is over 24 hrs ago, set the state timeout
+    if (query.state === 'running' && addXHours(query.startDttm, 24) < now()) {
+      this.props.actions.timeOutQuery(query);
+    }
+  }
   shouldCheckForQueries() {
     // if there are started or running queries, this method should return true
     const { queries } = this.props;
     const queryKeys = Object.keys(queries);
     const queriesAsArray = queryKeys.map(key => queries[key]);
+    queriesAsArray.map(q => this.setPotentialTimeout(q));
     return queriesAsArray.some(q =>
       ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0);
   }

--- a/superset/assets/javascripts/SqlLab/constants.js
+++ b/superset/assets/javascripts/SqlLab/constants.js
@@ -2,6 +2,7 @@ export const STATE_BSSTYLE_MAP = {
   failed: 'danger',
   pending: 'info',
   fetching: 'info',
+  timed_out: 'warning',
   running: 'warning',
   stopped: 'danger',
   success: 'success',
@@ -11,6 +12,7 @@ export const STATUS_OPTIONS = [
   'success',
   'failed',
   'running',
+  'timed_out',
 ];
 
 export const TIME_OPTIONS = [

--- a/superset/assets/javascripts/SqlLab/reducers.js
+++ b/superset/assets/javascripts/SqlLab/reducers.js
@@ -179,6 +179,9 @@ export const sqlLabReducer = function (state, action) {
       };
       return alterInObject(state, 'queries', action.query, alts);
     },
+    [actions.QUERY_TIMEOUT]() {
+      return alterInObject(state, 'queries', action.query, { state: 'timed_out' });
+    },
     [actions.QUERY_FAILED]() {
       if (action.query.state === 'stopped') {
         return state;

--- a/superset/assets/javascripts/modules/dates.js
+++ b/superset/assets/javascripts/modules/dates.js
@@ -78,6 +78,14 @@ export const now = function () {
   return moment().utc().valueOf();
 };
 
+export const addXHours = function (date, h) {
+  // add X hours to given utc date
+  return moment(date)
+  .add(h, 'hours')
+  .utc()
+  .valueOf();
+};
+
 export const epochTimeXHoursAgo = function (h) {
   return moment()
     .subtract(h, 'hours')

--- a/superset/assets/spec/javascripts/modules/dates_spec.js
+++ b/superset/assets/spec/javascripts/modules/dates_spec.js
@@ -5,6 +5,7 @@ import {
   formatDate,
   fDuration,
   now,
+  addXHours,
   epochTimeXHoursAgo,
   epochTimeXDaysAgo,
   epochTimeXYearsAgo,
@@ -44,6 +45,24 @@ describe('now', () => {
 
   it('returns a number', () => {
     expect(now()).to.be.a('number');
+  });
+});
+
+describe('addXHours', () => {
+  it('is a function', () => {
+    assert.isFunction(addXHours);
+  });
+
+  it('returns a number', () => {
+    expect(addXHours(0, 0)).to.be.a('number');
+  });
+
+  it('returns the expected output', () => {
+    expect(addXHours(1496293608897, 24)).to.equal(1496380008897);
+  });
+
+  it('returns the expected output', () => {
+    expect(addXHours(1496293608897, 0)).to.equal(1496293608897);
   });
 });
 

--- a/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
@@ -65,4 +65,12 @@ describe('QuerySearch', () => {
     /* eslint-disable no-unused-expressions */
     expect(search.called).to.equal(true);
   });
+
+  it('check for query timeouts prior to query refresh', () => {
+    const search = sinon.spy(QuerySearch.prototype, 'setPotentialTimeout');
+    wrapper = shallow(<QuerySearch {...mockedProps} />);
+    wrapper.find(Button).simulate('click');
+    /* eslint-disable no-unused-expressions */
+    expect(search.called).to.equal(true);
+  });
 });

--- a/superset/assets/spec/javascripts/sqllab/actions_spec.js
+++ b/superset/assets/spec/javascripts/sqllab/actions_spec.js
@@ -127,4 +127,33 @@ describe('async actions', () => {
       expect(ajaxStub.getCall(0).args[0].data).to.deep.equal(data);
     });
   });
+
+  describe('timeoutQuery', () => {
+    const makeRequest = () => {
+      const request = actions.timeOutQuery(query);
+      request(dispatch);
+    };
+
+    it('makes the ajax request', () => {
+      makeRequest();
+      expect(ajaxStub.calledOnce).to.be.true;
+    });
+
+    it('calls timeOutQuery', () => {
+      makeRequest();
+      expect(dispatch.args[0][0].type).to.equal(actions.QUERY_TIMEOUT);
+    });
+
+    it('calls the correct url', () => {
+      const url = '/superset/timeout_query/';
+      makeRequest();
+      expect(ajaxStub.getCall(0).args[0].url).to.equal(url);
+    });
+
+    it('sends the correct data', () => {
+      const data = { client_id: query.id };
+      makeRequest();
+      expect(ajaxStub.getCall(0).args[0].data).to.deep.equal(data);
+    });
+  });
 });

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -196,7 +196,8 @@ def execute_sql(ctask, query_id, return_results=True, store_results=False):
     conn.commit()
     conn.close()
 
-    if query.status == utils.QueryStatus.STOPPED:
+    if query.status == utils.QueryStatus.STOPPED or query.status == \
+            utils.QueryStatus.TIMED_OUT:
         return json.dumps({
             'query_id': query.id,
             'status': query.status,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1958,6 +1958,22 @@ class Superset(BaseSupersetView):
         return self.json_response('OK')
 
     @has_access_api
+    @expose("/timeout_query/", methods=['POST'])
+    @log_this
+    def timeout_query(self):
+        client_id = request.form.get('client_id')
+        try:
+            query = (
+                db.session.query(Query)
+                    .filter_by(client_id=client_id).one()
+            )
+            query.status = utils.QueryStatus.TIMED_OUT
+            db.session.commit()
+        except Exception as e:
+            pass
+        return self.json_response('OK')
+
+    @has_access_api
     @expose("/sql_json/", methods=['POST', 'GET'])
     @log_this
     def sql_json(self):


### PR DESCRIPTION
Hi all,

I know there are still some issues (ie code repetition in core.py) but I'd like to see if I'm approaching the issue correctly. 

My implementation currently behaves similarly to stopping a query. If a running query is older than 24hrs the newly exposed /timeout_query/ will be called via POST to set the state of the query to timed_out.  This check for a timeout_query takes place when polling and searching for queries.
I've also added a filter timed_out to the query search. 
![2017-07-07-114551_1903x378_scrot](https://user-images.githubusercontent.com/19409776/28084635-391db0ee-6647-11e7-968f-35c6d638d206.png)
I've also tried to add all the relevant unit tests

Please tell me what you guys think.
Thanks. 
