### PR TITLE
Create DATA_DIR after importing config

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -22,6 +22,9 @@ from superset import utils, config  # noqa
 APP_DIR = os.path.dirname(__file__)
 CONFIG_MODULE = os.environ.get('SUPERSET_CONFIG', 'superset.config')
 
+if not os.path.exists(config.DATA_DIR):
+    os.makedirs(config.DATA_DIR)
+
 with open(APP_DIR + '/static/assets/backendSync.json', 'r') as f:
     frontend_config = json.load(f)
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -28,8 +28,6 @@ if 'SUPERSET_HOME' in os.environ:
     DATA_DIR = os.environ['SUPERSET_HOME']
 else:
     DATA_DIR = os.path.join(os.path.expanduser('~'), '.superset')
-if not os.path.exists(DATA_DIR):
-    os.makedirs(DATA_DIR)
 
 # ---------------------------------------------------------
 # Superset specific config


### PR DESCRIPTION
Delay creating DATA_DIR until config is fully imported.

This allows superset_config.py to override DATA_DIR before superset
attempts to create it in a potentially unwriteable location.

Fixes #3223