### PR TITLE
[docstring] Refining warm_up_cache comment

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1674,7 +1674,10 @@ class Superset(BaseSupersetView):
     @has_access_api
     @expose("/warm_up_cache/", methods=['GET'])
     def warm_up_cache(self):
-        """Warms up the cache for the slice or table."""
+        """Warms up the cache for the slice or table.
+
+        Note for slices a force refresh occurs.
+        """
         slices = None
         session = db.session()
         slice_id = request.args.get('slice_id')


### PR DESCRIPTION
From the method description it wasn't clear to me whether the `/warm_up_cache/` API endpoint forces a hard refresh or merely ensures that the object is in the cache. I felt an additional comment would make this clearer.