### PR TITLE
[Explore][Adhoc Metrics/ Filters] disabled message for custom sql tab in druid

### DIFF
--- a/superset/assets/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopover.jsx
@@ -123,21 +123,24 @@ export default class AdhocFilterEditPopover extends React.Component {
               onHeightChange={this.adjustHeight}
             />
           </Tab>
-          {
-            (!this.props.datasource || this.props.datasource.type !== 'druid') &&
-            <Tab
-              className="adhoc-filter-edit-tab"
-              eventKey={EXPRESSION_TYPES.SQL}
-              title="Custom SQL"
-            >
+          <Tab
+            className="adhoc-filter-edit-tab"
+            eventKey={EXPRESSION_TYPES.SQL}
+            title="Custom SQL"
+          >
+            {
+              (!this.props.datasource || this.props.datasource.type !== 'druid') ?
               <AdhocFilterEditPopoverSqlTabContent
                 adhocFilter={this.state.adhocFilter}
                 onChange={this.onAdhocFilterChange}
                 options={this.props.options}
                 height={this.state.height}
-              />
-            </Tab>
-          }
+              /> :
+              <div className="custom-sql-disabled-message">
+                Custom SQL Filters are not available on druid datasources
+              </div>
+            }
+          </Tab>
         </Tabs>
         <div>
           <Button

--- a/superset/assets/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopover.jsx
@@ -130,12 +130,12 @@ export default class AdhocFilterEditPopover extends React.Component {
           >
             {
               (!this.props.datasource || this.props.datasource.type !== 'druid') ?
-              <AdhocFilterEditPopoverSqlTabContent
-                adhocFilter={this.state.adhocFilter}
-                onChange={this.onAdhocFilterChange}
-                options={this.props.options}
-                height={this.state.height}
-              /> :
+                <AdhocFilterEditPopoverSqlTabContent
+                  adhocFilter={this.state.adhocFilter}
+                  onChange={this.onAdhocFilterChange}
+                  options={this.props.options}
+                  height={this.state.height}
+                /> :
               <div className="custom-sql-disabled-message">
                 Custom SQL Filters are not available on druid datasources
               </div>

--- a/superset/assets/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopover.jsx
@@ -136,9 +136,9 @@ export default class AdhocFilterEditPopover extends React.Component {
                   options={this.props.options}
                   height={this.state.height}
                 /> :
-              <div className="custom-sql-disabled-message">
-                Custom SQL Filters are not available on druid datasources
-              </div>
+                <div className="custom-sql-disabled-message">
+                  Custom SQL Filters are not available on druid datasources
+                </div>
             }
           </Tab>
         </Tabs>

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -228,22 +228,22 @@ export default class AdhocMetricEditPopover extends React.Component {
           <Tab className="adhoc-metric-edit-tab" eventKey={EXPRESSION_TYPES.SQL} title="Custom SQL">
             {
               this.props.datasourceType !== 'druid' ?
-              <FormGroup>
-                <AceEditor
-                  ref={this.handleAceEditorRef}
-                  mode="sql"
-                  theme="github"
-                  height={(this.state.height - 43) + 'px'}
-                  onChange={this.onSqlExpressionChange}
-                  width="100%"
-                  showGutter={false}
-                  value={adhocMetric.sqlExpression || adhocMetric.translateToSql()}
-                  editorProps={{ $blockScrolling: true }}
-                  enableLiveAutocompletion
-                  className="adhoc-filter-sql-editor"
-                  wrapEnabled
-                />
-              </FormGroup> :
+                <FormGroup>
+                  <AceEditor
+                    ref={this.handleAceEditorRef}
+                    mode="sql"
+                    theme="github"
+                    height={(this.state.height - 43) + 'px'}
+                    onChange={this.onSqlExpressionChange}
+                    width="100%"
+                    showGutter={false}
+                    value={adhocMetric.sqlExpression || adhocMetric.translateToSql()}
+                    editorProps={{ $blockScrolling: true }}
+                    enableLiveAutocompletion
+                    className="adhoc-filter-sql-editor"
+                    wrapEnabled
+                  />
+                </FormGroup> :
               <div className="custom-sql-disabled-message">
                 Custom SQL Metrics are not available on druid datasources
               </div>

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -225,9 +225,9 @@ export default class AdhocMetricEditPopover extends React.Component {
               <OnPasteSelect {...this.selectProps} {...aggregateSelectProps} />
             </FormGroup>
           </Tab>
-          {
-            this.props.datasourceType !== 'druid' &&
-            <Tab className="adhoc-metric-edit-tab" eventKey={EXPRESSION_TYPES.SQL} title="Custom SQL">
+          <Tab className="adhoc-metric-edit-tab" eventKey={EXPRESSION_TYPES.SQL} title="Custom SQL">
+            {
+              this.props.datasourceType !== 'druid' ?
               <FormGroup>
                 <AceEditor
                   ref={this.handleAceEditorRef}
@@ -243,9 +243,12 @@ export default class AdhocMetricEditPopover extends React.Component {
                   className="adhoc-filter-sql-editor"
                   wrapEnabled
                 />
-              </FormGroup>
-            </Tab>
-          }
+              </FormGroup> :
+              <div className="custom-sql-disabled-message">
+                Custom SQL Metrics are not available on druid datasources
+              </div>
+            }
+          </Tab>
         </Tabs>
         <div>
           <Button

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -244,9 +244,9 @@ export default class AdhocMetricEditPopover extends React.Component {
                     wrapEnabled
                   />
                 </FormGroup> :
-              <div className="custom-sql-disabled-message">
-                Custom SQL Metrics are not available on druid datasources
-              </div>
+                <div className="custom-sql-disabled-message">
+                  Custom SQL Metrics are not available on druid datasources
+                </div>
             }
           </Tab>
         </Tabs>

--- a/superset/assets/src/explore/main.css
+++ b/superset/assets/src/explore/main.css
@@ -210,3 +210,10 @@
   margin-left: 3px;
   position: static;
 }
+
+.custom-sql-disabled-message {
+  color: gray;
+  font-size: 11px;
+  text-align: center;
+  margin-top: 60px;
+}


### PR DESCRIPTION
The Custom SQL tab only makes sense for SQLA datasources since its quite difficult to write custom druid json queries. To avoid confusion of why the tab is present on sqla datasources but not druid, I added the tab back in for druid datasources with a placeholder message explaining why its not available.

before:
![image](https://user-images.githubusercontent.com/2455694/41126736-651f4962-6a5d-11e8-9879-d4822d63f38a.png)

after:
![image](https://user-images.githubusercontent.com/2455694/41126680-32c64fba-6a5d-11e8-95f0-899454f82ea5.png)


test plan:
- loaded a druid datasource
- verified it had the placeholder tab
- loaded a sqla datasource
- verified it had the functional tab

to:
@michellethomas @john-bodley @graceguo-supercat @mistercrunch 