### PR TITLE
Fix multi layer

### DIFF
--- a/superset/assets/visualizations/deckgl/multi.jsx
+++ b/superset/assets/visualizations/deckgl/multi.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import $ from 'jquery';
 
 import DeckGLContainer from './DeckGLContainer';
-import { getExploreUrl } from '../../javascripts/explore/exploreUtils';
+import { getExploreLongUrl } from '../../javascripts/explore/exploreUtils';
 import layerGenerators from './layers';
 
 
@@ -47,7 +47,7 @@ function deckMulti(slice, payload, setControlValue) {
       },
     };
 
-    const url = getExploreUrl(subsliceCopy.form_data, 'json');
+    const url = getExploreLongUrl(subsliceCopy.form_data, 'json');
     $.get(url, (data) => {
       // Late import to avoid circular deps
       const layer = layerGenerators[subsliceCopy.form_data.viz_type](subsliceCopy.form_data, data);


### PR DESCRIPTION
Deck.gl multi layer was using an old function name — `getExploreUrl` instead of `getExploreLongUrl`.