### PR TITLE
correct config language key to pt_BR

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -164,7 +164,7 @@ LANGUAGES = {
     'zh': {'flag': 'cn', 'name': 'Chinese'},
     'ja': {'flag': 'jp', 'name': 'Japanese'},
     'de': {'flag': 'de', 'name': 'German'},
-    'pt-BR': {'flag': 'br', 'name': 'Brazilian Portuguese'},
+    'pt_BR': {'flag': 'br', 'name': 'Brazilian Portuguese'},
     'ru': {'flag': 'ru', 'name': 'Russian'},
 }
 # ---------------------------------------------------


### PR DESCRIPTION
With the current value of `pt-BR` Superset throws the following exception:

```
        Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/flask_appbuilder/security/views.py", line 503, in login
    appbuilder=self.appbuilder)
  File "/usr/local/lib/python2.7/dist-packages/flask_appbuilder/baseviews.py", line 160, in render_template
    return render_template(template, **dict(list(kwargs.items()) + list(self.extra_args.items())))
  File "/usr/local/lib/python2.7/dist-packages/flask/templating.py", line 134, in render_template
    context, ctx.app)
  File "/usr/local/lib/python2.7/dist-packages/flask/templating.py", line 116, in _render
    rv = template.render(context)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html", line 2, in top-level template code
    {% extends "appbuilder/base.html" %}
  File "/usr/local/lib/python2.7/dist-packages/flask_appbuilder/templates/appbuilder/base.html", line 1, in top-level template code
    {% extends base_template %}
  File "/usr/local/lib/python2.7/dist-packages/superset/templates/superset/base.html", line 1, in top-level template code
    {% extends "appbuilder/baselayout.html" %}
  File "/usr/local/lib/python2.7/dist-packages/superset/templates/appbuilder/baselayout.html", line 2, in top-level template code
    {% import 'appbuilder/baselib.html' as baselib %}
  File "/usr/local/lib/python2.7/dist-packages/flask_appbuilder/templates/appbuilder/init.html", line 46, in top-level template code
    {% block body %}
  File "/usr/local/lib/python2.7/dist-packages/superset/templates/appbuilder/baselayout.html", line 5, in block "body"
    {% include 'appbuilder/general/confirm.html' %}
  File "/usr/local/lib/python2.7/dist-packages/flask_appbuilder/templates/appbuilder/general/confirm.html", line 6, in top-level template code
    {{_('User confirmation needed')}}
  File "/usr/local/lib/python2.7/dist-packages/jinja2/ext.py", line 134, in _gettext_alias
    return __context.call(__context.resolve('gettext'), *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/ext.py", line 140, in gettext
    rv = __context.call(func, __string)
  File "/usr/local/lib/python2.7/dist-packages/flask_babel/__init__.py", line 113, in <lambda>
    lambda x: get_translations().ugettext(x),
  File "/usr/local/lib/python2.7/dist-packages/flask_babel/__init__.py", line 216, in get_translations
    catalog = support.Translations.load(dirname, [get_locale()])
  File "/usr/local/lib/python2.7/dist-packages/flask_babel/__init__.py", line 248, in get_locale
    locale = Locale.parse(rv)
  File "/usr/local/lib/python2.7/dist-packages/babel/core.py", line 268, in parse
    parts = parse_locale(identifier, sep=sep)
  File "/usr/local/lib/python2.7/dist-packages/babel/core.py", line 1094, in parse_locale
    raise ValueError('expected only letters, got %r' % lang)
ValueError: expected only letters, got u'pt-br'
```

the correct value is `pt_BR`