### PR TITLE
Use 3 letters month prefix in default date format

### DIFF
--- a/superset/assets/javascripts/modules/dates.js
+++ b/superset/assets/javascripts/modules/dates.js
@@ -42,25 +42,32 @@ export const tickMultiFormat = d3.time.format.multi([
   ],
   // If there are hours that are multiples of 3, show date and AM/PM
   [
-    '%a %b %d',
+    '%a %b %e',
     function (d) {
-      return d.getDate() !== 1;
+      return d.getDate() >= 10;
     },
   ],
-  // If not the first of the month, do "month day, year."
+  // If not the first of the month: "Tue Mar 2"
   [
-    '%B %Y',
+    '%a %b%e',
+    function (d) {
+      return d.getDate() > 1;
+    },
+  ],
+  // If >= 10th of the month, compensate for padding : "Sun Mar 15"
+  [
+    '%b %Y',
     function (d) {
       return d.getMonth() !== 0 && d.getDate() === 1;
     },
   ],
-  // If the first of the month, do "month day, year."
+  // If the first of the month: 'Mar 2020'
   [
     '%Y',
     function () {
       return true;
     },
-  ],  // fall back on month, year
+  ],  // fall back on just year: '2020'
 ]);
 export const formatDate = function (dttm) {
   const d = UTC(new Date(dttm));

--- a/superset/assets/spec/javascripts/modules/dates_spec.js
+++ b/superset/assets/spec/javascripts/modules/dates_spec.js
@@ -20,6 +20,19 @@ describe('formatDate', () => {
   it('is a function', () => {
     assert.isFunction(formatDate);
   });
+
+  it('shows only year when 1st day of the year', () => {
+    expect(formatDate(new Date('2020-01-01'))).to.equal('2020');
+  });
+
+  it('shows month and year when 1st of month', () => {
+    expect(formatDate(new Date('2020-03-01'))).to.equal('Mar 2020');
+  });
+
+  it('shows weekday when any day of the month', () => {
+    expect(formatDate(new Date('2020-03-03'))).to.equal('Tue Mar 3');
+    expect(formatDate(new Date('2020-03-15'))).to.equal('Sun Mar 15');
+  });
 });
 
 describe('fDuration', () => {


### PR DESCRIPTION
Using 3-letters month name is clear enough and allows for a smaller and even x axis margin on line charts.