### PR TITLE
Make Table Columns & Metrics Bulk-actionable

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -17,7 +17,7 @@ from superset.views.base import (
 from . import models
 
 
-class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
+class TableColumnInlineView(CompactCRUDMixin, SupersetModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.TableColumn)
 
     list_title = _('List Columns')
@@ -94,7 +94,7 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
 appbuilder.add_view_no_menu(TableColumnInlineView)
 
 
-class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
+class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(models.SqlMetric)
 
     list_title = _('List Metrics')


### PR DESCRIPTION
Adds the DeleteMixin to both the sqlalchemy table column view and the SQL metric view to allow mass column management. Very useful for removing large numbers of auto-generated fields.