### PR TITLE
[Bugfix] Single druid extraction dimension error

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -977,7 +977,13 @@ class DruidDatasource(Model, BaseDatasource):
         if len(groupby) == 0 and not having_filters:
             del qry['dimensions']
             client.timeseries(**qry)
-        if not having_filters and len(groupby) == 1 and order_desc:
+
+        if (
+            not having_filters and
+            len(groupby) == 1 and
+            order_desc and
+            not isinstance(list(qry.get('dimensions'))[0], dict)
+        ):
             dim = list(qry.get('dimensions'))[0]
             if timeseries_limit_metric:
                 order_by = timeseries_limit_metric
@@ -999,7 +1005,7 @@ class DruidDatasource(Model, BaseDatasource):
             if phase == 1:
                 return query_str
             query_str += (
-              "//\nPhase 2 (built based on phase one's results)\n")
+              "// Phase 2 (built based on phase one's results)\n")
             df = client.export_pandas()
             qry['filter'] = self._add_filter_from_pre_query_data(
                                 df,
@@ -1041,7 +1047,7 @@ class DruidDatasource(Model, BaseDatasource):
                 if phase == 1:
                     return query_str
                 query_str += (
-                    "//\nPhase 2 (built based on phase one's results)\n")
+                    "// Phase 2 (built based on phase one's results)\n")
                 df = client.export_pandas()
                 qry['filter'] = self._add_filter_from_pre_query_data(
                                     df,


### PR DESCRIPTION
If you have a single dimension that is an extraction, e.g.
```javascript
{
    "outputName": "country_uppercase", 
    "extractionFn": {
      "type": "upper"
    }, 
    "type": "extraction", 
    "dimension": "country", 
    "outputType": "STRING"
}
```
And `order_desc` is set to true, the query results in an error because `dimension` is set to the dictionary value, instead of just the dimension name.