### PR TITLE
[WorldMap] Add required parameter validation

### DIFF
--- a/superset/assets/src/explore/visTypes.js
+++ b/superset/assets/src/explore/visTypes.js
@@ -1390,6 +1390,7 @@ export const visTypes = {
       },
       {
         label: t('Bubbles'),
+        expanded: true,
         controlSetRows: [
           ['show_bubbles'],
           ['secondary_metric'],
@@ -1408,6 +1409,7 @@ export const visTypes = {
       },
       secondary_metric: {
         label: t('Bubble size'),
+        validators: [v.nonEmpty],
         description: t('Metric that defines the size of the bubble'),
       },
     },


### PR DESCRIPTION
<img width="1191" alt="screen_shot_2018-05-02_at_3_25_08_pm-3" src="https://user-images.githubusercontent.com/27990562/39553859-78886bd2-4e24-11e8-9c91-9ce9223dac86.png">

If user didn't set `bubble size`, chart will throw confusing error message.

@michellethomas @mistercrunch 