### PR TITLE
Pin moment.js library since 2.19.0 creates problem

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -59,7 +59,7 @@
     "jed": "^1.1.1",
     "jquery": "3.1.1",
     "lodash.throttle": "^4.1.1",
-    "moment": "^2.14.1",
+    "moment": "2.18.1",
     "mustache": "^2.2.1",
     "nvd3": "1.8.6",
     "po2json": "^0.4.5",


### PR DESCRIPTION
The 2.19.0 released today (2017-10-10) creates issues with the
DateFilterControl somehow. Pining lib to latest known version.