### PR TITLE
Fix datatable scroll height when using search box or pagination controls

### DIFF
--- a/superset/assets/javascripts/modules/utils.js
+++ b/superset/assets/javascripts/modules/utils.js
@@ -123,7 +123,11 @@ export function toggleCheckbox(apiUrlPrefix, selector) {
  */
 export const fixDataTableBodyHeight = function ($tableDom, height) {
   const headHeight = $tableDom.find('.dataTables_scrollHead').height();
-  $tableDom.find('.dataTables_scrollBody').css('max-height', height - headHeight);
+  const filterHeight = $tableDom.find('.dataTables_filter').height() || 0;
+  const pageLengthHeight = $tableDom.find('.dataTables_length').height() || 0;
+  const paginationHeight = $tableDom.find('.dataTables_paginate').height() || 0;
+  const controlsHeight = (pageLengthHeight > filterHeight) ? pageLengthHeight : filterHeight;
+  $tableDom.find('.dataTables_scrollBody').css('max-height', height - headHeight - controlsHeight - paginationHeight);
 };
 
 export function d3format(format, number) {


### PR DESCRIPTION
Currently the table is getting clipped at the bottom when you add pagination controls or the search box:

![screen shot 2017-08-26 at 2 22 27 pm](https://user-images.githubusercontent.com/6452112/29737868-35b65e0a-8a6a-11e7-816b-8b525da285e7.png)

The fix is to subtract the height of these elements in `fixDataTableBodyHeight` function.