### PR TITLE
Proper error handling in Hive Queries

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -846,7 +846,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         from TCLIService import ttypes
         state = cursor.poll()
         if state.operationState == ttypes.TOperationState.ERROR_STATE:
-            raise Exception("Query error", state.errorMessage)
+            raise Exception('Query error', state.errorMessage)
         if cls.limit_method == LimitMethod.FETCH_MANY:
             return cursor.fetchmany(limit)
         return cursor.fetchall()

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -841,6 +841,16 @@ class HiveEngineSpec(PrestoEngineSpec):
         return BaseEngineSpec.fetch_result_sets(
             db, datasource_type, force=force)
 
+    @classmethod
+    def fetch_data(cls, cursor, limit):
+        from TCLIService import ttypes
+        state = cursor.poll()
+        if state.operationState == ttypes.TOperationState.ERROR_STATE:
+            raise Exception("Query error", state.errorMessage)
+        if cls.limit_method == LimitMethod.FETCH_MANY:
+            return cursor.fetchmany(limit)
+        return cursor.fetchall()
+
     @staticmethod
     def create_table_from_csv(form, table):
         """Uploads a csv file and creates a superset datasource in Hive."""

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -847,7 +847,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         state = cursor.poll()
         if state.operationState == ttypes.TOperationState.ERROR_STATE:
             raise Exception('Query error', state.errorMessage)
-        return super(HiveEngineSpec, cls).fetch_data(cls, cursor, limit)
+        return super(HiveEngineSpec, cls).fetch_data(cursor, limit)
 
     @staticmethod
     def create_table_from_csv(form, table):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -846,10 +846,8 @@ class HiveEngineSpec(PrestoEngineSpec):
         from TCLIService import ttypes
         state = cursor.poll()
         if state.operationState == ttypes.TOperationState.ERROR_STATE:
-            raise Exception('Query error', state.errorMessage)
-        if cls.limit_method == LimitMethod.FETCH_MANY:
-            return cursor.fetchmany(limit)
-        return cursor.fetchall()
+            raise Exception("Query error", state.errorMessage.replace("\\n", "\n"))
+        return super(HiveEngineSpec, cls).fetch_data(cls, cursor, limit)
 
     @staticmethod
     def create_table_from_csv(form, table):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -846,7 +846,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         from TCLIService import ttypes
         state = cursor.poll()
         if state.operationState == ttypes.TOperationState.ERROR_STATE:
-            raise Exception("Query error", state.errorMessage.replace("\\n", "\n"))
+            raise Exception('Query error', state.errorMessage)
         return super(HiveEngineSpec, cls).fetch_data(cls, cursor, limit)
 
     @staticmethod


### PR DESCRIPTION
Resolves: #4414
Fetch_many gives strange exception when hive query is in Error state.
So we're reading status to get proper error message before calling fetch_many