### PR TITLE
Update exception status for No Data

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -23,7 +23,7 @@ class MetricPermException(SupersetException):
 
 
 class NoDataException(SupersetException):
-    status = 400
+    status = 204
 
 
 class SupersetTemplateException(SupersetException):


### PR DESCRIPTION
I believe a `NoDataException` shouldn't return an 400 status code. Since the query completed and No data was available the user should be prompted accordingly. This is an expected result in my opinion with the given query and the appropriate response is a `204 No Content`