### PR TITLE
Removing yarn warnings during install

### DIFF
--- a/superset/assets/.babelrc
+++ b/superset/assets/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets" : ["airbnb", "es2015", "react"],
+  "presets" : ["airbnb", "env", "react"],
 }

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -15,7 +15,7 @@
     "prod": "NODE_ENV=production node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js -p --colors --progress",
     "build": "NODE_ENV=production webpack --colors --progress",
     "lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx .",
-    "sync-backend": "babel-node --presets es2015 javascripts/syncBackend.js"
+    "sync-backend": "babel-node --presets env javascripts/syncBackend.js"
   },
   "repository": {
     "type": "git",
@@ -101,7 +101,7 @@
     "babel-plugin-css-modules-transform": "^1.1.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-airbnb": "^2.1.1",
-    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.11.1",
     "chai": "^4.0.2",
     "clean-webpack-plugin": "^0.1.16",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -128,7 +128,7 @@
     "react-addons-test-utils": "^15.5.1",
     "react-test-renderer": "^15.5.1",
     "redux-mock-store": "^1.2.3",
-    "sinon": "^3.2.1",
+    "sinon": "^4.0.0",
     "style-loader": "^0.18.2",
     "transform-loader": "^0.2.3",
     "uglifyjs-webpack-plugin": "^0.4.6",

--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -52,7 +52,7 @@ const config = {
         query: {
           presets: [
             'airbnb',
-            'es2015',
+            'env',
             'react',
           ],
         },


### PR DESCRIPTION
- removing deprecated babel-preset-es2015 in favor of babel-preset-env

    This removes this yarn warning during install:

    ```
    warning babel-preset-es2015@6.24.1:
    Thanks for using Babel: we recommend using babel-preset-env now:
    please read babeljs.io/env to update!
    ```

- updating sinon to 4.0.0

    This removes wrench from its dependencies and this yarn warning during install:

    ```
    warning wrench@1.3.9: wrench.js is deprecated!
    You should check out fs-extra (https://github.com/jprichardson/node-fs-extra)
    for any operations you were using wrench for.
    Thanks for all the usage over the years.
    ```