### PR TITLE
Sort out dependencies in travis/tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 env:
   global:
     - TRAVIS_CACHE=$HOME/.travis_cache/
-    - TRAVIS_NODE_VERSION="8.8.1"
   matrix:
     - TOX_ENV=flake8
     - TOX_ENV=javascript
@@ -19,8 +18,6 @@ env:
     - TOX_ENV=py34-sqlite
     - TOX_ENV=py27-mysql
     - TOX_ENV=py27-sqlite
-before_install:
-  - npm install -g npm@'>=5.4.1'
 before_script:
   - mysql -u root -e "DROP DATABASE IF EXISTS superset; CREATE DATABASE superset DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci"
   - mysql -u root -e "CREATE USER 'mysqluser'@'localhost' IDENTIFIED BY 'mysqluserpassword';"
@@ -31,6 +28,4 @@ before_script:
 install:
   - pip install --upgrade pip
   - pip install tox tox-travis
-  - pip install --upgrade flake8
-  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
 script: tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,6 @@ deps =
     wheel
     coveralls
 whitelist_externals =
-    /bin/rm
-    git
-    cd
-    source
     pip
     npm
 passenv =
@@ -65,7 +61,7 @@ deps =
 
 [testenv:javascript]
 commands =
-    npm install -g npm@'>=5.4.1'
+    npm install -g npm@'>=5.6.0'
     {toxinidir}/superset/assets/js_build.sh
 
 [testenv:pylint]

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,13 @@ find_links =
 deps =
     wheel
     coveralls
+whitelist_externals =
+    /bin/rm
+    git
+    cd
+    source
+    pip
+    npm
 passenv =
     HOME
     TRAVIS
@@ -48,6 +55,7 @@ commands =
 
 [testenv:flake8]
 commands =
+    pip install --upgrade flake8
     flake8
 deps =
     flake8
@@ -56,7 +64,9 @@ deps =
     flake8-quotes
 
 [testenv:javascript]
-commands = {toxinidir}/superset/assets/js_build.sh
+commands =
+    npm install -g npm@'>=5.4.1'
+    {toxinidir}/superset/assets/js_build.sh
 
 [testenv:pylint]
 commands =


### PR DESCRIPTION
Networking on travis / npm / pip has been flimsy with jobs failing randomly (network issues on some travis nodes?). 

This PR removes some python deps from the javascript build and removes npm installation from python-related builds in the matrix