### PR TITLE
Workaround pandas bug in datetimes with time zones

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -14,6 +14,7 @@ from datetime import date, datetime
 
 import numpy as np
 import pandas as pd
+from pandas.core.common import _maybe_box_datetimelike
 from pandas.core.dtypes.dtypes import ExtensionDtype
 from past.builtins import basestring
 
@@ -48,7 +49,10 @@ class SupersetDataFrame(object):
 
     @property
     def data(self):
-        return self.__df.to_dict(orient='records')
+        # work around for https://github.com/pandas-dev/pandas/issues/18372
+        return [dict((k, _maybe_box_datetimelike(v))
+                     for k, v in zip(self.__df.columns, np.atleast_1d(row)))
+                for row in self.__df.values]
 
     @classmethod
     def db_type(cls, dtype):


### PR DESCRIPTION
A bug in to_dict(orient="records") in pandas/core/frame.py prevents
datetimes with time zones to be worked with. This works around the
issue in superset by re-implementing the logic of pandas in the
correct way. Until pandas fixes the issue this code should stay.

https://github.com/pandas-dev/pandas/issues/18372

This closes #1929 

cc: @tfellison @rumbin @xrmx