### PR TITLE
Make instant controls store state in URL

### DIFF
--- a/superset/assets/javascripts/chart/chartAction.js
+++ b/superset/assets/javascripts/chart/chartAction.js
@@ -102,8 +102,8 @@ export function triggerQuery(value = true, key) {
 
 // this action is used for forced re-render without fetch data
 export const RENDER_TRIGGERED = 'RENDER_TRIGGERED';
-export function renderTriggered(value, key) {
-  return { type: RENDER_TRIGGERED, value, key };
+export function renderTriggered(timestamp, latestQueryFormData, key) {
+  return { type: RENDER_TRIGGERED, timestamp, latestQueryFormData, key };
 }
 
 export const RUN_QUERY = 'RUN_QUERY';

--- a/superset/assets/javascripts/chart/chartAction.js
+++ b/superset/assets/javascripts/chart/chartAction.js
@@ -102,8 +102,13 @@ export function triggerQuery(value = true, key) {
 
 // this action is used for forced re-render without fetch data
 export const RENDER_TRIGGERED = 'RENDER_TRIGGERED';
-export function renderTriggered(timestamp, latestQueryFormData, key) {
-  return { type: RENDER_TRIGGERED, timestamp, latestQueryFormData, key };
+export function renderTriggered(value, key) {
+  return { type: RENDER_TRIGGERED, value, key };
+}
+
+export const UPDATE_QUERY_FORM_DATA = 'UPDATE_QUERY_FORM_DATA';
+export function updateQueryFormData(value, key) {
+  return { type: UPDATE_QUERY_FORM_DATA, value, key };
 }
 
 export const RUN_QUERY = 'RUN_QUERY';
@@ -170,6 +175,7 @@ export function runQuery(formData, force = false, timeout = 60, key) {
     return Promise.all([
       queryPromise,
       dispatch(triggerQuery(false, key)),
+      dispatch(updateQueryFormData(payload, key)),
       ...annotationLayers.map(x => dispatch(runAnnotationQuery(x, timeout, formData, key))),
     ]);
   };

--- a/superset/assets/javascripts/chart/chartReducer.js
+++ b/superset/assets/javascripts/chart/chartReducer.js
@@ -47,7 +47,6 @@ export default function chartReducer(charts = {}, action) {
         chartUpdateEndTime: null,
         chartUpdateStartTime: now(),
         queryRequest: action.queryRequest,
-        latestQueryFormData: action.latestQueryFormData,
       };
     },
     [actions.CHART_UPDATE_STOPPED](state) {

--- a/superset/assets/javascripts/chart/chartReducer.js
+++ b/superset/assets/javascripts/chart/chartReducer.js
@@ -91,7 +91,10 @@ export default function chartReducer(charts = {}, action) {
       return { ...state, triggerQuery: action.value };
     },
     [actions.RENDER_TRIGGERED](state) {
-      return { ...state, lastRendered: action.value };
+      return { ...state,
+        lastRendered: action.timestamp,
+        latestQueryFormData: action.latestQueryFormData,
+      };
     },
     [actions.ANNOTATION_QUERY_STARTED](state) {
       if (state.annotationQuery &&

--- a/superset/assets/javascripts/chart/chartReducer.js
+++ b/superset/assets/javascripts/chart/chartReducer.js
@@ -91,10 +91,10 @@ export default function chartReducer(charts = {}, action) {
       return { ...state, triggerQuery: action.value };
     },
     [actions.RENDER_TRIGGERED](state) {
-      return { ...state,
-        lastRendered: action.timestamp,
-        latestQueryFormData: action.latestQueryFormData,
-      };
+      return { ...state, lastRendered: action.value };
+    },
+    [actions.UPDATE_QUERY_FORM_DATA](state) {
+      return { ...state, latestQueryFormData: action.value };
     },
     [actions.ANNOTATION_QUERY_STARTED](state) {
       if (state.annotationQuery &&

--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -76,16 +76,18 @@ class ExploreViewContainer extends React.Component {
       this.props.actions.fetchDatasourceMetadata(np.form_data.datasource, true);
     }
     // if any control value changed and it's an instant control
-    if (Object.keys(np.controls).some(key => (np.controls[key].renderTrigger &&
-      typeof this.props.controls[key] !== 'undefined' &&
-      !areObjectsEqual(np.controls[key].value, this.props.controls[key].value)))
-    ) {
+    if (this.instantControlChanged(this.props.controls, np.controls)) {
       this.props.actions.renderTriggered(new Date().getTime(), this.props.chart.chartKey);
     }
   }
 
-  componentDidUpdate() {
+  /* eslint no-unused-vars: 0 */
+  componentDidUpdate(prevProps, prevState) {
     this.triggerQueryIfNeeded();
+
+    if (this.instantControlChanged(prevProps.controls, this.props.controls)) {
+      this.addHistory({});
+    }
   }
 
   componentWillUnmount() {
@@ -115,6 +117,14 @@ class ExploreViewContainer extends React.Component {
     }
     const navHeight = this.props.standalone ? 0 : 90;
     return `${window.innerHeight - navHeight}px`;
+  }
+
+  instantControlChanged(prevControls, currentControls) {
+    return Object.keys(currentControls).some(key => (
+      currentControls[key].renderTrigger &&
+      typeof prevControls[key] !== 'undefined' &&
+      !areObjectsEqual(currentControls[key].value, prevControls[key].value)
+    ));
   }
 
   triggerQueryIfNeeded() {

--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -77,9 +77,9 @@ class ExploreViewContainer extends React.Component {
     }
     // if any control value changed and it's an instant control
     if (this.instantControlChanged(this.props.controls, np.controls)) {
-      const latestQueryFormData = getFormDataFromControls(np.controls);
-      this.props.actions.renderTriggered(
-        new Date().getTime(), latestQueryFormData, this.props.chart.chartKey);
+      this.props.actions.updateQueryFormData(
+        getFormDataFromControls(np.controls), this.props.chart.chartKey);
+      this.props.actions.renderTriggered(new Date().getTime(), this.props.chart.chartKey);
     }
   }
 

--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -77,7 +77,9 @@ class ExploreViewContainer extends React.Component {
     }
     // if any control value changed and it's an instant control
     if (this.instantControlChanged(this.props.controls, np.controls)) {
-      this.props.actions.renderTriggered(new Date().getTime(), this.props.chart.chartKey);
+      const latestQueryFormData = getFormDataFromControls(np.controls);
+      this.props.actions.renderTriggered(
+        new Date().getTime(), latestQueryFormData, this.props.chart.chartKey);
     }
   }
 


### PR DESCRIPTION
When an instant control is changed the visualization is re-rendered, but the `form_data` parameter in the URL is not updated. This means that if someone copies the URL, or generates a short URL, it will not point to the current visualization.

I created a new action `UPDATE_QUERY_FORM_DATA` that is called whenever a query is run, but also when an instant control changes. This way, the URL and short URL reflect the current visualization, and can be shared as expected.

(This PR is 1 of 2 addressing #4379)