### PR TITLE
Fix chart title color in IE

### DIFF
--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -229,7 +229,7 @@ table.table-no-hover tr:hover {
 
 .editable-title input[type="button"] {
     border-color: transparent;
-    background: inherit;
+    background: transparent;
     white-space: normal;
     text-align: left;
 }


### PR DESCRIPTION
Chart titles in Superset have `background: inherit` which appears to be broken in IE 11 and the chart titles appear as a grey box. This PR changes the background to `transparent`.

Editing charts in IE before the change:
![ie-chart-title-before](https://user-images.githubusercontent.com/222699/36277390-5a1b84fe-1256-11e8-8ee7-0ff5d66b854d.png)

Viewing charts in dashboards before the change:
![ie-chart-title-dash-before](https://user-images.githubusercontent.com/222699/36277407-66431742-1256-11e8-9e5a-dcbda05d8253.PNG)

Editing charts in IE after the change:
![ie-chart-title-after](https://user-images.githubusercontent.com/222699/36277412-6bed1440-1256-11e8-9069-d0b5bdd782a7.PNG)

Viewing charts in dashboards before the change:
![ie-chart-title-dash-after](https://user-images.githubusercontent.com/222699/36277420-75a570ae-1256-11e8-9234-c3ee50bad82e.PNG)

