### PR TITLE
Removing [dashboard] and [slice] titles to show name

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1299,7 +1299,7 @@ class Superset(BaseSupersetView):
         if slc:
             title = slc.slice_name
         else:
-            title = '[explore] ' + table_name
+            title = 'Explore - ' + table_name
         return self.render_template(
             'superset/basic.html',
             bootstrap_data=json.dumps(bootstrap_data),

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1297,7 +1297,7 @@ class Superset(BaseSupersetView):
             if datasource_type == 'table' \
             else datasource.datasource_name
         if slc:
-            title = '[slice] ' + slc.slice_name
+            title = slc.slice_name
         else:
             title = '[explore] ' + table_name
         return self.render_template(
@@ -2064,7 +2064,7 @@ class Superset(BaseSupersetView):
             'superset/dashboard.html',
             entry='dashboard',
             standalone_mode=standalone_mode,
-            title='[dashboard] ' + dash.dashboard_title,
+            title=dash.dashboard_title,
             bootstrap_data=json.dumps(bootstrap_data),
         )
 


### PR DESCRIPTION
Showing [dashboard] and [slice] hide the name of the dashboard or slice in the tab. Anyone object to removing these labels?

@john-bodley @graceguo-supercat @mistercrunch 