### PR TITLE
[sql lab] preserve schema through visualize flow

### DIFF
--- a/superset/assets/javascripts/SqlLab/components/QuerySearch.jsx
+++ b/superset/assets/javascripts/SqlLab/components/QuerySearch.jsx
@@ -13,7 +13,7 @@ const $ = window.$ = require('jquery');
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
-  height: PropTypes.number.isRequired,
+  height: PropTypes.string.isRequired,
 };
 
 class QuerySearch extends React.PureComponent {

--- a/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
+++ b/superset/assets/javascripts/SqlLab/components/VisualizeModal.jsx
@@ -31,6 +31,7 @@ const propTypes = {
   onHide: PropTypes.func,
   query: PropTypes.object,
   show: PropTypes.bool,
+  schema: PropTypes.string,
   datasource: PropTypes.string,
   errorMessage: PropTypes.string,
   timeout: PropTypes.number,
@@ -48,6 +49,7 @@ class VisualizeModal extends React.PureComponent {
       chartType: CHART_TYPES[0],
       datasourceName: this.datasourceName(),
       columns: this.getColumnFromProps(),
+      schema: props.query ? props.query.schema : null,
       hints: [],
     };
   }
@@ -126,6 +128,7 @@ class VisualizeModal extends React.PureComponent {
   buildVizOptions() {
     return {
       chartType: this.state.chartType.value,
+      schema: this.state.schema,
       datasourceName: this.state.datasourceName,
       columns: this.state.columns,
       sql: this.props.query.sql,

--- a/superset/assets/spec/javascripts/sqllab/VisualizeModal_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/VisualizeModal_spec.jsx
@@ -269,6 +269,7 @@ describe('VisualizeModal', () => {
       chartType: wrapper.state().chartType.value,
       datasourceName: wrapper.state().datasourceName,
       columns: wrapper.state().columns,
+      schema: 'test_schema',
       sql: wrapper.instance().props.query.sql,
       dbId: wrapper.instance().props.query.dbId,
     });

--- a/superset/assets/spec/javascripts/sqllab/fixtures.js
+++ b/superset/assets/spec/javascripts/sqllab/fixtures.js
@@ -197,7 +197,7 @@ export const queries = [
     rows: 42,
     endDttm: 1476910566798,
     limit_reached: false,
-    schema: null,
+    schema: 'test_schema',
     errorMessage: null,
     db: 'main',
     user: 'admin',

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2160,6 +2160,7 @@ class Superset(BaseSupersetView):
         if not table:
             table = SqlaTable(table_name=table_name)
         table.database_id = data.get('dbId')
+        table.schema = data.get('schema')
         q = SupersetQuery(data.get('sql'))
         table.sql = q.stripped()
         db.session.add(table)

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -253,7 +253,7 @@ class SqlLabTests(SupersetTestCase):
                 GROUP BY viz_type""",
             'dbId': 1,
         }
-        data = {"data": json.dumps(payload)}
+        data = {'data': json.dumps(payload)}
         resp = self.get_json_resp('/superset/sqllab_viz/', data=data)
         self.assertIn('table_id', resp)
 

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -226,6 +226,37 @@ class SqlLabTests(SupersetTestCase):
         self.assertEquals(len(data), cdf.size)
         self.assertEquals(len(cols), len(cdf.columns))
 
+    def test_sqllab_viz(self):
+        payload = {
+            'chartType': 'dist_bar',
+            'datasourceName': 'test_viz_flow_table',
+            'schema': 'superset',
+            'columns': {
+                'viz_type': {
+                    'is_date': False,
+                    'type': 'STRING',
+                    'nam:qe': 'viz_type',
+                    'is_dim': True,
+                },
+                'ccount': {
+                    'is_date': False,
+                    'type': 'OBJECT',
+                    'name': 'ccount',
+                    'is_dim': True,
+                    'agg': 'sum',
+                },
+            },
+            'sql': """\
+                SELECT viz_type, count(1) as ccount
+                FROM slices
+                WHERE viz_type LIKE '%%a%%'
+                GROUP BY viz_type""",
+            'dbId': 1,
+        }
+        data = {"data": json.dumps(payload)}
+        resp = self.get_json_resp('/superset/sqllab_viz/', data=data)
+        self.assertIn('table_id', resp)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
https://github.com/apache/incubator-superset/pull/4696 got tangled
into refactoring views out of views/core.py and onto views/sql_lab.py

This is the same PR without the refactoring.