### PR TITLE
[Bugfix] Creating new filter options in FilterBox

### DIFF
--- a/superset/assets/visualizations/filter_box.jsx
+++ b/superset/assets/visualizations/filter_box.jsx
@@ -77,19 +77,20 @@ class FilterBox extends React.Component {
     }
     // Add created options to filtersChoices, even though it doesn't exist,
     // or these options will exist in query sql but invisible to end user.
-    if (this.state.selectedValues.hasOwnProperty()) {
-      for (const filterKey of this.state.selectedValues) {
-        const existValues = this.props.filtersChoices[filterKey].map(f => f.id);
-        for (const v of this.state.selectedValues[filterKey]) {
-          if (existValues.indexOf(v) === -1) {
-            const addChoice = {
-              filter: filterKey,
-              id: v,
-              text: v,
-              metric: 0,
-            };
-            this.props.filtersChoices[filterKey].push(addChoice);
-          }
+    for (const filterKey in this.state.selectedValues) {
+      if (!this.state.selectedValues.hasOwnProperty(filterKey)) {
+        continue;
+      }
+      const existValues = this.props.filtersChoices[filterKey].map(f => f.id);
+      for (const v of this.state.selectedValues[filterKey]) {
+        if (existValues.indexOf(v) === -1) {
+          const addChoice = {
+            filter: filterKey,
+            id: v,
+            text: v,
+            metric: 0,
+          };
+          this.props.filtersChoices[filterKey].push(addChoice);
         }
       }
     }


### PR DESCRIPTION
Fixed a bug where new options would affect queries but not show up in the UI:

<div style="display:flex">
<img src="https://media.giphy.com/media/l1J9JMbA0PGQ9EgVy/giphy.gif"/>
</div>