### PR TITLE
docs: athena can be installed from pypi

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -230,10 +230,6 @@ database you want to connect to should get you to the right place.
 (AWS) Athena
 ------------
 
-This currently relies on an unreleased future version of `PyAthenaJDBC <https://github.com/laughingman7743/PyAthenaJDBC>`_. If you're adventurous or simply impatient, you can install directly from git: ::
-
-    pip install git+https://github.com/laughingman7743/PyAthenaJDBC@support_sqlalchemy
-
 The connection string for Athena looks like this ::
 
     awsathena+jdbc://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com/{schema_name}?s3_staging_dir={s3_staging_dir}&...


### PR DESCRIPTION
As sqlalchemy support has been merged and available in a release
since a few.