### PR TITLE
Cleaning html tags from text

### DIFF
--- a/superset/assets/src/visualizations/big_number.js
+++ b/superset/assets/src/visualizations/big_number.js
@@ -1,5 +1,6 @@
 import d3 from 'd3';
 import d3tip from 'd3-tip';
+import dompurify from 'dompurify';
 import { d3FormatPreset, d3TimeFormatPreset } from '../modules/utils';
 
 import './big_number.css';
@@ -153,7 +154,7 @@ function bigNumberVis(slice, payload) {
 
     const renderTooltip = (d) => {
       const date = formatDate(d[0]);
-      const value = f(d[1]);
+      const value = dompurify.sanitize(f(d[1]));
       return `
         <div>
           <span style="margin-right: 10px;">${date}: </span>

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -7,6 +7,7 @@ import 'nvd3/build/nv.d3.min.css';
 import mathjs from 'mathjs';
 import moment from 'moment';
 import d3tip from 'd3-tip';
+import dompurify from 'dompurify';
 
 import { getColorFromScheme } from '../modules/colors';
 import AnnotationTypes, {
@@ -439,7 +440,7 @@ export default function nvd3Vis(slice, payload) {
                     `style="border: 2px solid ${series.highlight ? 'black' : 'transparent'}; background-color: ${series.color};"` +
                   '></div>' +
                 '</td>' +
-                `<td>${series.key}</td>` +
+                `<td>${dompurify.sanitize(series.key)}</td>` +
                 `<td>${yAxisFormatter(series.value)}</td>` +
               '</tr>'
             );

--- a/superset/assets/src/visualizations/table.js
+++ b/superset/assets/src/visualizations/table.js
@@ -1,6 +1,7 @@
 import d3 from 'd3';
 import dt from 'datatables.net-bs';
 import 'datatables.net-bs/css/dataTables.bootstrap.css';
+import dompurify from 'dompurify';
 
 import { fixDataTableBodyHeight, d3TimeFormatPreset } from '../modules/utils';
 import './table.css';
@@ -87,7 +88,7 @@ function tableVis(slice, payload) {
         html = tsFormatter(val);
       }
       if (typeof (val) === 'string') {
-        html = `<span class="like-pre">${val}</span>`;
+        html = `<span class="like-pre">${dompurify.sanitize(val)}</span>`;
       }
       if (isMetric) {
         html = slice.d3format(c, val);


### PR DESCRIPTION
There are a few cases where we are using d3.html() which intentionally doesn't escape html. In these cases if a user has data with html tags we are not escaping it so some js can be executed. For example if a group by column in a table has an html tag with an onerror, the onerror will get executed in the browser when the table renders.

Initially I tried to do this in some central place so that we didn't have to go into individual files in /visualizations but when looking into it more, it seems to happen when we are using d3.html(). Let me know if there's a better way to do this. I may have missed a few cases, mainly trying to quickly get a fix out for the most used visualizations.

@mistercrunch @graceguo-supercat 