### PR TITLE
[sql lab] Fix issue around VARBINARY type in Presto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-dateutil==2.6.1
 python-geohash==0.8.5
 pyyaml==3.12
 requests==2.18.4
-simplejson==3.13.2
+simplejson==3.15.0
 six==1.11.0
 sqlalchemy==1.2.2
 sqlalchemy-utils==0.32.21

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'python-geohash',
         'pyyaml>=3.11',
         'requests',
-        'simplejson',
+        'simplejson>=3.15.0',
         'six',
         'sqlalchemy',
         'sqlalchemy-utils',

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -310,7 +310,6 @@ def datetime_f(dttm):
 
 
 def base_json_conv(obj):
-
     if isinstance(obj, numpy.int64):
         return int(obj)
     elif isinstance(obj, numpy.bool_):
@@ -323,6 +322,11 @@ def base_json_conv(obj):
         return str(obj)
     elif isinstance(obj, timedelta):
         return str(obj)
+    elif isinstance(obj, bytes):
+        try:
+            return '{}'.format(obj)
+        except Exception:
+            return '[bytes]'
 
 
 def json_iso_dttm_ser(obj, pessimistic=False):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2467,7 +2467,11 @@ class Superset(BaseSupersetView):
                     rendered_query,
                     return_results=True)
             payload = json.dumps(
-                data, default=utils.pessimistic_json_iso_dttm_ser, ignore_nan=True)
+                data,
+                default=utils.pessimistic_json_iso_dttm_ser,
+                ignore_nan=True,
+                encoding=None,
+            )
         except Exception as e:
             logging.exception(e)
             return json_error_response('{}'.format(e))


### PR DESCRIPTION
When receiving a VARBINARY field out of Presto, it shows up as type
`bytes` out of the pyhive driver. Then the pre 3.15 version of
simplejson attempts to convert it to utf8 by default and it craps out.

I bumped to simplejson>=3.25.0 and set `encoding=None` as documented
here
https://simplejson.readthedocs.io/en/latest/#basic-usage so that we can
handle bytes on our own.