### PR TITLE
updating react-alert dependency to v2.3.0

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -68,7 +68,7 @@
     "react-ace": "^5.0.1",
     "react-addons-css-transition-group": "^15.6.0",
     "react-addons-shallow-compare": "^15.4.2",
-    "react-alert": "^1.0.14",
+    "react-alert": "^2.3.0",
     "react-bootstrap": "^0.31.2",
     "react-bootstrap-table": "^4.0.2",
     "react-dom": "^15.6.2",


### PR DESCRIPTION
it was downgraded in commit 7045018d86176e805fab58d95b480bb5309aa9b3.
The old version used React.PropTypes and it was deprecated.
This version is compatible with React 15+.

Fix #3588