### PR TITLE
Add more time grains

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -490,6 +490,9 @@ class SqliteEngineSpec(BaseEngineSpec):
         Grain('month', _('month'),
               "DATE({col}, -strftime('%d', {col}) || ' days', '+1 day')",
               'P1M'),
+        Grain('year', _('year'),
+              "DATETIME(STRFTIME('%Y-01-01T00:00:00', {col}))",
+              'P1Y'),
         Grain('week_ending_saturday', _('week_ending_saturday'),
               "DATE({col}, 'weekday 6')",
               'P1W/1970-01-03T00:00:00Z'),
@@ -1356,6 +1359,27 @@ class DruidEngineSpec(BaseEngineSpec):
     """Engine spec for Druid.io"""
     engine = 'druid'
     inner_joins = False
+
+    time_grains = (
+        Grain('Time Column', _('Time Column'), '{col}', None),
+        Grain(
+            'millisecond',
+            _('millisecond'),
+            "TIME_FLOOR({col}, 'PT0.001S')",
+            'PT0.001S',
+        ),
+        Grain('second', _('second'), "TIME_FLOOR({col}, 'PT1S')", 'PT1S'),
+        Grain('minute', _('minute'), "TIME_FLOOR({col}, 'PT1M')", 'PT1M'),
+        Grain('hour', _('hour'), "TIME_FLOOR({col}, 'PT1H')", 'PT1H'),
+        Grain('day', _('day'), "TIME_FLOOR({col}, 'P1D')", 'P1D'),
+        Grain('week', _('week'), "TIME_FLOOR({col}, 'P1W')", 'P1W'),
+        Grain('month', _('month'), "TIME_FLOOR({col}, 'P1M')", 'P1M'),
+        Grain('quarter', _('quarter'), "TIME_FLOOR({col}, 'P3M')", 'P3M'),
+        Grain('year', _('year'), "TIME_FLOOR({col}, 'P1Y')", 'P1Y'),
+        Grain('decade', _('decade'), "TIME_FLOOR({col}, 'P10Y')", 'P10Y'),
+        Grain('century', _('century'), "TIME_FLOOR({col}, 'P100Y')", 'P100Y'),
+        Grain('millenium', _('millenium'), "TIME_FLOOR({col}, 'P1000Y')", 'P1000Y'),
+    )
 
 
 class KylinEngineSpec(BaseEngineSpec):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1362,14 +1362,14 @@ class DruidEngineSpec(BaseEngineSpec):
 
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}', None),
-        Grain('second', _('second'), "FLOOR({col} TO SECOND)", 'PT1S'),
-        Grain('minute', _('minute'), "FLOOR({col} TO MINUTE)", 'PT1M'),
-        Grain('hour', _('hour'), "FLOOR({col} TO HOUR)", 'PT1H'),
-        Grain('day', _('day'), "FLOOR({col} TO DAY)", 'P1D'),
-        Grain('week', _('week'), "FLOOR({col} TO WEEK)", 'P1W'),
-        Grain('month', _('month'), "FLOOR({col} TO MONTH)", 'P1M'),
-        Grain('quarter', _('quarter'), "FLOOR({col} TO QUARTER)", 'P3M'),
-        Grain('year', _('year'), "FLOOR({col} TO YEAR)", 'P1Y'),
+        Grain('second', _('second'), 'FLOOR({col} TO SECOND)', 'PT1S'),
+        Grain('minute', _('minute'), 'FLOOR({col} TO MINUTE)', 'PT1M'),
+        Grain('hour', _('hour'), 'FLOOR({col} TO HOUR)', 'PT1H'),
+        Grain('day', _('day'), 'FLOOR({col} TO DAY)', 'P1D'),
+        Grain('week', _('week'), 'FLOOR({col} TO WEEK)', 'P1W'),
+        Grain('month', _('month'), 'FLOOR({col} TO MONTH)', 'P1M'),
+        Grain('quarter', _('quarter'), 'FLOOR({col} TO QUARTER)', 'P3M'),
+        Grain('year', _('year'), 'FLOOR({col} TO YEAR)', 'P1Y'),
     )
 
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1362,23 +1362,14 @@ class DruidEngineSpec(BaseEngineSpec):
 
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}', None),
-        Grain(
-            'millisecond',
-            _('millisecond'),
-            "TIME_FLOOR({col}, 'PT0.001S')",
-            'PT0.001S',
-        ),
-        Grain('second', _('second'), "TIME_FLOOR({col}, 'PT1S')", 'PT1S'),
-        Grain('minute', _('minute'), "TIME_FLOOR({col}, 'PT1M')", 'PT1M'),
-        Grain('hour', _('hour'), "TIME_FLOOR({col}, 'PT1H')", 'PT1H'),
-        Grain('day', _('day'), "TIME_FLOOR({col}, 'P1D')", 'P1D'),
-        Grain('week', _('week'), "TIME_FLOOR({col}, 'P1W')", 'P1W'),
-        Grain('month', _('month'), "TIME_FLOOR({col}, 'P1M')", 'P1M'),
-        Grain('quarter', _('quarter'), "TIME_FLOOR({col}, 'P3M')", 'P3M'),
-        Grain('year', _('year'), "TIME_FLOOR({col}, 'P1Y')", 'P1Y'),
-        Grain('decade', _('decade'), "TIME_FLOOR({col}, 'P10Y')", 'P10Y'),
-        Grain('century', _('century'), "TIME_FLOOR({col}, 'P100Y')", 'P100Y'),
-        Grain('millenium', _('millenium'), "TIME_FLOOR({col}, 'P1000Y')", 'P1000Y'),
+        Grain('second', _('second'), "FLOOR({col} TO SECOND)", 'PT1S'),
+        Grain('minute', _('minute'), "FLOOR({col} TO MINUTE)", 'PT1M'),
+        Grain('hour', _('hour'), "FLOOR({col} TO HOUR)", 'PT1H'),
+        Grain('day', _('day'), "FLOOR({col} TO DAY)", 'P1D'),
+        Grain('week', _('week'), "FLOOR({col} TO WEEK)", 'P1W'),
+        Grain('month', _('month'), "FLOOR({col} TO MONTH)", 'P1M'),
+        Grain('quarter', _('quarter'), "FLOOR({col} TO QUARTER)", 'P3M'),
+        Grain('year', _('year'), "FLOOR({col} TO YEAR)", 'P1Y'),
     )
 
 


### PR DESCRIPTION
This PR adds the "year" time grain to SQLite, and all the time grains supported by [Druid SQL](http://druid.io/docs/latest/querying/sql.html#time-functions).