### PR TITLE
Only refreshing non instant filters on apply

### DIFF
--- a/superset/assets/javascripts/dashboard/reducers.js
+++ b/superset/assets/javascripts/dashboard/reducers.js
@@ -134,9 +134,9 @@ const dashboard = function (state = {}, action) {
           // d3.merge pass in array of arrays while some value form filter components
           // from and to filter box require string to be process and return
         } else if (state.filters[sliceId][col] instanceof Array) {
-          newFilter = d3.merge([state.filters[sliceId][col], vals]);
+          newFilter[col] = d3.merge([state.filters[sliceId][col], vals]);
         } else {
-          newFilter = d3.merge([[state.filters[sliceId][col]], vals])[0] || '';
+          newFilter[col] = d3.merge([[state.filters[sliceId][col]], vals])[0] || '';
         }
         filters = { ...state.filters, [sliceId]: newFilter };
       }

--- a/superset/assets/visualizations/filter_box.jsx
+++ b/superset/assets/visualizations/filter_box.jsx
@@ -72,7 +72,14 @@ class FilterBox extends React.Component {
     return control;
   }
   clickApply() {
-    this.props.onChange(Object.keys(this.state.selectedValues)[0], [], true, true);
+    const { selectedValues } = this.state;
+    Object.keys(selectedValues).forEach((fltr, i, arr) => {
+      let refresh = false;
+      if (i === arr.length - 1) {
+        refresh = true;
+      }
+      this.props.onChange(fltr, selectedValues[fltr], false, refresh);
+    });
     this.setState({ hasChanged: false });
   }
   changeFilter(filter, options) {
@@ -90,7 +97,9 @@ class FilterBox extends React.Component {
     const selectedValues = Object.assign({}, this.state.selectedValues);
     selectedValues[fltr] = vals;
     this.setState({ selectedValues, hasChanged: true });
-    this.props.onChange(fltr, vals, false, this.props.instantFiltering);
+    if (this.props.instantFiltering) {
+      this.props.onChange(fltr, vals, false, true);
+    }
   }
   render() {
     let dateFilter;


### PR DESCRIPTION
If instant filter is turned off for filter_box the filters get refreshed in the reducer on changeFilter not clickApply. clickApply should be not changing any of the filters but setting refresh to true. But on the dashboard side we check to see that the filters have changed and refresh is set to true before we refresh the slices.

This changes the filter box logic so it only updates state when you clickApply on a filter.

Also I believe newFilter in the reducer should be an object where the col name maps to the filter values. Currently we are just setting newFilter to the result of d3.merge (which is a list or string).

Solves issue #3888 

