### PR TITLE
Feature: Display the verbose name for metrics within Timeseries charts and legend.

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -840,16 +840,11 @@ class NVD3TimeSeriesViz(NVD3Viz):
             ys = series[name]
             if df[name].dtype.kind not in "biufc":
                 continue
-            if isinstance(name, string_types):
-                series_title = name
-            else:
-                name = ["{}".format(s) for s in name]
-                if len(self.form_data.get('metrics')) > 1:
-                    series_title = ", ".join(name)
-                else:
-                    series_title = ", ".join(name[1:])
-            if title_suffix:
+            series_title = name
+            if isinstance(series_title, string_types):
                 series_title += title_suffix
+            elif title_suffix and isinstance(series_title, list):
+                series_title.append(title_suffix)
 
             d = {
                 "key": series_title,


### PR DESCRIPTION
This solves the verbose name issues, like #3437, but only for nvd3Vis charts (line charts, bar charts, area charts, etc...) 

The entire renaming logic was moved into JS and the presentation layer. This should address the issues that @mistercrunch brought up. I'm happy to close the other MR if we decide to go with this approach.

No need for new screenshots, they look the same.