### PR TITLE
Dashboard save button

### DIFF
--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -74,6 +74,11 @@ export function toggleExpandSlice(sliceId) {
   return { type: TOGGLE_EXPAND_SLICE, sliceId };
 }
 
+export const UPDATE_CSS = 'UPDATE_CSS';
+export function updateCss(css) {
+  return { type: UPDATE_CSS, css };
+}
+
 export const SET_EDIT_MODE = 'SET_EDIT_MODE';
 export function setEditMode(editMode) {
   return { type: SET_EDIT_MODE, editMode };

--- a/superset/assets/src/dashboard/components/Controls.jsx
+++ b/superset/assets/src/dashboard/components/Controls.jsx
@@ -5,7 +5,6 @@ import $ from 'jquery';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import RefreshIntervalModal from './RefreshIntervalModal';
-import SaveModal from './SaveModal';
 import { t } from '../../locales';
 
 function updateDom(css) {
@@ -31,11 +30,7 @@ const propTypes = {
   addDangerToast: PropTypes.func.isRequired,
   dashboardInfo: PropTypes.object.isRequired,
   dashboardTitle: PropTypes.string.isRequired,
-  layout: PropTypes.object.isRequired,
-  filters: PropTypes.object.isRequired,
-  expandedSlices: PropTypes.object.isRequired,
   slices: PropTypes.array,
-  onSave: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   forceRefreshAllCharts: PropTypes.func.isRequired,
   startPeriodicRender: PropTypes.func.isRequired,
@@ -79,12 +74,8 @@ class Controls extends React.PureComponent {
   render() {
     const {
       dashboardTitle,
-      layout,
-      filters,
-      expandedSlices,
       startPeriodicRender,
       forceRefreshAllCharts,
-      onSave,
       editMode,
     } = this.props;
 
@@ -109,19 +100,6 @@ class Controls extends React.PureComponent {
               startPeriodicRender(refreshInterval * 1000)
             }
             triggerNode={<span>{t('Set auto-refresh interval')}</span>}
-          />
-          <SaveModal
-            addSuccessToast={this.props.addSuccessToast}
-            addDangerToast={this.props.addDangerToast}
-            dashboardId={this.props.dashboardInfo.id}
-            dashboardTitle={dashboardTitle}
-            layout={layout}
-            filters={filters}
-            expandedSlices={expandedSlices}
-            onSave={onSave}
-            css={this.state.css}
-            triggerNode={<span>{editMode ? t('Save') : t('Save as')}</span>}
-            isMenuItem
           />
           {editMode && (
             <MenuItem

--- a/superset/assets/src/dashboard/components/Controls.jsx
+++ b/superset/assets/src/dashboard/components/Controls.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import $ from 'jquery';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
+import CssEditor from './CssEditor';
 import RefreshIntervalModal from './RefreshIntervalModal';
 import { t } from '../../locales';
 
@@ -30,8 +31,10 @@ const propTypes = {
   addDangerToast: PropTypes.func.isRequired,
   dashboardInfo: PropTypes.object.isRequired,
   dashboardTitle: PropTypes.string.isRequired,
+  css: PropTypes.string.isRequired,
   slices: PropTypes.array,
   onChange: PropTypes.func.isRequired,
+  updateCss: PropTypes.func.isRequired,
   forceRefreshAllCharts: PropTypes.func.isRequired,
   startPeriodicRender: PropTypes.func.isRequired,
   editMode: PropTypes.bool,
@@ -46,9 +49,11 @@ class Controls extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      css: '',
+      css: props.css,
       cssTemplates: [],
     };
+
+    this.changeCss = this.changeCss.bind(this);
   }
 
   componentWillMount() {
@@ -69,6 +74,7 @@ class Controls extends React.PureComponent {
       updateDom(css);
     });
     this.props.onChange();
+    this.props.updateCss(css);
   }
 
   render() {
@@ -111,6 +117,14 @@ class Controls extends React.PureComponent {
           )}
           {editMode && (
             <MenuItem href={emailLink}>{t('Email dashboard link')}</MenuItem>
+          )}
+          {editMode && (
+            <CssEditor
+              triggerNode={<span>{t('Edit CSS')}</span>}
+              initialCss={this.state.css}
+              templates={this.state.cssTemplates}
+              onChange={this.changeCss}
+            />
           )}
         </DropdownButton>
       </span>

--- a/superset/assets/src/dashboard/components/Header.jsx
+++ b/superset/assets/src/dashboard/components/Header.jsx
@@ -146,7 +146,8 @@ class Header extends React.PureComponent {
       hasUnsavedChanges,
     } = this.props;
 
-    const userCanEdit = dashboardInfo.dash_save_perm;
+    const userCanEdit = dashboardInfo.dash_edit_perm;
+    const userCanSaveAs = dashboardInfo.dash_save_perm;
 
     return (
       <div className="dashboard-header">
@@ -167,7 +168,7 @@ class Header extends React.PureComponent {
           </span>
         </div>
         <ButtonToolbar>
-          {userCanEdit && (
+          {userCanSaveAs && (
             <ButtonGroup>
               {editMode && (
                 <Button
@@ -202,6 +203,7 @@ class Header extends React.PureComponent {
                   bsSize="small"
                   onClick={this.toggleEditMode}
                   bsStyle={hasUnsavedChanges ? 'primary' : undefined}
+                  disabled={!userCanEdit}
                 >
                   {editMode ? t('Switch to view mode') : t('Edit dashboard')}
                 </Button>
@@ -234,6 +236,7 @@ class Header extends React.PureComponent {
                   onSave={onSave}
                   isMenuItem
                   triggerNode={<span>{t('Save as')}</span>}
+                  canOverwrite={userCanEdit}
                 />
                 {hasUnsavedChanges && (
                   <MenuItem eventKey="discard" onSelect={Header.discardChanges}>

--- a/superset/assets/src/dashboard/components/Header.jsx
+++ b/superset/assets/src/dashboard/components/Header.jsx
@@ -30,6 +30,7 @@ const propTypes = {
   layout: PropTypes.object.isRequired,
   filters: PropTypes.object.isRequired,
   expandedSlices: PropTypes.object.isRequired,
+  css: PropTypes.string.isRequired,
   isStarred: PropTypes.bool.isRequired,
   onSave: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
@@ -42,6 +43,7 @@ const propTypes = {
   setEditMode: PropTypes.func.isRequired,
   showBuilderPane: PropTypes.bool.isRequired,
   toggleBuilderPane: PropTypes.func.isRequired,
+  updateCss: PropTypes.func.isRequired,
   hasUnsavedChanges: PropTypes.bool.isRequired,
   maxUndoHistoryExceeded: PropTypes.bool.isRequired,
 
@@ -108,6 +110,7 @@ class Header extends React.PureComponent {
       dashboardTitle,
       layout: positions,
       expandedSlices,
+      css,
       filters,
       dashboardInfo,
     } = this.props;
@@ -115,6 +118,7 @@ class Header extends React.PureComponent {
     const data = {
       positions,
       expanded_slices: expandedSlices,
+      css,
       dashboard_title: dashboardTitle,
       default_filters: JSON.stringify(filters),
     };
@@ -128,12 +132,14 @@ class Header extends React.PureComponent {
       layout,
       filters,
       expandedSlices,
+      css,
       onUndo,
       onRedo,
       undoLength,
       redoLength,
       onChange,
       onSave,
+      updateCss,
       editMode,
       showBuilderPane,
       dashboardInfo,
@@ -224,11 +230,10 @@ class Header extends React.PureComponent {
                   layout={layout}
                   filters={filters}
                   expandedSlices={expandedSlices}
+                  css={css}
                   onSave={onSave}
                   isMenuItem
                   triggerNode={<span>{t('Save as')}</span>}
-                  // @TODO need to figure out css
-                  css=""
                 />
                 {hasUnsavedChanges && (
                   <MenuItem eventKey="discard" onSelect={Header.discardChanges}>
@@ -247,10 +252,12 @@ class Header extends React.PureComponent {
             layout={layout}
             filters={filters}
             expandedSlices={expandedSlices}
+            css={css}
             onSave={onSave}
             onChange={onChange}
             forceRefreshAllCharts={this.forceRefresh}
             startPeriodicRender={this.props.startPeriodicRender}
+            updateCss={updateCss}
             editMode={editMode}
           />
         </ButtonToolbar>

--- a/superset/assets/src/dashboard/components/SaveModal.jsx
+++ b/superset/assets/src/dashboard/components/SaveModal.jsx
@@ -21,6 +21,7 @@ const propTypes = {
   css: PropTypes.string.isRequired,
   onSave: PropTypes.func.isRequired,
   isMenuItem: PropTypes.bool,
+  canOverwrite: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -113,6 +114,7 @@ class SaveModal extends React.PureComponent {
               value={SAVE_TYPE_OVERWRITE}
               onChange={this.handleSaveTypeChange}
               checked={this.state.saveType === SAVE_TYPE_OVERWRITE}
+              disabled={!this.props.canOverwrite}
             >
               {t('Overwrite Dashboard [%s]', this.props.dashboardTitle)}
             </Radio>

--- a/superset/assets/src/dashboard/components/SaveModal.jsx
+++ b/superset/assets/src/dashboard/components/SaveModal.jsx
@@ -18,6 +18,7 @@ const propTypes = {
   saveType: PropTypes.oneOf([SAVE_TYPE_OVERWRITE, SAVE_TYPE_NEWDASHBOARD]),
   triggerNode: PropTypes.node.isRequired,
   filters: PropTypes.object.isRequired,
+  css: PropTypes.string.isRequired,
   onSave: PropTypes.func.isRequired,
   isMenuItem: PropTypes.bool,
 };
@@ -70,6 +71,7 @@ class SaveModal extends React.PureComponent {
     const {
       dashboardTitle,
       layout: positions,
+      css,
       expandedSlices,
       filters,
       dashboardId,
@@ -77,6 +79,7 @@ class SaveModal extends React.PureComponent {
 
     const data = {
       positions,
+      css,
       expanded_slices: expandedSlices,
       dashboard_title: dashboardTitle,
       default_filters: JSON.stringify(filters),

--- a/superset/assets/src/dashboard/components/SaveModal.jsx
+++ b/superset/assets/src/dashboard/components/SaveModal.jsx
@@ -1,13 +1,12 @@
 /* eslint-env browser */
 import React from 'react';
 import PropTypes from 'prop-types';
-import $ from 'jquery';
 
 import { Button, FormControl, FormGroup, Radio } from 'react-bootstrap';
-import { getAjaxErrorMsg } from '../../modules/utils';
 import ModalTrigger from '../../components/ModalTrigger';
 import { t } from '../../locales';
 import Checkbox from '../../components/Checkbox';
+import { SAVE_TYPE_OVERWRITE, SAVE_TYPE_NEWDASHBOARD } from '../util/constants';
 
 const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,
@@ -16,6 +15,7 @@ const propTypes = {
   dashboardTitle: PropTypes.string.isRequired,
   expandedSlices: PropTypes.object.isRequired,
   layout: PropTypes.object.isRequired,
+  saveType: PropTypes.oneOf([SAVE_TYPE_OVERWRITE, SAVE_TYPE_NEWDASHBOARD]),
   triggerNode: PropTypes.node.isRequired,
   filters: PropTypes.object.isRequired,
   onSave: PropTypes.func.isRequired,
@@ -24,13 +24,14 @@ const propTypes = {
 
 const defaultProps = {
   isMenuItem: false,
+  saveType: SAVE_TYPE_OVERWRITE,
 };
 
 class SaveModal extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      saveType: 'overwrite',
+      saveType: props.saveType,
       newDashName: `${props.dashboardTitle} [copy]`,
       duplicateSlices: false,
     };
@@ -40,6 +41,7 @@ class SaveModal extends React.PureComponent {
     this.saveDashboard = this.saveDashboard.bind(this);
     this.setModalRef = this.setModalRef.bind(this);
     this.toggleDuplicateSlices = this.toggleDuplicateSlices.bind(this);
+    this.onSave = this.props.onSave.bind(this);
   }
 
   setModalRef(ref) {
@@ -59,37 +61,7 @@ class SaveModal extends React.PureComponent {
   handleNameChange(event) {
     this.setState({
       newDashName: event.target.value,
-      saveType: 'newDashboard',
-    });
-  }
-
-  // @TODO this should all be moved to actions
-  saveDashboardRequest(data, url, saveType) {
-    $.ajax({
-      type: 'POST',
-      url,
-      data: {
-        data: JSON.stringify(data),
-      },
-      success: resp => {
-        this.modal.close();
-        this.props.onSave();
-        if (saveType === 'newDashboard') {
-          window.location = `/superset/dashboard/${resp.id}/`;
-        } else {
-          this.props.addSuccessToast(
-            t('This dashboard was saved successfully.'),
-          );
-        }
-      },
-      error: error => {
-        this.modal.close();
-        const errorMsg = getAjaxErrorMsg(error);
-        this.props.addDangerToast(
-          `${t('Sorry, there was an error saving this dashboard: ')}
-          ${errorMsg}`,
-        );
-      },
+      saveType: SAVE_TYPE_NEWDASHBOARD,
     });
   }
 
@@ -111,20 +83,17 @@ class SaveModal extends React.PureComponent {
       duplicate_slices: this.state.duplicateSlices,
     };
 
-    let url = null;
-    if (saveType === 'overwrite') {
-      url = `/superset/save_dash/${dashboardId}/`;
-      this.saveDashboardRequest(data, url, saveType);
-    } else if (saveType === 'newDashboard') {
-      if (!newDashName) {
-        this.props.addDangerToast(
-          t('You must pick a name for the new dashboard'),
-        );
-      } else {
-        data.dashboard_title = newDashName;
-        url = `/superset/copy_dash/${dashboardId}/`;
-        this.saveDashboardRequest(data, url, saveType);
-      }
+    if (saveType === SAVE_TYPE_NEWDASHBOARD && !newDashName) {
+      this.props.addDangerToast(
+        t('You must pick a name for the new dashboard'),
+      );
+    } else {
+      this.onSave(data, dashboardId, saveType).done(resp => {
+        if (saveType === SAVE_TYPE_NEWDASHBOARD) {
+          window.location = `/superset/dashboard/${resp.id}/`;
+        }
+      });
+      this.modal.close();
     }
   }
 
@@ -138,17 +107,17 @@ class SaveModal extends React.PureComponent {
         modalBody={
           <FormGroup>
             <Radio
-              value="overwrite"
+              value={SAVE_TYPE_OVERWRITE}
               onChange={this.handleSaveTypeChange}
-              checked={this.state.saveType === 'overwrite'}
+              checked={this.state.saveType === SAVE_TYPE_OVERWRITE}
             >
               {t('Overwrite Dashboard [%s]', this.props.dashboardTitle)}
             </Radio>
             <hr />
             <Radio
-              value="newDashboard"
+              value={SAVE_TYPE_NEWDASHBOARD}
               onChange={this.handleSaveTypeChange}
-              checked={this.state.saveType === 'newDashboard'}
+              checked={this.state.saveType === SAVE_TYPE_NEWDASHBOARD}
             >
               {t('Save as:')}
             </Radio>

--- a/superset/assets/src/dashboard/components/SliceAdder.jsx
+++ b/superset/assets/src/dashboard/components/SliceAdder.jsx
@@ -39,6 +39,10 @@ const KEYS_TO_SORT = [
   { key: 'changed_on', label: 'Recent' },
 ];
 
+const MARGIN_BOTTOM = 16;
+const SIDEPANE_HEADER_HEIGHT = 55;
+const SLICE_ADDER_CONTROL_HEIGHT = 64;
+
 class SliceAdder extends React.Component {
   static sortByComparator(attr) {
     const desc = attr === 'changed_on' ? -1 : 1;
@@ -166,6 +170,11 @@ class SliceAdder extends React.Component {
   }
 
   render() {
+    const slicesListHeight =
+      this.props.height -
+      SIDEPANE_HEADER_HEIGHT -
+      SLICE_ADDER_CONTROL_HEIGHT -
+      MARGIN_BOTTOM;
     return (
       <div className="slice-adder-container">
         <div className="controls">
@@ -202,7 +211,7 @@ class SliceAdder extends React.Component {
           this.state.filteredSlices.length > 0 && (
             <List
               width={376}
-              height={this.props.height}
+              height={slicesListHeight}
               rowCount={this.state.filteredSlices.length}
               rowHeight={136}
               rowRenderer={this.rowRenderer}

--- a/superset/assets/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset/assets/src/dashboard/components/SliceHeaderControls.jsx
@@ -11,6 +11,8 @@ const propTypes = {
   isCached: PropTypes.bool,
   isExpanded: PropTypes.bool,
   cachedDttm: PropTypes.string,
+  supersetCanExplore: PropTypes.bool,
+  sliceCanEdit: PropTypes.bool,
   toggleExpandSlice: PropTypes.func,
   forceRefresh: PropTypes.func,
   exploreChart: PropTypes.func,
@@ -25,6 +27,8 @@ const defaultProps = {
   cachedDttm: null,
   isCached: false,
   isExpanded: false,
+  supersetCanExplore: false,
+  sliceCanEdit: false,
 };
 
 const VerticalDotsTrigger = () => (
@@ -93,13 +97,19 @@ class SliceHeaderControls extends React.PureComponent {
             </MenuItem>
           )}
 
-          <MenuItem href={slice.edit_url} target="_blank">
-            {t('Edit chart metadata')}
-          </MenuItem>
+          {this.props.sliceCanEdit && (
+            <MenuItem href={slice.edit_url} target="_blank">
+              {t('Edit chart metadata')}
+            </MenuItem>
+          )}
 
           <MenuItem onClick={this.exportCSV}>{t('Export CSV')}</MenuItem>
 
-          <MenuItem onClick={this.exploreChart}>{t('Explore chart')}</MenuItem>
+          {this.props.supersetCanExplore && (
+            <MenuItem onClick={this.exploreChart}>
+              {t('Explore chart')}
+            </MenuItem>
+          )}
         </Dropdown.Menu>
       </Dropdown>
     );

--- a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
@@ -29,6 +29,8 @@ const propTypes = {
   removeFilter: PropTypes.func.isRequired,
   editMode: PropTypes.bool.isRequired,
   isExpanded: PropTypes.bool.isRequired,
+  supersetCanExplore: PropTypes.bool.isRequired,
+  sliceCanEdit: PropTypes.bool.isRequired,
 };
 
 // we use state + shouldComponentUpdate() logic to prevent perf-wrecking
@@ -155,6 +157,8 @@ class Chart extends React.Component {
       sliceName,
       toggleExpandSlice,
       timeout,
+      supersetCanExplore,
+      sliceCanEdit,
     } = this.props;
 
     const { width } = this.state;
@@ -179,6 +183,8 @@ class Chart extends React.Component {
           exportCSV={this.exportCSV}
           updateSliceName={updateSliceName}
           sliceName={sliceName}
+          supersetCanExplore={supersetCanExplore}
+          sliceCanEdit={sliceCanEdit}
         />
 
         {/*

--- a/superset/assets/src/dashboard/containers/Chart.jsx
+++ b/superset/assets/src/dashboard/containers/Chart.jsx
@@ -40,6 +40,8 @@ function mapStateToProps(
     }),
     editMode: dashboardState.editMode,
     isExpanded: !!dashboardState.expandedSlices[id],
+    supersetCanExplore: !!dashboardInfo.superset_can_explore,
+    sliceCanEdit: !!dashboardInfo.slice_can_edit,
   };
 }
 

--- a/superset/assets/src/dashboard/containers/DashboardHeader.jsx
+++ b/superset/assets/src/dashboard/containers/DashboardHeader.jsx
@@ -10,6 +10,7 @@ import {
   saveFaveStar,
   fetchCharts,
   startPeriodicRender,
+  updateCss,
   onChange,
   saveDashboardRequest,
   setMaxUndoHistoryExceeded,
@@ -42,6 +43,7 @@ function mapStateToProps({
       (undoableLayout.present[DASHBOARD_HEADER_ID] || {}).meta || {}
     ).text,
     expandedSlices: dashboard.expandedSlices,
+    css: dashboard.css,
     charts,
     userId: dashboardInfo.userId,
     isStarred: !!dashboard.isStarred,
@@ -66,6 +68,7 @@ function mapDispatchToProps(dispatch) {
       fetchCharts,
       startPeriodicRender,
       updateDashboardTitle,
+      updateCss,
       onChange,
       onSave: saveDashboardRequest,
       setMaxUndoHistoryExceeded,

--- a/superset/assets/src/dashboard/containers/DashboardHeader.jsx
+++ b/superset/assets/src/dashboard/containers/DashboardHeader.jsx
@@ -11,7 +11,7 @@ import {
   fetchCharts,
   startPeriodicRender,
   onChange,
-  saveDashboard,
+  saveDashboardRequest,
   setMaxUndoHistoryExceeded,
   maxUndoHistoryToast,
 } from '../actions/dashboardState';
@@ -67,7 +67,7 @@ function mapDispatchToProps(dispatch) {
       startPeriodicRender,
       updateDashboardTitle,
       onChange,
-      onSave: saveDashboard,
+      onSave: saveDashboardRequest,
       setMaxUndoHistoryExceeded,
       maxUndoHistoryToast,
     },

--- a/superset/assets/src/dashboard/reducers/dashboardState.js
+++ b/superset/assets/src/dashboard/reducers/dashboardState.js
@@ -14,13 +14,13 @@ import {
   TOGGLE_BUILDER_PANE,
   TOGGLE_EXPAND_SLICE,
   TOGGLE_FAVE_STAR,
-  UPDATE_DASHBOARD_TITLE,
+  UPDATE_CSS,
 } from '../actions/dashboardState';
 
 export default function dashboardStateReducer(state = {}, action) {
   const actionHandlers = {
-    [UPDATE_DASHBOARD_TITLE]() {
-      return { ...state, title: action.title };
+    [UPDATE_CSS]() {
+      return { ...state, css: action.css };
     },
     [ADD_SLICE]() {
       const updatedSliceIds = new Set(state.sliceIds);

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -121,6 +121,8 @@ export default function(bootstrapData) {
       userId: user_id,
       dash_edit_perm: dashboard.dash_edit_perm,
       dash_save_perm: dashboard.dash_save_perm,
+      superset_can_explore: dashboard.superset_can_explore,
+      slice_can_edit: dashboard.slice_can_edit,
       common,
     },
     dashboardState: {

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -58,10 +58,7 @@ export default function(bootstrapData) {
     future: [],
   };
 
-  delete dashboard.position_json;
-  delete dashboard.css;
-
-  // creat a lookup to sync layout names with slice names
+  // create a lookup to sync layout names with slice names
   const chartIdToLayoutId = {};
   Object.values(layout).forEach(layoutComponent => {
     if (layoutComponent.type === CHART_TYPE) {
@@ -131,6 +128,7 @@ export default function(bootstrapData) {
       refresh: false,
       filters,
       expandedSlices: dashboard.metadata.expanded_slices || {},
+      css: dashboard.css || '',
       editMode: false,
       showBuilderPane: false,
       hasUnsavedChanges: false,

--- a/superset/assets/src/dashboard/stylesheets/builder.less
+++ b/superset/assets/src/dashboard/stylesheets/builder.less
@@ -46,7 +46,12 @@
 /* @TODO remove upon new theme */
 .btn.btn-primary {
   background: @almost-black !important;
+  border-color: @almost-black;
   color: white !important;
+}
+
+.dropdown-toggle.btn.btn-primary .caret {
+  color: white;
 }
 
 .background--transparent {

--- a/superset/assets/src/dashboard/stylesheets/dashboard.less
+++ b/superset/assets/src/dashboard/stylesheets/dashboard.less
@@ -38,6 +38,29 @@
   }
 }
 
+.dashboard .dashboard-header {
+  #save-dash-split-button {
+    border-radius: 0;
+    margin-left: -8px;
+    height: 30px;
+    width: 30px;
+
+    &.btn.btn-primary {
+      border-left-color: white;
+    }
+
+    .caret {
+      position: absolute;
+      top: 24px;
+      left: 3px;
+    }
+
+    & + .dropdown-menu.dropdown-menu-right {
+      min-width: unset;
+    }
+  }
+}
+
 .dashboard .chart-header,
 .dashboard .dashboard-header {
   .dropdown-menu {
@@ -63,7 +86,7 @@
   padding: 0 16px;
   position: absolute;
   top: 0;
-  right: -22px;
+  right: -16px; //increase the click-able area for the button
 
   &:hover {
     cursor: pointer;
@@ -80,11 +103,16 @@
 
   .is-cached & {
     background-color: @pink;
-    margin-right: 6px;
   }
 
   .vertical-dots-container & {
     display: block;
+  }
+
+  a[role="menuitem"] & {
+    width: 8px;
+    height: 8px;
+    margin-right: 8px;
   }
 }
 

--- a/superset/assets/src/dashboard/util/constants.js
+++ b/superset/assets/src/dashboard/util/constants.js
@@ -41,3 +41,7 @@ export const DANGER_TOAST = 'DANGER_TOAST';
 
 // undo-redo
 export const UNDO_LIMIT = 50;
+
+// save dash options
+export const SAVE_TYPE_OVERWRITE = 'overwrite';
+export const SAVE_TYPE_NEWDASHBOARD = 'newDashboard';

--- a/superset/assets/src/modules/utils.js
+++ b/superset/assets/src/modules/utils.js
@@ -198,7 +198,7 @@ export function slugify(string) {
 
 export function getAjaxErrorMsg(error) {
   const respJSON = error.responseJSON;
-  return (respJSON && respJSON.message) ? respJSON.message :
+  return (respJSON && respJSON.error) ? respJSON.error :
           error.responseText;
 }
 


### PR DESCRIPTION
![tr6goydv67](https://user-images.githubusercontent.com/27990562/39950499-50f79cbe-5536-11e8-809e-c0986894f524.gif)


- save dashboard button
- bring back save custom css feature
- also hide/disable button when user didn't have access:

- for read-only user:
<img width="1447" alt="screen shot 2018-05-22 at 3 48 38 pm" src="https://user-images.githubusercontent.com/27990562/40394328-d6d3a748-5dd7-11e8-8a1f-7c1af6151e3b.png">

- for user can copy dashboard (not the owner of dashboard): they can save a new copy then edit on his new copy. `Edit Dashboard` and `Overwrite dashboard` options are disabled:
<img width="1267" alt="screen shot 2018-05-22 at 3 57 38 pm" src="https://user-images.githubusercontent.com/27990562/40394686-4ff6c596-5dd9-11e8-8498-9d7daac296a5.png">

<img width="1261" alt="screen shot 2018-05-22 at 3 59 00 pm" src="https://user-images.githubusercontent.com/27990562/40394628-1339d6de-5dd9-11e8-9130-669ad822162d.png">


- for user has full access to dashboard: they can edit, save, save-as:
<img width="1266" alt="screen shot 2018-05-22 at 4 02 29 pm" src="https://user-images.githubusercontent.com/27990562/40394750-95fdc74c-5dd9-11e8-92ec-1c088b3c42c6.png">

