### PR TITLE
[config] Updating configuration logic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,7 +349,7 @@ underscore `_` "function".
 We use `import {t, tn, TCT} from locales;` in js, JSX file, locales is in `./superset/assets/javascripts/` directory.
 
 To enable changing language in your environment, you can simply add the
-`LANGUAGES` parameter to your `superset_config.py`. Having more than one
+`LANGUAGES` parameter to your config file. Having more than one
 options here will add a language selection dropdown on the right side of the
 navigation bar.
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -7,3 +7,4 @@ assists people when migrating to a new version.
 
 * [4565](https://github.com/apache/incubator-superset/pull/4565)
 * [4587](https://github.com/apache/incubator-superset/pull/4587)
+* [4827](https://github.com/apache/incubator-superset/pull/4827)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -69,7 +69,7 @@ There are many reasons may cause long query timing out.
 
   ``superset runserver -t 300``
 
-- If you are seeing timeouts (504 Gateway Time-out) when loading dashboard or explore slice, you are probably behind gateway or proxy server (such as Nginx). If it did not receive a timely response from Superset server (which is processing long queries), these web servers will send 504 status code to clients directly. Superset has a client-side timeout limit to address this issue. If query didn't come back within clint-side timeout (60 seconds by default), Superset will display warning message to avoid gateway timeout message. If you have a longer gateway timeout limit, you can change the timeout settings in ``superset_config.py``:
+- If you are seeing timeouts (504 Gateway Time-out) when loading dashboard or explore slice, you are probably behind gateway or proxy server (such as Nginx). If it did not receive a timely response from Superset server (which is processing long queries), these web servers will send 504 status code to clients directly. Superset has a client-side timeout limit to address this issue. If query didn't come back within clint-side timeout (60 seconds by default), Superset will display warning message to avoid gateway timeout message. If you have a longer gateway timeout limit, you can change the timeout settings in the config file:
 
   ``SUPERSET_WEBSERVER_TIMEOUT = 60``
 
@@ -78,7 +78,7 @@ Why is the map not visible in the mapbox visualization?
 -------------------------------------------------------
 
 You need to register to mapbox.com, get an API key and configure it as
-``MAPBOX_API_KEY`` in ``superset_config.py``.
+``MAPBOX_API_KEY`` in the config file.
 
 
 How to add dynamic filters to a dashboard?
@@ -177,7 +177,7 @@ __ https://www.sqlite.org/lockingv3.html
 
 You can override this path using the ``SUPERSET_HOME`` environment variable.
 
-Another work around is to change where superset stores the sqlite database by adding ``SQLALCHEMY_DATABASE_URI = 'sqlite:////new/location/superset.db'`` in superset_config.py (create the file if needed), then adding the directory where superset_config.py lives to PYTHONPATH environment variable (e.g. ``export PYTHONPATH=/opt/logs/sandbox/airbnb/``).
+Another work around is to change where superset stores the sqlite database by adding ``SQLALCHEMY_DATABASE_URI = 'sqlite:////new/location/superset.db'`` in the config file.
 
 What if the table schema changed?
 ---------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -167,7 +167,7 @@ in that context. Also note that the development web
 server (`superset runserver -d`) is not intended for production use.
 
 If not using gunicorn, you may want to disable the use of flask-compress
-by setting `ENABLE_FLASK_COMPRESS = False` in your `superset_config.py`
+by setting `ENABLE_FLASK_COMPRESS = False` in your config file.
 
 Flask-AppBuilder Permissions
 ----------------------------
@@ -183,7 +183,7 @@ by setting the :envvar:`SUPERSET_UPDATE_PERMS` environment variable to `0`.
 The value `1` enables it, `0` disables it. Note if undefined the functionality
 is enabled to maintain backwards compatibility.
 
-In a production environment initialization could take on the following form:
+In a production environment initialization could take on the following form: ::
 
   export SUPERSET_UPDATE_PERMS=1
   superset init
@@ -213,8 +213,13 @@ For the Apache webserver this can be set as follows: ::
 Configuration
 -------------
 
-To configure your application, you need to create a file (module)
-``superset_config.py`` and make sure it is in your PYTHONPATH. Here are some
+You can configure your application by overriding the default values with the
+contents of the file the ``SUPERSET_CONFIG_FILE`` environment variable points
+to, i.e., ::
+
+    export SUPERSET_CONFIG_FILE=/path/to/config/file
+
+Note the file is typically named ``superset.conf``. Here are some
 of the parameters you can copy / paste in that configuration module: ::
 
     #---------------------------------------------------------
@@ -250,12 +255,12 @@ of the parameters you can copy / paste in that configuration module: ::
 
 All the parameters and default values defined in
 https://github.com/apache/incubator-superset/blob/master/superset/config.py
-can be altered in your local ``superset_config.py`` .
+can be altered in your local config file.
 Administrators will want to
 read through the file to understand what can be configured locally
 as well as the default values in place.
 
-Since ``superset_config.py`` acts as a Flask configuration module, it
+Since the config file acts as a Flask configuration module, it
 can be used to alter the settings Flask itself,
 as well as Flask extensions like ``flask-wtf``, ``flask-cache``,
 ``flask-migrate``, and ``flask-appbuilder``. Flask App Builder, the web
@@ -341,7 +346,7 @@ Caching
 
 Superset uses `Flask-Cache <https://pythonhosted.org/Flask-Cache/>`_ for
 caching purpose. Configuring your caching backend is as easy as providing
-a ``CACHE_CONFIG``, constant in your ``superset_config.py`` that
+a ``CACHE_CONFIG``, constant in your config file that
 complies with the Flask-Cache specifications.
 
 Flask-Cache supports multiple caching backends (Redis, Memcached,
@@ -356,7 +361,7 @@ For setting your timeouts, this is done in the Superset metadata and goes
 up the "timeout searchpath", from your slice configuration, to your
 data source's configuration, to your database's and ultimately falls back
 into your global default defined in ``CACHE_CONFIG``.
-	
+
 .. code-block:: python
 
     CACHE_CONFIG = {
@@ -462,7 +467,7 @@ The extra CORS Dependency must be installed:
     superset[cors]
 
 
-The following keys in `superset_config.py` can be specified to configure CORS:
+The following keys in the config file can be specified to configure CORS:
 
 
 * ``ENABLE_CORS``: Must be set to True in order to enable CORS
@@ -473,7 +478,7 @@ MIDDLEWARE
 ----------
 
 Superset allows you to add your own middleware. To add your own middleware, update the ``ADDITIONAL_MIDDLEWARE`` key in
-your `superset_config.py`. ``ADDITIONAL_MIDDLEWARE`` should be a list of your additional middleware classes.
+your config file. ``ADDITIONAL_MIDDLEWARE`` should be a list of your additional middleware classes.
 
 For example, to use AUTH_REMOTE_USER from behind a proxy server like nginx, you have to add a simple middleware class to
 add the value of ``HTTP_X_PROXY_REMOTE_USER`` (or any other custom header from the proxy) to Gunicorn's ``REMOTE_USER``
@@ -525,7 +530,7 @@ necessary to configure an asynchronous backend for Superset which consist of:
   results
 
 Configuring Celery requires defining a ``CELERY_CONFIG`` in your
-``superset_config.py``. Both the worker and web server processes should
+config file. Both the worker and web server processes should
 have the same configuration.
 
 .. code-block:: python
@@ -544,10 +549,10 @@ To start a Celery worker to leverage the configuration run: ::
 
 To setup a result backend, you need to pass an instance of a derivative
 of ``werkzeug.contrib.cache.BaseCache`` to the ``RESULTS_BACKEND``
-configuration key in your ``superset_config.py``. It's possible to use
+configuration key in your config file. It's possible to use
 Memcached, Redis, S3 (https://pypi.python.org/pypi/s3werkzeugcache),
 memory or the file system (in a single server-type setup or for testing),
-or to write your own caching interface. Your ``superset_config.py`` may
+or to write your own caching interface. Your config file may
 look something like:
 
 .. code-block:: python
@@ -637,7 +642,7 @@ Superset is instrumented to log events to StatsD if desired. Most endpoints hit
 are logged as well as key events like query start and end in SQL Lab.
 
 To setup StatsD logging, it's a matter of configuring the logger in your
-``superset_config.py``.
+config file.
 
 .. code-block:: python
 

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -23,7 +23,6 @@ from superset.connectors.connector_registry import ConnectorRegistry
 from superset.security import SupersetSecurityManager
 
 APP_DIR = os.path.dirname(__file__)
-CONFIG_MODULE = os.environ.get('SUPERSET_CONFIG', 'superset.config')
 
 if not os.path.exists(config.DATA_DIR):
     os.makedirs(config.DATA_DIR)
@@ -32,7 +31,8 @@ with open(APP_DIR + '/static/assets/backendSync.json', 'r') as f:
     frontend_config = json.load(f)
 
 app = Flask(__name__)
-app.config.from_object(CONFIG_MODULE)
+app.config.from_object('superset.config')
+app.config.from_envvar('SUPERSET_CONFIG_FILE', silent=True)
 conf = app.config
 
 #################################################################

--- a/superset/config.py
+++ b/superset/config.py
@@ -1,20 +1,13 @@
 # -*- coding: utf-8 -*-
-"""The main config file for Superset
-
-All configuration in this file can be overridden by providing a superset_config
-in your PYTHONPATH as there is a ``from superset_config import *``
-at the end of this file.
-"""
+"""The main config file for Superset"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
 from collections import OrderedDict
-import imp
 import json
 import os
-import sys
 
 from dateutil import tz
 from flask_appbuilder.security.manager import AUTH_DB
@@ -323,8 +316,6 @@ JINJA_CONTEXT_ADDONS = {}
 # by humans.
 ROBOT_PERMISSION_ROLES = ['Public', 'Gamma', 'Alpha', 'Admin', 'sql_lab']
 
-CONFIG_PATH_ENV_VAR = 'SUPERSET_CONFIG_PATH'
-
 # If a callable is specified, it will be called at app startup while passing
 # a reference to the Flask app. This can be used to alter the Flask app
 # in whatever way.
@@ -411,25 +402,3 @@ SQL_QUERY_MUTATOR = None
 # When not using gunicorn, (nginx for instance), you may want to disable
 # using flask-compress
 ENABLE_FLASK_COMPRESS = True
-
-try:
-    if CONFIG_PATH_ENV_VAR in os.environ:
-        # Explicitly import config module that is not in pythonpath; useful
-        # for case where app is being executed via pex.
-        print('Loaded your LOCAL configuration at [{}]'.format(
-            os.environ[CONFIG_PATH_ENV_VAR]))
-        module = sys.modules[__name__]
-        override_conf = imp.load_source(
-            'superset_config',
-            os.environ[CONFIG_PATH_ENV_VAR])
-        for key in dir(override_conf):
-            if key.isupper():
-                setattr(module, key, getattr(override_conf, key))
-
-    else:
-        from superset_config import *  # noqa
-        import superset_config
-        print('Loaded your LOCAL configuration at [{}]'.format(
-            superset_config.__file__))
-except ImportError:
-    pass

--- a/tests/superset.conf
+++ b/tests/superset.conf
@@ -1,18 +1,12 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
-from superset.config import *
+import os
 
 AUTH_USER_REGISTRATION_ROLE = 'alpha'
-SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'unittests.db')
 DEBUG = True
 SUPERSET_WEBSERVER_PORT = 8081
-
-# Allowing SQLALCHEMY_DATABASE_URI to be defined as an env var for
-# continuous integration
-if 'SUPERSET__SQLALCHEMY_DATABASE_URI' in os.environ:
-    SQLALCHEMY_DATABASE_URI = os.environ.get('SUPERSET__SQLALCHEMY_DATABASE_URI')
-
-SQL_CELERY_RESULTS_DB_FILE_PATH = os.path.join(DATA_DIR, 'celery_results.sqlite')
+SQLALCHEMY_DATABASE_URI = os.environ['SUPERSET__SQLALCHEMY_DATABASE_URI']
+SQL_CELERY_RESULTS_DB_FILE_PATH = os.path.join(os.environ['SUPERSET_HOME'], 'celery_results.sqlite')
 SQL_SELECT_AS_CTA = True
 SQL_MAX_ROW = 666
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     nose
 setenv =
     PYTHONPATH = {toxinidir}
-    SUPERSET_CONFIG = tests.superset_test_config
+    SUPERSET_CONFIG_FILE = {toxinidir}/tests/superset.conf
     SUPERSET_HOME = {envtmpdir}
     py27-mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
     py34-mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset


### PR DESCRIPTION
This PR standardizes the configuration logic following the [suggestions](http://flask.pocoo.org/docs/0.12/config/#configuring-from-files) defined in the Flask documentation.

Pros:
- Uses the recommended Flask approach.
- Reduces the number of configuration options and environment variables from three (`PYTHONPATH`, `SUPERSET_CONFIG`, `SUPERSET_CONFIG_PATH`) to one (`SUPERSET_CONFIG_FILE`). Note I renamed `SUPERSET_CONFIG_PATH` to `SUPERSET_CONFIG_FILE` as it is more intuitive that it refers to a file as opposed to either a directory or file path.
- Raises an error for ill-defined config files (which is handled by Flask). Note previously neither of the `PYTHONPATH` or `SUPERSET_CONFIG_PATH` approaches would raise an error if the config file was ill-formed which meant it wasn't apparent what state the configuration was in. We've been caught out by this issue a few times in the past.
- Reduces the code footprint.

Cons:
- Breaking change. The `PYTHONPATH` environment variable needs to be replaced with the `SUPERSET_CONFIG_FILE`.

to: @fabianmenges @mistercrunch