### PR TITLE
Stamping version to 0.21.0dev

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superset",
-  "version": "0.20.1",
+  "version": "0.21.0dev",
   "description": "Superset is a data exploration platform designed to be visual, intuitive, and interactive.",
   "license": "Apache-2.0",
   "directories": {


### PR DESCRIPTION
Making it clear that master has a `dev`-suffixed version. Proper release
number will be created in release branches.

There are constraints as to what npm and setuptools will accept as a
proper version number and N.N.Ndev seems to work so I'm rolling with it

Open to suggestion as to how to tag `master`