### PR TITLE
Add dummy file to fix symlink

### DIFF
--- a/docs/_build/html/README.md
+++ b/docs/_build/html/README.md
@@ -1,0 +1,1 @@
+Folder containing the sphinx-generated documentation


### PR DESCRIPTION
In `assets/static` we have a symlink pointing to `docs/_build/html`
which is .gitignored and missing in the repo since we don't want the
html-generated docs in the repo, meaning the symlink is broken

Having the symlink broken creates issues with pip-compile somehow.

Adding a dummy file here addresses that