### PR TITLE
Improve database type inference

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -74,7 +74,8 @@ class SupersetDataFrame(object):
             db_engine_spec.get_normalized_column_names(cursor_description))
 
         data = data or []
-        df = pd.DataFrame(list(data), columns=column_names).infer_objects()
+        self.df = (
+            pd.DataFrame(list(data), columns=column_names).infer_objects())
 
         self._type_dict = {}
         try:
@@ -95,8 +96,8 @@ class SupersetDataFrame(object):
     def data(self):
         # work around for https://github.com/pandas-dev/pandas/issues/18372
         data = [dict((k, _maybe_box_datetimelike(v))
-                for k, v in zip(self.__df.columns, np.atleast_1d(row)))
-                for row in self.__df.values]
+                for k, v in zip(self.df.columns, np.atleast_1d(row)))
+                for row in self.df.values]
         for d in data:
             for k, v in list(d.items()):
                 # if an int is too big for Java Script to handle

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -153,7 +153,7 @@ class SupersetDataFrame(object):
         # consider checking for key substring too.
         if cls.is_id(column_name):
             return 'count_distinct'
-        if (hasattr(dtype, 'tupe') and issubclass(dtype.type, np.generic) and
+        if (hasattr(dtype, 'type') and issubclass(dtype.type, np.generic) and
                 np.issubdtype(dtype, np.number)):
             return 'sum'
         return None

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -73,13 +73,8 @@ class SupersetDataFrame(object):
         self.column_names = dedup(
             db_engine_spec.get_normalized_column_names(cursor_description))
 
-        # check whether the result set has any nested dict columns
-        if data:
-            has_dict_col = any([isinstance(c, dict) for c in data[0]])
-            df_data = list(data) if has_dict_col else np.array(data, dtype=object)
-        else:
-            df_data = []
-        df = pd.DataFrame(df_data, columns=column_names)
+        data = data or []
+        df = pd.DataFrame(list(data), columns=column_names).infer_objects()
 
         self._type_dict = {}
         try:

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -86,7 +86,6 @@ class SupersetDataFrame(object):
             }
         except Exception as e:
             logging.exception(e)
-        self.df = df.where((pd.notnull(df)), None)
 
     @property
     def size(self):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -698,11 +698,6 @@ class PrestoEngineSpec(BaseEngineSpec):
         return uri
 
     @classmethod
-    def get_datatype(cls, type_code):
-        if isinstance(type_code, basestring) and len(type_code):
-            return type_code.upper()
-
-    @classmethod
     def convert_dttm(cls, target_type, dttm):
         tt = target_type.upper()
         if tt == 'DATE':

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -30,6 +30,7 @@ import boto3
 from flask import g
 from flask_babel import lazy_gettext as _
 import pandas
+from past.builtins import basestring
 import sqlalchemy as sqla
 from sqlalchemy import select
 from sqlalchemy.engine import create_engine
@@ -84,6 +85,11 @@ class BaseEngineSpec(object):
     @classmethod
     def epoch_ms_to_dttm(cls):
         return cls.epoch_to_dttm().replace('{col}', '({col}/1000.0)')
+
+    @classmethod
+    def get_datatype(cls, type_code):
+        if isinstance(type_code, basestring) and len(type_code):
+            return type_code
 
     @classmethod
     def extra_table_metadata(cls, database, table_name, schema_name):
@@ -592,6 +598,7 @@ class MySQLEngineSpec(BaseEngineSpec):
               'INTERVAL DAYOFWEEK(DATE_SUB({col}, INTERVAL 1 DAY)) - 1 DAY))',
               'P1W'),
     )
+    type_code_map = {}  # loaded from get_datatype only if needed
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):
@@ -605,6 +612,24 @@ class MySQLEngineSpec(BaseEngineSpec):
         if selected_schema:
             uri.database = selected_schema
         return uri
+
+    @classmethod
+    def get_datatype(cls, type_code):
+        if not cls.type_code_map:
+            # only import and store if needed at least once
+            import MySQLdb
+            ft = MySQLdb.constants.FIELD_TYPE
+            cls.type_code_map = {
+                getattr(ft, k): k
+                for k in dir(ft)
+                if not k.startswith('_')
+            }
+            print(cls.type_code_map)
+        datatype = type_code
+        if isinstance(type_code, int):
+            datatype = cls.type_code_map.get(type_code)
+        if datatype and isinstance(datatype, basestring) and len(datatype):
+            return datatype
 
     @classmethod
     def epoch_to_dttm(cls):
@@ -672,6 +697,11 @@ class PrestoEngineSpec(BaseEngineSpec):
                 database += '/' + selected_schema
             uri.database = database
         return uri
+
+    @classmethod
+    def get_datatype(cls, type_code):
+        if isinstance(type_code, basestring) and len(type_code):
+            return type_code.upper()
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -89,7 +89,7 @@ class BaseEngineSpec(object):
     @classmethod
     def get_datatype(cls, type_code):
         if isinstance(type_code, basestring) and len(type_code):
-            return type_code
+            return type_code.upper()
 
     @classmethod
     def extra_table_metadata(cls, database, table_name, schema_name):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -624,7 +624,6 @@ class MySQLEngineSpec(BaseEngineSpec):
                 for k in dir(ft)
                 if not k.startswith('_')
             }
-            print(cls.type_code_map)
         datatype = type_code
         if isinstance(type_code, int):
             datatype = cls.type_code_map.get(type_code)

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -14,7 +14,7 @@ import unittest
 import pandas as pd
 from past.builtins import basestring
 
-from superset import app, cli, dataframe, db, security_manager
+from superset import app, cli, db, security_manager
 from superset.models.helpers import QueryStatus
 from superset.models.sql_lab import Query
 from superset.sql_parse import SupersetQuery
@@ -244,55 +244,6 @@ class CeleryTestCase(SupersetTestCase):
     @classmethod
     def dictify_list_of_dicts(cls, l, k):
         return {str(o[k]): cls.de_unicode_dict(o) for o in l}
-
-    def test_get_columns(self):
-        main_db = self.get_main_database(db.session)
-        df = main_db.get_df('SELECT * FROM multiformat_time_series', None)
-        cdf = dataframe.SupersetDataFrame(df)
-
-        # Making ordering non-deterministic
-        cols = self.dictify_list_of_dicts(cdf.columns, 'name')
-
-        if main_db.sqlalchemy_uri.startswith('sqlite'):
-            self.assertEqual(self.dictify_list_of_dicts([
-                {'is_date': True, 'type': 'STRING', 'name': 'ds',
-                    'is_dim': False},
-                {'is_date': True, 'type': 'STRING', 'name': 'ds2',
-                    'is_dim': False},
-                {'agg': 'sum', 'is_date': False, 'type': 'INT',
-                    'name': 'epoch_ms', 'is_dim': False},
-                {'agg': 'sum', 'is_date': False, 'type': 'INT',
-                    'name': 'epoch_s', 'is_dim': False},
-                {'is_date': True, 'type': 'STRING', 'name': 'string0',
-                    'is_dim': False},
-                {'is_date': False, 'type': 'STRING',
-                    'name': 'string1', 'is_dim': True},
-                {'is_date': True, 'type': 'STRING', 'name': 'string2',
-                    'is_dim': False},
-                {'is_date': False, 'type': 'STRING',
-                    'name': 'string3', 'is_dim': True}], 'name'),
-                cols,
-            )
-        else:
-            self.assertEqual(self.dictify_list_of_dicts([
-                {'is_date': True, 'type': 'DATETIME', 'name': 'ds',
-                    'is_dim': False},
-                {'is_date': True, 'type': 'DATETIME',
-                    'name': 'ds2', 'is_dim': False},
-                {'agg': 'sum', 'is_date': False, 'type': 'INT',
-                    'name': 'epoch_ms', 'is_dim': False},
-                {'agg': 'sum', 'is_date': False, 'type': 'INT',
-                    'name': 'epoch_s', 'is_dim': False},
-                {'is_date': True, 'type': 'STRING', 'name': 'string0',
-                    'is_dim': False},
-                {'is_date': False, 'type': 'STRING',
-                    'name': 'string1', 'is_dim': True},
-                {'is_date': True, 'type': 'STRING', 'name': 'string2',
-                    'is_dim': False},
-                {'is_date': False, 'type': 'STRING',
-                    'name': 'string3', 'is_dim': True}], 'name'),
-                cols,
-            )
 
 
 if __name__ == '__main__':

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -24,6 +24,7 @@ import sqlalchemy as sqla
 
 from superset import dataframe, db, jinja_context, security_manager, sql_lab, utils
 from superset.connectors.sqla.models import SqlaTable
+from superset.db_engine_specs import BaseEngineSpec
 from superset.models import core as models
 from superset.models.sql_lab import Query
 from superset.views.core import DatabaseView
@@ -626,8 +627,7 @@ class CoreTests(SupersetTestCase):
             (datetime.datetime(2017, 11, 18, 21, 53, 0, 219225, tzinfo=tz),),
             (datetime.datetime(2017, 11, 18, 22, 6, 30, 61810, tzinfo=tz),),
         ]
-        df = dataframe.SupersetDataFrame(pd.DataFrame(data=list(data),
-                                                      columns=['data']))
+        df = dataframe.SupersetDataFrame(list(data), [['data']], BaseEngineSpec)
         data = df.data
         self.assertDictEqual(
             data[0],

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from superset.dataframe import dedup
+from .base_tests import SupersetTestCase
+
+
+class SupersetDataFrameTestCase(SupersetTestCase):
+    def test_dedup(self):
+        self.assertEquals(
+            dedup(['foo', 'bar']),
+            ['foo', 'bar'],
+        )
+        self.assertEquals(
+            dedup(['foo', 'bar', 'foo', 'bar']),
+            ['foo', 'bar', 'foo__1', 'bar__1'],
+        )
+        self.assertEquals(
+            dedup(['foo', 'bar', 'bar', 'bar']),
+            ['foo', 'bar', 'bar__1', 'bar__2'],
+        )

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -79,7 +79,8 @@ class SupersetDataFrameTestCase(SupersetTestCase):
                     'is_date': False,
                     'type': 'INT',
                     'name': 'b',
-                    'is_dim': True,
+                    'is_dim': False,
+                    'agg': 'sum',
                 },
             ],
         )
@@ -101,12 +102,14 @@ class SupersetDataFrameTestCase(SupersetTestCase):
                     'is_date': False,
                     'type': 'FLOAT',
                     'name': 'a',
-                    'is_dim': True,
+                    'is_dim': False,
+                    'agg': 'sum',
                 }, {
                     'is_date': False,
                     'type': 'INT',
                     'name': 'b',
-                    'is_dim': True,
+                    'is_dim': False,
+                    'agg': 'sum',
                 },
             ],
         )

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -4,7 +4,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from superset.dataframe import dedup
+from superset.dataframe import dedup, SupersetDataFrame
+from superset.db_engine_specs import BaseEngineSpec
 from .base_tests import SupersetTestCase
 
 
@@ -21,4 +22,91 @@ class SupersetDataFrameTestCase(SupersetTestCase):
         self.assertEquals(
             dedup(['foo', 'bar', 'bar', 'bar']),
             ['foo', 'bar', 'bar__1', 'bar__2'],
+        )
+
+    def test_get_columns_basic(self):
+        data = [
+            ('a1', 'b1', 'c1'),
+            ('a2', 'b2', 'c2'),
+        ]
+        cursor_descr = (
+            ('a', 'string'),
+            ('b', 'string'),
+            ('c', 'string'),
+        )
+        cdf = SupersetDataFrame(data, cursor_descr, BaseEngineSpec)
+        self.assertEqual(
+            cdf.columns,
+            [
+                {
+                    'is_date': False,
+                    'type': 'STRING',
+                    'name': 'a',
+                    'is_dim': True,
+                }, {
+                    'is_date': False,
+                    'type': 'STRING',
+                    'name': 'b',
+                    'is_dim': True,
+                }, {
+                    'is_date': False,
+                    'type': 'STRING',
+                    'name': 'c',
+                    'is_dim': True,
+                },
+            ],
+        )
+
+    def test_get_columns_with_int(self):
+        data = [
+            ('a1', 1),
+            ('a2', 2),
+        ]
+        cursor_descr = (
+            ('a', 'string'),
+            ('b', 'int'),
+        )
+        cdf = SupersetDataFrame(data, cursor_descr, BaseEngineSpec)
+        self.assertEqual(
+            cdf.columns,
+            [
+                {
+                    'is_date': False,
+                    'type': 'STRING',
+                    'name': 'a',
+                    'is_dim': True,
+                }, {
+                    'is_date': False,
+                    'type': 'INT',
+                    'name': 'b',
+                    'is_dim': True,
+                },
+            ],
+        )
+
+    def test_get_columns_type_inference(self):
+        data = [
+            (1.2, 1),
+            (3.14, 2),
+        ]
+        cursor_descr = (
+            ('a', None),
+            ('b', None),
+        )
+        cdf = SupersetDataFrame(data, cursor_descr, BaseEngineSpec)
+        self.assertEqual(
+            cdf.columns,
+            [
+                {
+                    'is_date': False,
+                    'type': 'FLOAT',
+                    'name': 'a',
+                    'is_dim': True,
+                }, {
+                    'is_date': False,
+                    'type': 'INT',
+                    'name': 'b',
+                    'is_dim': True,
+                },
+            ],
         )

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -7,7 +7,9 @@ from __future__ import unicode_literals
 import textwrap
 
 from superset.db_engine_specs import (
-    HiveEngineSpec, MssqlEngineSpec, MySQLEngineSpec)
+    BaseEngineSpec, HiveEngineSpec, MssqlEngineSpec,
+    MySQLEngineSpec, PrestoEngineSpec,
+)
 from superset.models.core import Database
 from .base_tests import SupersetTestCase
 
@@ -193,3 +195,9 @@ class DbEngineSpecsTestCase(SupersetTestCase):
                 FROM
                 table LIMIT 1000"""),
         )
+
+    def test_get_datatype(self):
+        self.assertEquals('STRING', PrestoEngineSpec.get_datatype('string'))
+        self.assertEquals('TINY', MySQLEngineSpec.get_datatype(1))
+        self.assertEquals('VARCHAR', MySQLEngineSpec.get_datatype(15))
+        self.assertEquals('VARCHAR', BaseEngineSpec.get_datatype('VARCHAR'))

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -12,8 +12,9 @@ import unittest
 from flask_appbuilder.security.sqla import models as ab_models
 
 from superset import db, security_manager, utils
+from superset.dataframe import SupersetDataFrame
+from superset.db_engine_specs import BaseEngineSpec
 from superset.models.sql_lab import Query
-from superset.sql_lab import convert_results_to_df
 from .base_tests import SupersetTestCase
 
 
@@ -203,9 +204,13 @@ class SqlLabTests(SupersetTestCase):
             raise_on_error=True)
 
     def test_df_conversion_no_dict(self):
-        cols = ['string_col', 'int_col', 'float_col']
+        cols = [
+            ['string_col', 'string'],
+            ['int_col', 'int'],
+            ['float_col', 'float'],
+        ]
         data = [['a', 4, 4.0]]
-        cdf = convert_results_to_df(cols, data)
+        cdf = SupersetDataFrame(data, cols, BaseEngineSpec)
 
         self.assertEquals(len(data), cdf.size)
         self.assertEquals(len(cols), len(cdf.columns))
@@ -213,7 +218,7 @@ class SqlLabTests(SupersetTestCase):
     def test_df_conversion_tuple(self):
         cols = ['string_col', 'int_col', 'list_col', 'float_col']
         data = [(u'Text', 111, [123], 1.0)]
-        cdf = convert_results_to_df(cols, data)
+        cdf = SupersetDataFrame(data, cols, BaseEngineSpec)
 
         self.assertEquals(len(data), cdf.size)
         self.assertEquals(len(cols), len(cdf.columns))
@@ -221,7 +226,7 @@ class SqlLabTests(SupersetTestCase):
     def test_df_conversion_dict(self):
         cols = ['string_col', 'dict_col', 'int_col']
         data = [['a', {'c1': 1, 'c2': 2, 'c3': 3}, 4]]
-        cdf = convert_results_to_df(cols, data)
+        cdf = SupersetDataFrame(data, cols, BaseEngineSpec)
 
         self.assertEquals(len(data), cdf.size)
         self.assertEquals(len(cols), len(cdf.columns))


### PR DESCRIPTION
Python's DBAPI isn't super clear and homogeneous on the
cursor.description specification, and this PR attempts to improve
inferring the datatypes returned in the cursor.

This work started around Presto's TIMESTAMP type being mishandled as
string as the database driver (pyhive) returns it as a string. The work
here fixes this bug and does a better job at inferring MySQL and Presto types.
It also creates a new method in db_engine_specs allowing for other
databases engines to implement and become more precise on type-inference
as needed.

Note that the role of `SupersetDataFrame` isn't super clear here. I think the original intent was to derive pandas.DataFrame but this isn't allowed by the pandas lib. So it became more of a wrapper around `pandas.DataFrame`.

Now its role becomes even less clear here after the PR.

The longer term vision is probably to make this class a pandas DataFrame-related utility wrapper, meaning it would know how to get a dataframe give a query & cursor and will be able to do things like type-inference or other operation that are dataframe related.