### PR TITLE
Fix msg "'<' not supported between instances of 'str' and 'int'"

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1237,14 +1237,20 @@ class DruidDatasource(Model, BaseDatasource):
 
         # Reordering columns
         cols = []
+        groupby = query_obj.get('groupby') or []
+        columns = query_obj.get('columns') or []
+        metrics = query_obj.get('metrics') or []
         if DTTM_ALIAS in df.columns:
             cols += [DTTM_ALIAS]
-        cols += query_obj.get('groupby') or []
-        cols += query_obj.get('columns') or []
-        cols += query_obj.get('metrics') or []
+        cols += groupby
+        cols += columns
+        cols += metrics
 
         cols = [col for col in cols if col in df.columns]
         df = df[cols]
+
+        for col in groupby + columns:
+            df[col] = df[col].astype('str')
 
         time_offset = DruidDatasource.time_offset(query_obj['granularity'])
 

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -55,6 +55,7 @@ GB_RESULT_SET = [
         'timestamp': '2012-01-01T00:00:00.000Z',
         'event': {
             'dim1': 'Canada',
+            'dim2': 0,
             'metric1': 12345678,
         },
     },
@@ -63,6 +64,7 @@ GB_RESULT_SET = [
         'timestamp': '2012-01-01T00:00:00.000Z',
         'event': {
             'dim1': 'USA',
+            'dim2': 'false',
             'metric1': 12345678 / 2,
         },
     },
@@ -152,7 +154,7 @@ class DruidTests(SupersetTestCase):
             'row_limit': 5000,
             'include_search': 'false',
             'metrics': ['count'],
-            'groupby': ['dim1', 'dim2d'],
+            'groupby': ['dim1', 'dim2'],
             'force': 'true',
         }
         # two groupby
@@ -162,6 +164,7 @@ class DruidTests(SupersetTestCase):
         )
         resp = self.get_json_resp(url)
         self.assertEqual('Canada', resp['data']['records'][0]['dim1'])
+        self.assertEqual('0', resp['data']['records'][0]['dim2'])
 
     def test_druid_sync_from_config(self):
         CLUSTER_NAME = 'new_druid'


### PR DESCRIPTION
Druid returns NULL as 0, typed as int. This causes pandas to fail
when it tries to sort heterogeneous types.