### PR TITLE
Revert "[get_df] Adding support for multi-statement SQL"

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -690,13 +690,9 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         return self.get_dialect().identifier_preparer.quote
 
     def get_df(self, sql, schema):
-        sqls = [x.strip() for x in sql.strip().strip(';').split(';')]
+        sql = sql.strip().strip(';')
         eng = self.get_sqla_engine(schema=schema)
-
-        for i in range(len(sqls) - 1):
-            eng.execute(sqls[i])
-
-        df = pd.read_sql_query(sqls[-1], eng)
+        df = pd.read_sql_query(sql, eng)
 
         def needs_conversion(df_series):
             if df_series.empty:

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -106,20 +106,6 @@ class DatabaseModelTestCase(SupersetTestCase):
         self.assertEquals(d.get('P1D').function, 'DATE({col})')
         self.assertEquals(d.get('Time Column').function, '{col}')
 
-    def test_single_statement(self):
-        main_db = self.get_main_database(db.session)
-
-        if main_db.backend == 'mysql':
-            df = main_db.get_df('SELECT 1', None)
-            self.assertEquals(df.iat[0, 0], 1)
-
-    def test_multi_statement(self):
-        main_db = self.get_main_database(db.session)
-
-        if main_db.backend == 'mysql':
-            df = main_db.get_df('USE superset; SELECT 1', None)
-            self.assertEquals(df.iat[0, 0], 1)
-
 
 class SqlaTableModelTestCase(SupersetTestCase):
 


### PR DESCRIPTION
Reverts apache/incubator-superset#5060

@mistercrunch I'm temporary reverting this as splitting on `;` isn't quite right as queries may contain the `;` character embedded in strings. 

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa  
cc: @betodealmeida 