### PR TITLE
Break word on InfoTooltip

### DIFF
--- a/superset/assets/javascripts/components/InfoTooltipWithTrigger.jsx
+++ b/superset/assets/javascripts/components/InfoTooltipWithTrigger.jsx
@@ -21,11 +21,12 @@ const defaultProps = {
 export default function InfoTooltipWithTrigger({
     label, tooltip, icon, className, onClick, placement, bsStyle }) {
   const iconClass = `fa fa-${icon} ${className} ${bsStyle ? 'text-' + bsStyle : ''}`;
+  const tooltipStyle = { wordWrap: 'break-word' };
   return (
     <OverlayTrigger
       placement={placement}
       overlay={
-        <Tooltip id={`${slugify(label)}-tooltip`} style={{ wordWrap: 'break-word' }}>
+        <Tooltip id={`${slugify(label)}-tooltip`} style={tooltipStyle}>
           {tooltip}
         </Tooltip>
       }

--- a/superset/assets/javascripts/components/InfoTooltipWithTrigger.jsx
+++ b/superset/assets/javascripts/components/InfoTooltipWithTrigger.jsx
@@ -24,7 +24,11 @@ export default function InfoTooltipWithTrigger({
   return (
     <OverlayTrigger
       placement={placement}
-      overlay={<Tooltip id={`${slugify(label)}-tooltip`}>{tooltip}</Tooltip>}
+      overlay={
+        <Tooltip id={`${slugify(label)}-tooltip`} style={{ wordWrap: 'break-word' }}>
+          {tooltip}
+        </Tooltip>
+      }
     >
       <i
         className={iconClass}


### PR DESCRIPTION
Someone on slack mentioned that the text was getting cut off for the expression tooltip. Because it's one long string with no word breaks, the expression text gets cut off. I'm proposing adding `wordWrap: 'break-word'` to the InfoTooltipWithTrigger so that the text will wrap.

If you don't think this should be the default behavior for all tooltips, I can change it to pass the styles in.

It [looks like](https://github.com/twbs/bootstrap/issues/19315) there's no bootstrap class for `break-word`. If there's a better way to add specific styles in, let me know.

Before:
![image](https://user-images.githubusercontent.com/817955/30876079-5d35254e-a2aa-11e7-98e8-965f9b543d99.png)
After:
![image](https://user-images.githubusercontent.com/817955/30876086-65e7603a-a2aa-11e7-8f9a-10bd89924605.png)

