### PR TITLE
Fix the segment interval for pulling metadata

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -492,7 +492,7 @@ class DruidDatasource(Model, BaseDatasource):
             lbound = datetime(1901, 1, 1).isoformat()[:10]
             rbound = datetime(2050, 1, 1).isoformat()[:10]
             if not self.version_higher(self.cluster.druid_version, '0.8.2'):
-                rbound = datetime.now().isoformat()[:10]
+                rbound = datetime.now().isoformat()
             try:
                 segment_metadata = client.segment_metadata(
                     datasource=self.datasource_name,


### PR DESCRIPTION
Hi all,

When refreshing the Druid metadata. The end of the interval was truncated on today's date, e.g. `1901-01-01/2017-07-25`, which means that you will exclude today according to ISO-8601. If, in our case, the realtime ingestion job runs shorter than a day, the metadata cannot be pulled from the druid cluster because today's segments will be excluded. This will change `1901-01-01/2017-07-25` into `1901-01-01/2017-07-24T15:00:23.742353` so we also include segments from today-midnight till now.

This will fix #2350 and might fix #1816 and #2273, but the latter issues do not expose too much information about the actual underlying problem.

Cheers, Fokko