### PR TITLE
Allow multiple time shifts

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1575,11 +1575,20 @@ export const controls = {
   },
 
   time_compare: {
-    type: 'TextControl',
+    type: 'SelectControl',
+    multi: true,
+    freeForm: true,
     label: t('Time Shift'),
-    default: null,
-    description: t('Overlay a timeseries from a ' +
-    'relative time period. Expects relative time delta ' +
+    default: [],
+    choices: formatSelectOptions([
+      '1 day',
+      '1 week',
+      '28 days',
+      '30 days',
+      '1 year',
+    ]),
+    description: t('Overlay one or more timeseries from a ' +
+    'relative time period. Expects relative time deltas ' +
     'in natural language (example:  24 hours, 7 days, ' +
     '56 weeks, 365 days)'),
   },

--- a/superset/assets/src/explore/visTypes.js
+++ b/superset/assets/src/explore/visTypes.js
@@ -74,7 +74,7 @@ export const sections = {
       'of query results'),
       controlSetRows: [
         ['rolling_type', 'rolling_periods', 'min_periods'],
-        ['time_compare', null],
+        ['time_compare'],
         ['num_period_compare', 'period_ratio_type'],
         ['resample_how', 'resample_rule', 'resample_fillmethod'],
       ],

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -86,7 +86,7 @@ class BaseViz(object):
         self._some_from_cache = False
         self._any_cache_key = None
         self._any_cached_dttm = None
-        self._extra_chart_data = None
+        self._extra_chart_data = []
 
         self.process_metrics()
 
@@ -1199,10 +1199,10 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
     def run_extra_queries(self):
         fd = self.form_data
-        time_compare = fd.get('time_compare')
-        if time_compare:
+        time_compare = fd.get('time_compare') or []
+        for option in time_compare:
             query_object = self.query_obj()
-            delta = utils.parse_human_timedelta(time_compare)
+            delta = utils.parse_human_timedelta(option)
             query_object['inner_from_dttm'] = query_object['from_dttm']
             query_object['inner_to_dttm'] = query_object['to_dttm']
 
@@ -1215,10 +1215,11 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
             df2 = self.get_df_payload(query_object).get('df')
             if df2 is not None:
+                label = '{} offset'. format(option)
                 df2[DTTM_ALIAS] += delta
                 df2 = self.process_data(df2)
-                self._extra_chart_data = self.to_series(
-                    df2, classed='superset', title_suffix='---')
+                self._extra_chart_data.extend(self.to_series(
+                    df2, classed='superset', title_suffix=label))
 
     def get_data(self, df):
         df = self.process_data(df)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1199,7 +1199,12 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
     def run_extra_queries(self):
         fd = self.form_data
+
         time_compare = fd.get('time_compare') or []
+        # backwards compatibility
+        if not isinstance(time_compare, list):
+            time_compare = [time_compare]
+
         for option in time_compare:
             query_object = self.query_obj()
             delta = utils.parse_human_timedelta(option)


### PR DESCRIPTION
This PR changes the Advanced Analytics section to allow multiple time shifts, instead of only one:

![multiple_time_shifts](https://user-images.githubusercontent.com/1534870/40458735-7fb5a3b8-5eb2-11e8-9501-e18c86fec84f.gif)
