### PR TITLE
[Dashboard bug] Fix merged filter param name

### DIFF
--- a/superset/assets/javascripts/dashboard/components/Dashboard.jsx
+++ b/superset/assets/javascripts/dashboard/components/Dashboard.jsx
@@ -121,7 +121,7 @@ class Dashboard extends React.PureComponent {
   getFormDataExtra(slice) {
     const formDataExtra = Object.assign({}, slice.formData);
     const extraFilters = this.effectiveExtraFilters(slice.slice_id);
-    formDataExtra.filters = formDataExtra.filters.concat(extraFilters);
+    formDataExtra.extra_filters = formDataExtra.filters.concat(extraFilters);
     return formDataExtra;
   }
 


### PR DESCRIPTION
After front-end merged time filter params, should update query with param name 'extra_filters'.