### PR TITLE
[Explore] Save custom url parameters when user save slices

### DIFF
--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -293,6 +293,13 @@ ExploreViewContainer.propTypes = propTypes;
 
 function mapStateToProps({ explore, charts, impressionId }) {
   const form_data = getFormDataFromControls(explore.controls);
+  // fill in additional params stored in form_data but not used by control
+  Object.keys(explore.rawFormData)
+    .forEach((key) => {
+      if (form_data[key] === undefined) {
+        form_data[key] = explore.rawFormData[key];
+      }
+    });
   const chartKey = Object.keys(charts)[0];
   const chart = charts[chartKey];
   return {

--- a/superset/assets/javascripts/explore/index.jsx
+++ b/superset/assets/javascripts/explore/index.jsx
@@ -25,6 +25,7 @@ initJQueryAjax();
 const exploreViewContainer = document.getElementById('app');
 const bootstrapData = JSON.parse(exploreViewContainer.getAttribute('data-bootstrap'));
 const controls = getControlsState(bootstrapData, bootstrapData.form_data);
+const rawFormData = { ...bootstrapData.form_data };
 delete bootstrapData.form_data;
 delete bootstrapData.common.locale;
 delete bootstrapData.common.language_pack;
@@ -32,6 +33,7 @@ delete bootstrapData.common.language_pack;
 // Initial state
 const bootstrappedState = Object.assign(
   bootstrapData, {
+    rawFormData,
     controls,
     filterColumnOpts: [],
     isDatasourceMetaLoading: false,

--- a/superset/assets/javascripts/explore/stores/store.js
+++ b/superset/assets/javascripts/explore/stores/store.js
@@ -109,6 +109,13 @@ export function applyDefaultFormData(form_data) {
       formData[k] = form_data[k];
     }
   });
+  // fill in additional params stored in form_data but not used by control
+  Object.keys(form_data)
+    .forEach((key) => {
+      if (formData[key] === undefined) {
+        formData[key] = form_data[key];
+      }
+    });
   return formData;
 }
 

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -38,8 +38,6 @@ def url_param(param, default=None):
     :param default: the value to return in the absence of the parameter
     :type default: str
     """
-    print('request args', request.args)
-    print('request form', request.form)
     if request.args.get(param):
         return request.args.get(param, default)
     # Supporting POST as well as get

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -43,7 +43,8 @@ def url_param(param, default=None):
     # Supporting POST as well as get
     if request.form.get('form_data'):
         form_data = json.loads(request.form.get('form_data'))
-        return form_data.get(param, default)
+        url_params = form_data['url_params'] or {}
+        return url_params.get(param, default)
     return default
 
 

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 from datetime import datetime, timedelta
 import inspect
+import json
 import random
 import time
 import uuid
@@ -30,15 +31,22 @@ BASE_CONTEXT.update(config.get('JINJA_CONTEXT_ADDONS', {}))
 
 
 def url_param(param, default=None):
-    """Get a url paramater
+    """Get a url or post data parameter
 
-    :param param: the url parameter to lookup
+    :param param: the parameter to lookup
     :type param: str
     :param default: the value to return in the absence of the parameter
     :type default: str
     """
-    print(request.args)
-    return request.args.get(param, default)
+    print('request args', request.args)
+    print('request form', request.form)
+    if request.args.get(param):
+        return request.args.get(param, default)
+    # Supporting POST as well as get
+    if request.form.get('form_data'):
+        form_data = json.loads(request.form.get('form_data'))
+        return form_data.get(param, default)
+    return default
 
 
 def current_user_id():

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -835,6 +835,13 @@ def merge_extra_filters(form_data):
         del form_data['extra_filters']
 
 
+def merge_request_params(form_data, params):
+    for key, value in params.items():
+        if key == 'form_data':
+            continue
+        form_data[key] = value
+
+
 def get_update_perms_flag():
     val = os.environ.get('SUPERSET_UPDATE_PERMS')
     return val.lower() not in ('0', 'false', 'no') if val else True

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -836,10 +836,12 @@ def merge_extra_filters(form_data):
 
 
 def merge_request_params(form_data, params):
+    url_params = {}
     for key, value in params.items():
-        if key == 'form_data':
+        if key in ('form_data', 'r'):
             continue
-        form_data[key] = value
+        url_params[key] = value
+    form_data['url_params'] = url_params
 
 
 def get_update_perms_flag():

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -43,7 +43,9 @@ from superset.legacy import cast_form_data
 import superset.models.core as models
 from superset.models.sql_lab import Query
 from superset.sql_parse import SupersetQuery
-from superset.utils import has_access, merge_extra_filters, QueryStatus
+from superset.utils import (
+    has_access, merge_extra_filters, merge_request_params, QueryStatus,
+)
 from .base import (
     api, BaseSupersetView, CsvResponse, DeleteMixin,
     generate_download_headers, get_error_msg, get_user_roles,
@@ -1257,11 +1259,7 @@ class Superset(BaseSupersetView):
 
         # merge request url params
         if request.method == 'GET':
-            url_params = request.args
-            for key, value in url_params.items():
-                if key == 'form_data':
-                    continue
-                form_data[key] = value
+            merge_request_params(form_data, request.args)
 
         # handle save or overwrite
         action = request.args.get('action')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1255,6 +1255,14 @@ class Superset(BaseSupersetView):
         # On explore, merge extra filters into the form data
         merge_extra_filters(form_data)
 
+        # merge request url params
+        if request.method == 'GET':
+            url_params = request.args
+            for key, value in url_params.items():
+                if key == 'form_data':
+                    continue
+                form_data[key] = value
+
         # handle save or overwrite
         action = request.args.get('action')
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -227,7 +227,8 @@ class UtilsTestCase(unittest.TestCase):
             'dashboard_ids': '(1,2,3,4,5)',
         }
         merge_request_params(form_data, url_params)
-        self.assertIn('dashboard_ids', form_data.keys())
+        self.assertIn('url_params', form_data.keys())
+        self.assertIn('dashboard_ids', form_data['url_params'])
         self.assertNotIn('form_data', form_data.keys())
 
     def test_datetime_f(self):

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -14,7 +14,8 @@ import numpy
 
 from superset.utils import (
     base_json_conv, datetime_f, json_int_dttm_ser, json_iso_dttm_ser,
-    JSONEncodedDict, memoized, merge_extra_filters, parse_human_timedelta,
+    JSONEncodedDict, memoized, merge_extra_filters, merge_request_params,
+    parse_human_timedelta,
     SupersetException, validate_json, zlib_compress, zlib_decompress_to_string,
 )
 
@@ -215,6 +216,19 @@ class UtilsTestCase(unittest.TestCase):
         ]}
         merge_extra_filters(form_data)
         self.assertEquals(form_data, expected)
+
+    def test_merge_request_params(self):
+        form_data = {
+            'since': '2000',
+            'until': 'now',
+        }
+        url_params = {
+            'form_data': form_data,
+            'dashboard_ids': '(1,2,3,4,5)',
+        }
+        merge_request_params(form_data, url_params)
+        self.assertIn('dashboard_ids', form_data.keys())
+        self.assertNotIn('form_data', form_data.keys())
 
     def test_datetime_f(self):
         self.assertEquals(


### PR DESCRIPTION
fix #4439

- when user passed custom parameters in /explore/ request, i wrap these request parameters into `url_params` inside form_data. So that request parameters become part of query state.

- when user save slice, i will save this form_data as slice parameter, so that query state is persistence.
- I also update jinja helper function url_param to read `url_params` from post form as well as other request parameters.

