### PR TITLE
display the verbose_name of columns in list view, just like in the me…

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -35,7 +35,7 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
         'groupby', 'filterable', 'count_distinct', 'sum', 'min', 'max']
     add_columns = edit_columns
     list_columns = [
-        'column_name', 'type', 'groupby', 'filterable', 'count_distinct',
+        'column_name', 'verbose_name', 'type', 'groupby', 'filterable', 'count_distinct',
         'sum', 'min', 'max']
     can_delete = False
     page_size = 500

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -39,7 +39,7 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
         'is_dttm', 'python_date_format', 'database_expression']
     add_columns = edit_columns
     list_columns = [
-        'column_name', 'type', 'groupby', 'filterable', 'count_distinct',
+        'column_name', 'verbose_name', 'type', 'groupby', 'filterable', 'count_distinct',
         'sum', 'min', 'max', 'is_dttm']
     page_size = 500
     description_columns = {


### PR DESCRIPTION
Display the verbose_name of columns in list view, just like in the metrics list.
It's meaningful to distinguish the columns in the list view.