### PR TITLE
[druid] Allow custom druid postaggregators

### DIFF
--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -319,6 +319,12 @@ class DruidTests(SupersetTestCase):
         assert pv is not None
 
     def test_metrics_and_post_aggs(self):
+        """
+        Test generation of metrics and post-aggregations from an initial list
+        of superset metrics (which may include the results of either). This
+        primarily tests that specifying a post-aggregator metric will also
+        require the raw aggregation of the associated druid metric column.
+        """
         metrics_dict = {
             'unused_count': DruidMetric(
                 metric_name='unused_count',
@@ -363,14 +369,14 @@ class DruidTests(SupersetTestCase):
 
         metrics = ['some_sum']
         all_metrics, post_aggs = DruidDatasource._metrics_and_post_aggs(
-                metrics, metrics_dict)
+            metrics, metrics_dict)
 
         assert all_metrics == ['some_sum']
         assert post_aggs == {}
 
         metrics = ['quantile_p95']
         all_metrics, post_aggs = DruidDatasource._metrics_and_post_aggs(
-                metrics, metrics_dict)
+            metrics, metrics_dict)
 
         result_postaggs = set(['quantile_p95'])
         assert all_metrics == ['a_histogram']
@@ -378,7 +384,7 @@ class DruidTests(SupersetTestCase):
 
         metrics = ['aCustomPostAgg']
         all_metrics, post_aggs = DruidDatasource._metrics_and_post_aggs(
-                metrics, metrics_dict)
+            metrics, metrics_dict)
 
         result_postaggs = set(['aCustomPostAgg'])
         assert all_metrics == ['aCustomMetric']

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -11,8 +11,8 @@ import unittest
 from mock import Mock, patch
 
 from superset import db, sm, security
-from superset.connectors.druid.models import DruidCluster, DruidDatasource
-from superset.connectors.druid.models import PyDruid
+from superset.connectors.druid.models import DruidMetric, DruidCluster, DruidDatasource
+from superset.connectors.druid.models import PyDruid, Quantile, Postaggregator
 
 from .base_tests import SupersetTestCase
 
@@ -38,7 +38,7 @@ SEGMENT_METADATA = [{
     "metric1": {
         "type": "longSum",
         "name": "metric1",
-        "fieldName": "metric1"}
+        "fieldName": "metric1"},
   },
   "size": 300000,
   "numRows": 5000000
@@ -318,6 +318,71 @@ class DruidTests(SupersetTestCase):
             permission=permission, view_menu=view_menu).first()
         assert pv is not None
 
+    def test_metrics_and_post_aggs(self):
+        metrics_dict = {
+            'unused_count': DruidMetric(
+                metric_name='unused_count',
+                verbose_name='COUNT(*)',
+                metric_type='count',
+                json=json.dumps({'type': 'count', 'name': 'unused_count'})),
+            'some_sum': DruidMetric(
+                metric_name='some_sum',
+                verbose_name='SUM(*)',
+                metric_type='sum',
+                json=json.dumps({'type': 'sum', 'name': 'sum'})),
+            'a_histogram': DruidMetric(
+                metric_name='a_histogram',
+                verbose_name='APPROXIMATE_HISTOGRAM(*)',
+                metric_type='approxHistogramFold',
+                json=json.dumps({'type': 'approxHistogramFold', 'name': 'a_histogram'})),
+            'aCustomMetric': DruidMetric(
+                metric_name='aCustomMetric',
+                verbose_name='MY_AWESOME_METRIC(*)',
+                metric_type='aCustomType',
+                json=json.dumps({'type': 'customMetric', 'name': 'aCustomMetric'})),
+            'quantile_p95': DruidMetric(
+                metric_name='quantile_p95',
+                verbose_name='P95(*)',
+                metric_type='postagg',
+                json=json.dumps({
+                    'type': 'quantile',
+                    'probability': 0.95,
+                    'name': 'p95',
+                    'fieldName': 'a_histogram'})),
+            'aCustomPostAgg': DruidMetric(
+                metric_name='aCustomPostAgg',
+                verbose_name='CUSTOM_POST_AGG(*)',
+                metric_type='postagg',
+                json=json.dumps({
+                    'type': 'customPostAgg',
+                    'name': 'aCustomPostAgg',
+                    'field': {
+                        'type': 'fieldAccess',
+                        'fieldName': 'aCustomMetric'}})),
+        }
+
+        metrics = ['some_sum']
+        all_metrics, post_aggs = DruidDatasource._metrics_and_post_aggs(
+                metrics, metrics_dict)
+
+        assert all_metrics == ['some_sum']
+        assert post_aggs == {}
+
+        metrics = ['quantile_p95']
+        all_metrics, post_aggs = DruidDatasource._metrics_and_post_aggs(
+                metrics, metrics_dict)
+
+        result_postaggs = set(['quantile_p95'])
+        assert all_metrics == ['a_histogram']
+        assert set(post_aggs.keys()) == result_postaggs
+
+        metrics = ['aCustomPostAgg']
+        all_metrics, post_aggs = DruidDatasource._metrics_and_post_aggs(
+                metrics, metrics_dict)
+
+        result_postaggs = set(['aCustomPostAgg'])
+        assert all_metrics == ['aCustomMetric']
+        assert set(post_aggs.keys()) == result_postaggs
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix the postaggregation for approxHistogram quantiles so it adds
the dependent field and that can show up in the graphs/tables.

In general, postAggregators add significant power, in developing custom
postAggregators, I've run into barriers integrating with Superset. Plywood
and other Druid query planners typically have escape hatches to specify
custom postAggregators without requiring a custom type definition for each
one.

This commit adds a similar capability for Superset and a additional
field/fields/fieldName breakdown of the typical naming for dependent
aggregations, which should make it significantly easier to develop
approxHistogram and custom postAggregation-required dashboards.

This should be able to supercede:
https://github.com/apache/incubator-superset/pull/2345
since it is strictly more general.

This should at least pull in the right dependent metrics and allow some custom aggregations and quantile/histogram links. @mistercrunch 