### PR TITLE
convert DATETIME columns when exporting from cache to CSV

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2171,7 +2171,7 @@ class Superset(BaseSupersetView):
             obj = json.loads(json_payload)
             columns = [c['name'] for c in obj['columns']]
             df = pd.DataFrame.from_records(obj['data'], columns=columns)
-            for dt_col in [c['name'] for c in obj['columns'] if c['type']=='DATETIME']:
+            for dt_col in [c['name'] for c in obj['columns'] if c['type'] == 'DATETIME']:
                 df[dt_col] = pd.to_datetime(df[dt_col], errors='ignore', infer_datetime_format=True)
             logging.info("Using pandas to convert to CSV")
             csv = df.to_csv(index=False, **config.get('CSV_EXPORT'))

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2171,6 +2171,8 @@ class Superset(BaseSupersetView):
             obj = json.loads(json_payload)
             columns = [c['name'] for c in obj['columns']]
             df = pd.DataFrame.from_records(obj['data'], columns=columns)
+            for dt_col in [c['name'] for c in obj['columns'] if c['type']=='DATETIME']:
+                df[dt_col] = pd.to_datetime(df[dt_col], errors='ignore', infer_datetime_format=True)
             logging.info("Using pandas to convert to CSV")
             csv = df.to_csv(index=False, **config.get('CSV_EXPORT'))
         else:


### PR DESCRIPTION
Fixes #3704.

I'm not quite sure _why_ this is for the CSV export in SQLLab, while the CSV export in Explore handles DATETIME columns nicely when exporting from cached data.
To be honest, I could not manage to find the corresponding code used for Explore's CSV export. For this reason, this approach is totally independent.