### PR TITLE
[sql_lab] Handle PyHive DatabaseError format

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -615,6 +615,13 @@ class PrestoEngineSpec(BaseEngineSpec):
                 error_dict.get('errorLocation'),
                 error_dict.get('message'),
             )
+        if (
+                type(e).__name__ == 'DatabaseError' and
+                hasattr(e, 'args') and
+                len(e.args) > 0
+        ):
+            error_dict = e.args[0]
+            return error_dict.get('message')
         return utils.error_msg_from_exception(e)
 
     @classmethod


### PR DESCRIPTION
Fixes #4013 

Converts this:
<img width="1429" alt="screen shot 2017-12-05 at 17 32 09" src="https://user-images.githubusercontent.com/7461607/33658022-67a4eaf6-da7b-11e7-8c2d-f9814ded67a9.png">

into this:
![screen shot 2017-12-06 at 11 44 05](https://user-images.githubusercontent.com/7461607/33658007-5bee4e32-da7b-11e7-8a56-1acba3f118cd.png)


Current implementation is based on what is available in debugger when running superset locally. Plus on the current implementation of the [PyHive](https://github.com/dropbox/PyHive).

Not sure where the [current approach](https://github.com/apache/incubator-superset/blob/e98a1c35378b97702b92396e12845bee1d4d5568/superset/db_engine_specs.py#L608) comes from, but I left it there since  according to @mistercrunch it seems to still work in some cases.

