### PR TITLE
[cli] force update perms on superset init

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -771,6 +771,10 @@ def merge_request_params(form_data, params):
 
 
 def get_update_perms_flag():
+    # When running CLI command `superset init`, alway update perms
+    if len(sys.argv) > 1 and sys.argv[1] == 'init':
+        return True
+    # Otherwise, do it based on env var SUPERSET_UPDATE_PERMS
     val = os.environ.get('SUPERSET_UPDATE_PERMS')
     return val.lower() not in ('0', 'false', 'no') if val else True
 


### PR DESCRIPTION
I set up a new environment today, while I kept my `superset_config.py` that happen to contain `os.environ['SUPERSET_UPDATE_PERMS'] = '0'`.

This prevented `superset init` from creating the right perms, which can be confusing, so this here forces `superset init` to disregard `SUPERSET_UPDATE_PERMS`

👀 @john-bodley 