### PR TITLE
Allow scrolling timetable viz on dashboard

### DIFF
--- a/superset/assets/visualizations/time_table.css
+++ b/superset/assets/visualizations/time_table.css
@@ -1,3 +1,3 @@
 .time_table.slice_container {
-  overflow: auto;
+  overflow: auto !important;
 }


### PR DESCRIPTION
Sorry I didn't catch this in the previous PR. Overflow auto needs to be important for the time table viz to be scrollable from the dashboard.