### PR TITLE
[hotfix] resolve utf-8 encoding issue in db migration

### DIFF
--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """smaller_grid
 Revision ID: e866bd2d4976
 Revises: 21e88bc06c02

--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """smaller_grid
 Revision ID: e866bd2d4976
 Revises: 21e88bc06c02
@@ -69,6 +68,6 @@ def downgrade():
         dashboard.position_json = json.dumps(positions, indent=2)
         session.merge(dashboard)
         session.commit()
-        print('Downgraded ({}/{}): {}'.format(
+        print(u'Downgraded ({}/{}): {}'.format(
             i, len(dashboards), dashboard.dashboard_title))
     pass

--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -31,12 +31,12 @@ def upgrade():
     session = db.Session(bind=bind)
 
     dashboards = session.query(Dashboard).all()
-    print('Upgrading ({}/{}): {}'.format(
-        i, len(dashboards), dashboard.id))
     for i, dashboard in enumerate(dashboards):
+        print('Upgrading ({}/{}): {}'.format(
+            i, len(dashboards), dashboard.id))
         positions = json.loads(dashboard.position_json or '{}')
         for pos in positions:
-            if type(pos) == dict and pos.get('v', 0) == 0:
+            if pos.get('v', 0) == 0:
                 pos['size_x'] = pos['size_x'] * RATIO
                 pos['size_y'] = pos['size_y'] * RATIO
                 pos['col'] = ((pos['col'] - 1) * RATIO) + 1
@@ -55,9 +55,9 @@ def downgrade():
     session = db.Session(bind=bind)
 
     dashboards = session.query(Dashboard).all()
-    print('Downgrading ({}/{}): {}'.format(
-        i, len(dashboards), dashboard.id))
     for i, dashboard in enumerate(dashboards):
+        print('Downgrading ({}/{}): {}'.format(
+            i, len(dashboards), dashboard.id))
         positions = json.loads(dashboard.position_json or '{}')
         for pos in positions:
             if pos.get('v', 0) == 1:

--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -31,6 +31,8 @@ def upgrade():
     session = db.Session(bind=bind)
 
     dashboards = session.query(Dashboard).all()
+    print('Upgrading ({}/{}): {}'.format(
+        i, len(dashboards), dashboard.id))
     for i, dashboard in enumerate(dashboards):
         positions = json.loads(dashboard.position_json or '{}')
         for pos in positions:
@@ -44,8 +46,6 @@ def upgrade():
         dashboard.position_json = json.dumps(positions, indent=2)
         session.merge(dashboard)
         session.commit()
-        print('Upgraded ({}/{}): {}'.format(
-            i, len(dashboards), dashboard.id))
 
     session.close()
 
@@ -55,6 +55,8 @@ def downgrade():
     session = db.Session(bind=bind)
 
     dashboards = session.query(Dashboard).all()
+    print('Downgrading ({}/{}): {}'.format(
+        i, len(dashboards), dashboard.id))
     for i, dashboard in enumerate(dashboards):
         positions = json.loads(dashboard.position_json or '{}')
         for pos in positions:
@@ -68,6 +70,4 @@ def downgrade():
         dashboard.position_json = json.dumps(positions, indent=2)
         session.merge(dashboard)
         session.commit()
-        print('Downgraded ({}/{}): {}'.format(
-            i, len(dashboards), dashboard.dashboard_title))
     pass

--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -68,6 +68,6 @@ def downgrade():
         dashboard.position_json = json.dumps(positions, indent=2)
         session.merge(dashboard)
         session.commit()
-        print(u'Downgraded ({}/{}): {}'.format(
+        print('Downgraded ({}/{}): {}'.format(
             i, len(dashboards), dashboard.dashboard_title))
     pass

--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -34,7 +34,7 @@ def upgrade():
     for i, dashboard in enumerate(dashboards):
         positions = json.loads(dashboard.position_json or '{}')
         for pos in positions:
-            if pos.get('v', 0) == 0:
+            if type(pos) == dict and pos.get('v', 0) == 0:
                 pos['size_x'] = pos['size_x'] * RATIO
                 pos['size_y'] = pos['size_y'] * RATIO
                 pos['col'] = ((pos['col'] - 1) * RATIO) + 1
@@ -45,7 +45,7 @@ def upgrade():
         session.merge(dashboard)
         session.commit()
         print('Upgraded ({}/{}): {}'.format(
-            i, len(dashboards), dashboard.dashboard_title))
+            i, len(dashboards), dashboard.id))
 
     session.close()
 


### PR DESCRIPTION
Migrations cannot run because dashboard title contains utf8 characters. 
We also rearranged the logging statement so as to have the ID of the failed dashboard show before it fails. 

@john-bodley @graceguo-supercat @michellethomas 