### PR TITLE
[minor] proper tooltip on ControlHeader's instant re-render trigger

### DIFF
--- a/superset/assets/javascripts/explore/components/ControlHeader.jsx
+++ b/superset/assets/javascripts/explore/components/ControlHeader.jsx
@@ -40,7 +40,7 @@ export default class ControlHeader extends React.Component {
             <span>
               <InfoTooltipWithTrigger
                 label={t('bolt')}
-                tooltip={this.props.description}
+                tooltip={t('Changing this control takes effect instantly')}
                 placement="top"
                 icon="bolt"
               />


### PR DESCRIPTION
<img width="277" alt="screen shot 2017-10-08 at 9 19 39 pm" src="https://user-images.githubusercontent.com/487433/31325142-a47db786-ac6e-11e7-880f-661c8d6334e7.png">
