### PR TITLE
[druid] Excluding refreshing verbose name

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -372,7 +372,7 @@ class DruidColumn(Model, BaseColumn):
         for metric in metrics.values():
             dbmetric = dbmetrics.get(metric.metric_name)
             if dbmetric:
-                for attr in ['json', 'metric_type', 'verbose_name']:
+                for attr in ['json', 'metric_type']:
                     setattr(dbmetric, attr, getattr(metric, attr))
             else:
                 with db.session.no_autoflush:


### PR DESCRIPTION
The verbose name is often user defined however when refreshing Druid metrics this would be overwritten. This PR removes setting of the `verbose_name` attribute for existing metrics during a refresh. 

Note I added a unit test for this case and decided to re-factor the various refresh metadata checks into separate tests. 

to: @michellethomas @mistercrunch 