### PR TITLE
Expose metrics to JS

### DIFF
--- a/superset/assets/javascripts/modules/sandbox.js
+++ b/superset/assets/javascripts/modules/sandbox.js
@@ -22,6 +22,10 @@ export default function sandboxedEval(code, context, opts) {
   Object.keys(sandboxContext).forEach(function (key) {
     sandbox[key] = sandboxContext[key];
   });
-  vm.runInNewContext(codeToEval, sandbox, opts);
-  return sandbox[resultKey];
+  try {
+    vm.runInNewContext(codeToEval, sandbox, opts);
+    return sandbox[resultKey];
+  } catch (error) {
+    return () => error;
+  }
 }

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2037,6 +2037,7 @@ class DeckScatterViz(BaseDeckGLViz):
 
     def get_properties(self, d):
         return {
+            'metric': d.get(self.metric),
             'radius': self.fixed_value if self.fixed_value else d.get(self.metric),
             'cat_color': d.get(self.dim) if self.dim else None,
             'position': d.get('spatial'),


### PR DESCRIPTION
@vylc requested the ability of exposing the metrics to the JS advanced tooltip:

<img width="1680" alt="screen shot 2018-03-20 at 2 59 37 pm" src="https://user-images.githubusercontent.com/1534870/37685172-b4537a04-2c4f-11e8-9e3e-37259ab4db5e.png">

I also added a `try/except` block around the sandbox eval, so that the query still runs when the JS is broken, and the exception is shown:

<img width="1680" alt="screen shot 2018-03-20 at 3 03 19 pm" src="https://user-images.githubusercontent.com/1534870/37685215-dbc1ed3c-2c4f-11e8-925d-ed59ec60c645.png">
