### PR TITLE
[sqllab] force limit queries only when there is no existing limit

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -104,14 +104,8 @@ class BaseEngineSpec(object):
             )
             return database.compile_sqla_query(qry)
         elif LimitMethod.FORCE_LIMIT:
-            no_limit = re.sub(r"""
-                (?ix)        # case insensitive, verbose
-                \s+          # whitespace
-                LIMIT\s+\d+  # LIMIT $ROWS
-                ;?           # optional semi-colon
-                (\s|;)*$     # remove trailing spaces tabs or semicolons
-                """, '', sql)
-            return '{no_limit} LIMIT {limit}'.format(**locals())
+            sql_without_limit = utils.get_query_without_limit(sql)
+            return '{sql_without_limit} LIMIT {limit}'.format(**locals())
         return sql
 
     @staticmethod

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -171,6 +171,7 @@ def execute_sql(
     # Limit enforced only for retrieving the data, not for the CTA queries.
     superset_query = SupersetQuery(rendered_query)
     executed_sql = superset_query.stripped()
+    SQL_MAX_ROWS = int(app.config.get('SQL_MAX_ROW', None))
     if not superset_query.is_select() and not database.allow_dml:
         return handle_error(
             'Only `SELECT` statements are allowed against this database')
@@ -185,7 +186,8 @@ def execute_sql(
                 query.user_id, start_dttm.strftime('%Y_%m_%d_%H_%M_%S'))
         executed_sql = superset_query.as_create_table(query.tmp_table_name)
         query.select_as_cta_used = True
-    elif (query.limit and superset_query.is_select()):
+    elif (not query.limit and superset_query.is_select() and SQL_MAX_ROWS):
+        query.limit = SQL_MAX_ROWS
         executed_sql = database.apply_limit_to_sql(executed_sql, query.limit)
         query.limit_used = True
 

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -186,11 +186,10 @@ def execute_sql(
                 query.user_id, start_dttm.strftime('%Y_%m_%d_%H_%M_%S'))
         executed_sql = superset_query.as_create_table(query.tmp_table_name)
         query.select_as_cta_used = True
-    elif (superset_query.is_select() and SQL_MAX_ROWS and
+    if (superset_query.is_select() and SQL_MAX_ROWS and
             (not query.limit or query.limit > SQL_MAX_ROWS)):
         query.limit = SQL_MAX_ROWS
         executed_sql = database.apply_limit_to_sql(executed_sql, query.limit)
-        query.limit_used = True
 
     # Hook to allow environment-specific mutation (usually comments) to the SQL
     SQL_QUERY_MUTATOR = config.get('SQL_QUERY_MUTATOR')

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -171,7 +171,7 @@ def execute_sql(
     # Limit enforced only for retrieving the data, not for the CTA queries.
     superset_query = SupersetQuery(rendered_query)
     executed_sql = superset_query.stripped()
-    SQL_MAX_ROWS = int(app.config.get('SQL_MAX_ROW', None))
+    SQL_MAX_ROWS = app.config.get('SQL_MAX_ROW')
     if not superset_query.is_select() and not database.allow_dml:
         return handle_error(
             'Only `SELECT` statements are allowed against this database')
@@ -186,7 +186,8 @@ def execute_sql(
                 query.user_id, start_dttm.strftime('%Y_%m_%d_%H_%M_%S'))
         executed_sql = superset_query.as_create_table(query.tmp_table_name)
         query.select_as_cta_used = True
-    elif (not query.limit and superset_query.is_select() and SQL_MAX_ROWS):
+    elif (superset_query.is_select() and SQL_MAX_ROWS and
+            (not query.limit or query.limit > SQL_MAX_ROWS)):
         query.limit = SQL_MAX_ROWS
         executed_sql = database.apply_limit_to_sql(executed_sql, query.limit)
         query.limit_used = True

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -18,7 +18,6 @@ import functools
 import json
 import logging
 import os
-import re
 import signal
 import smtplib
 import sys
@@ -883,29 +882,3 @@ def split_adhoc_filters_into_base_filters(fd):
         fd['having_filters'] = simple_having_filters
         fd['filters'] = simple_where_filters
         del fd['adhoc_filters']
-
-
-def get_query_without_limit(sql):
-    return re.sub(r"""
-                (?ix)        # case insensitive, verbose
-                \s+          # whitespace
-                LIMIT\s+\d+  # LIMIT $ROWS
-                ;?           # optional semi-colon
-                (\s|;)*$     # remove trailing spaces tabs or semicolons
-                """, '', sql)
-
-
-def get_limit_from_sql(sql):
-    # returns the limit of the quest or None if it has no limit.
-
-    limit_pattern = re.compile(r"""
-                (?ix)          # case insensitive, verbose
-                \s+            # whitespace
-                LIMIT\s+(\d+)  # LIMIT $ROWS
-                ;?             # optional semi-colon
-                (\s|;)*$       # remove trailing spaces tabs or semicolons
-                """)
-    matches = limit_pattern.findall(sql)
-
-    if matches:
-        return int(matches[0])

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -882,3 +882,17 @@ def split_adhoc_filters_into_base_filters(fd):
         fd['having_filters'] = simple_having_filters
         fd['filters'] = simple_where_filters
         del fd['adhoc_filters']
+
+
+def get_limit_from_sql(sql):
+    sql = sql.lower()
+    limit = None
+    tokens = sql.split()
+    try:
+        if 'limit' in tokens:
+            limit_pos = tokens.index('limit') + 1
+            limit = int(tokens[limit_pos])
+    except Exception as e:
+        # fail quietly so we can get the more intelligible error from the database.
+        logging.error('Non-numeric limit added.\n{}'.format(e))
+    return limit

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2394,7 +2394,7 @@ class Superset(BaseSupersetView):
 
         query = Query(
             database_id=int(database_id),
-            limit=int(app.config.get('SQL_MAX_ROW', None)),
+            limit=utils.get_limit_from_sql(sql),
             sql=sql,
             schema=schema,
             select_as_cta=request.form.get('select_as_cta') == 'true',

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2394,7 +2394,7 @@ class Superset(BaseSupersetView):
 
         query = Query(
             database_id=int(database_id),
-            limit=utils.get_limit_from_sql(sql),
+            limit=mydb.db_engine_spec.get_limit_from_sql(sql),
             sql=sql,
             schema=schema,
             select_as_cta=request.form.get('select_as_cta') == 'true',

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -196,13 +196,11 @@ class CeleryTestCase(SupersetTestCase):
         self.assertEqual([{'name': 'Admin'}], df.to_dict(orient='records'))
         self.assertEqual(QueryStatus.SUCCESS, query.status)
         self.assertTrue('FROM tmp_async_1' in query.select_sql)
-        self.assertTrue('LIMIT 666' in query.select_sql)
         self.assertEqual(
             'CREATE TABLE tmp_async_1 AS \nSELECT name FROM ab_role '
             "WHERE name='Admin'", query.executed_sql)
         self.assertEqual(sql_where, query.sql)
         self.assertEqual(0, query.rows)
-        self.assertEqual(666, query.limit)
         self.assertEqual(False, query.limit_used)
         self.assertEqual(True, query.select_as_cta)
         self.assertEqual(True, query.select_as_cta_used)

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -196,11 +196,13 @@ class CeleryTestCase(SupersetTestCase):
         self.assertEqual([{'name': 'Admin'}], df.to_dict(orient='records'))
         self.assertEqual(QueryStatus.SUCCESS, query.status)
         self.assertTrue('FROM tmp_async_1' in query.select_sql)
+        self.assertTrue('LIMIT 666' in query.select_sql)
         self.assertEqual(
             'CREATE TABLE tmp_async_1 AS \nSELECT name FROM ab_role '
             "WHERE name='Admin'", query.executed_sql)
         self.assertEqual(sql_where, query.sql)
         self.assertEqual(0, query.rows)
+        self.assertEqual(666, query.limit)
         self.assertEqual(False, query.limit_used)
         self.assertEqual(True, query.select_as_cta)
         self.assertEqual(True, query.select_as_cta_used)

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -95,6 +95,19 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         limited = engine_spec_class.apply_limit_to_sql(sql, limit, main)
         self.assertEquals(expected_sql, limited)
 
+    def test_extract_limit_from_query(self, engine_spec_class=MySQLEngineSpec):
+        q0 = 'select * from table'
+        q1 = 'select * from mytable limit 10'
+        q2 = 'select * from (select * from my_subquery limit 10) where col=1 limit 20'
+        q3 = 'select * from (select * from my_subquery limit 10);'
+        q4 = 'select * from (select * from my_subquery limit 10) where col=1 limit 20;'
+
+        self.assertEqual(engine_spec_class.get_limit_from_sql(q0), None)
+        self.assertEqual(engine_spec_class.get_limit_from_sql(q1), 10)
+        self.assertEqual(engine_spec_class.get_limit_from_sql(q2), 20)
+        self.assertEqual(engine_spec_class.get_limit_from_sql(q3), None)
+        self.assertEqual(engine_spec_class.get_limit_from_sql(q4), 20)
+
     def test_wrapped_query(self):
         self.sql_limit_regex(
             'SELECT * FROM a',


### PR DESCRIPTION
This PR (https://github.com/apache/incubator-superset/pull/4947) implemented a more efficient way to limit queries by attaching the limit statement to the statement. However, it always attaches the default limit to all queries even when a fifferent (possibly smaller) limit is specified in the query. This is because query.limit is always set to the default value, never the specified limit value. 
In this PR, I do some query parsing to make sure query.limit is correctly specified upstream. Then the query augnmenting logic is only called when there no limit specified. 

@mistercrunch @john-bodley @michellethomas 