### PR TITLE
[Bugfix] Allowing sqlExpression to be blank

### DIFF
--- a/superset/assets/src/explore/AdhocFilter.js
+++ b/superset/assets/src/explore/AdhocFilter.js
@@ -45,7 +45,8 @@ export default class AdhocFilter {
       this.clause = adhocFilter.clause;
       this.sqlExpression = null;
     } else if (this.expressionType === EXPRESSION_TYPES.SQL) {
-      this.sqlExpression = adhocFilter.sqlExpression ||
+      this.sqlExpression = typeof adhocFilter.sqlExpression === 'string' ?
+        adhocFilter.sqlExpression :
         translateToSql(adhocFilter, { useSimple: true });
       this.clause = adhocFilter.clause;
       this.subject = null;


### PR DESCRIPTION
If you remove the sql in the custom sql filter, you'll see a message `null undefined null`.  `adhocFilter.sqlExpression || translateToSql(adhocFilter, { useSimple: true })` was running translateToSql with simple: true on an empty string. Change it to specifically check for undefined.

@GabeLoins 