### PR TITLE
Add missing dep on contextlib2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'boto3>=1.4.6',
         'celery',
         'colorama',
+        'contextlib2',
         'cryptography',
         'flask<1.0.0',
         'flask-appbuilder',


### PR DESCRIPTION
@john-bodley community contributed https://github.com/apache/incubator-superset/pull/4927 added dep in `requirements.txt` but not in `setup.py` causing Travis to succeed but the installation of pypi to fail for many.

With unpinned deps, should we have an extra suite of tests not using `requirements.txt` to catch when new releases of libs break our stuff?

fixes https://github.com/apache/incubator-superset/issues/5004