### PR TITLE
[issue] Resolving issue 2530 with non-ASCII characters in query string

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -6,6 +6,7 @@ from flask_appbuilder import Model
 from flask_babel import lazy_gettext as _
 import pandas as pd
 from past.builtins import basestring
+import six
 import sqlalchemy as sa
 from sqlalchemy import (
     and_, asc, Boolean, Column, DateTime, desc, ForeignKey, Integer, or_,
@@ -319,7 +320,7 @@ class SqlaTable(Model, BaseDatasource):
     def get_query_str(self, query_obj):
         engine = self.database.get_sqla_engine()
         qry = self.get_sqla_query(**query_obj)
-        sql = str(
+        sql = six.text_type(
             qry.compile(
                 engine,
                 compile_kwargs={'literal_binds': True},


### PR DESCRIPTION
This PR resolves issue [#2530](https://github.com/apache/incubator-superset/issues/2530) related to having non-ascii characters in an explore query.

The actual fix was proposed by @xrmx [here](https://github.com/apache/incubator-superset/issues/2530#issuecomment-293191532) which remedies the problem in Python2 given that `str(...)` uses the ASCII codec, i.e., 
```
>>> str(u'Andalucía')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 7: ordinal not in range(128)
```
The fix is to use `six.text_type(...)` which calls `unicode(...)` in Python 2 and `str(...)` in Python 3.
```
>>> unicode(u'Andalucía')
u'Andaluc\xeda'
```
@xrmx I don't fully understand your comment, 
> but the code is still broken with non-ascii chars on python2
as the problem seems to be specific to Python 2 and using `six.text_type(...)` remedies the problem.

![screen shot 2017-11-14 at 11 38 26 am](https://user-images.githubusercontent.com/4567245/32800876-5f45c490-c930-11e7-84e6-51a45a2c5477.png)
