### PR TITLE
Return __time in Druid scan

### DIFF
--- a/superset/assets/visualizations/deckgl/layers/scatter.jsx
+++ b/superset/assets/visualizations/deckgl/layers/scatter.jsx
@@ -14,7 +14,7 @@ import { unitToRadius } from '../../../javascripts/modules/geo';
 import sandboxedEval from '../../../javascripts/modules/sandbox';
 
 function getStep(timeGrain) {
-  // grain in microseconds
+  // grain in milliseconds
   const MINUTE = 60 * 1000;
   const HOUR = 60 * MINUTE;
   const DAY = 24 * HOUR;

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -130,7 +130,8 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
         return json.loads(requests.get(endpoint).text)
 
     def get_druid_version(self):
-        endpoint = self.get_base_url(self.coordinator_host, self.coordinator_port) + '/status'
+        endpoint = self.get_base_url(
+            self.coordinator_host, self.coordinator_port) + '/status'
         return json.loads(requests.get(endpoint).text)['version']
 
     def refresh_datasources(

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -130,7 +130,7 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
         return json.loads(requests.get(endpoint).text)
 
     def get_druid_version(self):
-        endpoint = self.get_base_coordinator_url() + '/status'
+        endpoint = self.get_base_url(self.coordinator_host, self.coordinator_port) + '/status'
         return json.loads(requests.get(endpoint).text)['version']
 
     def refresh_datasources(
@@ -1114,6 +1114,7 @@ class DruidDatasource(Model, BaseDatasource):
         order_direction = 'descending' if order_desc else 'ascending'
 
         if columns:
+            columns.append('__time')
             del qry['post_aggregations']
             del qry['aggregations']
             qry['dimensions'] = columns

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2040,7 +2040,7 @@ class DeckScatterViz(BaseDeckGLViz):
             'radius': self.fixed_value if self.fixed_value else d.get(self.metric),
             'cat_color': d.get(self.dim) if self.dim else None,
             'position': d.get('spatial'),
-            '__timestamp': d.get('__timestamp') or d.get('__time'),
+            '__timestamp': d.get(DTTM_ALIAS) or d.get('__time'),
         }
 
     def get_data(self, df):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2040,7 +2040,7 @@ class DeckScatterViz(BaseDeckGLViz):
             'radius': self.fixed_value if self.fixed_value else d.get(self.metric),
             'cat_color': d.get(self.dim) if self.dim else None,
             'position': d.get('spatial'),
-            '__timestamp': d.get('__timestamp'),
+            '__timestamp': d.get('__timestamp') or d.get('__time'),
         }
 
     def get_data(self, df):


### PR DESCRIPTION
When doing a scan in Druid we're not returning the temporal column `__time`, which is needed for the play slider.

I also fixed the status URL, which is broken in master.