### PR TITLE
Fix form data issue switching viz types

### DIFF
--- a/superset/assets/src/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/src/explore/components/ExploreViewContainer.jsx
@@ -293,12 +293,6 @@ ExploreViewContainer.propTypes = propTypes;
 
 function mapStateToProps({ explore, charts, impressionId }) {
   const form_data = getFormDataFromControls(explore.controls);
-  // fill in additional params stored in form_data but not used by control
-  Object.keys(explore.rawFormData).forEach((key) => {
-    if (form_data[key] === undefined) {
-      form_data[key] = explore.rawFormData[key];
-    }
-  });
   const chartKey = Object.keys(charts)[0];
   const chart = charts[chartKey];
   return {

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1888,6 +1888,13 @@ export const controls = {
     description: t('The number of seconds before expiring the cache'),
   },
 
+  url_params: {
+    type: 'HiddenControl',
+    label: t('URL Parameters'),
+    hidden: true,
+    description: t('Extra parameters for use in jinja templated queries'),
+  },
+
   order_by_entity: {
     type: 'CheckboxControl',
     label: t('Order by entity id'),

--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -121,13 +121,6 @@ export function applyDefaultFormData(form_data) {
       formData[k] = form_data[k];
     }
   });
-  // fill in additional params stored in form_data but not used by control
-  Object.keys(form_data)
-    .forEach((key) => {
-      if (formData[key] === undefined) {
-        formData[key] = form_data[key];
-      }
-    });
   return formData;
 }
 

--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -23,7 +23,7 @@ export const sections = {
     controlSetRows: [
       ['datasource'],
       ['viz_type'],
-      ['slice_id', 'cache_timeout'],
+      ['slice_id', 'cache_timeout', 'url_params'],
     ],
   },
   colorScheme: {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -933,7 +933,7 @@ class Superset(BaseSupersetView):
         session.commit()
         return redirect('/accessrequestsmodelview/list/')
 
-    def get_form_data(self, slice_id=None):
+    def get_form_data(self, slice_id=None, use_slice_data=False):
         form_data = {}
         post_data = request.form.get('form_data')
         request_args_data = request.args.get('form_data')
@@ -970,7 +970,9 @@ class Superset(BaseSupersetView):
         slice_id = form_data.get('slice_id') or slice_id
         slc = None
 
-        if slice_id and not post_data:
+        # Include the slice_form_data if request from explore or slice calls
+        # explore_json calls should not include slice form_data
+        if slice_id and use_slice_data:
             slc = db.session.query(models.Slice).filter_by(id=slice_id).first()
             slice_form_data = slc.form_data.copy()
             # allow form_data in request override slice from_data
@@ -1010,7 +1012,7 @@ class Superset(BaseSupersetView):
     @has_access
     @expose('/slice/<slice_id>/')
     def slice(self, slice_id):
-        form_data, slc = self.get_form_data(slice_id)
+        form_data, slc = self.get_form_data(slice_id, use_slice_data=True)
         endpoint = '/superset/explore/?form_data={}'.format(
             parse.quote(json.dumps(form_data)),
         )
@@ -1217,7 +1219,7 @@ class Superset(BaseSupersetView):
     @expose('/explore/', methods=['GET', 'POST'])
     def explore(self, datasource_type=None, datasource_id=None):
         user_id = g.user.get_id() if g.user else None
-        form_data, slc = self.get_form_data()
+        form_data, slc = self.get_form_data(use_slice_data=True)
 
         datasource_id, datasource_type = self.datasource_info(
             datasource_id, datasource_type, form_data)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -970,7 +970,7 @@ class Superset(BaseSupersetView):
         slice_id = form_data.get('slice_id') or slice_id
         slc = None
 
-        if slice_id:
+        if slice_id and not post_data:
             slc = db.session.query(models.Slice).filter_by(id=slice_id).first()
             slice_form_data = slc.form_data.copy()
             # allow form_data in request override slice from_data

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -970,9 +970,12 @@ class Superset(BaseSupersetView):
         slice_id = form_data.get('slice_id') or slice_id
         slc = None
 
+        # Check if form data only contains slice_id
+        contains_only_slc_id = not any(key != 'slice_id' for key in form_data)
+
         # Include the slice_form_data if request from explore or slice calls
-        # explore_json calls should not include slice form_data
-        if slice_id and use_slice_data:
+        # or if form_data only contains slice_id
+        if slice_id and (use_slice_data or contains_only_slc_id):
             slc = db.session.query(models.Slice).filter_by(id=slice_id).first()
             slice_form_data = slc.form_data.copy()
             # allow form_data in request override slice from_data


### PR DESCRIPTION
We've been having an issue with extra params getting into the form data (that are not valid controls for a particular viz type), this breaks the query and there's no way to remove it from the controls. This happens when you switch from a time series with a group by to a big number. The group by in the rawFormData will get added to the form_data and create a query that's invalid for a big number chart (that doesn't have a group by control).

It looks like this was introduced [here](https://github.com/apache/incubator-superset/pull/4578/files) so I'm assuming that the only extra form data param is our url params section. If this is not true let me know.

@graceguo-supercat @mistercrunch 