### PR TITLE
Using indexOf instead of includes for isXAxisString

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -351,7 +351,7 @@ function nvd3Vis(slice, payload) {
       chart.x2Axis.tickFormat(xAxisFormatter);
       height += 30;
     }
-    const isXAxisString = ['dist_bar', 'box_plot'].includes(vizType) >= 0;
+    const isXAxisString = ['dist_bar', 'box_plot'].indexOf(vizType) >= 0;
     if (!isXAxisString && chart.xAxis && chart.xAxis.tickFormat) {
       chart.xAxis.tickFormat(xAxisFormatter);
     }


### PR DESCRIPTION
This [PR](https://github.com/apache/incubator-superset/pull/3722) added a check for `isXAxisString = ['dist_bar', 'box_plot'].includes(vizType) >= 0` but for a different viz type (like line) includes will evaluate to false and `false >= 0` will evaluate to true (so the formatter was not getting set).

Changing to use indexOf.