### PR TITLE
[FAB] configuring updating of permissions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -167,6 +167,27 @@ work on Windows so the `superset runserver` command is not expected to work
 in that context. Also note that the development web
 server (`superset runserver -d`) is not intended for production use.
 
+Flask-AppBuilder Permissions
+----------------------------
+
+By default every time the Flask-AppBuilder (FAB) app is initialized the
+permissions and views are added automatically to the backend and associated with
+the ‘Admin’ role. The issue however is when you are running multiple concurrent
+workers this creates a lot of contention and race conditions when defining
+permissions and views.
+
+To alleviate this issue, the automatic updating of permissions can be disabled
+by setting the :envvar:`SUPERSET_UPDATE_PERMS` environment variable to `0`.
+The value `1` enables it, `0` disables it. Note if undefined the functionality
+is enabled to maintain backwards compatibility.
+
+In a production environment initialization could take on the following form:
+
+  export SUPERSET_UPDATE_PERMS=1
+  superset init
+
+  export SUPERSET_UPDATE_PERMS=0
+  gunicorn -w 10 ... superset:app
 
 Configuration behind a load balancer
 ------------------------------------
@@ -181,7 +202,7 @@ If the load balancer is inserting X-Forwarded-For/X-Forwarded-Proto headers, you
 should set `ENABLE_PROXY_FIX = True` in the superset config file to extract and use
 the headers.
 
-In case that the reverse proxy is used for providing ssl encryption, 
+In case that the reverse proxy is used for providing ssl encryption,
 an explicit definition of the `X-Forwarded-Proto` may be required.
 For the Apache webserver this can be set as follows: ::
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'colorama==0.3.9',
         'cryptography==1.9',
         'flask==0.12.2',
-        'flask-appbuilder==1.9.4',
+        'flask-appbuilder==1.9.5',
         'flask-cache==0.13.1',
         'flask-migrate==2.0.3',
         'flask-script==2.0.5',

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -152,7 +152,9 @@ appbuilder = AppBuilder(
     db.session,
     base_template='superset/base.html',
     indexview=MyIndexView,
-    security_manager_class=app.config.get('CUSTOM_SECURITY_MANAGER'))
+    security_manager_class=app.config.get('CUSTOM_SECURITY_MANAGER'),
+    update_perms=utils.get_update_perms_flag(),
+)
 
 sm = appbuilder.sm
 

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -767,3 +767,8 @@ def merge_extra_filters(form_data):
                     form_data['filters'] += [filtr]
         # Remove extra filters from the form data since no longer needed
         del form_data['extra_filters']
+
+
+def get_update_perms_flag():
+    val = os.environ.get('SUPERSET_UPDATE_PERMS')
+    return val.lower() not in ('0', 'false', 'no') if val else True


### PR DESCRIPTION
This PR leverages @mistercrunch's FAB [change](https://github.com/dpgaspar/Flask-AppBuilder/pull/625) (which was released in `1.9.5`) to optionally disable updating of Flask-AppBuilder (FAB) permissions which can create a lot of contention and race conditions in the perm-related tables when running multiple Gunicorn instances. 

I toiled for a bit about how best to implement optionally enabling/disabling this feature (which really only needs to be enabled whilst running `superset init`). Sadly given that the  Flask-AppBuilder is configured in a global context `__init__.py` which is defined before anything else It seems like there's two options to configure Flask-AppBuilder dynamically from within the CLI.: 
1. A configuration variable defined in `config.py`
2. An environment variable

I opted for the later as this feature really is a switch which needs to change state during the initialization process (as described in `installation.rst`) and the the former would require a second configuration file simply to enable/disable the feature.

to: @mistercrunch 
cc: @michellethomas



  