### PR TITLE
Translate string to array for multi fields in getControlsState

### DIFF
--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -56,6 +56,10 @@ export function getControlsState(state, form_data) {
       delete control.mapStateToProps;
     }
 
+    if (control.multi && typeof formData[k] === 'string') {
+        formData[k] = [formData[k]];
+    }
+
     // If the value is not valid anymore based on choices, clear it
     if (control.type === 'SelectControl' && control.choices && k !== 'datasource' && formData[k]) {
       const choiceValues = control.choices.map(c => c[0]);

--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -56,9 +56,8 @@ export function getControlsState(state, form_data) {
       delete control.mapStateToProps;
     }
 
-    if (control.multi && typeof formData[k] === 'string') {
-        formData[k] = [formData[k]];
-    }
+    formData[k] = (control.multi && formData[k] && !Array.isArray(formData[k])) ? [formData[k]]
+      : formData[k];
 
     // If the value is not valid anymore based on choices, clear it
     if (control.type === 'SelectControl' && control.choices && k !== 'datasource' && formData[k]) {


### PR DESCRIPTION
In the explore store.js, I'm adding logic that will handle a string value being passed to a multi control by making it an array. This would handle errors with existing slices when making a SelectControl multi. 

Fixes #5011 
@mistercrunch @graceguo-supercat 