### PR TITLE
[flask-appbuilder] Bumping version to 1.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'colorama==0.3.9',
         'cryptography==1.9',
         'flask==0.12.2',
-        'flask-appbuilder==1.9.6',
+        'flask-appbuilder==1.10.0',
         'flask-cache==0.13.1',
         'flask-migrate==2.1.1',
         'flask-script==2.0.6',


### PR DESCRIPTION
This PR bumps the `Flask-AppBuilder` package to version [1.10.0](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/docs/versions.rst#improvements-and-bug-fixes-on-1100) which includes a fix to ensure that associations are unique. 