### PR TITLE
[geo] JS function to receive the whole data array instead on individual objects

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1881,10 +1881,11 @@ export const controls = {
     },
   },
 
-  js_datapoint_mutator: jsFunctionControl(
-    t('Javascript data point mutator'),
-    t('Define a javascript function that receives each data point and can alter it ' +
-      'before getting sent to the deck.gl layer'),
+  js_data_mutator: jsFunctionControl(
+    t('Javascript data interceptor'),
+    t('Define a javascript function that receives the data array used in the visualization ' +
+      'and is expected to return a modified version of that array. This can be used ' +
+      'to alter properties of the data, filter, or enrich the array.'),
   ),
 
   js_data: jsFunctionControl(

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -437,7 +437,7 @@ export const visTypes = {
         label: t('Advanced'),
         controlSetRows: [
           ['js_columns'],
-          ['js_datapoint_mutator'],
+          ['js_data_mutator'],
           ['js_tooltip'],
           ['js_onclick_href'],
         ],
@@ -509,7 +509,7 @@ export const visTypes = {
         label: t('Advanced'),
         controlSetRows: [
           ['js_columns'],
-          ['js_datapoint_mutator'],
+          ['js_data_mutator'],
           ['js_tooltip'],
           ['js_onclick_href'],
         ],
@@ -549,7 +549,7 @@ export const visTypes = {
         label: t('Advanced'),
         controlSetRows: [
           ['js_columns'],
-          ['js_datapoint_mutator'],
+          ['js_data_mutator'],
           ['js_tooltip'],
           ['js_onclick_href'],
         ],
@@ -621,7 +621,7 @@ export const visTypes = {
         label: t('Advanced'),
         controlSetRows: [
           ['js_columns'],
-          ['js_datapoint_mutator'],
+          ['js_data_mutator'],
           ['js_tooltip'],
           ['js_onclick_href'],
         ],

--- a/superset/assets/visualizations/deckgl/layers/path.jsx
+++ b/superset/assets/visualizations/deckgl/layers/path.jsx
@@ -14,9 +14,9 @@ export default function getLayer(formData, payload, slice) {
     color: fixedColor,
   }));
 
-  if (fd.js_datapoint_mutator) {
-    const jsFnMutator = sandboxedEval(fd.js_datapoint_mutator);
-    data = data.map(jsFnMutator);
+  if (fd.js_data_mutator) {
+    const jsFnMutator = sandboxedEval(fd.js_data_mutator);
+    data = jsFnMutator(data);
   }
 
   return new PathLayer({

--- a/superset/assets/visualizations/deckgl/layers/polygon.jsx
+++ b/superset/assets/visualizations/deckgl/layers/polygon.jsx
@@ -11,10 +11,10 @@ export default function polygonLayer(formData, payload, slice) {
     fillColor: [fc.r, fc.g, fc.b, 255 * fc.a],
   }));
 
-  if (fd.js_datapoint_mutator) {
+  if (fd.js_data_mutator) {
     // Applying user defined data mutator if defined
-    const jsFnMutator = sandboxedEval(fd.js_datapoint_mutator);
-    data = data.map(jsFnMutator);
+    const jsFnMutator = sandboxedEval(fd.js_data_mutator);
+    data = jsFnMutator(data);
   }
 
   return new PolygonLayer({

--- a/superset/assets/visualizations/deckgl/layers/scatter.jsx
+++ b/superset/assets/visualizations/deckgl/layers/scatter.jsx
@@ -28,10 +28,10 @@ export default function getLayer(formData, payload, slice) {
     };
   });
 
-  if (fd.js_datapoint_mutator) {
+  if (fd.js_data_mutator) {
     // Applying user defined data mutator if defined
-    const jsFnMutator = sandboxedEval(fd.js_datapoint_mutator);
-    data = data.map(jsFnMutator);
+    const jsFnMutator = sandboxedEval(fd.js_data_mutator);
+    data = jsFnMutator(data);
   }
 
   return new ScatterplotLayer({


### PR DESCRIPTION
Moving from having the user define an interceptor function that operates
on one object at a time to passing the whole array.

By passing the entire array, it's possible to do multiple passes where
needed. A common pattern might be to figure out a max value of a prop in order
to define a scaler function. That's only possible if dealing with the
whole array.

No change management is necessary as this feature has not been officially released yet.