### PR TITLE
[flake8] Adding flake8-coding

### DIFF
--- a/scripts/permissions_cleanup.py
+++ b/scripts/permissions_cleanup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Package's main module!"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/config.py
+++ b/superset/config.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """The main config file for Superset
 
 All configuration in this file can be overridden by providing a superset_config

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/connectors/base/views.py
+++ b/superset/connectors/base/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/connectors/druid/__init__.py
+++ b/superset/connectors/druid/__init__.py
@@ -1,2 +1,3 @@
+# -*- coding: utf-8 -*-
 from . import models  # noqa
 from . import views  # noqa

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # pylint: disable=invalid-unary-operand-type
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/connectors/sqla/__init__.py
+++ b/superset/connectors/sqla/__init__.py
@@ -1,2 +1,3 @@
+# -*- coding: utf-8 -*-
 from . import models  # noqa
 from . import views  # noqa

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Views used by the SqlAlchemy connector"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """ Superset wrapper around pandas.DataFrame.
 
 TODO(bkyryliuk): add support for the conventions like: *_dim or dim_*

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Compatibility layer for different database engines
 
 This modules stores logic specific to different database engines. Things

--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/db_engines/presto.py
+++ b/superset/db_engines/presto.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/dict_import_export_util.py
+++ b/superset/dict_import_export_util.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Contains the logic to create cohesive forms on the explore view"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/import_util.py
+++ b/superset/import_util.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Defines the templating context for SQL Lab"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/legacy.py
+++ b/superset/legacy.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Code related with dealing with legacy / change management"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import with_statement
 
 import logging

--- a/superset/migrations/versions/1226819ee0e3_fix_wrong_constraint_on_table_columns.py
+++ b/superset/migrations/versions/1226819ee0e3_fix_wrong_constraint_on_table_columns.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Fix wrong constraint on table columns
 
 Revision ID: 1226819ee0e3

--- a/superset/migrations/versions/1296d28ec131_druid_exports.py
+++ b/superset/migrations/versions/1296d28ec131_druid_exports.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Adds params to the datasource (druid) table
 
 Revision ID: 1296d28ec131

--- a/superset/migrations/versions/12d55656cbca_is_featured.py
+++ b/superset/migrations/versions/12d55656cbca_is_featured.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """is_featured
 
 Revision ID: 12d55656cbca

--- a/superset/migrations/versions/18e88e1cc004_making_audit_nullable.py
+++ b/superset/migrations/versions/18e88e1cc004_making_audit_nullable.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """making audit nullable
 
 Revision ID: 18e88e1cc004

--- a/superset/migrations/versions/19a814813610_adding_metric_warning_text.py
+++ b/superset/migrations/versions/19a814813610_adding_metric_warning_text.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Adding metric warning_text
 
 Revision ID: 19a814813610

--- a/superset/migrations/versions/1a48a5411020_adding_slug_to_dash.py
+++ b/superset/migrations/versions/1a48a5411020_adding_slug_to_dash.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """adding slug to dash
 
 Revision ID: 1a48a5411020

--- a/superset/migrations/versions/1d2ddd543133_log_dt.py
+++ b/superset/migrations/versions/1d2ddd543133_log_dt.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """log dt
 
 Revision ID: 1d2ddd543133

--- a/superset/migrations/versions/1e2841a4128_.py
+++ b/superset/migrations/versions/1e2841a4128_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 1e2841a4128

--- a/superset/migrations/versions/21e88bc06c02_annotation_migration.py
+++ b/superset/migrations/versions/21e88bc06c02_annotation_migration.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 
 from alembic import op

--- a/superset/migrations/versions/2591d77e9831_user_id.py
+++ b/superset/migrations/versions/2591d77e9831_user_id.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """user_id
 
 Revision ID: 2591d77e9831

--- a/superset/migrations/versions/27ae655e4247_make_creator_owners.py
+++ b/superset/migrations/versions/27ae655e4247_make_creator_owners.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Make creator owners
 
 Revision ID: 27ae655e4247

--- a/superset/migrations/versions/289ce07647b_add_encrypted_password_field.py
+++ b/superset/migrations/versions/289ce07647b_add_encrypted_password_field.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Add encrypted password field
 
 Revision ID: 289ce07647b

--- a/superset/migrations/versions/2929af7925ed_tz_offsets_in_data_sources.py
+++ b/superset/migrations/versions/2929af7925ed_tz_offsets_in_data_sources.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """TZ offsets in data sources
 
 Revision ID: 2929af7925ed

--- a/superset/migrations/versions/2fcdcb35e487_saved_queries.py
+++ b/superset/migrations/versions/2fcdcb35e487_saved_queries.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """saved_queries
 
 Revision ID: 2fcdcb35e487
@@ -30,8 +31,8 @@ def upgrade():
         sa.Column('created_by_fk', sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(['changed_by_fk'], ['ab_user.id'], ),
         sa.ForeignKeyConstraint(['created_by_fk'], ['ab_user.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], [u'ab_user.id'], ),
-        sa.ForeignKeyConstraint(['db_id'], [u'dbs.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['ab_user.id'], ),
+        sa.ForeignKeyConstraint(['db_id'], ['dbs.id'], ),
         sa.PrimaryKeyConstraint('id')
     )
 

--- a/superset/migrations/versions/315b3f4da9b0_adding_log_model.py
+++ b/superset/migrations/versions/315b3f4da9b0_adding_log_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """adding log model
 
 Revision ID: 315b3f4da9b0

--- a/superset/migrations/versions/33d996bcc382_update_slice_model.py
+++ b/superset/migrations/versions/33d996bcc382_update_slice_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from alembic import op
 import sqlalchemy as sa
 from superset import db

--- a/superset/migrations/versions/3b626e2a6783_sync_db_with_models.py
+++ b/superset/migrations/versions/3b626e2a6783_sync_db_with_models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Sync DB with the models.py.
 
 Sqlite doesn't support alter on tables, that's why most of the operations

--- a/superset/migrations/versions/3c3ffe173e4f_add_sql_string_to_table.py
+++ b/superset/migrations/versions/3c3ffe173e4f_add_sql_string_to_table.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """add_sql_string_to_table
 
 Revision ID: 3c3ffe173e4f

--- a/superset/migrations/versions/41f6a59a61f2_database_options_for_sql_lab.py
+++ b/superset/migrations/versions/41f6a59a61f2_database_options_for_sql_lab.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """database options for sql lab
 
 Revision ID: 41f6a59a61f2

--- a/superset/migrations/versions/430039611635_log_more.py
+++ b/superset/migrations/versions/430039611635_log_more.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """log more
 
 Revision ID: 430039611635

--- a/superset/migrations/versions/43df8de3a5f4_dash_json.py
+++ b/superset/migrations/versions/43df8de3a5f4_dash_json.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 43df8de3a5f4

--- a/superset/migrations/versions/4500485bde7d_allow_run_sync_async.py
+++ b/superset/migrations/versions/4500485bde7d_allow_run_sync_async.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """allow_run_sync_async
 
 Revision ID: 4500485bde7d

--- a/superset/migrations/versions/472d2f73dfd4_.py
+++ b/superset/migrations/versions/472d2f73dfd4_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 472d2f73dfd4

--- a/superset/migrations/versions/4736ec66ce19_.py
+++ b/superset/migrations/versions/4736ec66ce19_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 4736ec66ce19

--- a/superset/migrations/versions/4e6a06bad7a8_init.py
+++ b/superset/migrations/versions/4e6a06bad7a8_init.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Init
 
 Revision ID: 4e6a06bad7a8

--- a/superset/migrations/versions/4fa88fe24e94_owners_many_to_many.py
+++ b/superset/migrations/versions/4fa88fe24e94_owners_many_to_many.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """owners_many_to_many
 
 Revision ID: 4fa88fe24e94
@@ -19,16 +20,16 @@ def upgrade():
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('user_id', sa.Integer(), nullable=True),
         sa.Column('dashboard_id', sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(['dashboard_id'], [u'dashboards.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], [u'ab_user.id'], ),
+        sa.ForeignKeyConstraint(['dashboard_id'], ['dashboards.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['ab_user.id'], ),
         sa.PrimaryKeyConstraint('id'),
     )
     op.create_table('slice_user',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('user_id', sa.Integer(), nullable=True),
         sa.Column('slice_id', sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(['slice_id'], [u'slices.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], [u'ab_user.id'], ),
+        sa.ForeignKeyConstraint(['slice_id'], ['slices.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['ab_user.id'], ),
         sa.PrimaryKeyConstraint('id'),
     )
 

--- a/superset/migrations/versions/525c854f0005_log_this_plus.py
+++ b/superset/migrations/versions/525c854f0005_log_this_plus.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """log_this_plus
 
 Revision ID: 525c854f0005

--- a/superset/migrations/versions/55179c7f25c7_sqla_descr.py
+++ b/superset/migrations/versions/55179c7f25c7_sqla_descr.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """sqla_descr
 
 Revision ID: 55179c7f25c7

--- a/superset/migrations/versions/5a7bad26f2a7_.py
+++ b/superset/migrations/versions/5a7bad26f2a7_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 5a7bad26f2a7

--- a/superset/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
+++ b/superset/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Add access_request table to manage requests to access datastores.
 
 Revision ID: 5e4a03ef0bf0

--- a/superset/migrations/versions/6414e83d82b7_.py
+++ b/superset/migrations/versions/6414e83d82b7_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 6414e83d82b7

--- a/superset/migrations/versions/65903709c321_allow_dml.py
+++ b/superset/migrations/versions/65903709c321_allow_dml.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """allow_dml
 
 Revision ID: 65903709c321

--- a/superset/migrations/versions/67a6ac9b727b_update_spatial_params.py
+++ b/superset/migrations/versions/67a6ac9b727b_update_spatial_params.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """update_spatial_params
 
 Revision ID: 67a6ac9b727b

--- a/superset/migrations/versions/732f1c06bcbf_add_fetch_values_predicate.py
+++ b/superset/migrations/versions/732f1c06bcbf_add_fetch_values_predicate.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """add fetch values predicate
 
 Revision ID: 732f1c06bcbf

--- a/superset/migrations/versions/763d4b211ec9_fixing_audit_fk.py
+++ b/superset/migrations/versions/763d4b211ec9_fixing_audit_fk.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """fixing audit fk
 
 Revision ID: 763d4b211ec9

--- a/superset/migrations/versions/7dbf98566af7_slice_description.py
+++ b/superset/migrations/versions/7dbf98566af7_slice_description.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 7dbf98566af7

--- a/superset/migrations/versions/7e3ddad2a00b_results_key_to_query.py
+++ b/superset/migrations/versions/7e3ddad2a00b_results_key_to_query.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """results_key to query
 
 Revision ID: 7e3ddad2a00b

--- a/superset/migrations/versions/836c0bf75904_cache_timeouts.py
+++ b/superset/migrations/versions/836c0bf75904_cache_timeouts.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """cache_timeouts
 
 Revision ID: 836c0bf75904

--- a/superset/migrations/versions/867bf4f117f9_adding_extra_field_to_database_model.py
+++ b/superset/migrations/versions/867bf4f117f9_adding_extra_field_to_database_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Adding extra field to Database model
 
 Revision ID: 867bf4f117f9

--- a/superset/migrations/versions/8e80a26a31db_.py
+++ b/superset/migrations/versions/8e80a26a31db_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 8e80a26a31db

--- a/superset/migrations/versions/956a063c52b3_adjusting_key_length.py
+++ b/superset/migrations/versions/956a063c52b3_adjusting_key_length.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """adjusting key length
 
 Revision ID: 956a063c52b3

--- a/superset/migrations/versions/960c69cb1f5b_.py
+++ b/superset/migrations/versions/960c69cb1f5b_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """add dttm_format related fields in table_columns
 
 Revision ID: 960c69cb1f5b

--- a/superset/migrations/versions/979c03af3341_.py
+++ b/superset/migrations/versions/979c03af3341_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: 979c03af3341

--- a/superset/migrations/versions/a2d606a761d9_adding_favstar_model.py
+++ b/superset/migrations/versions/a2d606a761d9_adding_favstar_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """adding favstar model
 
 Revision ID: a2d606a761d9

--- a/superset/migrations/versions/a65458420354_add_result_backend_time_logging.py
+++ b/superset/migrations/versions/a65458420354_add_result_backend_time_logging.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """add_result_backend_time_logging
 
 Revision ID: a65458420354

--- a/superset/migrations/versions/a6c18f869a4e_query_start_running_time.py
+++ b/superset/migrations/versions/a6c18f869a4e_query_start_running_time.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """query.start_running_time
 
 Revision ID: a6c18f869a4e

--- a/superset/migrations/versions/a99f2f7c195a_rewriting_url_from_shortner_with_new_.py
+++ b/superset/migrations/versions/a99f2f7c195a_rewriting_url_from_shortner_with_new_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """rewriting url from shortner with new format
 
 Revision ID: a99f2f7c195a

--- a/superset/migrations/versions/a9c47e2c1547_add_impersonate_user_to_dbs.py
+++ b/superset/migrations/versions/a9c47e2c1547_add_impersonate_user_to_dbs.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """add impersonate_user to dbs
 
 Revision ID: a9c47e2c1547

--- a/superset/migrations/versions/ab3d66c4246e_add_cache_timeout_to_druid_cluster.py
+++ b/superset/migrations/versions/ab3d66c4246e_add_cache_timeout_to_druid_cluster.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """add_cache_timeout_to_druid_cluster
 
 Revision ID: ab3d66c4246e

--- a/superset/migrations/versions/ad4d656d92bc_add_avg_metric.py
+++ b/superset/migrations/versions/ad4d656d92bc_add_avg_metric.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Add avg() to default metrics
 
 Revision ID: ad4d656d92bc

--- a/superset/migrations/versions/ad82a75afd82_add_query_model.py
+++ b/superset/migrations/versions/ad82a75afd82_add_query_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Update models to support storing the queries.
 
 Revision ID: ad82a75afd82
@@ -39,8 +40,8 @@ def upgrade():
         sa.Column('start_time', sa.Numeric(precision=20, scale=6), nullable=True),
         sa.Column('changed_on', sa.DateTime(), nullable=True),
         sa.Column('end_time', sa.Numeric(precision=20, scale=6), nullable=True),
-        sa.ForeignKeyConstraint(['database_id'], [u'dbs.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], [u'ab_user.id'], ),
+        sa.ForeignKeyConstraint(['database_id'], ['dbs.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['ab_user.id'], ),
         sa.PrimaryKeyConstraint('id')
     )
     op.add_column('dbs', sa.Column('select_as_create_table_as', sa.Boolean(),

--- a/superset/migrations/versions/b318dfe5fb6c_adding_verbose_name_to_druid_column.py
+++ b/superset/migrations/versions/b318dfe5fb6c_adding_verbose_name_to_druid_column.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """adding verbose_name to druid column
 
 Revision ID: b318dfe5fb6c

--- a/superset/migrations/versions/b347b202819b_.py
+++ b/superset/migrations/versions/b347b202819b_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: b347b202819b

--- a/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
+++ b/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """change_table_unique_constraint
 
 Revision ID: b4456560d4f3
@@ -17,9 +18,9 @@ def upgrade():
     try:
         # Trying since sqlite doesn't like constraints
         op.drop_constraint(
-            u'tables_table_name_key', 'tables', type_='unique')
+            'tables_table_name_key', 'tables', type_='unique')
         op.create_unique_constraint(
-            u'_customer_location_uc', 'tables',
+            '_customer_location_uc', 'tables',
             ['database_id', 'schema', 'table_name'])
     except Exception:
         pass

--- a/superset/migrations/versions/b46fa1b0b39e_add_params_to_tables.py
+++ b/superset/migrations/versions/b46fa1b0b39e_add_params_to_tables.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Add json_metadata to the tables table.
 
 Revision ID: b46fa1b0b39e

--- a/superset/migrations/versions/bb51420eaf83_add_schema_to_table_model.py
+++ b/superset/migrations/versions/bb51420eaf83_add_schema_to_table_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """add schema to table model
 
 Revision ID: bb51420eaf83

--- a/superset/migrations/versions/bcf3126872fc_add_keyvalue.py
+++ b/superset/migrations/versions/bcf3126872fc_add_keyvalue.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Add keyvalue table
 
 Revision ID: bcf3126872fc

--- a/superset/migrations/versions/c3a8f8611885_materializing_permission.py
+++ b/superset/migrations/versions/c3a8f8611885_materializing_permission.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Materializing permission
 
 Revision ID: c3a8f8611885

--- a/superset/migrations/versions/c611f2b591b8_dim_spec.py
+++ b/superset/migrations/versions/c611f2b591b8_dim_spec.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """dim_spec
 
 Revision ID: c611f2b591b8

--- a/superset/migrations/versions/ca69c70ec99b_tracking_url.py
+++ b/superset/migrations/versions/ca69c70ec99b_tracking_url.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """tracking_url
 
 Revision ID: ca69c70ec99b

--- a/superset/migrations/versions/d2424a248d63_.py
+++ b/superset/migrations/versions/d2424a248d63_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: d2424a248d63

--- a/superset/migrations/versions/d39b1e37131d_.py
+++ b/superset/migrations/versions/d39b1e37131d_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: d39b1e37131d

--- a/superset/migrations/versions/d6db5a5cdb5d_.py
+++ b/superset/migrations/versions/d6db5a5cdb5d_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: d6db5a5cdb5d

--- a/superset/migrations/versions/d827694c7555_css_templates.py
+++ b/superset/migrations/versions/d827694c7555_css_templates.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """css templates
 
 Revision ID: d827694c7555

--- a/superset/migrations/versions/d8bc074f7aad_add_new_field_is_restricted_to_.py
+++ b/superset/migrations/versions/d8bc074f7aad_add_new_field_is_restricted_to_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Add new field 'is_restricted' to SqlMetric and DruidMetric
 
 Revision ID: d8bc074f7aad
@@ -30,7 +31,7 @@ class SqlMetric(Base):
     __tablename__ = 'sql_metrics'
     id = Column(Integer, primary_key=True)
     is_restricted = Column(Boolean, default=False, nullable=True)
-    
+
 def upgrade():
     op.add_column('metrics', sa.Column('is_restricted', sa.Boolean(), nullable=True))
     op.add_column('sql_metrics', sa.Column('is_restricted', sa.Boolean(), nullable=True))
@@ -38,7 +39,7 @@ def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
 
-    # don't use models.DruidMetric 
+    # don't use models.DruidMetric
     # because it assumes the context is consistent with the application
     for obj in session.query(DruidMetric).all():
         obj.is_restricted = False

--- a/superset/migrations/versions/db0c65b146bd_update_slice_model_json.py
+++ b/superset/migrations/versions/db0c65b146bd_update_slice_model_json.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """update_slice_model_json
 
 Revision ID: db0c65b146bd

--- a/superset/migrations/versions/db527d8c4c78_add_db_verbose_name.py
+++ b/superset/migrations/versions/db527d8c4c78_add_db_verbose_name.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Add verbose name to DruidCluster and Database
 
 Revision ID: db527d8c4c78

--- a/superset/migrations/versions/ddd6ebdd853b_annotations.py
+++ b/superset/migrations/versions/ddd6ebdd853b_annotations.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """annotations
 
 Revision ID: ddd6ebdd853b
@@ -42,7 +43,7 @@ def upgrade():
         sa.Column('created_by_fk', sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(['changed_by_fk'], ['ab_user.id'], ),
         sa.ForeignKeyConstraint(['created_by_fk'], ['ab_user.id'], ),
-        sa.ForeignKeyConstraint(['layer_id'], [u'annotation_layer.id'], ),
+        sa.ForeignKeyConstraint(['layer_id'], ['annotation_layer.id'], ),
         sa.PrimaryKeyConstraint('id')
     )
     op.create_index(

--- a/superset/migrations/versions/e46f2d27a08e_materialize_perms.py
+++ b/superset/migrations/versions/e46f2d27a08e_materialize_perms.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """materialize perms
 
 Revision ID: e46f2d27a08e

--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """smaller_grid
 Revision ID: e866bd2d4976
 Revises: 21e88bc06c02

--- a/superset/migrations/versions/ea033256294a_.py
+++ b/superset/migrations/versions/ea033256294a_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: ea033256294a

--- a/superset/migrations/versions/eca4694defa7_sqllab_setting_defaults.py
+++ b/superset/migrations/versions/eca4694defa7_sqllab_setting_defaults.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """sqllab_setting_defaults
 
 Revision ID: eca4694defa7

--- a/superset/migrations/versions/ef8843b41dac_.py
+++ b/superset/migrations/versions/ef8843b41dac_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: ef8843b41dac

--- a/superset/migrations/versions/f0fbf6129e13_adding_verbose_name_to_tablecolumn.py
+++ b/superset/migrations/versions/f0fbf6129e13_adding_verbose_name_to_tablecolumn.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Adding verbose_name to tablecolumn
 
 Revision ID: f0fbf6129e13

--- a/superset/migrations/versions/f162a1dea4c4_d3format_by_metric.py
+++ b/superset/migrations/versions/f162a1dea4c4_d3format_by_metric.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """d3format_by_metric
 
 Revision ID: f162a1dea4c4

--- a/superset/migrations/versions/f18570e03440_add_query_result_key_index.py
+++ b/superset/migrations/versions/f18570e03440_add_query_result_key_index.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Add index on the result key to the query table.
 
 Revision ID: f18570e03440

--- a/superset/migrations/versions/f1f2d4af5b90_.py
+++ b/superset/migrations/versions/f1f2d4af5b90_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Enable Filter Select
 
 Revision ID: f1f2d4af5b90

--- a/superset/migrations/versions/f959a6652acd_.py
+++ b/superset/migrations/versions/f959a6652acd_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: f959a6652acd

--- a/superset/migrations/versions/fee7b758c130_.py
+++ b/superset/migrations/versions/fee7b758c130_.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """empty message
 
 Revision ID: fee7b758c130

--- a/superset/models/__init__.py
+++ b/superset/models/__init__.py
@@ -1,2 +1,3 @@
+# -*- coding: utf-8 -*-
 from . import core  # noqa
 from . import sql_lab  # noqa

--- a/superset/models/annotations.py
+++ b/superset/models/annotations.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """a collection of Annotation-related models"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A collection of ORM sqlalchemy models for Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """a collection of model-related helper classes and functions"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A collection of ORM sqlalchemy models for SQL Lab"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/security.py
+++ b/superset/security.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A set of constants and methods to manage permissions and security"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/stats_logger.py
+++ b/superset/stats_logger.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/translations/utils.py
+++ b/superset/translations/utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Utility functions used across Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/superset/views/__init__.py
+++ b/superset/views/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from . import base  # noqa
 from . import core  # noqa
 from . import sql_lab  # noqa

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -349,7 +350,7 @@ class CsvToDatabaseView(SimpleFormView):
                 os.remove(os.path.join(config['UPLOAD_FOLDER'], csv_filename))
             except OSError:
                 pass
-            message = u'Table name {} already exists. Please pick another'.format(
+            message = 'Table name {} already exists. Please pick another'.format(
                 form.name.data) if isinstance(e, IntegrityError) else text_type(e)
             flash(
                 message,
@@ -359,7 +360,7 @@ class CsvToDatabaseView(SimpleFormView):
         os.remove(os.path.join(config['UPLOAD_FOLDER'], csv_filename))
         # Go back to welcome page / splash screen
         db_name = table.database.database_name
-        message = _(u'CSV file "{0}" uploaded to table "{1}" in '
+        message = _('CSV file "{0}" uploaded to table "{1}" in '
                     'database "{2}"'.format(csv_filename,
                                             form.name.data,
                                             db_name))

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """This module contains the 'Viz' objects
 
 These objects represent the backend of all the visualizations that

--- a/tests/access_tests.py
+++ b/tests/access_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for Superset Celery worker"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tests/dict_import_export_tests.py
+++ b/tests/dict_import_export_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/email_tests.py
+++ b/tests/email_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for email service in Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/import_export_tests.py
+++ b/tests/import_export_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for Superset"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unit tests for Sql Lab"""
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/superset_test_config.py
+++ b/tests/superset_test_config.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # flake8: noqa
 from superset.config import *
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
 skipsdist=True
 
 [flake8]
+accept-encodings = utf-8
 application-import-names = superset
 exclude =
     .tox
@@ -65,6 +66,7 @@ commands =
     flake8
 deps =
     flake8
+    flake8-coding
     flake8-commas
     flake8-future-import
     flake8-import-order


### PR DESCRIPTION
To try to further ensure unicode consistency between Python 2 and Python 3 this PR adds the `flake8-config` check to ensure that every Python file includes:

    # -*- coding: utf-8 -*-

which ensures that it is encoded as UTF-8 in Python 2 (which is the default in Python 3) as opposed to ASCII. 

This PR also removes all `u'...'` references which are no longer required. 

to: @mistercrunch @xrmx