### PR TITLE
[explore] add collapsible `Control` sections

### DIFF
--- a/superset/assets/javascripts/explore/components/ControlPanelSection.jsx
+++ b/superset/assets/javascripts/explore/components/ControlPanelSection.jsx
@@ -6,25 +6,38 @@ import InfoTooltipWithTrigger from '../../components/InfoTooltipWithTrigger';
 const propTypes = {
   label: PropTypes.string,
   description: PropTypes.string,
-  tooltip: PropTypes.string,
   children: PropTypes.node.isRequired,
+  startExpanded: PropTypes.bool,
 };
 
 const defaultProps = {
   label: null,
   description: null,
-  tooltip: null,
+  startExpanded: false,
 };
 
 export default class ControlPanelSection extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { expanded: this.props.startExpanded };
+  }
+  toggleExpand() {
+    this.setState({ expanded: !this.state.expanded });
+  }
   renderHeader() {
-    const { label, tooltip } = this.props;
+    const { label, description } = this.props;
     let header;
     if (label) {
       header = (
         <div>
-          {label} &nbsp;
-          {tooltip && <InfoTooltipWithTrigger label={label} tooltip={tooltip} />}
+          <i
+            className={`text-primary expander fa fa-caret-${this.state.expanded ? 'down' : 'right'}`}
+            onClick={this.toggleExpand.bind(this)}
+          />
+          {' '}
+          <span onClick={this.toggleExpand.bind(this)}>{label}</span>
+          {' '}
+          {description && <InfoTooltipWithTrigger label={label} tooltip={description} />}
         </div>
       );
     }
@@ -35,6 +48,8 @@ export default class ControlPanelSection extends React.Component {
     return (
       <Panel
         className="control-panel-section"
+        collapsible
+        expanded={this.state.expanded}
         header={this.renderHeader()}
       >
         {this.props.children}

--- a/superset/assets/javascripts/explore/components/ControlPanelsContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ControlPanelsContainer.jsx
@@ -67,11 +67,13 @@ class ControlPanelsContainer extends React.Component {
             <ControlPanelSection
               key={section.label}
               label={section.label}
-              tooltip={section.description}
+              startExpanded={section.expanded}
+              description={section.description}
             >
               {section.controlSetRows.map((controlSets, i) => (
                 <ControlRow
                   key={`controlsetrow-${i}`}
+                  className="control-row"
                   controls={controlSets.map(controlName => (
                     controlName &&
                     this.props.controls[controlName] &&

--- a/superset/assets/javascripts/explore/main.css
+++ b/superset/assets/javascripts/explore/main.css
@@ -73,3 +73,16 @@
   height: 10px;
   margin: 9px 1px;
 }
+.control-panel-section .panel-body {
+  margin-left: 15px;
+  padding-bottom: 0px;
+}
+.control-panel-section .control-label {
+  margin-bottom: 0px;
+}
+.fa.expander {
+  width: 15px;
+}
+.control-panel-section span.label {
+  display: inline-block;
+}

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -4,6 +4,7 @@ import * as v from '../validators';
 export const sections = {
   druidTimeSeries: {
     label: 'Time',
+    expanded: true,
     description: 'Time related form attributes',
     controlSetRows: [
       ['granularity', 'druid_time_origin'],
@@ -12,6 +13,7 @@ export const sections = {
   },
   datasourceAndVizType: {
     label: 'Datasource & Chart Type',
+    expanded: true,
     controlSetRows: [
       ['datasource'],
       ['viz_type'],
@@ -27,6 +29,7 @@ export const sections = {
   sqlaTimeSeries: {
     label: 'Time',
     description: 'Time related form attributes',
+    expanded: true,
     controlSetRows: [
       ['granularity_sqla', 'time_grain_sqla'],
       ['since', 'until'],
@@ -42,7 +45,8 @@ export const sections = {
   },
   NVD3TimeSeries: [
     {
-      label: null,
+      label: 'Query',
+      expanded: true,
       controlSetRows: [
         ['metrics'],
         ['groupby'],
@@ -66,14 +70,12 @@ export const sections = {
   filters: [
     {
       label: 'Filters',
-      description: 'Filters are defined using comma delimited strings as in <US,FR,Other>' +
-      'Leave the value control empty to filter empty strings or nulls' +
-      'For filters with comma in values, wrap them in single quotes' +
-      "as in <NY, 'Tahoe, CA', DC>",
+      expanded: true,
       controlSetRows: [['filters']],
     },
     {
       label: 'Result Filters',
+      expanded: true,
       description: 'The filters to apply after post-aggregation.' +
       'Leave the value control empty to filter empty strings or nulls',
       controlSetRows: [['having_filters']],
@@ -119,10 +121,16 @@ export const visTypes = {
     showOnExplore: true,
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['metrics', 'groupby'],
           ['limit'],
+        ],
+      },
+      {
+        label: 'Chart Options',
+        controlSetRows: [
           ['pie_label_type'],
           ['donut', 'show_legend'],
           ['labels_outside'],
@@ -347,7 +355,7 @@ export const visTypes = {
     label: 'Markup',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Code',
         controlSetRows: [
           ['markup_type'],
           ['code'],
@@ -360,12 +368,18 @@ export const visTypes = {
     label: 'Pivot Table',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['groupby', 'columns'],
-          ['metrics', 'pandas_aggfunc'],
+          ['metrics'],
+        ],
+      },
+      {
+        label: 'Pivot Options',
+        controlSetRows: [
+          ['pandas_aggfunc', 'pivot_margins'],
           ['number_format', 'combine_metric'],
-          ['pivot_margins'],
         ],
       },
     ],
@@ -379,7 +393,7 @@ export const visTypes = {
     label: 'Separator',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Code',
         controlSetRows: [
           ['markup_type'],
           ['code'],
@@ -401,9 +415,15 @@ export const visTypes = {
     label: 'Word Cloud',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['series', 'metric', 'limit'],
+        ],
+      },
+      {
+        label: 'Options',
+        controlSetRows: [
           ['size_from', 'size_to'],
           ['rotation'],
           ['color_scheme'],
@@ -416,7 +436,8 @@ export const visTypes = {
     label: 'Treemap',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['metrics'],
           ['groupby'],
@@ -443,9 +464,15 @@ export const visTypes = {
     requiresTime: true,
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['metric'],
+        ],
+      },
+      {
+        label: 'Options',
+        controlSetRows: [
           ['domain_granularity'],
           ['subdomain_granularity'],
         ],
@@ -457,7 +484,8 @@ export const visTypes = {
     label: 'Box Plot',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['metrics'],
           ['groupby', 'limit'],
@@ -477,7 +505,8 @@ export const visTypes = {
     label: 'Bubble Chart',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['series', 'entity'],
           ['size', 'limit'],
@@ -528,7 +557,14 @@ export const visTypes = {
     requiresTime: false,
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
+        controlSetRows: [
+          ['metric'],
+        ],
+      },
+      {
+        label: 'Chart Options',
         controlSetRows: [
           ['metric'],
           ['ranges', 'range_labels'],
@@ -543,9 +579,15 @@ export const visTypes = {
     label: 'Big Number with Trendline',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['metric'],
+        ],
+      },
+      {
+        label: 'Chart Options',
+        controlSetRows: [
           ['compare_lag', 'compare_suffix'],
           ['y_axis_format', null],
         ],
@@ -562,9 +604,15 @@ export const visTypes = {
     label: 'Big Number',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['metric'],
+        ],
+      },
+      {
+        label: 'Chart Options',
+        controlSetRows: [
           ['subheader'],
           ['y_axis_format'],
         ],
@@ -581,14 +629,15 @@ export const visTypes = {
     label: 'Histogram',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['all_columns_x'],
           ['row_limit'],
         ],
       },
       {
-        label: 'Histogram Options',
+        label: 'Chart Options',
         controlSetRows: [
           ['color_scheme'],
           ['link_length'],
@@ -612,11 +661,17 @@ export const visTypes = {
     label: 'Sunburst',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['groupby'],
           ['metric', 'secondary_metric'],
           ['row_limit'],
+        ],
+      },
+      {
+        label: 'Chart Options',
+        controlSetRows: [
           ['color_scheme'],
         ],
       },
@@ -643,11 +698,17 @@ export const visTypes = {
     label: 'Sankey',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['groupby'],
           ['metric'],
           ['row_limit'],
+        ],
+      },
+      {
+        label: 'Chart Options',
+        controlSetRows: [
           ['color_scheme'],
         ],
       },
@@ -664,7 +725,8 @@ export const visTypes = {
     label: 'Directed Force Layout',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['groupby'],
           ['metric'],
@@ -672,7 +734,7 @@ export const visTypes = {
         ],
       },
       {
-        label: 'Force Layout',
+        label: 'Options',
         controlSetRows: [
           ['link_length'],
           ['charge'],
@@ -690,11 +752,17 @@ export const visTypes = {
     label: 'Chord Diagram',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['groupby', 'columns'],
-          ['metric'],
-          ['row_limit', 'y_axis_format'],
+          ['metric', 'row_limit'],
+        ],
+      },
+      {
+        label: 'Chart Options',
+        controlSetRows: [
+          ['y_axis_format', null],
           ['color_scheme'],
         ],
       },
@@ -722,11 +790,17 @@ export const visTypes = {
     label: 'Country Map',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
-          ['select_country'],
           ['entity'],
           ['metric'],
+        ],
+      },
+      {
+        label: 'Options',
+        controlSetRows: [
+          ['select_country'],
           ['linear_color_scheme'],
         ],
       },
@@ -749,7 +823,8 @@ export const visTypes = {
     label: 'World Map',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['entity'],
           ['country_fieldtype'],
@@ -785,11 +860,17 @@ export const visTypes = {
     label: 'Filter Box',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
-          ['date_filter', 'instant_filtering'],
           ['groupby'],
           ['metric'],
+        ],
+      },
+      {
+        label: 'Options',
+        controlSetRows: [
+          ['date_filter', 'instant_filtering'],
         ],
       },
     ],
@@ -811,7 +892,7 @@ export const visTypes = {
     label: 'iFrame',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Options',
         controlSetRows: [
           ['url'],
         ],
@@ -823,12 +904,18 @@ export const visTypes = {
     label: 'Parallel Coordinates',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['series'],
           ['metrics'],
           ['secondary_metric'],
           ['limit'],
+        ],
+      },
+      {
+        label: 'Options',
+        controlSetRows: [
           ['show_datatable', 'include_series'],
         ],
       },
@@ -883,13 +970,13 @@ export const visTypes = {
     label: 'Mapbox',
     controlPanelSections: [
       {
-        label: null,
+        label: 'Query',
+        expanded: true,
         controlSetRows: [
           ['all_columns_x', 'all_columns_y'],
           ['clustering_radius'],
           ['row_limit'],
           ['groupby'],
-          ['render_while_dragging'],
         ],
       },
       {
@@ -909,6 +996,7 @@ export const visTypes = {
       {
         label: 'Visual Tweaks',
         controlSetRows: [
+          ['render_while_dragging'],
           ['mapbox_style'],
           ['global_opacity'],
           ['mapbox_color'],


### PR DESCRIPTION
<img width="1086" alt="screen shot 2017-08-21 at 6 19 05 pm" src="https://user-images.githubusercontent.com/487433/29544589-139f5d1e-869e-11e7-8cd4-033d6e4d080d.png">
The left panel of the explore view has become crowded and overwhelming
overtime. This PR adds functionality to collapse the control sections,
and sets most sections to be collapse by default as the explore view
opens up.

* "indent" panel body in control groups
* breakdown `Query` section for most viz
* bring filters to the top, under Query section
* collapse most sections by default
* removed confusing outdated description for Filter section