### PR TITLE
Cache the query string

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -315,9 +315,11 @@ class BaseViz(object):
                 try:
                     cache_value = pkl.loads(cache_value)
                     df = cache_value['df']
-                    is_loaded = True
-                    self._any_cache_key = cache_key
+                    self.query = cache_value['query']
                     self._any_cached_dttm = cache_value['dttm']
+                    self._any_cache_key = cache_key
+                    self.status = utils.QueryStatus.SUCCESS
+                    is_loaded = True
                 except Exception as e:
                     logging.exception(e)
                     logging.error('Error reading cache: ' +
@@ -346,6 +348,7 @@ class BaseViz(object):
                     cache_value = dict(
                         dttm=cached_dttm,
                         df=df if df is not None else None,
+                        query=self.query,
                     )
                     cache_value = pkl.dumps(
                         cache_value, protocol=pkl.HIGHEST_PROTOCOL)

--- a/tests/cache_tests.py
+++ b/tests/cache_tests.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for Superset with caching"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import json
 
 from superset import cache, db, utils

--- a/tests/cache_tests.py
+++ b/tests/cache_tests.py
@@ -1,0 +1,34 @@
+import json
+
+from superset import cache, db, utils
+from .base_tests import SupersetTestCase
+
+
+class CacheTests(SupersetTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(CacheTests, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_cache_value(self):
+        self.login(username='admin')
+        slc = self.get_slice('Girls', db.session)
+
+        json_endpoint = (
+            '/superset/explore_json/{}/{}/'
+            .format(slc.datasource_type, slc.datasource_id)
+        )
+        resp = self.get_json_resp(
+            json_endpoint, {'form_data': json.dumps(slc.viz.form_data)})
+        resp_from_cache = self.get_json_resp(
+            json_endpoint, {'form_data': json.dumps(slc.viz.form_data)})
+        self.assertFalse(resp['is_cached'])
+        self.assertTrue(resp_from_cache['is_cached'])
+        self.assertEqual(resp_from_cache['status'], utils.QueryStatus.SUCCESS)
+        self.assertEqual(resp['data'], resp_from_cache['data'])
+        self.assertEqual(resp['query'], resp_from_cache['query'])

--- a/tests/superset_test_config.py
+++ b/tests/superset_test_config.py
@@ -23,6 +23,7 @@ PUBLIC_ROLE_LIKE_GAMMA = True
 AUTH_ROLE_PUBLIC = 'Public'
 EMAIL_NOTIFICATIONS = False
 
+CACHE_CONFIG = {'CACHE_TYPE': 'simple'}
 
 class CeleryConfig(object):
     BROKER_URL = 'redis://localhost'


### PR DESCRIPTION
Only the underlying dataframe was being cached, which caused issues in other parts of the application that expect a query string or other information. For example, the `DisplayQueryButton` takes in the query response as a parameter, and if no query string is provided in the query response, it sends a request to fetch the query string, which in some cases (druid), runs the query again. This would happen any time a chart was generated from cached data.

I also returned the query status in the cached response, as I felt that it made sense to do so.

@fabianmenges @GeorgeSirois