### PR TITLE
allow customizable caching permissions

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -110,6 +110,10 @@ class SupersetSecurityManager(SecurityManager):
             self.can_access('schema_access', datasource.schema_perm, user=user)
         )
 
+    def has_cache_access(self, datasource):
+        # By default if you can access the datasource, you can access the cache
+        return True
+
     def datasource_access(self, datasource, user=None):
         return (
             self.schema_access(datasource, user=user) or

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -34,7 +34,7 @@ import simplejson as json
 from six import string_types, text_type
 from six.moves import cPickle as pkl, reduce
 
-from superset import app, cache, get_manifest_file, utils
+from superset import app, cache, get_manifest_file, security_manager, utils
 from superset.utils import DTTM_ALIAS, merge_extra_filters
 
 
@@ -309,7 +309,10 @@ class BaseViz(object):
         stacktrace = None
         df = None
         cached_dttm = datetime.utcnow().isoformat().split('.')[0]
-        if cache_key and cache and not self.force:
+        if (
+            cache_key and cache and not self.force and
+            security_manager.has_cache_access(self.datasource)
+        ):
             cache_value = cache.get(cache_key)
             if cache_value:
                 stats_logger.incr('loaded_from_cache')


### PR DESCRIPTION
This PR allows deployments to restrict access to the cache with their custom logic by extending the new SupersetSecurityManager

@mistercrunch @john-bodley 
cc @fabianmenges I remember George Siros also expressing interest in this functionality. 