### PR TITLE
[Explore] applying refresh chart overlay when chart is stale

### DIFF
--- a/superset/assets/javascripts/chart/Chart.jsx
+++ b/superset/assets/javascripts/chart/Chart.jsx
@@ -234,6 +234,7 @@ class Chart extends React.PureComponent {
             vizType={this.props.vizType}
             height={this.height}
             width={this.width}
+            stale={this.props.chartIsStale}
             ref={(inner) => {
               this.container = inner;
             }}

--- a/superset/assets/javascripts/chart/Chart.jsx
+++ b/superset/assets/javascripts/chart/Chart.jsx
@@ -37,7 +37,7 @@ const propTypes = {
   queryResponse: PropTypes.object,
   lastRendered: PropTypes.number,
   triggerQuery: PropTypes.bool,
-  chartIsStale: PropTypes.bool,
+  refreshOverlayVisible: PropTypes.bool,
   errorMessage: PropTypes.node,
   // dashboard callbacks
   addFilter: PropTypes.func,
@@ -219,11 +219,13 @@ class Chart extends React.PureComponent {
         />
         }
 
-        {!isLoading && !this.props.chartAlert && this.props.chartIsStale &&
+        {!isLoading &&
+          !this.props.chartAlert &&
+          this.props.refreshOverlayVisible &&
+          !this.props.errorMessage &&
           <RefreshChartOverlay
             height={this.height()}
             width={this.width()}
-            errorMessage={this.props.errorMessage}
             onQuery={this.props.onQuery}
             onDismiss={this.props.onDismissRefreshOverlay}
           />
@@ -234,7 +236,7 @@ class Chart extends React.PureComponent {
             vizType={this.props.vizType}
             height={this.height}
             width={this.width}
-            stale={this.props.chartIsStale}
+            faded={this.props.refreshOverlayVisible && !this.props.errorMessage}
             ref={(inner) => {
               this.container = inner;
             }}

--- a/superset/assets/javascripts/chart/Chart.jsx
+++ b/superset/assets/javascripts/chart/Chart.jsx
@@ -9,6 +9,7 @@ import ChartBody from './ChartBody';
 import Loading from '../components/Loading';
 import { Logger, LOG_ACTIONS_RENDER_EVENT } from '../logger';
 import StackTraceMessage from '../components/StackTraceMessage';
+import RefreshChartOverlay from '../components/RefreshChartOverlay';
 import visMap from '../../visualizations/main';
 import sandboxedEval from '../modules/sandbox';
 import './chart.css';
@@ -36,11 +37,15 @@ const propTypes = {
   queryResponse: PropTypes.object,
   lastRendered: PropTypes.number,
   triggerQuery: PropTypes.bool,
+  chartIsStale: PropTypes.bool,
+  errorMessage: PropTypes.node,
   // dashboard callbacks
   addFilter: PropTypes.func,
   getFilters: PropTypes.func,
   clearFilter: PropTypes.func,
   removeFilter: PropTypes.func,
+  onQuery: PropTypes.func,
+  onDismissRefreshOverlay: PropTypes.func,
 };
 
 const defaultProps = {
@@ -214,6 +219,15 @@ class Chart extends React.PureComponent {
         />
         }
 
+        {!isLoading && !this.props.chartAlert && this.props.chartIsStale &&
+          <RefreshChartOverlay
+            height={this.height()}
+            width={this.width()}
+            errorMessage={this.props.errorMessage}
+            onQuery={this.props.onQuery}
+            onDismiss={this.props.onDismissRefreshOverlay}
+          />
+        }
         {!isLoading && !this.props.chartAlert &&
           <ChartBody
             containerId={this.containerId}

--- a/superset/assets/javascripts/chart/ChartBody.jsx
+++ b/superset/assets/javascripts/chart/ChartBody.jsx
@@ -7,6 +7,7 @@ const propTypes = {
   vizType: PropTypes.string.isRequired,
   height: PropTypes.func.isRequired,
   width: PropTypes.func.isRequired,
+  stale: PropTypes.bool,
 };
 
 class ChartBody extends React.PureComponent {
@@ -42,7 +43,7 @@ class ChartBody extends React.PureComponent {
     return (
       <div
         id={this.props.containerId}
-        className={`slice_container ${this.props.vizType}`}
+        className={`slice_container ${this.props.vizType}${this.props.stale ? ' stale' : ''}`}
         ref={(el) => { this.el = el; }}
       />
     );

--- a/superset/assets/javascripts/chart/ChartBody.jsx
+++ b/superset/assets/javascripts/chart/ChartBody.jsx
@@ -7,7 +7,7 @@ const propTypes = {
   vizType: PropTypes.string.isRequired,
   height: PropTypes.func.isRequired,
   width: PropTypes.func.isRequired,
-  stale: PropTypes.bool,
+  faded: PropTypes.bool,
 };
 
 class ChartBody extends React.PureComponent {
@@ -43,7 +43,7 @@ class ChartBody extends React.PureComponent {
     return (
       <div
         id={this.props.containerId}
-        className={`slice_container ${this.props.vizType}${this.props.stale ? ' stale' : ''}`}
+        className={`slice_container ${this.props.vizType}${this.props.faded ? ' faded' : ''}`}
         ref={(el) => { this.el = el; }}
       />
     );

--- a/superset/assets/javascripts/components/RefreshChartOverlay.jsx
+++ b/superset/assets/javascripts/components/RefreshChartOverlay.jsx
@@ -19,10 +19,9 @@ class RefreshChartOverlay extends React.PureComponent {
         className="refresh-chart-overlay"
       >
         <div>
-          <Button 
-            bsSize="md" 
-            className="query" 
-            onClick={this.props.onQuery} 
+          <Button
+            className="query"
+            onClick={this.props.onQuery}
             disabled={!!this.props.errorMessage}
             bsStyle={this.props.errorMessage ? 'danger' : 'primary'}
           >

--- a/superset/assets/javascripts/components/RefreshChartOverlay.jsx
+++ b/superset/assets/javascripts/components/RefreshChartOverlay.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from '../components/Button';
+import Link from '../SqlLab/components/Link';
+
+const propTypes = {
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
+  errorMessage: PropTypes.node,
+  onQuery: PropTypes.func,
+  onDismiss: PropTypes.func,
+};
+
+class RefreshChartOverlay extends React.PureComponent {
+  render() {
+    return (
+      <div
+        style={{ height: this.props.height, width: this.props.width }}
+        className="refresh-chart-overlay"
+      >
+        <div>
+          <Button 
+            bsSize="md" 
+            className="query" 
+            onClick={this.props.onQuery} 
+            disabled={!!this.props.errorMessage}
+            bsStyle={this.props.errorMessage ? 'danger' : 'primary'}
+          >
+            <i className="fa fa-bolt" /> Refresh Chart
+          </Button>
+          <div><Link onClick={this.props.onDismiss}>(dismiss)</Link></div>
+        </div>
+      </div>
+    );
+  }
+}
+
+RefreshChartOverlay.propTypes = propTypes;
+
+export default RefreshChartOverlay;

--- a/superset/assets/javascripts/components/RefreshChartOverlay.jsx
+++ b/superset/assets/javascripts/components/RefreshChartOverlay.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../components/Button';
-import Link from '../SqlLab/components/Link';
+import { t } from '../locales';
 
 const propTypes = {
   height: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
-  errorMessage: PropTypes.node,
   onQuery: PropTypes.func,
   onDismiss: PropTypes.func,
 };
@@ -16,18 +15,22 @@ class RefreshChartOverlay extends React.PureComponent {
     return (
       <div
         style={{ height: this.props.height, width: this.props.width }}
-        className="refresh-chart-overlay"
+        className="explore-chart-overlay"
       >
         <div>
           <Button
-            className="query"
+            className="refresh-overlay-btn"
             onClick={this.props.onQuery}
-            disabled={!!this.props.errorMessage}
-            bsStyle={this.props.errorMessage ? 'danger' : 'primary'}
+            bsStyle="primary"
           >
-            <i className="fa fa-bolt" /> Refresh Chart
+            {t('Run Query')}
           </Button>
-          <div><Link onClick={this.props.onDismiss}>(dismiss)</Link></div>
+          <Button
+            className="dismiss-overlay-btn"
+            onClick={this.props.onDismiss}
+          >
+            {t('Dismiss')}
+          </Button>
         </div>
       </div>
     );

--- a/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
@@ -26,8 +26,9 @@ const propTypes = {
   form_data: PropTypes.object,
   standalone: PropTypes.bool,
   timeout: PropTypes.number,
-  chartIsStale: PropTypes.bool,
+  refreshOverlayVisible: PropTypes.bool,
   chart: PropTypes.shape(chartPropType),
+  errorMessage: PropTypes.node,
 };
 
 class ExploreChartPanel extends React.PureComponent {
@@ -48,7 +49,7 @@ class ExploreChartPanel extends React.PureComponent {
         setControlValue={this.props.actions.setControlValue}
         timeout={this.props.timeout}
         vizType={this.props.vizType}
-        chartIsStale={this.props.chartIsStale}
+        refreshOverlayVisible={this.props.refreshOverlayVisible}
         errorMessage={this.props.errorMessage}
         onQuery={this.props.onQuery}
         onDismissRefreshOverlay={this.props.onDismissRefreshOverlay}

--- a/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
@@ -10,6 +10,8 @@ import ExploreChartHeader from './ExploreChartHeader';
 const propTypes = {
   actions: PropTypes.object.isRequired,
   addHistory: PropTypes.func,
+  onQuery: PropTypes.func,
+  onDismissRefreshOverlay: PropTypes.func,
   can_overwrite: PropTypes.bool.isRequired,
   can_download: PropTypes.bool.isRequired,
   datasource: PropTypes.object,
@@ -24,6 +26,7 @@ const propTypes = {
   form_data: PropTypes.object,
   standalone: PropTypes.bool,
   timeout: PropTypes.number,
+  chartIsStale: PropTypes.bool,
   chart: PropTypes.shape(chartPropType),
 };
 
@@ -45,6 +48,10 @@ class ExploreChartPanel extends React.PureComponent {
         setControlValue={this.props.actions.setControlValue}
         timeout={this.props.timeout}
         vizType={this.props.vizType}
+        chartIsStale={this.props.chartIsStale}
+        errorMessage={this.props.errorMessage}
+        onQuery={this.props.onQuery}
+        onDismissRefreshOverlay={this.props.onDismissRefreshOverlay}
       />
     );
   }

--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -50,6 +50,7 @@ class ExploreViewContainer extends React.Component {
       width: this.getWidth(),
       showModal: false,
       chartIsStale: false,
+      refreshOverlayVisible: false,
     };
 
     this.addHistory = this.addHistory.bind(this);
@@ -84,7 +85,7 @@ class ExploreViewContainer extends React.Component {
       this.props.actions.renderTriggered(new Date().getTime(), this.props.chart.chartKey);
     }
     if (this.hasQueryControlChanged(changedControlKeys, np.controls)) {
-      this.setState({ chartIsStale: true });
+      this.setState({ chartIsStale: true, refreshOverlayVisible: true });
     }
   }
 
@@ -108,12 +109,12 @@ class ExploreViewContainer extends React.Component {
     this.props.actions.removeControlPanelAlert();
     this.props.actions.triggerQuery(true, this.props.chart.chartKey);
 
-    this.setState({ chartIsStale: false });
+    this.setState({ chartIsStale: false, refreshOverlayVisible: false });
     this.addHistory({});
   }
 
   onDismissRefreshOverlay() {
-    this.setState({ chartIsStale: false });
+    this.setState({ refreshOverlayVisible: false });
   }
 
   onStop() {
@@ -232,7 +233,7 @@ class ExploreViewContainer extends React.Component {
         height={this.state.height}
         {...this.props}
         errorMessage={this.renderErrorMessage()}
-        chartIsStale={this.state.chartIsStale}
+        refreshOverlayVisible={this.state.refreshOverlayVisible}
         addHistory={this.addHistory}
         onQuery={this.onQuery.bind(this)}
         onDismissRefreshOverlay={this.onDismissRefreshOverlay.bind(this)}

--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -112,6 +112,10 @@ class ExploreViewContainer extends React.Component {
     this.addHistory({});
   }
 
+  onDismissRefreshOverlay() {
+    this.setState({ chartIsStale: false });
+  }
+
   onStop() {
     return this.props.chart.queryRequest.abort();
   }
@@ -227,7 +231,11 @@ class ExploreViewContainer extends React.Component {
         width={this.state.width}
         height={this.state.height}
         {...this.props}
+        errorMessage={this.renderErrorMessage()}
+        chartIsStale={this.state.chartIsStale}
         addHistory={this.addHistory}
+        onQuery={this.onQuery.bind(this)}
+        onDismissRefreshOverlay={this.onDismissRefreshOverlay.bind(this)}
       />);
   }
 

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -185,7 +185,7 @@ div.widget .chart-header a {
   display: none;
 }
 
-.slice_container.stale {
+.slice_container.faded {
   opacity: .2;
 }
 
@@ -429,11 +429,23 @@ g.annotation-container {
     color: @brand-primary;
 }
 
-.refresh-chart-overlay {
+.explore-chart-overlay {
   position: absolute;
   z-index: 100;
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
+}
+
+.refresh-overlay-btn {
+  font-weight: bold;
+  margin-right: 10px;
+}
+
+.dismiss-overlay-btn {
+  font-weight: bold;
+  background: white;
+  color: @brand-primary;
+  border-color: @brand-primary;
 }

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -185,6 +185,10 @@ div.widget .chart-header a {
   display: none;
 }
 
+.slice_container.stale {
+  opacity: .2;
+}
+
 div.widget {
   .slice_container {
     overflow: hidden;
@@ -428,7 +432,6 @@ g.annotation-container {
 .refresh-chart-overlay {
   position: absolute;
   z-index: 100;
-  background: rgba(51, 51, 51, .5);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -424,3 +424,13 @@ g.annotation-container {
     content: "\f0dd";
     color: @brand-primary;
 }
+
+.refresh-chart-overlay {
+  position: absolute;
+  z-index: 100;
+  background: rgba(51, 51, 51, .5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}


### PR DESCRIPTION
This is a follow up to apache#4459 to make it more obvious when the chart should be refreshed.

after making a change affecting the query:
![image](https://user-images.githubusercontent.com/2455694/36706013-c54d522e-1b1c-11e8-908a-583a5b465515.png)

dismissing the overlay still keeps the run button highlighted:
![image](https://user-images.githubusercontent.com/2455694/36706021-d6b28eee-1b1c-11e8-9830-56f45b924b01.png)

but if you make a change causing errors no overlay appears:
![image](https://user-images.githubusercontent.com/2455694/36706027-e20b90ec-1b1c-11e8-81e0-7044055b5c7b.png)

test plan:
- make a change to the query params
- verify the overlay appears
- verify run query works
- verify the overlay can be dismissed

reviewers:
@graceguo-supercat @michellethomas @mistercrunch 