### PR TITLE
[explore] set working default for MetricsControl

### DIFF
--- a/superset/assets/javascripts/explore/stores/controls.jsx
+++ b/superset/assets/javascripts/explore/stores/controls.jsx
@@ -175,14 +175,17 @@ export const controls = {
     label: t('Metrics'),
     validators: [v.nonEmpty],
     default: (c) => {
-      const metric = mainMetric(c.options);
+      const metric = mainMetric(c.savedMetrics);
       return metric ? [metric] : null;
     },
-    mapStateToProps: state => ({
-      columns: state.datasource ? state.datasource.columns : [],
-      savedMetrics: state.datasource ? state.datasource.metrics : [],
-      datasourceType: state.datasource && state.datasource.type,
-    }),
+    mapStateToProps: (state) => {
+      const datasource = state.datasource;
+      return {
+        columns: datasource ? datasource.columns : [],
+        savedMetrics: datasource ? datasource.metrics : [],
+        datasourceType: datasource && datasource.type,
+      };
+    },
     description: t('One or many metrics to display'),
   },
 
@@ -264,7 +267,7 @@ export const controls = {
     label: t('Metric'),
     clearable: false,
     validators: [v.nonEmpty],
-    default: c => mainMetric(c.options),
+    default: props => mainMetric(props.savedMetrics),
     mapStateToProps: state => ({
       columns: state.datasource ? state.datasource.columns : [],
       savedMetrics: state.datasource ? state.datasource.metrics : [],

--- a/superset/assets/javascripts/modules/utils.js
+++ b/superset/assets/javascripts/modules/utils.js
@@ -260,17 +260,17 @@ export function getParam(name) {
   return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
 }
 
-export function mainMetric(metricOptions) {
+export function mainMetric(savedMetrics) {
   // Using 'count' as default metric if it exists, otherwise using whatever one shows up first
   let metric;
-  if (metricOptions && metricOptions.length > 0) {
-    metricOptions.forEach((m) => {
+  if (savedMetrics && savedMetrics.length > 0) {
+    savedMetrics.forEach((m) => {
       if (m.metric_name === 'count') {
         metric = 'count';
       }
     });
     if (!metric) {
-      metric = metricOptions[0].metric_name;
+      metric = savedMetrics[0].metric_name;
     }
   }
   return metric;


### PR DESCRIPTION
The default setting which would look for either `count` first and then
any metric stopped working when we landed MetricsControl. This mimics
the previous behavior.

👀  @GabeLoins 