### PR TITLE
Add link on how to get permission to permission error

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -349,6 +349,10 @@ SILENCE_FAB = True
 # It will be appended at the bottom of sql_lab errors.
 TROUBLESHOOTING_LINK = ''
 
+# This link should lead to a page with instructions on how to gain access to a
+# Datasource. It will be placed at the bottom of permissions errors. 
+PERMISSION_INSTRUCTIONS_LINK = ''
+
 
 # Integrate external Blueprints to the app by passing them to your
 # configuration. These blueprints will get integrated in the app

--- a/superset/config.py
+++ b/superset/config.py
@@ -350,9 +350,8 @@ SILENCE_FAB = True
 TROUBLESHOOTING_LINK = ''
 
 # This link should lead to a page with instructions on how to gain access to a
-# Datasource. It will be placed at the bottom of permissions errors. 
+# Datasource. It will be placed at the bottom of permissions errors.
 PERMISSION_INSTRUCTIONS_LINK = ''
-
 
 # Integrate external Blueprints to the app by passing them to your
 # configuration. These blueprints will get integrated in the app

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -64,7 +64,13 @@ DATASOURCE_MISSING_ERR = __('The datasource seems to have been deleted')
 ACCESS_REQUEST_MISSING_ERR = __(
     'The access requests seem to have been deleted')
 USER_MISSING_ERR = __('The user seems to have been deleted')
-DATASOURCE_ACCESS_ERR = __("You don't have access to this datasource")
+perms_instruction_link = config.get("PERMISSION_INSTRUCTIONS_LINK")
+if perms_instruction_link:
+    DATASOURCE_ACCESS_ERR = __(
+        "You don't have access to this datasource. <a href='{}'>How to gain access</a>"
+        .format(perms_instruction_link))
+else:
+    DATASOURCE_ACCESS_ERR = __("You don't have access to this datasource") 
 
 
 def get_database_access_error_msg(database_name):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -64,13 +64,14 @@ DATASOURCE_MISSING_ERR = __('The datasource seems to have been deleted')
 ACCESS_REQUEST_MISSING_ERR = __(
     'The access requests seem to have been deleted')
 USER_MISSING_ERR = __('The user seems to have been deleted')
-perms_instruction_link = config.get("PERMISSION_INSTRUCTIONS_LINK")
+perms_instruction_link = config.get('PERMISSION_INSTRUCTIONS_LINK')
 if perms_instruction_link:
     DATASOURCE_ACCESS_ERR = __(
-        "You don't have access to this datasource. <a href='{}'>How to gain access</a>"
-        .format(perms_instruction_link))
+        "You don't have access to this datasource. <a href='{}'>How to gain access.</a>"
+        .format(perms_instruction_link),
+    )
 else:
-    DATASOURCE_ACCESS_ERR = __("You don't have access to this datasource") 
+    DATASOURCE_ACCESS_ERR = __("You don't have access to this datasource")
 
 
 def get_database_access_error_msg(database_name):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -67,7 +67,7 @@ USER_MISSING_ERR = __('The user seems to have been deleted')
 perms_instruction_link = config.get('PERMISSION_INSTRUCTIONS_LINK')
 if perms_instruction_link:
     DATASOURCE_ACCESS_ERR = __(
-        "You don't have access to this datasource. <a href='{}'>How to gain access.</a>"
+        "You don't have access to this datasource. <a href='{}'>(Gain access)</a>"
         .format(perms_instruction_link),
     )
 else:


### PR DESCRIPTION
This PR creates a way for users to be shown a link to a document that shows them how to gain the right permissions to be able to access datasources. This often varies across companies so it is manually configured in the config file. If set, the end result should look like the image below. 

<img width="1060" alt="screen shot 2018-02-12 at 2 18 53 pm" src="https://user-images.githubusercontent.com/30888507/36122850-b66507ac-0fff-11e8-86be-fc83d5bb5e27.png">


@john-bodley @michellethomas @mistercrunch 