### PR TITLE
Added multi-tenancy support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ superset/assets/version_info.json
 
 # IntelliJ
 *.iml
+venv

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -196,6 +196,7 @@ of the parameters you can copy / paste in that configuration module: ::
     SUPERSET_WORKERS = 4
 
     SUPERSET_WEBSERVER_PORT = 8088
+    ENABLE_MULTI_TENANCY = False
     #---------------------------------------------------------
 
     #---------------------------------------------------------
@@ -234,6 +235,16 @@ In case you need to exempt endpoints from CSRF, e.g. you are running a custom
 auth postback endpoint, you can add them to *WTF_CSRF_EXEMPT_LIST*
 
      WTF_CSRF_EXEMPT_LIST = ['']
+
+Enable Multi Tenancy
+---------------------
+
+To achieve multi-tenancy follow following steps:
+
+* set *ENABLE_MULTI_TENANCY = True* in superset_config file.
+* add column *tenant_id StringDataType(256)* in the tables or views in which you want multi-tenancy. This tenant_id is the same tenant_id as in ab_user table.
+* Make sure that ab_user table have the column *tenant_id* else alter the table to add column tenant_id.
+* if you want to enable multi-tenancy with *CUSTOM_SECURITY_MANAGER*, then your custom security manager class should be a subclass of *MultiTenantSecurityManager* class.
 
 Database dependencies
 ---------------------

--- a/superset/config.py
+++ b/superset/config.py
@@ -48,6 +48,9 @@ SUPERSET_WEBSERVER_ADDRESS = '0.0.0.0'
 SUPERSET_WEBSERVER_PORT = 8088
 SUPERSET_WEBSERVER_TIMEOUT = 60
 EMAIL_NOTIFICATIONS = False
+ENABLE_MULTI_TENANCY = False
+# CUSTOM_SECURITY_MANAGER will not be used if ENABLE_MULTI_TENANCY
+# is True and it is not a subclass of MultiTenantSecurityManager class.
 CUSTOM_SECURITY_MANAGER = None
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 # ---------------------------------------------------------

--- a/superset/multi_tenant.py
+++ b/superset/multi_tenant.py
@@ -1,0 +1,37 @@
+from flask_appbuilder.security.sqla.manager import SecurityManager
+from flask_appbuilder.security.sqla.models import User
+from sqlalchemy import Column, Integer, ForeignKey, String, Sequence, Table
+from sqlalchemy.orm import relationship, backref
+from flask_appbuilder import Model
+from flask_appbuilder.security.views import UserDBModelView
+from flask_babel import lazy_gettext
+
+class MultiTenantUser(User):
+    tenant_id = Column(String(256))
+
+class MultiTenantUserDBModelView(UserDBModelView):
+    show_fieldsets = [
+        (lazy_gettext('User info'),
+         {'fields': ['username', 'active', 'roles', 'login_count', 'tenant_id']}),
+        (lazy_gettext('Personal Info'),
+         {'fields': ['first_name', 'last_name', 'email'], 'expanded': True}),
+        (lazy_gettext('Audit Info'),
+         {'fields': ['last_login', 'fail_login_count', 'created_on',
+                     'created_by', 'changed_on', 'changed_by'], 'expanded': False}),
+    ]
+
+    user_show_fieldsets = [
+        (lazy_gettext('User info'),
+         {'fields': ['username', 'active', 'roles', 'login_count']}),
+        (lazy_gettext('Personal Info'),
+         {'fields': ['first_name', 'last_name', 'email'], 'expanded': True}),
+    ]
+
+    add_columns = ['first_name', 'last_name', 'username', 'active', 'email', 'roles', 'tenant_id', 'password', 'conf_password']
+    list_columns = ['first_name', 'last_name', 'username', 'email', 'active', 'roles']
+    edit_columns = ['first_name', 'last_name', 'username', 'active', 'email', 'roles', 'tenant_id']
+
+# This will add multi tenant support in user model
+class MultiTenantSecurityManager(SecurityManager):
+    user_model = MultiTenantUser
+    userdbmodelview = MultiTenantUserDBModelView

--- a/superset/security.py
+++ b/superset/security.py
@@ -35,7 +35,8 @@ ADMIN_ONLY_VIEW_MENUS = {
     'ResetPasswordView',
     'RoleModelView',
     'Security',
-    'UserDBModelView',
+    'UserDBModelView' if not conf.get('ENABLE_MULTI_TENANCY')\
+        else 'MultiTenantUserDBModelView',
 }
 
 ADMIN_ONLY_PERMISSIONS = {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -701,7 +701,13 @@ class Superset(BaseSupersetView):
 
         role_name = data['role_name']
         role = sm.find_role(role_name)
-        role.user = existing_users
+        # This will fetch the User objects instead of sm.user_model as role.user
+        # expect the User object.
+        role_users = []
+        for user in existing_users:
+            role_users.append(db.session.query(ab_models.User).filter(
+                ab_models.User.username == user.username).first())
+        role.user = role_users
         sm.get_session.commit()
         return self.json_response({
             'role': role_name,

--- a/tests/access_tests.py
+++ b/tests/access_tests.py
@@ -562,8 +562,12 @@ class RequestAccessTests(SupersetTestCase):
             follow_redirects=True
         )
         update_role = sm.find_role(update_role_str)
+        update_role_users = []
+        # Convert the User model to sm.user_model
+        for user in update_role.user:
+            update_role_users.append(sm.find_user(username=user.username))
         self.assertEquals(
-            update_role.user, [sm.find_user(username='gamma')])
+            update_role_users, [sm.find_user(username='gamma')])
         self.assertEquals(resp.status_code, 201)
 
         resp = self.client.post(
@@ -586,8 +590,12 @@ class RequestAccessTests(SupersetTestCase):
         )
         self.assertEquals(resp.status_code, 201)
         update_role = sm.find_role(update_role_str)
+        update_role_users = []
+        # Convert the User model to sm.user_model
+        for user in update_role.user:
+            update_role_users.append(sm.find_user(username=user.username))
         self.assertEquals(
-            update_role.user, [
+            update_role_users, [
                 sm.find_user(username='alpha'),
                 sm.find_user(username='unknown'),
             ])

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -119,7 +119,7 @@ class CoreTests(SupersetTestCase):
             assert_func('ResetPasswordView', view_menus)
             assert_func('RoleModelView', view_menus)
             assert_func('Security', view_menus)
-            assert_func('UserDBModelView', view_menus)
+            assert_func(sm.userdbmodelview.__name__, view_menus)
             assert_func('SQL Lab',
                         view_menus)
             assert_func('AccessRequestsModelView', view_menus)

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -80,7 +80,7 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_cannot_write('AccessRequestsModelView', perm_set)
         self.assert_cannot_write('Queries', perm_set)
         self.assert_cannot_write('RoleModelView', perm_set)
-        self.assert_cannot_write('UserDBModelView', perm_set)
+        self.assert_cannot_write(sm.userdbmodelview.__name__, perm_set)
 
     def assert_can_admin(self, perm_set):
         self.assert_can_all('DatabaseAsync', perm_set)
@@ -88,7 +88,7 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_can_all('DruidClusterModelView', perm_set)
         self.assert_can_all('AccessRequestsModelView', perm_set)
         self.assert_can_all('RoleModelView', perm_set)
-        self.assert_can_all('UserDBModelView', perm_set)
+        self.assert_can_all(sm.userdbmodelview.__name__, perm_set)
 
         self.assertIn(('all_database_access', 'all_database_access'), perm_set)
         self.assertIn(('can_override_role_permissions', 'Superset'), perm_set)
@@ -111,7 +111,7 @@ class RolePermissionTests(SupersetTestCase):
                 'can_show', 'AccessRequestsModelView')))
         self.assertTrue(security.is_admin_only(
             sm.find_permission_view_menu(
-                'can_edit', 'UserDBModelView')))
+                'can_edit', sm.userdbmodelview.__name__)))
         self.assertTrue(security.is_admin_only(
             sm.find_permission_view_menu(
                 'can_approve', 'Superset')))


### PR DESCRIPTION
Issue: apache/incubator-superset#1089

To achieve multi-tenancy:
1. set "ENABLE_MULTI_TENANCY = True" in superset_config file.
2. add column tenant_id String(256) in the tables or views in which you want multi-tenancy.
3. if you are adding the multi-tenancy in existing project then
   make sure that ab_user table have the column tenant_id else alter the table.
4. if you want to enable multi-tenancy with CUSTOM_SECURITY_MANAGER,
   then your custom security manager class should be a subclass of MultiTenantSecurityManager class.

Added the documentation for multi-tenancy.

Fixed few typing errors. Also remove tenant_id from user view.
Fixes few test cases and role update api to support the custom user model.