### PR TITLE
[Explore][Adhoc Filters] fixing LIKE constant name

### DIFF
--- a/superset/assets/spec/javascripts/explore/components/AdhocFilterEditPopoverSimpleTabContent_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocFilterEditPopoverSimpleTabContent_spec.jsx
@@ -113,13 +113,13 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
   it('will filter operators for table datasources', () => {
     const { wrapper } = setup({ datasource: { type: 'table' } });
     expect(wrapper.instance().isOperatorRelevant('regex')).to.be.false;
-    expect(wrapper.instance().isOperatorRelevant('like')).to.be.true;
+    expect(wrapper.instance().isOperatorRelevant('LIKE')).to.be.true;
   });
 
   it('will filter operators for druid datasources', () => {
     const { wrapper } = setup({ datasource: { type: 'druid' } });
     expect(wrapper.instance().isOperatorRelevant('regex')).to.be.true;
-    expect(wrapper.instance().isOperatorRelevant('like')).to.be.false;
+    expect(wrapper.instance().isOperatorRelevant('LIKE')).to.be.false;
   });
 
   it('expands when its multi comparator input field expands', () => {

--- a/superset/assets/src/explore/AdhocFilter.js
+++ b/superset/assets/src/explore/AdhocFilter.js
@@ -19,7 +19,7 @@ const OPERATORS_TO_SQL = {
   '<=': '<=',
   in: 'in',
   'not in': 'not in',
-  like: 'like',
+  LIKE: 'like',
 };
 
 function translateToSql(adhocMetric, { useSimple } = {}) {

--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -42,6 +42,8 @@ function translateOperator(operator) {
     return 'equals';
   } else if (operator === OPERATORS['!=']) {
     return 'not equal to';
+  } else if (operator === OPERATORS.LIKE) {
+    return 'like';
   }
   return operator;
 }

--- a/superset/assets/src/explore/constants.js
+++ b/superset/assets/src/explore/constants.js
@@ -16,11 +16,11 @@ export const OPERATORS = {
   '<=': '<=',
   in: 'in',
   'not in': 'not in',
-  like: 'like',
+  LIKE: 'LIKE',
   regex: 'regex',
 };
 
-export const TABLE_ONLY_OPERATORS = [OPERATORS.like];
+export const TABLE_ONLY_OPERATORS = [OPERATORS.LIKE];
 export const DRUID_ONLY_OPERATORS = [OPERATORS.regex];
 export const HAVING_OPERATORS = [
   OPERATORS['=='],


### PR DESCRIPTION
The name for the like function is incorrect, and is causing LIKE filters to be dropped by flask.

test plan:
- created a like filter and verified it worked:
![image](https://user-images.githubusercontent.com/2455694/40750860-97729252-641d-11e8-83fe-f99a2ccc1f8c.png)

- run specs

reviewers:
@john-bodley @michellethomas @graceguo-supercat @mistercrunch 