### PR TITLE
[Explore View] Fix Stop Query Button behavior

### DIFF
--- a/superset/assets/javascripts/chart/chartAction.js
+++ b/superset/assets/javascripts/chart/chartAction.js
@@ -14,10 +14,7 @@ export function chartUpdateSucceeded(queryResponse, key) {
 }
 
 export const CHART_UPDATE_STOPPED = 'CHART_UPDATE_STOPPED';
-export function chartUpdateStopped(queryRequest, key) {
-  if (queryRequest) {
-    queryRequest.abort();
-  }
+export function chartUpdateStopped(key) {
   return { type: CHART_UPDATE_STOPPED, key };
 }
 
@@ -119,7 +116,9 @@ export function runQuery(formData, force = false, timeout = 60, key) {
       .catch((err) => {
         if (err.statusText === 'timeout') {
           dispatch(chartUpdateTimeout(err.statusText, timeout, key));
-        } else if (err.statusText !== 'abort') {
+        } else if (err.statusText === 'abort') {
+          dispatch(chartUpdateStopped(key));
+        } else {
           let errObject;
           if (err.responseJSON) {
             errObject = err.responseJSON;

--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -79,7 +79,7 @@ class ExploreViewContainer extends React.Component {
   }
 
   onStop() {
-    this.props.actions.chartUpdateStopped(this.props.chart.queryRequest);
+    return this.props.chart.queryRequest.abort();
   }
 
   getWidth() {


### PR DESCRIPTION
When user start a query in explore view, click on "Stop Query" button has no effect.

@michellethomas @mistercrunch @williaster 