### PR TITLE
redirect edit url of chart under dashboard to explore

### DIFF
--- a/superset/assets/src/dashboard/components/SliceHeader.jsx
+++ b/superset/assets/src/dashboard/components/SliceHeader.jsx
@@ -131,7 +131,7 @@ class SliceHeader extends React.PureComponent {
               </a>
               }
               {this.props.sliceCanEdit &&
-                <a href={slice.edit_url} target="_blank">
+                <a href={slice.slice_url} target="_blank">
                   <TooltipWrapper
                     placement="top"
                     label="edit"


### PR DESCRIPTION
if i want to edit my existed chart under one dashboard , like 
![wx20180511-211430](https://user-images.githubusercontent.com/987877/39926005-6b870b3a-5560-11e8-99ba-8806fbfbc43e.png)

then will open slicemodelview/edit page, but in general we hope to explore my chart, like

![wx20180511-211932](https://user-images.githubusercontent.com/987877/39926208-07c13a66-5561-11e8-9e7b-de0bb968bec4.png)

