### PR TITLE
Fix dashboard export download

### DIFF
--- a/superset/templates/superset/export_dashboards.html
+++ b/superset/templates/superset/export_dashboards.html
@@ -1,6 +1,6 @@
 <script>
     window.onload = function() {
-        window.open(window.location += '&action=go');
+        window.open(window.location += '&action=go', '_blank');
         window.location = '{{ dashboards_url }}';
     };
 </script>


### PR DESCRIPTION
@graceguo-supercat When using the dashboard exporting functionality in chrome, the popup gets blocked so the download doesn't happen. This fixes the popup getting blocked.