### PR TITLE
[Header] fixing spacing issue on internationalization dropdown

### DIFF
--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -6,7 +6,7 @@
 {% if languages.keys()|length > 1 %}
 <li class="dropdown">
     <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:void(0)">
-       <div class="f16"><i class="flag {{languages[locale].get('flag')}}"></i><b class="caret"></b>
+       <div class="f16"><i class="flag {{languages[locale].get('flag')}}"></i>&nbsp;<b class="caret"></b>
        </div>
     </a>
     <ul class="dropdown-menu" id="language-picker">


### PR DESCRIPTION
When visiting pages that are not built by flask app builder there is a whitespace issue where the internationalization flag navbar item is floating a little bit higher than the rest. Adding this whitespace fixes the issue.

before:
![image](https://user-images.githubusercontent.com/2455694/36447367-0b7de1d4-1639-11e8-8dcc-e10712d433c3.png)

after:
![image](https://user-images.githubusercontent.com/2455694/36447382-1dcd6486-1639-11e8-999c-855140ec5ef3.png)

@graceguo-supercat @michellethomas 

cc @mistercrunch I'm changing the code!
