### PR TITLE
[bugfix] preserve order in groupby

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -112,10 +112,13 @@ class BaseViz(object):
     def query_obj(self):
         """Building a query object"""
         form_data = self.form_data
-        groupby = form_data.get("groupby") or []
+        gb = form_data.get("groupby") or []
         metrics = form_data.get("metrics") or []
         columns = form_data.get("columns") or []
-        groupby = list(set(groupby + columns))
+        groupby = []
+        for o in gb + columns:
+            if o not in groupby:
+                groupby.append(o)
 
         is_timeseries = self.is_timeseries
         if DTTM_ALIAS in groupby:


### PR DESCRIPTION
Recently in
https://github.com/apache/incubator-superset/commit/4c3313b01cb508ced8519a68f6479db423974929
I introduced an issue where the order of groupby fields might change.

This addresses this issue and will preserve ordering.