### PR TITLE
After saving slice fixing redirect

### DIFF
--- a/superset/assets/javascripts/explore/components/SaveModal.jsx
+++ b/superset/assets/javascripts/explore/components/SaveModal.jsx
@@ -108,7 +108,11 @@ class SaveModal extends React.Component {
     this.props.actions.saveSlice(saveUrl)
       .then((data) => {
         // Go to new slice url or dashboard url
-        window.location = data.slice.slice_url;
+        if (gotodash) {
+          window.location = data.dashboard;
+        } else {
+          window.location = data.slice.slice_url;
+        }
       });
     this.props.onHide();
   }

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1194,16 +1194,18 @@ class Superset(BaseSupersetView):
             dash.slices.append(slc)
             db.session.commit()
 
+        response = {
+            "can_add": slice_add_perm,
+            "can_download": slice_download_perm,
+            "can_overwrite": is_owner(slc, g.user),
+            'form_data': form_data,
+            'slice': slc.data,
+        }
+
         if request.args.get('goto_dash') == 'true':
-            return dash.url
-        else:
-            return json_success(json.dumps({
-                "can_add": slice_add_perm,
-                "can_download": slice_download_perm,
-                "can_overwrite": is_owner(slc, g.user),
-                'form_data': form_data,
-                'slice': slc.data,
-            }))
+            response.update({'dashboard': dash.url})
+
+        return json_success(json.dumps(response))
 
     def save_slice(self, slc):
         session = db.session()


### PR DESCRIPTION
When saving a slice and going to a dashboard, the redirect to the dashboard url is breaking. We were redirecting to `data.slice.slice_url` but data was a string when goto_dashboard is true.

@graceguo-supercat was thinking it may be useful to always return the full slice object, but I can also just return `{'dashboard': dash.url}` instead of adding it to the response.

Thanks for the help @graceguo-supercat 