### PR TITLE
[logs] Dropping dt column

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -6,3 +6,4 @@ assists people when migrating to a new version.
 ## Superset 0.23.0
 
 * [4565](https://github.com/apache/incubator-superset/pull/4565)
+* [4587](https://github.com/apache/incubator-superset/pull/4587)

--- a/superset/migrations/versions/30bb17c0dc76_.py
+++ b/superset/migrations/versions/30bb17c0dc76_.py
@@ -1,0 +1,26 @@
+"""empty message
+
+Revision ID: 30bb17c0dc76
+Revises: f231d82b9b26
+Create Date: 2018-04-08 07:34:12.149910
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '30bb17c0dc76'
+down_revision = 'f231d82b9b26'
+
+from datetime import date
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('logs') as batch_op:
+        batch_op.drop_column('dt')
+
+
+def downgrade():
+    with op.batch_alter_table('logs') as batch_op:
+        batch_op.add_column(sa.Column('dt', sa.Date,  default=date.today()))

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from copy import copy, deepcopy
-from datetime import date, datetime
+from datetime import datetime
 import functools
 import json
 import logging
@@ -20,7 +20,7 @@ import numpy
 import pandas as pd
 import sqlalchemy as sqla
 from sqlalchemy import (
-    Boolean, Column, create_engine, Date, DateTime, ForeignKey, Integer,
+    Boolean, Column, create_engine, DateTime, ForeignKey, Integer,
     MetaData, select, String, Table, Text,
 )
 from sqlalchemy.engine import url
@@ -865,7 +865,6 @@ class Log(Model):
     user = relationship(
         security_manager.user_model, backref='logs', foreign_keys=[user_id])
     dttm = Column(DateTime, default=datetime.utcnow)
-    dt = Column(Date, default=date.today())
     duration_ms = Column(Integer)
     referrer = Column(String(1024))
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1474,24 +1474,6 @@ class Superset(BaseSupersetView):
 
     @api
     @has_access_api
-    @expose('/activity_per_day')
-    def activity_per_day(self):
-        """endpoint to power the calendar heatmap on the welcome page"""
-        Log = models.Log  # noqa
-        qry = (
-            db.session
-            .query(
-                Log.dt,
-                sqla.func.count())
-            .group_by(Log.dt)
-            .all()
-        )
-        payload = {str(time.mktime(dt.timetuple())):
-                   ccount for dt, ccount in qry if dt}
-        return json_success(json.dumps(payload))
-
-    @api
-    @has_access_api
     @expose('/schemas/<db_id>/')
     def schemas(self, db_id):
         db_id = int(db_id)

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -254,7 +254,6 @@ class SupersetTestCase(unittest.TestCase):
 
         self.assertIn(('can_add_slices', 'Superset'), gamma_perm_set)
         self.assertIn(('can_copy_dash', 'Superset'), gamma_perm_set)
-        self.assertIn(('can_activity_per_day', 'Superset'), gamma_perm_set)
         self.assertIn(('can_created_dashboards', 'Superset'), gamma_perm_set)
         self.assertIn(('can_created_slices', 'Superset'), gamma_perm_set)
         self.assertIn(('can_csv', 'Superset'), gamma_perm_set)

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -55,7 +55,6 @@ class RolePermissionTests(SupersetTestCase):
 
         self.assertIn(('can_add_slices', 'Superset'), perm_set)
         self.assertIn(('can_copy_dash', 'Superset'), perm_set)
-        self.assertIn(('can_activity_per_day', 'Superset'), perm_set)
         self.assertIn(('can_created_dashboards', 'Superset'), perm_set)
         self.assertIn(('can_created_slices', 'Superset'), perm_set)
         self.assertIn(('can_csv', 'Superset'), perm_set)


### PR DESCRIPTION
Whist looking through the Superset `logs` table I discovered that there was a misalignment of the date defined in the `dt` column vs `dttm`.

The reason for the inconsistency is `dttm` is defined in reference to the UTC timezone whereas `dt` use the date in reference to one's local timezone. One possible fix is
 
    dt = Column(Date, default=ddatetime.utcnow().date())

however given that `dt` and `dttm` aren't using the same now instance, there's still no guarantee there will be consistency between these columns especially around 12:00:00 am UTC. 

The fix here is simply to remove the `dt` column which is unnecessary as this information is completely defined by the `dttm` column. Note I also removed the deprecated `activity_per_day` which used the `Log.dt` column which is no longer used in the code.

Additionally tested by running: 

    superset db upgrade
    superset db downgrade

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 