### PR TITLE
[sql lab] handle query stop race condition

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -232,13 +232,7 @@ def execute_sql(
         conn.close()
 
     if query.status == utils.QueryStatus.STOPPED:
-        return json.dumps(
-            {
-                'query_id': query.id,
-                'status': query.status,
-                'query': query.to_dict(),
-            },
-            default=utils.json_iso_dttm_ser)
+        return handle_error('The query has been stopped')
 
     cdf = convert_results_to_df(cursor_description, data)
 


### PR DESCRIPTION
fixes https://github.com/apache/incubator-superset/issues/4926

In rare cases where the query is stopped before it is started, SQL Lab
returns an unexpected string payload instead of a normal dictionary.

This aligns the process to handle the error in a homogeneous fashion.