### PR TITLE
Set limit of Recent Activity endpoint

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1621,6 +1621,12 @@ class Superset(BaseSupersetView):
     def recent_activity(self, user_id):
         """Recent activity (actions) for a given user"""
         M = models  # noqa
+
+        if request.args.get('limit'):
+            limit = int(request.args.get('limit'))
+        else:
+            limit = 1000
+
         qry = (
             db.session.query(M.Log, M.Dashboard, M.Slice)
             .outerjoin(
@@ -1638,7 +1644,7 @@ class Superset(BaseSupersetView):
                 ),
             )
             .order_by(M.Log.dttm.desc())
-            .limit(1000)
+            .limit(limit)
         )
         payload = []
         for log in qry.all():


### PR DESCRIPTION
Check limit to cut query length for recent activity.

@mistercrunch  @graceguo-supercat 

Reference: #4463 