### PR TITLE
[Bugfix] Single Druid dimension spec error (part 2)

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1018,7 +1018,7 @@ class DruidDatasource(Model, BaseDatasource):
             del qry['dimensions']
             qry['metric'] = list(qry['aggregations'].keys())[0]
             client.topn(**qry)
-        elif len(groupby) > 1 or having_filters or not order_desc:
+        else:
             # If grouping on multiple fields or using a having filter
             # we have to force a groupby query
             if timeseries_limit and is_timeseries:


### PR DESCRIPTION
issue: https://github.com/apache/incubator-superset/issues/3908

As a follow up to https://github.com/apache/incubator-superset/pull/3796, where I forgot to change the condition on the second branch, which is just an `else` now. 

Curious, why is there a branch to specifically handle a single dimension (which can't be a spec), with no `having_filters` and `order_desc = True`?