### PR TITLE
[flake8] Adding future-import check

### DIFF
--- a/scripts/permissions_cleanup.py
+++ b/scripts/permissions_cleanup.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from collections import defaultdict
 
 from superset import sm

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import json
 import os
 import subprocess

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from flask import request
 
 from superset import tables_cache

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import json
 
 from sqlalchemy import (

--- a/superset/connectors/base/views.py
+++ b/superset/connectors/base/views.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from flask import Markup
 
 from superset.utils import SupersetException

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from sqlalchemy.orm import subqueryload
 
 

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1,4 +1,9 @@
 # pylint: disable=invalid-unary-operand-type
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime, timedelta

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from datetime import datetime
 import json
 import logging

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from datetime import datetime
 import logging
 

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -1,4 +1,9 @@
 """Views used by the SqlAlchemy connector"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from flask import flash, Markup, redirect
 from flask_appbuilder import CompactCRUDMixin, expose
 from flask_appbuilder.actions import action

--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from pyhive import hive
 from TCLIService import ttypes
 from thrift import Thrift

--- a/superset/db_engines/presto.py
+++ b/superset/db_engines/presto.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from pyhive import presto
 
 

--- a/superset/dict_import_export_util.py
+++ b/superset/dict_import_export_util.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import logging
 
 from superset.connectors.druid.models import DruidCluster

--- a/superset/extract_table_names.py
+++ b/superset/extract_table_names.py
@@ -11,6 +11,10 @@
 #
 # See:
 # http://groups.google.com/group/sqlparse/browse_thread/thread/b0bd9a022e9d4895
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import sqlparse
 from sqlparse.sql import Identifier, IdentifierList

--- a/superset/import_util.py
+++ b/superset/import_util.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import logging
 
 from sqlalchemy.orm.session import make_transient

--- a/superset/stats_logger.py
+++ b/superset/stats_logger.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import logging
 
 from colorama import Fore, Style

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from datetime import datetime
 import functools
 import json

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from flask import g, redirect
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import json
 import unittest
 

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from sqlalchemy.engine.url import make_url

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from superset import app, security, sm
 from .base_tests import SupersetTestCase
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 import unittest

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from datetime import datetime
 import unittest
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,17 @@ exclude =
     superset/migrations
     superset/templates
 ignore =
+    FI12
+    FI15
+    FI16
+    FI17
+    FI50
+    FI51
+    FI53
+    FI54
 import-order-style = google
 max-line-length = 90
+require-code = True
 
 [global]
 wheel_dir = {homedir}/.wheelhouse
@@ -57,6 +66,7 @@ commands =
 deps =
     flake8
     flake8-commas
+    flake8-future-import
     flake8-import-order
     flake8-quotes
 


### PR DESCRIPTION
This PR adds the `flake8-future-import` check to ensure that all files have the [necessary](http://python-future.org/quickstart.html#to-convert-existing-python-3-code) __future__ imports to help ensure that the codebase is both Python 2 and 3 compatible. 

Note for context this PR is one of possibly many to help address unicode issues which have stung us in the past. 

to: @mistercrunch @xrmx 