### PR TITLE
Adding column type label to dropdowns

### DIFF
--- a/superset/assets/javascripts/components/ColumnOption.jsx
+++ b/superset/assets/javascripts/components/ColumnOption.jsx
@@ -16,10 +16,10 @@ export default function ColumnOption({ column, showType }) {
   const hasExpression = column.expression && column.expression !== column.column_name;
 
   let columnType = column.type;
-  if (hasExpression) {
-    columnType = 'expression';
-  } else if (column.is_dttm) {
+  if (column.is_dttm) {
     columnType = 'time';
+  } else if (hasExpression) {
+    columnType = 'expression';
   }
 
   return (

--- a/superset/assets/javascripts/components/ColumnOption.jsx
+++ b/superset/assets/javascripts/components/ColumnOption.jsx
@@ -14,9 +14,17 @@ const defaultProps = {
 
 export default function ColumnOption({ column, showType }) {
   const hasExpression = column.expression && column.expression !== column.column_name;
+
+  let columnType = column.type;
+  if (hasExpression) {
+    columnType = 'expression';
+  } else if (column.is_dttm) {
+    columnType = 'time';
+  }
+
   return (
     <span>
-      {showType && <ColumnTypeLabel type={hasExpression ? 'expression' : column.type} />}
+      {showType && <ColumnTypeLabel type={columnType} />}
       <span className="m-r-5 option-label">
         {column.verbose_name || column.column_name}
       </span>

--- a/superset/assets/javascripts/components/ColumnOption.jsx
+++ b/superset/assets/javascripts/components/ColumnOption.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import ColumnTypeLabel from './ColumnTypeLabel';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 
 const propTypes = {
@@ -12,8 +13,10 @@ const defaultProps = {
 };
 
 export default function ColumnOption({ column, showType }) {
+  const hasExpression = column.expression && column.expression !== column.column_name;
   return (
     <span>
+      {showType && <ColumnTypeLabel type={hasExpression ? 'expression' : column.type} />}
       <span className="m-r-5 option-label">
         {column.verbose_name || column.column_name}
       </span>
@@ -25,16 +28,13 @@ export default function ColumnOption({ column, showType }) {
           label={`descr-${column.column_name}`}
         />
       }
-      {column.expression && column.expression !== column.column_name &&
+      {hasExpression &&
         <InfoTooltipWithTrigger
           className="m-r-5 text-muted"
           icon="question-circle-o"
           tooltip={column.expression}
           label={`expr-${column.column_name}`}
         />
-      }
-      {showType &&
-        <span className="text-muted">{column.type}</span>
       }
     </span>);
 }

--- a/superset/assets/javascripts/components/ColumnTypeLabel.jsx
+++ b/superset/assets/javascripts/components/ColumnTypeLabel.jsx
@@ -6,28 +6,27 @@ const propTypes = {
 };
 
 export default function ColumnTypeLabel({ type }) {
-  let stringIcon;
-  let iconSize = '13';
+  let stringIcon = '';
   if (type === '' || type === 'expression') {
     stringIcon = 'ƒ';
   } else if (type.match(/.*char.*/i) || type.match(/string.*/i) || type.match(/.*text.*/i)) {
     stringIcon = 'ABC';
-    iconSize = '11';
   } else if (type.match(/.*int.*/i) || type === 'LONG' || type === 'DOUBLE') {
     stringIcon = '#';
   } else if (type.match(/.*bool.*/i)) {
     stringIcon = 'T/F';
   } else if (type.match(/.*time.*/i)) {
     stringIcon = 'time';
-  } else {
+  } else if (type.match(/unknown/i)) {
     stringIcon = '?';
   }
 
-  const typeIcon = stringIcon === 'time' ? <i className="fa fa-clock-o text-muted type-label" /> : (
-    <div className="text-muted type-label" style={{ fontSize: iconSize }}>{stringIcon}</div>);
+  const typeIcon = stringIcon === 'time' ?
+    <i className="fa fa-clock-o type-label" /> :
+    <div className="type-label">{stringIcon}</div>;
 
   return (
-    <span className="m-r-5">
+    <span>
       {typeIcon}
     </span>);
 }

--- a/superset/assets/javascripts/components/ColumnTypeLabel.jsx
+++ b/superset/assets/javascripts/components/ColumnTypeLabel.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  type: PropTypes.string.isRequired,
+};
+
+export default function ColumnTypeLabel({ type }) {
+  let stringIcon;
+  let iconSize = '13';
+  if (type === '' || type === 'expression') {
+    stringIcon = 'ƒ';
+  } else if (type.match(/.*char.*/i) || type.match(/string.*/i) || type.match(/.*text.*/i)) {
+    stringIcon = 'ABC';
+    iconSize = '11';
+  } else if (type.match(/.*int.*/i) || type === 'LONG' || type === 'DOUBLE') {
+    stringIcon = '#';
+  } else if (type.match(/.*bool.*/i)) {
+    stringIcon = 'T/F';
+  } else if (type.match(/.*time.*/i)) {
+    stringIcon = 'time';
+  } else {
+    stringIcon = '?';
+  }
+
+  const typeIcon = stringIcon === 'time' ? <i className="fa fa-clock-o text-muted type-label" /> : (
+    <div className="text-muted type-label" style={{ fontSize: iconSize }}>{stringIcon}</div>);
+
+  return (
+    <span className="m-r-5">
+      {typeIcon}
+    </span>);
+}
+ColumnTypeLabel.propTypes = propTypes;

--- a/superset/assets/javascripts/components/MetricOption.jsx
+++ b/superset/assets/javascripts/components/MetricOption.jsx
@@ -1,23 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import ColumnTypeLabel from './ColumnTypeLabel';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 
 const propTypes = {
   metric: PropTypes.object.isRequired,
   openInNewWindow: PropTypes.bool,
   showFormula: PropTypes.bool,
+  showType: PropTypes.bool,
   url: PropTypes.string,
 };
 const defaultProps = {
   showFormula: true,
+  showType: false,
 };
 
-export default function MetricOption({ metric, openInNewWindow, showFormula, url }) {
+export default function MetricOption({ metric, openInNewWindow, showFormula, showType, url }) {
   const verbose = metric.verbose_name || metric.metric_name;
   const link = url ? <a href={url} target={openInNewWindow ? '_blank' : null}>{verbose}</a> : verbose;
   return (
     <div>
+      {showType && <ColumnTypeLabel type="expression" />}
       <span className="m-r-5 option-label">{link}</span>
       {metric.description &&
         <InfoTooltipWithTrigger

--- a/superset/assets/javascripts/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/javascripts/explore/components/controls/DatasourceControl.jsx
@@ -153,7 +153,7 @@ export default class DatasourceControl extends React.PureComponent {
             </Label>
             {` ${datasource.database.name} `}
           </div>
-          <Row>
+          <Row className="datasource-container">
             <Col md={6}>
               <strong>Columns</strong>
               {datasource.columns.map(col => (
@@ -163,7 +163,7 @@ export default class DatasourceControl extends React.PureComponent {
             <Col md={6}>
               <strong>Metrics</strong>
               {datasource.metrics.map(m => (
-                <div key={m.metric_name}><MetricOption metric={m} /></div>
+                <div key={m.metric_name}><MetricOption metric={m} showType /></div>
               ))}
             </Col>
           </Row>

--- a/superset/assets/javascripts/explore/main.css
+++ b/superset/assets/javascripts/explore/main.css
@@ -123,3 +123,12 @@
   background-color: transparent;
 }
 
+.type-label {
+  width: 25px;
+  display: inline-block;
+  text-align: center;
+}
+
+.datasource-container {
+  overflow: auto;
+}

--- a/superset/assets/javascripts/explore/main.css
+++ b/superset/assets/javascripts/explore/main.css
@@ -124,9 +124,11 @@
 }
 
 .type-label {
-  width: 25px;
+  margin-right: 8px;
+  width: 30px;
   display: inline-block;
   text-align: center;
+  font-weight: bold;
 }
 
 .datasource-container {

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -56,7 +56,7 @@ const groupByControl = {
   default: [],
   includeTime: false,
   description: t('One or many controls to group by'),
-  optionRenderer: c => <ColumnOption column={c} />,
+  optionRenderer: c => <ColumnOption column={c} showType />,
   valueRenderer: c => <ColumnOption column={c} />,
   valueKey: 'column_name',
   mapStateToProps: (state, control) => {
@@ -129,7 +129,7 @@ export const controls = {
     label: t('Metrics'),
     validators: [v.nonEmpty],
     valueKey: 'metric_name',
-    optionRenderer: m => <MetricOption metric={m} />,
+    optionRenderer: m => <MetricOption metric={m} showType />,
     valueRenderer: m => <MetricOption metric={m} />,
     default: c => c.options && c.options.length > 0 ? [c.options[0].metric_name] : null,
     mapStateToProps: state => ({
@@ -143,7 +143,7 @@ export const controls = {
     multi: true,
     label: t('Percentage Metrics'),
     valueKey: 'metric_name',
-    optionRenderer: m => <MetricOption metric={m} />,
+    optionRenderer: m => <MetricOption metric={m} showType />,
     valueRenderer: m => <MetricOption metric={m} />,
     mapStateToProps: state => ({
       options: (state.datasource) ? state.datasource.metrics : [],
@@ -202,7 +202,7 @@ export const controls = {
     clearable: false,
     description: t('Choose the metric'),
     validators: [v.nonEmpty],
-    optionRenderer: m => <MetricOption metric={m} />,
+    optionRenderer: m => <MetricOption metric={m} showType />,
     valueRenderer: m => <MetricOption metric={m} />,
     default: c => c.options && c.options.length > 0 ? c.options[0].metric_name : null,
     valueKey: 'metric_name',
@@ -219,7 +219,7 @@ export const controls = {
     clearable: true,
     description: t('Choose a metric for right axis'),
     valueKey: 'metric_name',
-    optionRenderer: m => <MetricOption metric={m} />,
+    optionRenderer: m => <MetricOption metric={m} showType />,
     valueRenderer: m => <MetricOption metric={m} />,
     mapStateToProps: state => ({
       options: (state.datasource) ? state.datasource.metrics : [],
@@ -522,8 +522,11 @@ export const controls = {
     label: t('Columns'),
     default: [],
     description: t('Columns to display'),
+    optionRenderer: c => <ColumnOption column={c} showType />,
+    valueRenderer: c => <ColumnOption column={c} />,
+    valueKey: 'column_name',
     mapStateToProps: state => ({
-      choices: (state.datasource) ? state.datasource.all_cols : [],
+      options: (state.datasource) ? state.datasource.columns : [],
     }),
   },
 
@@ -756,7 +759,7 @@ export const controls = {
       return null;
     },
     clearable: false,
-    optionRenderer: c => <ColumnOption column={c} />,
+    optionRenderer: c => <ColumnOption column={c} showType />,
     valueRenderer: c => <ColumnOption column={c} />,
     valueKey: 'column_name',
     mapStateToProps: (state) => {
@@ -978,7 +981,7 @@ export const controls = {
     description: t('Metric assigned to the [X] axis'),
     default: null,
     validators: [v.nonEmpty],
-    optionRenderer: m => <MetricOption metric={m} />,
+    optionRenderer: m => <MetricOption metric={m} showType />,
     valueRenderer: m => <MetricOption metric={m} />,
     valueKey: 'metric_name',
     mapStateToProps: state => ({
@@ -992,7 +995,7 @@ export const controls = {
     default: null,
     validators: [v.nonEmpty],
     description: t('Metric assigned to the [Y] axis'),
-    optionRenderer: m => <MetricOption metric={m} />,
+    optionRenderer: m => <MetricOption metric={m} showType />,
     valueRenderer: m => <MetricOption metric={m} />,
     valueKey: 'metric_name',
     mapStateToProps: state => ({
@@ -1005,7 +1008,7 @@ export const controls = {
     label: t('Bubble Size'),
     default: null,
     validators: [v.nonEmpty],
-    optionRenderer: m => <MetricOption metric={m} />,
+    optionRenderer: m => <MetricOption metric={m} showType />,
     valueRenderer: m => <MetricOption metric={m} />,
     valueKey: 'metric_name',
     mapStateToProps: state => ({

--- a/superset/assets/spec/javascripts/components/ColumnOption_spec.jsx
+++ b/superset/assets/spec/javascripts/components/ColumnOption_spec.jsx
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import ColumnOption from '../../../javascripts/components/ColumnOption';
+import ColumnTypeLabel from '../../../javascripts/components/ColumnTypeLabel';
 import InfoTooltipWithTrigger from '../../../javascripts/components/InfoTooltipWithTrigger';
 
 describe('ColumnOption', () => {
@@ -14,6 +15,7 @@ describe('ColumnOption', () => {
       expression: 'SUM(foo)',
       description: 'Foo is the greatest column of all',
     },
+    showType: false,
   };
 
   let wrapper;
@@ -43,5 +45,16 @@ describe('ColumnOption', () => {
     props.column.verbose_name = null;
     wrapper = shallow(factory(props));
     expect(wrapper.find('.option-label').first().text()).to.equal('foo');
+  });
+  it('shows a column type label when showType is true', () => {
+    props.showType = true;
+    wrapper = shallow(factory(props));
+    expect(wrapper.find(ColumnTypeLabel)).to.have.length(1);
+  });
+  it('column with expression has correct column label if showType is true', () => {
+    props.showType = true;
+    wrapper = shallow(factory(props));
+    expect(wrapper.find(ColumnTypeLabel)).to.have.length(1);
+    expect(wrapper.find(ColumnTypeLabel).props().type).to.equal('expression');
   });
 });

--- a/superset/assets/spec/javascripts/components/ColumnOption_spec.jsx
+++ b/superset/assets/spec/javascripts/components/ColumnOption_spec.jsx
@@ -57,4 +57,11 @@ describe('ColumnOption', () => {
     expect(wrapper.find(ColumnTypeLabel)).to.have.length(1);
     expect(wrapper.find(ColumnTypeLabel).props().type).to.equal('expression');
   });
+  it('dttm column has correct column label if showType is true', () => {
+    props.showType = true;
+    props.column.is_dttm = true;
+    wrapper = shallow(factory(props));
+    expect(wrapper.find(ColumnTypeLabel)).to.have.length(1);
+    expect(wrapper.find(ColumnTypeLabel).props().type).to.equal('time');
+  });
 });

--- a/superset/assets/spec/javascripts/components/ColumnTypeLabel_spec.jsx
+++ b/superset/assets/spec/javascripts/components/ColumnTypeLabel_spec.jsx
@@ -10,53 +10,43 @@ describe('ColumnOption', () => {
     type: 'string',
   };
 
-  let wrapper;
-  let props;
-  const factory = o => <ColumnTypeLabel {...o} />;
-  beforeEach(() => {
-    wrapper = shallow(factory(defaultProps));
-    props = Object.assign({}, defaultProps);
-  });
+  const props = { ...defaultProps };
+
+  function getWrapper(overrides) {
+    const wrapper = shallow(<ColumnTypeLabel {...props} {...overrides} />);
+    return wrapper;
+  }
+
   it('is a valid element', () => {
     expect(React.isValidElement(<ColumnTypeLabel {...defaultProps} />)).to.equal(true);
   });
   it('string type shows ABC icon', () => {
-    const lbl = wrapper.find('.type-label');
+    const lbl = getWrapper({}).find('.type-label');
     expect(lbl).to.have.length(1);
     expect(lbl.first().text()).to.equal('ABC');
   });
   it('int type shows # icon', () => {
-    props.type = 'int(164)';
-    wrapper = shallow(factory(props));
-    const lbl = wrapper.find('.type-label');
+    const lbl = getWrapper({ type: 'int(164)' }).find('.type-label');
     expect(lbl).to.have.length(1);
     expect(lbl.first().text()).to.equal('#');
   });
   it('bool type shows T/F icon', () => {
-    props.type = 'BOOL';
-    wrapper = shallow(factory(props));
-    const lbl = wrapper.find('.type-label');
+    const lbl = getWrapper({ type: 'BOOL' }).find('.type-label');
     expect(lbl).to.have.length(1);
     expect(lbl.first().text()).to.equal('T/F');
   });
   it('expression type shows function icon', () => {
-    props.type = 'expression';
-    wrapper = shallow(factory(props));
-    const lbl = wrapper.find('.type-label');
+    const lbl = getWrapper({ type: 'expression' }).find('.type-label');
     expect(lbl).to.have.length(1);
     expect(lbl.first().text()).to.equal('ƒ');
   });
   it('unknown type shows question mark', () => {
-    props.type = 'unknown';
-    wrapper = shallow(factory(props));
-    const lbl = wrapper.find('.type-label');
+    const lbl = getWrapper({ type: 'unknown' }).find('.type-label');
     expect(lbl).to.have.length(1);
     expect(lbl.first().text()).to.equal('?');
   });
   it('unknown type shows question mark', () => {
-    props.type = 'datetime';
-    wrapper = shallow(factory(props));
-    const lbl = wrapper.find('.fa-clock-o');
+    const lbl = getWrapper({ type: 'datetime' }).find('.fa-clock-o');
     expect(lbl).to.have.length(1);
   });
 });

--- a/superset/assets/spec/javascripts/components/ColumnTypeLabel_spec.jsx
+++ b/superset/assets/spec/javascripts/components/ColumnTypeLabel_spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
-import ColumnTypeLabel from '../../../../javascripts/components/ColumnTypeLabel';
+import ColumnTypeLabel from '../../../javascripts/components/ColumnTypeLabel';
 
 describe('ColumnOption', () => {
   const defaultProps = {
@@ -45,5 +45,18 @@ describe('ColumnOption', () => {
     const lbl = wrapper.find('.type-label');
     expect(lbl).to.have.length(1);
     expect(lbl.first().text()).to.equal('ƒ');
+  });
+  it('unknown type shows question mark', () => {
+    props.type = 'unknown';
+    wrapper = shallow(factory(props));
+    const lbl = wrapper.find('.type-label');
+    expect(lbl).to.have.length(1);
+    expect(lbl.first().text()).to.equal('?');
+  });
+  it('unknown type shows question mark', () => {
+    props.type = 'datetime';
+    wrapper = shallow(factory(props));
+    const lbl = wrapper.find('.fa-clock-o');
+    expect(lbl).to.have.length(1);
   });
 });

--- a/superset/assets/spec/javascripts/components/MetricOption_spec.jsx
+++ b/superset/assets/spec/javascripts/components/MetricOption_spec.jsx
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import MetricOption from '../../../javascripts/components/MetricOption';
+import ColumnTypeLabel from '../../../javascripts/components/ColumnTypeLabel';
 import InfoTooltipWithTrigger from '../../../javascripts/components/InfoTooltipWithTrigger';
 
 describe('MetricOption', () => {
@@ -15,6 +16,7 @@ describe('MetricOption', () => {
       description: 'Foo is the greatest metric of all',
       warning_text: 'Be careful when using foo',
     },
+    showType: false,
   };
 
   let wrapper;
@@ -58,5 +60,10 @@ describe('MetricOption', () => {
     props.openInNewWindow = true;
     wrapper = shallow(factory(props));
     expect(wrapper.find('a').prop('target')).to.equal('_blank');
+  });
+  it('shows a metric type label when showType is true', () => {
+    props.showType = true;
+    wrapper = shallow(factory(props));
+    expect(wrapper.find(ColumnTypeLabel)).to.have.length(1);
   });
 });

--- a/superset/assets/spec/javascripts/explore/components/ColumnTypeLabel_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ColumnTypeLabel_spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { shallow } from 'enzyme';
+
+import ColumnTypeLabel from '../../../../javascripts/components/ColumnTypeLabel';
+
+describe('ColumnOption', () => {
+  const defaultProps = {
+    type: 'string',
+  };
+
+  let wrapper;
+  let props;
+  const factory = o => <ColumnTypeLabel {...o} />;
+  beforeEach(() => {
+    wrapper = shallow(factory(defaultProps));
+    props = Object.assign({}, defaultProps);
+  });
+  it('is a valid element', () => {
+    expect(React.isValidElement(<ColumnTypeLabel {...defaultProps} />)).to.equal(true);
+  });
+  it('string type shows ABC icon', () => {
+    const lbl = wrapper.find('.type-label');
+    expect(lbl).to.have.length(1);
+    expect(lbl.first().text()).to.equal('ABC');
+  });
+  it('int type shows # icon', () => {
+    props.type = 'int(164)';
+    wrapper = shallow(factory(props));
+    const lbl = wrapper.find('.type-label');
+    expect(lbl).to.have.length(1);
+    expect(lbl.first().text()).to.equal('#');
+  });
+  it('bool type shows T/F icon', () => {
+    props.type = 'BOOL';
+    wrapper = shallow(factory(props));
+    const lbl = wrapper.find('.type-label');
+    expect(lbl).to.have.length(1);
+    expect(lbl.first().text()).to.equal('T/F');
+  });
+  it('expression type shows function icon', () => {
+    props.type = 'expression';
+    wrapper = shallow(factory(props));
+    const lbl = wrapper.find('.type-label');
+    expect(lbl).to.have.length(1);
+    expect(lbl.first().text()).to.equal('ƒ');
+  });
+});


### PR DESCRIPTION
Adding column type information to the optionRenderer for any controls that use ColumnOption or MetricOption. So this will show up in the dropdown but not inline in the value renderer. This deviates from our original designs but it was making the page look pretty busy when I added it to our current page.

Would love to get more design feedback!

In the future, in the metrics section we can distinguish between aggregations and columns. Also, once some of the metrics work Gabe is doing gets in, I'd like to add this to all dropdowns for consistency. 

@GabeLoins @williaster @mistercrunch 

![image](https://user-images.githubusercontent.com/817955/37125942-98f584fe-2223-11e8-8bcb-20e48e066169.png)
![image](https://user-images.githubusercontent.com/817955/37125948-a04d8fc6-2223-11e8-8375-5a88ee3cd250.png)
![image](https://user-images.githubusercontent.com/817955/37125951-a6ae1dfe-2223-11e8-91d3-5d711645fb63.png)
![image](https://user-images.githubusercontent.com/817955/37125958-ad244a5a-2223-11e8-9656-431410c05405.png)



