### PR TITLE
BugFix(#3573) Fix heatmap tooltip disappears under the slice's header

### DIFF
--- a/superset/assets/visualizations/cal_heatmap.css
+++ b/superset/assets/visualizations/cal_heatmap.css
@@ -1,3 +1,9 @@
 .cal_heatmap .slice_container {
   padding: 10px;
+  position: static !important;
+}
+
+.cal_heatmap .slice_container .ch-tooltip {
+  margin-left: 20px;
+  margin-top: 5px;
 }


### PR DESCRIPTION
The issue is that the container has the css properties:

overflow: hidden;
position: relative;

This makes the tooltip disappear. 

Besides fixing this, the tooltip wasn't displayed above the cursor due to the padding in the parent container so I added a bit of margin to compensate it and now it displays properly. 