### PR TITLE
Remove useless empty npm-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ app.db
 *.entry.js
 *.js.map
 node_modules
-npm-debug.log
+npm-debug.log*
 yarn.lock
 superset/assets/version_info.json
 


### PR DESCRIPTION
The log file comes from
https://github.com/apache/incubator-superset/commit/a7a6678d5ca535e29e6e021b7404c2e5c3599fdb

Also modify .gitignore to ignore all future npm-debug.log