### PR TITLE
Add required flask-appbuilder to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'contextlib2',
         'cryptography',
         'flask<1.0.0',
-        'flask-appbuilder',
+        'flask-appbuilder==1.10.0',
         'flask-caching',
         'flask-compress',
         'flask-migrate',


### PR DESCRIPTION
1.10.0 is needed to run superset db upgrade:
```
Traceback (most recent call last):
  File "/home/rm/superset/venv/bin/superset", line 12, in <module>
    from superset.cli import manager
  File "/home/rm/superset/venv/lib/python3.4/site-packages/superset/__init__.py", line 169, in <module>
    update_perms=utils.get_update_perms_flag(),
TypeError: __init__() got an unexpected keyword argument 'update_perms'
```