### PR TITLE
Better default for MAPBOX_API_KEY

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -246,7 +246,7 @@ INTERVAL = 1
 BACKUP_COUNT = 30
 
 # Set this API key to enable Mapbox visualizations
-MAPBOX_API_KEY = ''
+MAPBOX_API_KEY = os.environ.get('MAPBOX_API_KEY', '')
 
 # Maximum number of rows returned in the SQL editor
 SQL_MAX_ROW = 1000000


### PR DESCRIPTION
Every time I'm working on geospatial visualization I need to add my Mapbox key to `config.py` in order to test my changes, and then remove it from the commit. I changed the default to read from the environment.