### PR TITLE
[bugfix] fix `setControlValue` call in Chart

### DIFF
--- a/superset/assets/javascripts/chart/Chart.jsx
+++ b/superset/assets/javascripts/chart/Chart.jsx
@@ -139,7 +139,7 @@ class Chart extends React.PureComponent {
   renderViz() {
     const viz = visMap[this.props.vizType];
     try {
-      viz(this, this.props.queryResponse, this.props.actions.setControlValue);
+      viz(this, this.props.queryResponse, this.props.setControlValue);
     } catch (e) {
       this.props.actions.chartRenderingFailed(e, this.props.chartKey);
     }


### PR DESCRIPTION
This has been broken since the dashboard refactor I believe