### PR TITLE
Add CRUD action to refresh table metadata

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -213,3 +213,11 @@ How can I set a default filter on my dashboard?
 
 Easy. Simply apply the filter and save the dashboard while the filter
 is active.
+
+How do I get Superset to refresh the schema of my table?
+--------------------------------------------------------
+
+When adding columns to a table, you can have Superset detect and merge the
+new columns in by using the "Refresh Metadata" action in the
+``Source -> Tables`` page. Simply check the box next to the tables
+you want the schema refreshed, and click ``Actions -> Refresh Metadata``.

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -3,6 +3,7 @@ from past.builtins import basestring
 
 from flask import Markup, flash, redirect
 from flask_appbuilder import CompactCRUDMixin, expose
+from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
 from flask_babel import lazy_gettext as _
@@ -271,6 +272,20 @@ class TableModelView(DatasourceModelView, DeleteMixin):  # noqa
         if isinstance(resp, basestring):
             return resp
         return redirect('/superset/explore/table/{}/'.format(pk))
+
+    @action(
+        "refresh",
+        __("Refresh Metadata"),
+        __("Refresh column metadata"),
+        "fa-refresh")
+    def refresh(self, tables):
+        for t in tables:
+            t.fetch_metadata()
+        msg = _(
+            "Metadata refreshed for the following table(s): %(tables)s",
+            tables=", ".join([t.table_name for t in tables]))
+        flash(msg, 'info')
+        return redirect('/tablemodelview/list/')
 
 appbuilder.add_view(
     TableModelView,


### PR DESCRIPTION
A shortcut to make it easy to refresh a table's schema.
<img width="446" alt="screen shot 2017-10-25 at 4 42 36 pm" src="https://user-images.githubusercontent.com/487433/32028650-8e9e488e-b9a4-11e7-800e-7e758cf07905.png">
