### PR TITLE
[cache] Fixing cache key w/ merged extra filters

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -668,8 +668,8 @@ def get_celery_app(config):
 def merge_extra_filters(form_data):
     # extra_filters are temporary/contextual filters that are external
     # to the slice definition. We use those for dynamic interactive
-    # filters like the ones emitted by the 'Filter Box' visualization
-    if form_data.get('extra_filters'):
+    # filters like the ones emitted by the "Filter Box" visualization
+    if 'extra_filters' in form_data:
         # __form and __to are special extra_filters that target time
         # boundaries. The rest of extra_filters are simple
         # [column_name in list_of_values]. `__` prefix is there to avoid

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -220,7 +220,9 @@ class BaseViz(object):
 
     @property
     def cache_key(self):
-        s = str([(k, self.form_data[k]) for k in sorted(self.form_data.keys())])
+        form_data = self.form_data.copy()
+        merge_extra_filters(form_data)
+        s = str([(k, form_data[k]) for k in sorted(form_data.keys())])
         return hashlib.md5(s.encode('utf-8')).hexdigest()
 
     def get_annotations(self):

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -61,9 +61,9 @@ class UtilsTestCase(unittest.TestCase):
         expected = {'A': 1, 'B': 2, 'c': 'test'}
         merge_extra_filters(form_data)
         self.assertEquals(form_data, expected)
-        # does nothing if empty extra_filters
+        # empty extra_filters
         form_data = {'A': 1, 'B': 2, 'c': 'test', 'extra_filters': []}
-        expected = {'A': 1, 'B': 2, 'c': 'test', 'extra_filters': []}
+        expected = {'A': 1, 'B': 2, 'c': 'test', 'filters': []}
         merge_extra_filters(form_data)
         self.assertEquals(form_data, expected)
         # copy over extra filters into empty filters


### PR DESCRIPTION
I was alerted to this issue when after force refreshing a dashboard and then exploring the slice, I observed that the slice wasn't cache and/or there were inconsistencies in the cached values. 

It turns out that the reason is the cache key for a slice is different from these views, as the dashboard key contained the `extra_filters` which were absent from the slice view. The remedy was to simply update the cache key logic to mutate the form data which is being used as the cache key by calling the `merge_extra_filters` method. Note I don't have full context over these extra filters or whether this call should be abstracted in some way. 

Also the `merge_extra_filters` method previously only handled the case when the `extra_filters` field was non-empty, however this logic needed to be loosen to handle the case of the field being present to ensure that the field is removed.

Note I'm uncertain whether an additional test case is required. I had something of the form,
```python
    def test_cache_payload_from_dashboard(self):
        dash = (
            db.session.query(models.Dashboard)
            .filter_by(slug='births')
            .first()
        )

        # An HTTP request for the dashboard caches all the slices.
        self.client.get(dash.url)

        for slice in dash.slices:
            payload = slice.viz.get_payload()
            assert payload['is_cached']
```
however the `dash.url` leverages async functionality and thus I'm uncertain how best to wait for the page content to load.