### PR TITLE
Refactor NULL handling into method, disable for DECK.gl vizes

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -145,6 +145,10 @@ class BaseViz(object):
         """
         pass
 
+    def handle_nulls(self, df):
+        fillna = self.get_fillna_for_columns(df.columns)
+        df = df.fillna(fillna)
+
     def get_fillna_for_col(self, col):
         """Returns the value for use as filler for a specific Column.type"""
         if col:
@@ -208,8 +212,7 @@ class BaseViz(object):
             self.df_metrics_to_num(df, query_obj.get('metrics') or [])
 
             df.replace([np.inf, -np.inf], np.nan)
-            fillna = self.get_fillna_for_columns(df.columns)
-            df = df.fillna(fillna)
+            self.handle_nulls(df)
         return df
 
     @staticmethod
@@ -2040,6 +2043,9 @@ class BaseDeckGLViz(BaseViz):
     is_timeseries = False
     credits = '<a href="https://uber.github.io/deck.gl/">deck.gl</a>'
     spatial_control_keys = []
+
+    def handle_nulls(self, df):
+        pass
 
     def get_metrics(self):
         self.metric = self.form_data.get('size')


### PR DESCRIPTION
Moving `handle_nulls` to its own method will allow visualizations to override this part.

This specifically turns off null handling for DECK.gl visualizations as there are issues with spatial dimensions getting replaced by `" NULL"` which triggers errors in places where `NULL` or `None` are handled properly.

Following this simple refactor, we can move forward with more appropriate and per-visualization defined null handling.

@betodealmeida @john-bodley 