### PR TITLE
[Explore][AdhocMetrics] treating floats like doubles for druid versions lower than 11.0.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -277,7 +277,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,pandas,alembic.op,sqlalchemy,alembic.context,flask_appbuilder.security.sqla.PermissionView.role,flask_appbuilder.Model.metadata,flask_appbuilder.Base.metadata
+ignored-modules=numpy,pandas,alembic.op,sqlalchemy,alembic.context,flask_appbuilder.security.sqla.PermissionView.role,flask_appbuilder.Model.metadata,flask_appbuilder.Base.metadata,distutils
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -76,6 +76,8 @@ GB_RESULT_SET = [
     },
 ]
 
+DruidCluster.get_druid_version = lambda _: '0.9.1'
+
 
 class DruidTests(SupersetTestCase):
 
@@ -114,7 +116,6 @@ class DruidTests(SupersetTestCase):
 
         db.session.add(cluster)
         cluster.get_datasources = PickableMock(return_value=['test_datasource'])
-        cluster.get_druid_version = PickableMock(return_value='0.9.1')
 
         return cluster
 
@@ -324,7 +325,6 @@ class DruidTests(SupersetTestCase):
         cluster.get_datasources = PickableMock(
             return_value=['test_datasource'],
         )
-        cluster.get_druid_version = PickableMock(return_value='0.9.1')
 
         cluster.refresh_datasources()
         cluster.datasources[0].merge_flag = True


### PR DESCRIPTION
In the AdhocMetric feature, we construct Druid queries by taking a column object and an aggregate from the user and construct a druid JSON blob in the flask app. However, the query object is not always a function of just the column's type and the aggregate chosen.

Depending on the Druid version being used, we want to sum floats using `doubleSum` in versions 
earlier than 11.0.0 and sum floats using `floatSum` in versions including and after 11.0.0

A great explanation of why this is the case is provided here: https://groups.google.com/forum/#!topic/druid-development/VEYkW_5dWd8

reviewers:
@john-bodley @michellethomas @mistercrunch @betodealmeida 