### PR TITLE
Unset 'series limit' default from 50 to null

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -862,8 +862,11 @@ export const controls = {
     label: t('Series limit'),
     validators: [v.integer],
     choices: formatSelectOptions(SERIES_LIMITS),
-    default: 50,
-    description: t('Limits the number of time series that get displayed'),
+    description: t(
+      'Limits the number of time series that get displayed. A sub query ' +
+      '(or an extra phase where sub queries are not supported) is applied to limit ' +
+      'the number of time series that get fetched and displayed. This feature is useful ' +
+      'when grouping by high cardinality dimension(s).'),
   },
 
   timeseries_limit_metric: {


### PR DESCRIPTION
Setting "Series Limit" by default results in a subquery (or 2 phase)
which can be suboptimal / unecessary where low cardinality dims
are used.

closes https://github.com/apache/incubator-superset/issues/4397