### PR TITLE
Jsonify dashboard payload

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1961,6 +1961,9 @@ class Superset(BaseSupersetView):
             'common': self.common_bootsrap_payload(),
         }
 
+        if request.args.get('json') == 'true':
+            return json_success(json.dumps(bootstrap_data))
+
         return self.render_template(
             'superset/dashboard.html',
             entry='dashboard',


### PR DESCRIPTION
By setting `json=true` in query params, the dashboard data will be jsonified. This will open up the ability to build more native components in the very near future like next week. 😄 💯 

@mistercrunch @betodealmeida 