### PR TITLE
utf8 fixes to csv -> hive upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',
         'unidecode>=0.04.21',
+        'unicodecsv==0.14.1',
         'bleach==2.1.2',
     ],
     extras_require={

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from collections import defaultdict, namedtuple
-import csv
 import inspect
 import logging
 import os
@@ -34,6 +33,7 @@ from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.sql import text
 import sqlparse
+import unicodecsv
 from werkzeug.utils import secure_filename
 
 from superset import app, cache_util, conf, db, utils
@@ -849,7 +849,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         """Uploads a csv file and creates a superset datasource in Hive."""
         def get_column_names(filepath):
             with open(filepath, 'rb') as f:
-                return csv.reader(f).next()
+                return unicodecsv.reader(f, encoding='utf-8-sig').next()
 
         table_name = form.name.data
         filename = form.csv_file.data.filename
@@ -873,11 +873,12 @@ class HiveEngineSpec(PrestoEngineSpec):
         s3 = boto3.client('s3')
         location = os.path.join('s3a://', bucket_path, upload_prefix, table_name)
         s3.upload_file(
-            upload_path, 'airbnb-superset',
+            upload_path, bucket_path,
             os.path.join(upload_prefix, table_name, filename))
         sql = """CREATE EXTERNAL TABLE {table_name} ( {schema_definition} )
             ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS
-            TEXTFILE LOCATION '{location}'""".format(**locals())
+            TEXTFILE LOCATION '{location}'
+            tblproperties ('skip.header.line.count'='1')""".format(**locals())
         logging.info(form.con.data)
         engine = create_engine(form.con.data.sqlalchemy_uri)
         engine.execute(sql)


### PR DESCRIPTION
This pr fixes 4 issues. 

1. When users upload utf8 encoded files, the first bytes are often bytes to indicate the utf version being used and this makes hive barf. This removes the encoding before passing it to hive. 
2. When users upload utf8 files, the construction of the part of the query with the column names and types has utf8 errors. 
2. A newer version of hive allows a better way to ignore the first line of the CSV file which contains the column names 
3. I erroneously left airbnb-superset as the default bucket name. Now it's the value specified in the config file.

How was this tested?
Tested on my development machine.

@john-bodley @mistercrunch 