### PR TITLE
[Bugfix] On Vistype changes, set until to default (now)

### DIFF
--- a/superset/assets/javascripts/explore/stores/store.js
+++ b/superset/assets/javascripts/explore/stores/store.js
@@ -81,6 +81,10 @@ export function getControlsState(state, form_data) {
     control.value = formData[k] !== undefined ? formData[k] : control.default;
     controlsState[k] = control;
   });
+
+  // With VisType change alter until to always hit default
+  controlsState.until.value = controlsState.until.default;
+
   return controlsState;
 }
 


### PR DESCRIPTION
Set end date to default (now) when ever the visualization type changes

@mistercrunch 