### PR TITLE
[payload] Set status code on error rather than query status

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1084,7 +1084,10 @@ class Superset(BaseSupersetView):
             return json_error_response(utils.error_msg_from_exception(e))
 
         status = 200
-        if payload.get('status') == QueryStatus.FAILED:
+        if (
+            payload.get('status') == QueryStatus.FAILED or
+            payload.get('error') is not None
+        ):
             status = 400
 
         return json_success(viz_obj.json_dumps(payload), status=status)


### PR DESCRIPTION
@mistercrunch previously you used to raise an [exception](https://github.com/apache/incubator-superset/pull/4396/files) if there was no-data, which would then get caught [here](https://github.com/apache/incubator-superset/blob/master/superset/views/core.py#L1093) and thus the non-200 status code would ensure that the error message was reported.

When I removed the exception, and instead set the error message (to ensure consistency with how other query errors were handled) the exception wasn't raised, and the response status code was defined purely on whether the query failed or not rather than also checking the presence of an error. 

Note in the future I'll try to take a pass at unifying some of this logic; standardizing payloads, determining when exceptions should/shouldn't be thrown, etc.