### PR TITLE
Downgrade flask-appbuilder dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'contextlib2',
         'cryptography',
         'flask<1.0.0',
-        'flask-appbuilder',
+        'flask-appbuilder<1.11.0',
         'flask-caching',
         'flask-compress',
         'flask-migrate',


### PR DESCRIPTION
It seems that `flask-appbuilder-1.11` is more strict about `sqlalchemy` exceptions than `1.10`. Should fix #5088