### PR TITLE
[webpack] add a 'npm run dev-fast' command that is much faster

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -11,6 +11,7 @@
     "test": "mocha --require ignore-styles --compilers js:babel-core/register --require spec/helpers/browser.js --recursive spec/**/*_spec.*",
     "cover": "babel-node node_modules/.bin/babel-istanbul cover _mocha -- --require spec/helpers/browser.js --recursive spec/**/*_spec.*",
     "dev": "NODE_ENV=dev webpack --watch --colors --progress --debug --output-pathinfo --devtool inline-source-map",
+    "dev-fast": "NODE_ENV=dev webpack --watch --colors --progress --debug --output-pathinfo --devtool eval-cheap-source-map",
     "prod": "NODE_ENV=production node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js -p --colors --progress",
     "build": "NODE_ENV=production webpack --colors --progress",
     "lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx .",


### PR DESCRIPTION
The tradeoff is that the sourcemap isn't as reliable, but good enough in most cases. I'm using this faster mode now and I'm thinking that if I need to do deeper debugging I'll fire up the old `npm run dev`

@graceguo-supercat you should try it out, it's so much faster!