### PR TITLE
Ensure text appears on buttons inside tables

### DIFF
--- a/superset/assets/stylesheets/less/cosmo/bootswatch.less
+++ b/superset/assets/stylesheets/less/cosmo/bootswatch.less
@@ -145,6 +145,10 @@ table,
     a {
       color: #fff;
     }
+
+    .btn-default {
+      color: @gray;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #3321 

The CSS for table .success > a was overriding the color for .btn-default. This is a straightforward fix for it.