### PR TITLE
Set tooltip to show extent of sparkData

### DIFF
--- a/superset/assets/visualizations/time_table.jsx
+++ b/superset/assets/visualizations/time_table.jsx
@@ -70,10 +70,10 @@ function viz(slice, payload) {
           // Period ratio sparkline
           sparkData = [];
           for (let i = c.timeRatio; i < data.length; i++) {
-            sparkData.push(data[i][metric] / data[i - c.timeRatio][metric]);
+            sparkData.push(d3.round(data[i][metric] / data[i - c.timeRatio][metric], 2));
           }
         }
-        const extent = d3.extent(data, d => d[metric]);
+        const extent = d3.extent(sparkData);
         const tooltip = `min: ${extent[0]}, max: ${extent[1]}`;
         row[c.key] = (
           <TooltipWrapper label="tt-spark" tooltip={tooltip}>

--- a/superset/assets/visualizations/time_table.jsx
+++ b/superset/assets/visualizations/time_table.jsx
@@ -70,11 +70,12 @@ function viz(slice, payload) {
           // Period ratio sparkline
           sparkData = [];
           for (let i = c.timeRatio; i < data.length; i++) {
-            sparkData.push(d3.round(data[i][metric] / data[i - c.timeRatio][metric], 2));
+            sparkData.push(data[i][metric] / data[i - c.timeRatio][metric]);
           }
         }
         const extent = d3.extent(sparkData);
-        const tooltip = `min: ${extent[0]}, max: ${extent[1]}`;
+        const tooltip = `min: ${d3format(c.d3format, extent[0])}, \
+          max: ${d3format(c.d3format, extent[1])}`;
         row[c.key] = (
           <TooltipWrapper label="tt-spark" tooltip={tooltip}>
             <div>


### PR DESCRIPTION
On the tooltip for sparklines in the time table viz we are showing the max and min of the underlying data instead of the data being returned in the chart. So when the user selects a period ratio we are not showing the max and min for the ratio. Updating to calculate the extent on sparkData.

Also, for period ratios the numbers are often long decimals so I rounded them, but not sure how you feel about this, users may want to see more of the ratio.