### PR TITLE
[WiP] Bumping react-select to rc10

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -80,7 +80,7 @@
     "react-map-gl": "^3.0.4",
     "react-redux": "^5.0.2",
     "react-resizable": "^1.3.3",
-    "react-select": "1.0.0-rc.3",
+    "react-select": "1.0.0-rc.10",
     "react-select-fast-filter-options": "^0.2.1",
     "react-sortable-hoc": "^0.6.7",
     "react-split-pane": "^0.1.66",

--- a/superset/assets/stylesheets/react-select/select.less
+++ b/superset/assets/stylesheets/react-select/select.less
@@ -1,99 +1,13 @@
-// @mistercrunch
-@select-primary-color: black;
-
-/**
- * React Select
- * ============
- * Created by Jed Watson and Joss Mackison for KeystoneJS, http://www.keystonejs.com/
- * https://twitter.com/jedwatson https://twitter.com/jossmackison https://twitter.com/keystonejs
- * MIT License: https://github.com/keystonejs/react-select
-*/
-
-// Variables
-// ------------------------------
-
-// common
-//@select-primary-color:             #007eff;
-
-// control options
-@select-input-bg:                  #fff;
-@select-input-bg-disabled:         #f9f9f9;
-@select-input-border-color:        #ccc;
-@select-input-border-radius:       4px;
-@select-input-border-focus:        @select-primary-color;
-@select-input-border-width:        1px;
-@select-input-height:              30px;
-@select-input-internal-height:     (@select-input-height - (@select-input-border-width * 2));
-@select-input-placeholder:         #aaa;
-@select-text-color:                #333;
-@select-link-hover-color:          @select-input-border-focus;
-
-@select-padding-vertical:          8px;
-@select-padding-horizontal:        10px;
-
-// menu options
-@select-menu-zindex:               1;
-@select-menu-max-height:           200px;
-
-@select-option-color:              lighten(@select-text-color, 20%);
-@select-option-bg:                 @select-input-bg;
-@select-option-focused-color:      @select-text-color;
-@select-option-focused-bg:         fade(@select-primary-color, 8%);
-@select-option-focused-bg-fb:      mix(@select-primary-color, @select-option-bg, 8%);  // Fallback color for IE 8
-@select-option-selected-color:     @select-text-color;
-@select-option-selected-bg:        fade(@select-primary-color, 4%);
-@select-option-selected-bg-fb:      mix(@select-primary-color, @select-option-bg, 4%);  // Fallback color for IE 8
-@select-option-disabled-color:     lighten(@select-text-color, 60%);
-
-@select-noresults-color:           lighten(@select-text-color, 40%);
-
-// clear "x" button
-@select-clear-size:                floor((@select-input-height / 2));
-@select-clear-color:               #999;
-@select-clear-hover-color:         #D0021B; // red
-@select-clear-width:               (@select-input-internal-height / 2);
-
-// arrow indicator
-@select-arrow-color:               #999;
-@select-arrow-color-hover:         #666;
-@select-arrow-width:               5px;
-
-// loading indicator
-@select-loading-size:              16px;
-@select-loading-color:             @select-text-color;
-@select-loading-color-bg:          @select-input-border-color;
-
-// multi-select item
-@select-item-font-size:            .9em;
-
-@select-item-bg:                   fade(@select-primary-color, 8%);
-@select-item-bg-fb:                mix(@select-primary-color, @select-input-bg, 8%);  // Fallback color for IE 8
-@select-item-color:                @select-primary-color;
-@select-item-border-color:         fade(@select-primary-color, 24%);
-@select-item-border-color-fb:      mix(@select-primary-color, @select-input-bg, 24%);  // Fallback color for IE 8
-@select-item-hover-color:          darken(@select-item-color, 5%);
-@select-item-hover-bg:             darken(@select-item-bg, 5%);
-@select-item-hover-bg-fb:          mix(darken(@select-primary-color, 5%), @select-item-bg-fb, 8%);  // Fallback color for IE 8
-@select-item-disabled-color:       #333;
-@select-item-disabled-bg:          #fcfcfc;
-@select-item-disabled-border-color: darken(@select-item-disabled-bg, 10%);
-
-@select-item-border-radius:        2px;
-@select-item-gutter:               5px;
-
-@select-item-padding-horizontal:   5px;
-@select-item-padding-vertical:     2px;
+@import "~react-select/less/select.less";
+@select-primary-color:              black;
 
 // imports
-// @mistercrunch: these were altered to point to react-select/less
-@import "../../node_modules/react-select/less/control.less";
-@import "../../node_modules/react-select/less/menu.less";
-@import "../../node_modules/react-select/less/mixins.less";
-@import "../../node_modules/react-select/less/multi.less";
-@import "../../node_modules/react-select/less/spinner.less";
+@import "~react-select/less/control.less";
+@import "~react-select/less/menu.less";
+@import "~react-select/less/mixins.less";
+@import "~react-select/less/multi.less";
+@import "~react-select/less/spinner.less";
 
-// importing css from "../../node_modules/react-virtualized-select/styles.css";
-// so the background color of a selected option matches the other selects
 .VirtualSelectGrid {
   z-index: 1;
 }


### PR DESCRIPTION
Attempt at bumping `react-select` to rc10 to remove React warning messages. Also cleaning up the copy-pasta of `select.less`.

Somehow the css is a little off and can't figure it out. I think it has to do with this hack here:
https://github.com/apache/incubator-superset/blob/master/superset/assets/stylesheets/superset.less#L344

<img width="186" alt="screen shot 2017-10-27 at 12 28 28 am" src="https://user-images.githubusercontent.com/487433/32092521-cb65d174-baad-11e7-88c8-bfcff548c6d3.png">

@graceguo-supercat can you help getting this through?