### PR TITLE
[dashboard] Fix JS error when position_json data is empty

### DIFF
--- a/superset/assets/javascripts/dashboard/reducers.js
+++ b/superset/assets/javascripts/dashboard/reducers.js
@@ -34,10 +34,12 @@ export function getInitialState(bootstrapData) {
 
   dashboard.posDict = {};
   dashboard.layout = [];
-  if (dashboard.position_json) {
+  if (Array.isArray(dashboard.position_json)) {
     dashboard.position_json.forEach((position) => {
       dashboard.posDict[position.slice_id] = position;
     });
+  } else {
+    dashboard.position_json = [];
   }
   const lastRowId = Math.max.apply(null,
     dashboard.position_json.map(pos => (pos.row + pos.size_y)));


### PR DESCRIPTION
![screen shot 2018-02-26 at 11 56 48 am](https://user-images.githubusercontent.com/27990562/36697135-03eacf74-1afb-11e8-982c-b197581cce9c.png)

position_json data used to be array or null. after recent smaller_grid migration it became array or {}.

@mistercrunch @michellethomas 
