### PR TITLE
Make port number optional in superset for druid

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -117,10 +117,7 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
         if not re.match('http(s)?://', host):
             host = 'http://' + host
 
-        if port:
-            url = '{0}:{1}'.format(host, port)
-        else:
-            url = host
+        url = '{0}:{1}'.format(host, port) if port else host
         return url
 
     def get_base_coordinator_url(self):

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -116,7 +116,12 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
     def get_base_url(host, port):
         if not re.match('http(s)?://', host):
             host = 'http://' + host
-        return '{0}:{1}'.format(host, port)
+
+        if port:
+            url = '{0}:{1}'.format(host, port)
+        else:
+            url = host
+        return url
 
     def get_base_coordinator_url(self):
         base_url = self.get_base_url(


### PR DESCRIPTION
It appears that urllib throws error with ssl if port number is provided

```
    url = "https://example.com:443/druid/v2"

    req = urllib.request.Request(url, druid_query_str, headers)
    res = urllib.request.urlopen(req)

```

The above call fails with the following error:

```
urllib2.HTTPError: HTTP Error 404: Not Found
```

If url is set to https://example.com/druid/v2 it works, this change
makes the port number optional.