### PR TITLE
Fix ImportError when using BigQuery in SQL Editor

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1200,8 +1200,7 @@ class BQEngineSpec(BaseEngineSpec):
     @classmethod
     def fetch_data(cls, cursor, limit):
         data = super(BQEngineSpec, cls).fetch_data(cursor, limit)
-        from google.cloud.bigquery._helpers import Row  # pylint: disable=import-error
-        if len(data) != 0 and isinstance(data[0], Row):
+        if len(data) != 0 and type(data[0]).__name__ == 'Row':
             data = [r.values() for r in data]
         return data
 


### PR DESCRIPTION
This fixes an issue with the newer Google's DBAPI library, which moved Row from google.cloud.bigquery._helpers.Row to google.cloud.bigquery.Row, causing ImportError.