### PR TITLE
Removing dependency on pythrifthiveapi

### DIFF
--- a/dev-reqs.txt
+++ b/dev-reqs.txt
@@ -7,7 +7,6 @@ mysqlclient
 nose
 psycopg2
 pylint
-pythrifthiveapi
 pyyaml
 redis
 statsd

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -668,7 +668,7 @@ class HiveEngineSpec(PrestoEngineSpec):
     def patch(cls):
         from pyhive import hive
         from superset.db_engines import hive as patched_hive
-        from pythrifthiveapi.TCLIService import (
+        from TCLIService import (
             constants as patched_constants,
             ttypes as patched_ttypes,
             TCLIService as patched_TCLIService)

--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -1,5 +1,5 @@
 from pyhive import hive
-from pythrifthiveapi.TCLIService import ttypes
+from TCLIService import ttypes
 from thrift import Thrift
 
 


### PR DESCRIPTION
Since the latest pyhive, we don't need pythrifthiveapi as they ship with
the latest version.

There's actually a conflict between the new pyhive and pythrifthiveapi
and this fixes it.