### PR TITLE
[line chart] add 'min_periods' control related to rolling windows

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -664,7 +664,7 @@ export const controls = {
       'you may want your "Min Period" to be 7, so that all data points ' +
       'shown are the total of 7 periods. This will hide the "ramp up" ' +
       'taking place over the first 7 periods'
-    )
+    ),
   },
 
   series: {

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -654,6 +654,19 @@ export const controls = {
     'relative to the time granularity selected',
   },
 
+  min_periods: {
+    type: 'TextControl',
+    label: 'Min Periods',
+    isInt: true,
+    description: (
+      'The minimum number of rolling periods required to show ' +
+      'a value. For instance if you do a cumulative sum on 7 days ' +
+      'you may want your "Min Period" to be 7, so that all data points ' +
+      'shown are the total of 7 periods. This will hide the "ramp up" ' +
+      'taking place over the first 7 periods'
+    )
+  },
+
   series: {
     type: 'SelectControl',
     label: 'Series',

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -59,11 +59,10 @@ export const sections = {
       'that allow for advanced analytical post processing ' +
       'of query results',
       controlSetRows: [
-        ['rolling_type', 'rolling_periods'],
-        ['time_compare'],
+        ['rolling_type', 'rolling_periods', 'min_periods'],
+        ['time_compare', null],
         ['num_period_compare', 'period_ratio_type'],
-        ['resample_how', 'resample_rule'],
-        ['resample_fillmethod'],
+        ['resample_how', 'resample_rule', 'resample_fillmethod'],
       ],
     },
   ],

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -886,18 +886,25 @@ class NVD3TimeSeriesViz(NVD3Viz):
             dft = df.T
             df = (dft / dft.sum()).T
 
-        rolling_periods = fd.get("rolling_periods")
         rolling_type = fd.get("rolling_type")
+        rolling_periods = int(fd.get("rolling_periods") or 0)
+        min_periods = int(fd.get("min_periods") or 0)
 
         if rolling_type in ('mean', 'std', 'sum') and rolling_periods:
+            kwargs = dict(
+                arg=df,
+                window=rolling_periods,
+                min_periods=min_periods)
             if rolling_type == 'mean':
-                df = pd.rolling_mean(df, int(rolling_periods), min_periods=0)
+                df = pd.rolling_mean(**kwargs)
             elif rolling_type == 'std':
-                df = pd.rolling_std(df, int(rolling_periods), min_periods=0)
+                df = pd.rolling_std(**kwargs)
             elif rolling_type == 'sum':
-                df = pd.rolling_sum(df, int(rolling_periods), min_periods=0)
+                df = pd.rolling_sum(**kwargs)
         elif rolling_type == 'cumsum':
             df = df.cumsum()
+        if min_periods:
+            df = df[min_periods:]
 
         num_period_compare = fd.get("num_period_compare")
         if num_period_compare:
@@ -911,7 +918,6 @@ class NVD3TimeSeriesViz(NVD3Viz):
                 df = df / df.shift(num_period_compare)
 
             df = df[num_period_compare:]
-
         return df
 
     def get_data(self, df):


### PR DESCRIPTION
This new control ties in directly with Pandas min_periods:
http://pandas.pydata.org/pandas-docs/version/0.17.0/generated/pandas.rolling_mean.html
<img width="446" alt="screen shot 2017-08-30 at 11 47 02 am" src="https://user-images.githubusercontent.com/487433/29889480-29aa9fce-8d79-11e7-92da-ed38eba859be.png">
