### PR TITLE
[BUGFIX]: Check datatype of results before converting to DataFrame

### DIFF
--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -12,6 +12,7 @@ from flask_appbuilder.security.sqla import models as ab_models
 
 from superset import appbuilder, db, sm, utils
 from superset.models.sql_lab import Query
+from superset.sql_lab import convert_results_to_df
 from .base_tests import SupersetTestCase
 
 
@@ -199,6 +200,22 @@ class SqlLabTests(SupersetTestCase):
             client_id='2e2df3',
             user_name='admin',
             raise_on_error=True)
+
+    def test_df_conversion_no_dict(self):
+        cols = [['string_col'], ['int_col']]
+        data = [['a', 4]]
+        cdf = convert_results_to_df(cols, data)
+
+        self.assertEquals(len(data), cdf.size)
+        self.assertEquals(len(cols), len(cdf.columns))
+
+    def test_df_conversion_dict(self):
+        cols = [['string_col'], ['dict_col'], ['int_col']]
+        data = [['a', {'c1': 1, 'c2': 2, 'c3': 3}, 4]]
+        cdf = convert_results_to_df(cols, data)
+
+        self.assertEquals(len(data), cdf.size)
+        self.assertEquals(len(cols), len(cdf.columns))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The [merged hotfix](https://github.com/apache/incubator-superset/pull/2412) #2412 resolved an [issue with Presto/Hive columns](https://github.com/apache/incubator-superset/issues/2398) #2398 which are lists of dictionaries.

However, this introduced issue #3934 with traditional RDB datasources like MS SQL Server, which only return lists of lists. Wrapping such results in an outer list causes pandas to interpret the list as a single column.

This PR attempts to resolve that issue by introspecting the datatypes of the columns in the first row of the returned `data`. The type check may not be checking for exactly the right thing, but we likely need some sort of conditional to avoid wrapping a list of lists in an outer list