### PR TITLE
[Bug Fix] Making timeseries_limit not required for phase 2

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1066,10 +1066,7 @@ class DruidDatasource(Model, BaseDatasource):
         if not is_timeseries:
             granularity = 'all'
 
-        if (
-                granularity == 'all' or
-                timeseries_limit is None or
-                timeseries_limit == 0):
+        if granularity == 'all':
             phase = 1
         inner_from_dttm = inner_from_dttm or from_dttm
         inner_to_dttm = inner_to_dttm or to_dttm
@@ -1148,7 +1145,8 @@ class DruidDatasource(Model, BaseDatasource):
 
             client.topn(**pre_qry)
             logging.info('Phase 1 Complete')
-            query_str += '// Two phase query\n// Phase 1\n'
+            if phase == 2:
+                query_str += '// Two phase query\n// Phase 1\n'
             query_str += json.dumps(
                 client.query_builder.last_query.query_dict, indent=2)
             query_str += '\n'


### PR DESCRIPTION
We have an issue on time series group by queries, if the chart doesn't have a limit, the data is incorrect. It gets run as a phase 1 query and shows only a single datapoint for each group by value instead of listing the full timeseries data.

It looks like this was added [here](https://github.com/apache/incubator-superset/pull/4032/files#diff-a8dd5ec8d8decda2e3c5571d1ec0cdb6R1032), but I don't think queries without a limit should automatically be phase 1. I changed this but I'm not quite sure why it was added, is this needed for deckgl viz types?

I tested this on time series phase 2 queries and phase 1 without a limit, and tested bar and pie chart visualizations. 

Fixes #4208 

@mistercrunch @john-bodley 