### PR TITLE
allow user press Enter key to end editing title

### DIFF
--- a/superset/assets/javascripts/components/EditableTitle.jsx
+++ b/superset/assets/javascripts/components/EditableTitle.jsx
@@ -23,6 +23,7 @@ class EditableTitle extends React.PureComponent {
     this.handleClick = this.handleClick.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
   }
   handleClick() {
     if (!this.props.canEdit) {
@@ -58,6 +59,13 @@ class EditableTitle extends React.PureComponent {
       title: ev.target.value,
     });
   }
+  handleKeyPress(ev) {
+    if (ev.key === 'Enter') {
+      ev.preventDefault();
+
+      this.handleBlur();
+    }
+  }
   render() {
     return (
       <span className="editable-title">
@@ -72,6 +80,7 @@ class EditableTitle extends React.PureComponent {
             onChange={this.handleChange}
             onBlur={this.handleBlur}
             onClick={this.handleClick}
+            onKeyPress={this.handleKeyPress}
           />
         </TooltipWrapper>
       </span>


### PR DESCRIPTION
In dashboard, and explore view, we allow user inline editing dashboard or slice title.
This PR is to support Enter key.  now we allow user to type enter key, then title change is automatically saved, just like click somewhere else (blur text input).