### PR TITLE
Druid support via SQLAlchemy

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1015,7 +1015,10 @@ class DruidDatasource(Model, BaseDatasource):
             orderby=None,
             extras=None,  # noqa
             columns=None, phase=2, client=None, form_data=None,
-            order_desc=True):
+            order_desc=True,
+            prequeries=None,
+            is_prequery=False,
+        ):
         """Runs a query against Druid and returns a dataframe.
         """
         # TODO refactor into using a TBD Query object

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -540,14 +540,12 @@ class SqlaTable(Model, BaseDatasource):
                     inner_from_dttm or from_dttm,
                     inner_to_dttm or to_dttm,
                 )
-                subq = subq.where(
-                    and_(*(where_clause_and + [inner_time_filter])))
+                subq = subq.where(and_(*(where_clause_and + [inner_time_filter])))
                 subq = subq.group_by(*inner_groupby_exprs)
 
                 ob = inner_main_metric_expr
                 if timeseries_limit_metric:
-                    timeseries_limit_metric = metrics_dict.get(
-                        timeseries_limit_metric)
+                    timeseries_limit_metric = metrics_dict.get(timeseries_limit_metric)
                     ob = timeseries_limit_metric.sqla_col
                 direction = desc if order_desc else asc
                 subq = subq.order_by(direction(ob))

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -602,7 +602,8 @@ class SqlaTable(Model, BaseDatasource):
         qry_start_dttm = datetime.now()
 
         # run query storing any prequeries for 2-phase backends
-        prequeries = prequeries or []
+        if prequeries is None:
+            prequeries = []
         sql = self.get_query_str(query_obj, prequeries, is_prequery)
 
         status = QueryStatus.SUCCESS
@@ -619,7 +620,8 @@ class SqlaTable(Model, BaseDatasource):
         # if this is a main query with prequeries, combine them together
         if not is_prequery and prequeries:
             prequeries.append(sql)
-            sql = ';\n\n'.join(prequeries) + ';'
+            sql = ';\n\n'.join(prequeries)
+        sql += ';'
 
         return QueryResult(
             status=status,

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -824,8 +824,7 @@ class HiveEngineSpec(PrestoEngineSpec):
             [s + ' STRING ' for s in column_names])
 
         s3 = boto3.client('s3')
-        location = os.path.join('s3a://', bucket_path,
-                                upload_prefix, table_name)
+        location = os.path.join('s3a://', bucket_path, upload_prefix, table_name)
         s3.upload_file(
             upload_path, 'airbnb-superset',
             os.path.join(upload_prefix, table_name, filename))

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -62,6 +62,7 @@ class BaseEngineSpec(object):
     time_groupby_inline = False
     limit_method = LimitMethod.FETCH_MANY
     time_secondary_columns = False
+    inner_joins = True
 
     @classmethod
     def fetch_data(cls, cursor, limit):
@@ -823,7 +824,8 @@ class HiveEngineSpec(PrestoEngineSpec):
             [s + ' STRING ' for s in column_names])
 
         s3 = boto3.client('s3')
-        location = os.path.join('s3a://', bucket_path, upload_prefix, table_name)
+        location = os.path.join('s3a://', bucket_path,
+                                upload_prefix, table_name)
         s3.upload_file(
             upload_path, 'airbnb-superset',
             os.path.join(upload_prefix, table_name, filename))
@@ -1221,6 +1223,7 @@ class DruidEngineSpec(BaseEngineSpec):
     """Engine spec for Druid.io"""
     engine = 'druid'
     limit_method = LimitMethod.FETCH_MANY
+    inner_joins = False
 
 
 engines = {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -986,9 +986,15 @@ class Superset(BaseSupersetView):
     def get_query_string_response(self, viz_obj):
         try:
             query_obj = viz_obj.query_obj()
-            query = viz_obj.datasource.get_query_str(query_obj)
+            prequeries = []
+            query = viz_obj.datasource.get_query_str(query_obj, prequeries)
         except Exception as e:
             return json_error_response(e)
+
+        if prequeries:
+            prequeries.append(query)
+            query = ';\n\n'.join(prequeries) + ';'
+
         return Response(
             json.dumps({
                 'query': query,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -993,7 +993,8 @@ class Superset(BaseSupersetView):
 
         if prequeries:
             prequeries.append(query)
-            query = ';\n\n'.join(prequeries) + ';'
+            query = ';\n\n'.join(prequeries)
+        query += ';'
 
         return Response(
             json.dumps({

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -986,14 +986,13 @@ class Superset(BaseSupersetView):
     def get_query_string_response(self, viz_obj):
         try:
             query_obj = viz_obj.query_obj()
-            prequeries = []
-            query = viz_obj.datasource.get_query_str(query_obj, prequeries)
+            query = viz_obj.datasource.get_query_str(query_obj)
         except Exception as e:
             return json_error_response(e)
 
-        if prequeries:
-            prequeries.append(query)
-            query = ';\n\n'.join(prequeries)
+        if query_obj['prequeries']:
+            query_obj['prequeries'].append(query)
+            query = ';\n\n'.join(query_obj['prequeries'])
         query += ';'
 
         return Response(

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -200,6 +200,8 @@ class BaseViz(object):
             'timeseries_limit_metric': timeseries_limit_metric,
             'form_data': form_data,
             'order_desc': order_desc,
+            'prequeries': [],
+            'is_prequery': False,
         }
         return d
 


### PR DESCRIPTION
I recently created a module called [`druiddb`](https://github.com/betodealmeida/druid-dbapi) (merged into `pydruid` this week) that provides a SQLAlchemy dialect for Druid. This allows Superset to talk to Druid using its standard SQLAlchemy connector, instead of the custom one.

One problem with this approach is that Druid does not support joins, and some queries (timeseries with limit) perform an inner join to get the top overall groups. In order to handle Druid correctly I added a new attribute to engine specs called `inner_joins`, defaulting to true.

If this attribute is false, instead of building the inner join we run a "prequery", fetching the top groups similar to how the Druid connector works. The values are then used as an extra filter in the main query. Eg, this is how a query **with** join works (from the `birth_names` dataset):

```sql
SELECT name AS name,
       ds AS __timestamp,
       SUM(birth_names.num) AS sum__num
FROM birth_names
JOIN
  (SELECT name AS name__,
          SUM(birth_names.num) AS mme_inner__
   FROM birth_names
   WHERE ds >= '1918-01-05 00:00:00.000000'
     AND ds <= '2018-01-05 11:59:32.000000'
   GROUP BY name
   ORDER BY mme_inner__ DESC
   LIMIT 5
   OFFSET 0) AS anon_1 ON name = name__
WHERE ds >= '1918-01-05 00:00:00.000000'
  AND ds <= '2018-01-05 11:59:32.000000'
GROUP BY name,
         ds
ORDER BY sum__num DESC
LIMIT 50000
OFFSET 0;
```

And here how it looks when inner joins are **not supported**:

```sql
SELECT name AS name,
       SUM(birth_names.num) AS sum__num
FROM birth_names
WHERE ds >= '1918-01-05 00:00:00.000000'
  AND ds <= '2018-01-05 12:00:29.000000'
GROUP BY name
ORDER BY SUM(birth_names.num) DESC
LIMIT 5
OFFSET 0;

SELECT name AS name,
       ds AS __timestamp,
       SUM(birth_names.num) AS sum__num
FROM birth_names
WHERE ds >= '1918-01-05 00:00:00.000000'
  AND ds <= '2018-01-05 12:00:29.000000'
  AND (name = 'Michael'
       OR name = 'Christopher'
       OR name = 'David'
       OR name = 'James'
       OR name = 'John')
GROUP BY name,
         ds
ORDER BY sum__num DESC
LIMIT 50000
OFFSET 0;
```

Both queries are shown when clicking "View Query", instead of only the last one. See the screenshot:

<img width="1679" alt="screen shot 2018-01-05 at 12 24 41 pm" src="https://user-images.githubusercontent.com/1534870/34627100-259e633e-f214-11e7-960b-442f18d9bdef.png">

In order to do that, I added two new arguments to the query object:

1. `prequeries` is a list that stores prequeries;
2. `is_prequery` is a boolean indicating if a given query is the final one, or a prequery.

When a main query runs a prequery, it will append it to `prequeries`. The functions `query` and `get_query_string_response` then take care of combining prequeries with the main query, so it can be displayed to the user correctly.