### PR TITLE
[druid] Fixing issue 3894  multi-processing w/ Gunicorn

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 import json
 import logging
-from multiprocessing import Pool
+from multiprocessing.pool import ThreadPool
 
 from dateutil.parser import parse as dparse
 from flask import escape, Markup
@@ -157,7 +157,7 @@ class DruidCluster(Model, AuditMixinNullable):
         session.flush()
 
         # Prepare multithreaded executation
-        pool = Pool()
+        pool = ThreadPool()
         ds_refresh = list(ds_map.values())
         metadata = pool.map(_fetch_metadata_for, ds_refresh)
         pool.close()


### PR DESCRIPTION
This PR fixes issue https://github.com/apache/incubator-superset/issues/3894. 

It seems that using multi-processing for fetching Druid datasource metadata asynchronously fails under a Gunicorn environment. Switching to multi-threading seems to remedy the problem. 

Note previously `Pool()` created only 4 processes and I'm not overly certain why this part of the code needs to leverage multi-processing from a performance standpoint, i.e., I would be supportive of remove the multi-threading/processing logic entirely.

Also it seems like we're using the synchronous [PyClient](https://github.com/apache/incubator-superset/blob/master/superset/connectors/druid/models.py#L14) and thus `refresh_async` seems like a misnomer to me.

to: @mistercrunch @Mogball @xrmx 