### PR TITLE
[Explore] overriding Annotations and Layers' control tab

### DIFF
--- a/superset/assets/javascripts/explore/components/ControlPanelsContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ControlPanelsContainer.jsx
@@ -92,8 +92,13 @@ class ControlPanelsContainer extends React.Component {
     const displaySectionsToRender = [];
     allSectionsToRender.forEach((section) => {
       if (section.controlSetRows.some(rows => rows.some(
-        control => controls[control] && !controls[control].renderTrigger,
-      ))) {
+        control => (
+          controls[control] &&
+          (
+            !controls[control].renderTrigger ||
+            controls[control].tabOverride === 'data'
+          )
+        )))) {
         querySectionsToRender.push(section);
       } else {
         displaySectionsToRender.push(section);

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1702,6 +1702,7 @@ export const controls = {
     default: [],
     description: 'Annotation Layers',
     renderTrigger: true,
+    tabOverride: 'data',
   },
 
   having_filters: {


### PR DESCRIPTION
as reported by @williaster- the annotations and layers control should live in the Data tab and not the Style tab, despite its renderTrigger value. Added this override in.

test plan:
- visit line chart page
- expect to see annotations and layers control in the data tab

Reviewers:
@michellethomas 
@williaster
@graceguo-supercat 

cc
@mistercrunch 