### PR TITLE
Issue #5104 - Results are not updated when the last search filter is cleared

### DIFF
--- a/superset/templates/appbuilder/general/widgets/search.html
+++ b/superset/templates/appbuilder/general/widgets/search.html
@@ -28,6 +28,8 @@
 
 <script>
 (function($) {
+    hasFilterPrev = 0
+
     function checkSearchButton() {
         var hasFilter = $('.filters tr').length;
         if (hasFilter) {
@@ -35,8 +37,12 @@
             $('.filters a.remove-filter').on('click', checkSearchButton);
             $('.filter-action').toggle(true);
         } else {
+            if (hasFilterPrev == 1){
+                $('#search-action').click()
+            }
             $('.filter-action').toggle(false);
         }
+        hasFilterPrev = hasFilter
     }
 
     $('.list-search-container').on('hidden.bs.dropdown', checkSearchButton);


### PR DESCRIPTION

Expected results:
Wherever FAB menus(lists) are created, search feature works smoothly. After clearing the search filters off, user is expected to press the search button explicitly which is fine. However once all the search filters are crossed off (i.e. after removing the last filter), all the results should be displayed.
The search button is toggled off here, so the user can also not perform empty search manually.

Actual results:
The results instead appear to be static. They are't refreshed. The results remain the same as were according to the last filter applied.

Refer to the Issue #5104 more information