### PR TITLE
Set default row_limit to 50k

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -852,7 +852,7 @@ export const controls = {
     freeForm: true,
     label: t('Row limit'),
     validators: [v.integer],
-    default: null,
+    default: 50000,
     choices: formatSelectOptions(ROW_LIMIT_OPTIONS),
   },
 


### PR DESCRIPTION
Note that users can still bump up or clear that number and effectively not limit the amount of data returned.