### PR TITLE
[bugfix] dealing with DBAPIs that return unserilizable types

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -299,7 +299,7 @@ def base_json_conv(obj):
         return str(obj)
 
 
-def json_iso_dttm_ser(obj):
+def json_iso_dttm_ser(obj, pessimistic=False):
     """
     json serializer that deals with dates
 
@@ -317,9 +317,19 @@ def json_iso_dttm_ser(obj):
     elif isinstance(obj, time):
         obj = obj.isoformat()
     else:
-        raise TypeError(
-            'Unserializable object {} of type {}'.format(obj, type(obj)))
+        if pessimistic:
+            return 'Unserializable [{}]'.format(type(obj))
+        else:
+            raise TypeError(
+                'Unserializable object {} of type {}'.format(obj, type(obj)))
     return obj
+
+
+def pessimistic_json_iso_dttm_ser(obj):
+    """Proxy to call json_iso_dttm_ser in a pessimistic way
+
+    If one of object is not serializable to json, it will still succeed"""
+    return json_iso_dttm_ser(obj, pessimistic=True)
 
 
 def datetime_to_epoch(dttm):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2310,12 +2310,14 @@ class Superset(BaseSupersetView):
                 data = sql_lab.get_sql_results(
                     query_id=query_id, return_results=True,
                     template_params=template_params)
+            payload = json.dumps(
+                data, default=utils.pessimistic_json_iso_dttm_ser)
         except Exception as e:
             logging.exception(e)
             return json_error_response('{}'.format(e))
         if data.get('status') == QueryStatus.FAILED:
             return json_error_response(payload=data)
-        return json_success(json.dumps(data, default=utils.json_iso_dttm_ser))
+        return json_success(payload)
 
     @has_access
     @expose('/csv/<client_id>')


### PR DESCRIPTION
Funky datatypes in some databases like BLOBs will have the DBAPI return
python types that can't be serialized to JSON out of the box.

Currently, when this happens SQL Lab fails in a bad way with a gigantic
HTML error message.

This allows specifying a pessimistic JSON serializer handler that will
simply show "Unserializable [type]"