### PR TITLE
[Bug Fix] Removing escape_sql so we dont double escape

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -432,8 +432,6 @@ class SqlaTable(Model, BaseDatasource):
             from_sql = self.sql
             if template_processor:
                 from_sql = template_processor.process_template(from_sql)
-            if db_engine_spec:
-                from_sql = db_engine_spec.escape_sql(from_sql)
             from_sql = sqlparse.format(from_sql, strip_comments=True)
             return TextAsFrom(sa.text(from_sql), []).alias('expr_qry')
         return self.get_sqla_table()

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -146,11 +146,6 @@ class BaseEngineSpec(object):
         BaseEngineSpec.df_to_db(**df_to_db_kwargs)
 
     @classmethod
-    def escape_sql(cls, sql):
-        """Escapes the raw SQL"""
-        return sql
-
-    @classmethod
     def convert_dttm(cls, target_type, dttm):
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
@@ -551,10 +546,6 @@ class PrestoEngineSpec(BaseEngineSpec):
                 database += '/' + selected_schema
             uri.database = database
         return uri
-
-    @classmethod
-    def escape_sql(cls, sql):
-        return re.sub(r'%%|%', '%%', sql)
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):


### PR DESCRIPTION
@john-bodley Removing escape_sql because this seems to be handled by `qry.compile(engine)` [here](https://github.com/apache/incubator-superset/blob/master/superset/connectors/sqla/models.py#L411) and both of them escaping double escapes.