### PR TITLE
Introduce an onInit method for when a new viz_type is selected

### DIFF
--- a/superset/assets/javascripts/explore/stores/store.js
+++ b/superset/assets/javascripts/explore/stores/store.js
@@ -82,7 +82,7 @@ export function getControlsState(state, form_data) {
     controlsState[k] = control;
   });
   if (viz.onInit) {
-    viz.onInit(controlsState);
+    return viz.onInit(controlsState);
   }
   return controlsState;
 }

--- a/superset/assets/javascripts/explore/stores/store.js
+++ b/superset/assets/javascripts/explore/stores/store.js
@@ -81,6 +81,9 @@ export function getControlsState(state, form_data) {
     control.value = formData[k] !== undefined ? formData[k] : control.default;
     controlsState[k] = control;
   });
+  if (viz.onInit) {
+    viz.onInit(controlsState);
+  }
   return controlsState;
 }
 

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -627,16 +627,17 @@ export const visTypes = {
   deck_scatter: {
     label: t('Deck.gl - Scatter plot'),
     requiresTime: true,
-    onInit: (controlsState) => {
-      /* eslint-disable no-param-reassign */
-      if (controlsState.time_grain_sqla) {
-        controlsState.time_grain_sqla.value = null;
-      }
-      if (controlsState.granularity) {
-        controlsState.granularity.value = null;
-      }
-      /* eslint-enable no-param-reassign */
-    },
+    onInit: controlState => ({
+      ...controlState,
+      time_grain_sqla: {
+        ...controlState.time_grain_sqla,
+        value: null,
+      },
+      granularity: {
+        ...controlState.granularity,
+        value: null,
+      },
+    }),
     controlPanelSections: [
       {
         label: t('Query'),

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -627,6 +627,16 @@ export const visTypes = {
   deck_scatter: {
     label: t('Deck.gl - Scatter plot'),
     requiresTime: true,
+    onInit: (controlsState) => {
+      /* eslint-disable no-param-reassign */
+      if (controlsState.time_grain_sqla) {
+        controlsState.time_grain_sqla.value = null;
+      }
+      if (controlsState.granularity) {
+        controlsState.granularity.value = null;
+      }
+      /* eslint-enable no-param-reassign */
+    },
     controlPanelSections: [
       {
         label: t('Query'),


### PR DESCRIPTION
This allows for clearing certain controls where/when needed. For
instance here, when loading deck_scatter, even if there was a time
granularity picked for the previous viz_type, we want to unselect it.