### PR TITLE
Fix separator visualization by propagating header height - Resolves issue #3619

### DIFF
--- a/superset/assets/javascripts/chart/Chart.jsx
+++ b/superset/assets/javascripts/chart/Chart.jsx
@@ -20,6 +20,7 @@ const propTypes = {
   containerId: PropTypes.string.isRequired,
   datasource: PropTypes.object.isRequired,
   formData: PropTypes.object.isRequired,
+  headerHeight: PropTypes.number,
   height: PropTypes.number,
   width: PropTypes.number,
   setControlValue: PropTypes.func,
@@ -63,6 +64,7 @@ class Chart extends React.PureComponent {
     this.getFilters = this.getFilters.bind(this);
     this.clearFilter = this.clearFilter.bind(this);
     this.removeFilter = this.removeFilter.bind(this);
+    this.headerHeight = this.headerHeight.bind(this);
     this.height = this.height.bind(this);
     this.width = this.width.bind(this);
   }
@@ -127,6 +129,10 @@ class Chart extends React.PureComponent {
 
   width() {
     return this.props.width || this.container.el.offsetWidth;
+  }
+
+  headerHeight() {
+    return this.props.headerHeight || 0;
   }
 
   height() {

--- a/superset/assets/javascripts/dashboard/components/GridCell.jsx
+++ b/superset/assets/javascripts/dashboard/components/GridCell.jsx
@@ -73,14 +73,19 @@ class GridCell extends React.PureComponent {
 
   height(slice) {
     const widgetHeight = this.props.widgetHeight;
-    const headerId = this.getHeaderId(slice);
+    const headerHeight = this.headerHeight(slice);
     const descriptionId = this.getDescriptionId(slice);
-    const headerHeight = this.refs[headerId] ? this.refs[headerId].offsetHeight : 30;
     let descriptionHeight = 0;
     if (this.props.isExpanded && this.refs[descriptionId]) {
       descriptionHeight = this.refs[descriptionId].offsetHeight + 10;
     }
+
     return widgetHeight - headerHeight - descriptionHeight;
+  }
+
+  headerHeight(slice) {
+    const headerId = this.getHeaderId(slice);
+    return this.refs[headerId] ? this.refs[headerId].offsetHeight : 30;
   }
 
   render() {
@@ -130,6 +135,7 @@ class GridCell extends React.PureComponent {
             chartKey={chartKey}
             datasource={datasource}
             formData={formData}
+            headerHeight={this.headerHeight(slice)}
             height={this.height(slice)}
             width={this.width()}
             timeout={timeout}

--- a/superset/assets/visualizations/markup.js
+++ b/superset/assets/visualizations/markup.js
@@ -9,6 +9,13 @@ function markupWidget(slice, payload) {
     overflow: 'auto',
   });
 
+  // markup height is slice height - (marginTop + marginBottom)
+  let iframeHeight = slice.height() - 20;
+  if (slice.props.vizType === 'separator') {
+    // separator height is the entire chart container: slice height + header
+    iframeHeight = slice.height() + slice.headerHeight();
+  }
+
   const iframeId = `if__${slice.containerId}`;
   const html = `
     <html>
@@ -22,7 +29,7 @@ function markupWidget(slice, payload) {
   jqdiv.html(`
     <iframe id="${iframeId}"
       frameborder="0"
-      height="${slice.height() - 20}"
+      height="${iframeHeight}"
       sandbox="allow-same-origin allow-scripts allow-top-navigation allow-popups">
     </iframe>
   `);


### PR DESCRIPTION
This fix is to resolves issue #3619 

The separator slice is using an iframe with a height smaller than the chart's container. This causes the text to be truncated and a scroll bar to appear. This is because the markup chart shares the same visualization as separators and the styling has been updated to work with markup only.

Before the attached changes, you can see markup charts look correct while separators are cut off:

![separator-fix-before](https://user-images.githubusercontent.com/222699/36275120-8fff157e-124f-11e8-99ec-06716b8d8da6.png)

After the changes, both charts are sized correctly:
![separator-fix-after](https://user-images.githubusercontent.com/222699/36275130-95e72530-124f-11e8-9f87-addac8900df1.PNG)
