### PR TITLE
Move from deprecated flask-cache to flask-caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ colorama==0.3.9
 cryptography==1.9
 flask==0.12.2
 flask-appbuilder==1.10.0
-flask-cache==0.13.1
+flask-caching==1.4.0
 flask-compress==1.4.0
 flask-migrate==2.1.1
 flask-script==2.0.6

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'cryptography',
         'flask',
         'flask-appbuilder',
-        'flask-cache',
+        'flask-caching',
         'flask-compress',
         'flask-migrate',
         'flask-script',

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -29,7 +29,7 @@ import celery
 from dateutil.parser import parse
 from flask import flash, Markup, render_template
 from flask_babel import gettext as __
-from flask_cache import Cache
+from flask_caching import Cache
 import markdown as md
 import numpy
 import pandas as pd


### PR DESCRIPTION
It appears the officially maintained fork of flask-cache is
flask-caching https://github.com/sh4nks/flask-caching . It is fully
compatible with flask-cache.

closes https://github.com/apache/incubator-superset/issues/4934