### PR TITLE
Added /healthcheck endpoint for integrations with envoy

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -582,6 +582,9 @@ appbuilder.add_view(
 def health():
     return "OK"
 
+@app.route('/healthcheck')
+def healthcheck():
+    return "OK"
 
 @app.route('/ping')
 def ping():
@@ -1441,6 +1444,15 @@ class Superset(BaseSupersetView):
                     # the password-masked uri was passed
                     # use the URI associated with this database
                     uri = database.sqlalchemy_uri_decrypted
+<<<<<<< HEAD
+=======
+
+            url = make_url(uri)
+            db_engine = models.Database.get_db_engine_spec_for_backend(url.get_backend_name())
+            db_engine.patch()
+            uri = db_engine.get_uri_for_impersonation(uri, impersonate_user, username)
+            masked_url = database.get_password_masked_url_from_uri(uri)
+>>>>>>> 5187dc2d... add healthcheck for envoy integrations
 
             configuration = {}
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1444,15 +1444,6 @@ class Superset(BaseSupersetView):
                     # the password-masked uri was passed
                     # use the URI associated with this database
                     uri = database.sqlalchemy_uri_decrypted
-<<<<<<< HEAD
-=======
-
-            url = make_url(uri)
-            db_engine = models.Database.get_db_engine_spec_for_backend(url.get_backend_name())
-            db_engine.patch()
-            uri = db_engine.get_uri_for_impersonation(uri, impersonate_user, username)
-            masked_url = database.get_password_masked_url_from_uri(uri)
->>>>>>> 5187dc2d... add healthcheck for envoy integrations
 
             configuration = {}
 

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -271,6 +271,7 @@ class CoreTests(SupersetTestCase):
 
     def test_misc(self):
         assert self.get_resp('/health') == "OK"
+        assert self.get_resp('/healthcheck') == "OK"
         assert self.get_resp('/ping') == "OK"
 
     def test_testconn(self, username='admin'):


### PR DESCRIPTION
Set healthcheck for envoy to integrate and check service health. Easier for us to add endpoint vs. switching envoys reference.

https://github.com/lyft/incubator-superset/pull/2

@mistercrunch