### PR TITLE
Adding hook for CSRF exempting flask views.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -157,6 +157,8 @@ of the parameters you can copy / paste in that configuration module: ::
 
     # Flask-WTF flag for CSRF
     WTF_CSRF_ENABLED = True
+    # Add endpoints that need to be exempt from CSRF protection
+    WTF_CSRF_EXEMPT_LIST = []
 
     # Set this API key to enable Mapbox visualizations
     MAPBOX_API_KEY = ''
@@ -171,6 +173,11 @@ Please make sure to change:
 
 * *SQLALCHEMY_DATABASE_URI*, by default it is stored at *~/.superset/superset.db*
 * *SECRET_KEY*, to a long random string
+
+In case you need to exempt endpoints from CSRF, e.g. you are running a custom
+auth postback endpoint, you can add them to *WTF_CSRF_EXEMPT_LIST*
+
+     WTF_CSRF_EXEMPT_LIST = ['']
 
 Database dependencies
 ---------------------

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -83,6 +83,9 @@ db = SQLA(app)
 
 if conf.get('WTF_CSRF_ENABLED'):
     csrf = CSRFProtect(app)
+    csrf_exempt_list = conf.get('WTF_CSRF_EXEMPT_LIST', [])
+    for ex in csrf_exempt_list:
+        csrf.exempt(ex)
 
 utils.pessimistic_connection_handling(db.engine)
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -66,6 +66,9 @@ QUERY_SEARCH_LIMIT = 1000
 # Flask-WTF flag for CSRF
 WTF_CSRF_ENABLED = True
 
+# Add endpoints that need to be exempt from CSRF protection
+WTF_CSRF_EXEMPT_LIST = []
+
 # Whether to run the web server in debug mode or not
 DEBUG = False
 FLASK_USE_RELOAD = True


### PR DESCRIPTION
This is useful if you have a postback authentication scheme (e.g. oauth) that is not supported by flask-appbulider.