### PR TITLE
[Dashboard bug]Fix userId prop in Explore view Save_Modal

### DIFF
--- a/superset/assets/javascripts/explore/components/SaveModal.jsx
+++ b/superset/assets/javascripts/explore/components/SaveModal.jsx
@@ -243,7 +243,7 @@ function mapStateToProps({ explore, saveModal }) {
     datasource: explore.datasource,
     slice: explore.slice,
     can_overwrite: explore.can_overwrite,
-    userId: explore.userId,
+    userId: explore.user_id,
     dashboards: saveModal.dashboards,
     alert: saveModal.saveModalAlert,
   };

--- a/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -24,7 +24,7 @@ describe('SaveModal', () => {
     },
     explore: {
       can_overwrite: true,
-      userId: '1',
+      user_id: '1',
       datasource: {},
       slice: {
         slice_id: 1,


### PR DESCRIPTION
For userId, the attribute name in bootstrap data is user_id.

@michellethomas @mistercrunch 