### PR TITLE
[bug] Fix CSV upload feature for DB with password

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -135,7 +135,7 @@ class BaseEngineSpec(object):
             'table': table,
             'df': df,
             'name': form.name.data,
-            'con': create_engine(form.con.data.sqlalchemy_uri, echo=False),
+            'con': create_engine(form.con.data.sqlalchemy_uri_decrypted, echo=False),
             'schema': form.schema.data,
             'if_exists': form.if_exists.data,
             'index': form.index.data,
@@ -875,7 +875,7 @@ class HiveEngineSpec(PrestoEngineSpec):
             TEXTFILE LOCATION '{location}'
             tblproperties ('skip.header.line.count'='1')""".format(**locals())
         logging.info(form.con.data)
-        engine = create_engine(form.con.data.sqlalchemy_uri)
+        engine = create_engine(form.con.data.sqlalchemy_uri_decrypted)
         engine.execute(sql)
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ commands =
 [testenv:py27-mysql]
 basepython = python2.7
 setenv =
-    SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset
+    SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
 
 [testenv:py34-mysql]
 basepython = python3.4

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ commands =
 [testenv:py27-mysql]
 basepython = python2.7
 setenv =
-    SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://root@localhost/superset?charset=utf8
+    SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset
 
 [testenv:py34-mysql]
 basepython = python3.4


### PR DESCRIPTION
As of #4298, the call to `create_engine` within `create_table_from_csv` located [here](https://github.com/apache/incubator-superset/blob/master/superset/db_engine_specs.py#L138) is using `sqlalchemy_uri` to create a new SQLAlchemy engine. This works as expected if the URI does not contain a password - however if it does, this string contains the masked password (i.e. XXXXXXXX), and authentication is attempted using that instead. 

This change should fix #4285 and #4287.