### PR TITLE
bump pyhive version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2
 pydruid==0.4.2
-pyhive==0.5.0
+pyhive==0.5.1
 python-dateutil==2.6.1
 python-geohash==0.8.5
 pyyaml==3.12
@@ -38,3 +38,4 @@ thrift-sasl==0.3.0
 unicodecsv==0.14.1
 unidecode==1.0.22
 contextlib2==0.5.5
+


### PR DESCRIPTION
This PR bumps this pyhive version to 0.5.1 which includes my change to resolve the `Should not Have nextUri if failed' 
https://github.com/dropbox/PyHive/pull/164

@michellethomas