### PR TITLE
[Bugfix] Event annotation should have min width

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -683,8 +683,8 @@ function nvd3Vis(slice, payload) {
                   x: d => Math.min(xScale(new Date(d[e.timeColumn])),
                     xScale(new Date(d[e.intervalEndColumn]))),
                   y: 0,
-                  width: d => Math.abs(xScale(new Date(d[e.intervalEndColumn])) -
-                    xScale(new Date(d[e.timeColumn]))),
+                  width: d => Math.max(Math.abs(xScale(new Date(d[e.intervalEndColumn])) -
+                    xScale(new Date(d[e.timeColumn]))), 1),
                   height: annotationHeight,
                 })
                 .attr('class', `${e.opacity} ${e.style}`)


### PR DESCRIPTION
Currently, if an event annotation has the same start end and end date it will not be displayed because its width will be set to 0. This change sets a minimum width of 1px.

@graceguo-supercat 