### PR TITLE
Pass timezone to Druid Query granularity

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1072,7 +1072,7 @@ class DruidDatasource(Model, BaseDatasource):
         inner_from_dttm = inner_from_dttm or from_dttm
         inner_to_dttm = inner_to_dttm or to_dttm
 
-        timezone = from_dttm.tzname() if from_dttm else None
+        timezone = from_dttm.replace(tzinfo=DRUID_TZ).tzname() if from_dttm else None
 
         query_str = ''
         metrics_dict = {m.metric_name: m for m in self.metrics}


### PR DESCRIPTION
superset appends DRUID_TZ info to intervals but not to granularity which causes one day's data return as 2 days. This fix is also pass DRUID_TZ to granularity.