### PR TITLE
Updated installation documentation to include MySql devlopment libraries

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,13 +25,15 @@ Here's how to install them:
 For **Debian** and **Ubuntu**, the following command will ensure that
 the required dependencies are installed: ::
 
-    sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip libsasl2-dev libldap2-dev libmysqlclient-dev
+    sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip libsasl2-dev libldap2-dev
+    sudo apt-get install libmysqlclient-dev
 
 For **Fedora** and **RHEL-derivatives**, the following command will ensure
 that the required dependencies are installed: ::
 
     sudo yum upgrade python-setuptools
-    sudo yum install gcc gcc-c++ libffi-devel python-devel python-pip python-wheel openssl-devel libsasl2-devel openldap-devel mysql-devel
+    sudo yum install gcc gcc-c++ libffi-devel python-devel python-pip python-wheel openssl-devel libsasl2-devel openldap-devel
+    sudo yum install mysql-devel
 
 **OSX**, system python is not recommended. brew's python also ships with pip  ::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,13 +25,13 @@ Here's how to install them:
 For **Debian** and **Ubuntu**, the following command will ensure that
 the required dependencies are installed: ::
 
-    sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip libsasl2-dev libldap2-dev
+    sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip libsasl2-dev libldap2-dev libmysqlclient-dev
 
 For **Fedora** and **RHEL-derivatives**, the following command will ensure
 that the required dependencies are installed: ::
 
     sudo yum upgrade python-setuptools
-    sudo yum install gcc gcc-c++ libffi-devel python-devel python-pip python-wheel openssl-devel libsasl2-devel openldap-devel
+    sudo yum install gcc gcc-c++ libffi-devel python-devel python-pip python-wheel openssl-devel libsasl2-devel openldap-devel mysql-devel
 
 **OSX**, system python is not recommended. brew's python also ships with pip  ::
 


### PR DESCRIPTION
In order to fix the following error we need to have mysql libraries installed. I have updated the documentation to include the mysql package.

```
(env) root@localhost:~/superset# pip install -r dev-reqs.txt
Collecting codeclimate-test-reporter (from -r dev-reqs.txt (line 1))
  Downloading codeclimate-test-reporter-0.2.3.tar.gz
Collecting coveralls (from -r dev-reqs.txt (line 2))
  Downloading coveralls-1.2.0-py2.py3-none-any.whl
Collecting flake8 (from -r dev-reqs.txt (line 3))
  Downloading flake8-3.4.1-py2.py3-none-any.whl (68kB)
    100% |████████████████████████████████| 71kB 7.5MB/s
Collecting flask_cors (from -r dev-reqs.txt (line 4))
  Downloading Flask_Cors-3.0.3-py2.py3-none-any.whl
Collecting mock (from -r dev-reqs.txt (line 5))
  Downloading mock-2.0.0-py2.py3-none-any.whl (56kB)
    100% |████████████████████████████████| 61kB 6.3MB/s
Collecting mysqlclient (from -r dev-reqs.txt (line 6))
  Downloading mysqlclient-1.3.10.tar.gz (82kB)
    100% |████████████████████████████████| 92kB 7.4MB/s
    Complete output from command python setup.py egg_info:
    sh: 1: mysql_config: not found
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ya2nJ5/mysqlclient/setup.py", line 17, in <module>
        metadata, options = get_config()
      File "setup_posix.py", line 44, in get_config
        libs = mysql_config("libs_r")
      File "setup_posix.py", line 26, in mysql_config
        raise EnvironmentError("%s not found" % (mysql_config.path,))
    EnvironmentError: mysql_config not found

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-ya2nJ5/mysqlclient/
```