### PR TITLE
Adding X and Y axis Formats to the Bubble Chart Tooltip 

### DIFF
--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -123,8 +123,10 @@ export default function nvd3Vis(slice, payload) {
 
   let width = slice.width();
   const fd = slice.formData;
+  
   let xAxisFormatter = d3FormatPreset(fd.x_axis_format);
   const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
+  
   const barchartWidth = function () {
     let bars;
     if (fd.bar_stacked) {
@@ -371,7 +373,7 @@ export default function nvd3Vis(slice, payload) {
       chart.xScale(d3.scale.log());
     }
 
-    let xAxisFormatter = d3FormatPreset(fd.x_axis_format);
+    //let xAxisFormatter = d3FormatPreset(fd.x_axis_format);
     if (isTimeSeries) {
       xAxisFormatter = d3TimeFormatPreset(fd.x_axis_format);
       // In tooltips, always use the verbose time format
@@ -385,7 +387,7 @@ export default function nvd3Vis(slice, payload) {
       chart.xAxis.tickFormat(xAxisFormatter);
     }
 
-    const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
+    //const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
     if (chart.yAxis && chart.yAxis.tickFormat) {
       if (fd.num_period_compare || fd.contribution) {
         // When computing a "Period Ratio" or "Contribution" selected, we force a percentage format

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -352,6 +352,7 @@ export default function nvd3Vis(slice, payload) {
         chart.showLegend(false);
       } else {
         chart.showLegend(fd.show_legend);
+        chart.legend.margin({ top: 5, right: 30, left: 80, bottom: 30 });
       }
     }
 

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -123,7 +123,8 @@ export default function nvd3Vis(slice, payload) {
 
   let width = slice.width();
   const fd = slice.formData;
-
+  let xAxisFormatter = d3FormatPreset(fd.x_axis_format);
+  const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
   const barchartWidth = function () {
     let bars;
     if (fd.bar_stacked) {

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -123,10 +123,8 @@ export default function nvd3Vis(slice, payload) {
 
   let width = slice.width();
   const fd = slice.formData;
-  
   let xAxisFormatter = d3FormatPreset(fd.x_axis_format);
   const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
-  
   const barchartWidth = function () {
     let bars;
     if (fd.bar_stacked) {
@@ -373,7 +371,6 @@ export default function nvd3Vis(slice, payload) {
       chart.xScale(d3.scale.log());
     }
 
-  
     if (isTimeSeries) {
       xAxisFormatter = d3TimeFormatPreset(fd.x_axis_format);
       // In tooltips, always use the verbose time format

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -373,7 +373,7 @@ export default function nvd3Vis(slice, payload) {
       chart.xScale(d3.scale.log());
     }
 
-    //let xAxisFormatter = d3FormatPreset(fd.x_axis_format);
+  
     if (isTimeSeries) {
       xAxisFormatter = d3TimeFormatPreset(fd.x_axis_format);
       // In tooltips, always use the verbose time format
@@ -387,7 +387,6 @@ export default function nvd3Vis(slice, payload) {
       chart.xAxis.tickFormat(xAxisFormatter);
     }
 
-    //const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
     if (chart.yAxis && chart.yAxis.tickFormat) {
       if (fd.num_period_compare || fd.contribution) {
         // When computing a "Period Ratio" or "Contribution" selected, we force a percentage format

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -301,8 +301,8 @@ export default function nvd3Vis(slice, payload) {
             `<tr><td style="color: ${p.color};">` +
               `<strong>${p[fd.entity]}</strong> (${p.group})` +
             '</td></tr>');
-          s += row(fd.x, formatter(p.x));
-          s += row(fd.y, formatter(p.y));
+          s += row(fd.x, xAxisFormatter(p.x));
+          s += row(fd.y, yAxisFormatter(p.y));
           s += row(fd.size, formatter(p.size));
           s += '</table>';
           return s;


### PR DESCRIPTION
The Bubble chart does not apply the formatting options on the metrics in the tooltip . Adding the x-axis and y-axis formatting for the tooltip .