### PR TITLE
Fixing time table viz for adhoc metrics

### DIFF
--- a/superset/assets/src/components/MetricOption.jsx
+++ b/superset/assets/src/components/MetricOption.jsx
@@ -17,7 +17,7 @@ const defaultProps = {
 };
 
 export default function MetricOption({ metric, openInNewWindow, showFormula, showType, url }) {
-  const verbose = metric.verbose_name || metric.metric_name;
+  const verbose = metric.verbose_name || metric.metric_name || metric.label;
   const link = url ? <a href={url} target={openInNewWindow ? '_blank' : null}>{verbose}</a> : verbose;
   return (
     <div>


### PR DESCRIPTION
The time table viz is broken for adhoc metrics. In the time table viz MetricOption is passed metric information that was gathered from `slice.datasource.metrics`, but AdhocMetrics aren't in that list so it errors. We can pass through the metric if it's already an object.

`MetricOption` in this case is just being used to display the metric name or verbose name with a link from a given url. So it's not a problem that metrics from the database are structured differently from AdhocMetrics, the label/name/verbose name is the only necessary prop.

@GabeLoins @mistercrunch @graceguo-supercat 