### PR TITLE
Add permission checks to save_or_overwrite_slice

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1179,12 +1179,12 @@ class Superset(BaseSupersetView):
 
         if action == 'overwrite' and not slice_overwrite_perm:
             return json_error_response(
-                "You don't have the rights to alter this slice",
+                _("You don't have the rights to ") + _("alter this ") + _("chart"),
                 status=400)
 
         if action == 'saveas' and not slice_add_perm:
             return json_error_response(
-                "You don't have the rights to create this slice",
+                _("You don't have the rights to ") + _("create a ") + _("chart"),
                 status=400)
 
         if action in ('saveas', 'overwrite'):
@@ -1297,7 +1297,7 @@ class Superset(BaseSupersetView):
             dash_overwrite_perm = check_ownership(dash, raise_if_false=False)
             if not dash_overwrite_perm:
                 return json_error_response(
-                    "You don't have the rights to alter this dashboard",
+                    _("You don't have the rights to ") + _("alter this ") + _("dashboard"),
                     status=400)
 
             flash(
@@ -1310,7 +1310,7 @@ class Superset(BaseSupersetView):
             dash_add_perm = self.can_access('can_add', 'DashboardModelView')
             if not dash_add_perm:
                 return json_error_response(
-                    "You don't have the rights to create a dashboard",
+                    _("You don't have the rights to ") + _("create a ") + _("dashboard"),
                     status=400)
 
             dash = models.Dashboard(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1179,12 +1179,12 @@ class Superset(BaseSupersetView):
 
         if action == 'overwrite' and not slice_overwrite_perm:
             return json_error_response(
-                _("You don't have the rights to ") + _("alter this ") + _("chart"),
+                _('You don\'t have the rights to ') + _('alter this ') + _('chart'),
                 status=400)
 
         if action == 'saveas' and not slice_add_perm:
             return json_error_response(
-                _("You don't have the rights to ") + _("create a ") + _("chart"),
+                _('You don\'t have the rights to ') + _('create a ') + _('chart'),
                 status=400)
 
         if action in ('saveas', 'overwrite'):
@@ -1297,7 +1297,8 @@ class Superset(BaseSupersetView):
             dash_overwrite_perm = check_ownership(dash, raise_if_false=False)
             if not dash_overwrite_perm:
                 return json_error_response(
-                    _("You don't have the rights to ") + _("alter this ") + _("dashboard"),
+                    _('You don\'t have the rights to ') + _('alter this ') +
+                    _('dashboard'),
                     status=400)
 
             flash(
@@ -1310,7 +1311,7 @@ class Superset(BaseSupersetView):
             dash_add_perm = self.can_access('can_add', 'DashboardModelView')
             if not dash_add_perm:
                 return json_error_response(
-                    _("You don't have the rights to ") + _("create a ") + _("dashboard"),
+                    _('You don\'t have the rights to ') + _('create a ') + _('dashboard'),
                     status=400)
 
             dash = models.Dashboard(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1294,7 +1294,7 @@ class Superset(BaseSupersetView):
             )
 
             # check edit dashboard permissions
-            dash_overwrite_perm = is_owner(dash, g.user)
+            dash_overwrite_perm = check_ownership(dash, raise_if_false=False)
             if not dash_overwrite_perm:
                 return json_error_response(
                     "You don't have the rights to alter this dashboard",


### PR DESCRIPTION
This PR is meant to resolve issue #3498 

- Add Slice permission check for `saveas` to `explore` request
- Add Dashboard permission check for `add_to_dash == existing` to `explore` request
- Add Dashboard permission check for `add_to_dash == new` to `explore` request

