### PR TITLE
[linting] Cleaning up linting documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,10 +287,10 @@ We use [Mocha](https://mochajs.org/), [Chai](http://chaijs.com/) and [Enzyme](ht
 Lint the project with:
 
     # for python
-    flake8
+    tox -e flake8
 
     # for javascript
-    npm run lint
+    tox -e eslint
 
 ## Linting with codeclimate
 Codeclimate is a service we use to measure code quality and test coverage. To get codeclimate's report on your branch, ideally before sending your PR, you can setup codeclimate against your Superset fork. After you push to your fork, you should be able to get the report at http://codeclimate.com . Alternatively, if you prefer to work locally, you can install the codeclimate cli tool.

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,11 @@ commands =
   pip install -r dev-reqs.txt
   {toxinidir}/run_tests.sh
 
+[testenv:eslint]
+changedir = {toxinidir}/superset/assets
+commands =
+    npm run lint
+
 [testenv:flake8]
 commands =
     flake8


### PR DESCRIPTION
Per @timifasubaa's suggestion I updated the linting logic in `CONTRIBUTING.md`. Simply running `flake8` or (`npm run lint` for that matter) doesn't work off the bat as one needs to i) install all the `flake8` extensions, and ii) cd to `superset/assets` respectively. 

For the `flake8` case given that the configuration logic resides in the `tox.ini` file it seemed to make more sense to direct people to invoke `tox` locally for linting both Python and Javascript code. The later required an additional `tox` test environment which is not invoked by Travis since the `javascript` environment is a superset of `eslint`.  