### PR TITLE
Fix 'pip install .'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ flask-cache==0.13.1
 flask-compress==1.4.0
 flask-migrate==2.1.1
 flask-script==2.0.6
-flask-sqlalchemy==2.1
 flask-testing==0.7.1
 flask-wtf==0.14.2
 flower==0.9.2

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
         'flask-compress',
         'flask-migrate',
         'flask-script',
-        'flask-sqlalchemy',
         'flask-testing',
         'flask-wtf',
         'flower',  # deprecated


### PR DESCRIPTION
Fix error :
> flask-appbuilder 1.10.0 has requirement Flask-SQLAlchemy==2.1,
> but you'll have flask-sqlalchemy 2.3.2 which is incompatible.
> botocore 1.10.5 has requirement python-dateutil<2.7.0,>=2.1, but you'll
> have python-dateutil 2.7.2 which is incompatible.