### PR TITLE
remove DISTINCT ON statement

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -394,7 +394,7 @@ class SqlaTable(Model, BaseDatasource):
         qry = (
             select([target_col.sqla_col])
             .select_from(self.get_from_clause(tp, db_engine_spec))
-            .distinct(column_name)
+            .distinct()
         )
         if limit:
             qry = qry.limit(limit)


### PR DESCRIPTION
this function is used in the 'Enable Filter Select' function. Because it passes `column_name` to `distinct` the function is only usable by backends which support the `DISTINCT ON` statement, i.e. only postgres.

Here is (gist of) the error string I get:

```
SELECT DISTINCT ON is not supported [SQL: 'SELECT DISTINCT ON (column_name) column_name AS column_name \nFROM public.table_name \n LIMIT 10000 (Background on this error at: http://sqlalche.me/e/tw8g)
```

DISTINCT ON is only meaningful when selecting values from multiple columns. Because we are selecting rows from only one column, the above processed statement is logically identical to `SELECT DISTINCT column_name FROM table_name LIMIT 10`. 

this passes CI / tox / etc since it's a one line change.