### PR TITLE
[druid] Fixing Druid version check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -277,7 +277,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,pandas,alembic.op,sqlalchemy,alembic.context,flask_appbuilder.security.sqla.PermissionView.role,flask_appbuilder.Model.metadata,flask_appbuilder.Base.metadata
+ignored-modules=numpy,pandas,alembic.op,sqlalchemy,alembic.context,flask_appbuilder.security.sqla.PermissionView.role,flask_appbuilder.Model.metadata,flask_appbuilder.Base.metadata,distutils
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime, timedelta
+from distutils.version import LooseVersion
 import json
 import logging
 from multiprocessing.pool import ThreadPool
@@ -576,38 +577,6 @@ class DruidDatasource(Model, BaseDatasource):
             db.session, i_datasource, lookup_cluster, lookup_datasource,
             import_time)
 
-    @staticmethod
-    def version_higher(v1, v2):
-        """is v1 higher than v2
-
-        >>> DruidDatasource.version_higher('0.8.2', '0.9.1')
-        False
-        >>> DruidDatasource.version_higher('0.8.2', '0.6.1')
-        True
-        >>> DruidDatasource.version_higher('0.8.2', '0.8.2')
-        False
-        >>> DruidDatasource.version_higher('0.8.2', '0.9.BETA')
-        False
-        >>> DruidDatasource.version_higher('0.8.2', '0.9')
-        False
-        """
-        def int_or_0(v):
-            try:
-                v = int(v)
-            except (TypeError, ValueError):
-                v = 0
-            return v
-        v1nums = [int_or_0(n) for n in v1.split('.')]
-        v2nums = [int_or_0(n) for n in v2.split('.')]
-        v1nums = (v1nums + [0, 0, 0])[:3]
-        v2nums = (v2nums + [0, 0, 0])[:3]
-        return (
-            v1nums[0] > v2nums[0] or
-            (v1nums[0] == v2nums[0] and v1nums[1] > v2nums[1]) or
-            (v1nums[0] == v2nums[0] and v1nums[1] == v2nums[1] and
-                v1nums[2] > v2nums[2])
-        )
-
     def latest_metadata(self):
         """Returns segment metadata from the latest segment"""
         logging.info('Syncing datasource [{}]'.format(self.datasource_name))
@@ -626,7 +595,7 @@ class DruidDatasource(Model, BaseDatasource):
         # realtime segments, which triggered a bug (fixed in druid 0.8.2).
         # https://groups.google.com/forum/#!topic/druid-user/gVCqqspHqOQ
         lbound = (max_time - timedelta(days=7)).isoformat()
-        if not self.version_higher(self.cluster.druid_version, '0.8.2'):
+        if LooseVersion(self.cluster.druid_version) < LooseVersion('0.8.2'):
             rbound = (max_time - timedelta(1)).isoformat()
         else:
             rbound = max_time.isoformat()
@@ -643,7 +612,7 @@ class DruidDatasource(Model, BaseDatasource):
         if not segment_metadata:
             # if no segments in the past 7 days, look at all segments
             lbound = datetime(1901, 1, 1).isoformat()[:10]
-            if not self.version_higher(self.cluster.druid_version, '0.8.2'):
+            if LooseVersion(self.cluster.druid_version) < LooseVersion('0.8.2'):
                 rbound = datetime.now().isoformat()
             else:
                 rbound = datetime(2050, 1, 1).isoformat()[:10]


### PR DESCRIPTION
While investigation another issue with @GabeLoins we realized that the Druid version check was invalid, i.e., per the comment on line #626 this issue was fixed in `0.8.2`, yet the following condition 
```
 not self.version_higher(self.cluster.druid_version, '0.8.2')
```
returns `True` for any version less than or equal to `0.8.2` rather than being exclusive of `0.8.2` since this is the version which included the fix. The same logic was wrong on line #646.

The fix is to use `distutils.version.LooseVersion` for version checking which abides by [Druid's semantic versioning](http://druid.io/docs/latest/development/versioning.html).

to: @GabeLoins @mistercrunch 