### PR TITLE
Unnecessary to specify order_columns for DatasourceModelView

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -178,8 +178,6 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin):  # noqa
     list_widget = ListWidgetWithCheckboxes
     list_columns = [
         'datasource_link', 'cluster', 'changed_by_', 'modified']
-    order_columns = [
-        'datasource_link', 'changed_on_', 'offset']
     related_views = [DruidColumnInlineView, DruidMetricInlineView]
     edit_columns = [
         'datasource_name', 'cluster', 'slices', 'description', 'owner',

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -160,8 +160,6 @@ class TableModelView(DatasourceModelView, DeleteMixin):  # noqa
     list_columns = [
         'link', 'database',
         'changed_by_', 'modified']
-    order_columns = [
-        'link', 'database', 'changed_on_']
     add_columns = ['database', 'schema', 'table_name']
     edit_columns = [
         'table_name', 'sql', 'filter_select_enabled', 'slices',


### PR DESCRIPTION
`changed_on_` and `offset` are not included in the `list_columns` of  DruidDatasourceModelView.
And `changed_on_` is not included in the `list_columns` of TableModelView.

The default value of `order_columns` is get from`list_columns`.