### PR TITLE
Remove trailing '/' from Mailing list link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Installation & Configuration
 
 Resources
 -------------
-* [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org/)
+* [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
 * [Gitter (live chat) Channel](https://gitter.im/airbnb/superset)
 * [Docker image](https://hub.docker.com/r/amancevice/superset/) (community contributed)
 * [Slides from Strata (March 2016)](https://drive.google.com/open?id=0B5PVE0gzO81oOVJkdF9aNkJMSmM)


### PR DESCRIPTION
Was looking through superset repo and found the mailing list link to be broken