### PR TITLE
fix missing datasource error message

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1229,7 +1229,10 @@ class Superset(BaseSupersetView):
         datasource = form_data.get('datasource', '')
         if '__' in datasource:
             datasource_id, datasource_type = datasource.split('__')
-        datasource_id = int(datasource_id)
+            # The case where the datasource has been deleted
+            datasource_id = None if datasource_id == 'None' else datasource_id
+
+        datasource_id = int(datasource_id) if datasource_id else None
         return datasource_id, datasource_type
 
     @log_this

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1232,7 +1232,10 @@ class Superset(BaseSupersetView):
             # The case where the datasource has been deleted
             datasource_id = None if datasource_id == 'None' else datasource_id
 
-        datasource_id = int(datasource_id) if datasource_id else None
+        if not datasource_id:
+            raise Exception(
+                'The data source associated with this chart no longer exists')
+        datasource_id = int(datasource_id)
         return datasource_id, datasource_type
 
     @log_this

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1234,7 +1234,7 @@ class Superset(BaseSupersetView):
 
         if not datasource_id:
             raise Exception(
-                'The data source associated with this chart no longer exists')
+                'The datasource associated with this chart no longer exists')
         datasource_id = int(datasource_id)
         return datasource_id, datasource_type
 


### PR DESCRIPTION
When a datasource is deleted, slices show a cryptic error message in image 1. 
This PR fixes it so it shows a more intelligible error message as in image 2. 

@john-bodley @michellethomas 
<img width="390" alt="screen shot 2018-05-16 at 12 23 05 pm" src="https://user-images.githubusercontent.com/30888507/40139491-dd925b6a-5904-11e8-919c-a586a077d128.png">

<img width="381" alt="screen shot 2018-05-16 at 12 30 15 pm" src="https://user-images.githubusercontent.com/30888507/40139505-ed09670a-5904-11e8-90cb-99f48fb41dba.png">

