### PR TITLE
Enable SQL syntax highlighting in View Query

### DIFF
--- a/superset/assets/javascripts/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/javascripts/explore/components/DisplayQueryButton.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/dist/light';
 import html from 'react-syntax-highlighter/dist/languages/htmlbars';
 import markdown from 'react-syntax-highlighter/dist/languages/markdown';
+import sql from 'react-syntax-highlighter/dist/languages/sql';
 import github from 'react-syntax-highlighter/dist/styles/github';
 import CopyToClipboard from './../../components/CopyToClipboard';
 
@@ -12,6 +13,7 @@ import { t } from '../../locales';
 
 registerLanguage('markdown', markdown);
 registerLanguage('html', html);
+registerLanguage('sql', sql);
 
 const $ = window.$ = require('jquery');
 


### PR DESCRIPTION
Syntax highlight was not enabled for SQL in the "View Query" button. It now works:

![screen shot 2018-01-09 at 1 54 41 pm](https://user-images.githubusercontent.com/1534870/34745305-e3fe237c-f544-11e7-8140-c1ef39342eb8.png)
