### PR TITLE
[BugFix] Allowing limit ordering by post-aggregation metrics

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1146,7 +1146,7 @@ class DruidDatasource(Model, BaseDatasource):
             pre_qry = deepcopy(qry)
             if timeseries_limit_metric:
                 order_by = timeseries_limit_metric
-                aggs_dict, adhoc_dict, post_aggs_dict = DruidDatasource.metrics_and_post_aggs(
+                aggs_dict, adhoc_dict, post_aggs_dict = self.metrics_and_post_aggs(
                     [timeseries_limit_metric],
                     metrics_dict)
                 if phase == 1:
@@ -1204,7 +1204,7 @@ class DruidDatasource(Model, BaseDatasource):
 
                 if timeseries_limit_metric:
                     order_by = timeseries_limit_metric
-                    aggs_dict, adhoc_dict, post_aggs_dict = DruidDatasource.metrics_and_post_aggs(
+                    aggs_dict, adhoc_dict, post_aggs_dict = self.metrics_and_post_aggs(
                         [timeseries_limit_metric],
                         metrics_dict)
                     if phase == 1:

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -894,7 +894,7 @@ class DruidDatasource(Model, BaseDatasource):
         post_aggs[postagg.metric_name] = DruidDatasource.get_post_agg(postagg.json_obj)
 
     @staticmethod
-    def aggs_and_post_aggs(metrics, metrics_dict):
+    def metrics_and_post_aggs(metrics, metrics_dict):
         # Separate metrics into those that are aggregations
         # and those that are post aggregations
         saved_agg_names = set()
@@ -1091,7 +1091,7 @@ class DruidDatasource(Model, BaseDatasource):
         metrics_dict = {m.metric_name: m for m in self.metrics}
         columns_dict = {c.column_name: c for c in self.columns}
 
-        aggregations, adhoc_metrics, post_aggs = DruidDatasource.aggs_and_post_aggs(
+        aggregations, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics,
             metrics_dict)
 
@@ -1146,7 +1146,7 @@ class DruidDatasource(Model, BaseDatasource):
             pre_qry = deepcopy(qry)
             if timeseries_limit_metric:
                 order_by = timeseries_limit_metric
-                aggs_dict, post_aggs_dict = DruidDatasource.aggs_and_post_aggs(
+                aggs_dict, adhoc_dict, post_aggs_dict = DruidDatasource.metrics_and_post_aggs(
                     [timeseries_limit_metric],
                     metrics_dict)
                 pre_qry['aggregations'] = aggs_dict

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1149,8 +1149,8 @@ class DruidDatasource(Model, BaseDatasource):
                 aggs_dict, adhoc_dict, post_aggs_dict = DruidDatasource.metrics_and_post_aggs(
                     [timeseries_limit_metric],
                     metrics_dict)
-                pre_qry['aggregations'] = aggs_dict
-                pre_qry['post_aggregations'] = post_aggs_dict
+                pre_qry['aggregations'].update(aggs_dict)
+                pre_qry['post_aggregations'].update(post_aggs_dict)
             else:
                 order_by = list(qry['aggregations'].keys())[0]
             # Limit on the number of timeseries, doing a two-phases query

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -596,7 +596,7 @@ class DruidFuncTestCase(unittest.TestCase):
         saved_metrics, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
 
-        assert saved_metrics == ['some_sum']
+        assert set(saved_metrics.keys()) == {'some_sum'}
         assert adhoc_metrics == []
         assert post_aggs == {}
 
@@ -604,7 +604,7 @@ class DruidFuncTestCase(unittest.TestCase):
         saved_metrics, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
 
-        assert saved_metrics == []
+        assert set(saved_metrics.keys()) == set([])
         assert adhoc_metrics == [adhoc_metric]
         assert post_aggs == {}
 
@@ -612,7 +612,7 @@ class DruidFuncTestCase(unittest.TestCase):
         saved_metrics, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
 
-        assert saved_metrics == ['some_sum']
+        assert set(saved_metrics.keys()) == {'some_sum'}
         assert adhoc_metrics == [adhoc_metric]
         assert post_aggs == {}
 
@@ -621,7 +621,7 @@ class DruidFuncTestCase(unittest.TestCase):
             metrics, metrics_dict)
 
         result_postaggs = set(['quantile_p95'])
-        assert saved_metrics == ['a_histogram']
+        assert set(saved_metrics.keys()) == {'a_histogram'}
         assert adhoc_metrics == []
         assert set(post_aggs.keys()) == result_postaggs
 
@@ -630,7 +630,7 @@ class DruidFuncTestCase(unittest.TestCase):
             metrics, metrics_dict)
 
         result_postaggs = set(['aCustomPostAgg'])
-        assert saved_metrics == ['aCustomMetric']
+        assert set(saved_metrics.keys()) == {'aCustomMetric'}
         assert adhoc_metrics == []
         assert set(post_aggs.keys()) == result_postaggs
 

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -513,7 +513,7 @@ class DruidFuncTestCase(unittest.TestCase):
         depends_on('I', ['H', 'K'])
         depends_on('J', 'K')
         depends_on('K', ['m8', 'm9'])
-        aggs, saved_metrics, postaggs = DruidDatasource.metrics_and_post_aggs(
+        aggs, postaggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
         expected_metrics = set(aggs.keys())
         self.assertEqual(9, len(aggs))
@@ -594,45 +594,40 @@ class DruidFuncTestCase(unittest.TestCase):
         }
 
         metrics = ['some_sum']
-        saved_metrics, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
+        saved_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
 
         assert set(saved_metrics.keys()) == {'some_sum'}
-        assert adhoc_metrics == []
         assert post_aggs == {}
 
         metrics = [adhoc_metric]
-        saved_metrics, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
+        saved_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
 
-        assert set(saved_metrics.keys()) == set([])
-        assert adhoc_metrics == [adhoc_metric]
+        assert set(saved_metrics.keys()) == set([adhoc_metric['label']])
         assert post_aggs == {}
 
         metrics = ['some_sum', adhoc_metric]
-        saved_metrics, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
+        saved_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
 
-        assert set(saved_metrics.keys()) == {'some_sum'}
-        assert adhoc_metrics == [adhoc_metric]
+        assert set(saved_metrics.keys()) == {'some_sum', adhoc_metric['label']}
         assert post_aggs == {}
 
         metrics = ['quantile_p95']
-        saved_metrics, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
+        saved_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
 
         result_postaggs = set(['quantile_p95'])
         assert set(saved_metrics.keys()) == {'a_histogram'}
-        assert adhoc_metrics == []
         assert set(post_aggs.keys()) == result_postaggs
 
         metrics = ['aCustomPostAgg']
-        saved_metrics, adhoc_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
+        saved_metrics, post_aggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
 
         result_postaggs = set(['aCustomPostAgg'])
         assert set(saved_metrics.keys()) == {'aCustomMetric'}
-        assert adhoc_metrics == []
         assert set(post_aggs.keys()) == result_postaggs
 
     def test_druid_type_from_adhoc_metric(self):

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -157,9 +157,9 @@ class DruidFuncTestCase(unittest.TestCase):
         col1 = DruidColumn(column_name='col1')
         col2 = DruidColumn(column_name='col2')
         ds.columns = [col1, col2]
-        all_metrics = []
+        aggs = []
         post_aggs = ['some_agg']
-        ds._metrics_and_post_aggs = Mock(return_value=(all_metrics, post_aggs))
+        ds._metrics_and_post_aggs = Mock(return_value=(aggs, post_aggs))
         groupby = []
         metrics = ['metric1']
         ds.get_having_filters = Mock(return_value=[])
@@ -242,9 +242,9 @@ class DruidFuncTestCase(unittest.TestCase):
         col1 = DruidColumn(column_name='col1')
         col2 = DruidColumn(column_name='col2')
         ds.columns = [col1, col2]
-        all_metrics = ['metric1']
+        aggs = ['metric1']
         post_aggs = ['some_agg']
-        ds._metrics_and_post_aggs = Mock(return_value=(all_metrics, post_aggs))
+        ds._metrics_and_post_aggs = Mock(return_value=(aggs, post_aggs))
         groupby = ['col1']
         metrics = ['metric1']
         ds.get_having_filters = Mock(return_value=[])
@@ -316,9 +316,9 @@ class DruidFuncTestCase(unittest.TestCase):
         col1 = DruidColumn(column_name='col1')
         col2 = DruidColumn(column_name='col2')
         ds.columns = [col1, col2]
-        all_metrics = []
+        aggs = []
         post_aggs = ['some_agg']
-        ds._metrics_and_post_aggs = Mock(return_value=(all_metrics, post_aggs))
+        ds._metrics_and_post_aggs = Mock(return_value=(aggs, post_aggs))
         groupby = ['col1', 'col2']
         metrics = ['metric1']
         ds.get_having_filters = Mock(return_value=[])
@@ -512,10 +512,10 @@ class DruidFuncTestCase(unittest.TestCase):
         depends_on('I', ['H', 'K'])
         depends_on('J', 'K')
         depends_on('K', ['m8', 'm9'])
-        all_metrics, saved_metrics, postaggs = DruidDatasource.metrics_and_post_aggs(
+        aggs, saved_metrics, postaggs = DruidDatasource.metrics_and_post_aggs(
             metrics, metrics_dict)
-        expected_metrics = set(all_metrics)
-        self.assertEqual(9, len(all_metrics))
+        expected_metrics = set(aggs.keys())
+        self.assertEqual(9, len(aggs))
         for i in range(1, 10):
             expected_metrics.remove('m' + str(i))
         self.assertEqual(0, len(expected_metrics))

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -706,8 +706,8 @@ class DruidFuncTestCase(unittest.TestCase):
                             'type': 'fieldAccess',
                         },
                     ],
-                })
-            )
+                }),
+            ),
         }
         ds.columns = [dim1, dim2]
         ds.metrics = list(metrics_dict.values())
@@ -726,8 +726,8 @@ class DruidFuncTestCase(unittest.TestCase):
         self.assertEqual('sum1', qry_obj['metric'])
         aggregations = qry_obj['aggregations']
         post_aggregations = qry_obj['post_aggregations']
-        self.assertItemsEqual(['count1', 'sum1'], list(aggregations.keys()))
-        self.assertItemsEqual([], list(post_aggregations.keys()))
+        self.assertEqual(set(['count1', 'sum1']), set(aggregations.keys()))
+        self.assertEqual(set([]), set(post_aggregations.keys()))
 
         # get the counts of the top 5 'dim1's, order by 'div1'
         ds.run_query(
@@ -740,8 +740,8 @@ class DruidFuncTestCase(unittest.TestCase):
         self.assertEqual('div1', qry_obj['metric'])
         aggregations = qry_obj['aggregations']
         post_aggregations = qry_obj['post_aggregations']
-        self.assertItemsEqual(['count1', 'sum1', 'sum2'], list(aggregations.keys()))
-        self.assertItemsEqual(['div1'], list(post_aggregations.keys()))
+        self.assertEqual(set(['count1', 'sum1', 'sum2']), set(aggregations.keys()))
+        self.assertEqual(set(['div1']), set(post_aggregations.keys()))
 
         groupby = ['dim1', 'dim2']
         # get the counts of the top 5 ['dim1', 'dim2']s, order by 'sum1'
@@ -751,12 +751,12 @@ class DruidFuncTestCase(unittest.TestCase):
             client=client, order_desc=True, filter=[],
         )
         qry_obj = client.groupby.call_args_list[0][1]
-        self.assertItemsEqual(['dim1', 'dim2'], qry_obj['dimensions'])
+        self.assertEqual(set(['dim1', 'dim2']), set(qry_obj['dimensions']))
         self.assertEqual('sum1', qry_obj['limit_spec']['columns'][0]['dimension'])
         aggregations = qry_obj['aggregations']
         post_aggregations = qry_obj['post_aggregations']
-        self.assertItemsEqual(['count1', 'sum1'], list(aggregations.keys()))
-        self.assertItemsEqual([], list(post_aggregations.keys()))
+        self.assertEqual(set(['count1', 'sum1']), set(aggregations.keys()))
+        self.assertEqual(set([]), set(post_aggregations.keys()))
 
         # get the counts of the top 5 ['dim1', 'dim2']s, order by 'div1'
         ds.run_query(
@@ -765,9 +765,9 @@ class DruidFuncTestCase(unittest.TestCase):
             client=client, order_desc=True, filter=[],
         )
         qry_obj = client.groupby.call_args_list[1][1]
-        self.assertItemsEqual(['dim1', 'dim2'], qry_obj['dimensions'])
+        self.assertEqual(set(['dim1', 'dim2']), set(qry_obj['dimensions']))
         self.assertEqual('div1', qry_obj['limit_spec']['columns'][0]['dimension'])
         aggregations = qry_obj['aggregations']
         post_aggregations = qry_obj['post_aggregations']
-        self.assertItemsEqual(['count1', 'sum1', 'sum2'], list(aggregations.keys()))
-        self.assertItemsEqual(['div1'], list(post_aggregations.keys()))
+        self.assertEqual(set(['count1', 'sum1', 'sum2']), set(aggregations.keys()))
+        self.assertEqual(set(['div1']), set(post_aggregations.keys()))


### PR DESCRIPTION
This is an extension of this fix https://github.com/apache/incubator-superset/pull/4203 to account for post-aggregation metrics as well. I also did a bit of refactoring to make it clear that aggregations and post-aggregations are different things.

The old fix replaced the existing fields of the query, which caused issues for single phase queries that select multiple metrics, or metrics that are not the `timeseries_limit_metric`. I instead updated the existing fields for single-phase queries, and left replacement for two-phase queries.

@fabianmenges @georgesirois