### PR TITLE
[Explore][Adhoc Filters] empty lists are invalid comparators

### DIFF
--- a/superset/assets/spec/javascripts/explore/AdhocFilter_spec.js
+++ b/superset/assets/spec/javascripts/explore/AdhocFilter_spec.js
@@ -112,6 +112,26 @@ describe('AdhocFilter', () => {
     });
     // eslint-disable-next-line no-unused-expressions
     expect(adhocFilter3.isValid()).to.be.false;
+
+    const adhocFilter4 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: 'value',
+      operator: 'in',
+      comparator: [],
+      clause: CLAUSES.WHERE,
+    });
+    // eslint-disable-next-line no-unused-expressions
+    expect(adhocFilter4.isValid()).to.be.false;
+
+    const adhocFilter5 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: 'value',
+      operator: 'in',
+      comparator: ['val1'],
+      clause: CLAUSES.WHERE,
+    });
+    // eslint-disable-next-line no-unused-expressions
+    expect(adhocFilter5.isValid()).to.be.true;
   });
 
   it('can translate from simple expressions to sql expressions', () => {

--- a/superset/assets/src/explore/AdhocFilter.js
+++ b/superset/assets/src/explore/AdhocFilter.js
@@ -83,7 +83,13 @@ export default class AdhocFilter {
 
   isValid() {
     if (this.expressionType === EXPRESSION_TYPES.SIMPLE) {
-      return !!(this.operator && this.subject && this.comparator && this.clause);
+      return !!(
+        this.operator &&
+        this.subject &&
+        this.comparator &&
+        this.comparator.length > 0 &&
+        this.clause
+      );
     } else if (this.expressionType === EXPRESSION_TYPES.SQL) {
       return !!(this.sqlExpression && this.clause);
     }


### PR DESCRIPTION
Thanks to @michellethomas for reporting. Previously it was valid to add a simple filter formatted as `column in ()` or `NOT column in ()`. These are both relatively useless clauses as the first will always evaluate to true and the second will always evaluate to false. I added a check to prevent this filters from being added.

Now the button will be disabled if the comparator is an empty list:

![image](https://user-images.githubusercontent.com/2455694/41119600-0ab76b2c-6a48-11e8-86c8-3094890526b1.png)

test plan:
- tried to add a `column in ()` simple filter and verified I could not
- ran the specs

@michellethomas @john-bodley @graceguo-supercat @mistercrunch 