### PR TITLE
Removing empty filters from explore url

### DIFF
--- a/superset/assets/javascripts/explore/exploreUtils.js
+++ b/superset/assets/javascripts/explore/exploreUtils.js
@@ -24,6 +24,14 @@ export function getExploreUrl(form_data, endpointType = 'base', force = false,
   const [datasource_id, datasource_type] = form_data.datasource.split('__');
   directory += `${datasource_type}/${datasource_id}/`;
 
+  // Removing empty filters
+  if ('filters' in form_data) {
+    // eslint-disable-next-line no-param-reassign
+    form_data.filters = form_data.filters.filter(filter => (
+      Array.isArray(filter.val) ? filter.val.length : filter.val
+    ));
+  }
+
   // Building the querystring (search) part of the URI
   const search = uri.search(true);
   search.form_data = JSON.stringify(form_data);

--- a/superset/assets/javascripts/explore/exploreUtils.js
+++ b/superset/assets/javascripts/explore/exploreUtils.js
@@ -28,7 +28,8 @@ export function getExploreUrl(form_data, endpointType = 'base', force = false,
   if ('filters' in form_data) {
     // eslint-disable-next-line no-param-reassign
     form_data.filters = form_data.filters.filter(filter => (
-      Array.isArray(filter.val) ? filter.val.length : filter.val
+      // Filter empty strings or arrays
+      !((typeof filter.val === 'string' || Array.isArray(filter.val)) && filter.val.length === 0)
     ));
   }
 


### PR DESCRIPTION
We've been having issues with urls that are too long. This is one quick solution where getExploreUrl removes any filters where the value is empty. These seem to be getting added from the dashboard filters, but I don't believe they are needed.

This will mean that even if an empty filter is set, it won't get saved to the slice. Is there any reason someone would need to set an empty filter?

I tested creating and saving a slice with an empty filter. The filter does not get saved with the slice. On a dashboard a filter works with that slice.