### PR TITLE
Allow underscores in slugs

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -506,7 +506,7 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
         obj.slug = obj.slug.strip() or None
         if obj.slug:
             obj.slug = obj.slug.replace(' ', '-')
-            obj.slug = re.sub(r'[^a-zA-Z0-9\-]+', '', obj.slug)
+            obj.slug = re.sub(r'[^a-zA-Z0-9\-_]+', '', obj.slug)
         if g.user not in obj.owners:
             obj.owners.append(g.user)
         utils.validate_json(obj.json_metadata)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -506,7 +506,7 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
         obj.slug = obj.slug.strip() or None
         if obj.slug:
             obj.slug = obj.slug.replace(' ', '-')
-            obj.slug = re.sub(r'[^a-zA-Z0-9\-_]+', '', obj.slug)
+            obj.slug = re.sub(r'[^\w\-]+', '', obj.slug)
         if g.user not in obj.owners:
             obj.owners.append(g.user)
         utils.validate_json(obj.json_metadata)


### PR DESCRIPTION
It looks like in [this](https://github.com/apache/incubator-superset/pull/3876) PR we updated the slug function to remove anything that is not a character, number, or hyphen. I think we should also allow underscores in the slug.

The [wiki](https://en.wikipedia.org/wiki/Semantic_URL#Slug) article mentions that underscores or hyphens would be appropriate in a slug. 

A number of users here currently use underscores in slugs, especially for the templated links in the time table viz (like /superset/dashboard/dashboard_{{metric }}) where the metric would have an underscore). So when they edit dashboards the underscores get removed and their links no longer work.

@mistercrunch @john-bodley 