### PR TITLE
Only show overlay if container is set

### DIFF
--- a/superset/assets/javascripts/chart/Chart.jsx
+++ b/superset/assets/javascripts/chart/Chart.jsx
@@ -223,6 +223,7 @@ class Chart extends React.PureComponent {
           !this.props.chartAlert &&
           this.props.refreshOverlayVisible &&
           !this.props.errorMessage &&
+          this.container &&
           <RefreshChartOverlay
             height={this.height()}
             width={this.width()}

--- a/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
@@ -44,7 +44,6 @@ class ExploreChartPanel extends React.PureComponent {
         datasource={this.props.datasource}
         formData={this.props.form_data}
         height={this.getHeight()}
-        width={parseInt(this.props.width, 10)}
         slice={this.props.slice}
         chartKey={this.props.chart.chartKey}
         setControlValue={this.props.actions.setControlValue}

--- a/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreChartPanel.jsx
@@ -44,6 +44,7 @@ class ExploreChartPanel extends React.PureComponent {
         datasource={this.props.datasource}
         formData={this.props.form_data}
         height={this.getHeight()}
+        width={parseInt(this.props.width, 10)}
         slice={this.props.slice}
         chartKey={this.props.chart.chartKey}
         setControlValue={this.props.actions.setControlValue}


### PR DESCRIPTION
When switching viz types, the overlay `refreshOverlayVisible` is called before the container ref is set, causing an error because it can't determine the width. I added a check before showing the overlay, and now it works correctly:

![switch2](https://user-images.githubusercontent.com/1534870/37308101-2f36351a-25fa-11e8-8fe9-3534313b1309.gif)
