### PR TITLE
[BugFix] Remove setting spatial in DeckPathViz class

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1982,7 +1982,6 @@ class DeckPathViz(BaseDeckGLViz):
         'json': json.loads,
         'polyline': polyline.decode,
     }
-    spatial_control_keys = ['spatial']
 
     def query_obj(self):
         d = super(DeckPathViz, self).query_obj()


### PR DESCRIPTION
Remove unneeded spatial key for DeckPathViz class

@mistercrunch 