### PR TITLE
[viz] Fix payload force logic

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -244,7 +244,6 @@ class BaseViz(object):
         """Handles caching around the json payload retrieval"""
         cache_key = self.cache_key
         payload = None
-        force = force if force else self.form_data.get('force') == 'true'
         if not force and cache:
             payload = cache.get(cache_key)
 


### PR DESCRIPTION
The logic to force fetch the visualization payload is specified via the `force` request argument rather than the `force` key in the form-data. 

Note the form-data serves as the cache key and thus if this logic were correct the `force` field would need to be removed from `cache_key`, i.e., the key should be agnostic of forcing function. 