### PR TITLE
[line chart] fix time shift color

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -939,7 +939,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
             if isinstance(series_title, string_types):
                 series_title += title_suffix
             elif title_suffix and isinstance(series_title, (list, tuple)):
-                series_title = series_title + (title_suffix,)
+                series_title = text_type(series_title[-1]) + title_suffix
 
             values = []
             for ds in df.index:


### PR DESCRIPTION
Bug occurs only when using a groupby, not when using only metrics only
## before
<img width="278" alt="screen shot 2018-01-11 at 3 59 55 pm" src="https://user-images.githubusercontent.com/487433/34853437-8a622cb4-f6e8-11e7-8095-fa0c2ede420c.png">

## after
<img width="268" alt="screen shot 2018-01-11 at 3 59 31 pm" src="https://user-images.githubusercontent.com/487433/34853438-8a782cc6-f6e8-11e7-88e0-9ce315cd634a.png">

closes https://github.com/apache/incubator-superset/issues/4198