### PR TITLE
Add druiddb dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'celery==4.1.0',
         'colorama==0.3.9',
         'cryptography==1.9',
+        'druiddb==0.1.11',
         'flask==0.12.2',
         'flask-appbuilder==1.9.5',
         'flask-cache==0.13.1',


### PR DESCRIPTION
The `druiddb` module (providing a SQLAlchemy interface to Druid) has been merged into `pydruid`, but until a new version of `pydruid` is released we need to explicitly list `druiddb` as a dependency.