### PR TITLE
Fix AdhocFilterControl for single metric options

### DIFF
--- a/superset/assets/src/explore/components/controls/AdhocFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/AdhocFilterControl.jsx
@@ -206,7 +206,7 @@ export default class AdhocFilterControl extends React.Component {
   optionsForSelect(props) {
     const options = [
       ...props.columns,
-      ...[...props.formData.metrics, props.formData.metric].map(metric => (
+      ...[...(props.formData.metrics || []), props.formData.metric].map(metric => (
         metric && (
           typeof metric === 'string' ?
           { saved_metric_name: metric } :


### PR DESCRIPTION
The filter control will break a slice that has a single metric. Metrics will be undefined and we get an error `Cannot convert undefined or null to object`.

@GabeLoins @graceguo-supercat 