### PR TITLE
Fix raise error when query datasource

### DIFF
--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import subqueryload
+from sqlalchemy.orm.exc import NoResultFound
 
 
 class ConnectorRegistry(object):
@@ -17,11 +18,15 @@ class ConnectorRegistry(object):
 
     @classmethod
     def get_datasource(cls, datasource_type, datasource_id, session):
-        return (
-            session.query(cls.sources[datasource_type])
-            .filter_by(id=datasource_id)
-            .first()
-        )
+        try:
+            datasource = (
+                session.query(cls.sources[datasource_type])
+                .filter_by(id=datasource_id)
+                .first()
+            )
+        except NoResultFound:
+            datasource = None
+        return datasource
 
     @classmethod
     def get_all_datasources(cls, session):

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -1,5 +1,4 @@
 from sqlalchemy.orm import subqueryload
-from sqlalchemy.orm.exc import NoResultFound
 
 
 class ConnectorRegistry(object):

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -18,15 +18,11 @@ class ConnectorRegistry(object):
 
     @classmethod
     def get_datasource(cls, datasource_type, datasource_id, session):
-        try:
-            datasource = (
-                session.query(cls.sources[datasource_type])
-                .filter_by(id=datasource_id)
-                .first()
-            )
-        except NoResultFound:
-            datasource = None
-        return datasource
+        return (
+            session.query(cls.sources[datasource_type])
+            .filter_by(id=datasource_id)
+            .first()
+        )
 
     @classmethod
     def get_all_datasources(cls, session):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1991,7 +1991,7 @@ class Superset(BaseSupersetView):
         schema = request.form.get('schema') or None
 
         session = db.session()
-        mydb = session.query(models.Database).filter_by(id=database_id).one()
+        mydb = session.query(models.Database).filter_by(id=database_id).first()
 
         if not mydb:
             json_error_response(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1039,12 +1039,8 @@ class Superset(BaseSupersetView):
             slc = db.session.query(models.Slice).filter_by(id=slice_id).first()
 
         error_redirect = '/slicemodelview/list/'
-        datasource = (
-            db.session.query(ConnectorRegistry.sources[datasource_type])
-            .filter_by(id=datasource_id)
-            .one()
-        )
-
+        datasource = ConnectorRegistry.get_datasource(
+            datasource_type, datasource_id, db.session)
         if not datasource:
             flash(DATASOURCE_MISSING_ERR, "danger")
             return redirect(error_redirect)
@@ -1119,13 +1115,8 @@ class Superset(BaseSupersetView):
         :return:
         """
         # TODO: Cache endpoint by user, datasource and column
-        datasource_class = ConnectorRegistry.sources[datasource_type]
-        datasource = (
-            db.session.query(datasource_class)
-            .filter_by(id=datasource_id)
-            .first()
-        )
-
+        datasource = ConnectorRegistry.get_datasource(
+            datasource_type, datasource_id, db.session)
         if not datasource:
             return json_error_response(DATASOURCE_MISSING_ERR)
         if not self.datasource_access(datasource):
@@ -2138,13 +2129,8 @@ class Superset(BaseSupersetView):
     def fetch_datasource_metadata(self):
         datasource_id, datasource_type = (
             request.args.get('datasourceKey').split('__'))
-        datasource_class = ConnectorRegistry.sources[datasource_type]
-        datasource = (
-            db.session.query(datasource_class)
-            .filter_by(id=int(datasource_id))
-            .first()
-        )
-
+        datasource = ConnectorRegistry.get_datasource(
+            datasource_type, datasource_id, db.session)
         # Check if datasource exists
         if not datasource:
             return json_error_response(DATASOURCE_MISSING_ERR)


### PR DESCRIPTION
Optimize the code by changing the `db.session.query()...` method to call `get_datasource()`.
And fix the error in `line: 1056` and `line: 2003`, query using `one()`, which will raise ``sqlalchemy.orm.exc.NoResultFound`` if the query selects no rows.