### PR TITLE
Create CsvResponse to manage csv exports encoding

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -336,3 +336,10 @@ class DatasourceFilter(SupersetFilter):
         perms = self.get_view_menus('datasource_access')
         # TODO(bogdan): add `schema_access` support here
         return query.filter(self.model.perm.in_(perms))
+
+
+class CsvResponse(Response):
+    """
+    Override Response to take into account csv encoding from config.py
+    """
+    charset = conf.get('CSV_EXPORT').get('encoding', 'utf-8')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -43,8 +43,8 @@ from superset.sql_parse import SupersetQuery
 
 from .base import (
     api, SupersetModelView, BaseSupersetView, DeleteMixin,
-    SupersetFilter, get_user_roles, json_error_response, get_error_msg
-)
+    SupersetFilter, get_user_roles, json_error_response, get_error_msg,
+    CsvResponse)
 
 config = app.config
 stats_logger = config.get('STATS_LOGGER')
@@ -959,7 +959,7 @@ class Superset(BaseSupersetView):
             return json_error_response(DATASOURCE_ACCESS_ERR, status=404)
 
         if request.args.get("csv") == "true":
-            return Response(
+            return CsvResponse(
                 viz_obj.get_csv(),
                 status=200,
                 headers=generate_download_headers("csv"),


### PR DESCRIPTION
Fix choosing encoding for writing csv with python3.

Pandas does not manage encoding choices when writing csv on a file descriptor : https://github.com/pandas-dev/pandas/blob/master/pandas/io/common.py#L486
This is a pandas issue (https://github.com/pandas-dev/pandas/issues/13068).

To fix this, I propose to change the encoding as Response level.

fix https://github.com/apache/incubator-superset/issues/1519#issuecomment-330187976