### PR TITLE
exploreview fixed could not parse date string None error

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -155,7 +155,7 @@ class BaseViz(object):
 
         from_dttm = utils.parse_human_datetime(since)
 
-        until = extra_filters.get('__to') or form_data.get("until", "now")
+        until = extra_filters.get('__to') or form_data.get("until") or "now"
         to_dttm = utils.parse_human_datetime(until)
         if from_dttm and to_dttm and from_dttm > to_dttm:
             raise Exception(_("From date cannot be larger than to date"))


### PR DESCRIPTION
I was using the explore screen to add a slice the other day. When I cleared all the controls in the timesection. 

![screenshot](https://user-images.githubusercontent.com/4454540/29892908-c2e78ce0-8de9-11e7-8499-864a7221b6f1.png)

I got parse error

error:"Couldn't parse date string [None]"

Further investigation revealed that until is not getting set.

Below is the python get function source code

`def get(self, key, default=None):   `
     `return self[key] if key in self else default`
     
