### PR TITLE
Don't use fully qualified column names in metric definitions

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -660,7 +660,7 @@ class SqlaTable(Model, BaseDatasource):
             if not any_date_col and dbcol.is_time:
                 any_date_col = col.name
 
-            quoted = str(col.compile(dialect=db_dialect))
+            quoted = col.name
             if dbcol.sum:
                 metrics.append(M(
                     metric_name='sum__' + dbcol.column_name,


### PR DESCRIPTION
When generating an auto SUM() metric on a column, Superset currently
will go `SUM(table_name.column_name)`. This is an issue when moving to
point to another table. It's common to work on some temporary table or
work table and eventually need to point Superset to an alternate table.