### PR TITLE
Enable Impala impersonation by passing cursor configuration.

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -665,6 +665,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         logging.info('Database.get_sqla_engine(). Masked URL: {0}'.format(masked_url))
 
         params = extra.get('engine_params', {})
+        self.cursor_kwargs = self.db_engine_spec.get_cursor_configuration_for_impersonation(str(url), self.impersonate_user, effective_username)
         if nullpool:
             params['poolclass'] = NullPool
 
@@ -676,7 +677,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
                 self.impersonate_user,
                 effective_username))
         if configuration:
-            params['connect_args'] = {'configuration': configuration}
+            params.update(configuration)
 
         DB_CONNECTION_MUTATOR = config.get('DB_CONNECTION_MUTATOR')
         if DB_CONNECTION_MUTATOR:

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -212,7 +212,7 @@ def execute_sql(
             user_name=user_name,
         )
         conn = engine.raw_connection()
-        cursor = conn.cursor()
+        cursor = conn.cursor(**database.cursor_kwargs)
         logging.info('Running query: \n{}'.format(executed_sql))
         logging.info(query.executed_sql)
         cursor.execute(query.executed_sql,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1684,10 +1684,11 @@ class Superset(BaseSupersetView):
                 .get('engine_params', {})
                 .get('connect_args', {}))
 
+            engine_params = {}
             if configuration:
-                connect_args['configuration'] = configuration
+                engine_params.update(configuration) # impersonation configuration have to include parent keys, like "connect_args" and "configuration"
 
-            engine = create_engine(uri, connect_args=connect_args)
+            engine = create_engine(uri, **engine_params)
             engine.connect()
             return json_success(json.dumps(engine.table_names(), indent=4))
         except Exception as e:


### PR DESCRIPTION
This commit will only work if pull request #298 at cloudera/impyla is accepted,
but it may not do no harm if not. ImpalaEngineSpec.get_schema_names() had to be moved to cloudera/impyla-s [SQLAlchemy API](https://github.com/cloudera/impyla/blob/master/impala/sqlalchemy.py), in order to be able to get an impersonated cursor for the inspector.

It has also touched Hive impersonation, though it should not affect it.
It works for me, but feel free to completly rewrite it, to make it fit better in the overall picture.