### PR TITLE
Add db_engine_spec for Druid

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1217,6 +1217,12 @@ class ImpalaEngineSpec(BaseEngineSpec):
         return schemas
 
 
+class DruidEngineSpec(BaseEngineSpec):
+    """Engine spec for Druid.io"""
+    engine = 'druid'
+    limit_method = LimitMethod.FETCH_MANY
+
+
 engines = {
     o.engine: o for o in globals().values()
     if inspect.isclass(o) and issubclass(o, BaseEngineSpec)}


### PR DESCRIPTION
The `druiddb` pypi package provides a dbapi and sqlalchemy dialect for
Druid. This PR hooks adds some superset-specific conf.