### PR TITLE
Fix styles in Separator widget

### DIFF
--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -358,6 +358,7 @@ export const visTypes = {
       {
         label: null,
         controlSetRows: [
+          ['markup_type'],
           ['code'],
         ],
       },

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -449,10 +449,6 @@ class SeparatorViz(MarkupViz):
     viz_type = "separator"
     verbose_name = _("Separator")
 
-    def get_data(self, df):
-        code = markdown(self.form_data.get("code", ''))
-        return dict(html=code)
-
 
 class WordCloudViz(BaseViz):
 


### PR DESCRIPTION
Style wasn't working right for separator widget since the iframe sandboxing of
the markup widget. This addresses this small issue and also now allows
for html in the separator widget