### PR TITLE
[bufix] filtered column was removed

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -2,6 +2,7 @@ import { getExploreUrlAndPayload, getAnnotationJsonUrl } from '../explore/explor
 import { requiresQuery, ANNOTATION_SOURCE_TYPES } from '../modules/AnnotationTypes';
 import { Logger, LOG_ACTIONS_LOAD_EVENT } from '../logger';
 import { COMMON_ERR_MESSAGES } from '../common';
+import { t } from '../locales';
 
 const $ = window.$ = require('jquery');
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -582,12 +582,12 @@ class SqlaTable(Model, BaseDatasource):
             col = flt['col']
             op = flt['op']
             col_obj = cols.get(col)
-            is_list_target = op in ('in', 'not in')
-            eq = self.filter_values_handler(
-                flt.get('val'),
-                target_column_is_numeric=col_obj.is_num,
-                is_list_target=is_list_target)
             if col_obj:
+                is_list_target = op in ('in', 'not in')
+                eq = self.filter_values_handler(
+                    flt.get('val'),
+                    target_column_is_numeric=col_obj.is_num,
+                    is_list_target=is_list_target)
                 if op in ('in', 'not in'):
                     cond = col_obj.sqla_col.in_(eq)
                     if '<NULL>' in eq:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -23,7 +23,7 @@ import traceback
 import uuid
 
 from dateutil import relativedelta as rdelta
-from flask import escape, request
+from flask import request
 from flask_babel import lazy_gettext as _
 import geohash
 from geopy.point import Point
@@ -368,7 +368,7 @@ class BaseViz(object):
             except Exception as e:
                 logging.exception(e)
                 if not self.error_message:
-                    self.error_message = escape('{}'.format(e))
+                    self.error_message = '{}'.format(e)
                 self.status = utils.QueryStatus.FAILED
                 stacktrace = traceback.format_exc()
 


### PR DESCRIPTION
<img width="448" alt="screen shot 2018-05-02 at 9 03 07 am" src="https://user-images.githubusercontent.com/487433/39535063-d7d86d22-4de7-11e8-965b-41ae316116d9.png">

if a filter is created on a chart, and the column is removed from the
dataset, you get a "&#39;NoneType&#39; object has no attribute
&#39;is_num&#39;" or something to that
effect. This fix disregards the filter.

Also error messages were HTML escaped which React does already anyways
so that's not necessary [anymore] here.