### PR TITLE
Adding dashboard add view

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -507,7 +507,7 @@ class SliceAddView(SliceModelView):  # noqa
     list_columns = [
         'id', 'slice_name', 'slice_link', 'viz_type',
         'datasource_link', 'owners', 'modified', 'changed_on']
-    show_columns = SliceModelView.edit_columns + list_columns
+    show_columns = list(set(SliceModelView.edit_columns + list_columns))
 
 
 appbuilder.add_view_no_menu(SliceAddView)
@@ -639,7 +639,7 @@ class DashboardAddView(DashboardModelView):  # noqa
         'id', 'dashboard_link', 'creator', 'modified', 'dashboard_title',
         'changed_on', 'url', 'changed_by_name',
     ]
-    show_columns = DashboardModelView.edit_columns + list_columns
+    show_columns = list(set(DashboardModelView.edit_columns + list_columns))
 
 
 appbuilder.add_view_no_menu(DashboardAddView)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -507,6 +507,7 @@ class SliceAddView(SliceModelView):  # noqa
     list_columns = [
         'id', 'slice_name', 'slice_link', 'viz_type',
         'datasource_link', 'owners', 'modified', 'changed_on']
+    show_columns = SliceModelView.edit_columns + list_columns
 
 
 appbuilder.add_view_no_menu(SliceAddView)
@@ -631,6 +632,17 @@ class DashboardModelViewAsync(DashboardModelView):  # noqa
 
 
 appbuilder.add_view_no_menu(DashboardModelViewAsync)
+
+
+class DashboardAddView(DashboardModelView):  # noqa
+    list_columns = [
+        'id', 'dashboard_link', 'creator', 'modified', 'dashboard_title',
+        'changed_on', 'url', 'changed_by_name',
+    ]
+    show_columns = DashboardModelView.edit_columns + list_columns
+
+
+appbuilder.add_view_no_menu(DashboardAddView)
 
 
 class LogModelView(SupersetModelView):

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -237,6 +237,13 @@ class CoreTests(SupersetTestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
 
+    def test_get_user_slices(self):
+        self.login(username='admin')
+        userid = appbuilder.sm.find_user('admin').id
+        url = '/sliceaddview/api/read?_flt_0_created_by={}'.format(userid)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
     def test_slices_V2(self):
         # Add explore-v2-beta role to admin user
         # Test all slice urls as user with with explore-v2-beta role


### PR DESCRIPTION
I've been using the flask app builder apis to programmatically create slices and dashboards, but when posting to `sliceaddview/api/create` or `dashboardmodelview/api/create` the result doesn't include fields that are useful. They both don't include the `id` of the dashboard or slice created (which makes it difficult to keep track of).

show_columns is the field that determines what data gets returned after a request, so I'm adding additional fields to show_columns.

SliceAddView already exists and is being used to get all slices for a user, so because I don't want to introduce any future issues I'm adding tests for sliceaddview.

@john-bodley 