### PR TITLE
Add permissions decider for delegating access controls.

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -364,6 +364,21 @@ TRACKING_URL_TRANSFORMER = lambda x: x  # noqa: E731
 # Interval between consecutive polls when using Hive Engine
 HIVE_POLL_INTERVAL = 5
 
+#System to handle delegated data access (Must implement is_allowed_access() which will be called from within superset)
+class PermsDecider:
+    def __init__(self, ):
+        pass
+
+    def is_eligible_datasource(datasource):
+        #this returns whether or not this perms decider can decide access for this datasource.
+        return False
+
+    def is_allowed_access(self, username, datasource):
+        #returns whether or not the user has access to the datasource.
+        return False
+
+DATA_PERMS_DECIDER = PermsDecider()
+
 try:
     if CONFIG_PATH_ENV_VAR in os.environ:
         # Explicitly import config module that is not in pythonpath; useful

--- a/superset/config.py
+++ b/superset/config.py
@@ -364,18 +364,21 @@ TRACKING_URL_TRANSFORMER = lambda x: x  # noqa: E731
 # Interval between consecutive polls when using Hive Engine
 HIVE_POLL_INTERVAL = 5
 
-#System to handle delegated data access (Must implement is_allowed_access() which will be called from within superset)
+
+# System to handle delegated data access. Implement both is_allowed_access() and
+# is_eligible_datasource() to delegate access controls.
 class PermsDecider:
-    def __init__(self, ):
+    def __init__(self):
         pass
 
-    def is_eligible_datasource(datasource):
-        #this returns whether or not this perms decider can decide access for this datasource.
+    def is_eligible_datasource(self, datasource):
+        # This returns whether this perms decider can decide access for this datasource.
         return False
 
     def is_allowed_access(self, username, datasource):
-        #returns whether or not the user has access to the datasource.
+        # returns whether or not the user has access to the datasource.
         return False
+
 
 DATA_PERMS_DECIDER = PermsDecider()
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -20,7 +20,7 @@ import traceback
 import uuid
 
 from dateutil import relativedelta as rdelta
-from flask import g, escape, request
+from flask import escape, request
 from flask_babel import lazy_gettext as _
 import geohash
 from markdown import markdown
@@ -307,11 +307,7 @@ class BaseViz(object):
         cached_dttm = datetime.utcnow().isoformat().split('.')[0]
         if cache_key and cache and not self.force:
             cache_value = cache.get(cache_key)
-            perms_decider = config.get("DATA_PERMS_DECIDER")
-            perms_decider_approves = 
-                not (perms_decider.is_eligible_datasource(self.datasource) and 
-                    perms_decider.is_allowed_access(g.user.username, datasource))
-            if cache_value and perms_decider_approves:
+            if cache_value:
                 stats_logger.incr('loaded_from_cache')
                 try:
                     cache_value = pkl.loads(cache_value)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -20,7 +20,7 @@ import traceback
 import uuid
 
 from dateutil import relativedelta as rdelta
-from flask import escape, request
+from flask import g, escape, request
 from flask_babel import lazy_gettext as _
 import geohash
 from markdown import markdown
@@ -307,7 +307,11 @@ class BaseViz(object):
         cached_dttm = datetime.utcnow().isoformat().split('.')[0]
         if cache_key and cache and not self.force:
             cache_value = cache.get(cache_key)
-            if cache_value:
+            perms_decider = config.get("DATA_PERMS_DECIDER")
+            perms_decider_approves = 
+                not (perms_decider.is_eligible_datasource(self.datasource) and 
+                    perms_decider.is_allowed_access(g.user.username, datasource))
+            if cache_value and perms_decider_approves:
                 stats_logger.incr('loaded_from_cache')
                 try:
                     cache_value = pkl.loads(cache_value)


### PR DESCRIPTION
This PR creates the perms_decider object in the config which gives different deployments the ability to delegate data access control with the 
`is_eligible_datasource()` which decides if the perms_decider can handle access decisions for a datasource and 
`is_allowed_access()` which decides if the user has access. 

I also added in a case where we consult the perms decider before loading from the cache. With the default options, the cache flow doesn't change since is_eligible_datasource returns False.

@fabianmenges @john-bodley  @mistercrunch