### PR TITLE
Removing iso from data in time_table viz

### DIFF
--- a/superset/assets/visualizations/time_table.jsx
+++ b/superset/assets/visualizations/time_table.jsx
@@ -38,7 +38,7 @@ function viz(slice, payload) {
   slice.container.css('height', slice.height());
   const records = payload.data.records;
   const fd = payload.form_data;
-  const data = Object.keys(records).sort().map(iso => ({ ...records[iso], iso }));
+  const data = Object.keys(records).sort().map(iso => ({ ...records[iso] }));
   const reversedData = [...data].reverse();
   const metricMap = {};
   slice.datasource.metrics.forEach((m) => {


### PR DESCRIPTION
I noticed this issue when testing something else on staging. This line was restructured in [this pr](https://github.com/apache/incubator-superset/pull/3767) and iso was added to data, when it should just be the unpacking of records [iso]. It causes an error when calculating the contribution to total.

@williaster @graceguo-supercat 