### PR TITLE
[markup] Enable allow-forms

### DIFF
--- a/superset/assets/src/visualizations/markup.js
+++ b/superset/assets/src/visualizations/markup.js
@@ -30,7 +30,7 @@ function markupWidget(slice, payload) {
     <iframe id="${iframeId}"
       frameborder="0"
       height="${iframeHeight}"
-      sandbox="allow-same-origin allow-scripts allow-top-navigation allow-popups">
+      sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation">
     </iframe>
   `);
 


### PR DESCRIPTION
This PR fixes an issue where a dashboard contained a markup slice with links to other dashboards, and when one tried to either export or explore a slice on the referenced dashboard the following error occurred:

```
Blocked form submission to <url> because the form's frame is sandboxed and the 'allow-forms' permission is not set.
```
The solution is simply to enable the `allow-forms` permission in the markup iframe component. 

Note given the complexity of the issue, I'm unsure whether one could write a unit test for this scenario, though I was able to validate the fix in my local environment. 

to: @williaster @graceguo-supercat @michellethomas @mistercrunch  