### PR TITLE
Adding option to visualize negative values in Table view

### DIFF
--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -2211,14 +2211,20 @@
     "table_filter": {
       "type": "CheckboxControl",
       "label": "Table Filter",
-      "default": false,
+      "default": true,
       "description": "Whether to apply filter when table cell is clicked"
     },
-    "visualize_negative_values": {
+    "right_align": {
       "type": "CheckboxControl",
-      "label": "Visualize Negative Values",
+      "label": "Right Align",
+      "default": true,
+      "description": "Whether to right align background chart"
+    },
+    "highlight_negative": {
+      "type": "CheckboxControl",
+      "label": "Highlight Negative",
       "default": false,
-      "description": "Whether to show visualization for negative values"
+      "description": "Whether to highlight negative values"
     },
     "show_bubbles": {
       "type": "CheckboxControl",

--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -2214,6 +2214,12 @@
       "default": false,
       "description": "Whether to apply filter when table cell is clicked"
     },
+    "visualize_negative_values": {
+      "type": "CheckboxControl",
+      "label": "Visualize Negative Values",
+      "default": false,
+      "description": "Whether to show visualization for negative values"
+    },
     "show_bubbles": {
       "type": "CheckboxControl",
       "label": "Show Bubbles",

--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -2211,7 +2211,7 @@
     "table_filter": {
       "type": "CheckboxControl",
       "label": "Table Filter",
-      "default": true,
+      "default": false,
       "description": "Whether to apply filter when table cell is clicked"
     },
     "right_align": {
@@ -2223,7 +2223,7 @@
     "highlight_negative": {
       "type": "CheckboxControl",
       "label": "Highlight Negative",
-      "default": false,
+      "default": true,
       "description": "Whether to highlight negative values"
     },
     "show_bubbles": {

--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -2214,17 +2214,19 @@
       "default": false,
       "description": "Whether to apply filter when table cell is clicked"
     },
-    "right_align": {
+    "align_pn": {
       "type": "CheckboxControl",
-      "label": "Right Align",
-      "default": true,
-      "description": "Whether to right align background chart"
+      "label": "Align +/-",
+      "renderTrigger": true,
+      "default": false,
+      "description": "Whether to align the background chart for +/- values"
     },
-    "highlight_negative": {
+    "color_pn": {
       "type": "CheckboxControl",
-      "label": "Highlight Negative",
-      "default": true,
-      "description": "Whether to highlight negative values"
+      "label": "Color +/-",
+      "renderTrigger": true,
+      "default": false,
+      "description": "Whether to color +/- values"
     },
     "show_bubbles": {
       "type": "CheckboxControl",

--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -2225,7 +2225,7 @@
       "type": "CheckboxControl",
       "label": "Color +/-",
       "renderTrigger": true,
-      "default": false,
+      "default": true,
       "description": "Whether to color +/- values"
     },
     "show_bubbles": {

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1337,7 +1337,7 @@ export const controls = {
     type: 'CheckboxControl',
     label: t('Color +/-'),
     renderTrigger: true,
-    default: false,
+    default: true,
     description: t('Whether to color +/- values'),
   },
 

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1325,6 +1325,13 @@ export const controls = {
     description: t('Whether to apply filter when table cell is clicked'),
   },
 
+  visualize_negative_values: {
+    type: 'CheckboxControl',
+    label: t('Visualize Negative Values'),
+    default: false,
+    description: t('Whether to show visualization for negative values'),
+  },
+
   show_bubbles: {
     type: 'CheckboxControl',
     label: t('Show Bubbles'),

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1325,18 +1325,20 @@ export const controls = {
     description: t('Whether to apply filter when table cell is clicked'),
   },
 
-  right_align: {
+  align_pn: {
     type: 'CheckboxControl',
-    label: t('Right Align'),
-    default: true,
-    description: t('Whether to right align background chart'),
+    label: t('Align +/-'),
+    renderTrigger: true,
+    default: false,
+    description: t('Whether to align the background chart for +/- values'),
   },
 
-  highlight_negative: {
+  color_pn: {
     type: 'CheckboxControl',
-    label: t('Highlight Negative'),
-    default: true,
-    description: t('Whether to highlight negative values'),
+    label: t('Color +/-'),
+    renderTrigger: true,
+    default: false,
+    description: t('Whether to color +/- values'),
   },
 
   show_bubbles: {

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1325,11 +1325,18 @@ export const controls = {
     description: t('Whether to apply filter when table cell is clicked'),
   },
 
-  visualize_negative_values: {
+  right_align: {
     type: 'CheckboxControl',
-    label: t('Visualize Negative Values'),
-    default: false,
-    description: t('Whether to show visualization for negative values'),
+    label: t('Right Align'),
+    default: true,
+    description: t('Whether to right align background chart'),
+  },
+
+  highlight_negative: {
+    type: 'CheckboxControl',
+    label: t('Highlight Negative'),
+    default: true,
+    description: t('Whether to highlight negative values'),
   },
 
   show_bubbles: {

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -770,6 +770,7 @@ export const visTypes = {
           ['table_timestamp_format'],
           ['row_limit', 'page_length'],
           ['include_search', 'table_filter'],
+          ['visualize_negative_values'],
         ],
       },
     ],

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -770,7 +770,7 @@ export const visTypes = {
           ['table_timestamp_format'],
           ['row_limit', 'page_length'],
           ['include_search', 'table_filter'],
-          ['visualize_negative_values'],
+          ['right_align','highlight_negative'],
         ],
       },
     ],

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -770,7 +770,7 @@ export const visTypes = {
           ['table_timestamp_format'],
           ['row_limit', 'page_length'],
           ['include_search', 'table_filter'],
-          ['right_align', 'highlight_negative'],
+          ['align_pn', 'color_pn'],
         ],
       },
     ],

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -770,7 +770,7 @@ export const visTypes = {
           ['table_timestamp_format'],
           ['row_limit', 'page_length'],
           ['include_search', 'table_filter'],
-          ['right_align','highlight_negative'],
+          ['right_align', 'highlight_negative'],
         ],
       },
     ],

--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -106,31 +106,29 @@ function tableVis(slice, payload) {
     .append('td')
     .style('background-image', function (d) {
       if (d.isMetric) {
-        const r_val = (fd.highlight_negative) ? 100 : 0;
+        const rVal = (fd.highlight_negative) ? 100 : 0;
+        const r = (d.val > 0) ? 0 : rVal;
         if (fd.right_align) {
           const perc = Math.abs(Math.round((d.val / maxes[d.col]) * 100));
-          const r = (d.val > 0) ? 0 : r_val;
           // The 0.01 to 0.001 is a workaround for what appears to be a
           // CSS rendering bug on flat, transparent colors
           return (
             `linear-gradient(to left, rgba(${r},0,0,0.2), rgba(${r},0,0,0.2) ${perc}%, ` +
             `rgba(0,0,0,0.01) ${perc}%, rgba(0,0,0,0.001) 100%)`
           );
-        } else {
-          const pos_ext = Math.abs(Math.max(maxes[d.col], 0));
-          const neg_ext = Math.abs(Math.min(mins[d.col], 0));
-          const tot = pos_ext + neg_ext;
-          const perc1 = Math.round((Math.min(neg_ext + d.val, neg_ext) / tot) * 100);
-          const perc2 = Math.round((Math.abs(d.val) / tot) * 100);
-          const r = (d.val > 0) ? 0 : r_val;
-          // The 0.01 to 0.001 is a workaround for what appears to be a
-          // CSS rendering bug on flat, transparent colors
-          return (
-            `linear-gradient(to right, rgba(0,0,0,0.01), rgba(0,0,0,0.001) ${perc1}%, ` +
-            `rgba(${r},0,0,0.2) ${perc1}%, rgba(${r},0,0,0.2) ${perc1 + perc2}%, ` +
-            `rgba(0,0,0,0.01) ${perc1 + perc2}%, rgba(0,0,0,0.001) 100%)`
-          );
         }
+        const posExtent = Math.abs(Math.max(maxes[d.col], 0));
+        const negExtent = Math.abs(Math.min(mins[d.col], 0));
+        const tot = posExtent + negExtent;
+        const perc1 = Math.round((Math.min(negExtent + d.val, negExtent) / tot) * 100);
+        const perc2 = Math.round((Math.abs(d.val) / tot) * 100);
+        // The 0.01 to 0.001 is a workaround for what appears to be a
+        // CSS rendering bug on flat, transparent colors
+        return (
+          `linear-gradient(to right, rgba(0,0,0,0.01), rgba(0,0,0,0.001) ${perc1}%, ` +
+          `rgba(${r},0,0,0.2) ${perc1}%, rgba(${r},0,0,0.2) ${perc1 + perc2}%, ` +
+          `rgba(0,0,0,0.01) ${perc1 + perc2}%, rgba(0,0,0,0.001) 100%)`
+        );
       }
       return null;
     })

--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -31,7 +31,11 @@ function tableVis(slice, payload) {
   }
   const maxes = {};
   for (let i = 0; i < metrics.length; i += 1) {
-    maxes[metrics[i]] = d3.max(col(metrics[i]));
+    if (fd.visualize_negative_values) {
+      maxes[metrics[i]] = d3.max(col(metrics[i]).map(Math.abs));
+    } else {
+      maxes[metrics[i]] = d3.max(col(metrics[i]));
+    }
   }
 
   const tsFormatter = d3TimeFormatPreset(fd.table_timestamp_format);
@@ -100,11 +104,16 @@ function tableVis(slice, payload) {
     .append('td')
     .style('background-image', function (d) {
       if (d.isMetric) {
-        const perc = Math.round((d.val / maxes[d.col]) * 100);
+        let perc = Math.round((d.val / maxes[d.col]) * 100);
+        let r = 0;
+        if (fd.visualize_negative_values && perc < 0) {
+          r = 100;
+          perc = Math.abs(perc);
+        }
         // The 0.01 to 0.001 is a workaround for what appears to be a
         // CSS rendering bug on flat, transparent colors
         return (
-          `linear-gradient(to left, rgba(0,0,0,0.2), rgba(0,0,0,0.2) ${perc}%, ` +
+          `linear-gradient(to left, rgba(${r},0,0,0.2), rgba(${r},0,0,0.2) ${perc}%, ` +
           `rgba(0,0,0,0.01) ${perc}%, rgba(0,0,0,0.001) 100%)`
         );
       }

--- a/superset/assets/visualizations/table.js
+++ b/superset/assets/visualizations/table.js
@@ -32,7 +32,7 @@ function tableVis(slice, payload) {
   const maxes = {};
   const mins = {};
   for (let i = 0; i < metrics.length; i += 1) {
-    if (fd.right_align) {
+    if (fd.align_pn) {
       maxes[metrics[i]] = d3.max(col(metrics[i]).map(Math.abs));
     } else {
       maxes[metrics[i]] = d3.max(col(metrics[i]));
@@ -106,14 +106,13 @@ function tableVis(slice, payload) {
     .append('td')
     .style('background-image', function (d) {
       if (d.isMetric) {
-        const rVal = (fd.highlight_negative) ? 100 : 0;
-        const r = (d.val > 0) ? 0 : rVal;
-        if (fd.right_align) {
+        const r = (fd.color_pn && d.val < 0) ? 150 : 0;
+        if (fd.align_pn) {
           const perc = Math.abs(Math.round((d.val / maxes[d.col]) * 100));
           // The 0.01 to 0.001 is a workaround for what appears to be a
           // CSS rendering bug on flat, transparent colors
           return (
-            `linear-gradient(to left, rgba(${r},0,0,0.2), rgba(${r},0,0,0.2) ${perc}%, ` +
+            `linear-gradient(to right, rgba(${r},0,0,0.2), rgba(${r},0,0,0.2) ${perc}%, ` +
             `rgba(0,0,0,0.01) ${perc}%, rgba(0,0,0,0.001) 100%)`
           );
         }


### PR DESCRIPTION
Resolving #4495 

Currently, rows with negative values will not show background bars.

The PR adds a new option "Visualize Negative Values" which will show red tinted bars signifying negative values. This will make it useful for situations where negative values are also important (i.e. A/B testing result).

The direction of the bars for positive and negative values are the same since it'll be less cluttered and we can compare the magnitudes easily.

Passes `run_tests.sh` and `npm run test`

@michellethomas @williaster @GabeLoins @mistercrunch 

![screen shot 2018-03-07 at 2 29 18 pm](https://user-images.githubusercontent.com/729913/37122917-35e9a392-2217-11e8-9f34-8ad98d42aada.png)

![screen shot 2018-03-07 at 2 29 43 pm](https://user-images.githubusercontent.com/729913/37122977-642b7c76-2217-11e8-824f-46161354b592.png)

![screen shot 2018-03-07 at 2 29 53 pm](https://user-images.githubusercontent.com/729913/37122982-679e165c-2217-11e8-88ba-815bf668c56d.png)
