### PR TITLE
[cache] Fixing json.dumps for timestamp

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -289,7 +289,7 @@ class BaseViz(object):
                     self.status != utils.QueryStatus.FAILED):
                 cached_dttm = datetime.utcnow().isoformat().split('.')[0]
                 try:
-                    cache_value = json.dumps({
+                    cache_value = self.json_dumps({
                         'data': data,
                         'dttm': cached_dttm,
                     })


### PR DESCRIPTION
Apologies when updating the cache logic I didn't realize that we were using `self.json_dumps(...)` rather than `json.dumps(...)` which handles the case when the data contains timestamps.

to: @michellethomas @mistercrunch 