### PR TITLE
Validate JSON in slice's params on save

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -193,7 +193,12 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
 
     @property
     def form_data(self):
-        form_data = json.loads(self.params)
+        form_data = {}
+        try:
+            form_data = json.loads(self.params)
+        except Exception as e:
+            logging.error("Malformed json in slice's params")
+            logging.exception(e)
         form_data.update({
             'slice_id': self.id,
             'viz_type': self.viz_type,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -386,7 +386,11 @@ class SliceModelView(SupersetModelView, DeleteMixin):  # noqa
         'viz_type': _("Visualization Type"),
     }
 
+    def pre_add(self, obj):
+        utils.validate_json(obj.params)
+
     def pre_update(self, obj):
+        utils.validate_json(obj.params)
         check_ownership(obj)
 
     def pre_delete(self, obj):


### PR DESCRIPTION
fixes https://github.com/apache/incubator-superset/issues/3507

This prevents malformed JSON from getting saved in a slice's params. It
also prevents the issue described in #3507 from happening though as a
result malformed slices will render using default control values.