### PR TITLE
Make margin width based on container width instead of slice width

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -18,7 +18,8 @@ import './nvd3_vis.css';
 import { VIZ_TYPES } from './main';
 
 const minBarWidth = 15;
-const minMarginPad = 50;
+// Limit on how large axes margins can grow as the chart window is resized
+const maxMarginPad = 50;
 const animationTime = 1000;
 
 const BREAKPOINTS = {
@@ -466,7 +467,7 @@ function nvd3Vis(slice, payload) {
       // Hack to adjust y axis left margin to accommodate long numbers
       const containerWidth = slice.container.width();
       const marginPad = Math.min(isExplore ? containerWidth * 0.01 : containerWidth * 0.03,
-        minMarginPad);
+        maxMarginPad);
       const maxYAxisLabelWidth = chart.yAxis2 ? getMaxLabelSize(slice.container, 'nv-y1')
                                               : getMaxLabelSize(slice.container, 'nv-y');
       const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x');

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -19,7 +19,7 @@ import { VIZ_TYPES } from './main';
 
 const minBarWidth = 15;
 // Limit on how large axes margins can grow as the chart window is resized
-const maxMarginPad = 50;
+const maxMarginPad = 30;
 const animationTime = 1000;
 
 const BREAKPOINTS = {

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -18,6 +18,7 @@ import './nvd3_vis.css';
 import { VIZ_TYPES } from './main';
 
 const minBarWidth = 15;
+const minMarginPad = 50;
 const animationTime = 1000;
 
 const BREAKPOINTS = {
@@ -463,7 +464,9 @@ function nvd3Vis(slice, payload) {
 
     if (chart.yAxis !== undefined || chart.yAxis2 !== undefined) {
       // Hack to adjust y axis left margin to accommodate long numbers
-      const marginPad = isExplore ? width * 0.01 : width * 0.03;
+      const containerWidth = slice.container.width();
+      const marginPad = Math.min(isExplore ? containerWidth * 0.01 : containerWidth * 0.03,
+        minMarginPad);
       const maxYAxisLabelWidth = chart.yAxis2 ? getMaxLabelSize(slice.container, 'nv-y1')
                                               : getMaxLabelSize(slice.container, 'nv-y');
       const maxXAxisLabelHeight = getMaxLabelSize(slice.container, 'nv-x');


### PR DESCRIPTION
This issue is most noticeable when the chart width overflows beyond the chart container's width, most notably in bar charts. This happens because the margin padding is based on the width of the slice itself, rather than of the container that wraps it.

Fixes https://github.com/apache/incubator-superset/issues/4369 (more information in the issue)

I also included a limit on how wide the margin can grow to, in cases where users expand a chart onto very wide displays.