### PR TITLE
When checking if you should renderTriggered make sure controls[key] exists

### DIFF
--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -53,6 +53,7 @@ class ExploreViewContainer extends React.Component {
     }
     // if any control value changed and it's an instant control
     if (Object.keys(np.controls).some(key => (np.controls[key].renderTrigger &&
+      typeof this.props.controls[key] !== 'undefined' &&
       !areObjectsEqual(np.controls[key].value, this.props.controls[key].value)))) {
       this.props.actions.renderTriggered(new Date().getTime(), this.props.chart.chartKey);
     }


### PR DESCRIPTION
@graceguo-supercat @mistercrunch 

When switching visualization type `np.controls` and `this.props.controls` are different, so `this.props.controls[key]` is undefined. Alternatively, I could do a check to make sure the viz types are the same, but this seemed like a more explicit check.