### PR TITLE
Fix bullet chart rendering

### DIFF
--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -121,9 +121,14 @@ export default function nvd3Vis(slice, payload) {
 
   let data;
   if (payload.data) {
-    data = payload.data.map(x => ({
-      ...x, key: formatLabel(x.key, slice.datasource.verbose_map),
-    }));
+    if(Array.isArray(payload.data)) {
+        data = payload.data.map(x => ({
+            ...x, key: formatLabel(x.key, slice.datasource.verbose_map),
+        }));
+    }
+    else {
+      data = payload.data;
+    }
   } else {
     data = [];
   }

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -121,12 +121,11 @@ export default function nvd3Vis(slice, payload) {
 
   let data;
   if (payload.data) {
-    if(Array.isArray(payload.data)) {
+    if (Array.isArray(payload.data)) {
         data = payload.data.map(x => ({
             ...x, key: formatLabel(x.key, slice.datasource.verbose_map),
         }));
-    }
-    else {
+    } else {
       data = payload.data;
     }
   } else {


### PR DESCRIPTION
Bullet charts were erroring out with `t.data.map is not a function` (as in issue https://github.com/apache/incubator-superset/issues/3827), this PR addresses that.