### PR TITLE
[geo] turn off renderTrigger on viewport control

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1436,7 +1436,7 @@ export const controls = {
   viewport: {
     type: 'ViewportControl',
     label: t('Viewport'),
-    renderTrigger: true,
+    renderTrigger: false,
     description: t('Parameters related to the view and perspective on the map'),
     // default is whole world mostly centered
     default: defaultViewport,


### PR DESCRIPTION
For context, the viewport gets updated dynamically from the user
actions on the map. This is done on a timer every second or so to keep
the form data updated with the viewport settings.

With renderTrigger=true on that control that generates re-renders which
introduces glitches while zooming/panning. So turning it off as we don't
really expect users to input viewport info directly in the control
anyways.