### PR TITLE
[Bugfix] Escape columns names for time grains - postgres

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -214,14 +214,14 @@ class PostgresEngineSpec(BaseEngineSpec):
 
     time_grains = (
         Grain("Time Column", _('Time Column'), "{col}"),
-        Grain("second", _('second'), "DATE_TRUNC('second', {col})"),
-        Grain("minute", _('minute'), "DATE_TRUNC('minute', {col})"),
-        Grain("hour", _('hour'), "DATE_TRUNC('hour', {col})"),
-        Grain("day", _('day'), "DATE_TRUNC('day', {col})"),
-        Grain("week", _('week'), "DATE_TRUNC('week', {col})"),
-        Grain("month", _('month'), "DATE_TRUNC('month', {col})"),
-        Grain("quarter", _('quarter'), "DATE_TRUNC('quarter', {col})"),
-        Grain("year", _('year'), "DATE_TRUNC('year', {col})"),
+        Grain("second", _('second'), "DATE_TRUNC('second', \"{col}\")"),
+        Grain("minute", _('minute'), "DATE_TRUNC('minute', \"{col}\")"),
+        Grain("hour", _('hour'), "DATE_TRUNC('hour', \"{col}\")"),
+        Grain("day", _('day'), "DATE_TRUNC('day', \"{col}\")"),
+        Grain("week", _('week'), "DATE_TRUNC('week', \"{col}\")"),
+        Grain("month", _('month'), "DATE_TRUNC('month', \"{col}\")"),
+        Grain("quarter", _('quarter'), "DATE_TRUNC('quarter', \"{col}\")"),
+        Grain("year", _('year'), "DATE_TRUNC('year', \"{col}\")"),
     )
 
     @classmethod


### PR DESCRIPTION
Postgres will automatically lowercase all column names. The time charts thus do not work for postgres with any uppercase letters in table names.

Closes #3208