### PR TITLE
[deps] force flask<=1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'celery',
         'colorama',
         'cryptography',
-        'flask',
+        'flask<=1.0.0',
         'flask-appbuilder',
         'flask-caching',
         'flask-compress',


### PR DESCRIPTION
flask 1.0 came out and has backwards incompatible changes. People
are reporting that fresh install doesn't work anymore.

fixes https://github.com/apache/incubator-superset/issues/4953

@john-bodley with most of our libs with no upper bound, any lib release backwards incompatible changes has the potential to break the pypi version. I'm not sure how to handle this. We could tell folks in our installation instruction to clone the repo and `pip install -r requirements.txt` but that seems wrong as we should make sure that a simple `pip install superset` just works. I understand that the downside of that approach is that limits users in which version of libs they may want to have the flexibility to run.

We should ship a 0.25.1 with this in.