### PR TITLE
Fix has_table method

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -788,8 +788,8 @@ class Database(Model, AuditMixinNullable):
 
     def has_table(self, table):
         engine = self.get_sqla_engine()
-        return engine.dialect.has_table(
-            engine, table.table_name, table.schema or None)
+        return engine.has_table(
+            table.table_name, table.schema or None)
 
     def get_dialect(self):
         sqla_url = url.make_url(self.sqlalchemy_uri_decrypted)


### PR DESCRIPTION
Dialect's has_table method requires connection as the first argument, not engine (https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/engine/interfaces.py#L454). 

We can use engine's has_table method instead that handles the connection for us (https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/engine/base.py#L2141). 

Alternatively, we could call engine.dialect.has_table(engine.connect(), ...).