### PR TITLE
[bugfix] errors don't bubble up in explore view

### DIFF
--- a/superset/assets/javascripts/explore/components/ChartContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ChartContainer.jsx
@@ -325,7 +325,7 @@ ChartContainer.propTypes = propTypes;
 function mapStateToProps({ explore, chart }) {
   const formData = getFormDataFromControls(explore.controls);
   return {
-    alert: explore.chartAlert,
+    alert: chart.chartAlert,
     can_overwrite: explore.can_overwrite,
     can_download: explore.can_download,
     datasource: explore.datasource,


### PR DESCRIPTION
Looks like bug was introduced in
https://github.com/apache/incubator-superset/pull/3088
@graceguo-supercat 