### PR TITLE
[Bugfix] Copy to clipboard adds newline

### DIFF
--- a/superset/assets/javascripts/components/CopyToClipboard.jsx
+++ b/superset/assets/javascripts/components/CopyToClipboard.jsx
@@ -56,14 +56,16 @@ export default class CopyToClipboard extends React.Component {
     selection.removeAllRanges();
     document.activeElement.blur();
     const range = document.createRange();
-    const textArea = document.createElement('textarea');
+    const span = document.createElement('span');
+    span.textContent = textToCopy;
+    span.style.all = 'unset';
+    span.style.position = 'fixed';
+    span.style.top = 0;
+    span.style.clip = 'rect(0, 0, 0, 0)';
+    span.style.whiteSpace = 'pre';
 
-    textArea.style.position = 'fixed';
-    textArea.style.left = '-1000px';
-    textArea.value = textToCopy;
-
-    document.body.appendChild(textArea);
-    range.selectNode(textArea);
+    document.body.appendChild(span);
+    range.selectNode(span);
     selection.addRange(range);
     try {
       if (!document.execCommand('copy')) {
@@ -73,7 +75,7 @@ export default class CopyToClipboard extends React.Component {
       window.alert(t('Sorry, your browser does not support copying. Use Ctrl / Cmd + C!')); // eslint-disable-line
     }
 
-    document.body.removeChild(textArea);
+    document.body.removeChild(span);
     if (selection.removeRange) {
       selection.removeRange(range);
     } else {


### PR DESCRIPTION
issue: https://github.com/apache/incubator-superset/issues/3919

Switched from previously-used `textarea` to `span` for the copy element seems to fix the extra newline at the beginning.