### PR TITLE
[Mapbox] fix mapbox viz

### DIFF
--- a/superset/assets/visualizations/mapbox.jsx
+++ b/superset/assets/visualizations/mapbox.jsx
@@ -65,7 +65,7 @@ class ScatterPlotGlowOverlay extends React.Component {
     const canvas = this.refs.overlay;
     const ctx = canvas.getContext('2d');
     const radius = props.dotRadius;
-    const mercator = ViewportMercator(props);
+    const mercator = new ViewportMercator(props);
     const rgb = props.rgb;
     const clusterLabelMap = [];
     let maxLabel = -1;
@@ -264,7 +264,7 @@ class MapboxViz extends React.Component {
   }
 
   render() {
-    const mercator = ViewportMercator({
+    const mercator = new ViewportMercator({
       width: this.props.sliceWidth,
       height: this.props.sliceHeight,
       longitude: this.state.viewport.longitude,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27990562/37488700-b46dcedc-2852-11e8-9c40-314822cd1c04.png)


it needs `new` to call ViewportMercator constructor. otherwise it will throw `Cannot call a class as a function` error.


@michellethomas @williaster @mistercrunch 