### PR TITLE
[BUGFIX]: Fixing dttm_sql_literal to use python_date_format 

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -101,18 +101,19 @@ class TableColumn(Model, BaseColumn):
         If database_expression is not empty, the internal dttm
         will be parsed as the sql sentence for the database to convert
         """
-
-        tf = self.python_date_format or '%Y-%m-%d %H:%M:%S.%f'
+        tf = self.python_date_format
         if self.database_expression:
             return self.database_expression.format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
-        elif tf == 'epoch_s':
-            return str((dttm - datetime(1970, 1, 1)).total_seconds())
-        elif tf == 'epoch_ms':
-            return str((dttm - datetime(1970, 1, 1)).total_seconds() * 1000.0)
+        elif tf:
+            if tf == 'epoch_s':
+                return str((dttm - datetime(1970, 1, 1)).total_seconds())
+            elif tf == 'epoch_ms':
+                return str((dttm - datetime(1970, 1, 1)).total_seconds() * 1000.0)
+            return "'{}'".format(dttm.strftime(tf))
         else:
             s = self.table.database.db_engine_spec.convert_dttm(
                 self.type or '', dttm)
-            return s or "'{}'".format(dttm.strftime(tf))
+            return s or "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S.%f'))
 
 
 class SqlMetric(Model, BaseMetric):


### PR DESCRIPTION
Between this `or`
https://github.com/apache/incubator-superset/blob/fa35d7d2f47d2f5b664d0433ea1be677924767e6/superset/connectors/sqla/models.py#L105

and this `or`

https://github.com/apache/incubator-superset/blob/fa35d7d2f47d2f5b664d0433ea1be677924767e6/superset/connectors/sqla/models.py#L114

You can get in a situation where `python_date_format` is completely ignored. This fixes this.