### PR TITLE
[docs] making it clear sqlite shouldn't be used in a cluster

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -498,6 +498,11 @@ look something like:
     RESULTS_BACKEND = RedisCache(
         host='localhost', port=6379, key_prefix='superset_results')
 
+Note that it's important that all the worker nodes and web servers in
+the Superset cluster share a common metadata database.
+This means that SQLite will not work in this context since it has
+limited support for concurrency and
+typically lives on the local file system.
 
 Also note that SQL Lab supports Jinja templating in queries, and that it's
 possible to overload


### PR DESCRIPTION
fixes https://github.com/apache/incubator-superset/issues/3963