### PR TITLE
[sql lab] comment injection hook

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -382,9 +382,10 @@ ENABLE_JAVASCRIPT_CONTROLS = False
 # arbitrary logic. For instance you can wire different users to
 # use different connection parameters, or pass their email address as the
 # username. The function receives the connection uri object, connection
-# params, and user object, and returns the mutated uri and params objects.
+# params, the username, and returns the mutated uri and params objects.
 # Example:
-#   def DB_CONNECTION_MUTATOR(uri, params, user):
+#   def DB_CONNECTION_MUTATOR(uri, params, username, security_manager):
+#       user = security_manager.find_user(username=username)
 #       if user and user.email:
 #           uri.username = user.email
 #       return uri, params
@@ -392,6 +393,15 @@ ENABLE_JAVASCRIPT_CONTROLS = False
 # Note that the returned uri and params are passed directly to sqlalchemy's
 # as such `create_engine(url, **params)`
 DB_CONNECTION_MUTATOR = None
+
+# A function that intercepts the SQL to be executed and can alter it.
+# The use case is can be around adding some sort of comment header
+# with information such as the username and worker node information
+#
+#    def SQL_QUERY_MUTATOR(sql, username, security_manager):
+#        dttm = datetime.now().isoformat()
+#        return "-- [SQL LAB] {username} {dttm}\n sql"(**locals())
+SQL_QUERY_MUTATOR = None
 
 try:
     if CONFIG_PATH_ENV_VAR in os.environ:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -677,7 +677,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
         DB_CONNECTION_MUTATOR = config.get('DB_CONNECTION_MUTATOR')
         if DB_CONNECTION_MUTATOR:
-            url, params = DB_CONNECTION_MUTATOR(url, params, g.user)
+            url, params = DB_CONNECTION_MUTATOR(url, params, user_name, sm)
         return create_engine(url, **params)
 
     def get_reserved_words(self):

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -17,7 +17,7 @@ import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
-from superset import app, dataframe, db, results_backend, utils
+from superset import app, dataframe, db, results_backend, sm, utils
 from superset.db_engine_specs import LimitMethod
 from superset.jinja_context import get_template_processor
 from superset.models.sql_lab import Query
@@ -193,6 +193,11 @@ def execute_sql(
         logging.exception(e)
         msg = 'Template rendering failed: ' + utils.error_msg_from_exception(e)
         return handle_error(msg)
+
+    # Hook to allow environment-specific mutation (usually comments) to the SQL
+    SQL_QUERY_MUTATOR = config.get('SQL_QUERY_MUTATOR')
+    if SQL_QUERY_MUTATOR:
+        executed_sql = SQL_QUERY_MUTATOR(executed_sql, user_name, sm, database)
 
     query.executed_sql = executed_sql
     query.status = QueryStatus.RUNNING


### PR DESCRIPTION
This will allow us at Lyft to add a comment header that adds metadata to the query to the SQL sent to databases for audit/debug purpose. 

Also altering the logic of `DB_CONNECTION_MUTATOR` to receive the username instead of the user b object, which is out of scope on the worker when running in async mode.