### PR TITLE
[bugfix]fix metrics type error in pivot table viz

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -687,7 +687,7 @@ class PivotTableViz(BaseViz):
         df = df.pivot_table(
             index=self.form_data.get('groupby'),
             columns=self.form_data.get('columns'),
-            values=self.form_data.get('metrics'),
+            values=[self.get_metric_label(m) for m in self.form_data.get('metrics')],
             aggfunc=self.form_data.get('pandas_aggfunc'),
             margins=self.form_data.get('pivot_margins'),
         )


### PR DESCRIPTION
to fix this bug in pivot table viz  @xrmx @mistercrunch 
https://github.com/apache/incubator-superset/issues/4984

- transfer metrics dict label to the list of string