### PR TITLE
[Bug Fix] Fix sqllab numpy array

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -97,7 +97,7 @@ def convert_results_to_df(cursor_description, data):
     if data:
         first_row = data[0]
         has_dict_col = any([isinstance(c, dict) for c in first_row])
-        df_data = list(data) if has_dict_col else np.array(data)
+        df_data = list(data) if has_dict_col else np.array(data, dtype=object)
     else:
         df_data = []
 

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -210,6 +210,14 @@ class SqlLabTests(SupersetTestCase):
         self.assertEquals(len(data), cdf.size)
         self.assertEquals(len(cols), len(cdf.columns))
 
+    def test_df_conversion_tuple(self):
+        cols = [['string_col'], ['int_col'], ['list_col'], ['float_col']]
+        data = [(u'Text', 111, [123], 1.0)]
+        cdf = convert_results_to_df(cols, data)
+
+        self.assertEquals(len(data), cdf.size)
+        self.assertEquals(len(cols), len(cdf.columns))
+
     def test_df_conversion_dict(self):
         cols = [['string_col'], ['dict_col'], ['int_col']]
         data = [['a', {'c1': 1, 'c2': 2, 'c3': 3}, 4]]

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -203,8 +203,8 @@ class SqlLabTests(SupersetTestCase):
             raise_on_error=True)
 
     def test_df_conversion_no_dict(self):
-        cols = [['string_col'], ['int_col']]
-        data = [['a', 4]]
+        cols = [['string_col'], ['int_col'], ['float_col']]
+        data = [['a', 4, 4.0]]
         cdf = convert_results_to_df(cols, data)
 
         self.assertEquals(len(data), cdf.size)


### PR DESCRIPTION
We've been seeing some sqllab errors where results can't correctly be converted to a numpy array. [This answer](https://stackoverflow.com/questions/21803256/error-setting-an-array-element-with-a-sequence-python-numpy) says that we can set `dtype=object` to allow numpy to hold anything.

Added additional test that would error without this fix. 

@john-bodley 