### PR TITLE
[hotfix] backward compatibility on date expressions

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -146,6 +146,13 @@ class BaseViz(object):
             form_data.get("since")
         )
 
+        # Backward compatibility hack
+        since_words = since.split(' ')
+        if (
+                len(since_words) == 2 and
+                since_words[1] in ['days', 'years', 'hours', 'day', 'year']):
+            since += ' ago'
+
         from_dttm = utils.parse_human_datetime(since)
 
         until = extra_filters.get('__to') or form_data.get("until", "now")


### PR DESCRIPTION
Previously all 'since' date expression evaluated in the future like
`30 days` would be reassigned to the past (now - `30 days`). It would
extend to fixed dates which is a bad thing and was removed.

Now we have reports and dashboards in the wild that use things like `30
days` and we'd like to not break those as we roll out the next version.

This fix should allow for that.