### PR TITLE
Make access request redirect to dashboard if user already has access

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -842,6 +842,15 @@ class Superset(BaseSupersetView):
                 .one()
             )
             datasources.add(datasource)
+
+        has_access = all(
+            (
+                datasource and self.datasource_access(datasource)
+                for datasource in datasources
+            ))
+        if has_access:
+            return redirect('/superset/dashboard/{}'.format(dashboard_id))
+
         if request.args.get('action') == 'go':
             for datasource in datasources:
                 access_request = DAR(


### PR DESCRIPTION
With the access request feature, users who have access often revisit the access request page and are still shown the access request page.
This PR checks to make sure the user still doesn't have access before showing the access request page and redirects to the dashboard if they have access.

@john-bodley @mistercrunch 