### PR TITLE
Feature: Implementing incremental search for a column values 

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -179,7 +179,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
         """
         raise NotImplementedError()
 
-    def values_for_column(self, column_name, limit=10000):
+    def values_for_column(self, column_name, limit=10000, search_string=None):
         """Given a column, returns an iterable of distinct values
 
         This is used to populate the dropdown showing a list of

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from six import string_types
 
+import re
 import requests
 import sqlalchemy as sa
 from sqlalchemy import (
@@ -772,7 +773,8 @@ class DruidDatasource(Model, BaseDatasource):
 
     def values_for_column(self,
                           column_name,
-                          limit=10000):
+                          limit=10000,
+                          search_string=None):
         """Retrieve some values for the given column"""
         # TODO: Use Lexicographic TopNMetricSpec once supported by PyDruid
         if self.fetch_values_from:
@@ -790,10 +792,27 @@ class DruidDatasource(Model, BaseDatasource):
             threshold=limit,
         )
 
+        if search_string:
+            # Druid can't make the regex case-insensitive :(
+            pattern = ''.join([
+                '[{0}{1}]'.format(c.upper(), c.lower())
+                if c.isalpha() else re.escape(c)
+                for c in search_string])
+
+            filter_params = {
+                'type': 'regex',
+                'dimension': column_name,
+                'pattern': ".*{}.*".format(pattern),
+            }
+            qry['filter'] = Filter(**filter_params)
+
         client = self.cluster.get_pydruid_client()
         client.topn(**qry)
         df = client.export_pandas()
-        return [row[column_name] for row in df.to_records(index=False)]
+        if (df.values.any()):
+            return [row[column_name] for row in df.to_records(index=False)]
+        else:
+            return []
 
     def get_query_str(self, query_obj, phase=1, client=None):
         return self.run_query(client=client, phase=phase, **query_obj)
@@ -833,7 +852,9 @@ class DruidDatasource(Model, BaseDatasource):
 
         columns_dict = {c.column_name: c for c in self.columns}
 
-        all_metrics, post_aggs = self._metrics_and_post_aggs(metrics, metrics_dict)
+        all_metrics, post_aggs = self._metrics_and_post_aggs(
+            metrics,
+            metrics_dict)
 
         aggregations = OrderedDict()
         for m in self.metrics:
@@ -1109,6 +1130,7 @@ class DruidDatasource(Model, BaseDatasource):
             .filter_by(datasource_name=datasource_name)
             .all()
         )
+
 
 sa.event.listen(DruidDatasource, 'after_insert', set_perm)
 sa.event.listen(DruidDatasource, 'after_update', set_perm)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1106,14 +1106,17 @@ class Superset(BaseSupersetView):
     @api
     @has_access_api
     @expose("/filter/<datasource_type>/<datasource_id>/<column>/")
-    def filter(self, datasource_type, datasource_id, column):
+    @expose("/filter/<datasource_type>/<datasource_id>/<column>/<limit>/")
+    @expose("/filter/<datasource_type>/<datasource_id>/<column>/<limit>/<search_string>")
+    def filter(self, datasource_type, datasource_id, column, limit=10000, search_string=None):
         """
         Endpoint to retrieve values for specified column.
 
         :param datasource_type: Type of datasource e.g. table
         :param datasource_id: Datasource id
         :param column: Column name to retrieve values for
-        :return:
+        :param limit: Return at most these entries (default: 10000)
+        :return: search_string: Only return columns containing the search_string
         """
         # TODO: Cache endpoint by user, datasource and column
         datasource = ConnectorRegistry.get_datasource(
@@ -1124,7 +1127,9 @@ class Superset(BaseSupersetView):
             return json_error_response(DATASOURCE_ACCESS_ERR)
 
         payload = json.dumps(
-            datasource.values_for_column(column),
+            datasource.values_for_column(column_name=column,
+            limit=limit,
+            search_string=search_string),
             default=utils.json_int_dttm_ser)
         return json_success(payload)
 

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -183,7 +183,6 @@ class CoreTests(SupersetTestCase):
         assert slc.slice_name == new_slice_name
         db.session.delete(slc)
 
-
     def test_filter_endpoint(self):
         self.login(username='admin')
         slice_name = "Energy Sankey"
@@ -199,8 +198,28 @@ class CoreTests(SupersetTestCase):
             "datasource_id=1&datasource_type=table")
 
         # Changing name
-        resp = self.get_resp(url.format(tbl_id, slice_id))
-        assert len(resp) > 0
+        resp = json.loads(self.get_resp(url.format(tbl_id, slice_id)))
+        assert len(resp) > 1
+        assert 'Carbon Dioxide' in resp
+
+        # Limit to 3
+        url = (
+            "/superset/filter/table/{}/target/3?viz_type=sankey&groupby=source"
+            "&metric=sum__value&flt_col_0=source&flt_op_0=in&flt_eq_0=&"
+            "slice_id={}&datasource_name=energy_usage&"
+            "datasource_id=1&datasource_type=table")
+        resp = json.loads(self.get_resp(url.format(tbl_id, slice_id)))
+        assert len(resp) == 3
+
+        # With search_string = "carbon"
+        url = (
+            "/superset/filter/table/{}/target/100/carbon?"
+            "viz_type=sankey&groupby=source&"
+            "metric=sum__value&flt_col_0=source&flt_op_0=in&flt_eq_0=&"
+            "slice_id={}&datasource_name=energy_usage&"
+            "datasource_id=1&datasource_type=table")
+        resp = json.loads(self.get_resp(url.format(tbl_id, slice_id)))
+        assert len(resp) == 1
         assert 'Carbon Dioxide' in resp
 
     def test_slices(self):


### PR DESCRIPTION
This is the current fitler UI.
![currentfilter](https://user-images.githubusercontent.com/3138343/30230939-9ce9dc40-94b6-11e7-9820-2be7c44e72fb.png)
It will pre populate all possible values. Up to a threshold, that can not be changed. If you data source contains more distinct possible values for you filter it won't load those. 

This MR contains the backend for incremental search. I'm happy to make the necessary changes to the front end as well.

Example:
Searching for "me" on the "name" column of the "birth_names" datasource limited to five return values will return: 
![search_me](https://user-images.githubusercontent.com/3138343/30231085-3d0a4192-94b7-11e7-85a2-9b2ba291db62.png)
Searching for "mel" will return:
![search_mel](https://user-images.githubusercontent.com/3138343/30231089-3e88aad6-94b7-11e7-8432-936bb2644a6e.png)
The idea is that you make async calls to query for the possible filter values while the user is typing.



