### PR TITLE
[sql] Using read_sql_query instead of read_sql

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -693,7 +693,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     def get_df(self, sql, schema):
         sql = sql.strip().strip(';')
         eng = self.get_sqla_engine(schema=schema)
-        df = pd.read_sql(sql, eng)
+        df = pd.read_sql_query(sql, eng)
 
         def needs_conversion(df_series):
             if df_series.empty:


### PR DESCRIPTION
The Pandas [read_sql](https://github.com/pandas-dev/pandas/blob/v0.22.0/pandas/io/sql.py#L335-L416) method either reads a SQL query _or_ a database table (we require only the former) into a DataFrame. This results in an additional query (for non-SQLite databases) to determine whether the `sql` object represents a SQL query or table name. This is unnecessary as the `sql` object is always a SQL statement when called from `get_df`. 

This PR uses the [read_sql_query](https://github.com/pandas-dev/pandas/blob/v0.22.0/pandas/io/sql.py#L273-L332) method instead which merely reads the SQL query into a DataFrame thus saving us executing an unnecessary statement. 

Note for context about 15% of all our Presto queries originating from PyHive represented the now obsolete query.