### PR TITLE
[Explore] highlighting run query when chart is stale on explore view

### DIFF
--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -76,14 +76,15 @@ class ExploreViewContainer extends React.Component {
     if (np.controls.datasource.value !== this.props.controls.datasource.value) {
       this.props.actions.fetchDatasourceMetadata(np.form_data.datasource, true);
     }
-    // if any control value changed and it's a display control
-    if (this.hasDisplayControlChanged(this.props.controls, np.controls)) {
+
+    const changedControlKeys = this.findChangedControlKeys(this.props.controls, np.controls);
+    if (this.hasDisplayControlChanged(changedControlKeys, np.controls)) {
       this.props.actions.updateQueryFormData(
         getFormDataFromControls(np.controls), this.props.chart.chartKey);
       this.props.actions.renderTriggered(new Date().getTime(), this.props.chart.chartKey);
     }
-    if (this.hasQueryControlChanged(this.props.controls, np.controls)) {
-      this.setState({ chartIsStale: true })
+    if (this.hasQueryControlChanged(changedControlKeys, np.controls)) {
+      this.setState({ chartIsStale: true });
     }
   }
 
@@ -91,7 +92,8 @@ class ExploreViewContainer extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     this.triggerQueryIfNeeded();
 
-    if (this.hasDisplayControlChanged(prevProps.controls, this.props.controls)) {
+    const changedControlKeys = this.findChangedControlKeys(prevProps.controls, this.props.controls);
+    if (this.hasDisplayControlChanged(changedControlKeys, this.props.controls)) {
       this.addHistory({});
     }
   }
@@ -126,20 +128,19 @@ class ExploreViewContainer extends React.Component {
     return `${window.innerHeight - navHeight}px`;
   }
 
-  hasDisplayControlChanged(prevControls, currentControls) {
-    return Object.keys(currentControls).some(key => (
-      currentControls[key].renderTrigger &&
+  findChangedControlKeys(prevControls, currentControls) {
+    return Object.keys(currentControls).filter(key => (
       typeof prevControls[key] !== 'undefined' &&
       !areObjectsEqual(currentControls[key].value, prevControls[key].value)
     ));
   }
 
-  hasQueryControlChanged(prevControls, currentControls) {
-    return Object.keys(currentControls).some(key => (
-      !currentControls[key].renderTrigger &&
-      typeof prevControls[key] !== 'undefined' &&
-      !areObjectsEqual(currentControls[key].value, prevControls[key].value)
-    ));
+  hasDisplayControlChanged(changedControlKeys, currentControls) {
+    return changedControlKeys.some(key => (currentControls[key].renderTrigger));
+  }
+
+  hasQueryControlChanged(changedControlKeys, currentControls) {
+    return changedControlKeys.some(key => !currentControls[key].renderTrigger);
   }
 
   triggerQueryIfNeeded() {

--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -49,6 +49,7 @@ class ExploreViewContainer extends React.Component {
       height: this.getHeight(),
       width: this.getWidth(),
       showModal: false,
+      chartIsStale: false,
     };
 
     this.addHistory = this.addHistory.bind(this);
@@ -75,11 +76,14 @@ class ExploreViewContainer extends React.Component {
     if (np.controls.datasource.value !== this.props.controls.datasource.value) {
       this.props.actions.fetchDatasourceMetadata(np.form_data.datasource, true);
     }
-    // if any control value changed and it's an instant control
-    if (this.instantControlChanged(this.props.controls, np.controls)) {
+    // if any control value changed and it's a display control
+    if (this.hasDisplayControlChanged(this.props.controls, np.controls)) {
       this.props.actions.updateQueryFormData(
         getFormDataFromControls(np.controls), this.props.chart.chartKey);
       this.props.actions.renderTriggered(new Date().getTime(), this.props.chart.chartKey);
+    }
+    if (this.hasQueryControlChanged(this.props.controls, np.controls)) {
+      this.setState({ chartIsStale: true })
     }
   }
 
@@ -87,7 +91,7 @@ class ExploreViewContainer extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     this.triggerQueryIfNeeded();
 
-    if (this.instantControlChanged(prevProps.controls, this.props.controls)) {
+    if (this.hasDisplayControlChanged(prevProps.controls, this.props.controls)) {
       this.addHistory({});
     }
   }
@@ -102,6 +106,7 @@ class ExploreViewContainer extends React.Component {
     this.props.actions.removeControlPanelAlert();
     this.props.actions.triggerQuery(true, this.props.chart.chartKey);
 
+    this.setState({ chartIsStale: false });
     this.addHistory({});
   }
 
@@ -121,9 +126,17 @@ class ExploreViewContainer extends React.Component {
     return `${window.innerHeight - navHeight}px`;
   }
 
-  instantControlChanged(prevControls, currentControls) {
+  hasDisplayControlChanged(prevControls, currentControls) {
     return Object.keys(currentControls).some(key => (
       currentControls[key].renderTrigger &&
+      typeof prevControls[key] !== 'undefined' &&
+      !areObjectsEqual(currentControls[key].value, prevControls[key].value)
+    ));
+  }
+
+  hasQueryControlChanged(prevControls, currentControls) {
+    return Object.keys(currentControls).some(key => (
+      !currentControls[key].renderTrigger &&
       typeof prevControls[key] !== 'undefined' &&
       !areObjectsEqual(currentControls[key].value, prevControls[key].value)
     ));
@@ -245,6 +258,7 @@ class ExploreViewContainer extends React.Component {
               onSave={this.toggleModal.bind(this)}
               onStop={this.onStop.bind(this)}
               loading={this.props.chart.chartStatus === 'loading'}
+              chartIsStale={this.state.chartIsStale}
               errorMessage={this.renderErrorMessage()}
             />
             <br />

--- a/superset/assets/javascripts/explore/components/QueryAndSaveBtns.jsx
+++ b/superset/assets/javascripts/explore/components/QueryAndSaveBtns.jsx
@@ -11,6 +11,7 @@ const propTypes = {
   onSave: PropTypes.func,
   onStop: PropTypes.func,
   loading: PropTypes.bool,
+  chartIsStale: PropTypes.bool,
   errorMessage: PropTypes.node,
 };
 
@@ -21,11 +22,18 @@ const defaultProps = {
 };
 
 export default function QueryAndSaveBtns(
-  { canAdd, onQuery, onSave, onStop, loading, errorMessage }) {
+  { canAdd, onQuery, onSave, onStop, loading, chartIsStale, errorMessage }) {
   const saveClasses = classnames({
     'disabled disabledButton': canAdd !== 'True',
   });
-  const qryButtonStyle = errorMessage ? 'danger' : 'primary';
+
+  let qryButtonStyle = 'default';
+  if (errorMessage) {
+    qryButtonStyle = 'danger';
+  } else if (chartIsStale) {
+    qryButtonStyle = 'primary';
+  }
+
   const saveButtonDisabled = errorMessage ? true : loading;
   const qryOrStopButton = loading ? (
     <Button


### PR DESCRIPTION
This PR does two things:

1) makes the Run Query grey by default- we don't want to highlight this button unless it would actually provide a new result.

2) highlights the Run Query button when a change to the query powering the chart is made. Currently I determine a change is affecting the query if `renderTrigger` is falsey in the component's config. 

open questions:
1. I think whether we should trigger an instant refresh needs to be fleshed out a little bit more- for example moving a column from series to breakdowns doesn't affect the query but also doesn't trigger a rerender. Maybe we want to ditch the component level renderTrigger annotation and just look at the diff in the query (ignoring timestamp or something?) cc @graceguo-supercat @mistercrunch 
2. are there instances the chart should be updated that I'm not covering?

Before query change button is blank:
![image](https://user-images.githubusercontent.com/2455694/36500874-55c0922a-16fa-11e8-8637-d7c5fd0863b7.png)

After query change button pops:
![image](https://user-images.githubusercontent.com/2455694/36500894-631ebc08-16fa-11e8-90e3-b0be7876e057.png)

reviewers:
@graceguo-supercat 
@michellethomas 
@mistercrunch 
