### PR TITLE
[bugfix] Fixing regression introduced in #4396

### DIFF
--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -909,6 +909,34 @@ class CoreTests(SupersetTestCase):
         resp = self.get_resp(url)
         assert '"CA"' in resp
 
+    def test_slice_payload_no_data(self):
+        self.login(username='admin')
+        slc = self.get_slice('Girls', db.session)
+
+        url = slc.get_explore_url(
+            base_url='/superset/explore_json',
+            overrides={
+                'filters': [{'col': 'state', 'op': 'in', 'val': ['N/A']}],
+            },
+        )
+
+        data = self.get_json_resp(url)
+        self.assertEqual(data['status'], utils.QueryStatus.SUCCESS)
+        assert 'No data' in data['error']
+
+    def test_slice_payload_invalid_query(self):
+        self.login(username='admin')
+        slc = self.get_slice('Girls', db.session)
+
+        url = slc.get_explore_url(
+            base_url='/superset/explore_json',
+            overrides={'groupby': ['N/A']},
+        )
+
+        data = self.get_json_resp(url)
+        self.assertEqual(data['status'], utils.QueryStatus.FAILED)
+        assert 'KeyError' in data['stacktrace']
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -10,7 +10,6 @@ import unittest
 from mock import Mock, patch
 import pandas as pd
 
-import superset.utils as utils
 from superset.utils import DTTM_ALIAS
 import superset.viz as viz
 
@@ -53,8 +52,6 @@ class BaseVizTestCase(unittest.TestCase):
         result = test_viz.get_df(query_obj)
         self.assertEqual(type(result), pd.DataFrame)
         self.assertTrue(result.empty)
-        self.assertEqual(test_viz.error_message, 'No data.')
-        self.assertEqual(test_viz.status, utils.QueryStatus.FAILED)
 
     def test_get_df_handles_dttm_col(self):
         datasource = Mock()


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/apache/incubator-superset/pull/4396 which returned the error `No data` even when the query was unsuccessful for other reasons. This PR also refactors the `No data` logic (previously defined in two places) and also registered that the data was loaded if the query didn't fail. Note it seems like `BaseViz.get_df(...)` may never throw an exception give [this](https://github.com/apache/incubator-superset/blob/master/superset/connectors/sqla/models.py#L689) (and thus I'm uncertain whether [this](https://github.com/apache/incubator-superset/blob/master/superset/viz.py#L332) logic is needed) hence the additional check that the query succeeded is necessary to confirm that the data was loaded.

@mistercrunch from our offline conversation I found this difficult to write specific test cases, i.e., we discovered this regression in Presto when the underlying table metadata had changed either a column or the table no-longer existed. When I tried to mock this behavior, I was able to exercise the issue as in SQLite the inconsistency was discovered whilst the query was being compiled rather than during query execution.

to: @mistercrunch 
cc: @graceguo-supercat @michellethomas @timifasubaa 