### PR TITLE
Allowing to set the sort order during query with "group by"

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -364,7 +364,8 @@ class SqlaTable(Model, BaseDatasource):
             orderby=None,
             extras=None,
             columns=None,
-            form_data=None):
+            form_data=None,
+            order_desc=True):
         """Querying any sqla table from this common interface"""
         template_kwargs = {
             'from_dttm': from_dttm,
@@ -512,7 +513,8 @@ class SqlaTable(Model, BaseDatasource):
             qry = qry.where(and_(*where_clause_and))
         qry = qry.having(and_(*having_clause_and))
         if groupby:
-            qry = qry.order_by(desc(main_metric_expr))
+            direction = desc if order_desc else asc
+            qry = qry.order_by(direction(main_metric_expr))
         elif orderby:
             for col, ascending in orderby:
                 direction = asc if ascending else desc
@@ -539,7 +541,8 @@ class SqlaTable(Model, BaseDatasource):
             ob = inner_main_metric_expr
             if timeseries_limit_metric_expr is not None:
                 ob = timeseries_limit_metric_expr
-            subq = subq.order_by(desc(ob))
+            direction = desc if order_desc else asc
+            subq = subq.order_by(direction(ob))
             subq = subq.limit(timeseries_limit)
             on_clause = []
             for i, gb in enumerate(groupby):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -137,6 +137,9 @@ class BaseViz(object):
         row_limit = int(
             form_data.get("row_limit") or config.get("ROW_LIMIT"))
 
+        # default order direction
+        order_desc = form_data.get("order_desc", True)
+
         # __form and __to are special extra_filters that target time
         # boundaries. The rest of extra_filters are simple
         # [column_name in list_of_values]. `__` prefix is there to avoid
@@ -194,6 +197,7 @@ class BaseViz(object):
             'extras': extras,
             'timeseries_limit_metric': timeseries_limit_metric,
             'form_data': form_data,
+            'order_desc': order_desc
         }
         return d
 


### PR DESCRIPTION
If you run a "group by" query with a "series limit" you can specify the "sort by" metric but not the sort order. In the following example you can see that you get the top 5 names. There is currently no way to look at the bottom 5 names. (sort order is hard coded to desc).
![group_by](https://user-images.githubusercontent.com/3138343/30231539-6a735586-94b9-11e7-86fe-752a5a60ee5b.png)

This change includes the backend changes to add this functionality. I'm happy to help on the front end as well.
