### PR TITLE
[BUGFIX]: JavaScripts max int is 2^53 - 1, longs are bigger

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -54,6 +54,8 @@ PY3K = sys.version_info >= (3, 0)
 EPOCH = datetime(1970, 1, 1)
 DTTM_ALIAS = '__timestamp'
 
+JS_MAX_INTEGER = 9007199254740991   # Largest int Java Script can handle 2^53-1
+
 
 def can_access(sm, permission_name, view_name, user):
     """Protecting from has_access failing from missing perms/view"""

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -507,8 +507,8 @@ class TableViz(BaseViz):
 
         data = self.handle_js_int_overflow(
             dict(
-              records=df.to_dict(orient='records'),
-              columns=list(df.columns),
+                records=df.to_dict(orient='records'),
+                columns=list(df.columns),
             ))
 
         return data
@@ -1026,8 +1026,10 @@ class NVD3TimeSeriesViz(NVD3Viz):
             ys = series[name]
             if df[name].dtype.kind not in 'biufc':
                 continue
-            if isinstance(name, (list, tuple)):
+            if isinstance(name, list):
                 series_title = [str(title) for title in name]
+            elif isinstance(name, tuple):
+                series_title = tuple(str(title) for title in name)
             else:
                 series_title = str(name)
             if (

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -35,7 +35,7 @@ from six import string_types, text_type
 from six.moves import cPickle as pkl, reduce
 
 from superset import app, cache, get_manifest_file, utils
-from superset.utils import DTTM_ALIAS, merge_extra_filters
+from superset.utils import DTTM_ALIAS, JS_MAX_INTEGER, merge_extra_filters
 
 
 config = app.config
@@ -80,6 +80,17 @@ class BaseViz(object):
         self._any_cache_key = None
         self._any_cached_dttm = None
         self._extra_chart_data = None
+
+    @staticmethod
+    def handle_js_int_overflow(data):
+        for d in data.get('records', dict()):
+            for k, v in list(d.items()):
+                if isinstance(v, int):
+                    # if an int is too big for Java Script to handle
+                    # convert it to a string
+                    if abs(v) > JS_MAX_INTEGER:
+                        d[k] = str(v)
+        return data
 
     def run_extra_queries(self):
         """Lyfecycle method to use when more than one query is needed
@@ -494,10 +505,13 @@ class TableViz(BaseViz):
             ):
                 del df[m]
 
-        return dict(
-            records=df.to_dict(orient='records'),
-            columns=list(df.columns),
-        )
+        data = self.handle_js_int_overflow(
+            dict(
+              records=df.to_dict(orient='records'),
+              columns=list(df.columns),
+            ))
+
+        return data
 
     def json_dumps(self, obj, sort_keys=False):
         if self.form_data.get('all_columns'):
@@ -1012,7 +1026,10 @@ class NVD3TimeSeriesViz(NVD3Viz):
             ys = series[name]
             if df[name].dtype.kind not in 'biufc':
                 continue
-            series_title = name
+            if isinstance(name, (list, tuple)):
+                series_title = [str(title) for title in name]
+            else:
+                series_title = str(name)
             if (
                     isinstance(series_title, (list, tuple)) and
                     len(series_title) > 1 and


### PR DESCRIPTION
Twitter uses very long IDs for entities. This causes issues because Java Script can not handle these long IDs and will **round** them by treating them as a float. 

This is a very hack fix, that will just convert every integer that is longer than the longest integer supported by JS to a string for both SQL Lab as well as the default table visualization. 
This works since both python and JS are dynamically typed, but its not great.

Any suggestions how we should handle this correctly?