### PR TITLE
[sqllab/cosmetics] add margin-top for labels in query history

### DIFF
--- a/superset/assets/javascripts/SqlLab/main.css
+++ b/superset/assets/javascripts/SqlLab/main.css
@@ -265,7 +265,7 @@ div.tablePopover:hover {
 }
 
 .QueryTable .label {
-    margin-top: 5px;
+    display: inline-block;
 }
 
 .ResultsModal .modal-body {


### PR DESCRIPTION
Before/after
<img width="345" alt="screen shot 2017-08-01 at 9 16 24 am" src="https://user-images.githubusercontent.com/487433/28835433-272f9b78-769a-11e7-8e97-e9d0ded413d8.png">
<img width="361" alt="screen shot 2017-08-01 at 9 15 40 am" src="https://user-images.githubusercontent.com/487433/28835431-2728dd38-769a-11e7-9ada-2c72c0e590f4.png">

