### PR TITLE
DB migration of annotation_layers on slice objects 

### DIFF
--- a/superset/assets/javascripts/explore/components/controls/AnnotationLayer.jsx
+++ b/superset/assets/javascripts/explore/components/controls/AnnotationLayer.jsx
@@ -104,6 +104,7 @@ export default class AnnotationLayer extends React.PureComponent {
       isNew: !this.props.name,
       isLoadingOptions: true,
       valueOptions: [],
+      validationErrors: {},
     };
     this.submitAnnotation = this.submitAnnotation.bind(this);
     this.deleteAnnotation = this.deleteAnnotation.bind(this);
@@ -235,11 +236,17 @@ export default class AnnotationLayer extends React.PureComponent {
 
   applyAnnotation() {
     if (this.state.name.length) {
-      const annotation = { ...this.state };
-      annotation.color = annotation.color === AUTOMATIC_COLOR ? null : annotation.color;
+      const annotation = {};
+      Object.keys(this.state).forEach((k) => {
+        if (this.state[k] !== null) {
+          annotation[k] = this.state[k];
+        }
+      });
       delete annotation.isNew;
       delete annotation.valueOptions;
       delete annotation.isLoadingOptions;
+      delete annotation.validationErrors;
+      annotation.color = annotation.color === AUTOMATIC_COLOR ? null : annotation.color;
       this.props.addAnnotationLayer(annotation);
       this.setState({ isNew: false, oldName: this.state.name });
     }

--- a/superset/migrations/versions/21e88bc06c02_annotation_migration.py
+++ b/superset/migrations/versions/21e88bc06c02_annotation_migration.py
@@ -1,0 +1,60 @@
+import json
+
+from alembic import op
+from sqlalchemy import (
+  Column, Integer, or_, String, Text)
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+"""migrate_old_annotation_layers
+
+Revision ID: 21e88bc06c02
+Revises: 67a6ac9b727b
+Create Date: 2017-12-17 11:06:30.180267
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '21e88bc06c02'
+down_revision = '67a6ac9b727b'
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = 'slices'
+    id = Column(Integer, primary_key=True)
+    viz_type = Column(String(250))
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(or_(
+            Slice.viz_type.like('line'), Slice.viz_type.like('bar'))):
+        params = json.loads(slc.params)
+        layers = params.get('annotation_layers', [])
+        new_layers = []
+        if len(layers) and isinstance(layers[0], int):
+            for layer in layers:
+                new_layers.append(
+                    {
+                        'annotationType': 'INTERVAL',
+                        'style': 'solid',
+                        'name': 'Layer {}'.format(layer),
+                        'show': True,
+                        'overrides': {'since': None, 'until': None},
+                        'value': 1, 'width': 1, 'sourceType': 'NATIVE',
+                    })
+            params['annotation_layers'] = new_layers
+            slc.params = json.dumps(params)
+            session.merge(slc)
+            session.commit()
+    session.close()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Migrating `annotation_layers` saved on slices in the DB. 
Also slightly reducing the footprint of `annotation` objects in the `form_data`.