### PR TITLE
strip druid metric type when value is postagg

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -850,7 +850,7 @@ class DruidDatasource(Model, BaseDatasource):
         """Return a list of metrics that are post aggregations"""
         postagg_metrics = [
             metrics_dict[name] for name in postagg_names
-            if metrics_dict[name].metric_type == POST_AGG_TYPE
+            if (metrics_dict[name].metric_type).strip() == POST_AGG_TYPE
         ]
         # Remove post aggregations that were found
         for postagg in postagg_metrics:
@@ -910,7 +910,7 @@ class DruidDatasource(Model, BaseDatasource):
         for metric in metrics:
             if utils.is_adhoc_metric(metric):
                 adhoc_agg_configs.append(metric)
-            elif metrics_dict[metric].metric_type != POST_AGG_TYPE:
+            elif (metrics_dict[metric].metric_type).strip() != POST_AGG_TYPE:
                 saved_agg_names.add(metric)
             else:
                 postagg_names.append(metric)
@@ -1027,7 +1027,7 @@ class DruidDatasource(Model, BaseDatasource):
         for metric_name in saved_metrics:
             if metric_name in metrics_dict:
                 metric = metrics_dict[metric_name]
-                if metric.metric_type == POST_AGG_TYPE:
+                if (metric.metric_type).strip() == POST_AGG_TYPE:
                     invalid_metric_names.append(metric_name)
                 else:
                     aggregations[metric_name] = metric.json_obj


### PR DESCRIPTION
When some blank character ahead druid metric type specified as ‘postagg’, like :
<img width="657" alt="wx20180606-134418 2x" src="https://user-images.githubusercontent.com/987877/41019100-c47343ec-698f-11e8-9559-7ff57cfe157e.png">

Some error arised when explore it, like:
<img width="1232" alt="2" src="https://user-images.githubusercontent.com/987877/41019198-3c74fed0-6990-11e8-8d59-59f8edadb136.png">
