### PR TITLE
[geo] add controls for minRadiusPixels and maxRadiusPixels in deck_scatter

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1848,6 +1848,30 @@ export const controls = {
       'lower values are pruned first'),
   },
 
+  min_radius: {
+    type: 'TextControl',
+    label: t('Minimum Radius'),
+    isFloat: true,
+    validators: [v.nonEmpty],
+    renderTrigger: true,
+    default: 2,
+    description:
+    t('Minimum radius size of the circle, in pixels. As the zoom level changes, this ' +
+      'insures that the circle respects this minimum radius.'),
+  },
+
+  max_radius: {
+    type: 'TextControl',
+    label: t('Maximum Radius'),
+    isFloat: true,
+    validators: [v.nonEmpty],
+    renderTrigger: true,
+    default: 250,
+    description:
+    t('Maxium radius size of the circle, in pixels. As the zoom level changes, this ' +
+      'insures that the circle respects this maximum radius.'),
+  },
+
   partition_threshold: {
     type: 'TextControl',
     label: t('Partition Threshold'),

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -648,6 +648,7 @@ export const visTypes = {
         label: t('Point Size'),
         controlSetRows: [
           ['point_radius_fixed', 'point_unit'],
+          ['min_radius', 'max_radius'],
           ['multiplier', null],
         ],
       },

--- a/superset/assets/visualizations/deckgl/layers/scatter.jsx
+++ b/superset/assets/visualizations/deckgl/layers/scatter.jsx
@@ -76,6 +76,8 @@ function getLayer(formData, payload, slice, inFrame) {
     id: `scatter-layer-${fd.slice_id}`,
     data,
     fp64: true,
+    radiusMinPixels: fd.min_radius || null,
+    radiusMaxPixels: fd.max_radius || null,
     outline: false,
     ...common.commonLayerProps(fd, slice),
   });


### PR DESCRIPTION
<img width="887" alt="screen shot 2018-02-22 at 4 54 38 pm" src="https://user-images.githubusercontent.com/487433/36572539-4196b8f4-17f1-11e8-8e47-45f472369e0a.png">

@vyl
