### PR TITLE
Pre fill Druid ports

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -69,11 +69,11 @@ class DruidCluster(Model, AuditMixinNullable):
     # short unique name, used in permissions
     cluster_name = Column(String(250), unique=True)
     coordinator_host = Column(String(255))
-    coordinator_port = Column(Integer)
+    coordinator_port = Column(Integer, default=8081)
     coordinator_endpoint = Column(
         String(255), default='druid/coordinator/v1/metadata')
     broker_host = Column(String(255))
-    broker_port = Column(Integer)
+    broker_port = Column(Integer, default=8082)
     broker_endpoint = Column(String(255), default='druid/v2')
     metadata_last_refreshed = Column(DateTime)
     cache_timeout = Column(Integer)


### PR DESCRIPTION
Hi all,

For Druid set the default port for the broker and coordinator:
![image](https://user-images.githubusercontent.com/1134248/29136216-e0263378-7d3c-11e7-9bff-6e3ffc500ee2.png)

These are the default ports of Druid:
http://druid.io/docs/latest/configuration/broker.html
http://druid.io/docs/latest/configuration/coordinator.html

This makes it easier to add a Druid source. In all the example configuration files this port is set to the default port, therefore it might be easier to pre fill this. 

Cheers, Fokko
