### PR TITLE
[annotations] Fixing migration for annotation layers

### DIFF
--- a/superset/migrations/versions/21e88bc06c02_annotation_migration.py
+++ b/superset/migrations/versions/21e88bc06c02_annotation_migration.py
@@ -37,18 +37,19 @@ def upgrade():
             Slice.viz_type.like('line'), Slice.viz_type.like('bar'))):
         params = json.loads(slc.params)
         layers = params.get('annotation_layers', [])
-        new_layers = []
-        if len(layers) and isinstance(layers[0], int):
+        if layers:
+            new_layers = []
             for layer in layers:
-                new_layers.append(
-                    {
-                        'annotationType': 'INTERVAL',
-                        'style': 'solid',
-                        'name': 'Layer {}'.format(layer),
-                        'show': True,
-                        'overrides': {'since': None, 'until': None},
-                        'value': 1, 'width': 1, 'sourceType': 'NATIVE',
-                    })
+                new_layers.append({
+                    'annotationType': 'INTERVAL',
+                    'style': 'solid',
+                    'name': 'Layer {}'.format(layer),
+                    'show': True,
+                    'overrides': {'since': None, 'until': None},
+                    'value': layer,
+                    'width': 1,
+                    'sourceType': 'NATIVE',
+                })
             params['annotation_layers'] = new_layers
             slc.params = json.dumps(params)
             session.merge(slc)
@@ -57,4 +58,16 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(or_(
+            Slice.viz_type.like('line'), Slice.viz_type.like('bar'))):
+        params = json.loads(slc.params)
+        layers = params.get('annotation_layers', [])
+        if layers:
+            params['annotation_layers'] = [layer['value'] for layer in layers]
+            slc.params = json.dumps(params)
+            session.merge(slc)
+            session.commit()
+    session.close()


### PR DESCRIPTION
This PR resolves an issue with the annotation layer migration which @graceguo-supercat noticed during testing where the `value` field should actually be the layer ID. This also provides a one-to-one mapping between upgrade and downgrade, and thus for completeness I added a downgrade method. 

I tested this locally on a toy slice containing a single annotation layer, confirming that the corresponding record was correct after running `superset db upgrade` and `superset db downgrade`. 

Note given there's a downgrade method the check to inspect the type of the layer in the slice is no longer necessary. This was needed if someone previously ran, 
```
superset db upgrade
superset db downgrade
superset db upgrade
```

to: @fabianmenges @graceguo-supercat @michellethomas 
cc: @mistercrunch 