### PR TITLE
Fix for sorting distribution charts #4153

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -218,9 +218,11 @@ function nvd3Vis(slice, payload) {
         stacked = fd.bar_stacked;
         chart.stacked(stacked);
         if (fd.order_bars) {
-          data.forEach((d) => {
-            d.values.sort((a, b) => tryNumify(a.x) < tryNumify(b.x) ? -1 : 1);
-          });
+          // we sort the x-values from the first dataset so multiple dist_bar 
+          // charts on a dashboard sort the same way.
+          data[0].values.sort(
+            (a, b) => a.x < b.x ? -1 : 1
+          );
         }
         if (fd.show_bar_value) {
           setTimeout(function () {


### PR DESCRIPTION
This is to fix #4153. To get consistent sorting we need to limit it to the first dataset.  