### PR TITLE
fix the slice permission issue after user click-edit new slice title

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1212,7 +1212,7 @@ class Superset(BaseSupersetView):
             "can_add": slice_add_perm,
             "can_download": slice_download_perm,
             "can_overwrite": is_owner(slc, g.user),
-            'form_data': form_data,
+            'form_data': slc.form_data,
             'slice': slc.data,
         }
 


### PR DESCRIPTION
step to reproduce:

1. user start visualize a query from sql lab, and landing in explore view. At this time the title of visualized query is default to undefined - untitled
2. user click the slice title and change slice title.
3. then user clicks 'Save' button on upper left page, so that Save a Slice modal will show up.
4. when user save slice by using modal, they will see 'You don't have right to change this slice' message.


The root cause here is when user click-edit new query data, we save the query as new slice, but in the responses, should use updated form_data which was generated after slice was created. Otherwise we missed new slice_id in the form_data response data.