### PR TITLE
Call props.onChange only when closing filter

### DIFF
--- a/superset/assets/javascripts/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/javascripts/explore/components/controls/DateFilterControl.jsx
@@ -63,17 +63,6 @@ export default class DateFilterControl extends React.Component {
   onNumberChange(event) {
     this.setState({ num: event.target.value }, this.onChange);
   }
-  onChange() {
-    let val;
-    if (this.state.type === 'rel') {
-      val = `${this.state.num} ${this.state.grain} ${this.state.rel}`;
-    } else if (this.state.type === 'fix') {
-      val = this.state.dttm;
-    } else if (this.state.type === 'free') {
-      val = this.state.free;
-    }
-    this.props.onChange(val);
-  }
   onFreeChange(event) {
     this.setState({ free: event.target.value }, this.onChange);
   }
@@ -88,6 +77,15 @@ export default class DateFilterControl extends React.Component {
     this.setState({ dttm: dttm.format().substring(0, 19) }, this.onChange);
   }
   close() {
+    let val;
+    if (this.state.type === 'rel') {
+      val = `${this.state.num} ${this.state.grain} ${this.state.rel}`;
+    } else if (this.state.type === 'fix') {
+      val = this.state.dttm;
+    } else if (this.state.type === 'free') {
+      val = this.state.free;
+    }
+    this.props.onChange(val);
     this.refs.trigger.hide();
   }
   renderPopover() {


### PR DESCRIPTION
The `DateFilterControl` component calls `props.onChange` on its `onChange`, propagating instantly the values selected before "Ok" is clicked. This PR moves the call to `props.OnChange` to the `close` function, so that the new values are propagated only when "Ok" is clicked.

Screencast:

![out](https://user-images.githubusercontent.com/1534870/33584523-aae85f72-d914-11e7-88c9-81e24d5d0e7d.gif)

Unit test and lint ran fine:

    $ cd superset/assets/javascripts
    $ npm i
    $ npm run test
    ...
    409 passing (3s)
    $ npm run lint
    <no messages>

This PR fixes #3868.