### PR TITLE
Added option to add fill to area line charts

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -376,6 +376,14 @@ export const controls = {
     description: null,
   },
 
+  line_fill_area: {
+    type: 'CheckboxControl',
+    label: t('Fill Area of Line Chart'),
+    renderTrigger: true,
+    default: false,
+    description: null,
+  },
+
   pivot_margins: {
     type: 'CheckboxControl',
     label: t('Show totals'),

--- a/superset/assets/javascripts/explore/stores/visTypes.js
+++ b/superset/assets/javascripts/explore/stores/visTypes.js
@@ -187,6 +187,7 @@ export const visTypes = {
           ['y_axis_label', 'left_margin'],
           ['y_axis_showminmax', 'y_log_scale'],
           ['y_axis_format', 'y_axis_bounds'],
+          ['line_fill_area', null],
         ],
       },
       sections.NVD3TimeSeries[1],

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -75,6 +75,10 @@ function hideTooltips() {
   $('.nvtooltip').css({ opacity: 0 });
 }
 
+function setLineChartOpacity() {
+  $('.nvd3 .nv-group path.nv-area').css({ opacity: 0.1 });
+}
+
 function getMaxLabelSize(container, axisClass) {
   // axis class = .nv-y2  // second y axis on dual line chart
   // axis class = .nv-x  // x axis on time series line chart
@@ -179,6 +183,7 @@ function nvd3Vis(slice, payload) {
             ...d,
             area: true,
           }));
+
           chart.forceY([0]);
         }
 
@@ -478,6 +483,10 @@ function nvd3Vis(slice, payload) {
       .style('fill-opacity', 1);
     }
 
+    if (fd.line_fill_area) {
+      setLineChartOpacity();
+    }
+
     if (chart.yAxis !== undefined || chart.yAxis2 !== undefined) {
       // Hack to adjust y axis left margin to accommodate long numbers
       const containerWidth = slice.container.width();
@@ -663,7 +672,6 @@ function nvd3Vis(slice, payload) {
               const domain = [xMin, xMax];
               xScale.domain(domain);
               chart.xDomain(domain);
-
               annotations.selectAll('line')
                 .data(records)
                 .enter()

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -75,9 +75,6 @@ function hideTooltips() {
   $('.nvtooltip').css({ opacity: 0 });
 }
 
-function setLineChartOpacity() {
-  $('.nvd3 .nv-group path.nv-area').css({ opacity: 0.1 });
-}
 
 function getMaxLabelSize(container, axisClass) {
   // axis class = .nv-y2  // second y axis on dual line chart
@@ -483,10 +480,6 @@ function nvd3Vis(slice, payload) {
       .style('stroke-opacity', 1)
       .style('fill-opacity', 1);
     }
-
-    // if (fd.line_fill_area) {
-    //   setLineChartOpacity();
-    // }
 
     if (chart.yAxis !== undefined || chart.yAxis2 !== undefined) {
       // Hack to adjust y axis left margin to accommodate long numbers

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -182,6 +182,7 @@ function nvd3Vis(slice, payload) {
           data = data.map(d => ({
             ...d,
             area: true,
+            fillOpacity: 0.1,
           }));
 
           chart.forceY([0]);
@@ -483,9 +484,9 @@ function nvd3Vis(slice, payload) {
       .style('fill-opacity', 1);
     }
 
-    if (fd.line_fill_area) {
-      setLineChartOpacity();
-    }
+    // if (fd.line_fill_area) {
+    //   setLineChartOpacity();
+    // }
 
     if (chart.yAxis !== undefined || chart.yAxis2 !== undefined) {
       // Hack to adjust y axis left margin to accommodate long numbers

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -173,6 +173,14 @@ function nvd3Vis(slice, payload) {
         } else {
           chart = nv.models.lineChart();
         }
+
+        if (fd.line_fill_area) {
+          data = data.map(d => ({
+            ...d,
+            area: true,
+          }));
+        }
+
         // To alter the tooltip header
         // chart.interactiveLayer.tooltip.headerFormatter(function(){return '';});
         chart.xScale(d3.time.scale.utc());

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -179,6 +179,7 @@ function nvd3Vis(slice, payload) {
             ...d,
             area: true,
           }));
+          chart.forceY([0]);
         }
 
         // To alter the tooltip header


### PR DESCRIPTION
Allow line charts to have area filled for overlay visualization

![line_area](https://user-images.githubusercontent.com/27827808/37585165-5eae8b1a-2b15-11e8-85e4-70e0200313b2.gif)

@betodealmeida @mistercrunch 
