### PR TITLE
Adding limit to time_table viz to get druid query to work

### DIFF
--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -684,6 +684,7 @@ export const visTypes = {
         expanded: true,
         controlSetRows: [
           ['groupby', 'metrics'],
+          ['limit'],
           ['column_collection'],
           ['url'],
         ],


### PR DESCRIPTION
@graceguo-supercat @john-bodley Adding the limit control on the time series table visualization.

[Update] Pulled out the description for the issue [here](https://github.com/apache/incubator-superset/issues/4208). In short, the druid query for the time series table was incorrect because it required a limit to include the second part of the query.

I'm not as familiar with this part of the code so I'm just adding a temporary fix to get the time table viz working. But this also causes problems if you remove the `limit` on a line chart. 
