### PR TITLE
[travis] Fixing environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,12 @@ cache:
   - pip
 env:
   - TOXENV=javascript
-  - TOXENV=py27-flake8
+  - TOXENV=flake8
   - TOXENV=py27-mysql
   - TOXENV=py27-sqlite
-  - TOXENV=py27-pylint
-  - TOXENV=py34-flake8
   - TOXENV=py34-postgres
-  - TOXENV=py34-pylint
   - TOXENV=py34-sqlite
+  - TOXENV=pylint
 before_script:
   - mysql -u root -e "DROP DATABASE IF EXISTS superset; CREATE DATABASE superset DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci"
   - mysql -u root -e "CREATE USER 'mysqluser'@'localhost' IDENTIFIED BY 'mysqluserpassword';"

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -746,7 +746,7 @@ class CalHeatmapViz(BaseViz):
         start = utils.parse_human_datetime(form_data.get('since'))
         end = utils.parse_human_datetime(form_data.get('until'))
         if not start or not end:
-            raise Exception("Please provide both time bounds (Since and Until)")
+            raise Exception('Please provide both time bounds (Since and Until)')
         domain = form_data.get('domain_granularity')
         diff_delta = rdelta.relativedelta(end, start)
         diff_secs = (end - start).total_seconds()

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -7,10 +7,10 @@ from __future__ import unicode_literals
 import textwrap
 
 from sqlalchemy.engine.url import make_url
-from tests.base_tests import SupersetTestCase
 
 from superset import db
 from superset.models.core import Database
+from .base_tests import SupersetTestCase
 
 
 class DatabaseModelTestCase(SupersetTestCase):

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -10,10 +10,9 @@ import unittest
 from mock import Mock, patch
 import pandas as pd
 
-from tests.utils import load_fixture
-
 from superset.utils import DTTM_ALIAS
 import superset.viz as viz
+from .utils import load_fixture
 
 
 class BaseVizTestCase(unittest.TestCase):


### PR DESCRIPTION
Apologies I had misconfigured the Travis environments where `py{27,34}-{flake8,pylint}` didn't exist and thus defaulted to running the default `[testenv]` commands.