### PR TITLE
[Bugfix] Allow users to see query string when no data returned

### DIFF
--- a/superset/assets/javascripts/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/javascripts/explore/components/DisplayQueryButton.jsx
@@ -65,7 +65,10 @@ export default class DisplayQueryButton extends React.PureComponent {
     });
   }
   beforeOpen() {
-    if (['loading', null].indexOf(this.props.chartStatus) >= 0 || !this.props.queryResponse) {
+    if (
+      ['loading', null].indexOf(this.props.chartStatus) >= 0
+      || !this.props.queryResponse || !this.props.queryResponse.query
+    ) {
       this.fetchQuery();
     } else {
       this.setStateFromQueryResponse();


### PR DESCRIPTION
https://github.com/apache/incubator-superset/issues/3579

Before:
- Query strings when no data is returned only viewable after refreshing page

After:
- Query strings always viewable 