### PR TITLE
resolve python2 str() issue

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
 import simplejson as json
-from six import PY3, string_types
+from six import PY3, string_types, text_type
 from six.moves import reduce
 
 from superset import app, cache, get_manifest_file, utils
@@ -1300,9 +1300,9 @@ class DistributionBarViz(DistributionPieViz):
             for i, v in ys.iteritems():
                 x = i
                 if isinstance(x, (tuple, list)):
-                    x = ', '.join([str(s.encode('utf-8')) for s in x])
+                    x = ', '.join([text_type(s) for s in x])
                 else:
-                    x = str(x.encode('utf-8'))
+                    x = text_type(s)
                 values.append({
                     'x': x,
                     'y': v,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1300,7 +1300,7 @@ class DistributionBarViz(DistributionPieViz):
             for i, v in ys.iteritems():
                 x = i
                 if isinstance(x, (tuple, list)):
-                    x = ', '.join([str(s) for s in x])
+                    x = ', '.join([str(s.encode('utf8')) for s in x])
                 else:
                     x = str(x.encode('utf8'))
                 values.append({

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1302,7 +1302,7 @@ class DistributionBarViz(DistributionPieViz):
                 if isinstance(x, (tuple, list)):
                     x = ', '.join([str(s) for s in x])
                 else:
-                    x = str(x)
+                    x = str(x.encode('utf8'))
                 values.append({
                     'x': x,
                     'y': v,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1300,9 +1300,9 @@ class DistributionBarViz(DistributionPieViz):
             for i, v in ys.iteritems():
                 x = i
                 if isinstance(x, (tuple, list)):
-                    x = ', '.join([str(s.encode('utf8')) for s in x])
+                    x = ', '.join([str(s.encode('utf-8')) for s in x])
                 else:
-                    x = str(x.encode('utf8'))
+                    x = str(x.encode('utf-8'))
                 values.append({
                     'x': x,
                     'y': v,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1302,7 +1302,7 @@ class DistributionBarViz(DistributionPieViz):
                 if isinstance(x, (tuple, list)):
                     x = ', '.join([text_type(s) for s in x])
                 else:
-                    x = text_type(s)
+                    x = text_type(x)
                 values.append({
                     'x': x,
                     'y': v,


### PR DESCRIPTION
Some slices with utf8 characters are breaking during the string conversion in the lines changed. This removes the str and uses six.text_type so it stays unicode in python2 and becomes str in python3. 

@john-bodley @mistercrunch 

```Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/superset/viz.py", line 277, in get_payload
    data = self.get_data(df)
  File "/usr/local/lib/python2.7/dist-packages/superset/viz.py", line 1254, in get_data
    x = str(x)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 11: ordinal not in range(128)```