### PR TITLE
[Bugfix] nvd3 tooltips do not disappear

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -478,6 +478,19 @@ function nvd3Vis(slice, payload) {
       .call(chart);
     }
 
+    // clean up tooltips when switching to another viz
+    const container = $(slice.selector);
+    if (!container.data('observed')) {
+      container.data('observed', true); // limit to one observer
+      const observer = new MutationObserver(() => {
+        container.data('observed', false);
+        $('.nvtooltip').remove();
+        observer.disconnect();
+      });
+      const cfg = { attributes: true, attributeFilter: ['class'] };
+      observer.observe(container[0], cfg);
+    }
+
     // on scroll, hide tooltips. throttle to only 4x/second.
     $(window).scroll(throttle(hideTooltips, 250));
 


### PR DESCRIPTION
Addresses https://github.com/apache/incubator-superset/issues/3471

NVD3 tooltips remain in DOM when switching to another viz in explore view, and sometimes they aren't hidden. Added a `MutationObserver` to detect viz type change and then perform cleanup of tooltips.