### PR TITLE
Allowing an updated moment.js breaks lots of stuff

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -59,7 +59,7 @@
     "jed": "^1.1.1",
     "jquery": "3.1.1",
     "lodash.throttle": "^4.1.1",
-    "moment": "^2.14.1",
+    "moment": "~2.14.1",
     "mustache": "^2.2.1",
     "nvd3": "1.8.6",
     "po2json": "^0.4.5",


### PR DESCRIPTION
Moment.js changed the way they did exports since version 2.14.1, but if the dependency is set to "^2.14.1" yarn (and I think npm install) will install a later version (2.19.0) with the different exports. 

This solves that problem, though you might wanna take a look more broadly at your versions to ensure this doesn't happen elsewhere. 

Gitter chat from me discovering this is here: https://gitter.im/airbnb/superset?at=59dd10d7bbbf9f1a38453859 . 

Feel free to merge this in or just add it in on another branch, I just wanted to bring this up somewhere besides the gitter. 👍 
