### PR TITLE
[dashboard v2]  better grid drop ux, fix tab bugs 🐛

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/components/DashboardGrid_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/DashboardGrid_spec.jsx
@@ -42,12 +42,9 @@ describe('DashboardGrid', () => {
     expect(wrapper.find(DashboardComponent)).to.have.length(2);
   });
 
-  it('should render an empty DragDroppables target when the gridComponent has no children', () => {
-    const withChildren = setup({ editMode: true });
-    const withoutChildren = setup({
-      editMode: true,
-      gridComponent: { ...props.gridComponent, children: [] },
-    });
+  it('should render an empty DragDroppables in editMode to increase the drop target zone', () => {
+    const withChildren = setup({ editMode: false });
+    const withoutChildren = setup({ editMode: true });
     expect(withChildren.find(DragDroppable)).to.have.length(0);
     expect(withoutChildren.find(DragDroppable)).to.have.length(1);
   });

--- a/superset/assets/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset/assets/src/dashboard/components/DashboardBuilder.jsx
@@ -57,12 +57,18 @@ class DashboardBuilder extends React.Component {
       tabIndex: 0, // top-level tabs
     };
     this.handleChangeTab = this.handleChangeTab.bind(this);
+    this.handleDeleteTopLevelTabs = this.handleDeleteTopLevelTabs.bind(this);
   }
 
   getChildContext() {
     return {
       dragDropManager: this.context.dragDropManager || getDragDropManager(),
     };
+  }
+
+  handleDeleteTopLevelTabs() {
+    this.props.deleteTopLevelTabs();
+    this.setState({ tabIndex: 0 });
   }
 
   handleChangeTab({ tabIndex }) {
@@ -77,13 +83,7 @@ class DashboardBuilder extends React.Component {
   }
 
   render() {
-    const {
-      handleComponentDrop,
-      dashboardLayout,
-      deleteTopLevelTabs,
-      editMode,
-    } = this.props;
-
+    const { handleComponentDrop, dashboardLayout, editMode } = this.props;
     const { tabIndex } = this.state;
     const dashboardRoot = dashboardLayout[DASHBOARD_ROOT_ID];
     const rootChildId = dashboardRoot.children[0];
@@ -124,7 +124,7 @@ class DashboardBuilder extends React.Component {
                   <IconButton
                     className="fa fa-level-down"
                     label="Collapse tab content"
-                    onClick={deleteTopLevelTabs}
+                    onClick={this.handleDeleteTopLevelTabs}
                   />,
                 ]}
                 editMode={editMode}
@@ -155,7 +155,7 @@ class DashboardBuilder extends React.Component {
                 */
                 <TabContainer
                   id={DASHBOARD_GRID_ID}
-                  activeKey={tabIndex}
+                  activeKey={Math.min(tabIndex, childIds.length - 1)}
                   onSelect={this.handleChangeTab}
                   animation
                   mountOnEnter

--- a/superset/assets/src/dashboard/components/DashboardGrid.jsx
+++ b/superset/assets/src/dashboard/components/DashboardGrid.jsx
@@ -108,26 +108,25 @@ class DashboardGrid extends React.PureComponent {
             />
           ))}
 
-          {/* make the grid droppable in the case that there are no children */}
-          {editMode &&
-            gridComponent.children.length === 0 && (
-              <DragDroppable
-                component={gridComponent}
-                depth={depth}
-                parentComponent={null}
-                index={gridComponent.children.length}
-                orientation="column"
-                onDrop={handleComponentDrop}
-                className="empty-grid-droptarget--bottom"
-                editMode
-              >
-                {({ dropIndicatorProps }) =>
-                  dropIndicatorProps && (
-                    <div className="drop-indicator drop-indicator--top" />
-                  )
-                }
-              </DragDroppable>
-            )}
+          {/* make the area below components droppable */}
+          {editMode && (
+            <DragDroppable
+              component={gridComponent}
+              depth={depth}
+              parentComponent={null}
+              index={gridComponent.children.length}
+              orientation="column"
+              onDrop={handleComponentDrop}
+              className="empty-grid-droptarget--bottom"
+              editMode
+            >
+              {({ dropIndicatorProps }) =>
+                dropIndicatorProps && (
+                  <div className="drop-indicator drop-indicator--top" />
+                )
+              }
+            </DragDroppable>
+          )}
 
           {isResizing &&
             Array(GRID_COLUMN_COUNT)

--- a/superset/assets/src/dashboard/deprecated/PromptV2ConversionModal.jsx
+++ b/superset/assets/src/dashboard/deprecated/PromptV2ConversionModal.jsx
@@ -69,7 +69,7 @@ function PromptV2ConversionModal({
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://gist.github.com/williaster/bad4ac9c6a71b234cf9fc8ee629844e5#file-superset-dashboard-v2-md"
+            href="http://bit.ly/superset-dash-v2"
             onClick={logReadAboutV2Changes}
           >
             here

--- a/superset/assets/src/dashboard/deprecated/V2PreviewModal.jsx
+++ b/superset/assets/src/dashboard/deprecated/V2PreviewModal.jsx
@@ -81,7 +81,7 @@ class V2PreviewModal extends React.Component {
             <a
               target="_blank"
               rel="noopener noreferrer"
-              href="https://gist.github.com/williaster/bad4ac9c6a71b234cf9fc8ee629844e5#file-superset-dashboard-v2-md"
+              href="http://bit.ly/superset-dash-v2"
               onClick={V2PreviewModal.logReadAboutV2Changes}
             >
               here

--- a/superset/assets/src/dashboard/util/findParentId.js
+++ b/superset/assets/src/dashboard/util/findParentId.js
@@ -2,7 +2,7 @@ export default function findParentId({ childId, layout = {} }) {
   let parentId = null;
 
   const ids = Object.keys(layout);
-  for (let i = 0; i < ids.length - 1; i += 1) {
+  for (let i = 0; i <= ids.length - 1; i += 1) {
     const id = ids[i];
     const component = layout[id] || {};
     if (


### PR DESCRIPTION
This PR
- adds an empty drop target to the `DashboardGrid` to increase the drop zone surface area for better UX
- fixes a bug where deletion of top-level tabs when a non-zero tab index was selected resulted in an empty screen because the tabIndex was not reset
- fixes a bug in `findParentId` 🤦‍♂️ 

@graceguo-supercat 