### PR TITLE
[error handling] 'Time Comparison' query returns no data

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1127,10 +1127,11 @@ class NVD3TimeSeriesViz(NVD3Viz):
             query_object['to_dttm'] -= delta
 
             df2 = self.get_df_payload(query_object).get('df')
-            df2[DTTM_ALIAS] += delta
-            df2 = self.process_data(df2)
-            self.extra_chart_data = self.to_series(
-                df2, classed='superset', title_suffix='---')
+            if df2 is not None:
+                df2[DTTM_ALIAS] += delta
+                df2 = self.process_data(df2)
+                self.extra_chart_data = self.to_series(
+                    df2, classed='superset', title_suffix='---')
 
     def get_data(self, df):
         df = self.process_data(df)


### PR DESCRIPTION
Will show `No data` instead of `'NoneType' object has no attribute '__getitem__'`