### PR TITLE
[cache] Using the query as the basis of the cache key

### DIFF
--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -340,7 +340,6 @@ class CoreTests(SupersetTestCase):
         slc = self.get_slice('Girls', db.session)
         data = self.get_json_resp(
             '/superset/warm_up_cache?slice_id={}'.format(slc.id))
-
         assert data == [{'slice_id': slc.id, 'slice_name': slc.slice_name}]
 
         data = self.get_json_resp(

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -101,11 +101,8 @@ class BaseVizTestCase(unittest.TestCase):
 
     def test_cache_timeout(self):
         datasource = Mock()
-        form_data = {'cache_timeout': '10'}
-        test_viz = viz.BaseViz(datasource, form_data)
-        self.assertEqual(10, test_viz.cache_timeout)
-        del form_data['cache_timeout']
         datasource.cache_timeout = 156
+        test_viz = viz.BaseViz(datasource, form_data={})
         self.assertEqual(156, test_viz.cache_timeout)
         datasource.cache_timeout = None
         datasource.database = Mock()


### PR DESCRIPTION
This PR resolves issue https://github.com/apache/incubator-superset/issues/3840 where previously the visualization data query key was a hashed form of the `form_data`. 

Per the description in the issue the `form_data` stored in the DB which is what the `/warm_up_cache/` endpoint leverages is not the same form data in the explorer view (which is augmented by both the front- and back-ends). Given the cached data is the query response it makes more sense to simply use the hashed query string as the cache key. In addition to resolving this issue the cache is based purely on the relevant portions of the `form_data` which are used to generate the query, thus UI changes to the color palette etc. will not violate the cache. 

Note there is no way to determine via the cache API when the cache key was created and thus it is necessary to cache the DTTM alongside the data. 

Note the cache is now explorer view agnostic, i.e., a cache key may be shared by multiple explorer views/slices.

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 
   