### PR TITLE
[WiP] Cleanup & fix URL scheme for the explore view

### DIFF
--- a/run_specific_test.sh
+++ b/run_specific_test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 echo $DB
 rm -f .coverage
+export PYTHONPATH=./
 export SUPERSET_CONFIG=tests.superset_test_config
 set -e
 superset/bin/superset version -v

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,6 +4,7 @@ rm ~/.superset/unittests.db
 rm ~/.superset/celerydb.sqlite
 rm ~/.superset/celery_results.sqlite
 rm -f .coverage
+export PYTHONPATH=./
 export SUPERSET_CONFIG=tests.superset_test_config
 set -e
 superset/bin/superset db upgrade

--- a/superset/assets/javascripts/addSlice/AddSliceContainer.jsx
+++ b/superset/assets/javascripts/addSlice/AddSliceContainer.jsx
@@ -23,9 +23,8 @@ export default class AddSliceContainer extends React.PureComponent {
   }
 
   exploreUrl() {
-    const baseUrl = `/superset/explore/${this.state.datasourceType}/${this.state.datasourceId}`;
     const formData = encodeURIComponent(JSON.stringify({ viz_type: this.state.visType }));
-    return `${baseUrl}?form_data=${formData}`;
+    return `/superset/explore/?form_data=${formData}`;
   }
 
   gotoSlice() {

--- a/superset/assets/javascripts/explore/exploreUtils.js
+++ b/superset/assets/javascripts/explore/exploreUtils.js
@@ -25,9 +25,6 @@ export function getURIDirectory(formData, endpointType = 'base') {
   if (['json', 'csv', 'query'].indexOf(endpointType) >= 0) {
     directory = '/superset/explore_json/';
   }
-  const [datasource_id, datasource_type] = formData.datasource.split('__');
-  directory += `${datasource_type}/${datasource_id}/`;
-
   return directory;
 }
 

--- a/superset/assets/spec/javascripts/addSlice/AddSliceContainer_spec.jsx
+++ b/superset/assets/spec/javascripts/addSlice/AddSliceContainer_spec.jsx
@@ -53,7 +53,7 @@ describe('AddSliceContainer', () => {
       datasourceId: datasourceValue.split('__')[0],
       datasourceType: datasourceValue.split('__')[1],
     });
-    const formattedUrl = '/superset/explore/table/1?form_data=%7B%22viz_type%22%3A%22table%22%7D';
+    const formattedUrl = '/superset/explore/?form_data=%7B%22viz_type%22%3A%22table%22%7D';
     expect(wrapper.instance().exploreUrl()).to.equal(formattedUrl);
   });
 });

--- a/superset/assets/spec/javascripts/explore/utils_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/utils_spec.jsx
@@ -27,7 +27,7 @@ describe('utils', () => {
       });
       compareURI(
         URI(url),
-        URI('/superset/explore/table/1/'),
+        URI('/superset/explore/'),
       );
       expect(payload).to.deep.equals(formData);
     });
@@ -40,7 +40,7 @@ describe('utils', () => {
       });
       compareURI(
         URI(url),
-        URI('/superset/explore_json/table/1/'),
+        URI('/superset/explore_json/'),
       );
       expect(payload).to.deep.equals(formData);
     });
@@ -53,7 +53,7 @@ describe('utils', () => {
       });
       compareURI(
         URI(url),
-        URI('/superset/explore_json/table/1/')
+        URI('/superset/explore_json/')
           .search({ force: 'true' }),
       );
       expect(payload).to.deep.equals(formData);
@@ -67,7 +67,7 @@ describe('utils', () => {
       });
       compareURI(
         URI(url),
-        URI('/superset/explore_json/table/1/')
+        URI('/superset/explore_json/')
           .search({ csv: 'true' }),
       );
       expect(payload).to.deep.equals(formData);
@@ -81,7 +81,7 @@ describe('utils', () => {
       });
       compareURI(
         URI(url),
-        URI('/superset/explore/table/1/')
+        URI('/superset/explore/')
           .search({ standalone: 'true' }),
       );
       expect(payload).to.deep.equals(formData);
@@ -95,7 +95,7 @@ describe('utils', () => {
       });
       compareURI(
         URI(url),
-        URI('/superset/explore_json/table/1/')
+        URI('/superset/explore_json/')
           .search({ foo: 'bar' }),
       );
       expect(payload).to.deep.equals(formData);
@@ -109,7 +109,7 @@ describe('utils', () => {
       });
       compareURI(
         URI(url),
-        URI('/superset/explore_json/table/1/')
+        URI('/superset/explore_json/')
           .search({ foo: 'bar' }),
       );
       expect(payload).to.deep.equals(formData);
@@ -123,7 +123,7 @@ describe('utils', () => {
       });
       compareURI(
         URI(url),
-        URI('/superset/explore_json/table/1/')
+        URI('/superset/explore_json/')
           .search({ foo: 'bar' }),
       );
       expect(payload).to.deep.equals(formData);
@@ -134,7 +134,7 @@ describe('utils', () => {
     it('generates proper base url with form_data', () => {
       compareURI(
         URI(getExploreLongUrl(formData, 'base')),
-        URI('/superset/explore/table/1/').search({ form_data: sFormData }),
+        URI('/superset/explore/').search({ form_data: sFormData }),
       );
     });
   });

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -201,26 +201,30 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
         form_data.update({
             'slice_id': self.id,
             'viz_type': self.viz_type,
-            'datasource': str(self.datasource_id) + '__' + self.datasource_type,
+            'datasource': '{}__{}'.format(
+                self.datasource_id, self.datasource_type),
         })
         if self.cache_timeout:
             form_data['cache_timeout'] = self.cache_timeout
         return form_data
 
+    def get_explore_url(self, base_url='/superset/explore', overrides=None):
+        overrides = overrides or {}
+        form_data = {'slice_id': self.id}
+        form_data.update(overrides)
+        params = parse.quote(json.dumps(form_data))
+        return (
+            '{base_url}/?form_data={params}'.format(**locals()))
+
     @property
     def slice_url(self):
         """Defines the url to access the slice"""
-        form_data = {'slice_id': self.id}
-        return (
-            '/superset/explore/{obj.datasource_type}/'
-            '{obj.datasource_id}/?form_data={params}'.format(
-                obj=self, params=parse.quote(json.dumps(form_data))))
+        return self.get_explore_url()
 
     @property
-    def slice_id_url(self):
-        return (
-            '/superset/{slc.datasource_type}/{slc.datasource_id}/{slc.id}/'
-        ).format(slc=self)
+    def explore_json_url(self):
+        """Defines the url to access the slice"""
+        return self.get_explore_url('/superset/explore_json')
 
     @property
     def edit_url(self):


### PR DESCRIPTION
Moving `datasource_id` and `datasource_type` to the `form_data` blob as opposed to the URL directory (info was redundant)

* fix and unit tests around loading slice_id, and overriding form_data
* backward compatibility for previous URL schemes