### PR TITLE
db_engine_specs: use correct sqlite week time grain

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -424,7 +424,7 @@ class SqliteEngineSpec(BaseEngineSpec):
               'PT1H'),
         Grain('day', _('day'), 'DATE({col})', 'P1D'),
         Grain('week', _('week'),
-              "DATE({col}, -strftime('%w', {col}) || ' days')",
+              "DATE({col}, -strftime('%W', {col}) || ' days')",
               'P1W'),
         Grain('month', _('month'),
               "DATE({col}, -strftime('%d', {col}) || ' days', '+1 day')",


### PR DESCRIPTION
We want the week of year %W and not the day of week %w
when using week as time grain.

Reference:
https://www.sqlite.org/lang_datefunc.html