### PR TITLE
[Bugfix]: Fixing bug in label generation for multiple groupbys

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -77,17 +77,16 @@ function getMaxLabelSize(container, axisClass) {
 /* eslint-disable camelcase */
 function formatLabel(column, verbose_map) {
   let label;
-  if (verbose_map) {
-    if (Array.isArray(column) && column.length) {
-      label = verbose_map[column[0]];
-      if (column.length > 1) {
-        label += `, ${column.slice(1).join(', ')}`;
-      }
-    } else {
-      label = verbose_map[column];
+  if (Array.isArray(column) && column.length) {
+    label = verbose_map[column[0]] || column[0];
+    if (column.length > 1) {
+      label += ', ';
     }
+    label += column.slice(1).join(', ');
+  } else {
+    label = verbose_map[column] || column;
   }
-  return label || column;
+  return label;
 }
 /* eslint-enable camelcase */
 


### PR DESCRIPTION
Fixes: #3590 
Relates to:  #3504 #3563 #3566

I guess I started this so I'll take 99% of the blame here:

## History:

1. #3504 caused a bug where the metric names would be displayed in the legend even when there was only one metric.
2. #3563 fixed that bug, but caused #3590 where the legend for multiple group by s does not get generated correctly
3. #3566 would have fixed both issues but came too late

So we either apply this fix or roll back #3563 and apply #3566 

Hopefully this is the last issue :(