### PR TITLE
[get_df] Adding support for multi-statement SQL

### DIFF
--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -106,6 +106,26 @@ class DatabaseModelTestCase(SupersetTestCase):
         self.assertEquals(d.get('P1D').function, 'DATE({col})')
         self.assertEquals(d.get('Time Column').function, '{col}')
 
+    def test_single_statement(self):
+        main_db = self.get_main_database(db.session)
+
+        if main_db.backend == 'mysql':
+            df = main_db.get_df('SELECT 1', None)
+            self.assertEquals(df.iat[0, 0], 1)
+
+            df = main_db.get_df('SELECT 1;', None)
+            self.assertEquals(df.iat[0, 0], 1)
+
+    def test_multi_statement(self):
+        main_db = self.get_main_database(db.session)
+
+        if main_db.backend == 'mysql':
+            df = main_db.get_df('USE superset; SELECT 1', None)
+            self.assertEquals(df.iat[0, 0], 1)
+
+            df = main_db.get_df("USE superset; SELECT ';';", None)
+            self.assertEquals(df.iat[0, 0], ';')
+
 
 class SqlaTableModelTestCase(SupersetTestCase):
 


### PR DESCRIPTION
@mistercrunch sorry I previously reverted #5060 as it didn't handle the case of statements including the `;` character as part of a filter etc. Previously I was ignorantly splitting on the `;` character, whereas in this PR I use the `sqlparse` stdlib to parse the raw SQL which correctly identifies the statement(s). 

to: @betodealmeida @GabeLoins @michellethomas @mistercrunch