### PR TITLE
[Bugfix] Remedy for Dual Axis chart render bug

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -553,7 +553,7 @@ function nvd3Vis(slice, payload) {
         } else {
           xMin = chart.xAxis.scale().domain()[0].valueOf();
           xMax = chart.xAxis.scale().domain()[1].valueOf();
-          xScale = chart.xScale();
+          xScale = chart.xScale ? chart.xScale() : d3.scale.linear();
         }
 
         if (Array.isArray(formulas) && formulas.length) {
@@ -591,8 +591,8 @@ function nvd3Vis(slice, payload) {
           }));
           data.push(...formulaData);
         }
-
-        const annotationHeight = chart.yAxis.scale().range()[0];
+        const yAxis = chart.yAxis1 ? chart.yAxis1 : chart.yAxis;
+        const annotationHeight = yAxis.scale().range()[0];
         const tipFactory = layer => d3tip()
           .attr('class', 'd3-tip')
           .direction('n')


### PR DESCRIPTION
An attempt to remedy https://github.com/apache/incubator-superset/issues/4115, which seems to be the result of issues handling annotations for Dual Axis Line Charts.

The first issue is that the most recent nvd3 release `1.8.6` does not expose `xScale` (although it exists in `nvd3/master`), and secondly there is `yAxis1` and `yAxis2` instead of just `yAxis`. 

Making up for `xScale` isn't an issue because `multiChart` just uses `d3.scale.linear()` but I'm wondering how annotations are handled for two axes? @fabianmenges 