### PR TITLE
[setup] Fixing repo URLs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,9 +102,10 @@ setup(
     ],
     author='Maxime Beauchemin',
     author_email='maximebeauchemin@gmail.com',
-    url='https://github.com/airbnb/superset',
+    url='https://github.com/apache/incubator-superset',
     download_url=(
-        'https://github.com/airbnb/superset/tarball/' + version_string),
+        'https://github.com/apache/incubator-superset/tarball/' + version_string,
+    ),
     classifiers=[
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
This PR updates the GitHub URLs from `airbnb/superset` to `apache/incubator-superset`.