### PR TITLE
fix CSV_TO_HIVE_UPLOAD_S3_BUCKET variable name

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -806,7 +806,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         table_name = form.name.data
         filename = form.csv_file.data.filename
 
-        bucket_path = app.config['CSV_TO_HIVE_UPLOAD_BUCKET']
+        bucket_path = app.config['CSV_TO_HIVE_UPLOAD_S3_BUCKET']
 
         if not bucket_path:
             logging.info('No upload bucket specified')


### PR DESCRIPTION
In db_engine_spec.py, CSV_TO_HIVE_UPLOAD_S3_BUCKET is referenced as CSV_TO_HIVE_UPLOAD_BUCKET and that causes an error which this PR fixes.   
https://github.com/apache/incubator-superset/blob/eff5952641a6e03f6d910f688985e75824d7422c/superset/config.py#L307

@mistercrunch @john-bodley 