### PR TITLE
[bug fixes] annotations <> x domains, zeros in text

### DIFF
--- a/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
@@ -44,7 +44,6 @@ class ExploreChartPanel extends React.PureComponent {
         datasource={this.props.datasource}
         formData={this.props.form_data}
         height={this.getHeight()}
-        width={parseInt(this.props.width, 10)}
         slice={this.props.slice}
         chartKey={this.props.chart.chartKey}
         setControlValue={this.props.actions.setControlValue}

--- a/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
@@ -44,6 +44,7 @@ class ExploreChartPanel extends React.PureComponent {
         datasource={this.props.datasource}
         formData={this.props.form_data}
         height={this.getHeight()}
+        width={parseInt(this.props.width, 10)}
         slice={this.props.slice}
         chartKey={this.props.chart.chartKey}
         setControlValue={this.props.actions.setControlValue}

--- a/superset/assets/javascripts/explore/components/controls/TextControl.jsx
+++ b/superset/assets/javascripts/explore/components/controls/TextControl.jsx
@@ -31,7 +31,7 @@ export default class TextControl extends React.Component {
     this.onChange = this.onChange.bind(this);
   }
   onChange(event) {
-    let value = event.target.value || '';
+    let value = typeof event.target.value !== 'undefined' ? event.target.value : '';
 
     // Validation & casting
     const errors = [];
@@ -54,7 +54,8 @@ export default class TextControl extends React.Component {
     this.props.onChange(value, errors);
   }
   render() {
-    const value = this.props.value ? this.props.value.toString() : '';
+    const { value: rawValue } = this.props;
+    const value = typeof rawValue !== 'undefined' && rawValue !== null ? rawValue.toString() : '';
     return (
       <div>
         <ControlHeader {...this.props} />

--- a/superset/assets/javascripts/explore/components/controls/TextControl.jsx
+++ b/superset/assets/javascripts/explore/components/controls/TextControl.jsx
@@ -31,11 +31,11 @@ export default class TextControl extends React.Component {
     this.onChange = this.onChange.bind(this);
   }
   onChange(event) {
-    let value = typeof event.target.value !== 'undefined' ? event.target.value : '';
+    let value = event.target.value;
 
     // Validation & casting
     const errors = [];
-    if (this.props.isFloat) {
+    if (value !== '' && this.props.isFloat) {
       const error = v.numeric(value);
       if (error) {
         errors.push(error);
@@ -43,7 +43,7 @@ export default class TextControl extends React.Component {
         value = parseFloat(value);
       }
     }
-    if (this.props.isInt) {
+    if (value !== '' && this.props.isInt) {
       const error = v.integer(value);
       if (error) {
         errors.push(error);

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -629,13 +629,28 @@ function nvd3Vis(slice, payload) {
 
             const tip = tipFactory(e);
             const records = (slice.annotationData[e.name].records || []).map((r) => {
+<<<<<<< HEAD
               const timeColumn = new Date(moment.utc(r[e.timeColumn]));
+=======
+              const timeValue = new Date(r[e.timeColumn]);
+>>>>>>> [bugs] account for annotations in nvd3 x scale domain, fix dynamic width explore charts, allow 0 in text control
               return {
                 ...r,
-                [e.timeColumn]: timeColumn,
+                [e.timeColumn]: timeValue,
               };
-            }).filter(r => !Number.isNaN(r[e.timeColumn].getMilliseconds()));
+            }).filter((r) => {
+              const isValid = !Number.isNaN(r[e.timeColumn].getMilliseconds());
+              if (isValid) {
+                xMin = xMin < r[e.timeColumn] ? xMin : r[e.timeColumn];
+                xMax = xMax > r[e.timeColumn] ? xMax : r[e.timeColumn];
+              }
+              return isValid;
+            });
             if (records.length) {
+              const domain = [xMin, xMax];
+              xScale.domain(domain);
+              chart.xDomain(domain);
+
               annotations.selectAll('line')
                 .data(records)
                 .enter()
@@ -670,16 +685,29 @@ function nvd3Vis(slice, payload) {
             const tip = tipFactory(e);
 
             const records = (slice.annotationData[e.name].records || []).map((r) => {
-              const timeColumn = new Date(moment.utc(r[e.timeColumn]));
-              const intervalEndColumn = new Date(moment.utc(r[e.intervalEndColumn]));
+              const timeValue = new Date(moment.utc(r[e.timeColumn]));
+              const intervalEndValue = new Date(moment.utc(r[e.intervalEndColumn]));
               return {
                 ...r,
-                [e.timeColumn]: timeColumn,
-                [e.intervalEndColumn]: intervalEndColumn,
+                [e.timeColumn]: timeValue,
+                [e.intervalEndColumn]: intervalEndValue,
               };
-            }).filter(r => !Number.isNaN(r[e.timeColumn].getMilliseconds()) &&
-              !Number.isNaN(r[e.intervalEndColumn].getMilliseconds()));
+            }).filter((r) => {
+              const isValid = (
+                !Number.isNaN(r[e.timeColumn].getMilliseconds()) &&
+                !Number.isNaN(r[e.intervalEndColumn].getMilliseconds())
+              );
+              if (isValid) {
+                xMin = xMin < r[e.timeColumn] ? xMin : r[e.timeColumn];
+                xMax = xMax > r[e.intervalEndColumn] ? xMax : r[e.intervalEndColumn];
+              }
+              return isValid;
+            });
             if (records.length) {
+              const domain = [xMin, xMax];
+              xScale.domain(domain);
+              chart.xDomain(domain);
+
               annotations.selectAll('rect')
                 .data(records)
                 .enter()

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -539,8 +539,8 @@ function nvd3Vis(slice, payload) {
       // on scroll, hide tooltips. throttle to only 4x/second.
       $(window).scroll(throttle(hideTooltips, 250));
 
-      const annotationLayers = (slice.formData.annotation_layers || [])
-          .filter(x => x.show);
+      const annotationLayers = (slice.formData.annotation_layers || []).filter(x => x.show);
+
       if (isTimeSeries && annotationLayers) {
         // Formula annotations
         const formulas = annotationLayers.filter(a => a.annotationType === AnnotationTypes.FORMULA)
@@ -629,23 +629,22 @@ function nvd3Vis(slice, payload) {
 
             const tip = tipFactory(e);
             const records = (slice.annotationData[e.name].records || []).map((r) => {
-<<<<<<< HEAD
-              const timeColumn = new Date(moment.utc(r[e.timeColumn]));
-=======
-              const timeValue = new Date(r[e.timeColumn]);
->>>>>>> [bugs] account for annotations in nvd3 x scale domain, fix dynamic width explore charts, allow 0 in text control
+              const timeValue = new Date(moment.utc(r[e.timeColumn]));
+
               return {
                 ...r,
                 [e.timeColumn]: timeValue,
               };
-            }).filter((r) => {
-              const isValid = !Number.isNaN(r[e.timeColumn].getMilliseconds());
-              if (isValid) {
-                xMin = xMin < r[e.timeColumn] ? xMin : r[e.timeColumn];
-                xMax = xMax > r[e.timeColumn] ? xMax : r[e.timeColumn];
-              }
-              return isValid;
+            }).filter(record => !Number.isNaN(record[e.timeColumn].getMilliseconds()));
+
+            // account for the annotation in the x domain
+            records.forEach((record) => {
+              const timeValue = record[e.timeColumn];
+
+              xMin = Math.min(...[xMin, timeValue]);
+              xMax = Math.max(...[xMax, timeValue]);
             });
+
             if (records.length) {
               const domain = [xMin, xMax];
               xScale.domain(domain);
@@ -692,17 +691,20 @@ function nvd3Vis(slice, payload) {
                 [e.timeColumn]: timeValue,
                 [e.intervalEndColumn]: intervalEndValue,
               };
-            }).filter((r) => {
-              const isValid = (
-                !Number.isNaN(r[e.timeColumn].getMilliseconds()) &&
-                !Number.isNaN(r[e.intervalEndColumn].getMilliseconds())
-              );
-              if (isValid) {
-                xMin = xMin < r[e.timeColumn] ? xMin : r[e.timeColumn];
-                xMax = xMax > r[e.intervalEndColumn] ? xMax : r[e.intervalEndColumn];
-              }
-              return isValid;
+            }).filter(record => (
+              !Number.isNaN(record[e.timeColumn].getMilliseconds()) &&
+              !Number.isNaN(record[e.intervalEndColumn].getMilliseconds())
+            ));
+
+            // account for the annotation in the x domain
+            records.forEach((record) => {
+              const timeValue = record[e.timeColumn];
+              const intervalEndValue = record[e.intervalEndColumn];
+
+              xMin = Math.min(...[xMin, timeValue, intervalEndValue]);
+              xMax = Math.max(...[xMax, timeValue, intervalEndValue]);
             });
+
             if (records.length) {
               const domain = [xMin, xMax];
               xScale.domain(domain);


### PR DESCRIPTION
This PR fixes a couple bugs related to annotation usage
- when adding x-interval annotations to time series charts, the x-scale domain does not account for the annotation data. I updated the logic to account for this.
- when playing with annotations I noticed that you cannot currently enter a `0` in a `TextControl` component because the control only updates to values that evaluate `truthy`. I updated the logic to actually check for a value.

in examples below I added (`interval` or `event`) annotations with a `table slice` data source.

before (annotations clipped)
<img width="500" alt="screen shot 2018-01-10 at 4 36 38 pm" src="https://user-images.githubusercontent.com/4496521/34803673-5a1f5a3c-f629-11e7-9461-aacb2f904f10.png">

after (annotations included)
<img width="500" alt="screen shot 2018-01-10 at 4 36 38 pm" src="https://user-images.githubusercontent.com/4496521/34803618-0b697c10-f629-11e7-8942-505771f4af45.png">


@mistercrunch @fabianmenges @graceguo-supercat @michellethomas 

some other bugs I noted but didn't fix:
- if the source for event or interval annotations is a _table_, passing down "from" and "until" should actually perform a filter on the table columns defined by "interval start column" (and "interval end column"), not on the slices "from" and "until" form data.
- you can't set a y-max on a chart (looked into it, tricky with nvd3 without computing your own domain; I think we should fix with data-ui integration)