### PR TITLE
fix 'superset db history'

### DIFF
--- a/superset/migrations/versions/4736ec66ce19_.py
+++ b/superset/migrations/versions/4736ec66ce19_.py
@@ -36,10 +36,8 @@ datasources = sa.Table(
 
 
 def upgrade():
-
     bind = op.get_bind()
     insp = sa.engine.reflection.Inspector.from_engine(bind)
-
 
     # Add the new less restrictive uniqueness constraint.
     with op.batch_alter_table('datasources', naming_convention=conv) as batch_op:
@@ -117,8 +115,6 @@ def upgrade():
 def downgrade():
     bind = op.get_bind()
     insp = sa.engine.reflection.Inspector.from_engine(bind)
-
-
 
     # Add the new more restrictive uniqueness constraint which is required by
     # the foreign key constraints. Note this operation will fail if the

--- a/superset/migrations/versions/4736ec66ce19_.py
+++ b/superset/migrations/versions/4736ec66ce19_.py
@@ -34,11 +34,12 @@ datasources = sa.Table(
     sa.Column('datasource_name', sa.String(255)),
 )
 
-bind = op.get_bind()
-insp = sa.engine.reflection.Inspector.from_engine(bind)
-
 
 def upgrade():
+
+    bind = op.get_bind()
+    insp = sa.engine.reflection.Inspector.from_engine(bind)
+
 
     # Add the new less restrictive uniqueness constraint.
     with op.batch_alter_table('datasources', naming_convention=conv) as batch_op:
@@ -114,6 +115,10 @@ def upgrade():
 
 
 def downgrade():
+    bind = op.get_bind()
+    insp = sa.engine.reflection.Inspector.from_engine(bind)
+
+
 
     # Add the new more restrictive uniqueness constraint which is required by
     # the foreign key constraints. Note this operation will fail if the


### PR DESCRIPTION
Related Error msg when running `superset db history`:
"NameError: Can't invoke function 'get_bind', as the proxy object has not
yet been established for the Alembic 'Operations' class.  Try placing
this code inside a callable."

@john-bodley 