### PR TITLE
DB2 backend is called 'db2'

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -319,7 +319,7 @@ class PostgresEngineSpec(BaseEngineSpec):
 
 
 class Db2EngineSpec(BaseEngineSpec):
-    engine = 'ibm_db_sa'
+    engine = 'db2'
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}'),
         Grain('second', _('second'),


### PR DESCRIPTION
Because the engine is called 'ibm_db_sa', the DB2 time grain was not being retrieved, as the Db2EngineSpec is not found.
@openmax - Tagging you as per @mistercrunch request. :)