### PR TITLE
[Celery] fix the celery worker concurrency settings

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -192,7 +192,7 @@ def worker(workers):
         celery_app.conf.update(CELERYD_CONCURRENCY=workers)
     elif config.get("SUPERSET_CELERY_WORKERS"):
         celery_app.conf.update(
-            worker_concurrency=config.get("SUPERSET_CELERY_WORKERS"))
+            CELERYD_CONCURRENCY=config.get("SUPERSET_CELERY_WORKERS"))
 
     worker = celery_worker.worker(app=celery_app)
     worker.run()


### PR DESCRIPTION
From the [celery documentation](http://docs.celeryproject.org/en/latest/userguide/configuration.html), lower case settings and setting organization were introduced since version 4.0. Superset is still using version 3.x. So we can use upper case settings or upgrade celery to 4.x version.