### PR TITLE
[Adhoc Filters] integrating dashboard filters with adhoc filters

### DIFF
--- a/superset/assets/src/dashboard/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/components/Dashboard.jsx
@@ -144,8 +144,7 @@ class Dashboard extends React.PureComponent {
 
   getFormDataExtra(slice) {
     const formDataExtra = Object.assign({}, slice.formData);
-    const extraFilters = this.effectiveExtraFilters(slice.slice_id);
-    formDataExtra.extra_filters = formDataExtra.filters.concat(extraFilters);
+    formDataExtra.extra_filters = this.effectiveExtraFilters(slice.slice_id);
     return formDataExtra;
   }
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1279,6 +1279,7 @@ class Superset(BaseSupersetView):
         form_data['datasource'] = str(datasource_id) + '__' + datasource_type
 
         # On explore, merge extra filters into the form data
+        utils.split_adhoc_filters_into_base_filters(form_data)
         merge_extra_filters(form_data)
 
         # merge request url params


### PR DESCRIPTION
Thanks to @michellethomas for reporting. Filters on dashboards were not compatible with adhoc filters. This PR essentially factors out adhoc_filter => legacy filter conversion into a util function and then calls it both places `merge_extra_filters` is called.

relevant issue: https://github.com/apache/incubator-superset/issues/5049

![image](https://user-images.githubusercontent.com/2455694/40392373-37528fe2-5dd0-11e8-8656-adf6c239a02c.png)

test plan:
- created a dashboard locally with a filter
- added slices with no filters, with adhoc_filters and with legacy filters
- applied the filter to dashboard
- verified all the slices incorporated the filter when rendering
- clicked on various slices
- verified they all had the dashboard's filter applied in the explore view

reviewers:
@michellethomas @john-bodley @graceguo-supercat @williaster @mistercrunch 