### PR TITLE
[Sql Lab] Fix QueryAutoRefresh component pulling do not stop

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QueryAutoRefresh.jsx
@@ -22,7 +22,7 @@ class QueryAutoRefresh extends React.PureComponent {
     const queryKeys = Object.keys(queries);
     const queriesAsArray = queryKeys.map(key => queries[key]);
     return queriesAsArray.some(q =>
-      ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0);
+      ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0).length;
   }
   startTimer() {
     if (!(this.timer)) {


### PR DESCRIPTION
Currently in SQL lab, the query results pulling doesn't stop.

@michellethomas @williaster 