### PR TITLE
[explore] don't prompt to 'Run Query' on viewport change

### DIFF
--- a/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/javascripts/explore/components/ExploreViewContainer.jsx
@@ -145,7 +145,9 @@ class ExploreViewContainer extends React.Component {
   }
 
   hasQueryControlChanged(changedControlKeys, currentControls) {
-    return changedControlKeys.some(key => !currentControls[key].renderTrigger);
+    return changedControlKeys.some(key => (
+      !currentControls[key].renderTrigger && !currentControls[key].dontRefreshOnChange
+    ));
   }
 
   triggerQueryIfNeeded() {

--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1614,6 +1614,8 @@ export const controls = {
     description: t('Parameters related to the view and perspective on the map'),
     // default is whole world mostly centered
     default: defaultViewport,
+    // Viewport changes shouldn't prompt user to re-run query
+    dontRefreshOnChange: true,
   },
 
   viewport_zoom: {


### PR DESCRIPTION
This is another take on https://github.com/apache/incubator-superset/pull/4610

I couldn't come up with a better name than `dontRefreshOnChange` as I needed a "truthy" attribute to avoid having to touch all other controls.

@GabeLoins 