### PR TITLE
Allow generic before_request

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'gunicorn==19.7.1',
         'idna==2.5',
         'markdown==2.6.8',
+        'pyopenssl==17.4.0',
         'pandas==0.20.3',
         'parsedatetime==2.0.0',
         'pydruid==0.3.1',

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'gunicorn==19.7.1',
         'idna==2.5',
         'markdown==2.6.8',
-        'pyopenssl==17.4.0',
         'pandas==0.20.3',
         'parsedatetime==2.0.0',
         'pydruid==0.3.1',

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -8,14 +8,12 @@ import json
 import logging
 from logging.handlers import TimedRotatingFileHandler
 import os
-import urllib
 
-from flask import Flask, redirect, request
+from flask import Flask, redirect
 from flask_appbuilder import AppBuilder, IndexView, SQLA
 from flask_appbuilder.baseviews import expose
 from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
-import OpenSSL
 from werkzeug.contrib.fixers import ProxyFix
 
 from superset.connectors.connector_registry import ConnectorRegistry
@@ -155,23 +153,26 @@ appbuilder = AppBuilder(
 
 sm = appbuilder.sm
 
+before_request_functions = conf.get('BEFORE_REQUEST_FUNCTIONS')
+
+
+@app.before_request
+def before_request():
+    for f in before_request_functions:
+        try:
+            f()
+        except Exception as e:
+            print(
+                'Exception {} in before_request function {}'
+                .format(e, f.func_name))
+            logging.exception(e)
+
+
 results_backend = app.config.get('RESULTS_BACKEND')
 
 # Registering sources
 module_datasource_map = app.config.get('DEFAULT_MODULE_DS_MAP')
 module_datasource_map.update(app.config.get('ADDITIONAL_MODULE_DS_MAP'))
 ConnectorRegistry.register_sources(module_datasource_map)
-
-allowed_certs = conf.get('ALLOWED_CERT_COMMON_NAMES')
-if allowed_certs:
-    @app.before_request
-    def is_valid_request():
-        cert = request.headers.get('X-CLIENT-SSL-CERT')
-        if not cert:
-            raise Exception
-        cert = urllib.unquote(cert)
-        X509_cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert)
-        if X509_cert.get_subject().commonName not in allowed_certs:
-            raise Exception
 
 from superset import views  # noqa

--- a/superset/config.py
+++ b/superset/config.py
@@ -322,6 +322,8 @@ ROBOT_PERMISSION_ROLES = ['Public', 'Gamma', 'Alpha', 'Admin', 'sql_lab']
 
 CONFIG_PATH_ENV_VAR = 'SUPERSET_CONFIG_PATH'
 
+# Certificate common name for filtering requests.
+ALLOWED_CERT_COMMON_NAMES = []
 
 # smtp server configuration
 EMAIL_NOTIFICATIONS = False  # all the emails are sent using dryrun

--- a/superset/config.py
+++ b/superset/config.py
@@ -322,8 +322,8 @@ ROBOT_PERMISSION_ROLES = ['Public', 'Gamma', 'Alpha', 'Admin', 'sql_lab']
 
 CONFIG_PATH_ENV_VAR = 'SUPERSET_CONFIG_PATH'
 
-# Certificate common name for filtering requests.
-ALLOWED_CERT_COMMON_NAMES = []
+# List of functions that are executed before every request. Order may matter.
+BEFORE_REQUEST_FUNCTIONS = []
 
 # smtp server configuration
 EMAIL_NOTIFICATIONS = False  # all the emails are sent using dryrun


### PR DESCRIPTION
This PR allows users specify  functions that will be run before every request in their internal config file. These functions tend to be very specific so this approach allows each deployment have filters that don't interfere with other user deployments. 

Could help with https://github.com/apache/incubator-superset/issues/3623 

@john-bodley @mistercrunch 