### PR TITLE
Use sane Celery defaults to prevent tasks from being delayed

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -194,7 +194,7 @@ def worker(workers):
         celery_app.conf.update(
             CELERYD_CONCURRENCY=config.get("SUPERSET_CELERY_WORKERS"))
 
-    worker = celery_worker.worker(app=celery_app)
+    worker = celery_app.Worker(optimization='fair')
     worker.run()
 
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -245,6 +245,8 @@ class CeleryConfig(object):
   CELERY_RESULT_BACKEND = 'db+sqlite:///celery_results.sqlite'
   CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
   CELERYD_LOG_LEVEL = 'DEBUG'
+  CELERYD_PREFETCH_MULTIPLIER = 1
+  CELERY_ACKS_LATE = True
 CELERY_CONFIG = CeleryConfig
 """
 CELERY_CONFIG = None


### PR DESCRIPTION
@mistercrunch 

Using these three settings (of which two are provided in the config to show it's recommended), will make Celery scheduling "fair", which reduces latency which is what is wanted when we have long running tasks (note that the defaults prioritize throughput in the case with high volumes of short-running tasks)

Still need to test this