### PR TITLE
[coverage] Replacing coveralls with codecov

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: 4P9MpvLrZfJKzHdGZsdV3MzO43OZJgYFn 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,7 @@ before_script:
   - export PATH=${PATH}:/tmp/hive/bin
 install:
   - pip install --upgrade pip
-  - pip install tox tox-travis
+  - pip install codecov tox tox-travis
 script: tox -e $TOX_ENV
+after_success:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Superset
 
 [![Build Status](https://travis-ci.org/apache/incubator-superset.svg?branch=master)](https://travis-ci.org/apache/incubator-superset)
 [![PyPI version](https://badge.fury.io/py/superset.svg)](https://badge.fury.io/py/superset)
-[![Coverage Status](https://coveralls.io/repos/apache/incubator-superset/badge.svg?branch=master&service=github)](https://coveralls.io/github/apache/incubator-superset?branch=master)
+[![Coverage Status](https://codecov.io/github/apache/incubator-superset/coverage.svg?branch=master)](https://codecov.io/github/apache/incubator-superset)
 [![PyPI](https://img.shields.io/pypi/pyversions/superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/superset)
 [![Requirements Status](https://requires.io/github/apache/incubator-superset/requirements.svg?branch=master)](https://requires.io/github/apache/incubator-superset/requirements/?branch=master)
 [![Join the chat at https://gitter.im/airbnb/superset](https://badges.gitter.im/apache/incubator-superset.svg)](https://gitter.im/airbnb/superset?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -165,7 +165,7 @@ the world know they are using Superset. Join our growing community!
  - [Konfío](http://konfio.mx)
  - [Lyft](https://www.lyft.com/)
  - [Maieutical Labs](https://cloudschooling.it)
- - [PeopleDoc](https://www.people-doc.com) 
+ - [PeopleDoc](https://www.people-doc.com)
  - [Ona](https://ona.io)
  - [Pronto Tools](http://www.prontotools.io)
  - [Qunar](https://www.qunar.com/)

--- a/dev-reqs.txt
+++ b/dev-reqs.txt
@@ -1,5 +1,4 @@
 codeclimate-test-reporter
-coveralls
 flake8
 flask_cors
 ipdb

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,6 +10,3 @@ set -e
 superset/bin/superset db upgrade
 superset/bin/superset version -v
 python setup.py nosetests
-if [ "$CI" = "true" ] ; then
-  coveralls
-fi

--- a/tox.ini
+++ b/tox.ini
@@ -45,13 +45,8 @@ whitelist_externals =
     npm
 passenv =
     HOME
-    TRAVIS
-    TRAVIS_BRANCH
-    TRAVIS_BUILD_DIR
-    TRAVIS_JOB_ID
     USER
     TRAVIS_CACHE
-    TRAVIS_PULL_REQUEST
     PATH
 commands =
   python --version


### PR DESCRIPTION
I'm unsure why but `coveralls` hasn't run as part of the Travis CI since [December 2017](https://coveralls.io/github/apache/incubator-superset?branch=master). It seems nowadays most repos are using `codecov` rather than `coveralls` (including `incubator-airflow`) which is free and requires no token for public GitHub repos and thus I though there was merit in trying to leverage this. 

One really nice thing about `codecov` is they have a browser extension which works seamlessly with GitHub and allows you to see the code coverage right from within GitHub. See [here](https://github.com/codecov/browser-extension) for more details, which includes a demo on YouTube. What's every sweeter, is you can see code coverage of your PR which helps indicate whether you need to write additional unit tests for your change.

Previously `coveralls` was integrated with `tox` which meant passing Travis CI environment variables to `tox` and making the `run_tests.sh` script aware of whether it was running in a CI environment. Personally I'm not a fan of this interwoven dependency, i.e., I think of `tox` as a testing environment which can run locally via shell-based testing or with a CI server, and thus should be agnostic of the CI service. Although `codecov` can also be integrated with `tox`, given that `codecov` is primarily a web-based CI tool, personally it makes sense that this is handled completely within Travis CI. 

Note this PR produced the following [report](https://codecov.io/gh/apache/incubator-superset/commit/5bb74503ffa6ab169b51d2ebfb93936c2d7d7ecc). 

to: @mistercrunch @xrmx 