### PR TITLE
[Sql Lab] Remember Sql Editor window size after user switch tabs

### DIFF
--- a/superset/assets/javascripts/SqlLab/actions.js
+++ b/superset/assets/javascripts/SqlLab/actions.js
@@ -20,6 +20,8 @@ export const QUERY_EDITOR_SET_TITLE = 'QUERY_EDITOR_SET_TITLE';
 export const QUERY_EDITOR_SET_AUTORUN = 'QUERY_EDITOR_SET_AUTORUN';
 export const QUERY_EDITOR_SET_SQL = 'QUERY_EDITOR_SET_SQL';
 export const QUERY_EDITOR_SET_SELECTED_TEXT = 'QUERY_EDITOR_SET_SELECTED_TEXT';
+export const QUERY_EDITOR_PERSIST_HEIGHT = 'QUERY_EDITOR_PERSIST_HEIGHT';
+
 export const SET_DATABASES = 'SET_DATABASES';
 export const SET_ACTIVE_QUERY_EDITOR = 'SET_ACTIVE_QUERY_EDITOR';
 export const SET_ACTIVE_SOUTHPANE_TAB = 'SET_ACTIVE_SOUTHPANE_TAB';
@@ -344,6 +346,10 @@ export function removeTable(table) {
 
 export function refreshQueries(alteredQueries) {
   return { type: REFRESH_QUERIES, alteredQueries };
+}
+
+export function persistEditorHeight(queryEditor, currentHeight) {
+  return { type: QUERY_EDITOR_PERSIST_HEIGHT, queryEditor, currentHeight };
 }
 
 export function popStoredQuery(urlId) {

--- a/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SqlEditor.jsx
@@ -67,6 +67,10 @@ class SqlEditor extends React.PureComponent {
       southPaneHeight: height - this.refs.ace.clientHeight,
       height,
     });
+
+    if (this.refs.ace.clientHeight) {
+      this.props.actions.persistEditorHeight(this.props.queryEditor, this.refs.ace.clientHeight);
+    }
   }
   setQueryEditorSql(sql) {
     this.props.actions.queryEditorSetSql(this.props.queryEditor, sql);
@@ -191,7 +195,7 @@ class SqlEditor extends React.PureComponent {
   }
   render() {
     const height = this.sqlEditorHeight();
-    const defaultNorthHeight = 200;
+    const defaultNorthHeight = this.props.queryEditor.height || 200;
     return (
       <div
         className="SqlEditor"

--- a/superset/assets/javascripts/SqlLab/reducers.js
+++ b/superset/assets/javascripts/SqlLab/reducers.js
@@ -216,6 +216,9 @@ export const sqlLabReducer = function (state, action) {
     [actions.QUERY_EDITOR_SET_AUTORUN]() {
       return alterInArr(state, 'queryEditors', action.queryEditor, { autorun: action.autorun });
     },
+    [actions.QUERY_EDITOR_PERSIST_HEIGHT]() {
+      return alterInArr(state, 'queryEditors', action.queryEditor, { height: action.currentHeight });
+    },
     [actions.ADD_ALERT]() {
       return addToArr(state, 'alerts', action.alert);
     },


### PR DESCRIPTION
I save Editor current height as a state attribute (Redux store "queryEditors"). And the whole redux store will be persisted into localStorage.