### PR TITLE
[upload csv to hive] fix call to unicodereader.next()

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -869,7 +869,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         """Uploads a csv file and creates a superset datasource in Hive."""
         def get_column_names(filepath):
             with open(filepath, 'rb') as f:
-                return unicodecsv.reader(f, encoding='utf-8-sig').next()
+                return next(unicodecsv.reader(f, encoding='utf-8-sig'))
 
         table_name = form.name.data
         filename = form.csv_file.data.filename


### PR DESCRIPTION
Calling unicodeReader.next() was problematic because it works on python2 but not python3. The correct way to get the first item in the list is next(items) or for i in items. next(items) works in both python2 and 3. 

@michellethomas @john-bodley 