### PR TITLE
[import csv] ensure directory exists before saving csv file

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -12,6 +12,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate
+import errno
 import functools
 import json
 import logging
@@ -827,3 +828,11 @@ def is_adhoc_metric(metric):
 
 def get_metric_names(metrics):
     return [metric['label'] if is_adhoc_metric(metric) else metric for metric in metrics]
+
+
+def ensure_path_exists(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if not (os.path.isdir(path) and exc.errno == errno.EEXIST):
+            raise


### PR DESCRIPTION
Some users complained of the error while uploading CSV whereby the first uploading phase fails because directory does not exist. This PR adds an extra check to ensure the directory exists before saving the csv file. 

Fixes https://github.com/apache/incubator-superset/issues/4576