### PR TITLE
bugfix when use "Time Series - Line Chart" and "Big Number with Trendline" on dashboard

### DIFF
--- a/superset/assets/src/dashboard/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/components/Dashboard.jsx
@@ -145,7 +145,9 @@ class Dashboard extends React.PureComponent {
   getFormDataExtra(slice) {
     const formDataExtra = Object.assign({}, slice.formData);
     const extraFilters = this.effectiveExtraFilters(slice.slice_id);
-    formDataExtra.extra_filters = formDataExtra.filters.concat(extraFilters);
+    if (typeof formDataExtra.extra_filters !== 'undefined' && typeof formDataExtra.filters !== 'undefined') {
+      formDataExtra.extra_filters = formDataExtra.filters.concat(extraFilters);
+    }
     return formDataExtra;
   }
 


### PR DESCRIPTION
when i use "Time Series - Line Chart" and "Big Number with Trendline" on dashboard.
just show a blank page in grid-container.

error message in web console log : 
```
Dashboard.jsx:150 Uncaught TypeError: Cannot read property 'concat' of undefined
    at Dashboard.getFormDataExtra (Dashboard.jsx:150)
    at GridLayout.jsx:151
    at Array.map (<anonymous>)
    at GridLayout.render (GridLayout.jsx:134)
    at ReactCompositeComponent.js:793
    at measureLifeCyclePerf (ReactCompositeComponent.js:73)
    at ReactCompositeComponentWrapper._renderValidatedComponentWithoutOwnerOrContext (ReactCompositeComponent.js:792)
    at ReactCompositeComponentWrapper._renderValidatedComponent (ReactCompositeComponent.js:819)
    at ReactCompositeComponentWrapper.performInitialMount (ReactCompositeComponent.js:359)
    at ReactCompositeComponentWrapper.mountComponent (ReactCompositeComponent.js:255)
```		
because of formDataExtra.extra_filters and formDataExtra.filters is "undefined"
at incubator-superset/superset/assets/src/dashboard/components/Dashboard.jsx (about 145 lines)

