### PR TITLE
forms: make csv import parse dates accepts a list of columns

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -339,7 +339,6 @@ class CsvToDatabaseView(SimpleFormView):
         form.mangle_dupe_cols.data = True
         form.skipinitialspace.data = False
         form.skip_blank_lines.data = True
-        form.parse_dates.data = True
         form.infer_datetime_format.data = True
         form.decimal.data = '.'
         form.if_exists.data = 'append'

--- a/tests/form_tests.py
+++ b/tests/form_tests.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from tests.base_tests import SupersetTestCase
+from wtforms.form import Form
+
+from superset.forms import (
+    CommaSeparatedListField, filter_not_empty_values)
+
+
+class FormTestCase(SupersetTestCase):
+
+    def test_comma_separated_list_field(self):
+        field = CommaSeparatedListField().bind(Form(), 'foo')
+        field.process_formdata([u''])
+        self.assertEqual(field.data, [u''])
+
+        field.process_formdata(['a,comma,separated,list'])
+        self.assertEqual(field.data, [u'a', u'comma', u'separated', u'list'])
+
+    def test_filter_not_empty_values(self):
+        self.assertEqual(filter_not_empty_values(None), None)
+        self.assertEqual(filter_not_empty_values([]), None)
+        self.assertEqual(filter_not_empty_values(['']), None)
+        self.assertEqual(filter_not_empty_values(['hi']), ['hi'])


### PR DESCRIPTION
Instead of a boolean which has way less chances to work. While
at it add a proper label for the "con" field.

Fixes #4637

cc @timifasubaa 