### PR TITLE
[sql lab] fix encoding error in logging message

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from time import sleep
 from datetime import datetime
 import json
@@ -34,8 +36,8 @@ def dedup(l, suffix='__'):
     Always returns the same number of entries as provided, and always returns
     unique values.
 
-    >>> dedup(['foo', 'bar', 'bar', 'bar'])
-    ['foo', 'bar', 'bar__1', 'bar__2']
+    >>> print(','.join(dedup(['foo', 'bar', 'bar', 'bar'])))
+    foo,bar,bar__1,bar__2
     """
     new_l = []
     seen = {}

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 
 import sqlparse

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -26,6 +27,10 @@ class SupersetTestCase(unittest.TestCase):
         # quotes
         query = 'SELECT * FROM "tbname"'
         self.assertEquals({"tbname"}, self.extract_tables(query))
+
+        # unicode encoding
+        query = 'SELECT * FROM "tb_name" WHERE city = "Lübeck"'
+        self.assertEquals({"tb_name"}, self.extract_tables(query))
 
         # schema
         self.assertEquals(


### PR DESCRIPTION
In Sql Lab, user types in a query with unicode like this:

`SELECT * FROM "tb_name" WHERE city = "Lübeck"`

When sql_parse.py and sql_lab.py tried to log message like:
`logging.info("Parsing with sqlparse statement {}".format(self.sql))`
This cause exception thrown, and user got Internal Server Error from Sql Lab.