### PR TITLE
Add fastdom js dependency

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -57,6 +57,7 @@
     "datatables.net-bs": "^1.10.15",
     "deck.gl": "^4.1.5",
     "distributions": "^1.0.0",
+    "fastdom": "^1.0.6",
     "geolib": "^2.0.24",
     "immutable": "^3.8.2",
     "jed": "^1.1.1",
@@ -98,8 +99,8 @@
     "sprintf-js": "^1.1.1",
     "srcdoc-polyfill": "^1.0.0",
     "supercluster": "https://github.com/georgeke/supercluster/tarball/ac3492737e7ce98e07af679623aad452373bbc40",
-    "urijs": "^1.18.10",
     "underscore": "^1.8.3",
+    "urijs": "^1.18.10",
     "viewport-mercator-project": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The nvd3 docs say that it if the fastdom library is present it makes use
of it.

"Including Fastdom in your project can greatly increase the performance
of the line chart (particularly in Firefox and Internet Explorer) by
batching DOM read and write operations to avoid layout thrashing. NVD3
will take advantage of Fastdom if present."

Annectodal evidence refreshing a 4*nvd3 slices dashboard before/after fastdom
<img width="261" alt="screen shot 2017-11-27 at 11 08 48 pm" src="https://user-images.githubusercontent.com/487433/33306666-59e5492e-d3c8-11e7-86a0-d5066af5aac7.png">
<img width="261" alt="screen shot 2017-11-27 at 11 13 42 pm" src="https://user-images.githubusercontent.com/487433/33306748-a238a252-d3c8-11e7-83d5-0a28adcbd8c1.png">

