### PR TITLE
[migrations] Cleanup recent migrations

### DIFF
--- a/superset/migrations/versions/130915240929_is_sqllab_viz_flow.py
+++ b/superset/migrations/versions/130915240929_is_sqllab_viz_flow.py
@@ -45,7 +45,7 @@ def upgrade():
     for tbl in session.query(Table).all():
         if tbl.sql:
             tbl.is_sqllab_view = True
-            session.merge(tbl)
+
     session.commit()
     db.session.close()
 

--- a/superset/migrations/versions/c5756bec8b47_time_grain_sqla.py
+++ b/superset/migrations/versions/c5756bec8b47_time_grain_sqla.py
@@ -13,7 +13,7 @@ down_revision = 'e502db2af7be'
 from alembic import op
 import json
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy import Column, Integer, Text
 
 from superset import db
 
@@ -24,8 +24,6 @@ class Slice(Base):
     __tablename__ = 'slices'
 
     id = Column(Integer, primary_key=True)
-    datasource_type = Column(String(200))
-    slice_name = Column(String(250))
     params = Column(Text)
 
 


### PR DESCRIPTION
This PR cleans up a couple of issues with some recent migrations:

1. For `c5756bec8b47` it removes unnecessary definitions.
2. For `130915240929` it removes the unnecessary `merge` for each record which significantly impacts performance. The `session.commit()` is all that is required to commit the mutated `tbl` objects which is a similar pattern to `c5756bec8b47`.

to: @michellethomas @mistercrunch 