### PR TITLE
Fixing some warnings during tests

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/RunQueryActionButton.jsx
+++ b/superset/assets/javascripts/SqlLab/components/RunQueryActionButton.jsx
@@ -6,7 +6,7 @@ import { t } from '../../locales';
 const propTypes = {
   allowAsync: PropTypes.bool.isRequired,
   dbId: PropTypes.number,
-  queryState: PropTypes.string.isRequired,
+  queryState: PropTypes.string,
   runQuery: PropTypes.func.isRequired,
   selectedText: PropTypes.string,
   stopQuery: PropTypes.func.isRequired,

--- a/superset/assets/javascripts/SqlLab/components/SaveQuery.jsx
+++ b/superset/assets/javascripts/SqlLab/components/SaveQuery.jsx
@@ -112,7 +112,6 @@ class SaveQuery extends React.PureComponent {
       <span className="SaveQuery">
         <Overlay
           trigger="click"
-          target={this.state.target}
           show={this.state.showSave}
           placement="bottom"
           animation={this.props.animation}

--- a/superset/assets/javascripts/explore/components/Control.jsx
+++ b/superset/assets/javascripts/explore/components/Control.jsx
@@ -22,7 +22,8 @@ const propTypes = {
     PropTypes.string,
     PropTypes.number,
     PropTypes.bool,
-    PropTypes.array]),
+    PropTypes.array,
+    PropTypes.func]),
 };
 
 const defaultProps = {

--- a/superset/assets/javascripts/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset/assets/javascripts/explore/components/controls/ColorSchemeControl.jsx
@@ -12,7 +12,7 @@ const propTypes = {
   onChange: PropTypes.func,
   value: PropTypes.string,
   default: PropTypes.string,
-  choices: PropTypes.arrayOf(React.PropTypes.array).isRequired,
+  choices: PropTypes.arrayOf(PropTypes.array).isRequired,
   schemes: PropTypes.object.isRequired,
   isLinear: PropTypes.bool,
 };

--- a/superset/assets/spec/javascripts/sqllab/QueryStateLabel_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QueryStateLabel_spec.jsx
@@ -14,11 +14,6 @@ describe('SavedQuery', () => {
   };
   it('is valid', () => {
     expect(
-      React.isValidElement(<QueryStateLabel />),
-    ).to.equal(true);
-  });
-  it('is valid with props', () => {
-    expect(
       React.isValidElement(<QueryStateLabel {...mockedProps} />),
     ).to.equal(true);
   });


### PR DESCRIPTION
Removing some warnings during `yarn test`.

- ColorSchemeControl: fixing bad use of PropTypes

    Accessing PropTypes via the main React package is deprecated, and will be
    removed in React v16.0. Use the latest available v15.* prop-types package from
    npm instead. For info on usage, compatibility, migration and more, see
    https://fb.me/prop-types-docs

- Control: adding PropTypes.func in types allowed inside `value` prop

    This removes a warning during yarn tests

    Fix #3589

- tests(QueryStateLabel): removing missing prop warning

    ```
    Warning: Failed prop type: The prop `query` is marked as required in
    `QueryStateLabel`, but its value is `undefined`.
        in QueryStateLabel
    ```

- SaveQuery: removing invalid prop `target` supplied to `Overlay`.

    This removes a warning during yarn tests:

    ```
    Warning: Failed prop type: Invalid prop `target` supplied to `Overlay`.
    ```

- RunQueryActionButton: removing `isRequired` from queryState props

    This removes a warning during yarn tests:
    ```
    Warning: Failed prop type: The prop `queryState` is marked as required in
    `RunQueryActionButton`, but its value is `null`.
    ```