### PR TITLE
[bugfix] fix bar order

### DIFF
--- a/superset/assets/javascripts/modules/utils.js
+++ b/superset/assets/javascripts/modules/utils.js
@@ -229,14 +229,10 @@ export function initJQueryAjax() {
 }
 
 export function tryNumify(s) {
-  // Attempts casting to float, returns string when failing
-  try {
-    const parsed = parseFloat(s);
-    if (parsed) {
-      return parsed;
-    }
-  } catch (e) {
-    // pass
+  // Attempts casting to Number, returns string when failing
+  const n = Number(s);
+  if (isNaN(n)) {
+    return s;
   }
-  return s;
+  return n;
 }


### PR DESCRIPTION
Somehow `parseFloat('2016.Q4')` returns `2016` in javascript, this fixes these edge cases.