### PR TITLE
Fix chart rendering error in time series table

### DIFF
--- a/superset/assets/visualizations/time_table.jsx
+++ b/superset/assets/visualizations/time_table.jsx
@@ -137,9 +137,16 @@ function viz(slice, payload) {
       } else {
         const recent = reversedData[0][metric];
         let v;
+        let errorMsg;
         if (column.colType === 'time') {
           // Time lag ratio
-          v = reversedData[parseInt(column.timeLag, 10)][metric];
+          const timeLag = parseInt(column.timeLag, 10);
+          const totalLag = Object.keys(reversedData).length;
+          if (timeLag > totalLag) {
+            errorMsg = `The time lag set at ${timeLag} exceeds the length of data at ${reversedData.length}. No data available.`;
+          } else {
+            v = reversedData[timeLag][metric];
+          }
           if (column.comparisonType === 'diff') {
             v = recent - v;
           } else if (column.comparisonType === 'perc') {
@@ -175,11 +182,11 @@ function viz(slice, payload) {
         }
         row[column.key] = {
           data: v,
-          display: (
-            <div style={{ color }}>
+          display: errorMsg ?
+            (<div>{errorMsg}</div>) :
+            (<div style={{ color }}>
               <FormattedNumber num={v} format={column.d3format} />
-            </div>
-          ),
+            </div>),
           style: color && {
             boxShadow: `inset 0px -2.5px 0px 0px ${color}`,
             borderRight: '2px solid #fff',


### PR DESCRIPTION
In time series table chart, when total number of available lags less than timeLag param, we see JS rendering error. 
<img width="1011" alt="screen shot 2018-01-04 at 2 09 35 pm" src="https://user-images.githubusercontent.com/27990562/34587299-a5f04cd6-f15c-11e7-8a20-7981e24b250a.png">

  