### PR TITLE
Update UserInfo.jsx and set additional properties for react-gravatar

### DIFF
--- a/superset/assets/javascripts/profile/components/UserInfo.jsx
+++ b/superset/assets/javascripts/profile/components/UserInfo.jsx
@@ -15,6 +15,7 @@ const UserInfo = ({ user }) => (
         email={user.email}
         width="100%"
         height=""
+        size="220"
         alt={t('Profile picture provided by Gravatar')}
         className="img-rounded"
         style={{ borderRadius: 15 }}


### PR DESCRIPTION
Update UserInfo.jsx and set additional properties for react-gravatar.
Added size property and set it to 220 the base width of the container.

react-gravatar which is responsible for rendering a gravatar profile image defaults the size property to 50. This makes the gravatar profile image blurry for the container it is in.

Before fix
![image](https://user-images.githubusercontent.com/4106061/34345498-7d2477e2-e9bd-11e7-84cc-123bc9aca3d8.png)

After fix
![image](https://user-images.githubusercontent.com/4106061/34345516-997a97fa-e9bd-11e7-9603-8cc1345fe898.png)
