### PR TITLE
add customer order field when export csv at time series chart

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -413,7 +413,8 @@ class SqlaTable(Model, BaseDatasource):
         customer_order_column = query_obj.get('timeseries_limit_metric', None)
         is_timeseries = query_obj.get('is_timeseries', False)
         if is_timeseries:
-            customer_order_column = '__timestamp' if not customer_order_column else customer_order_column
+            if not customer_order_column:
+                customer_order_column = '__timestamp'
             left_index = sql.rfind('ORDER BY') + len('ORDER BY') + 1
             right_index = sql.rfind('DESC') - 1
             sql = sql[:left_index] + customer_order_column + sql[right_index:]

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -409,6 +409,14 @@ class SqlaTable(Model, BaseDatasource):
             ),
         )
         logging.info(sql)
+        # add customer order explore data at time series charts
+        customer_order_column = query_obj.get('timeseries_limit_metric', None)
+        is_timeseries = query_obj.get('is_timeseries', False)
+        if is_timeseries:
+            customer_order_column = '__timestamp' if not customer_order_column else customer_order_column
+            left_index = sql.rfind('ORDER BY') + len('ORDER BY') + 1
+            right_index = sql.rfind('DESC') - 1
+            sql = sql[:left_index] + customer_order_column + sql[right_index:]
         sql = sqlparse.format(sql, reindent=True)
         if query_obj['is_prequery']:
             query_obj['prequeries'].append(sql)


### PR DESCRIPTION
I need to export csv file from time series chart order by customer field at chart, but superset export csv file from time series chart sorts by first metrics field default and when I need to sort by specified field it can not work. So I change default behavior to receive params from the front page passed and the default sort field is the date column at db