### PR TITLE
[BugFix]: Creating a PostgresBaseEngineSpec so changes to the Postgre…

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -283,7 +283,7 @@ class BaseEngineSpec(object):
 class PostgresBaseEngineSpec(BaseEngineSpec):
     """ Abstract class for Postgres 'like' databases """
 
-    engine = 'postgresqlbase'
+    engine = ''
 
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}'),

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -280,8 +280,10 @@ class BaseEngineSpec(object):
         return {}
 
 
-class PostgresEngineSpec(BaseEngineSpec):
-    engine = 'postgresql'
+class PostgresBaseEngineSpec(BaseEngineSpec):
+    """ Abstract class for Postgres 'like' databases """
+
+    engine = 'postgresqlbase'
 
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}'),
@@ -311,12 +313,45 @@ class PostgresEngineSpec(BaseEngineSpec):
     def convert_dttm(cls, target_type, dttm):
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
+
+class PostgresEngineSpec(PostgresBaseEngineSpec):
+    engine = 'postgresql'
+
     @classmethod
     def get_table_names(cls, schema, inspector):
         """Need to consider foreign tables for PostgreSQL"""
         tables = inspector.get_table_names(schema)
         tables.extend(inspector.get_foreign_table_names(schema))
         return sorted(tables)
+
+
+class VerticaEngineSpec(PostgresBaseEngineSpec):
+    engine = 'vertica'
+
+
+class RedshiftEngineSpec(PostgresBaseEngineSpec):
+    engine = 'redshift'
+
+
+class OracleEngineSpec(PostgresBaseEngineSpec):
+    engine = 'oracle'
+
+    time_grains = (
+        Grain('Time Column', _('Time Column'), '{col}'),
+        Grain('minute', _('minute'), "TRUNC(TO_DATE({col}), 'MI')"),
+        Grain('hour', _('hour'), "TRUNC(TO_DATE({col}), 'HH')"),
+        Grain('day', _('day'), "TRUNC(TO_DATE({col}), 'DDD')"),
+        Grain('week', _('week'), "TRUNC(TO_DATE({col}), 'WW')"),
+        Grain('month', _('month'), "TRUNC(TO_DATE({col}), 'MONTH')"),
+        Grain('quarter', _('quarter'), "TRUNC(TO_DATE({col}), 'Q')"),
+        Grain('year', _('year'), "TRUNC(TO_DATE({col}), 'YEAR')"),
+    )
+
+    @classmethod
+    def convert_dttm(cls, target_type, dttm):
+        return (
+            """TO_TIMESTAMP('{}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""
+        ).format(dttm.isoformat())
 
 
 class Db2EngineSpec(BaseEngineSpec):
@@ -1044,42 +1079,6 @@ class MssqlEngineSpec(BaseEngineSpec):
     @classmethod
     def convert_dttm(cls, target_type, dttm):
         return "CONVERT(DATETIME, '{}', 126)".format(dttm.isoformat())
-
-
-class RedshiftEngineSpec(PostgresEngineSpec):
-    engine = 'redshift'
-
-
-class OracleEngineSpec(PostgresEngineSpec):
-    engine = 'oracle'
-
-    time_grains = (
-        Grain('Time Column', _('Time Column'), '{col}'),
-        Grain('minute', _('minute'),
-              "TRUNC(TO_DATE({col}), 'MI')"),
-        Grain('hour', _('hour'),
-              "TRUNC(TO_DATE({col}), 'HH')"),
-        Grain('day', _('day'),
-              "TRUNC(TO_DATE({col}), 'DDD')"),
-        Grain('week', _('week'),
-              "TRUNC(TO_DATE({col}), 'WW')"),
-        Grain('month', _('month'),
-              "TRUNC(TO_DATE({col}), 'MONTH')"),
-        Grain('quarter', _('quarter'),
-              "TRUNC(TO_DATE({col}), 'Q')"),
-        Grain('year', _('year'),
-              "TRUNC(TO_DATE({col}), 'YEAR')"),
-    )
-
-    @classmethod
-    def convert_dttm(cls, target_type, dttm):
-        return (
-            """TO_TIMESTAMP('{}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""
-        ).format(dttm.isoformat())
-
-
-class VerticaEngineSpec(PostgresEngineSpec):
-    engine = 'vertica'
 
 
 class AthenaEngineSpec(BaseEngineSpec):


### PR DESCRIPTION
…sEngineSpec don't affect every subclass

Refactored all classes that inherit from PostgresEngineSpec to inherit from PostgresBasesEngineSpec instead and moved them all to one place in the file.

 #3856 Broke `get_table_names` for Vertica and possibly Redshift and Oracle