### PR TITLE
Add .1s option to D3 Format dropdown

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -12,6 +12,7 @@ const D3_FORMAT_DOCS = 'D3 format syntax: https://github.com/d3/d3-format';
 
 // input choices & options
 const D3_FORMAT_OPTIONS = [
+  ['.1s', '.1s | 12k'],
   ['.3s', '.3s | 12.3k'],
   ['.3%', '.3% | 1234543.210%'],
   ['.4r', '.4r | 12350'],


### PR DESCRIPTION
Add option .1s to  D3_FORMAT_OPTIONS. 
This patch add the ability to display numbers like 12.0 as 12 where the dropdown is active.

This is not the solution for #4424, but we can think to add dropdown to let the user specify the format of the tooltip ?

