### PR TITLE
Override time grain in annotations

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -70,6 +70,10 @@ export function runAnnotationQuery(annotation, timeout = 60, formData = null, ke
       return Promise.resolve();
     }
 
+    const granularity = fd.time_grain_sqla || fd.granularity;
+    fd.time_grain_sqla = granularity;
+    fd.granularity = granularity;
+
     const sliceFormData = Object.keys(annotation.overrides)
       .reduce((d, k) => ({
         ...d,

--- a/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
@@ -269,8 +269,8 @@ export default class AnnotationLayer extends React.PureComponent {
       } else {
         label = 'Slice';
         description = `Use a pre defined Superset Slice as a source for annotations and overlays. 
-        'your Slice must be one of these visualization types:
-        '[${getSupportedSourceTypes(sourceType)
+        'your chart must be one of these visualization types:
+        '[${getSupportedSourceTypes(annotationType)
             .map(x => vizTypes[x].label).join(', ')}]'`;
       }
     } else if (annotationType === AnnotationTypes.FORMULA) {
@@ -400,7 +400,7 @@ export default class AnnotationLayer extends React.PureComponent {
                 name="annotation-override-since"
                 label="Override 'Since'"
                 description={`This controls whether the "Since" field from the current
-                  view should be passed down to the slice containing the annotation data.`}
+                  view should be passed down to the chart containing the annotation data.`}
                 value={!!Object.keys(overrides).find(x => x === 'since')}
                 onChange={(v) => {
                   delete overrides.since;
@@ -416,12 +416,35 @@ export default class AnnotationLayer extends React.PureComponent {
                 name="annotation-override-until"
                 label="Override 'Until'"
                 description={`This controls whether the "Until" field from the current
-                  view should be passed down to the slice containing the annotation data.`}
+                  view should be passed down to the chart containing the annotation data.`}
                 value={!!Object.keys(overrides).find(x => x === 'until')}
                 onChange={(v) => {
                   delete overrides.until;
                   if (v) {
                     this.setState({ overrides: { ...overrides, until: null } });
+                  } else {
+                    this.setState({ overrides: { ...overrides } });
+                  }
+                }}
+              />
+              <CheckboxControl
+                hovered
+                name="annotation-override-timegrain"
+                label="Override time grain"
+                description={`This controls whether the time grain field from the current
+                  view should be passed down to the chart containing the annotation data.`}
+                value={!!Object.keys(overrides).find(x => x === 'time_grain_sqla')}
+                onChange={(v) => {
+                  delete overrides.time_grain_sqla;
+                  delete overrides.granularity;
+                  if (v) {
+                    this.setState({
+                      overrides: {
+                        ...overrides,
+                        time_grain_sqla: null,
+                        granularity: null,
+                      },
+                    });
                   } else {
                     this.setState({ overrides: { ...overrides } });
                   }


### PR DESCRIPTION
Allow overriding the time grain of time series annotations.

The good news is that we've unified the granularity of Druid and SQLAlchemy, using ISO duration strings, so we can apply the time grain of a Druid time series to a SQLAlchemy time series annotation, and vice versa.

The bad news is that this is currently a bit ugly because we don't know if the time series annotation has a SQLAlchemy or a Druid datasource. So we pass the current time grain in both `granularity` and `time_grain_sqla`. This only works if the SQLAlchemy datasource has a main temporal table configured.

In the future we should unify this as a single parameter, IMHO.

The screenshot below shows an annotation that was saved with hourly grain (`sqla_hourly`) being loaded with daily grain. Note the new checkbox, "Override time grain":

<img width="1680" alt="screen shot 2018-05-25 at 12 46 32 pm" src="https://user-images.githubusercontent.com/1534870/40563650-67093dd4-601a-11e8-9dea-0946d7ce5d23.png">

