### PR TITLE
Disable user access request

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -326,10 +326,9 @@ CONFIG_PATH_ENV_VAR = 'SUPERSET_CONFIG_PATH'
 # example: FLASK_APP_MUTATOR = lambda x: x.before_request = f
 FLASK_APP_MUTATOR = None
 
-# Set this to true if you don't want users to be presented the 
-# option of requesting access from other users
-DISABLE_ACCESS_REQUEST = True
-
+# Set this to false if you don't want users to be able to request/grant
+# datasource access requests from/to other users.
+ENABLE_ACCESS_REQUEST = True
 
 # smtp server configuration
 EMAIL_NOTIFICATIONS = False  # all the emails are sent using dryrun

--- a/superset/config.py
+++ b/superset/config.py
@@ -326,6 +326,10 @@ CONFIG_PATH_ENV_VAR = 'SUPERSET_CONFIG_PATH'
 # example: FLASK_APP_MUTATOR = lambda x: x.before_request = f
 FLASK_APP_MUTATOR = None
 
+# Set this to true if you don't want users to be presented the 
+# option of requesting access from other users
+DISABLE_ACCESS_REQUEST = True
+
 
 # smtp server configuration
 EMAIL_NOTIFICATIONS = False  # all the emails are sent using dryrun

--- a/superset/config.py
+++ b/superset/config.py
@@ -328,7 +328,7 @@ FLASK_APP_MUTATOR = None
 
 # Set this to false if you don't want users to be able to request/grant
 # datasource access requests from/to other users.
-ENABLE_ACCESS_REQUEST = True
+ENABLE_ACCESS_REQUEST = False
 
 # smtp server configuration
 EMAIL_NOTIFICATIONS = False  # all the emails are sent using dryrun

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1918,14 +1918,15 @@ class Superset(BaseSupersetView):
             if datasource:
                 datasources.add(datasource)
 
-        for datasource in datasources:
-            if datasource and not self.datasource_access(datasource):
-                flash(
-                    __(get_datasource_access_error_msg(datasource.name)),
-                    'danger')
-                return redirect(
-                    'superset/request_access/?'
-                    'dashboard_id={dash.id}&'.format(**locals()))
+        if config.get('ENABLE_ACCESS_REQUEST'):
+            for datasource in datasources:
+                if datasource and not self.datasource_access(datasource):
+                    flash(
+                        __(get_datasource_access_error_msg(datasource.name)),
+                        'danger')
+                    return redirect(
+                        'superset/request_access/?'
+                        'dashboard_id={dash.id}&'.format(**locals()))
 
         # Hack to log the dashboard_id properly, even when getting a slug
         @log_this

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -362,30 +362,30 @@ class DatabaseTablesAsync(DatabaseView):
 appbuilder.add_view_no_menu(DatabaseTablesAsync)
 
 
-class AccessRequestsModelView(SupersetModelView, DeleteMixin):
-    datamodel = SQLAInterface(DAR)
-    list_columns = [
-        'username', 'user_roles', 'datasource_link',
-        'roles_with_datasource', 'created_on']
-    order_columns = ['created_on']
-    base_order = ('changed_on', 'desc')
-    label_columns = {
-        'username': _('User'),
-        'user_roles': _('User Roles'),
-        'database': _('Database URL'),
-        'datasource_link': _('Datasource'),
-        'roles_with_datasource': _('Roles to grant'),
-        'created_on': _('Created On'),
-    }
+if config.get('ENABLE_ACCESS_REQUEST'):
+    class AccessRequestsModelView(SupersetModelView, DeleteMixin):
+        datamodel = SQLAInterface(DAR)
+        list_columns = [
+            'username', 'user_roles', 'datasource_link',
+            'roles_with_datasource', 'created_on']
+        order_columns = ['created_on']
+        base_order = ('changed_on', 'desc')
+        label_columns = {
+            'username': _('User'),
+            'user_roles': _('User Roles'),
+            'database': _('Database URL'),
+            'datasource_link': _('Datasource'),
+            'roles_with_datasource': _('Roles to grant'),
+            'created_on': _('Created On'),
+        }
 
-
-appbuilder.add_view(
-    AccessRequestsModelView,
-    'Access requests',
-    label=__('Access requests'),
-    category='Security',
-    category_label=__('Security'),
-    icon='fa-table')
+    appbuilder.add_view(
+        AccessRequestsModelView,
+        'Access requests',
+        label=__('Access requests'),
+        category='Security',
+        category_label=__('Security'),
+        icon='fa-table')
 
 
 class SliceModelView(SupersetModelView, DeleteMixin):  # noqa

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -138,7 +138,6 @@ class CoreTests(SupersetTestCase):
             assert_func('UserDBModelView', view_menus)
             assert_func('SQL Lab',
                         view_menus)
-            assert_func('AccessRequestsModelView', view_menus)
 
         assert_admin_view_menus_in('Admin', self.assertIn)
         assert_admin_view_menus_in('Alpha', self.assertNotIn)

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -1,4 +1,4 @@
-from superset import security, sm
+from superset import app, security, sm
 from .base_tests import SupersetTestCase
 
 
@@ -76,7 +76,9 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(('muldelete', 'DruidDatasourceModelView'), perm_set)
 
     def assert_cannot_alpha(self, perm_set):
-        self.assert_cannot_write('AccessRequestsModelView', perm_set)
+        if app.config.get('ENABLE_ACCESS_REQUEST'):
+            self.assert_cannot_write('AccessRequestsModelView', perm_set)
+            self.assert_can_all('AccessRequestsModelView', perm_set)
         self.assert_cannot_write('Queries', perm_set)
         self.assert_cannot_write('RoleModelView', perm_set)
         self.assert_cannot_write('UserDBModelView', perm_set)
@@ -85,7 +87,6 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_can_all('DatabaseAsync', perm_set)
         self.assert_can_all('DatabaseView', perm_set)
         self.assert_can_all('DruidClusterModelView', perm_set)
-        self.assert_can_all('AccessRequestsModelView', perm_set)
         self.assert_can_all('RoleModelView', perm_set)
         self.assert_can_all('UserDBModelView', perm_set)
 
@@ -104,9 +105,10 @@ class RolePermissionTests(SupersetTestCase):
 
         self.assertTrue(security.is_admin_only(
             sm.find_permission_view_menu('can_delete', 'DatabaseView')))
-        self.assertTrue(security.is_admin_only(
-            sm.find_permission_view_menu(
-                'can_show', 'AccessRequestsModelView')))
+        if app.config.get('ENABLE_ACCESS_REQUEST'):
+            self.assertTrue(security.is_admin_only(
+                sm.find_permission_view_menu(
+                    'can_show', 'AccessRequestsModelView')))
         self.assertTrue(security.is_admin_only(
             sm.find_permission_view_menu(
                 'can_edit', 'UserDBModelView')))


### PR DESCRIPTION
The request access feature isn't fully implemented and it can potentially be misleading to users who click the access request button and expect to gain access eventually. This PR makes the access request button optional via a feature flag that allows it by default. 

If you set the flag to false, you'll no longer see the image below whenever you don't have access to any of the slices in a dashboard. 
<img width="1216" alt="no_access_" src="https://user-images.githubusercontent.com/30888507/36086390-eaa59808-0f80-11e8-8568-86500110bcdc.png">

Instead, you'll see all the slices and an error message for any one you don't have access to. Like in the image below. 
<img width="1087" alt="screen shot 2018-02-11 at 11 13 09 pm" src="https://user-images.githubusercontent.com/30888507/36086447-4bb56de4-0f81-11e8-9941-9a0e4254bf43.png">


@john-bodley @michellethomas  @mistercrunch  