### PR TITLE
Making the sort order for metrics pull from fd for time table viz

### DIFF
--- a/superset/assets/visualizations/time_table.jsx
+++ b/superset/assets/visualizations/time_table.jsx
@@ -44,8 +44,14 @@ function viz(slice, payload) {
     metricMap[m.metric_name] = m;
   });
 
-  const metrics = payload.data.columns;
-  const defaultSort = { column: fd.column_collection[0].key, direction: 'desc' };
+  let metrics;
+  let defaultSort = null;
+  if (payload.data.is_group_by) {
+    metrics = payload.data.columns;
+    defaultSort = { column: fd.column_collection[0].key, direction: 'desc' };
+  } else {
+    metrics = fd.metrics;
+  }
   const tableData = metrics.map((metric) => {
     let leftCell;
     const context = Object.assign({}, fd, { metric });


### PR DESCRIPTION
For the time table viz if it is not a group by, we should make the sort order be the order the metrics were input into the form data. defaultSort should only be passed through for group_by.