### PR TITLE
[Explore] [Adhoc Metrics/Filters] Force Ace editor to refresh when it is shown

### DIFF
--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
@@ -33,6 +33,7 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
     super(props);
     this.onSqlExpressionChange = this.onSqlExpressionChange.bind(this);
     this.onSqlExpressionClauseChange = this.onSqlExpressionClauseChange.bind(this);
+    this.handleAceEditorRef = this.handleAceEditorRef.bind(this);
 
     this.selectProps = {
       multi: false,
@@ -59,6 +60,10 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
     }
   }
 
+  componentDidUpdate() {
+    this.aceEditorRef.editor.resize();
+  }
+
   onSqlExpressionClauseChange(clause) {
     this.props.onChange(this.props.adhocFilter.duplicateWith({
       clause: clause && clause.clause,
@@ -71,6 +76,12 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
       sqlExpression,
       expressionType: EXPRESSION_TYPES.SQL,
     }));
+  }
+
+  handleAceEditorRef(ref) {
+    if (ref) {
+      this.aceEditorRef = ref;
+    }
   }
 
   render() {
@@ -101,6 +112,7 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
         </FormGroup>
         <FormGroup>
           <AceEditor
+            ref={this.handleAceEditorRef}
             mode="sql"
             theme="github"
             height={(height - 100) + 'px'}

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -46,6 +46,8 @@ export default class AdhocMetricEditPopover extends React.Component {
     this.onDragDown = this.onDragDown.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
+    this.handleAceEditorRef = this.handleAceEditorRef.bind(this);
+    this.refreshAceEditor = this.refreshAceEditor.bind(this);
     this.state = {
       adhocMetric: this.props.adhocMetric,
       width: startingWidth,
@@ -137,6 +139,16 @@ export default class AdhocMetricEditPopover extends React.Component {
     document.removeEventListener('mousemove', this.onMouseMove);
   }
 
+  handleAceEditorRef(ref) {
+    if (ref) {
+      this.aceEditorRef = ref;
+    }
+  }
+
+  refreshAceEditor() {
+    setTimeout(() => this.aceEditorRef.editor.resize(), 0);
+  }
+
   render() {
     const {
       adhocMetric: propsAdhocMetric,
@@ -200,6 +212,8 @@ export default class AdhocMetricEditPopover extends React.Component {
           defaultActiveKey={adhocMetric.expressionType}
           className="adhoc-metric-edit-tabs"
           style={{ height: this.state.height, width: this.state.width }}
+          onSelect={this.refreshAceEditor}
+          animation={false}
         >
           <Tab className="adhoc-metric-edit-tab" eventKey={EXPRESSION_TYPES.SIMPLE} title="Simple">
             <FormGroup>
@@ -216,6 +230,7 @@ export default class AdhocMetricEditPopover extends React.Component {
             <Tab className="adhoc-metric-edit-tab" eventKey={EXPRESSION_TYPES.SQL} title="Custom SQL">
               <FormGroup>
                 <AceEditor
+                  ref={this.handleAceEditorRef}
                   mode="sql"
                   theme="github"
                   height={(this.state.height - 43) + 'px'}


### PR DESCRIPTION
![acerefresh](https://user-images.githubusercontent.com/2455694/40253603-3f889938-5a95-11e8-9904-60430aac0005.gif)

AceEditor has an optimization where it won't refresh itself if its value is set while the editor is hidden. (https://github.com/ajaxorg/ace/issues/2497) Since the editor is hidden when its tab isn't selected, the editor has a stale value when it is shown after changes were made in the Simple tab.

In this PR I force refresh the editor using its exposed `resize` method every time it is foregrounded

test plan:
- visualized in gif above

reviewers:
@michellethomas @john-bodley @graceguo-supercat @mistercrunch 