### PR TITLE
Avoid dividing by zero for sparkline in time table viz

### DIFF
--- a/superset/assets/visualizations/time_table.jsx
+++ b/superset/assets/visualizations/time_table.jsx
@@ -72,7 +72,12 @@ function viz(slice, payload) {
           // Period ratio sparkline
           sparkData = [];
           for (let i = c.timeRatio; i < data.length; i++) {
-            sparkData.push(data[i][metric] / data[i - c.timeRatio][metric]);
+            const prevData = data[i - c.timeRatio][metric];
+            if (prevData && prevData !== 0) {
+              sparkData.push(data[i][metric] / prevData);
+            } else {
+              sparkData.push(null);
+            }
           }
         }
         const extent = d3.extent(sparkData);


### PR DESCRIPTION
When calculating ratios to add to the sparkline, we should not be dividing by zero or null values. Instead I'm passing a null value to sparkData. This will result in a blank space in the sparkline. This matches how the line chart handles dividing by zero or null.

![image](https://user-images.githubusercontent.com/817955/31634479-97a8ccac-b278-11e7-9d5b-f6ab2b197e81.png)

Currently, dividing by null values or 0 is breaking the sparkline so no part of the chart shows up.