### PR TITLE
[Bugfix] Table Viz overlapping metrics and percent metrics

### DIFF
--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -486,7 +486,8 @@ export const visTypes = {
         description: t('Use this section if you want a query that aggregates'),
         controlSetRows: [
           ['groupby'],
-          ['metrics', 'percent_metrics'],
+          ['metrics'],
+          ['percent_metrics'],
           ['include_time'],
           ['timeseries_limit_metric', 'order_desc'],
         ],


### PR DESCRIPTION
Issue: https://github.com/apache/incubator-superset/issues/3921

Metrics can have pretty long names; giving `Percent Metrics` its own column should alleviate the issue