### PR TITLE
Fix brush with annotations

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -75,10 +75,6 @@ function hideTooltips() {
   $('.nvtooltip').css({ opacity: 0 });
 }
 
-function bound(value, min, max) {
-  return Math.min(Math.max(value, min), max);
-}
-
 function getMaxLabelSize(container, axisClass) {
   // axis class = .nv-y2  // second y axis on dual line chart
   // axis class = .nv-x  // x axis on time series line chart
@@ -590,6 +586,7 @@ function nvd3Vis(slice, payload) {
           xMax = chart.xAxis.scale().domain()[1].valueOf();
           xScale = chart.xScale ? chart.xScale() : d3.scale.linear();
         }
+        xScale.clamp(true);
 
         if (Array.isArray(formulas) && formulas.length) {
           const xValues = [];
@@ -759,10 +756,10 @@ function nvd3Vis(slice, payload) {
               annotations.selectAll('rect')
                 .data(records)
                 .attr({
-                  x: d => bound(xScale(d[e.timeColumn]), 0, chartWidth),
+                  x: d => xScale(new Date(d[e.timeColumn])),
                   width: (d) => {
-                    const x1 = bound(xScale(d[e.timeColumn]), 0, chartWidth);
-                    const x2 = bound(xScale(d[e.intervalEndColumn]), 0, chartWidth);
+                    const x1 = xScale(new Date(d[e.timeColumn]));
+                    const x2 = xScale(new Date(d[e.intervalEndColumn]));
                     return x2 - x1;
                   },
                 });

--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -75,6 +75,10 @@ function hideTooltips() {
   $('.nvtooltip').css({ opacity: 0 });
 }
 
+function bound(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
 function getMaxLabelSize(container, axisClass) {
   // axis class = .nv-y2  // second y axis on dual line chart
   // axis class = .nv-x  // x axis on time series line chart
@@ -685,7 +689,7 @@ function nvd3Vis(slice, payload) {
             }
 
             // update annotation positions on brush event
-            chart.focus.dispatch.on("onBrush.event-annotation", function(extent) {
+            chart.focus.dispatch.on('onBrush.event-annotation', function () {
               annotations.selectAll('line')
                 .data(records)
                 .attr({
@@ -693,7 +697,7 @@ function nvd3Vis(slice, payload) {
                   y1: 0,
                   x2: d => xScale(new Date(d[e.timeColumn])),
                   y2: annotationHeight,
-                  opacity: d => {
+                  opacity: (d) => {
                     const x = xScale(new Date(d[e.timeColumn]));
                     return (x > 0) && (x < chartWidth) ? 1 : 0;
                   },
@@ -751,12 +755,12 @@ function nvd3Vis(slice, payload) {
             }
 
             // update annotation positions on brush event
-            chart.focus.dispatch.on("onBrush.interval-annotation", function(extent) {
+            chart.focus.dispatch.on('onBrush.interval-annotation', function () {
               annotations.selectAll('rect')
                 .data(records)
                 .attr({
                   x: d => bound(xScale(d[e.timeColumn]), 0, chartWidth),
-                  width: d => {
+                  width: (d) => {
                     const x1 = bound(xScale(d[e.timeColumn]), 0, chartWidth);
                     const x2 = bound(xScale(d[e.intervalEndColumn]), 0, chartWidth);
                     return x2 - x1;
@@ -776,10 +780,6 @@ function nvd3Vis(slice, payload) {
   hideTooltips();
 
   nv.addGraph(drawGraph);
-}
-
-function bound(value, min, max) {
-  return Math.min(Math.max(value, min), max);
 }
 
 module.exports = nvd3Vis;


### PR DESCRIPTION
The brush (time filter) currently does not work with annotations:

![brush_before](https://user-images.githubusercontent.com/1534870/38401235-7333332c-3909-11e8-8424-5a605fa31ded.gif)

I added a new callback that is dispatched when the brush is updated, and now it works:

![brush_after](https://user-images.githubusercontent.com/1534870/38401242-806ec0e2-3909-11e8-876b-539b1794a1f2.gif)
