### PR TITLE
Escaping the user's SQL in the explore view

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -74,6 +74,11 @@ class BaseEngineSpec(object):
         return {}
 
     @classmethod
+    def escape_sql(cls, sql):
+        """Escapes the raw SQL"""
+        return sql
+
+    @classmethod
     def convert_dttm(cls, target_type, dttm):
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
@@ -138,14 +143,6 @@ class BaseEngineSpec(object):
         the database component of the URL, that can be handled here.
         """
         return uri
-
-    @classmethod
-    def sql_preprocessor(cls, sql):
-        """If the SQL needs to be altered prior to running it
-
-        For example Presto needs to double `%` characters
-        """
-        return sql
 
     @classmethod
     def patch(cls):
@@ -398,6 +395,10 @@ class PrestoEngineSpec(BaseEngineSpec):
                 database += '/' + selected_schema
             uri.database = database
         return uri
+
+    @classmethod
+    def escape_sql(cls, sql):
+        return sql.replace('%', '%%')
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -398,7 +398,7 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     def escape_sql(cls, sql):
-        return sql.replace('%', '%%')
+        return re.sub(r'%%|%', "%%", sql)
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -154,7 +154,6 @@ def execute_sql(ctask, query_id, return_results=True, store_results=False):
         template_processor = get_template_processor(
             database=database, query=query)
         executed_sql = template_processor.process_template(executed_sql)
-        executed_sql = db_engine_spec.sql_preprocessor(executed_sql)
     except Exception as e:
         logging.exception(e)
         msg = "Template rendering failed: " + utils.error_msg_from_exception(e)


### PR DESCRIPTION
When executing SQL from SQL Lab, we use a lower level API to the
database which doesn't require escaping the SQL. When going through
the explore view, the stack chain leading to the same method may need
escaping depending on how the DBAPI driver is written, and that is the
case for Presto (and perhaps other drivers).