### PR TITLE
3829 Queries using table entity to filter on table_name and database id

### DIFF
--- a/superset/data/__init__.py
+++ b/superset/data/__init__.py
@@ -172,9 +172,7 @@ def load_world_bank_health_n_pop():
         index=False)
 
     print("Creating table [wb_health_population] reference")
-
     db_obj = get_or_create_main_db()
-
     tbl = db.session.query(TBL).filter_by(table_name=tbl_name, database=db_obj).first()
     if not tbl:
         tbl = TBL(table_name=tbl_name)
@@ -570,9 +568,7 @@ def load_birth_names():
     print("-" * 80)
 
     print("Creating table [birth_names] reference")
-
     db_obj = get_or_create_main_db()
-
     obj = db.session.query(TBL).filter_by(table_name='birth_names', database=db_obj).first()
     if not obj:
         obj = TBL(table_name='birth_names')
@@ -842,7 +838,6 @@ def load_unicode_test_data():
     print("-" * 80)
 
     print("Creating table [unicode_test] reference")
-
     db_obj=get_or_create_main_db()
     obj = db.session.query(TBL).filter_by(table_name='unicode_test', database=db_obj).first()
     if not obj:

--- a/superset/data/__init__.py
+++ b/superset/data/__init__.py
@@ -172,12 +172,15 @@ def load_world_bank_health_n_pop():
         index=False)
 
     print("Creating table [wb_health_population] reference")
-    tbl = db.session.query(TBL).filter_by(table_name=tbl_name).first()
+
+    db_obj = get_or_create_main_db()
+
+    tbl = db.session.query(TBL).filter_by(table_name=tbl_name, database=db_obj).first()
     if not tbl:
         tbl = TBL(table_name=tbl_name)
     tbl.description = utils.readfile(os.path.join(DATA_FOLDER, 'countries.md'))
     tbl.main_dttm_col = 'year'
-    tbl.database = get_or_create_main_db()
+    tbl.database = db_obj
     tbl.filter_select_enabled = True
     db.session.merge(tbl)
     db.session.commit()
@@ -567,11 +570,14 @@ def load_birth_names():
     print("-" * 80)
 
     print("Creating table [birth_names] reference")
-    obj = db.session.query(TBL).filter_by(table_name='birth_names').first()
+
+    db_obj = get_or_create_main_db()
+
+    obj = db.session.query(TBL).filter_by(table_name='birth_names', database=db_obj).first()
     if not obj:
         obj = TBL(table_name='birth_names')
     obj.main_dttm_col = 'ds'
-    obj.database = get_or_create_main_db()
+    obj.database = db_obj
     obj.filter_select_enabled = True
     db.session.merge(obj)
     db.session.commit()
@@ -836,11 +842,13 @@ def load_unicode_test_data():
     print("-" * 80)
 
     print("Creating table [unicode_test] reference")
-    obj = db.session.query(TBL).filter_by(table_name='unicode_test').first()
+
+    db_obj=get_or_create_main_db()
+    obj = db.session.query(TBL).filter_by(table_name='unicode_test', database=db_obj).first()
     if not obj:
         obj = TBL(table_name='unicode_test')
     obj.main_dttm_col = 'date'
-    obj.database = get_or_create_main_db()
+    obj.database = db_obj
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -914,11 +922,12 @@ def load_random_time_series_data():
     print("-" * 80)
 
     print("Creating table [random_time_series] reference")
-    obj = db.session.query(TBL).filter_by(table_name='random_time_series').first()
+    db_obj = get_or_create_main_db()
+    obj = db.session.query(TBL).filter_by(table_name='random_time_series', database=db_obj).first()
     if not obj:
         obj = TBL(table_name='random_time_series')
     obj.main_dttm_col = 'ds'
-    obj.database = get_or_create_main_db()
+    obj.database = db_obj
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -977,11 +986,12 @@ def load_country_map_data():
     print("Done loading table!")
     print("-" * 80)
     print("Creating table reference")
-    obj = db.session.query(TBL).filter_by(table_name='birth_france_by_region').first()
+    db_obj=get_or_create_main_db()
+    obj = db.session.query(TBL).filter_by(table_name='birth_france_by_region', database=db_obj).first()
     if not obj:
         obj = TBL(table_name='birth_france_by_region')
     obj.main_dttm_col = 'date'
-    obj.database = get_or_create_main_db()
+    obj.database = db_obj
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -1042,11 +1052,12 @@ def load_long_lat_data():
     print("-" * 80)
 
     print("Creating table reference")
-    obj = db.session.query(TBL).filter_by(table_name='long_lat').first()
+    db_obj = get_or_create_main_db()
+    obj = db.session.query(TBL).filter_by(table_name='long_lat', database=db_obj).first()
     if not obj:
         obj = TBL(table_name='long_lat')
     obj.main_dttm_col = 'date'
-    obj.database = get_or_create_main_db()
+    obj.database = db_obj
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -1103,11 +1114,12 @@ def load_multiformat_time_series_data():
     print("Done loading table!")
     print("-" * 80)
     print("Creating table [multiformat_time_series] reference")
-    obj = db.session.query(TBL).filter_by(table_name='multiformat_time_series').first()
+    db_obj = get_or_create_main_db()
+    obj = db.session.query(TBL).filter_by(table_name='multiformat_time_series', database=db_obj).first()
     if not obj:
         obj = TBL(table_name='multiformat_time_series')
     obj.main_dttm_col = 'ds'
-    obj.database = get_or_create_main_db()
+    obj.database = db_obj
     dttm_and_expr_dict = {
         'ds': [None, None],
         'ds2': [None, None],

--- a/superset/migrations/versions/cf50994ebd3a_tables_unique_on_table_name_and_database.py
+++ b/superset/migrations/versions/cf50994ebd3a_tables_unique_on_table_name_and_database.py
@@ -1,0 +1,69 @@
+"""tables unique on table name and database
+
+Revision ID: cf50994ebd3a
+Revises: f959a6652acd
+Create Date: 2017-11-16 12:36:52.492000
+
+"""
+
+# revision identifiers, used by Alembic.
+
+
+revision = 'cf50994ebd3a'
+down_revision = 'f959a6652acd'
+
+from superset import db
+from superset.utils import generic_find_constraint_name, table_has_constraint
+import logging
+from sqlalchemy.orm import sessionmaker
+
+def upgrade():
+
+    # wasn't created for sqlite in migrations b4456560d4f3, 3b626e2a6783
+    if not table_has_constraint('tables', '_customer_location_uc', db):
+        logging.info("_customer_location_uc does not exist; creating new table with constraint and copying data")
+
+        Session = sessionmaker(bind=db.engine)
+        session = Session()
+        try:
+            session.execute("ALTER TABLE tables RENAME TO temp_table")
+            session.execute("""CREATE TABLE "tables" ( 
+                                created_on DATETIME NOT NULL, 
+                                changed_on DATETIME NOT NULL, 
+                                id INTEGER NOT NULL, 
+                                table_name VARCHAR(250), 
+                                main_dttm_col VARCHAR(250), 
+                                default_endpoint TEXT, 
+                                database_id INTEGER NOT NULL, 
+                                created_by_fk INTEGER, 
+                                changed_by_fk INTEGER, 
+                                "offset" INTEGER, 
+                                description TEXT, 
+                                is_featured BOOLEAN, 
+                                user_id INTEGER, 
+                                cache_timeout INTEGER, 
+                                schema VARCHAR(255), 
+                                sql TEXT, 
+                                params TEXT, 
+                                perm VARCHAR(1000), 
+                                filter_select_enabled BOOLEAN, 
+                                fetch_values_predicate VARCHAR(1000), 
+                                PRIMARY KEY (id), 
+                                CHECK (is_featured IN (0, 1)), 
+                                CONSTRAINT user_id FOREIGN KEY(user_id) REFERENCES ab_user (id), 
+                                FOREIGN KEY(changed_by_fk) REFERENCES ab_user (id), 
+                                FOREIGN KEY(database_id) REFERENCES dbs (id), 
+                                FOREIGN KEY(created_by_fk) REFERENCES ab_user (id), 
+                                CONSTRAINT _customer_location_uc UNIQUE (table_name, schema, database_id) )""")
+            session.execute("""INSERT INTO tables 
+                                SELECT *
+                                FROM temp_table""")
+            session.execute("DROP TABLE temp_table")
+
+        except Exception as e:
+            session.rollback()
+            logging.warning(str(e))
+
+def downgrade():
+    # Nothing to downgrade as db ought to be in this state already (which is the case for all DBs except sqlite)
+    pass

--- a/superset/migrations/versions/cf50994ebd3a_tables_unique_on_table_name_and_database.py
+++ b/superset/migrations/versions/cf50994ebd3a_tables_unique_on_table_name_and_database.py
@@ -17,52 +17,55 @@ from superset.utils import generic_find_constraint_name, table_has_constraint
 import logging
 from sqlalchemy.orm import sessionmaker
 
+
 def upgrade():
+    try:
+        # wasn't created for sqlite in migrations b4456560d4f3, 3b626e2a6783
+        if db.engine.url.get_dialect().name.lower() == 'sqlite':
+            logging.info("_customer_location_uc does not exist; creating new table with constraint and copying data")
 
-    # wasn't created for sqlite in migrations b4456560d4f3, 3b626e2a6783
-    if not table_has_constraint('tables', '_customer_location_uc', db):
-        logging.info("_customer_location_uc does not exist; creating new table with constraint and copying data")
+            Session = sessionmaker(bind=db.engine)
+            session = Session()
+            try:
+                session.execute("ALTER TABLE tables RENAME TO temp_table")
+                session.execute("""CREATE TABLE "tables" ( 
+                                    created_on DATETIME NOT NULL, 
+                                    changed_on DATETIME NOT NULL, 
+                                    id INTEGER NOT NULL, 
+                                    table_name VARCHAR(250), 
+                                    main_dttm_col VARCHAR(250), 
+                                    default_endpoint TEXT, 
+                                    database_id INTEGER NOT NULL, 
+                                    created_by_fk INTEGER, 
+                                    changed_by_fk INTEGER, 
+                                    "offset" INTEGER, 
+                                    description TEXT, 
+                                    is_featured BOOLEAN, 
+                                    user_id INTEGER, 
+                                    cache_timeout INTEGER, 
+                                    schema VARCHAR(255), 
+                                    sql TEXT, 
+                                    params TEXT, 
+                                    perm VARCHAR(1000), 
+                                    filter_select_enabled BOOLEAN, 
+                                    fetch_values_predicate VARCHAR(1000), 
+                                    PRIMARY KEY (id), 
+                                    CHECK (is_featured IN (0, 1)), 
+                                    CONSTRAINT user_id FOREIGN KEY(user_id) REFERENCES ab_user (id), 
+                                    FOREIGN KEY(changed_by_fk) REFERENCES ab_user (id), 
+                                    FOREIGN KEY(database_id) REFERENCES dbs (id), 
+                                    FOREIGN KEY(created_by_fk) REFERENCES ab_user (id), 
+                                    CONSTRAINT _customer_location_uc UNIQUE (table_name, schema, database_id) )""")
+                session.execute("""INSERT INTO tables 
+                                    SELECT *
+                                    FROM temp_table""")
+                session.execute("DROP TABLE temp_table")
 
-        Session = sessionmaker(bind=db.engine)
-        session = Session()
-        try:
-            session.execute("ALTER TABLE tables RENAME TO temp_table")
-            session.execute("""CREATE TABLE "tables" ( 
-                                created_on DATETIME NOT NULL, 
-                                changed_on DATETIME NOT NULL, 
-                                id INTEGER NOT NULL, 
-                                table_name VARCHAR(250), 
-                                main_dttm_col VARCHAR(250), 
-                                default_endpoint TEXT, 
-                                database_id INTEGER NOT NULL, 
-                                created_by_fk INTEGER, 
-                                changed_by_fk INTEGER, 
-                                "offset" INTEGER, 
-                                description TEXT, 
-                                is_featured BOOLEAN, 
-                                user_id INTEGER, 
-                                cache_timeout INTEGER, 
-                                schema VARCHAR(255), 
-                                sql TEXT, 
-                                params TEXT, 
-                                perm VARCHAR(1000), 
-                                filter_select_enabled BOOLEAN, 
-                                fetch_values_predicate VARCHAR(1000), 
-                                PRIMARY KEY (id), 
-                                CHECK (is_featured IN (0, 1)), 
-                                CONSTRAINT user_id FOREIGN KEY(user_id) REFERENCES ab_user (id), 
-                                FOREIGN KEY(changed_by_fk) REFERENCES ab_user (id), 
-                                FOREIGN KEY(database_id) REFERENCES dbs (id), 
-                                FOREIGN KEY(created_by_fk) REFERENCES ab_user (id), 
-                                CONSTRAINT _customer_location_uc UNIQUE (table_name, schema, database_id) )""")
-            session.execute("""INSERT INTO tables 
-                                SELECT *
-                                FROM temp_table""")
-            session.execute("DROP TABLE temp_table")
-
-        except Exception as e:
-            session.rollback()
-            logging.warning(str(e))
+            except Exception as e:
+                session.rollback()
+                logging.warning(str(e))
+    except Exception as e:
+        logging.warning(str(e))
 
 def downgrade():
     # Nothing to downgrade as db ought to be in this state already (which is the case for all DBs except sqlite)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1888,14 +1888,14 @@ class Superset(BaseSupersetView):
         SqlaTable = ConnectorRegistry.sources['table']
         data = json.loads(request.form.get('data'))
         table_name = data.get('datasourceName')
-        SqlaTable = ConnectorRegistry.sources['table']
+        db_id = data.get('dbId')
         table = (
             db.session.query(SqlaTable)
-            .filter_by(table_name=table_name)
+            .filter_by(table_name=table_name, database_id=db_id)
             .first()
         )
         if not table:
-            table = SqlaTable(table_name=table_name)
+            table = SqlaTable(table_name=table_name, database_id=db_id)
         table.database_id = data.get('dbId')
         q = SupersetQuery(data.get('sql'))
         table.sql = q.stripped()


### PR DESCRIPTION
Some of the api queries only filter on table name where they should be filtering on table name and database id. 

Also, The current migration scripts do not successfully create the correct uniqueness constraint on sqlite. This is because doesn't allow dropping unnamed unique constraints:
https://stackoverflow.com/questions/42013265/remove-unique-constraint-on-a-column-in-sqlite-database

Original issue here: https://github.com/apache/incubator-superset/issues/3829
