### PR TITLE
Use json for imports and exports, not pickle

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -498,19 +498,6 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
 
     @classmethod
     def export_dashboards(cls, dashboard_ids):
-
-        class DashboardEncoder(json.JSONEncoder):
-            # pylint: disable=E0202
-            def default(self, o):
-                try:
-                    vals = {
-                        k: v for k, v in o.__dict__.items() if k != '_sa_instance_state'}
-                    return {'__{}__'.format(o.__class__.__name__): vals}
-                except Exception as e:
-                    if type(o) == datetime:
-                        return {'__datetime__': o.replace(microsecond=0).isoformat()}
-                    return json.JSONEncoder.default(self, o)
-
         copied_dashboards = []
         datasource_ids = set()
         for dashboard_id in dashboard_ids:
@@ -548,7 +535,7 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         return json.dumps({
             'dashboards': copied_dashboards,
             'datasources': eager_datasources,
-        }, cls=DashboardEncoder, indent=4)
+        }, cls=utils.DashboardEncoder, indent=4)
 
 
 class Database(Model, AuditMixinNullable, ImportMixin):

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -43,7 +43,6 @@ from sqlalchemy import event, exc, select
 from sqlalchemy.types import TEXT, TypeDecorator
 
 
-
 logging.getLogger('MARKDOWN').setLevel(logging.INFO)
 
 PY3K = sys.version_info >= (3, 0)
@@ -276,6 +275,19 @@ def decode_dashboards(o):
         return datetime.strptime(o['__datetime__'], '%Y-%m-%dT%H:%M:%S')
     else:
         return o
+
+
+class DashboardEncoder(json.JSONEncoder):
+    # pylint: disable=E0202
+    def default(self, o):
+        try:
+            vals = {
+                k: v for k, v in o.__dict__.items() if k != '_sa_instance_state'}
+            return {'__{}__'.format(o.__class__.__name__): vals}
+        except Exception:
+            if type(o) == datetime:
+                return {'__datetime__': o.replace(microsecond=0).isoformat()}
+            return json.JSONEncoder.default(self, o)
 
 
 def parse_human_timedelta(s):

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -42,6 +42,8 @@ import sqlalchemy as sa
 from sqlalchemy import event, exc, select
 from sqlalchemy.types import TEXT, TypeDecorator
 
+
+
 logging.getLogger('MARKDOWN').setLevel(logging.INFO)
 
 PY3K = sys.version_info >= (3, 0)
@@ -238,6 +240,42 @@ def parse_human_datetime(s):
 def dttm_from_timtuple(d):
     return datetime(
         d.tm_year, d.tm_mon, d.tm_mday, d.tm_hour, d.tm_min, d.tm_sec)
+
+
+def decode_dashboards(o):
+    """
+    Function to be passed into json.loads obj_hook parameter
+    Recreates the dashboard object from a json representation.
+    """
+    import superset.models.core as models
+    from superset.connectors.sqla.models import (
+        SqlaTable, SqlMetric, TableColumn,
+    )
+
+    if '__Dashboard__' in o:
+        d = models.Dashboard()
+        d.__dict__.update(o['__Dashboard__'])
+        return d
+    elif '__Slice__' in o:
+        d = models.Slice()
+        d.__dict__.update(o['__Slice__'])
+        return d
+    elif '__TableColumn__' in o:
+        d = TableColumn()
+        d.__dict__.update(o['__TableColumn__'])
+        return d
+    elif '__SqlaTable__' in o:
+        d = SqlaTable()
+        d.__dict__.update(o['__SqlaTable__'])
+        return d
+    elif '__SqlMetric__' in o:
+        d = SqlMetric()
+        d.__dict__.update(o['__SqlMetric__'])
+        return d
+    elif '__datetime__' in o:
+        return datetime.strptime(o['__datetime__'], '%Y-%m-%dT%H:%M:%S')
+    else:
+        return o
 
 
 def parse_human_timedelta(s):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 import json
 import logging
 import os
-import pickle
 import re
 import time
 import traceback
@@ -38,7 +37,9 @@ from superset import (
     viz,
 )
 from superset.connectors.connector_registry import ConnectorRegistry
-from superset.connectors.sqla.models import AnnotationDatasource, SqlaTable
+from superset.connectors.sqla.models import (
+    AnnotationDatasource, SqlaTable, SqlMetric, TableColumn,
+)
 from superset.forms import CsvToDatabaseForm
 from superset.legacy import cast_form_data
 import superset.models.core as models
@@ -601,7 +602,7 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
             ids = request.args.getlist('id')
             return Response(
                 models.Dashboard.export_dashboards(ids),
-                headers=generate_download_headers('pickle'),
+                headers=generate_download_headers('json'),
                 mimetype='application/text')
         return self.render_template(
             'superset/export_dashboards.html',
@@ -1114,15 +1115,17 @@ class Superset(BaseSupersetView):
     @has_access
     @expose('/import_dashboards', methods=['GET', 'POST'])
     def import_dashboards(self):
-        """Overrides the dashboards using pickled instances from the file."""
+        """Overrides the dashboards using json instances from the file."""
+
+
+
         f = request.files.get('file')
         if request.method == 'POST' and f:
             current_tt = int(time.time())
-            data = pickle.load(f)
+            data = json.loads(f.stream.read(), object_hook=utils.decode_dashboards)
             # TODO: import DRUID datasources
             for table in data['datasources']:
-                ds_class = ConnectorRegistry.sources.get(table.type)
-                ds_class.import_obj(table, import_time=current_tt)
+                type(table).import_obj(table, import_time=current_tt)
             db.session.commit()
             for dashboard in data['dashboards']:
                 models.Dashboard.import_obj(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -37,9 +37,7 @@ from superset import (
     viz,
 )
 from superset.connectors.connector_registry import ConnectorRegistry
-from superset.connectors.sqla.models import (
-    AnnotationDatasource, SqlaTable, SqlMetric, TableColumn,
-)
+from superset.connectors.sqla.models import AnnotationDatasource, SqlaTable
 from superset.forms import CsvToDatabaseForm
 from superset.legacy import cast_form_data
 import superset.models.core as models
@@ -1116,9 +1114,6 @@ class Superset(BaseSupersetView):
     @expose('/import_dashboards', methods=['GET', 'POST'])
     def import_dashboards(self):
         """Overrides the dashboards using json instances from the file."""
-
-
-
         f = request.files.get('file')
         if request.method == 'POST' and f:
             current_tt = int(time.time())


### PR DESCRIPTION
Importing and exporting dashboards with pickle files, which the user controls poses a security vulnerability. A well constructed pickle file can potentially spawn a shell. 
The exploit is fleshed out here (https://blog.nelhage.com/2011/03/exploiting-pickle/) 
This PR changes the format of the exported and imported files to json strings and eliminates this possibility. 

@mistercrunch @john-bodley @michellethomas 