### PR TITLE
Use React.PureComponent everywhere

### DIFF
--- a/superset/assets/src/SqlLab/components/HighlightedSql.jsx
+++ b/superset/assets/src/SqlLab/components/HighlightedSql.jsx
@@ -24,7 +24,7 @@ const propTypes = {
   shrink: PropTypes.bool,
 };
 
-class HighlightedSql extends React.Component {
+class HighlightedSql extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/SqlLab/components/TabStatusIcon.jsx
+++ b/superset/assets/src/SqlLab/components/TabStatusIcon.jsx
@@ -6,7 +6,7 @@ const propTypes = {
   tabState: PropTypes.string.isRequired,
 };
 
-class TabStatusIcon extends React.Component {
+class TabStatusIcon extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onMouseOver = this.onMouseOver.bind(this);

--- a/superset/assets/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset/assets/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -27,7 +27,7 @@ const defaultProps = {
   code: '{}',
 };
 
-export default class TemplateParamsEditor extends React.Component {
+export default class TemplateParamsEditor extends React.PureComponent {
   constructor(props) {
     super(props);
     const codeText = props.code || '{}';

--- a/superset/assets/src/components/AlteredSliceTag.jsx
+++ b/superset/assets/src/components/AlteredSliceTag.jsx
@@ -13,7 +13,7 @@ const propTypes = {
   currentFormData: PropTypes.object.isRequired,
 };
 
-export default class AlteredSliceTag extends React.Component {
+export default class AlteredSliceTag extends React.PureComponent {
 
   constructor(props) {
     super(props);

--- a/superset/assets/src/components/CopyToClipboard.jsx
+++ b/superset/assets/src/components/CopyToClipboard.jsx
@@ -21,7 +21,7 @@ const defaultProps = {
   tooltipText: t('Copy to clipboard'),
 };
 
-export default class CopyToClipboard extends React.Component {
+export default class CopyToClipboard extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/components/FaveStar.jsx
+++ b/superset/assets/src/components/FaveStar.jsx
@@ -11,7 +11,7 @@ const propTypes = {
   isStarred: PropTypes.bool.isRequired,
 };
 
-export default class FaveStar extends React.Component {
+export default class FaveStar extends React.PureComponent {
   componentDidMount() {
     this.props.fetchFaveStar(this.props.itemId);
   }

--- a/superset/assets/src/components/ModalTrigger.jsx
+++ b/superset/assets/src/components/ModalTrigger.jsx
@@ -30,7 +30,7 @@ const defaultProps = {
   className: '',
 };
 
-export default class ModalTrigger extends React.Component {
+export default class ModalTrigger extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/components/OnPasteSelect.jsx
+++ b/superset/assets/src/components/OnPasteSelect.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
 
-export default class OnPasteSelect extends React.Component {
+export default class OnPasteSelect extends React.PureComponent {
   onPaste(evt) {
     if (!this.props.multi) {
       return;

--- a/superset/assets/src/dashboard/components/GridLayout.jsx
+++ b/superset/assets/src/dashboard/components/GridLayout.jsx
@@ -49,7 +49,7 @@ const defaultProps = {
   removeFilter: () => ({}),
 };
 
-class GridLayout extends React.Component {
+class GridLayout extends React.PureComponent {
   constructor(props) {
     super(props);
 

--- a/superset/assets/src/dashboard/components/SliceAdder.jsx
+++ b/superset/assets/src/dashboard/components/SliceAdder.jsx
@@ -15,7 +15,7 @@ const propTypes = {
   addSlicesToDashboard: PropTypes.func,
 };
 
-class SliceAdder extends React.Component {
+class SliceAdder extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -35,7 +35,7 @@ const defaultProps = {
 const startingWidth = 300;
 const startingHeight = 180;
 
-export default class AdhocMetricEditPopover extends React.Component {
+export default class AdhocMetricEditPopover extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onSave = this.onSave.bind(this);

--- a/superset/assets/src/explore/components/AdhocMetricEditPopoverTitle.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopoverTitle.jsx
@@ -8,7 +8,7 @@ const propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
-export default class AdhocMetricEditPopoverTitle extends React.Component {
+export default class AdhocMetricEditPopoverTitle extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onMouseOver = this.onMouseOver.bind(this);

--- a/superset/assets/src/explore/components/ControlHeader.jsx
+++ b/superset/assets/src/explore/components/ControlHeader.jsx
@@ -24,7 +24,7 @@ const defaultProps = {
   hovered: false,
 };
 
-export default class ControlHeader extends React.Component {
+export default class ControlHeader extends React.PureComponent {
   renderOptionalIcons() {
     if (this.props.hovered) {
       return (

--- a/superset/assets/src/explore/components/ControlPanelSection.jsx
+++ b/superset/assets/src/explore/components/ControlPanelSection.jsx
@@ -18,7 +18,7 @@ const defaultProps = {
   hasErrors: false,
 };
 
-export default class ControlPanelSection extends React.Component {
+export default class ControlPanelSection extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = { expanded: this.props.startExpanded };

--- a/superset/assets/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset/assets/src/explore/components/ControlPanelsContainer.jsx
@@ -21,7 +21,7 @@ const propTypes = {
   isDatasourceMetaLoading: PropTypes.bool.isRequired,
 };
 
-class ControlPanelsContainer extends React.Component {
+class ControlPanelsContainer extends React.PureComponent {
   constructor(props) {
     super(props);
     this.removeAlert = this.removeAlert.bind(this);

--- a/superset/assets/src/explore/components/EmbedCodeButton.jsx
+++ b/superset/assets/src/explore/components/EmbedCodeButton.jsx
@@ -9,7 +9,7 @@ const propTypes = {
   latestQueryFormData: PropTypes.object.isRequired,
 };
 
-export default class EmbedCodeButton extends React.Component {
+export default class EmbedCodeButton extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/src/explore/components/ExploreViewContainer.jsx
@@ -32,7 +32,7 @@ const propTypes = {
   impressionId: PropTypes.string,
 };
 
-class ExploreViewContainer extends React.Component {
+class ExploreViewContainer extends React.PureComponent {
   constructor(props) {
     super(props);
     this.firstLoad = true;

--- a/superset/assets/src/explore/components/SaveModal.jsx
+++ b/superset/assets/src/explore/components/SaveModal.jsx
@@ -20,7 +20,7 @@ const propTypes = {
   datasource: PropTypes.object,
 };
 
-class SaveModal extends React.Component {
+class SaveModal extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/explore/components/URLShortLinkButton.jsx
+++ b/superset/assets/src/explore/components/URLShortLinkButton.jsx
@@ -10,7 +10,7 @@ const propTypes = {
   latestQueryFormData: PropTypes.object.isRequired,
 };
 
-export default class URLShortLinkButton extends React.Component {
+export default class URLShortLinkButton extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/explore/components/controls/BoundsControl.jsx
+++ b/superset/assets/src/explore/components/controls/BoundsControl.jsx
@@ -14,7 +14,7 @@ const defaultProps = {
   value: [null, null],
 };
 
-export default class BoundsControl extends React.Component {
+export default class BoundsControl extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/explore/components/controls/CheckboxControl.jsx
+++ b/superset/assets/src/explore/components/controls/CheckboxControl.jsx
@@ -18,7 +18,7 @@ const defaultProps = {
 
 const checkboxStyle = { paddingRight: '5px' };
 
-export default class CheckboxControl extends React.Component {
+export default class CheckboxControl extends React.PureComponent {
   onChange() {
     this.props.onChange(!this.props.value);
   }

--- a/superset/assets/src/explore/components/controls/CollectionControl.jsx
+++ b/superset/assets/src/explore/components/controls/CollectionControl.jsx
@@ -42,7 +42,7 @@ const SortableListGroup = SortableContainer(ListGroup);
 const SortableDragger = SortableHandle(() => (
   <i className="fa fa-bars text-primary" style={{ cursor: 'ns-resize' }} />));
 
-export default class CollectionControl extends React.Component {
+export default class CollectionControl extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onAdd = this.onAdd.bind(this);

--- a/superset/assets/src/explore/components/controls/ColorPickerControl.jsx
+++ b/superset/assets/src/explore/components/controls/ColorPickerControl.jsx
@@ -45,7 +45,7 @@ const styles = {
     background: 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMUlEQVQ4T2NkYGAQYcAP3uCTZhw1gGGYhAGBZIA/nYDCgBDAm9BGDWAAJyRCgLaBCAAgXwixzAS0pgAAAABJRU5ErkJggg==") left center',
   },
 };
-export default class ColorPickerControl extends React.Component {
+export default class ColorPickerControl extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onChange = this.onChange.bind(this);

--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -31,7 +31,7 @@ const defaultProps = {
   value: '',
 };
 
-export default class DateFilterControl extends React.Component {
+export default class DateFilterControl extends React.PureComponent {
   constructor(props) {
     super(props);
     const value = props.value || '';

--- a/superset/assets/src/explore/components/controls/Filter.jsx
+++ b/superset/assets/src/explore/components/controls/Filter.jsx
@@ -43,7 +43,7 @@ const defaultProps = {
   valueChoices: [],
 };
 
-export default class Filter extends React.Component {
+export default class Filter extends React.PureComponent {
 
   switchFilterValue(prevOp, nextOp) {
     if (operators[prevOp].type !== operators[nextOp].type) {

--- a/superset/assets/src/explore/components/controls/FilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/FilterControl.jsx
@@ -18,7 +18,7 @@ const defaultProps = {
   value: [],
 };
 
-export default class FilterControl extends React.Component {
+export default class FilterControl extends React.PureComponent {
 
   constructor(props) {
     super(props);

--- a/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -29,7 +29,7 @@ const defaultProps = {
   default: { type: controlTypes.fixed, value: 5 },
 };
 
-export default class FixedOrMetricControl extends React.Component {
+export default class FixedOrMetricControl extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onChange = this.onChange.bind(this);

--- a/superset/assets/src/explore/components/controls/SpatialControl.jsx
+++ b/superset/assets/src/explore/components/controls/SpatialControl.jsx
@@ -30,7 +30,7 @@ const defaultProps = {
   choices: [],
 };
 
-export default class SpatialControl extends React.Component {
+export default class SpatialControl extends React.PureComponent {
   constructor(props) {
     super(props);
     const v = props.value || {};

--- a/superset/assets/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset/assets/src/explore/components/controls/TextAreaControl.jsx
@@ -38,7 +38,7 @@ const defaultProps = {
   readOnly: false,
 };
 
-export default class TextAreaControl extends React.Component {
+export default class TextAreaControl extends React.PureComponent {
   onControlChange(event) {
     this.props.onChange(event.target.value);
   }

--- a/superset/assets/src/explore/components/controls/TextControl.jsx
+++ b/superset/assets/src/explore/components/controls/TextControl.jsx
@@ -25,7 +25,7 @@ const defaultProps = {
   disabled: false,
 };
 
-export default class TextControl extends React.Component {
+export default class TextControl extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onChange = this.onChange.bind(this);

--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -30,7 +30,7 @@ const colTypeOptions = [
   { value: 'avg', label: 'Period Average' },
 ];
 
-export default class TimeSeriesColumnControl extends React.Component {
+export default class TimeSeriesColumnControl extends React.PureComponent {
   constructor(props) {
     super(props);
     const state = { ...props };

--- a/superset/assets/src/explore/components/controls/ViewportControl.jsx
+++ b/superset/assets/src/explore/components/controls/ViewportControl.jsx
@@ -34,7 +34,7 @@ const defaultProps = {
   value: defaultViewport,
 };
 
-export default class ViewportControl extends React.Component {
+export default class ViewportControl extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onChange = this.onChange.bind(this);

--- a/superset/assets/src/visualizations/deckgl/AnimatableDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/AnimatableDeckGLContainer.jsx
@@ -20,7 +20,7 @@ const defaultProps = {
   step: 1,
 };
 
-export default class AnimatableDeckGLContainer extends React.Component {
+export default class AnimatableDeckGLContainer extends React.PureComponent {
   constructor(props) {
     super(props);
     const { getLayers, start, end, step, values, disabled, viewport, ...other } = props;

--- a/superset/assets/src/visualizations/deckgl/DeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/DeckGLContainer.jsx
@@ -17,7 +17,7 @@ const defaultProps = {
   onViewportChange: () => {},
 };
 
-export default class DeckGLContainer extends React.Component {
+export default class DeckGLContainer extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/visualizations/filter_box.jsx
+++ b/superset/assets/src/visualizations/filter_box.jsx
@@ -48,7 +48,7 @@ const defaultProps = {
   instantFiltering: true,
 };
 
-class FilterBox extends React.Component {
+class FilterBox extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset/assets/src/visualizations/mapbox.jsx
+++ b/superset/assets/src/visualizations/mapbox.jsx
@@ -22,7 +22,7 @@ import './mapbox.css';
 
 const NOOP = () => {};
 
-class ScatterPlotGlowOverlay extends React.Component {
+class ScatterPlotGlowOverlay extends React.PureComponent {
   componentDidMount() {
     this.redraw();
   }
@@ -239,7 +239,7 @@ ScatterPlotGlowOverlay.contextTypes = {
   isDragging: PropTypes.bool,
 };
 
-class MapboxViz extends React.Component {
+class MapboxViz extends React.PureComponent {
   constructor(props) {
     super(props);
     const longitude = this.props.viewportLongitude || DEFAULT_LONGITUDE;

--- a/superset/assets/src/visualizations/paired_ttest.jsx
+++ b/superset/assets/src/visualizations/paired_ttest.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 
 import './paired_ttest.css';
 
-class TTestTable extends React.Component {
+class TTestTable extends React.PureComponent {
 
   constructor(props) {
     super(props);


### PR DESCRIPTION
`s/React.Component/React.PureComponent/g`

Did a bit of manual testing but I think we've had good hygiene of not mutating props. This should result in much less rendering.

@graceguo-supercat @williaster what do you all think?