### PR TITLE
Always use fluid container for navbar.

### DIFF
--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -3,7 +3,7 @@
 {% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
 
 <div class="navbar navbar-static-top {{menu.extra_classes}}" role="navigation">
-  <div class="container{{ '-fluid' if not navbar_container else '' }}">
+  <div class="container-fluid">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
         <span class="icon-bar"></span>


### PR DESCRIPTION
As in https://github.com/apache/incubator-superset/pull/4147 removes the
final non fluid container navbar, I think there's no need to keep this
line of code. Just use navbar with fluid container, always.