### PR TITLE
[landing] Making Dashboards the first/default tab

### DIFF
--- a/superset/assets/javascripts/welcome/App.jsx
+++ b/superset/assets/javascripts/welcome/App.jsx
@@ -25,25 +25,7 @@ export default class App extends React.PureComponent {
     return (
       <div className="container welcome">
         <Tabs defaultActiveKey={1} id="uncontrolled-tab-example">
-          <Tab eventKey={1} title={t('Recently Viewed')}>
-            <Panel>
-              <Row>
-                <Col md={8}><h2>{t('Recently Viewed')}</h2></Col>
-              </Row>
-              <hr />
-              <RecentActivity user={this.props.user} />
-            </Panel>
-          </Tab>
-          <Tab eventKey={2} title={t('Favorites')}>
-            <Panel>
-              <Row>
-                <Col md={8}><h2>{t('Favorites')}</h2></Col>
-              </Row>
-              <hr />
-              <Favorites user={this.props.user} />
-            </Panel>
-          </Tab>
-          <Tab eventKey={3} title={t('Dashboards')}>
+          <Tab eventKey={1} title={t('Dashboards')}>
             <Panel>
               <Row>
                 <Col md={8}><h2>{t('Dashboards')}</h2></Col>
@@ -60,6 +42,24 @@ export default class App extends React.PureComponent {
               </Row>
               <hr />
               <DashboardTable search={this.state.search} />
+            </Panel>
+          </Tab>
+          <Tab eventKey={2} title={t('Recently Viewed')}>
+            <Panel>
+              <Row>
+                <Col md={8}><h2>{t('Recently Viewed')}</h2></Col>
+              </Row>
+              <hr />
+              <RecentActivity user={this.props.user} />
+            </Panel>
+          </Tab>
+          <Tab eventKey={3} title={t('Favorites')}>
+            <Panel>
+              <Row>
+                <Col md={8}><h2>{t('Favorites')}</h2></Col>
+              </Row>
+              <hr />
+              <Favorites user={this.props.user} />
             </Panel>
           </Tab>
         </Tabs>


### PR DESCRIPTION
@hughhhh I think that the "Recently Viewed" tab still needs some refinement in terms of what we show there, and that user's may be somewhat confused, i.e.,  

![screen shot 2018-03-06 at 5 35 12 pm](https://user-images.githubusercontent.com/4567245/37068702-da6b8e84-2164-11e8-93b4-027da966cf33.png)

This PR changes the tab ordering and makes the "Dashboards" tab the first (and thus default) tab, which should seem more useful and familiar to users,

![screen shot 2018-03-06 at 5 34 55 pm](https://user-images.githubusercontent.com/4567245/37068703-da873b84-2164-11e8-9374-d0f2d29935c5.png)

to: @hughhhh @mistercrunch 