### PR TITLE
Check for non-None database before using.

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -501,7 +501,7 @@ class PrestoEngineSpec(BaseEngineSpec):
     @classmethod
     def adjust_database_uri(cls, uri, selected_schema=None):
         database = uri.database
-        if selected_schema:
+        if selected_schema and database:
             if '/' in database:
                 database = database.split('/')[0] + '/' + selected_schema
             else:


### PR DESCRIPTION
Some valid sqlalchemy uri's return a URL object with database=None, which causes the following error:
```
2018-01-05 17:59:47,560:ERROR:root:argument of type 'NoneType' is not iterable
Traceback (most recent call last):
  File "/opt/incubator-superset/superset/sql_lab.py", line 186, in execute_sql
    user_name=user_name,
  File "/opt/incubator-superset/superset/utils.py", line 124, in __call__
    return self.func(*args, **kwargs)
  File "/opt/incubator-superset/superset/models/core.py", line 644, in get_sqla_engine
    url = self.db_engine_spec.adjust_database_uri(url, schema)
  File "/opt/incubator-superset/superset/db_engine_specs.py", line 505, in adjust_database_uri
    if '/' in database:
TypeError: argument of type 'NoneType' is not iterable
```
This patch corrects that problem.