### PR TITLE
Use a dummy version number on master

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superset",
-  "version": "0.23.0dev",
+  "version": "0.999.0dev",
   "description": "Superset is a data exploration platform designed to be visual, intuitive, and interactive.",
   "license": "Apache-2.0",
   "directories": {


### PR DESCRIPTION
Currently we assign release version number in release branches and
master was still pointing to some old version number from when the
process was different. We need a dummy version number that both setuptools
and npm are ok with.

fixes https://github.com/apache/incubator-superset/issues/4999