### PR TITLE
[migrations] Fix time grain SQLA

### DIFF
--- a/superset/migrations/versions/c5756bec8b47_time_grain_sqla.py
+++ b/superset/migrations/versions/c5756bec8b47_time_grain_sqla.py
@@ -1,0 +1,65 @@
+"""Time grain SQLA
+
+Revision ID: c5756bec8b47
+Revises: e502db2af7be
+Create Date: 2018-06-04 11:12:59.878742
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c5756bec8b47'
+down_revision = 'e502db2af7be'
+
+from alembic import op
+import json
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, String, Text
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = 'slices'
+
+    id = Column(Integer, primary_key=True)
+    datasource_type = Column(String(200))
+    slice_name = Column(String(250))
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).all():
+        try:
+            params = json.loads(slc.params)
+
+            if params.get('time_grain_sqla') == 'Time Column':
+                params['time_grain_sqla'] = None
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).all():
+        try:
+            params = json.loads(slc.params)
+
+            if params.get('time_grain_sqla') is None:
+                params['time_grain_sqla'] = 'Time Column'
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()


### PR DESCRIPTION
This PR adds a migration associated with https://github.com/apache/incubator-superset/pull/4821 which replaces the form-data `time_grain_sqla ` key with the associated `Time Column` value to `None`. Previously without the change the cache key was misaligned between a slice within a dashboard vs. within explorer view. 

to: @betodealmeida @GabeLoins @michellethomas @mistercrunch 