### PR TITLE
for 48 columns dashboard, adjust default size for newly added slices

### DIFF
--- a/superset/assets/javascripts/dashboard/reducers.js
+++ b/superset/assets/javascripts/dashboard/reducers.js
@@ -39,16 +39,21 @@ export function getInitialState(bootstrapData) {
       dashboard.posDict[position.slice_id] = position;
     });
   }
-  dashboard.slices.forEach((slice, index) => {
+  const lastRowId = Math.max.apply(null,
+    dashboard.position_json.map(pos => (pos.row + pos.size_y)));
+  let newSliceCounter = 0;
+  dashboard.slices.forEach((slice) => {
     const sliceId = slice.slice_id;
     let pos = dashboard.posDict[sliceId];
     if (!pos) {
+      // append new slices to dashboard bottom, 3 slices per row
       pos = {
-        col: (index * 4 + 1) % 12,
-        row: Math.floor((index) / 3) * 4,
-        size_x: 4,
-        size_y: 4,
+        col: (newSliceCounter % 3) * 16 + 1,
+        row: lastRowId + Math.floor(newSliceCounter / 3) * 16,
+        size_x: 16,
+        size_y: 16,
       };
+      newSliceCounter++;
     }
 
     dashboard.layout.push({


### PR DESCRIPTION
<img width="1342" alt="screen shot 2018-02-16 at 11 49 22 am" src="https://user-images.githubusercontent.com/27990562/36326362-aecf7b5e-130f-11e8-84b8-fd87c3379380.png">

- When user added new slice into dashboard, its default size was based on 12 columns layout. now we have 48 columns.
- adjust default size for newly added slices. 
- append newly added slices at the bottom of existed slices.
- if user added multiple slices, default set 3 slices per row.


@mistercrunch @michellethomas 