### PR TITLE
Update immutable.js to v3.8.2 (MIT license)

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -54,7 +54,7 @@
     "datamaps": "^0.5.8",
     "datatables.net-bs": "^1.10.15",
     "distributions": "^1.0.0",
-    "immutable": "^3.8.1",
+    "immutable": "^3.8.2",
     "jed": "^1.1.1",
     "po2json": "^0.4.5",
     "jquery": "3.1.1",


### PR DESCRIPTION
Ref: #3569 
Update immutable-js dependency to MIT licensed v3.8.2