### PR TITLE
Remove dangerouslySetInnerHTML in StackTraceMessage component

### DIFF
--- a/superset/assets/javascripts/components/StackTraceMessage.jsx
+++ b/superset/assets/javascripts/components/StackTraceMessage.jsx
@@ -26,20 +26,13 @@ class StackTraceMessage extends React.PureComponent {
   }
 
   render() {
-    const msg = (
-      <div>
-        <p
-          dangerouslySetInnerHTML={{ __html: this.props.message }}
-        />
-      </div>);
-
     return (
       <div className={`stack-trace-container${this.hasTrace() ? ' has-trace' : ''}`}>
         <Alert
           bsStyle="warning"
           onClick={() => this.setState({ showStackTrace: !this.state.showStackTrace })}
         >
-          {msg}
+          {this.props.message}
         </Alert>
         {this.hasTrace() &&
           <Collapse in={this.state.showStackTrace}>


### PR DESCRIPTION
Druid sometimes returns error message that are contained in "<>", as in
`<urlopen error [Errno 61] Connection refused>`. Since Superset's
approach is often to bubble up messages coming from external library,
it's impossible to predict whether it will contain special characters.

There are some cases where our error handling does return some html
(presto?),
but we should manage that upstream. Plus the current setup has security concerns,
so let's move away from that.