### PR TITLE
[flake8] Enabling flake8 linting

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,2 +1,0 @@
-[pycodestyle]
-max-line-length = 90

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - TRAVIS_CACHE=$HOME/.travis_cache/
     - TRAVIS_NODE_VERSION="7.10.0"
   matrix:
+    - TOX_ENV=flake8
     - TOX_ENV=javascript
     - TOX_ENV=pylint
     - TOX_ENV=py34-postgres
@@ -30,5 +31,6 @@ before_script:
 install:
   - pip install --upgrade pip
   - pip install tox tox-travis
+  - pip install --upgrade flake8
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
 script: tox -e $TOX_ENV

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,3 @@ detailed-errors=1
 with-coverage=1
 nocapture=1
 cover-package=superset
-
-[pycodestyle]
-max-line-length=90

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,61 @@ envlist =
     py35-mysql
 skipsdist=True
 
+[flake8]
+application-import-names = superset
+exclude =
+    .tox
+    docs
+    superset/assets
+    superset/migrations
+    superset/templates
+ignore =
+    C812
+    E111
+    E114
+    E116
+    E121
+    E123
+    E125
+    E126
+    E127
+    E128
+    E131
+    E203
+    E221
+    E225
+    E226
+    E241
+    E302
+    E303
+    E305
+    E306
+    E402
+    E501
+    E722
+    E703
+    E731
+    E741
+    F401
+    F403
+    F405
+    F601
+    F811
+    F841
+    I100
+    I101
+    I201
+    I202
+    Q000
+    Q001
+    W291
+    W292
+    W293
+    W391
+    W503
+import-order-style = google
+max-line-length = 90
+
 [global]
 wheel_dir = {homedir}/.wheelhouse
 find_links =
@@ -33,6 +88,15 @@ commands =
   pip install --find-links={homedir}/.wheelhouse --no-index .
   pip install -r dev-reqs.txt
   {toxinidir}/run_tests.sh
+
+[testenv:flake8]
+commands =
+    flake8
+deps =
+    flake8
+    flake8-commas
+    flake8-import-order
+    flake8-quotes
 
 [testenv:javascript]
 commands = {toxinidir}/superset/assets/js_build.sh


### PR DESCRIPTION
I felt it would be prudent to add additional linting to the Python code beyond `pylint` ensures to help enforce a consistent style. 

This PR enables `flake8` as part of the Travis CI though currently all errors which were triggered have been whitelisted to be ignored. My plan is to systematically address these errors via a series of digestible PRs in the coming days/weeks.

Note I deprecated `pycodestyle` as this `flake8` is a superset of `pep8`.

to: @mistercrunch 
cc: @graceguo-supercat @michellethomas @timifasubaa 