### PR TITLE
[druid] Renaming refresh_async method

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -122,9 +122,9 @@ class DruidCluster(Model, AuditMixinNullable):
             ds_refresh.append(datasource_name)
         else:
             return
-        self.refresh_async(ds_refresh, merge_flag, refreshAll)
+        self.refresh(ds_refresh, merge_flag, refreshAll)
 
-    def refresh_async(self, datasource_names, merge_flag, refreshAll):
+    def refresh(self, datasource_names, merge_flag, refreshAll):
         """
         Fetches metadata for the specified datasources andm
         merges to the Superset database


### PR DESCRIPTION
Whilst debugging https://github.com/apache/incubator-superset/issues/3894 I noticed that the method named `refresh_async` is somewhat of a misnomer as we're using the [synchronous](https://github.com/apache/incubator-superset/blob/master/superset/connectors/druid/models.py#L14) PyDruid client. 

This PR simply renames `refresh_async` to `refresh`. 

to: @Mogball 