### PR TITLE
[Explore] Reduced heading size for metrics in T-test table

### DIFF
--- a/superset/assets/visualizations/paired_ttest.jsx
+++ b/superset/assets/visualizations/paired_ttest.jsx
@@ -205,7 +205,7 @@ class TTestTable extends React.Component {
     ]);
     return (
       <div>
-        <h1>{metric}</h1>
+        <h3>{metric}</h3>
         <Table
           className="table"
           id={`table_${metric}`}


### PR DESCRIPTION
`h1 -> h3`