### PR TITLE
[axis formatting] Override the valueformat to be percentage when contribution is selected

### DIFF
--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -138,7 +138,6 @@ export default function nvd3Vis(slice, payload) {
 
   const vizType = fd.viz_type;
   const formatter = d3.format('.3s');
-  const percentageFormatter = d3.format('.1%');
   const reduceXTicks = fd.reduce_x_ticks || false;
   let stacked = false;
   let row;
@@ -333,10 +332,6 @@ export default function nvd3Vis(slice, payload) {
         throw new Error('Unrecognized visualization for nvd3' + vizType);
     }
 
-    if (fd.contribution) {
-      chart.valueFormat(percentageFormatter);
-    }
-
     if (chart.xAxis && chart.xAxis.staggerLabels) {
       chart.xAxis.staggerLabels(staggerLabels);
     }
@@ -390,9 +385,10 @@ export default function nvd3Vis(slice, payload) {
 
     const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
     if (chart.yAxis && chart.yAxis.tickFormat) {
-      if (fd.num_period_compare) {
-        // When computing a "Period Ratio", we force a percentage format
-        chart.yAxis.tickFormat(d3.format('.1%'));
+      if (fd.num_period_compare || fd.contribution) {
+        // When computing a "Period Ratio" or "Contribution" selected, we force a percentage format
+        const percentageFormat = d3.format('.1%');
+        chart.yAxis.tickFormat(percentageFormat);
       } else {
         chart.yAxis.tickFormat(yAxisFormatter);
       }

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -138,6 +138,7 @@ export default function nvd3Vis(slice, payload) {
 
   const vizType = fd.viz_type;
   const formatter = d3.format('.3s');
+  const percentageFormatter = d3.format('.1%');
   const reduceXTicks = fd.reduce_x_ticks || false;
   let stacked = false;
   let row;
@@ -252,7 +253,7 @@ export default function nvd3Vis(slice, payload) {
       case 'pie':
         chart = nv.models.pieChart();
         colorKey = 'x';
-        chart.valueFormat(f);
+        chart.valueFormat(formatter);
         if (fd.donut) {
           chart.donut(true);
         }
@@ -331,6 +332,12 @@ export default function nvd3Vis(slice, payload) {
       default:
         throw new Error('Unrecognized visualization for nvd3' + vizType);
     }
+
+
+    if (fd.contribution) {
+      chart.valueFormat(percentageFormatter);
+    }
+
 
     if (chart.xAxis && chart.xAxis.staggerLabels) {
       chart.xAxis.staggerLabels(staggerLabels);

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -333,11 +333,9 @@ export default function nvd3Vis(slice, payload) {
         throw new Error('Unrecognized visualization for nvd3' + vizType);
     }
 
-
     if (fd.contribution) {
       chart.valueFormat(percentageFormatter);
     }
-
 
     if (chart.xAxis && chart.xAxis.staggerLabels) {
       chart.xAxis.staggerLabels(staggerLabels);


### PR DESCRIPTION
Currently, the default value format when `contribution` is selected is not intuitive. (e.g., 0.5 -> 500m). In this PR, the value format will be overridden by `.1%`.

The reason here why I don' want want to change and save the current formatting to percentage are 1) the user selected format will be preserved when users uncheck `contribution`. 2) It seems in all the cases when user check `contribution`, percentage format for the value is the best approach. 

also, it fixed a typo where `f` hadn't changed to `valueFormater` in `piechart` 

@williaster 