### PR TITLE
[setup] Dropping 3.4 and adding 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ matrix:
     - python: 3.6
       env: TOXENV=pylint
   exclude:
-      - python: 2.7
-      - python: 3.6
+    - python: 2.7
+    - python: 3.6
 before_script:
   - mysql -u root -e "DROP DATABASE IF EXISTS superset; CREATE DATABASE superset DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci"
   - mysql -u root -e "CREATE USER 'mysqluser'@'localhost' IDENTIFIED BY 'mysqluserpassword';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,36 @@
 language: python
+python:
+  - 2.7
+  - 3.6
 services:
-    - mysql
-    - postgres
-    - redis-server
+  - mysql
+  - postgres
+  - redis-server
 cache:
   - pip
-env:
-  - TOXENV=javascript
-  - TOXENV=flake8
-  - TOXENV=py27-mysql
-  - TOXENV=py27-sqlite
-  - TOXENV=py34-postgres
-  - TOXENV=py34-sqlite
-  - TOXENV=pylint
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=flake8
+    - python: 2.7
+      env: TOXENV=py27-mysql
+    - python: 2.7
+      env: TOXENV=py27-sqlite
+    - python: 2.7
+      env: TOXENV=pylint
+    - python: 3.6
+      env: TOXENV=flake8
+    - python: 3.6
+      env: TOXENV=javascript
+    - python: 3.6
+      env: TOXENV=py36-postgres
+    - python: 3.6
+      env: TOXENV=py36-sqlite
+    - python: 3.6
+      env: TOXENV=pylint
+  exclude:
+      - python: 2.7
+      - python: 3.6
 before_script:
   - mysql -u root -e "DROP DATABASE IF EXISTS superset; CREATE DATABASE superset DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci"
   - mysql -u root -e "CREATE USER 'mysqluser'@'localhost' IDENTIFIED BY 'mysqluserpassword';"

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -7,3 +7,4 @@ assists people when migrating to a new version.
 
 * [4565](https://github.com/apache/incubator-superset/pull/4565)
 * [4587](https://github.com/apache/incubator-superset/pull/4587)
+* [4835](https://github.com/apache/incubator-superset/pull/4835)

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     ),
     classifiers=[
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -312,7 +312,7 @@ def update_datasources_cache():
             database.all_table_names(force=True)
             database.all_view_names(force=True)
         except Exception as e:
-            print('{}'.format(e.message))
+            print('{}'.format(str(e)))
 
 
 @manager.option(

--- a/tox.ini
+++ b/tox.ini
@@ -78,8 +78,5 @@ envlist =
     eslint
     flake8
     javascript
-    py27
-    py35
-    py36
     pylint
 skipsdist = true

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,8 @@ setenv =
     SUPERSET_HOME = {envtmpdir}
     py27-mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
     py34-mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset
-    {py27,py34}-postgres: SUPERSET__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://postgresuser:pguserpassword@localhost/superset
-    {py27,py34}-sqlite: SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
+    py{27,34,36}-postgres: SUPERSET__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://postgresuser:pguserpassword@localhost/superset
+    py{27,34,36}-sqlite: SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
 whitelist_externals =
     npm
 
@@ -79,6 +79,7 @@ envlist =
     flake8
     javascript
     py27
-    py34
+    py35
+    py36
     pylint
 skipsdist = true


### PR DESCRIPTION
Since [0.21.0](https://pypi.org/project/pandas/0.21.0/) Pandas has dropped support for Python 3.4 which is now causing problems with Travis CI. I speculate the issue is only now surfacing with the release of `pip` version `10.0` per [this](https://github.com/pandas-dev/pandas/issues/20697) thread. 

It seems other applications are dropping support for Python 3.4 and I was wondering whether we should do the same (and adding Python 3.6 as a replacement) as opposed to having to write specific logic to handle different Pandas versions.

This PR also updated the Travis CI matrix to include both Python 2.7 and 3.6 which ensures that the `nosetests` run in the Python version specified by Travis, and that both `flake8` and `pylint` run for all Python versions (previously these ran only for Python 2.7).

to: @fabianmenges @mistercrunch 
cc: @timifasubaa 