### PR TITLE
pin kombu dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ geopy==1.11.0
 gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
+kombu==4.1.0
 markdown==2.6.11
 pandas==0.22.0
 parsedatetime==2.0.0


### PR DESCRIPTION
CI is failing (https://travis-ci.org/apache/incubator-superset/jobs/388955214#L730)  because the latest kombu (4.2) is backwards incompatible and we didn't pin it. This PR fixes that by pining 

@williaster @john-bodley 