### PR TITLE
[Fab] cleaning up the table fab view since Metrics Control hides autogenerated metrics

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -37,12 +37,12 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
     edit_columns = [
         'column_name', 'verbose_name', 'description',
         'type', 'groupby', 'filterable',
-        'table', 'count_distinct', 'sum', 'min', 'max', 'expression',
+        'table', 'expression',
         'is_dttm', 'python_date_format', 'database_expression']
     add_columns = edit_columns
     list_columns = [
-        'column_name', 'verbose_name', 'type', 'groupby', 'filterable', 'count_distinct',
-        'sum', 'min', 'max', 'is_dttm']
+        'column_name', 'verbose_name', 'type', 'groupby', 'filterable',
+        'is_dttm']
     page_size = 500
     description_columns = {
         'is_dttm': _(
@@ -86,10 +86,6 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
         'groupby': _('Groupable'),
         'filterable': _('Filterable'),
         'table': _('Table'),
-        'count_distinct': _('Count Distinct'),
-        'sum': _('Sum'),
-        'min': _('Min'),
-        'max': _('Max'),
         'expression': _('Expression'),
         'is_dttm': _('Is temporal'),
         'python_date_format': _('Datetime Format'),


### PR DESCRIPTION
When https://github.com/apache/incubator-superset/pull/4914 is merged, the controls for marking columns as Count-distinct-able, Sum-able, Min-able and Max-able will no longer have any use. They are used to configure autogenerated metrics, which we hide in the metrics control.

new, more spacious fab view:
![image](https://user-images.githubusercontent.com/2455694/39951936-bb380368-5543-11e8-9776-124d5d535a1b.png)

test plan: verified that the fab view no longer contains these 4 columns

dependencies:
https://github.com/apache/incubator-superset/pull/4914

reviewers:
@michellethomas @williaster @mistercrunch @hughhhh @john-bodley @graceguo-supercat 