### PR TITLE
Remove double call to ConnectorRegistry.sources

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2083,7 +2083,6 @@ class Superset(BaseSupersetView):
         SqlaTable = ConnectorRegistry.sources['table']
         data = json.loads(request.form.get('data'))
         table_name = data.get('datasourceName')
-        SqlaTable = ConnectorRegistry.sources['table']
         table = (
             db.session.query(SqlaTable)
             .filter_by(table_name=table_name)


### PR DESCRIPTION
Removing the double call didn't cause any adverse effects upon removal. If required, a comment motivating the double call should be added.