### PR TITLE
[druid] Catch IOError when fetching Druid datasource time boundary

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -563,11 +563,15 @@ class DruidDatasource(Model, BaseDatasource):
         """Returns segment metadata from the latest segment"""
         logging.info('Syncing datasource [{}]'.format(self.datasource_name))
         client = self.cluster.get_pydruid_client()
-        results = client.time_boundary(datasource=self.datasource_name)
-        if not results:
-            return
-        max_time = results[0]['result']['maxTime']
-        max_time = dparse(max_time)
+        try:
+            results = client.time_boundary(datasource=self.datasource_name)
+        except IOError:
+            results = None
+        if results:
+            max_time = results[0]['result']['maxTime']
+            max_time = dparse(max_time)
+        else:
+            max_time = datetime.now()
         # Query segmentMetadata for 7 days back. However, due to a bug,
         # we need to set this interval to more than 1 day ago to exclude
         # realtime segments, which triggered a bug (fixed in druid 0.8.2).


### PR DESCRIPTION
Whilst debugging https://github.com/apache/incubator-superset/issues/3894 I noticed that the calling the PyDruid client `time_boundary(...)` function, an `IOError` can be thrown as described [here](https://github.com/druid-io/pydruid/blob/master/pydruid/client.py#L408).

This PR ensures we catch the exception and simply return `None` which is consistent with the case that no results are obtained. 

to: @mistercrunch @Mogball @xrmx 