### PR TITLE
Fixed dashboard filters carrying over to explore slice

### DIFF
--- a/superset/assets/javascripts/dashboard/components/SliceCell.jsx
+++ b/superset/assets/javascripts/dashboard/components/SliceCell.jsx
@@ -19,7 +19,7 @@ function SliceCell({ expandedSlices, removeSlice, slice }) {
             <span>{slice.slice_name}</span>
           </div>
           <div className="col-md-12 chart-controls">
-            <div className="pull-right">
+            <div id={'controls_' + slice.slice_id} className="pull-right">
               <a title="Move chart" data-toggle="tooltip">
                 <i className="fa fa-arrows drag" />
               </a>
@@ -42,10 +42,20 @@ function SliceCell({ expandedSlices, removeSlice, slice }) {
               >
                 <i className="fa fa-pencil" />
               </a>
-              <a href={getExploreUrl(slice.form_data, 'csv')} title="Export CSV" data-toggle="tooltip">
+              <a
+                className="exportCSV"
+                href={getExploreUrl(slice.form_data, 'csv')}
+                title="Export CSV"
+                data-toggle="tooltip"
+              >
                 <i className="fa fa-table" />
               </a>
-              <a href={getExploreUrl(slice.form_data)} title="Explore chart" data-toggle="tooltip">
+              <a
+                className="exploreChart"
+                href={getExploreUrl(slice.form_data)}
+                title="Explore chart"
+                data-toggle="tooltip"
+              >
                 <i className="fa fa-share" />
               </a>
               <a

--- a/superset/assets/javascripts/modules/superset.js
+++ b/superset/assets/javascripts/modules/superset.js
@@ -58,6 +58,7 @@ const px = function (state) {
   }
   const Slice = function (data, datasource, controller) {
     const token = $('#token_' + data.slice_id);
+    const controls = $('#controls_' + data.slice_id);
     const containerId = 'con_' + data.slice_id;
     const selector = '#' + containerId;
     const container = $(selector);
@@ -80,16 +81,11 @@ const px = function (state) {
         };
         return Mustache.render(s, context);
       },
-      jsonEndpoint() {
-        return this.endpoint('json');
+      jsonEndpoint(data) {
+        return this.endpoint(data, 'json');
       },
-      endpoint(endpointType = 'json') {
-        const formDataExtra = Object.assign({}, formData);
-        const flts = controller.effectiveExtraFilters(sliceId);
-        if (flts) {
-          formDataExtra.extra_filters = flts;
-        }
-        let endpoint = getExploreUrl(formDataExtra, endpointType, this.force);
+      endpoint(data, endpointType = 'json') {
+        let endpoint = getExploreUrl(data, endpointType, this.force);
         if (endpoint.charAt(0) !== '/') {
           // Known issue for IE <= 11:
           // https://connect.microsoft.com/IE/feedbackdetail/view/1002846/pathname-incorrect-for-out-of-document-elements
@@ -207,11 +203,16 @@ const px = function (state) {
         } else {
           this.force = force;
         }
+        const formDataExtra = Object.assign({}, formData);
+        const extraFilters = controller.effectiveExtraFilters(sliceId);
+        formDataExtra.filters = formDataExtra.filters.concat(extraFilters);
+        controls.find('a.exploreChart').attr('href', getExploreUrl(formDataExtra));
+        controls.find('a.exportCSV').attr('href', getExploreUrl(formDataExtra, 'csv'));
         token.find('img.loading').show();
         container.fadeTo(0.5, 0.25);
         container.css('height', this.height());
         $.ajax({
-          url: this.jsonEndpoint(),
+          url: this.jsonEndpoint(formDataExtra),
           timeout: timeout * 1000,
           success: (queryResponse) => {
             try {


### PR DESCRIPTION
To fix issue https://github.com/apache/incubator-superset/issues/3172

- Applying a dashboard filter in the filter_box will refresh the slices with the extra filters
- But clicking on "Explore Chart" afterwards did not display the slice with the dashboard filters

Solution

- The URLs for "Export CSV" and "Explore Chart" are updated to contain the dashboard filters whenever they are changed