### PR TITLE
Improve default placeholder text on SelectControl

### DIFF
--- a/superset/assets/javascripts/explore/components/controls/SelectControl.jsx
+++ b/superset/assets/javascripts/explore/components/controls/SelectControl.jsx
@@ -106,7 +106,7 @@ export default class SelectControl extends React.PureComponent {
   }
   render() {
     //  Tab, comma or Enter will trigger a new option created for FreeFormSelect
-    const placeholder = this.props.placeholder || t('Select %s', this.state.options.length);
+    const placeholder = this.props.placeholder || t('%s option(s)', this.state.options.length);
     const selectProps = {
       multi: this.props.multi,
       name: `select-${this.props.name}`,


### PR DESCRIPTION
## before
<img width="545" alt="screen shot 2018-02-15 at 9 57 06 pm" src="https://user-images.githubusercontent.com/487433/36295268-4525ab52-129b-11e8-8675-d65fccf8f9bc.png">

## after
<img width="536" alt="screen shot 2018-02-15 at 9 56 02 pm" src="https://user-images.githubusercontent.com/487433/36295269-4544615a-129b-11e8-8b25-9640bc292ed2.png">
