### PR TITLE
[time table] use sparkData values in tooltip

### DIFF
--- a/superset/assets/visualizations/time_table.jsx
+++ b/superset/assets/visualizations/time_table.jsx
@@ -87,8 +87,8 @@ function viz(slice, payload) {
           display: (
             <WithTooltip
               renderTooltip={({ index }) => (
-                <div style={{ minWidth: 140 }}>
-                  <strong>{d3format(c.d3format, data[index][metric])}</strong>
+                <div>
+                  <strong>{d3format(c.d3format, sparkData[index])}</strong>
                   <div>{formatDate(data[index].iso)}</div>
                 </div>
               )}


### PR DESCRIPTION
@michellethomas 

This fixes an issue where sparkline tooltips were always displaying a metric's value meaning they were wrong when there was a non-zero time lag. Fixed by pulling from the sparkline data array. Also removed an unnecessary min width on the tooltip

Before
![image](https://user-images.githubusercontent.com/4496521/32523067-b452ac30-c3ce-11e7-92a3-46711e2ecd95.png)

After
![image](https://user-images.githubusercontent.com/4496521/32523093-cb6954c8-c3ce-11e7-92e6-f1d6487c7f36.png)
