### PR TITLE
Add ipdb to dev dependencies.

### DIFF
--- a/dev-reqs.txt
+++ b/dev-reqs.txt
@@ -2,6 +2,7 @@ codeclimate-test-reporter
 coveralls
 flake8
 flask_cors
+ipdb
 mock
 mysqlclient
 nose


### PR DESCRIPTION
Though flask has a builtin web debugger, ipdb some times still work
better. So I think add ipdb to dev dependencies is a good option for
people who prefer CLI debugging.