### PR TITLE
[sql lab] a better approach at limiting queries

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -94,6 +94,7 @@ class BaseEngineSpec(object):
     def apply_limit_to_sql(cls, sql, limit, database):
         """Alters the SQL statement to apply a LIMIT clause"""
         if cls.limit_method == LimitMethod.WRAP_SQL:
+            sql = sql.strip('\t\n ;')
             qry = (
                 select('*')
                 .select_from(
@@ -104,6 +105,13 @@ class BaseEngineSpec(object):
             return database.compile_sqla_query(qry)
         elif LimitMethod.FORCE_LIMIT:
             no_limit = re.sub(r'(?i)\s+LIMIT\s+\d+;?(\s|;)*$', '', sql)
+            no_limit = re.sub(r"""
+                (?ix)        # case insensitive, verbose
+                \s+          # whitespace
+                LIMIT\s+\d+  # LIMIT $ROWS
+                ;?           # optional semi-colon
+                (\s|;)*$     # remove trailing spaces tabs or semicolons
+                """, '', sql)
             return '{no_limit} LIMIT {limit}'.format(**locals())
         return sql
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -103,7 +103,7 @@ class BaseEngineSpec(object):
             )
             return database.compile_sqla_query(qry)
         elif LimitMethod.FORCE_LIMIT:
-            no_limit = re.sub(r"(?i)\s+LIMIT\s+\d+;?(\s|;)*$", '', sql)
+            no_limit = re.sub(r'(?i)\s+LIMIT\s+\d+;?(\s|;)*$', '', sql)
             return "{no_limit} LIMIT {limit}".format(**locals())
         return sql
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -35,6 +35,7 @@ from sqlalchemy import select
 from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.sql import text
+from sqlalchemy.sql.expression import TextAsFrom
 import sqlparse
 import unicodecsv
 from werkzeug.utils import secure_filename
@@ -55,6 +56,7 @@ class LimitMethod(object):
     """Enum the ways that limits can be applied"""
     FETCH_MANY = 'fetch_many'
     WRAP_SQL = 'wrap_sql'
+    FORCE_LIMIT = 'force_limit'
 
 
 class BaseEngineSpec(object):
@@ -65,7 +67,7 @@ class BaseEngineSpec(object):
     cursor_execute_kwargs = {}
     time_grains = tuple()
     time_groupby_inline = False
-    limit_method = LimitMethod.FETCH_MANY
+    limit_method = LimitMethod.FORCE_LIMIT
     time_secondary_columns = False
     inner_joins = True
 
@@ -87,6 +89,23 @@ class BaseEngineSpec(object):
     def extra_table_metadata(cls, database, table_name, schema_name):
         """Returns engine-specific table metadata"""
         return {}
+
+    @classmethod
+    def apply_limit_to_sql(cls, sql, limit, database):
+        """Alters the SQL statement to apply a LIMIT clause"""
+        if cls.limit_method == LimitMethod.WRAP_SQL:
+            qry = (
+                select('*')
+                .select_from(
+                    TextAsFrom(text(sql), ['*']).alias('inner_qry'),
+                )
+                .limit(limit)
+            )
+            return database.compile_sqla_query(qry)
+        elif LimitMethod.FORCE_LIMIT:
+            no_limit = re.sub(r"(?i)\s+LIMIT\s+\d+;?(\s|;)*$", '', sql)
+            return "{no_limit} LIMIT {limit}".format(**locals())
+        return sql
 
     @staticmethod
     def csv_to_df(**kwargs):
@@ -337,7 +356,6 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
 
 class SnowflakeEngineSpec(PostgresBaseEngineSpec):
     engine = 'snowflake'
-
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}', None),
         Grain('second', _('second'), "DATE_TRUNC('SECOND', {col})", 'PT1S'),
@@ -361,6 +379,7 @@ class RedshiftEngineSpec(PostgresBaseEngineSpec):
 
 class OracleEngineSpec(PostgresBaseEngineSpec):
     engine = 'oracle'
+    limit_method = LimitMethod.WRAP_SQL
 
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}', None),
@@ -382,6 +401,7 @@ class OracleEngineSpec(PostgresBaseEngineSpec):
 
 class Db2EngineSpec(BaseEngineSpec):
     engine = 'ibm_db_sa'
+    limit_method = LimitMethod.WRAP_SQL
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}', None),
         Grain('second', _('second'),
@@ -1106,6 +1126,7 @@ class HiveEngineSpec(PrestoEngineSpec):
 class MssqlEngineSpec(BaseEngineSpec):
     engine = 'mssql'
     epoch_to_dttm = "dateadd(S, {col}, '1970-01-01')"
+    limit_method = LimitMethod.WRAP_SQL
 
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}', None),
@@ -1310,7 +1331,6 @@ class ImpalaEngineSpec(BaseEngineSpec):
 class DruidEngineSpec(BaseEngineSpec):
     """Engine spec for Druid.io"""
     engine = 'druid'
-    limit_method = LimitMethod.FETCH_MANY
     inner_joins = False
 
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -104,7 +104,6 @@ class BaseEngineSpec(object):
             )
             return database.compile_sqla_query(qry)
         elif LimitMethod.FORCE_LIMIT:
-            no_limit = re.sub(r'(?i)\s+LIMIT\s+\d+;?(\s|;)*$', '', sql)
             no_limit = re.sub(r"""
                 (?ix)        # case insensitive, verbose
                 \s+          # whitespace

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -104,7 +104,7 @@ class BaseEngineSpec(object):
             return database.compile_sqla_query(qry)
         elif LimitMethod.FORCE_LIMIT:
             no_limit = re.sub(r'(?i)\s+LIMIT\s+\d+;?(\s|;)*$', '', sql)
-            return "{no_limit} LIMIT {limit}".format(**locals())
+            return '{no_limit} LIMIT {limit}'.format(**locals())
         return sql
 
     @staticmethod

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -719,7 +719,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             self, table_name, schema=schema, limit=limit, show_cols=show_cols,
             indent=indent, latest_partition=latest_partition, cols=cols)
 
-    def wrap_sql_limit(self, sql, limit=1000):
+    def apply_limit_to_sql(self, sql, limit=1000):
         return self.db_engine_spec.apply_limit_to_sql(sql, limit, self)
 
     def safe_sqlalchemy_uri(self):

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -22,7 +22,7 @@ import pandas as pd
 import sqlalchemy as sqla
 from sqlalchemy import (
     Boolean, Column, create_engine, DateTime, ForeignKey, Integer,
-    MetaData, select, String, Table, Text,
+    MetaData, String, Table, Text,
 )
 from sqlalchemy.engine import url
 from sqlalchemy.engine.url import make_url
@@ -30,8 +30,6 @@ from sqlalchemy.orm import relationship, subqueryload
 from sqlalchemy.orm.session import make_transient
 from sqlalchemy.pool import NullPool
 from sqlalchemy.schema import UniqueConstraint
-from sqlalchemy.sql import text
-from sqlalchemy.sql.expression import TextAsFrom
 from sqlalchemy_utils import EncryptedType
 
 from superset import app, db, db_engine_specs, security_manager, utils

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -722,14 +722,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             indent=indent, latest_partition=latest_partition, cols=cols)
 
     def wrap_sql_limit(self, sql, limit=1000):
-        qry = (
-            select('*')
-            .select_from(
-                TextAsFrom(text(sql), ['*'])
-                .alias('inner_qry'),
-            ).limit(limit)
-        )
-        return self.compile_sqla_query(qry)
+        return self.db_engine_spec.apply_limit_to_sql(sql, limit, self)
 
     def safe_sqlalchemy_uri(self):
         return self.sqlalchemy_uri

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -17,7 +17,6 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
 from superset import app, dataframe, db, results_backend, security_manager, utils
-from superset.db_engine_specs import LimitMethod
 from superset.models.sql_lab import Query
 from superset.sql_parse import SupersetQuery
 from superset.utils import get_celery_app, QueryStatus

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -188,8 +188,7 @@ def execute_sql(
                 query.user_id, start_dttm.strftime('%Y_%m_%d_%H_%M_%S'))
         executed_sql = superset_query.as_create_table(query.tmp_table_name)
         query.select_as_cta_used = True
-    elif (query.limit and superset_query.is_select() and
-            db_engine_spec.limit_method == LimitMethod.WRAP_SQL):
+    elif (query.limit and superset_query.is_select()):
         executed_sql = database.wrap_sql_limit(executed_sql, query.limit)
         query.limit_used = True
 

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -188,7 +188,7 @@ def execute_sql(
         executed_sql = superset_query.as_create_table(query.tmp_table_name)
         query.select_as_cta_used = True
     elif (query.limit and superset_query.is_select()):
-        executed_sql = database.wrap_sql_limit(executed_sql, query.limit)
+        executed_sql = database.apply_limit_to_sql(executed_sql, query.limit)
         query.limit_used = True
 
     # Hook to allow environment-specific mutation (usually comments) to the SQL

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -139,38 +139,6 @@ class CeleryTestCase(SupersetTestCase):
         self.logout()
         return json.loads(resp.data.decode('utf-8'))
 
-    def test_add_limit_to_the_query(self):
-        main_db = self.get_main_database(db.session)
-
-        select_query = 'SELECT * FROM outer_space;'
-        updated_select_query = main_db.wrap_sql_limit(select_query, 100)
-        # Different DB engines have their own spacing while compiling
-        # the queries, that's why ' '.join(query.split()) is used.
-        # In addition some of the engines do not include OFFSET 0.
-        self.assertTrue(
-            'SELECT * FROM (SELECT * FROM outer_space;) AS inner_qry '
-            'LIMIT 100' in ' '.join(updated_select_query.split()),
-        )
-
-        select_query_no_semicolon = 'SELECT * FROM outer_space'
-        updated_select_query_no_semicolon = main_db.wrap_sql_limit(
-            select_query_no_semicolon, 100)
-        self.assertTrue(
-            'SELECT * FROM (SELECT * FROM outer_space) AS inner_qry '
-            'LIMIT 100' in
-            ' '.join(updated_select_query_no_semicolon.split()),
-        )
-
-        multi_line_query = (
-            "SELECT * FROM planets WHERE\n Luke_Father = 'Darth Vader';"
-        )
-        updated_multi_line_query = main_db.wrap_sql_limit(multi_line_query, 100)
-        self.assertTrue(
-            'SELECT * FROM (SELECT * FROM planets WHERE '
-            "Luke_Father = 'Darth Vader';) AS inner_qry LIMIT 100" in
-            ' '.join(updated_multi_line_query.split()),
-        )
-
     def test_run_sync_query_dont_exist(self):
         main_db = self.get_main_database(db.session)
         db_id = main_db.id

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -4,12 +4,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unittest
+from superset.db_engine_specs import MssqlEngineSpec, HiveEngineSpec, MySQLEngineSpec
+from superset.models.core import Database
+from .base_tests import SupersetTestCase
 
-from superset.db_engine_specs import HiveEngineSpec
 
-
-class DbEngineSpecsTestCase(unittest.TestCase):
+class DbEngineSpecsTestCase(SupersetTestCase):
     def test_0_progress(self):
         log = """
             17/02/07 18:26:27 INFO log.PerfLogger: <PERFLOG method=compile from=org.apache.hadoop.hive.ql.Driver>
@@ -80,3 +80,45 @@ class DbEngineSpecsTestCase(unittest.TestCase):
             17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
         """.split('\n')  # noqa ignore: E501
         self.assertEquals(60, HiveEngineSpec.progress(log))
+
+    def test_wrapped_query(self):
+        sql = "SELECT * FROM a"
+        db = Database(sqlalchemy_uri="mysql://localhost")
+        limited = MssqlEngineSpec.apply_limit_to_sql(sql, 1000, db)
+        expected = """SELECT * \nFROM (SELECT * FROM a) AS inner_qry \n LIMIT 1000"""
+        self.assertEquals(expected, limited)
+
+    def test_simple_limit_query(self):
+        sql = "SELECT * FROM a"
+        db = Database(sqlalchemy_uri="mysql://localhost")
+        limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
+        expected = """SELECT * FROM a LIMIT 1000"""
+        self.assertEquals(expected, limited)
+
+    def test_modify_limit_query(self):
+        sql = "SELECT * FROM a LIMIT 9999"
+        db = Database(sqlalchemy_uri="mysql://localhost")
+        limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
+        expected = """SELECT * FROM a LIMIT 1000"""
+        self.assertEquals(expected, limited)
+
+    def test_modify_newline_query(self):
+        sql = "SELECT * FROM a\nLIMIT 9999"
+        db = Database(sqlalchemy_uri="mysql://localhost")
+        limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
+        expected = """SELECT * FROM a LIMIT 1000"""
+        self.assertEquals(expected, limited)
+
+    def test_modify_lcase_limit_query(self):
+        sql = "SELECT * FROM a\tlimit 9999"
+        db = Database(sqlalchemy_uri="mysql://localhost")
+        limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
+        expected = """SELECT * FROM a LIMIT 1000"""
+        self.assertEquals(expected, limited)
+
+    def test_limit_query_with_limit_subquery(self):
+        sql = "SELECT * FROM (SELECT * FROM a LIMIT 10) LIMIT 9999"
+        db = Database(sqlalchemy_uri="mysql://localhost")
+        limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
+        expected = "SELECT * FROM (SELECT * FROM a LIMIT 10) LIMIT 1000"
+        self.assertEquals(expected, limited)

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -4,7 +4,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from superset.db_engine_specs import MssqlEngineSpec, HiveEngineSpec, MySQLEngineSpec
+from superset.db_engine_specs import (
+    HiveEngineSpec, MssqlEngineSpec, MySQLEngineSpec)
 from superset.models.core import Database
 from .base_tests import SupersetTestCase
 
@@ -82,43 +83,43 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         self.assertEquals(60, HiveEngineSpec.progress(log))
 
     def test_wrapped_query(self):
-        sql = "SELECT * FROM a"
-        db = Database(sqlalchemy_uri="mysql://localhost")
+        sql = 'SELECT * FROM a'
+        db = Database(sqlalchemy_uri='mysql://localhost')
         limited = MssqlEngineSpec.apply_limit_to_sql(sql, 1000, db)
-        expected = """SELECT * \nFROM (SELECT * FROM a) AS inner_qry \n LIMIT 1000"""
+        expected = 'SELECT * \nFROM (SELECT * FROM a) AS inner_qry \n LIMIT 1000'
         self.assertEquals(expected, limited)
 
     def test_simple_limit_query(self):
-        sql = "SELECT * FROM a"
-        db = Database(sqlalchemy_uri="mysql://localhost")
+        sql = 'SELECT * FROM a'
+        db = Database(sqlalchemy_uri='mysql://localhost')
         limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
-        expected = """SELECT * FROM a LIMIT 1000"""
+        expected = 'SELECT * FROM a LIMIT 1000'
         self.assertEquals(expected, limited)
 
     def test_modify_limit_query(self):
-        sql = "SELECT * FROM a LIMIT 9999"
-        db = Database(sqlalchemy_uri="mysql://localhost")
+        sql = 'SELECT * FROM a LIMIT 9999'
+        db = Database(sqlalchemy_uri='mysql://localhost')
         limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
-        expected = """SELECT * FROM a LIMIT 1000"""
+        expected = 'SELECT * FROM a LIMIT 1000'
         self.assertEquals(expected, limited)
 
     def test_modify_newline_query(self):
-        sql = "SELECT * FROM a\nLIMIT 9999"
-        db = Database(sqlalchemy_uri="mysql://localhost")
+        sql = 'SELECT * FROM a\nLIMIT 9999'
+        db = Database(sqlalchemy_uri='mysql://localhost')
         limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
-        expected = """SELECT * FROM a LIMIT 1000"""
+        expected = 'SELECT * FROM a LIMIT 1000'
         self.assertEquals(expected, limited)
 
     def test_modify_lcase_limit_query(self):
-        sql = "SELECT * FROM a\tlimit 9999"
-        db = Database(sqlalchemy_uri="mysql://localhost")
+        sql = 'SELECT * FROM a\tlimit 9999'
+        db = Database(sqlalchemy_uri='mysql://localhost')
         limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
-        expected = """SELECT * FROM a LIMIT 1000"""
+        expected = 'SELECT * FROM a LIMIT 1000'
         self.assertEquals(expected, limited)
 
     def test_limit_query_with_limit_subquery(self):
-        sql = "SELECT * FROM (SELECT * FROM a LIMIT 10) LIMIT 9999"
-        db = Database(sqlalchemy_uri="mysql://localhost")
+        sql = 'SELECT * FROM (SELECT * FROM a LIMIT 10) LIMIT 9999'
+        db = Database(sqlalchemy_uri='mysql://localhost')
         limited = MySQLEngineSpec.apply_limit_to_sql(sql, 1000, db)
-        expected = "SELECT * FROM (SELECT * FROM a LIMIT 10) LIMIT 1000"
+        expected = 'SELECT * FROM (SELECT * FROM a LIMIT 10) LIMIT 1000'
         self.assertEquals(expected, limited)


### PR DESCRIPTION
Currently there are two mechanisms that we use to enforce the row
limiting constraints, depending on the database engine:
1. use dbapi's `cursor.fetchmany()`
2. wrap the SQL into a limiting subquery

Method 1 isn't great as it can result in the database server storing
larger than required result sets in memory expecting another fetch
command while we know we don't need that.

Method 2 has a positive side of working with all database engines,
whether they use LIMIT, ROWNUM, TOP or whatever else since sqlalchemy
does the work as specified for the dialect. On the downside though
the query optimizer might not be able to optimize this as much as an
approach that doesn't use a subquery.

Since most modern DBs use the LIMIT syntax, this adds a regex approach
to modify the query and force a LIMIT clause without using a subquery
for the database that support this syntax and uses method 2 for all
others.