### PR TITLE
Flask as dependancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'celery==3.1.25',
         'colorama==0.3.9',
         'cryptography==1.9',
+        'flask==0.12.2',
         'flask-appbuilder==1.9.1',
         'flask-cache==0.13.1',
         'flask-migrate==2.0.3',


### PR DESCRIPTION
Hi guys,

I'm building a Docker image that will compile and install the Superset from the master branch. Because I'm building from a clean Ubuntu base, I get an error of a missing dependancy:
```
creating /usr/local/lib/python2.7/dist-packages/WTForms-2.1-py2.7.egg
Extracting WTForms-2.1-py2.7.egg to /usr/local/lib/python2.7/dist-packages
Adding WTForms 2.1 to easy-install.pth file

Installed /usr/local/lib/python2.7/dist-packages/WTForms-2.1-py2.7.egg
Searching for Flask
Downloading https://pypi.python.org/packages/ba/15/00a9693180f214225a2c0b1bb9077f3b0b21f2e86522cbba22e8ad6e570c/Flask-WTF-0.14.2.tar.gz#md5=586f50f233926cade42e3d744aca3e8f
Best match: Flask WTF-0.14.2
Processing Flask-WTF-0.14.2.tar.gz
Writing /tmp/easy_install-jIL1Fb/Flask-WTF-0.14.2/setup.cfg
Running Flask-WTF-0.14.2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-jIL1Fb/Flask-WTF-0.14.2/egg-dist-tmp-lNE55d
warning: no previously-included files matching '*.pyc' found under directory 'tests'
warning: no previously-included files matching '*.pyo' found under directory 'tests'
no previously-included directories found matching 'docs/_build'
warning: no previously-included files found matching 'docs/_themes/.git*'
warning: no previously-included files matching '*.pyc' found under directory 'docs'
warning: no previously-included files matching '*.pyo' found under directory 'docs'
removing '/usr/local/lib/python2.7/dist-packages/Flask_WTF-0.14.2-py2.7.egg' (and everything under it)
creating /usr/local/lib/python2.7/dist-packages/Flask_WTF-0.14.2-py2.7.egg
Extracting Flask_WTF-0.14.2-py2.7.egg to /usr/local/lib/python2.7/dist-packages
Flask-WTF 0.14.2 is already the active version in easy-install.pth

Installed /usr/local/lib/python2.7/dist-packages/Flask_WTF-0.14.2-py2.7.egg
error: The 'Flask' distribution was not found and is required by flask-wtf, flask-testing, flask-script, flask-cache
The command '/bin/sh -c apt-get update && apt-get install -y $BUILD_DEPS $RUNTIME_DEPS && pip install --upgrade setuptools pip && npm install -g npm@'>=5.0.3' && git clone https://github.com/apache/incubator-superset.git $SUPERSET_HOME && cd $SUPERSET_HOME/superset/assets && npm install && npm run build && cd $SUPERSET_HOME && python setup.py install && apt-get remove -y $BUILD_DEPS && apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf ~/.npm/' returned a non-zero code: 1
```
By adding Flask explicitly, I'm able to [build the image](https://github.com/Fokko/docker-superset/blob/master/Dockerfile) successfully.

Cheers, Fokko