### PR TITLE
add explicit message display for 'Fetching Annotation Layer' error

### DIFF
--- a/superset/assets/javascripts/components/AsyncSelect.jsx
+++ b/superset/assets/javascripts/components/AsyncSelect.jsx
@@ -42,19 +42,20 @@ class AsyncSelect extends React.PureComponent {
   fetchOptions() {
     this.setState({ isLoading: true });
     const mutator = this.props.mutator;
-    $.get(this.props.dataEndpoint, (data) => {
-      this.setState({ options: mutator ? mutator(data) : data, isLoading: false });
+    $.get(this.props.dataEndpoint)
+      .done((data) => {
+        this.setState({ options: mutator ? mutator(data) : data, isLoading: false });
 
-      if (!this.props.value && this.props.autoSelect && this.state.options.length) {
-        this.onChange(this.state.options[0]);
-      }
-    })
-    .fail(() => {
-      this.props.onAsyncError();
-    })
-    .always(() => {
-      this.setState({ isLoading: false });
-    });
+        if (!this.props.value && this.props.autoSelect && this.state.options.length) {
+          this.onChange(this.state.options[0]);
+        }
+      })
+      .fail((xhr) => {
+        this.props.onAsyncError(xhr.responseText);
+      })
+      .always(() => {
+        this.setState({ isLoading: false });
+      });
   }
   render() {
     return (

--- a/superset/assets/javascripts/explore/components/controls/SelectAsyncControl.jsx
+++ b/superset/assets/javascripts/explore/components/controls/SelectAsyncControl.jsx
@@ -37,7 +37,7 @@ const SelectAsyncControl = ({ value, onChange, dataEndpoint,
     <Select
       dataEndpoint={dataEndpoint}
       onChange={onSelectionChange}
-      onAsyncError={() => notify.error(onAsyncErrorMessage)}
+      onAsyncError={errorMsg => notify.error(onAsyncErrorMessage + ': ' + errorMsg)}
       mutator={mutator}
       multi={multi}
       value={value}

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -512,7 +512,7 @@ function nvd3Vis(slice, payload) {
       .call(chart);
 
       // add annotation_layer
-      if (isTimeSeries && payload.annotations.length) {
+      if (isTimeSeries && payload.annotations && payload.annotations.length) {
         const tip = d3tip()
           .attr('class', 'd3-tip')
           .direction('n')


### PR DESCRIPTION
our users report seeing `ERROR WHEN FETCHING ANNOTATION LAYER` error but I can't reproduce. This is a code clean-up, and show more details in error message.

1. add explicit message display if Fetching Annotation Layer error happens.
2. split done, fail, always callback separately.