### PR TITLE
[sql-lab] Fixing Run Query tooltip

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/RunQueryActionButton.jsx
+++ b/superset/assets/javascripts/SqlLab/components/RunQueryActionButton.jsx
@@ -19,7 +19,6 @@ export default function RunQueryActionButton(props) {
   const runBtnText = props.selectedText ? t('Run Selected Query') : t('Run Query');
   const btnStyle = props.selectedText ? 'warning' : 'primary';
   const shouldShowStopBtn = ['running', 'pending'].indexOf(props.queryState) > -1;
-  const asyncToolTip = t('Run query asynchronously');
 
   const commonBtnProps = {
     bsSize: 'small',
@@ -32,7 +31,7 @@ export default function RunQueryActionButton(props) {
       {...commonBtnProps}
       onClick={() => props.runQuery(false)}
       key="run-btn"
-      tooltip={asyncToolTip}
+      tooltip={t('Run query synchronously')}
     >
       <i className="fa fa-refresh" /> {runBtnText}
     </Button>
@@ -43,7 +42,7 @@ export default function RunQueryActionButton(props) {
       {...commonBtnProps}
       onClick={() => props.runQuery(true)}
       key="run-async-btn"
-      tooltip={asyncToolTip}
+      tooltip={t('Run query asynchronously')}
     >
       <i className="fa fa-table" /> {runBtnText}
     </Button>


### PR DESCRIPTION
This PR fixes the SQL Lab run query tooltip which previously stated "Run query asynchronously" regardless of whether the query was running in synchronous or asynchronous mode. 

![screen shot 2017-11-03 at 3 07 43 pm](https://user-images.githubusercontent.com/4567245/32397936-65f9ff02-c0a9-11e7-8681-b5893bf64dfb.png)

to: @graceguo-supercat @mistercrunch 