### PR TITLE
Add frontend logging functions and log loading time for Dashboard and explore view

### DIFF
--- a/superset/assets/javascripts/chart/Chart.jsx
+++ b/superset/assets/javascripts/chart/Chart.jsx
@@ -7,6 +7,7 @@ import { Tooltip } from 'react-bootstrap';
 import { d3format } from '../modules/utils';
 import ChartBody from './ChartBody';
 import Loading from '../components/Loading';
+import { Logger, LOG_ACTIONS_RENDER_EVENT } from '../logger';
 import StackTraceMessage from '../components/StackTraceMessage';
 import visMap from '../../visualizations/main';
 import sandboxedEval from '../modules/sandbox';
@@ -171,6 +172,7 @@ class Chart extends React.PureComponent {
     const viz = visMap[this.props.vizType];
     const fd = this.props.formData;
     const qr = this.props.queryResponse;
+    const renderStart = Logger.getTimestamp();
     try {
       // Executing user-defined data mutator function
       if (fd.js_data) {
@@ -178,6 +180,13 @@ class Chart extends React.PureComponent {
       }
       // [re]rendering the visualization
       viz(this, qr, this.props.setControlValue);
+      Logger.append(LOG_ACTIONS_RENDER_EVENT, {
+        label: this.props.chartKey,
+        vis_type: this.props.vizType,
+        start_offset: renderStart,
+        duration: Logger.getTimestamp() - renderStart,
+      });
+      this.props.actions.chartRenderingSucceeded(this.props.chartKey);
     } catch (e) {
       this.props.actions.chartRenderingFailed(e, this.props.chartKey);
     }

--- a/superset/assets/javascripts/chart/chartReducer.js
+++ b/superset/assets/javascripts/chart/chartReducer.js
@@ -55,6 +55,11 @@ export default function chartReducer(charts = {}, action) {
         chartAlert: t('Updating chart was stopped'),
       };
     },
+    [actions.CHART_RENDERING_SUCCEEDED](state) {
+      return { ...state,
+        chartStatus: 'rendered',
+      };
+    },
     [actions.CHART_RENDERING_FAILED](state) {
       return { ...state,
         chartStatus: 'failed',

--- a/superset/assets/javascripts/dashboard/components/DashboardContainer.jsx
+++ b/superset/assets/javascripts/dashboard/components/DashboardContainer.jsx
@@ -5,7 +5,7 @@ import * as dashboardActions from '../actions';
 import * as chartActions from '../../chart/chartAction';
 import Dashboard from './Dashboard';
 
-function mapStateToProps({ charts, dashboard }) {
+function mapStateToProps({ charts, dashboard, impressionId }) {
   return {
     initMessages: dashboard.common.flash_messages,
     timeout: dashboard.common.conf.SUPERSET_WEBSERVER_TIMEOUT,
@@ -17,6 +17,7 @@ function mapStateToProps({ charts, dashboard }) {
     userId: dashboard.userId,
     isStarred: !!dashboard.isStarred,
     editMode: dashboard.editMode,
+    impressionId,
   };
 }
 

--- a/superset/assets/javascripts/dashboard/reducers.js
+++ b/superset/assets/javascripts/dashboard/reducers.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import d3 from 'd3';
+import shortid from 'shortid';
 
 import charts, { chart } from '../chart/chartReducer';
 import * as actions from './actions';
@@ -200,4 +201,5 @@ export const dashboard = function (state = {}, action) {
 export default combineReducers({
   charts,
   dashboard,
+  impressionId: () => (shortid.generate()),
 });

--- a/superset/assets/javascripts/explore/index.jsx
+++ b/superset/assets/javascripts/explore/index.jsx
@@ -5,6 +5,7 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 
+import shortid from 'shortid';
 import { now } from '../modules/dates';
 import { initEnhancer } from '../reduxUtils';
 import { getChartKey } from './exploreUtils';
@@ -64,6 +65,7 @@ const initState = {
     saveModalAlert: null,
   },
   explore: bootstrappedState,
+  impressionId: shortid.generate(),
 };
 const store = createStore(rootReducer, initState,
   compose(applyMiddleware(thunk), initEnhancer(false)),

--- a/superset/assets/javascripts/explore/reducers/index.js
+++ b/superset/assets/javascripts/explore/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux';
+import shortid from 'shortid';
 
 import charts from '../../chart/chartReducer';
 import saveModal from './saveModalReducer';
@@ -8,4 +9,5 @@ export default combineReducers({
   charts,
   saveModal,
   explore,
+  impressionId: () => (shortid.generate()),
 });

--- a/superset/assets/javascripts/logger.js
+++ b/superset/assets/javascripts/logger.js
@@ -1,0 +1,114 @@
+import $ from 'jquery';
+
+export const LOG_ACTIONS_PAGE_LOAD = 'page_load_perf';
+export const LOG_ACTIONS_LOAD_EVENT = 'load_events';
+export const LOG_ACTIONS_RENDER_EVENT = 'render_events';
+
+const handlers = {};
+
+export const Logger = {
+  start(log) {
+    log.setAttribute('startAt', new Date().getTime() - this.getTimestamp());
+    log.eventNames.forEach((eventName) => {
+      if (!handlers[eventName]) {
+        handlers[eventName] = [];
+      }
+      handlers[eventName].push(log.addEvent.bind(log));
+    });
+  },
+
+  append(eventName, eventBody) {
+    return handlers[eventName].length &&
+      handlers[eventName].forEach(handler => (handler(eventName, eventBody)));
+  },
+
+  end(log) {
+    log.setAttribute('duration', new Date().getTime() - log.startAt);
+    this.send(log);
+
+    log.eventNames.forEach((eventName) => {
+      if (handlers[eventName].length) {
+        const index = handlers[eventName]
+          .findIndex(handler => (handler === log.addEvent));
+        handlers[eventName].splice(index, 1);
+      }
+    });
+  },
+
+  send(log) {
+    const { impressionId, actionType, source, sourceId, events, startAt, duration } = log;
+    const requestPrams = [];
+    requestPrams.push(['impression_id', impressionId]);
+    switch (source) {
+      case 'dashboard':
+        requestPrams.push(['dashboard_id', sourceId]);
+        break;
+      case 'slice':
+        requestPrams.push(['slice_id', sourceId]);
+        break;
+      default:
+        break;
+    }
+    let url = '/superset/log/';
+    if (requestPrams.length) {
+      url += '?' + requestPrams.map(([k, v]) => (k + '=' + v)).join('&');
+    }
+    const eventData = {};
+    for (const eventName in events) {
+      eventData[eventName] = [];
+      events[eventName].forEach((event) => {
+        eventData[eventName].push(event);
+      });
+    }
+
+    $.ajax({
+      url,
+      method: 'POST',
+      dataType: 'json',
+      data: {
+        source: 'client',
+        type: actionType,
+        started_time: startAt,
+        duration,
+        events: JSON.stringify(eventData),
+      },
+    });
+  },
+
+  getTimestamp() {
+    return Math.round(window.performance.now());
+  },
+};
+
+export class ActionLog {
+  constructor({ impressionId, actionType, source, sourceId, eventNames, sendNow }) {
+    this.impressionId = impressionId;
+    this.source = source;
+    this.sourceId = sourceId;
+    this.actionType = actionType;
+    this.eventNames = eventNames;
+    this.sendNow = sendNow || false;
+    this.startAt = 0;
+    this.duration = 0;
+    this.events = {};
+
+    this.addEvent = this.addEvent.bind(this);
+  }
+
+  setAttribute(name, value) {
+    this[name] = value;
+  }
+
+  addEvent(eventName, eventBody) {
+    if (!this.events[eventName]) {
+      this.events[eventName] = [];
+    }
+    this.events[eventName].push(eventBody);
+
+    if (this.sendNow) {
+      this.setAttribute('duration', new Date().getTime() - this.startAt);
+      Logger.send(this);
+      this.events = {};
+    }
+  }
+}

--- a/superset/assets/spec/helpers/browser.js
+++ b/superset/assets/spec/helpers/browser.js
@@ -38,4 +38,5 @@ global.sinon.useFakeXMLHttpRequest();
 
 global.window.XMLHttpRequest = global.XMLHttpRequest;
 global.window.location = { href: 'about:blank' };
+global.window.performance = { now: () => (new Date().getTime()) };
 global.$ = require('jquery')(global.window);

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -860,7 +860,7 @@ class Log(Model):
             if g.user:
                 user_id = g.user.get_id()
             d = request.args.to_dict()
-            post_data = request.form or {}
+            post_data = request.form.to_dict() or {}
             d.update(post_data)
             d.update(kwargs)
             slice_id = d.get('slice_id')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1974,6 +1974,13 @@ class Superset(BaseSupersetView):
             bootstrap_data=json.dumps(bootstrap_data),
         )
 
+    @api
+    @has_access_api
+    @log_this
+    @expose('/log/', methods=['POST'])
+    def log(self):
+        return Response(status=200)
+
     @has_access
     @expose('/sync_druid/', methods=['POST'])
     @log_this


### PR DESCRIPTION
- add frontend logging functions
- add loading log for dash and explore view, also breakdown dash to multiple charts loading time.

This Logger module provides an event-based logging system. Log events are independent of log type (for example page_load_perf). We can define different log type, and attach some new events for other tracking purpose.

Dashboard loading log sample:
Request:
http://localhost:8080/superset/log/?impression_id=rybDJ7xdrf&dashboard_id=35

Post body:
`{`
`source:client`
`type:page_load_perf`
`started_time:1516925660209`
`duration:4539`
`events:{"load_events":[{"label":"slice_44","is_cached":false,"row_count":37,"start_offset":3366,"duration":759},{"label":"slice_240","is_cached":false,"row_count":385,"start_offset":3357,"duration":961},{"label":"slice_53","is_cached":false,"row_count":14,"start_offset":3378,"duration":1143}],"render_events":[{"label":"slice_44","vis_type":"dist_bar","start_offset":4140,"duration":1},{"label":"slice_240","vis_type":"area","start_offset":4327,"duration":0},{"label":"slice_53","vis_type":"big_number","start_offset":4530,"duration":8}]}`
`}`

**source**: for client action logging
**type**: I will use page_load_perf for all dashboard/ explore view page load performance tracking.
**started_time**: timestamp for page load start
**duration**: from page load till all charts are rendered (or error-out)
**events** is serialized json object, which has render_events list and load_events list like this:

```
events: {
    "load_events": [{
        "label": "slice_44",
        "is_cached": false,
        "row_count": 37,
        "start_offset": 3366,
        "duration": 759
    }, {
        "label": "slice_240",
        "is_cached": false,
        "row_count": 385,
        "start_offset": 3357,
        "duration": 961
    }, {
        "label": "slice_53",
        "is_cached": false,
        "row_count": 14,
        "start_offset": 3378,
        "duration": 1143
    }],
    "render_events": [{
        "label": "slice_44",
        "vis_type": "dist_bar",
        "start_offset": 4140,
        "duration": 1
    }, {
        "label": "slice_240",
        "vis_type": "area",
        "start_offset": 4327,
        "duration": 0
    }, {
        "label": "slice_53",
        "vis_type": "big_number",
        "start_offset": 4530,
        "duration": 8
    }]
}
```
@john-bodley @michellethomas @timifasubaa @williaster @fabianmenges 