### PR TITLE
[bugfix] dedup groupby columns in Deck visualizations

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2019,6 +2019,7 @@ class BaseDeckGLViz(BaseViz):
         if fd.get('js_columns'):
             gb += fd.get('js_columns')
         metrics = self.get_metrics()
+        gb = list(set(gb))
         if metrics:
             d['groupby'] = gb
             d['metrics'] = self.get_metrics()


### PR DESCRIPTION
When specifying the same column twice as a `Extra Data for JS` and
`Categorical Color`, an error is issued. This addresses this issue.