### PR TITLE
[Explore] removing refresh chart overlay on deck_gl charts

### DIFF
--- a/superset/assets/javascripts/chart/Chart.jsx
+++ b/superset/assets/javascripts/chart/Chart.jsx
@@ -223,6 +223,7 @@ class Chart extends React.PureComponent {
           !this.props.chartAlert &&
           this.props.refreshOverlayVisible &&
           !this.props.errorMessage &&
+          !this.props.vizType.startsWith('deck_') &&
           <RefreshChartOverlay
             height={this.height()}
             width={this.width()}


### PR DESCRIPTION
Deck gl charts have this weird thing where scrolling the canvas isn't considered `renderTrigger: true` but also immediately updates the state of the chart. This scrolled state also does not persist across refreshes.

I'm not sure what the long term solution here is, but for the short term I'm disabling the refresh chart overlay for deckgl graphs.

test plan:
- scroll on a deck gl chart
- verify the state is updated and a refresh chart overlay does not appear

reviewers:
@john-bodley @michellethomas @mistercrunch 