### PR TITLE
[Explore][Adhoc Filters] adding null checks to adhoc filter popover

### DIFF
--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -139,8 +139,10 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
 
   handleMultiComparatorInputHeightChange() {
     if (this.multiComparatorComponent) {
-      // eslint-disable-next-line no-underscore-dangle
-      const multiComparatorDOMNode = this.multiComparatorComponent._selectRef.select.control;
+      /* eslint-disable no-underscore-dangle */
+      const multiComparatorDOMNode = this.multiComparatorComponent._selectRef &&
+        this.multiComparatorComponent._selectRef.select &&
+        this.multiComparatorComponent._selectRef.select.control;
       if (multiComparatorDOMNode) {
         if (multiComparatorDOMNode.clientHeight !== this.state.multiComparatorHeight) {
           this.props.onHeightChange((


### PR DESCRIPTION
Intermittently I have seen issues where due to refs being blank, this assignment causes errors. These extra checks prevent that risk.

reviewers:
@john-bodley @michellethomas @graceguo-supercat @mistercrunch 