### PR TITLE
[slice_json] pass slice id to get_form_data()

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -998,6 +998,7 @@ class Superset(BaseSupersetView):
         # the form_data from the DB with the other form_data provided
         slice_id = form_data.get('slice_id') or slice_id
         slc = None
+
         if slice_id:
             slc = db.session.query(models.Slice).filter_by(id=slice_id).first()
             slice_form_data = slc.form_data.copy()
@@ -1122,10 +1123,10 @@ class Superset(BaseSupersetView):
     @expose('/slice_json/<slice_id>')
     def slice_json(self, slice_id):
         try:
-            viz_obj = self.get_viz(slice_id)
-            datasource_type = viz_obj.datasource.type
-            datasource_id = viz_obj.datasource.id
-            form_data, slc = self.get_form_data()
+            form_data, slc = self.get_form_data(slice_id)
+            datasource_type = slc.datasource.type
+            datasource_id = slc.datasource.id
+
         except Exception as e:
             return json_error_response(
                 utils.error_msg_from_exception(e),


### PR DESCRIPTION
@mistercrunch @graceguo-supercat @fabianmenges 

[This line](https://github.com/apache/incubator-superset/commit/83524f97d7fcf3c8c86efd25f6e5f76fda1b48f5#diff-ac978615a4f22c4fad4d01f39e1d4595R1091) of #4490 broke all non-formula type annotations as it didn't pass the `slice_id` through to `get_form_data()`

before:
![image](https://user-images.githubusercontent.com/4496521/37363428-27c771d4-26b5-11e8-99bc-8464a3b1b83d.png)

after:
![image](https://user-images.githubusercontent.com/4496521/37363370-00526b54-26b5-11e8-9c83-26b355421a1f.png)
