### PR TITLE
[explore] set control default for *showminmax = false

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -1399,7 +1399,7 @@ export const controls = {
     type: 'CheckboxControl',
     label: t('X bounds'),
     renderTrigger: true,
-    default: true,
+    default: false,
     description: t('Whether to display the min and max values of the X axis'),
   },
 
@@ -1407,7 +1407,7 @@ export const controls = {
     type: 'CheckboxControl',
     label: t('Y bounds'),
     renderTrigger: true,
-    default: true,
+    default: false,
     description: t('Whether to display the min and max values of the Y axis'),
   },
 


### PR DESCRIPTION
Let's make the defaults less crowded on the axes by not showing the min
and max values on the axes (bounds)