### PR TITLE
[SQLA] Improving performance by disabling editing Associated Charts

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -165,14 +165,14 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
     order_columns = ['modified']
     add_columns = ['database', 'schema', 'table_name']
     edit_columns = [
-        'table_name', 'sql', 'filter_select_enabled', 'slices',
+        'table_name', 'sql', 'filter_select_enabled',
         'fetch_values_predicate', 'database', 'schema',
         'description', 'owner',
         'main_dttm_col', 'default_endpoint', 'offset', 'cache_timeout',
         'is_sqllab_view', 'template_params',
     ]
     base_filters = [['id', DatasourceFilter, lambda: []]]
-    show_columns = edit_columns + ['perm']
+    show_columns = edit_columns + ['perm', 'slices']
     related_views = [TableColumnInlineView, SqlMetricInlineView]
     base_order = ('changed_on', 'desc')
     search_columns = (


### PR DESCRIPTION
This PR helps to improve the performance of table CRUD view by removing the `slices` (Associated Charts) column from the edit view (it's still present for show). For reference for our datasource the page load time reduced from ~ 45 s to ~ 7 s.

As the number of slices grows the performance of this page is severely impacted as FAB needs to pre-fetch all the slices which are searchable in jQuery. Further it seems having the ability to either add/remove slices associated with a datasource via the CRUD view is somewhat atypical as it could result in ill-defined charts and dangling charts respectively. 

This significantly improves the performance when view the `Detail`, `List Columns`, or `List Metrics` columns. Note however the table drop-down is still susceptible to the same issue, however this field is required in order to associate a new column/metric with the datasource. 

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 