### PR TITLE
Add 24 hours refresh for dashboard

### DIFF
--- a/superset/assets/src/dashboard/components/RefreshIntervalModal.jsx
+++ b/superset/assets/src/dashboard/components/RefreshIntervalModal.jsx
@@ -21,6 +21,10 @@ const options = [
   [30, t('30 seconds')],
   [60, t('1 minute')],
   [300, t('5 minutes')],
+  [1800, t('30 minutes')],
+  [3600, t('1 hour')],
+  [21600, t('6 hours')],
+  [43200, t('12 hours')],
   [86400, t('24 hours')],
 ].map(o => ({ value: o[0], label: o[1] }));
 

--- a/superset/assets/src/dashboard/components/RefreshIntervalModal.jsx
+++ b/superset/assets/src/dashboard/components/RefreshIntervalModal.jsx
@@ -21,6 +21,7 @@ const options = [
   [30, t('30 seconds')],
   [60, t('1 minute')],
   [300, t('5 minutes')],
+  [86400, t('24 hours')],
 ].map(o => ({ value: o[0], label: o[1] }));
 
 class RefreshIntervalModal extends React.PureComponent {


### PR DESCRIPTION
For dashboards, add additional autorefresh time interval options of 30m, 1h, 6h, 12h, and 24h.

Fixes #5058.
@mistercrunch @michellethomas @niksem