### PR TITLE
add annotation option and a linear color map for heatmap viz.

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1087,12 +1087,12 @@ export const controls = {
     description: t('Whether to display the legend (toggles)'),
   },
 
-  show_annotation: {
+  show_values: {
     type: 'CheckboxControl',
-    label: t('Annotation'),
+    label: t('Show Values'),
     renderTrigger: true,
     default: false,
-    description: t('Whether to display the annotation (toggles)'),
+    description: t('Whether to display the numerical values within the cells'),
   },
 
   x_axis_showminmax: {

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -202,7 +202,7 @@ export const controls = {
       ['blue_white_yellow', 'blue/white/yellow'],
       ['white_black', 'white/black'],
       ['black_white', 'black/white'],
-      ['dark_blue', 'light/dark blue']
+      ['dark_blue', 'light/dark blue'],
     ],
     default: 'blue_white_yellow',
     clearable: false,

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -202,6 +202,7 @@ export const controls = {
       ['blue_white_yellow', 'blue/white/yellow'],
       ['white_black', 'white/black'],
       ['black_white', 'black/white'],
+      ['dark_blue', 'light/dark blue']
     ],
     default: 'blue_white_yellow',
     clearable: false,
@@ -1084,6 +1085,14 @@ export const controls = {
     renderTrigger: true,
     default: true,
     description: t('Whether to display the legend (toggles)'),
+  },
+
+  show_annotation: {
+    type: 'CheckboxControl',
+    label: t('Annotation'),
+    renderTrigger: true,
+    default: false,
+    description: t('Whether to display the annotation (toggles)'),
   },
 
   x_axis_showminmax: {

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -975,6 +975,7 @@ export const visTypes = {
           ['left_margin', 'bottom_margin'],
           ['y_axis_bounds', 'y_axis_format'],
           ['show_legend', 'show_perc'],
+          ['show_annotation'],
           ['sort_x_axis', 'sort_y_axis'],
         ],
       },

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -975,7 +975,7 @@ export const visTypes = {
           ['left_margin', 'bottom_margin'],
           ['y_axis_bounds', 'y_axis_format'],
           ['show_legend', 'show_perc'],
-          ['show_annotation'],
+          ['show_values'],
           ['sort_x_axis', 'sort_y_axis'],
         ],
       },

--- a/superset/assets/javascripts/modules/colors.js
+++ b/superset/assets/javascripts/modules/colors.js
@@ -94,6 +94,13 @@ export const spectrums = {
     'black',
     'white',
   ],
+  dark_blue: [
+    '#EBF5F8',
+    '#6BB1CC',
+    '#357E9B',
+    '#1B4150',
+    '#092935',
+  ],
 };
 
 export const getColorFromScheme = (function () {

--- a/superset/assets/visualizations/heatmap.js
+++ b/superset/assets/visualizations/heatmap.js
@@ -130,6 +130,25 @@ function heatmapVis(slice, payload) {
     .attr('height', height)
     .style('position', 'relative');
 
+  if (fd.show_annotation) {
+  var cells = svg.selectAll("rect")
+      .data(data)
+      .enter()
+      .append('g')
+      .attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+  cells.append('text')
+    .attr('transform',
+    function(d) {return 'translate(' + xRbScale(d.x) + ',' + yRbScale(d.y) + ')';})
+    .attr('y', function(d, i) { return yRbScale.rangeBand() / 2; })
+    .attr('x', function(d, i) { return xRbScale.rangeBand() / 2; })
+    .attr("text-anchor", "middle")
+    .attr("dy", ".35em")
+    .text(function(d, i) { return valueFormatter(d.v); })
+    .attr("font-size", Math.min(yRbScale.rangeBand(), xRbScale.rangeBand()) / 3 + "px")
+    .attr("fill", function(d, i) { return d.v >= payload.data.extents[1] / 2 ? 'white' : 'black';});
+  }
+
   if (fd.show_legend) {
     const legendScaler = colorScalerFactory(
       fd.linear_color_scheme, null, null, payload.data.extents);

--- a/superset/assets/visualizations/heatmap.js
+++ b/superset/assets/visualizations/heatmap.js
@@ -130,7 +130,7 @@ function heatmapVis(slice, payload) {
     .attr('height', height)
     .style('position', 'relative');
 
-  if (fd.show_annotation) {
+  if (fd.show_values) {
     const cells = svg.selectAll('rect')
       .data(data)
       .enter()
@@ -138,15 +138,14 @@ function heatmapVis(slice, payload) {
       .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
     cells.append('text')
-      .attr('transform',
-        function (d) { return 'translate(' + xRbScale(d.x) + ',' + yRbScale(d.y) + ')'; })
+      .attr('transform', d => `translate(${xRbScale(d.x)}, ${yRbScale(d.y)})`)
       .attr('y', yRbScale.rangeBand() / 2)
       .attr('x', xRbScale.rangeBand() / 2)
       .attr('text-anchor', 'middle')
       .attr('dy', '.35em')
-      .text(function (d) { return valueFormatter(d.v); })
+      .text(d => valueFormatter(d.v))
       .attr('font-size', Math.min(yRbScale.rangeBand(), xRbScale.rangeBand()) / 3 + 'px')
-      .attr('fill', function (d) { return d.v >= payload.data.extents[1] / 2 ? 'white' : 'black'; });
+      .attr('fill', d => d.v >= payload.data.extents[1] / 2 ? 'white' : 'black');
   }
 
   if (fd.show_legend) {

--- a/superset/assets/visualizations/heatmap.js
+++ b/superset/assets/visualizations/heatmap.js
@@ -131,22 +131,22 @@ function heatmapVis(slice, payload) {
     .style('position', 'relative');
 
   if (fd.show_annotation) {
-  var cells = svg.selectAll("rect")
+    const cells = svg.selectAll('rect')
       .data(data)
       .enter()
       .append('g')
       .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
-  cells.append('text')
-    .attr('transform',
-    function(d) {return 'translate(' + xRbScale(d.x) + ',' + yRbScale(d.y) + ')';})
-    .attr('y', function(d, i) { return yRbScale.rangeBand() / 2; })
-    .attr('x', function(d, i) { return xRbScale.rangeBand() / 2; })
-    .attr("text-anchor", "middle")
-    .attr("dy", ".35em")
-    .text(function(d, i) { return valueFormatter(d.v); })
-    .attr("font-size", Math.min(yRbScale.rangeBand(), xRbScale.rangeBand()) / 3 + "px")
-    .attr("fill", function(d, i) { return d.v >= payload.data.extents[1] / 2 ? 'white' : 'black';});
+    cells.append('text')
+      .attr('transform',
+        function (d) { return 'translate(' + xRbScale(d.x) + ',' + yRbScale(d.y) + ')'; })
+      .attr('y', yRbScale.rangeBand() / 2)
+      .attr('x', xRbScale.rangeBand() / 2)
+      .attr('text-anchor', 'middle')
+      .attr('dy', '.35em')
+      .text(function (d) { return valueFormatter(d.v); })
+      .attr('font-size', Math.min(yRbScale.rangeBand(), xRbScale.rangeBand()) / 3 + 'px')
+      .attr('fill', function (d) { return d.v >= payload.data.extents[1] / 2 ? 'white' : 'black'; });
   }
 
   if (fd.show_legend) {


### PR DESCRIPTION
allow user to put digits on a grid heat map, which is related to #3570 and visualization for churn rate.
  
<img width="438" alt="control" src="https://user-images.githubusercontent.com/2958091/31366152-97b619a2-adaa-11e7-9d07-cadef30b24d9.png">
<img width="872" alt="heatmap" src="https://user-images.githubusercontent.com/2958091/31366172-ad048e88-adaa-11e7-9c75-7bd823c6d88b.png">

