### PR TITLE
[bug-fix] #3137 Use state.datasource.type instead of state.datasource_type when rendering ControlPanelsContainer

### DIFF
--- a/superset/assets/javascripts/explore/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ChartContainer.jsx
@@ -341,7 +341,7 @@ function mapStateToProps(state) {
     table_name: formData.datasource_name,
     viz_type: formData.viz_type,
     triggerRender: state.triggerRender,
-    datasourceType: state.datasource_type,
+    datasourceType: state.datasource.type,
     datasourceId: state.datasource_id,
   };
 }

--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -187,7 +187,7 @@ function mapStateToProps(state) {
   const form_data = getFormDataFromControls(state.controls);
   return {
     chartStatus: state.chartStatus,
-    datasource_type: state.datasource_type,
+    datasource_type: state.datasource.type,
     controls: state.controls,
     form_data,
     standalone: state.standalone,


### PR DESCRIPTION
fix to #3137 