### PR TITLE
set default DB_URI to correct value

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -58,9 +58,9 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 SECRET_KEY = '\2\1thisismyscretkey\1\2\e\y\y\h'  # noqa
 
 # The SQLAlchemy connection string.
-# SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'superset.db')
+SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'superset.db')
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
-SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
+# SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 
 # In order to hook up a custom password store for all SQLACHEMY connections
 # implement a function that takes a single argument of type 'sqla.engine.url',


### PR DESCRIPTION
In the import_csv PR (https://github.com/apache/incubator-superset/pull/3643) I accidentally changed the defult SQLALCHEMY_DATABASE_URI. This corrects that (and fixes this issue https://github.com/apache/incubator-superset/issues/3954) 

@graceguo-supercat @xrmx 