### PR TITLE
Fix flower broker configuration

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -309,10 +309,18 @@ def flower(port, address):
 
     Celery Flower is a UI to monitor the Celery operation on a given
     broker"""
-    BROKER_URL = celery_app.conf.BROKER_URL
+    if not celery_app.conf.BROKER_URL:
+        print(
+            Fore.YELLOW +
+            'No Celery broker found in your superset configuration.\n'
+            'Please provide a CELERY_CONFIG setting, including a BROKER_URL.\n'
+            'Not starting Celery Flower.' +
+            Style.RESET_ALL,
+        )
+        return
     cmd = (
         'celery flower '
-        '--broker={BROKER_URL} '
+        '-A superset.cli.celery_app '
         '--port={port} '
         '--address={address} '
     ).format(**locals())


### PR DESCRIPTION
In case the celery broker is configured with transport options, these options would not be passed into flower with a --broker parameter.

A clear example is that, when launched with `superset flower`, the `superset.sql_lab.get_sql_results` task was not reported by flower on startup:

```
2018-03-16 16:57:37,208:INFO:flower.command:Registered tasks: 
['celery.accumulate',
 'celery.backend_cleanup',
 'celery.chain',
 'celery.chord',
 'celery.chord_unlock',
 'celery.chunks',
 'celery.group',
 'celery.map',
 'celery.starmap']
```

More importantly, flower could outright fail to work if a broker with less usual options was configured by superset, since these options were not passed at all into flower.