### PR TITLE
[header] make superset icon link to welcome page, not profile

### DIFF
--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -10,7 +10,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/superset/profile/{{ current_user.username }}/">
+      <a class="navbar-brand" href="/superset/welcome">
         <img
           width="126" src="{{ appbuilder.app_icon }}"
           alt="{{ appbuilder.app_name }}"


### PR DESCRIPTION
Currently, the superset icon on the header links to the profile page and this is inconsistent with the pattern in other sites. This PR makes the icon link to the welcome page

@mistercrunch @john-bodley 