### PR TITLE
Remove redundant has_access definition in superset

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -11,6 +11,7 @@ import logging
 from flask import flash, Markup, redirect
 from flask_appbuilder import CompactCRUDMixin, expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
+from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
 
@@ -300,7 +301,7 @@ appbuilder.add_view(
 class Druid(BaseSupersetView):
     """The base views for Superset!"""
 
-    @sm.has_method_access
+    @has_access
     @expose('/refresh_datasources/')
     def refresh_datasources(self, refreshAll=True):
         """endpoint that refreshes druid datasources metadata"""
@@ -325,7 +326,7 @@ class Druid(BaseSupersetView):
         session.commit()
         return redirect('/druiddatasourcemodelview/list/')
 
-    @sm.has_method_access
+    @has_access
     @expose('/scan_new_datasources/')
     def scan_new_datasources(self):
         """

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -17,7 +17,6 @@ from flask_babel import lazy_gettext as _
 from superset import appbuilder, db, security_manager, utils
 from superset.connectors.base.views import DatasourceModelView
 from superset.connectors.connector_registry import ConnectorRegistry
-from superset.utils import has_access
 from superset.views.base import (
     BaseSupersetView, DatasourceFilter, DeleteMixin,
     get_datasource_exist_error_mgs, ListWidgetWithCheckboxes, SupersetModelView,
@@ -301,7 +300,7 @@ appbuilder.add_view(
 class Druid(BaseSupersetView):
     """The base views for Superset!"""
 
-    @has_access
+    @sm.has_method_access
     @expose('/refresh_datasources/')
     def refresh_datasources(self, refreshAll=True):
         """endpoint that refreshes druid datasources metadata"""
@@ -326,7 +325,7 @@ class Druid(BaseSupersetView):
         session.commit()
         return redirect('/druiddatasourcemodelview/list/')
 
-    @has_access
+    @sm.has_method_access
     @expose('/scan_new_datasources/')
     def scan_new_datasources(self):
         """

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -9,6 +9,7 @@ from flask import flash, Markup, redirect
 from flask_appbuilder import CompactCRUDMixin, expose
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.interface import SQLAInterface
+from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
 from past.builtins import basestring
@@ -270,7 +271,7 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
         DeleteMixin._delete(self, pk)
 
     @expose('/edit/<pk>', methods=['GET', 'POST'])
-    @sm.has_method_access
+    @has_access
     def edit(self, pk):
         """Simple hack to redirect to explore view after saving"""
         resp = super(TableModelView, self).edit(pk)

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -15,7 +15,6 @@ from past.builtins import basestring
 
 from superset import appbuilder, db, security_manager, utils
 from superset.connectors.base.views import DatasourceModelView
-from superset.utils import has_access
 from superset.views.base import (
     DatasourceFilter, DeleteMixin, get_datasource_exist_error_mgs,
     ListWidgetWithCheckboxes, SupersetModelView, YamlExportMixin,
@@ -271,7 +270,7 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
         DeleteMixin._delete(self, pk)
 
     @expose('/edit/<pk>', methods=['GET', 'POST'])
-    @has_access
+    @sm.has_method_access
     def edit(self, pk):
         """Simple hack to redirect to explore view after saving"""
         resp = super(TableModelView, self).edit(pk)

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -25,13 +25,7 @@ import zlib
 import bleach
 import celery
 from dateutil.parser import parse
-from flask import flash, Markup, redirect, render_template, request, url_for
-from flask_appbuilder._compat import as_unicode
-from flask_appbuilder.const import (
-    FLAMSG_ERR_SEC_ACCESS_DENIED,
-    LOGMSG_ERR_SEC_ACCESS_DENIED,
-    PERMISSION_PREFIX,
-)
+from flask import flash, Markup, render_template
 from flask_babel import gettext as __
 from flask_cache import Cache
 import markdown as md
@@ -651,42 +645,6 @@ def get_email_address_list(address_string):
         else:
             address_string = [address_string]
     return address_string
-
-
-def has_access(f):
-    """
-        Use this decorator to enable granular security permissions to your
-        methods. Permissions will be associated to a role, and roles are
-        associated to users.
-
-        By default the permission's name is the methods name.
-
-        Forked from the flask_appbuilder.security.decorators
-        TODO(bkyryliuk): contribute it back to FAB
-    """
-    if hasattr(f, '_permission_name'):
-        permission_str = f._permission_name
-    else:
-        permission_str = f.__name__
-
-    def wraps(self, *args, **kwargs):
-        permission_str = PERMISSION_PREFIX + f._permission_name
-        if self.appbuilder.sm.has_access(permission_str,
-                                         self.__class__.__name__):
-            return f(self, *args, **kwargs)
-        else:
-            logging.warning(
-                LOGMSG_ERR_SEC_ACCESS_DENIED.format(permission_str,
-                                                    self.__class__.__name__))
-            flash(as_unicode(FLAMSG_ERR_SEC_ACCESS_DENIED), 'danger')
-        # adds next arg to forward to the original path once user is logged in.
-        return redirect(
-            url_for(
-                self.appbuilder.sm.auth_view.__class__.__name__ + '.login',
-                next=request.full_path))
-
-    f._permission_name = permission_str
-    return functools.update_wrapper(wraps, f)
 
 
 def choicify(values):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -19,7 +19,7 @@ from flask import (
 from flask_appbuilder import expose, SimpleFormView
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_appbuilder.security.decorators import has_access_api
+from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
 import pandas as pd
@@ -475,7 +475,7 @@ class SliceModelView(SupersetModelView, DeleteMixin):  # noqa
         check_ownership(obj)
 
     @expose('/add', methods=['GET', 'POST'])
-    @sm.has_method_access
+    @has_access
     def add(self):
         datasources = ConnectorRegistry.get_all_datasources(db.session)
         datasources = [
@@ -828,7 +828,7 @@ class Superset(BaseSupersetView):
         }, status=201)
 
     @log_this
-    @sm.has_method_access
+    @has_access
     @expose('/request_access/')
     def request_access(self):
         datasources = set()
@@ -851,12 +851,12 @@ class Superset(BaseSupersetView):
             )
             datasources.add(datasource)
 
-        sm.has_method_access = all(
+        has_access = all(
             (
                 datasource and security_manager.datasource_access(datasource)
                 for datasource in datasources
             ))
-        if sm.has_method_access:
+        if has_access:
             return redirect('/superset/dashboard/{}'.format(dashboard_id))
 
         if request.args.get('action') == 'go':
@@ -876,7 +876,7 @@ class Superset(BaseSupersetView):
         )
 
     @log_this
-    @sm.has_method_access
+    @has_access
     @expose('/approve')
     def approve(self):
         def clean_fulfilled_requests(session):
@@ -1032,7 +1032,7 @@ class Superset(BaseSupersetView):
             )
             return viz_obj
 
-    @sm.has_method_access
+    @has_access
     @expose('/slice/<slice_id>/')
     def slice(self, slice_id):
         form_data, slc = self.get_form_data(slice_id)
@@ -1183,7 +1183,7 @@ class Superset(BaseSupersetView):
                                   force=force)
 
     @log_this
-    @sm.has_method_access
+    @has_access
     @expose('/import_dashboards', methods=['GET', 'POST'])
     def import_dashboards(self):
         """Overrides the dashboards using json instances from the file."""
@@ -1203,7 +1203,7 @@ class Superset(BaseSupersetView):
         return self.render_template('superset/import_dashboards.html')
 
     @log_this
-    @sm.has_method_access
+    @has_access
     @expose('/explorev2/<datasource_type>/<datasource_id>/')
     def explorev2(self, datasource_type, datasource_id):
         """Deprecated endpoint, here for backward compatibility of urls"""
@@ -1227,7 +1227,7 @@ class Superset(BaseSupersetView):
         return datasource_id, datasource_type
 
     @log_this
-    @sm.has_method_access
+    @has_access
     @expose('/explore/<datasource_type>/<datasource_id>/', methods=['GET', 'POST'])
     @expose('/explore/', methods=['GET', 'POST'])
     def explore(self, datasource_type=None, datasource_id=None):
@@ -2021,7 +2021,7 @@ class Superset(BaseSupersetView):
         session.commit()
         return json_success(json.dumps({'count': count}))
 
-    @sm.has_method_access
+    @has_access
     @expose('/dashboard/<dashboard_id>/')
     def dashboard(self, dashboard_id):
         """Server side rendering for a dashboard"""
@@ -2092,7 +2092,7 @@ class Superset(BaseSupersetView):
     def log(self):
         return Response(status=200)
 
-    @sm.has_method_access
+    @has_access
     @expose('/sync_druid/', methods=['POST'])
     @log_this
     def sync_druid_source(self):
@@ -2144,7 +2144,7 @@ class Superset(BaseSupersetView):
             return json_error_response(utils.error_msg_from_exception(e))
         return Response(status=201)
 
-    @sm.has_method_access
+    @has_access
     @expose('/sqllab_viz/', methods=['POST'])
     @log_this
     def sqllab_viz(self):
@@ -2205,7 +2205,7 @@ class Superset(BaseSupersetView):
             'table_id': table.id,
         }))
 
-    @sm.has_method_access
+    @has_access
     @expose('/table/<database_id>/<table_name>/<schema>/')
     @log_this
     def table(self, database_id, table_name, schema):
@@ -2262,7 +2262,7 @@ class Superset(BaseSupersetView):
         }
         return json_success(json.dumps(tbl))
 
-    @sm.has_method_access
+    @has_access
     @expose('/extra_table_metadata/<database_id>/<table_name>/<schema>/')
     @log_this
     def extra_table_metadata(self, database_id, table_name, schema):
@@ -2272,7 +2272,7 @@ class Superset(BaseSupersetView):
             mydb, table_name, schema)
         return json_success(json.dumps(payload))
 
-    @sm.has_method_access
+    @has_access
     @expose('/select_star/<database_id>/<table_name>/')
     @log_this
     def select_star(self, database_id, table_name):
@@ -2458,7 +2458,7 @@ class Superset(BaseSupersetView):
             return json_error_response(payload=data)
         return json_success(payload)
 
-    @sm.has_method_access
+    @has_access
     @expose('/csv/<client_id>')
     @log_this
     def csv(self, client_id):
@@ -2501,7 +2501,7 @@ class Superset(BaseSupersetView):
         logging.info('Ready to return response')
         return response
 
-    @sm.has_method_access
+    @has_access
     @expose('/fetch_datasource_metadata')
     @log_this
     def fetch_datasource_metadata(self):
@@ -2544,7 +2544,7 @@ class Superset(BaseSupersetView):
         return json_success(
             json.dumps(dict_queries, default=utils.json_int_dttm_ser))
 
-    @sm.has_method_access
+    @has_access
     @expose('/search_queries')
     @log_this
     def search_queries(self):
@@ -2620,7 +2620,7 @@ class Superset(BaseSupersetView):
             bootstrap_data=json.dumps(payload, default=utils.json_iso_dttm_ser),
         )
 
-    @sm.has_method_access
+    @has_access
     @expose('/profile/<username>/')
     def profile(self, username):
         """User profile page"""
@@ -2639,7 +2639,7 @@ class Superset(BaseSupersetView):
             bootstrap_data=json.dumps(payload, default=utils.json_iso_dttm_ser),
         )
 
-    @sm.has_method_access
+    @has_access
     @expose('/sqllab')
     def sqllab(self):
         """SQL Editor"""

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -45,7 +45,7 @@ import superset.models.core as models
 from superset.models.sql_lab import Query
 from superset.sql_parse import SupersetQuery
 from superset.utils import (
-    has_access, merge_extra_filters, merge_request_params, QueryStatus,
+    merge_extra_filters, merge_request_params, QueryStatus,
 )
 from .base import (
     api, BaseSupersetView, CsvResponse, DeleteMixin,
@@ -475,7 +475,7 @@ class SliceModelView(SupersetModelView, DeleteMixin):  # noqa
         check_ownership(obj)
 
     @expose('/add', methods=['GET', 'POST'])
-    @has_access
+    @sm.has_method_access
     def add(self):
         datasources = ConnectorRegistry.get_all_datasources(db.session)
         datasources = [
@@ -828,7 +828,7 @@ class Superset(BaseSupersetView):
         }, status=201)
 
     @log_this
-    @has_access
+    @sm.has_method_access
     @expose('/request_access/')
     def request_access(self):
         datasources = set()
@@ -851,12 +851,12 @@ class Superset(BaseSupersetView):
             )
             datasources.add(datasource)
 
-        has_access = all(
+        sm.has_method_access = all(
             (
                 datasource and security_manager.datasource_access(datasource)
                 for datasource in datasources
             ))
-        if has_access:
+        if sm.has_method_access:
             return redirect('/superset/dashboard/{}'.format(dashboard_id))
 
         if request.args.get('action') == 'go':
@@ -876,7 +876,7 @@ class Superset(BaseSupersetView):
         )
 
     @log_this
-    @has_access
+    @sm.has_method_access
     @expose('/approve')
     def approve(self):
         def clean_fulfilled_requests(session):
@@ -1032,7 +1032,7 @@ class Superset(BaseSupersetView):
             )
             return viz_obj
 
-    @has_access
+    @sm.has_method_access
     @expose('/slice/<slice_id>/')
     def slice(self, slice_id):
         form_data, slc = self.get_form_data(slice_id)
@@ -1183,7 +1183,7 @@ class Superset(BaseSupersetView):
                                   force=force)
 
     @log_this
-    @has_access
+    @sm.has_method_access
     @expose('/import_dashboards', methods=['GET', 'POST'])
     def import_dashboards(self):
         """Overrides the dashboards using json instances from the file."""
@@ -1203,7 +1203,7 @@ class Superset(BaseSupersetView):
         return self.render_template('superset/import_dashboards.html')
 
     @log_this
-    @has_access
+    @sm.has_method_access
     @expose('/explorev2/<datasource_type>/<datasource_id>/')
     def explorev2(self, datasource_type, datasource_id):
         """Deprecated endpoint, here for backward compatibility of urls"""
@@ -1227,7 +1227,7 @@ class Superset(BaseSupersetView):
         return datasource_id, datasource_type
 
     @log_this
-    @has_access
+    @sm.has_method_access
     @expose('/explore/<datasource_type>/<datasource_id>/', methods=['GET', 'POST'])
     @expose('/explore/', methods=['GET', 'POST'])
     def explore(self, datasource_type=None, datasource_id=None):
@@ -2021,7 +2021,7 @@ class Superset(BaseSupersetView):
         session.commit()
         return json_success(json.dumps({'count': count}))
 
-    @has_access
+    @sm.has_method_access
     @expose('/dashboard/<dashboard_id>/')
     def dashboard(self, dashboard_id):
         """Server side rendering for a dashboard"""
@@ -2092,7 +2092,7 @@ class Superset(BaseSupersetView):
     def log(self):
         return Response(status=200)
 
-    @has_access
+    @sm.has_method_access
     @expose('/sync_druid/', methods=['POST'])
     @log_this
     def sync_druid_source(self):
@@ -2144,7 +2144,7 @@ class Superset(BaseSupersetView):
             return json_error_response(utils.error_msg_from_exception(e))
         return Response(status=201)
 
-    @has_access
+    @sm.has_method_access
     @expose('/sqllab_viz/', methods=['POST'])
     @log_this
     def sqllab_viz(self):
@@ -2205,7 +2205,7 @@ class Superset(BaseSupersetView):
             'table_id': table.id,
         }))
 
-    @has_access
+    @sm.has_method_access
     @expose('/table/<database_id>/<table_name>/<schema>/')
     @log_this
     def table(self, database_id, table_name, schema):
@@ -2262,7 +2262,7 @@ class Superset(BaseSupersetView):
         }
         return json_success(json.dumps(tbl))
 
-    @has_access
+    @sm.has_method_access
     @expose('/extra_table_metadata/<database_id>/<table_name>/<schema>/')
     @log_this
     def extra_table_metadata(self, database_id, table_name, schema):
@@ -2272,7 +2272,7 @@ class Superset(BaseSupersetView):
             mydb, table_name, schema)
         return json_success(json.dumps(payload))
 
-    @has_access
+    @sm.has_method_access
     @expose('/select_star/<database_id>/<table_name>/')
     @log_this
     def select_star(self, database_id, table_name):
@@ -2458,7 +2458,7 @@ class Superset(BaseSupersetView):
             return json_error_response(payload=data)
         return json_success(payload)
 
-    @has_access
+    @sm.has_method_access
     @expose('/csv/<client_id>')
     @log_this
     def csv(self, client_id):
@@ -2501,7 +2501,7 @@ class Superset(BaseSupersetView):
         logging.info('Ready to return response')
         return response
 
-    @has_access
+    @sm.has_method_access
     @expose('/fetch_datasource_metadata')
     @log_this
     def fetch_datasource_metadata(self):
@@ -2544,7 +2544,7 @@ class Superset(BaseSupersetView):
         return json_success(
             json.dumps(dict_queries, default=utils.json_int_dttm_ser))
 
-    @has_access
+    @sm.has_method_access
     @expose('/search_queries')
     @log_this
     def search_queries(self):
@@ -2620,7 +2620,7 @@ class Superset(BaseSupersetView):
             bootstrap_data=json.dumps(payload, default=utils.json_iso_dttm_ser),
         )
 
-    @has_access
+    @sm.has_method_access
     @expose('/profile/<username>/')
     def profile(self, username):
         """User profile page"""
@@ -2639,7 +2639,7 @@ class Superset(BaseSupersetView):
             bootstrap_data=json.dumps(payload, default=utils.json_iso_dttm_ser),
         )
 
-    @has_access
+    @sm.has_method_access
     @expose('/sqllab')
     def sqllab(self):
         """SQL Editor"""


### PR DESCRIPTION
This is a follow-up PR to https://github.com/apache/incubator-superset/pull/4565. It removes the has_access from superset since it is defined in FAB [here](http://flask-appbuilder.readthedocs.io/en/latest/_modules/flask_appbuilder/security/decorators.html).
The only difference is the next parameter in the url_for function. I have tested it and I doubt it will cause any issues. 

@john-bodley @mistercrunch 