### PR TITLE
[BugFix] Don't cache if there's no cache key

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -282,7 +282,11 @@ class BaseViz(object):
                 data = None
                 stacktrace = traceback.format_exc()
 
-            if data and cache and self.status != utils.QueryStatus.FAILED:
+            if (
+                    data and
+                    cache_key and
+                    cache and
+                    self.status != utils.QueryStatus.FAILED):
                 cached_dttm = datetime.utcnow().isoformat().split('.')[0]
                 try:
                     cache_value = json.dumps({


### PR DESCRIPTION
To follow up on [this](https://github.com/apache/incubator-superset/pull/4225) pr, we should also not add to cache if the cache_key is None.

@john-bodley @mistercrunch @graceguo-supercat 