### PR TITLE
Rollback bulk-delete of table columns

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -17,7 +17,7 @@ from superset.views.base import (
 from . import models
 
 
-class TableColumnInlineView(CompactCRUDMixin, SupersetModelView, DeleteMixin):  # noqa
+class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
     datamodel = SQLAInterface(models.TableColumn)
 
     list_title = _('List Columns')
@@ -94,7 +94,7 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView, DeleteMixin):  
 appbuilder.add_view_no_menu(TableColumnInlineView)
 
 
-class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView, DeleteMixin):  # noqa
+class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
     datamodel = SQLAInterface(models.SqlMetric)
 
     list_title = _('List Metrics')


### PR DESCRIPTION
This is a rollback of #3929. Given there are two inline crud interfaces on the same page the action button can sometimes pick the wrong model to try and update with unexpected results.

To re-enable, this will likely need a fix upstream in FAB. I'll reference this PR and the one above and submit a fix.