### PR TITLE
[Bugfix] _add_filters_from_pre_query doesn't handle dim specs

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import json
 import logging
 
 from flask import flash, Markup, redirect
@@ -61,9 +62,26 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
             True),
     }
 
+    def pre_update(self, col):
+        # If a dimension spec JSON is given, ensure that it is
+        # valid JSON and that `outputName` is specified
+        if col.dimension_spec_json:
+            try:
+                dimension_spec = json.loads(col.dimension_spec_json)
+            except ValueError as e:
+                raise ValueError('Invalid Dimension Spec JSON: ' + str(e))
+            if not isinstance(dimension_spec, dict):
+                raise ValueError('Dimension Spec must be a JSON object')
+            if 'outputName' not in dimension_spec:
+                raise ValueError('Dimension Spec does not contain `outputName`')
+            # `outputName` should be the same as the `column_name`
+            if dimension_spec['outputName'] != col.column_name:
+                raise ValueError(
+                    '`outputName` [{}] unequal to `column_name` [{}]'
+                    .format(dimension_spec['outputName'], col.column_name))
+
     def post_update(self, col):
         col.generate_metrics()
-        utils.validate_json(col.dimension_spec_json)
 
     def post_add(self, col):
         self.post_update(col)

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -74,6 +74,8 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
                 raise ValueError('Dimension Spec must be a JSON object')
             if 'outputName' not in dimension_spec:
                 raise ValueError('Dimension Spec does not contain `outputName`')
+            if 'dimension' not in dimension_spec:
+                raise ValueError('Dimension Spec is missing `dimension`')
             # `outputName` should be the same as the `column_name`
             if dimension_spec['outputName'] != col.column_name:
                 raise ValueError(

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -212,7 +212,8 @@ class DruidFuncTestCase(unittest.TestCase):
         self.assertIn('dimensions', client.groupby.call_args_list[0][1])
         self.assertEqual(['col1'], client.groupby.call_args_list[0][1]['dimensions'])
         # order_desc but timeseries and dimension spec
-        spec = {'spec': 1}
+        # calls topn with single dimension spec 'dimension'
+        spec = {'outputName': 'hello', 'dimension': 'matcho'}
         spec_json = json.dumps(spec)
         col3 = DruidColumn(column_name='col3', dimension_spec_json=spec_json)
         ds.columns.append(col3)
@@ -224,13 +225,14 @@ class DruidFuncTestCase(unittest.TestCase):
             client=client, order_desc=True, timeseries_limit=5,
             filter=[], row_limit=100,
         )
-        self.assertEqual(0, len(client.topn.call_args_list))
-        self.assertEqual(2, len(client.groupby.call_args_list))
+        self.assertEqual(2, len(client.topn.call_args_list))
+        self.assertEqual(0, len(client.groupby.call_args_list))
         self.assertEqual(0, len(client.timeseries.call_args_list))
-        self.assertIn('dimensions', client.groupby.call_args_list[0][1])
-        self.assertIn('dimensions', client.groupby.call_args_list[1][1])
-        self.assertEqual([spec], client.groupby.call_args_list[0][1]['dimensions'])
-        self.assertEqual([spec], client.groupby.call_args_list[1][1]['dimensions'])
+        self.assertIn('dimension', client.topn.call_args_list[0][1])
+        self.assertIn('dimension', client.topn.call_args_list[1][1])
+        # uses dimension for pre query and full spec for final query
+        self.assertEqual('matcho', client.topn.call_args_list[0][1]['dimension'])
+        self.assertEqual(spec, client.topn.call_args_list[1][1]['dimension'])
 
     def test_run_query_multiple_groupby(self):
         client = Mock()


### PR DESCRIPTION
Ok this should address the underlying issue behind https://github.com/apache/incubator-superset/issues/3943. `_add_filter_from_pre_query_data` wasn't at all handling dimension specs. Also added some better error checking on modifying dimension specs.

edit: https://github.com/apache/incubator-superset/issues/3889 similar issue