### PR TITLE
[druid] Updating refresh logic

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -166,10 +166,9 @@ def load_examples(load_test_data):
 )
 @manager.option(
     '-m', '--merge',
-    help=(
-        "Specify using 'merge' property during operation. "
-        'Default value is False '
-    ),
+    action='store_true',
+    help="Specify using 'merge' property during operation.",
+    default=False,
 )
 def refresh_druid(datasource, merge):
     """Refresh druid datasources"""

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -91,7 +91,7 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
                     .format(dimension_spec['outputName'], col.column_name))
 
     def post_update(self, col):
-        col.generate_metrics()
+        col.refresh_metrics()
 
     def post_add(self, col):
         self.post_update(col)
@@ -277,7 +277,7 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin
                     datasource.full_name))
 
     def post_add(self, datasource):
-        datasource.generate_metrics()
+        datasource.refresh_metrics()
         security.merge_perm(sm, 'datasource_access', datasource.get_perm())
         if datasource.schema:
             security.merge_perm(sm, 'schema_access', datasource.schema_perm)

--- a/superset/migrations/versions/f231d82b9b26_.py
+++ b/superset/migrations/versions/f231d82b9b26_.py
@@ -1,0 +1,72 @@
+"""empty message
+
+Revision ID: f231d82b9b26
+Revises: e68c4473c581
+Create Date: 2018-03-20 19:47:54.991259
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f231d82b9b26'
+down_revision = 'e68c4473c581'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.exc import OperationalError
+
+from superset.utils import generic_find_uq_constraint_name
+
+conv = {
+    'uq': 'uq_%(table_name)s_%(column_0_name)s',
+}
+
+names = {
+    'columns': 'column_name',
+    'metrics': 'metric_name',
+}
+
+bind = op.get_bind()
+insp = sa.engine.reflection.Inspector.from_engine(bind)
+
+
+def upgrade():
+
+    # Reduce the size of the metric_name column for constraint viability.
+    with op.batch_alter_table('metrics', naming_convention=conv) as batch_op:
+        batch_op.alter_column(
+            'metric_name',
+            existing_type=sa.String(length=512),
+            type_=sa.String(length=255),
+            existing_nullable=True,
+        )
+
+    # Add the missing uniqueness constraints.
+    for table, column in names.items():
+        with op.batch_alter_table(table, naming_convention=conv) as batch_op:
+            batch_op.create_unique_constraint(
+                'uq_{}_{}'.format(table, column),
+                [column, 'datasource_id'],
+            )
+
+def downgrade():
+
+    # Restore the size of the metric_name column.
+    with op.batch_alter_table('metrics', naming_convention=conv) as batch_op:
+        batch_op.alter_column(
+            'metric_name',
+            existing_type=sa.String(length=255),
+            type_=sa.String(length=512),
+            existing_nullable=True,
+        )
+
+    # Remove the previous missing uniqueness constraints.
+    for table, column in names.items():
+        with op.batch_alter_table(table, naming_convention=conv) as batch_op:
+            batch_op.drop_constraint(
+                    generic_find_uq_constraint_name(
+                        table,
+                        {column, 'datasource_id'},
+                        insp,
+                    ) or 'uq_{}_{}'.format(table, column),
+                    type_='unique',
+                )


### PR DESCRIPTION
Though the term "refresh" is somewhat vague from a Druid metadata perspective I sense this translates to create or update. Previously we were creating or updates Druid columns but only creating Druid metrics when the Druid metadata was synced/refreshed. 

This PR ensures that refreshing is consistent for both Druid columns and metrics and specifically addresses the following:
1. Removes redundancy by only controlling metric specifications within the `DruidMetric` class. Previously there was somewhat duplicate logic for both the `DruidColumn` and `DruidMetric` class.
2. Renames `generate_metrics` with `refresh_metrics` to imply that we're both creating and updating.
3. Updates the SQL filters to use `IN` rather than a series of `OR`s. 
4. Added metric creation for float types. 
5. Adds the missing migration for creating Druid uniqueness constraints to the `columns` and `metrics` tables which were added in https://github.com/apache/incubator-superset/pull/3978. Note to avoid [this](https://dba.stackexchange.com/questions/76567/how-to-resolve-specified-key-was-too-long-max-key-length-is-767-bytes) MySQL issue the `metric_name` column was reduced from 512 to 255 characters.
6. Corrects the `--merge` options for the `refresh_druid` command, which should be a flag (true/false) rather than an option.
7. Note I didn't want to change the structure of `get_metrics` in terms of checking whether said metric already exists to ensure consistency with SQLA, hence why the merging logic is handled in `refresh_metrics`.

@fabianmenges I only added the missing Druid migrations however I believe there are additional migrations from your PR (https://github.com/apache/incubator-superset/pull/3978) which are missing for the following tables:
- `table_columns`
- `tables`

to: @mistercrunch @Mogball 