### PR TITLE
[nvd3] fix single metric showing up in legend

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -884,9 +884,15 @@ class NVD3TimeSeriesViz(NVD3Viz):
             if df[name].dtype.kind not in "biufc":
                 continue
             series_title = name
+            if (
+                    isinstance(series_title, (list, tuple)) and
+                    len(series_title) > 1 and
+                    len(self.metrics) == 1):
+                # Removing metric from series name if only one metric
+                series_title = series_title[1:]
             if isinstance(series_title, string_types):
                 series_title += title_suffix
-            elif title_suffix and isinstance(series_title, list):
+            elif title_suffix and isinstance(series_title, (list, tuple)):
                 series_title.append(title_suffix)
 
             d = {


### PR DESCRIPTION
blame https://github.com/apache/incubator-superset/pull/3504

In the case where there's a single metric and a one or many dimension, the metric name would not be reported prior to this change, which is the desired behavior. Where before using metric count with gender dimension would give ['female', 'male', 'other'] in both the legend and tooltip, now it says ['count, female', 'count, male', 'count, other']