### PR TITLE
[cache] Ensuring that the datasource UID is defined

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -276,9 +276,10 @@ class BaseViz(object):
         for k in ['from_dttm', 'to_dttm']:
             del cache_dict[k]
 
-        for k in ['since', 'until', 'datasource']:
+        for k in ['since', 'until']:
             cache_dict[k] = self.form_data.get(k)
 
+        cache_dict['datasource'] = self.datasource.uid
         json_data = self.json_dumps(cache_dict, sort_keys=True)
         return hashlib.md5(json_data.encode('utf-8')).hexdigest()
 


### PR DESCRIPTION
@mistercrunch whist testing in production we noticed that we were getting cache key misses as it turned out the form data from the `warm_up_cache` API endpoint lacked the datasource value which is defined as the UID. 