### PR TITLE
Fixing label issue when columnType is null

### DIFF
--- a/superset/assets/javascripts/components/ColumnOption.jsx
+++ b/superset/assets/javascripts/components/ColumnOption.jsx
@@ -24,7 +24,7 @@ export default function ColumnOption({ column, showType }) {
 
   return (
     <span>
-      {showType && <ColumnTypeLabel type={columnType} />}
+      {showType && columnType && <ColumnTypeLabel type={columnType} />}
       <span className="m-r-5 option-label">
         {column.verbose_name || column.column_name}
       </span>

--- a/superset/assets/spec/javascripts/components/ColumnOption_spec.jsx
+++ b/superset/assets/spec/javascripts/components/ColumnOption_spec.jsx
@@ -47,8 +47,14 @@ describe('ColumnOption', () => {
     expect(wrapper.find('.option-label').first().text()).to.equal('foo');
   });
   it('shows a column type label when showType is true', () => {
-    props.showType = true;
-    wrapper = shallow(factory(props));
+    wrapper = shallow(factory({
+      ...props,
+      showType: true,
+      column: {
+        expression: null,
+        type: 'str',
+      },
+    }));
     expect(wrapper.find(ColumnTypeLabel)).to.have.length(1);
   });
   it('column with expression has correct column label if showType is true', () => {
@@ -56,6 +62,17 @@ describe('ColumnOption', () => {
     wrapper = shallow(factory(props));
     expect(wrapper.find(ColumnTypeLabel)).to.have.length(1);
     expect(wrapper.find(ColumnTypeLabel).props().type).to.equal('expression');
+  });
+  it('shows no column type label when type is null', () => {
+    wrapper = shallow(factory({
+      ...props,
+      showType: true,
+      column: {
+        expression: null,
+        type: null,
+      },
+    }));
+    expect(wrapper.find(ColumnTypeLabel)).to.have.length(0);
   });
   it('dttm column has correct column label if showType is true', () => {
     props.showType = true;


### PR DESCRIPTION
Fixing an issue where we shouldn't be showing the ColumnTypeLabel if columnType is null.

The tests didn't pick this up because expression was set for the column in the test (which maps to a specific columnType), so I fixed the tests and explicitly test for no column type if type is null.

@graceguo-supercat 