### PR TITLE
config: allow choosing separator character and encoding for csv writing

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -172,6 +172,11 @@ TABLE_NAMES_CACHE_CONFIG = {'CACHE_TYPE': 'null'}
 ENABLE_CORS = False
 CORS_OPTIONS = {}
 
+# CSV Options: key/value pairs that will be passed as argument to DataFrame.to_csv method
+# note: index option should not be overridden
+CSV_EXPORT = {
+    'encoding': 'utf-8',
+}
 
 # ---------------------------------------------------
 # List of viz_types not allowed in your environment

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2126,13 +2126,13 @@ class Superset(BaseSupersetView):
             columns = [c['name'] for c in obj['columns']]
             df = pd.DataFrame.from_records(obj['data'], columns=columns)
             logging.info("Using pandas to convert to CSV")
-            csv = df.to_csv(index=False, encoding='utf-8')
+            csv = df.to_csv(index=False, **config.get('CSV_EXPORT'))
         else:
             logging.info("Running a query to turn into CSV")
             sql = query.select_sql or query.executed_sql
             df = query.database.get_df(sql, query.schema)
             # TODO(bkyryliuk): add compression=gzip for big files.
-            csv = df.to_csv(index=False, encoding='utf-8')
+            csv = df.to_csv(index=False, **config.get('CSV_EXPORT'))
         response = Response(csv, mimetype='text/csv')
         response.headers['Content-Disposition'] = (
             'attachment; filename={}.csv'.format(query.name))

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -310,7 +310,7 @@ class BaseViz(object):
     def get_csv(self):
         df = self.get_df()
         include_index = not isinstance(df.index, pd.RangeIndex)
-        return df.to_csv(index=include_index, encoding="utf-8")
+        return df.to_csv(index=include_index, **config.get('CSV_EXPORT'))
 
     def get_data(self, df):
         return []


### PR DESCRIPTION
This PR adds two global variables in config.py, `CSV_SEP` and `CSV_ENCODING` allowing to configure at application level, which separator character and which encoding should be used to write a csv file.

Fixes #1519 