### PR TITLE
[sql lab] fix sluggish backspace in editor

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/AceEditorWrapper.jsx
+++ b/superset/assets/javascripts/SqlLab/components/AceEditorWrapper.jsx
@@ -45,6 +45,7 @@ class AceEditorWrapper extends React.PureComponent {
     super(props);
     this.state = {
       sql: props.sql,
+      selectedText: '',
     };
   }
   componentDidMount() {
@@ -77,8 +78,13 @@ class AceEditorWrapper extends React.PureComponent {
     });
     editor.$blockScrolling = Infinity; // eslint-disable-line no-param-reassign
     editor.selection.on('changeSelection', () => {
-      this.props.actions.queryEditorSetSelectedText(
-        this.props.queryEditor, editor.getSelectedText());
+      const selectedText = editor.getSelectedText();
+      // Backspace trigger 1 character selection, ignoring
+      if (selectedText !== this.state.selectedText && selectedText.length !== 1) {
+        this.setState({ selectedText });
+        this.props.actions.queryEditorSetSelectedText(
+          this.props.queryEditor, selectedText);
+      }
     });
   }
   getCompletions(aceEditor, session, pos, prefix, callback) {


### PR DESCRIPTION
Somehow Ace's "changeSelection" event is triggered when hitting
backspace (and shouldn't!).

changeSelection on our side triggers enough work to make the
holding backspace sluggish and laggy.

This fix ignores selection with a length of 1, avoiding mutating the
state altogether when hitting/holding backspace.