### PR TITLE
Feature: query string API endpoint

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2312,6 +2312,32 @@ class Superset(BaseSupersetView):
             entry='sqllab',
             bootstrap_data=json.dumps(d, default=utils.json_iso_dttm_ser)
         )
+
+    @api
+    @has_access_api
+    @expose("/slice/<slice_id>/query/")
+    def sliceQuery(self, slice_id):
+        """
+        This method exposes an API endpoint to
+        get the database query string for this slice
+        """
+        viz_obj = self.get_viz(slice_id)
+        if not self.datasource_access(viz_obj.datasource):
+            return json_error_response(DATASOURCE_ACCESS_ERR, status=401)
+        try:
+            query_obj = viz_obj.query_obj()
+            query = viz_obj.datasource.get_query_str(query_obj)
+        except Exception as e:
+            return json_error_response(e)
+        return Response(
+            json.dumps({
+                'query': query,
+                'language': viz_obj.datasource.query_language,
+            }),
+            status=200,
+            mimetype="application/json"
+        )
+
 appbuilder.add_view_no_menu(Superset)
 
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2318,7 +2318,7 @@ class Superset(BaseSupersetView):
 
     @api
     @has_access_api
-    @expose("/slice/<slice_id>/query/")
+    @expose("/slice_query/<slice_id>/")
     def sliceQuery(self, slice_id):
         """
         This method exposes an API endpoint to

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -944,6 +944,20 @@ class Superset(BaseSupersetView):
             endpoint += '&standalone=true'
         return redirect(endpoint)
 
+    def get_query_string_response(self, viz_obj):
+        try:
+            query_obj = viz_obj.query_obj()
+            query = viz_obj.datasource.get_query_str(query_obj)
+        except Exception as e:
+            return json_error_response(e)
+        return Response(
+            json.dumps({
+                'query': query,
+                'language': viz_obj.datasource.query_language,
+            }),
+            status=200,
+            mimetype="application/json")
+
     @log_this
     @has_access_api
     @expose("/explore_json/<datasource_type>/<datasource_id>/")
@@ -970,18 +984,7 @@ class Superset(BaseSupersetView):
                 mimetype="application/csv")
 
         if request.args.get("query") == "true":
-            try:
-                query_obj = viz_obj.query_obj()
-                query = viz_obj.datasource.get_query_str(query_obj)
-            except Exception as e:
-                return json_error_response(e)
-            return Response(
-                json.dumps({
-                    'query': query,
-                    'language': viz_obj.datasource.query_language,
-                }),
-                status=200,
-                mimetype="application/json")
+            return self.get_query_string_response(viz_obj)
 
         payload = {}
         try:
@@ -2324,19 +2327,7 @@ class Superset(BaseSupersetView):
         viz_obj = self.get_viz(slice_id)
         if not self.datasource_access(viz_obj.datasource):
             return json_error_response(DATASOURCE_ACCESS_ERR, status=401)
-        try:
-            query_obj = viz_obj.query_obj()
-            query = viz_obj.datasource.get_query_str(query_obj)
-        except Exception as e:
-            return json_error_response(e)
-        return Response(
-            json.dumps({
-                'query': query,
-                'language': viz_obj.datasource.query_language,
-            }),
-            status=200,
-            mimetype="application/json"
-        )
+        return self.get_query_string_response(viz_obj)
 
 appbuilder.add_view_no_menu(Superset)
 

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -762,7 +762,7 @@ class CoreTests(SupersetTestCase):
         # API endpoint for query string
         self.login(username="admin")
         slc = self.get_slice("Girls", db.session)
-        resp = self.get_resp('/superset/slice/{}/query/'.format(slc.id))
+        resp = self.get_resp('/superset/slice_query/{}/'.format(slc.id))
         assert 'query' in resp
         assert 'language' in resp
         self.logout();

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -758,6 +758,14 @@ class CoreTests(SupersetTestCase):
         self.get_json_resp(slc_url)
         self.assertEqual(1, qry.count())
 
+    def test_slice_query_endpoint(self):
+        # API endpoint for query string
+        self.login(username="admin")
+        slc = self.get_slice("Girls", db.session)
+        resp = self.get_resp('/superset/slice/{}/query/'.format(slc.id))
+        assert 'query' in resp
+        assert 'language' in resp
+        self.logout();
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -74,7 +74,9 @@ class UtilsTestCase(unittest.TestCase):
         obj = {'a': 5, 'b': ['a', 'g', 5]}
         val = '{"a": 5, "b": ["a", "g", 5]}'
         jsonObj = JSONEncodedDict()
-        self.assertEquals(jsonObj.process_bind_param(obj, 'dialect'), val)
+        resp = jsonObj.process_bind_param(obj, 'dialect')
+        self.assertIn('"a": 5', resp)
+        self.assertIn('"b": ["a", "g", 5]', resp)
         self.assertEquals(jsonObj.process_result_value(val, 'dialect'), obj)
 
     def test_validate_json(self):

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,7 +1,16 @@
 from datetime import datetime, date, timedelta, time
 from decimal import Decimal
 from superset.utils import (
-    json_int_dttm_ser, json_iso_dttm_ser, base_json_conv, parse_human_timedelta, zlib_compress, zlib_decompress_to_string
+    json_int_dttm_ser,
+    json_iso_dttm_ser,
+    base_json_conv,
+    parse_human_timedelta,
+    zlib_compress,
+    zlib_decompress_to_string,
+    datetime_f,
+    JSONEncodedDict,
+    validate_json,
+    SupersetException,
 )
 import unittest
 import uuid
@@ -52,3 +61,23 @@ class UtilsTestCase(unittest.TestCase):
         got_str = zlib_decompress_to_string(blob)
         self.assertEquals(json_str, got_str)
 
+    def test_datetime_f(self):
+        self.assertEquals(datetime_f(datetime(1990, 9, 21, 19, 11, 19, 626096)),
+            '<nobr>1990-09-21T19:11:19.626096</nobr>')
+        self.assertEquals(len(datetime_f(datetime.now())), 28)
+        self.assertEquals(datetime_f(None), '<nobr>None</nobr>')
+        iso = datetime.now().isoformat()[:10].split('-')
+        [a, b, c] = [int(v) for v in iso]
+        self.assertEquals(datetime_f(datetime(a, b, c)), '<nobr>00:00:00</nobr>')
+
+    def test_json_encoded_obj(self):
+        obj = {'a': 5, 'b': ['a', 'g', 5]}
+        val = '{"a": 5, "b": ["a", "g", 5]}'
+        jsonObj = JSONEncodedDict()
+        self.assertEquals(jsonObj.process_bind_param(obj, 'dialect'), val)
+        self.assertEquals(jsonObj.process_result_value(val, 'dialect'), obj)
+
+    def test_validate_json(self):
+        invalid = '{"a": 5, "b": [1, 5, ["g", "h]]}'
+        with self.assertRaises(SupersetException):
+            validate_json(invalid)


### PR DESCRIPTION
Exposes an endpoint `superset/slices/<slice_id>/query` that returns the corresponding query string and language for that slice in the form `{ query: querystring, language: querylang }`, which would be seen when clicking on `Query` in the explore slice view.

Also includes some unit tests.