### PR TITLE
Fix regression in timestamp expression

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -131,7 +131,7 @@ class TableColumn(Model, BaseColumn):
                     expr = db_spec.epoch_ms_to_dttm().format(col=expr)
             grain = self.table.database.grains_dict().get(time_grain)
             literal = grain.function if grain else '{col}'
-            literal = expr.format(col=expr)
+            literal = literal.format(col=expr)
         return literal_column(literal, type_=DateTime).label(DTTM_ALIAS)
 
     @classmethod


### PR DESCRIPTION
Change to superset/connectors/sqla/models.py in #4821 introduced a regression, breaking time grain rendering.