### PR TITLE
[dashboard] Fix slices overlapped in new dashboard (without layout)

### DIFF
--- a/superset/assets/javascripts/dashboard/reducers.js
+++ b/superset/assets/javascripts/dashboard/reducers.js
@@ -41,8 +41,9 @@ export function getInitialState(bootstrapData) {
   } else {
     dashboard.position_json = [];
   }
-  const lastRowId = Math.max.apply(null,
-    dashboard.position_json.map(pos => (pos.row + pos.size_y)));
+
+  const lastRowId = Math.max(0, Math.max.apply(null,
+    dashboard.position_json.map(pos => (pos.row + pos.size_y))));
   let newSliceCounter = 0;
   dashboard.slices.forEach((slice) => {
     const sliceId = slice.slice_id;


### PR DESCRIPTION
From #4446, I append newly added slices at the bottom of existed dashboard.
If new dashboard doesn't any layout defined, the function for getting last row id return `Number.NEGATIVE_INFINITY` instead of 0. This cause all newly added slices are overlapped to row 0.


@michellethomas @mistercrunch 