### PR TITLE
Fixing json decode error on druiddatasourcemodelview/api/read

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -91,6 +91,9 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
     def __repr__(self):
         return self.verbose_name if self.verbose_name else self.cluster_name
 
+    def __html__(self):
+        return self.__repr__()
+
     @property
     def data(self):
         return {


### PR DESCRIPTION
I've been getting a JSON decode error on `druiddatasourcemodelview/api/read` and from looking at [this](https://github.com/dpgaspar/Flask-AppBuilder/issues/313) issue, it seemed like having a __repr__ method on the DruidCluster model would work, but it seems __html__ is needed as well for DruidDatasources to decode the relationship to DruidCluster correctly.

@john-bodley 