### PR TITLE
[bugfix] Template rendering failed: '_AppCtxGlobals' object has no at…

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -43,7 +43,7 @@ def url_param(param, default=None):
 
 def current_user_id():
     """The id of the user who is currently logged in"""
-    if g.user:
+    if hasattr(g, 'user') and g.user:
         return g.user.id
 
 


### PR DESCRIPTION
…tribute 'user'

Somehow the nature of `g` in Flask has changed where `g.user` used to
be provided outside the web request scope and its not anymore.

The fix here should address that.