### PR TITLE
[form-data] Quoting /slice/<slice_id> form data

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -12,6 +12,7 @@ import pickle
 import re
 import time
 import traceback
+from urllib import parse
 
 import sqlalchemy as sqla
 
@@ -937,7 +938,7 @@ class Superset(BaseSupersetView):
             .format(
                 viz_obj.datasource.type,
                 viz_obj.datasource.id,
-                json.dumps(viz_obj.form_data)
+                parse.quote(json.dumps(viz_obj.form_data)),
             )
         )
         if request.args.get("standalone") == "true":


### PR DESCRIPTION
This PR ensures that the `form_data` argument for the `/slice/<slice_id>` route is quoted to ensure that the request can be correctly parsed. This is consistent with https://github.com/apache/incubator-superset/blob/master/superset/models/core.py#L214. 