### PR TITLE
[style] no bold on dashboard widget headers

### DIFF
--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -152,9 +152,6 @@ img.viz-thumb-option {
 }
 
 
-div.header {
-  font-weight: bold;
-}
 li.widget:hover {
   z-index: 1000;
 }


### PR DESCRIPTION
Thought things looked better without the boldeness
<img width="620" alt="screen shot 2017-09-25 at 11 21 50 pm" src="https://user-images.githubusercontent.com/487433/30845468-75f2ee0c-a248-11e7-80dc-dd8dd8eb712b.png">
<img width="579" alt="screen shot 2017-09-25 at 11 21 36 pm" src="https://user-images.githubusercontent.com/487433/30845469-7607019e-a248-11e7-8340-ca33937d2ac7.png">
