### PR TITLE
Feature: name+percent and name+value labels for piechart

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -926,6 +926,8 @@ export const controls = {
       ['key', 'Category Name'],
       ['value', 'Value'],
       ['percent', 'Percentage'],
+      ['key_value', 'Category and Value'],
+      ['key_percent', 'Category and Percentage'],
     ],
     description: t('What should be shown on the label?'),
   },

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -229,14 +229,21 @@ function nvd3Vis(slice, payload) {
           chart.donut(true);
         }
         chart.labelsOutside(fd.labels_outside);
-        chart.labelThreshold(0.05)  // Configure the minimum slice size for labels to show up
-          .labelType(fd.pie_label_type);
+        chart.labelThreshold(0.05);  // Configure the minimum slice size for labels to show up
+        if (fd.pie_label_type !== 'key_percent' && fd.pie_label_type !== 'key_value') {
+          chart.labelType(fd.pie_label_type);
+        } else if (fd.pie_label_type === 'key_value') {
+          chart.labelType(d => `${d.data.x}: ${d3.format('.3s')(d.data.y)}`);
+        }
         chart.cornerRadius(true);
 
-        if (fd.pie_label_type === 'percent') {
+        if (fd.pie_label_type === 'percent' || fd.pie_label_type === 'key_percent') {
           let total = 0;
           data.forEach((d) => { total += d.y; });
           chart.tooltip.valueFormatter(d => `${((d / total) * 100).toFixed()}%`);
+          if (fd.pie_label_type === 'key_percent') {
+            chart.labelType(d => `${d.data.x}: ${((d.data.y / total) * 100).toFixed()}%`);
+          }
         }
 
         break;


### PR DESCRIPTION
As per https://github.com/apache/incubator-superset/issues/3048

Adds to Chart Options for `Pie Chart` two label types: `Category and Percent` and `Category and Value` which displays the percentages and values next to the category names on the chart:

![Pie Chart labels GIF](https://media.giphy.com/media/3ohhwklNBeFr83dR0A/giphy.gif)