### PR TITLE
setup: Bump sqlalchemy-utils to 0.32.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'simplejson==3.10.0',
         'six==1.10.0',
         'sqlalchemy==1.1.9',
-        'sqlalchemy-utils==0.32.14',
+        'sqlalchemy-utils==0.32.16',
         'sqlparse==0.2.3',
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',


### PR DESCRIPTION
Now sqlalchemy-utils will make explicit that we are trying
decoding the secret with the wrong key instead of a generic
UnicodeDecodeError.

Fix #2600