### PR TITLE
defaultSort should be false when no sort is necessary

### DIFF
--- a/superset/assets/visualizations/time_table.jsx
+++ b/superset/assets/visualizations/time_table.jsx
@@ -44,7 +44,7 @@ function viz(slice, payload) {
   });
 
   let metrics;
-  let defaultSort = null;
+  let defaultSort = false;
   if (payload.data.is_group_by) {
     metrics = payload.data.columns;
     defaultSort = { column: fd.column_collection[0].key, direction: 'desc' };


### PR DESCRIPTION
In the time table viz I start off by setting defaultSort to null when it should be false. Reactable has a few checks for `sortBy !== false` when updating sort, which causes issues if defaultSort not false (but null).