### PR TITLE
asciifying http header for csv download; fixes #3952

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'sqlparse==0.2.3',
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',
+        'unidecode>=0.04.21',
     ],
     extras_require={
         'cors': ['Flask-Cors>=2.0.0'],

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -13,6 +13,7 @@ import re
 import time
 import traceback
 from urllib import parse
+from unidecode import unidecode
 
 from flask import (
     flash, g, Markup, redirect, render_template, request, Response, url_for,
@@ -2288,7 +2289,7 @@ class Superset(BaseSupersetView):
             csv = df.to_csv(index=False, **config.get('CSV_EXPORT'))
         response = Response(csv, mimetype='text/csv')
         response.headers['Content-Disposition'] = (
-            'attachment; filename={}.csv'.format(query.name))
+            'attachment; filename={}.csv'.format(unidecode(query.name)))
         logging.info('Ready to return response')
         return response
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -13,7 +13,6 @@ import re
 import time
 import traceback
 from urllib import parse
-from unidecode import unidecode
 
 from flask import (
     flash, g, Markup, redirect, render_template, request, Response, url_for,
@@ -29,6 +28,7 @@ import pandas as pd
 import sqlalchemy as sqla
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
+from unidecode import unidecode
 from werkzeug.routing import BaseConverter
 from werkzeug.utils import secure_filename
 


### PR DESCRIPTION
I think this should be all that is needed to fix #3952.

This way, the rather pathologic tab label `→ʬéıρδ Ñämë←` will get converted to `WWeird_Name`, which is pretty much what I would expect it to be in non-unicode representation.