### PR TITLE
Fix left padding in dashboard widgets

### DIFF
--- a/superset/assets/stylesheets/dashboard.css
+++ b/superset/assets/stylesheets/dashboard.css
@@ -35,7 +35,6 @@ div.widget:hover .chart-controls {
 
 .slice-grid .slice_container {
   background-color: #fff;
-  padding-left: 5px;
 }
 
 .dashboard .slice-grid .dragging,


### PR DESCRIPTION
<img width="419" alt="screen shot 2017-11-21 at 8 29 29 am" src="https://user-images.githubusercontent.com/487433/33084173-1f92de4e-ce96-11e7-8543-bec9c576cc05.png">

<img width="417" alt="screen shot 2017-11-21 at 8 29 02 am" src="https://user-images.githubusercontent.com/487433/33084179-221c6518-ce96-11e7-8539-cc75affd3293.png">
