### PR TITLE
[dash builder fix] combine markdown and slice name, slice picker height

### DIFF
--- a/superset/assets/src/dashboard/actions/sliceEntities.js
+++ b/superset/assets/src/dashboard/actions/sliceEntities.js
@@ -56,7 +56,9 @@ export function fetchAllSlices(userId) {
                 description: slice.description,
                 description_markdown: slice.description_markeddown,
                 viz_type: slice.viz_type,
-                modified: slice.modified,
+                modified: slice.modified
+                  ? slice.modified.replace(/<[^>]*>/g, '')
+                  : '',
               };
             }
           });

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -93,6 +93,7 @@ export default function(bootstrapData) {
         datasource: slice.form_data.datasource,
         description: slice.description,
         description_markeddown: slice.description_markeddown,
+        modified: slice.modified ? slice.modified.replace(/<[^>]*>/g, '') : '',
       };
 
       sliceIds.add(key);

--- a/superset/assets/src/dashboard/stylesheets/builder-sidepane.less
+++ b/superset/assets/src/dashboard/stylesheets/builder-sidepane.less
@@ -87,6 +87,7 @@
     }
 
     .card-title {
+      margin-right: 60px;
       margin-bottom: 8px;
       font-weight: 800;
     }
@@ -96,8 +97,12 @@
       flex-direction: column;
 
       .item {
-        span:first-child {
-          font-weight: 400;
+        span {
+          word-break: break-all;
+
+          &:first-child {
+            font-weight: 400;
+          }
         }
       }
     }

--- a/superset/assets/src/dashboard/stylesheets/builder-sidepane.less
+++ b/superset/assets/src/dashboard/stylesheets/builder-sidepane.less
@@ -76,7 +76,6 @@
     .chart-card {
       border: 1px solid @gray-light;
       font-weight: 200;
-      height: 120px;
       padding: 16px;
       margin: 16px;
       position: relative;
@@ -97,8 +96,6 @@
       flex-direction: column;
 
       .item {
-        height: 18px;
-
         span:first-child {
           font-weight: 400;
         }
@@ -118,7 +115,6 @@
       text-transform: uppercase;
       position: absolute;
       padding: 4px 8px;
-      position: absolute;
       top: 32px;
       right: 32px;
       pointer-events: none;

--- a/superset/assets/src/dashboard/util/dashboardLayoutConverter.js
+++ b/superset/assets/src/dashboard/util/dashboardLayoutConverter.js
@@ -88,13 +88,13 @@ function getChartHolder(item) {
     Math.round(size_y / GRID_RATIO * 100 / ROW_HEIGHT),
   );
   if (code !== undefined) {
-    let markdownContent = '';
-    if (slice_name) {
+    let markdownContent = ' '; // white-space markdown
+    if (code) {
+      markdownContent = code;
+    } else if (slice_name.trim()) {
       markdownContent = `##### **${slice_name}**\n`;
     }
-    if (code) {
-      markdownContent += code;
-    }
+
     return {
       type: MARKDOWN_TYPE,
       id: `DASHBOARD_MARKDOWN_TYPE-${generateId()}`,

--- a/superset/assets/src/dashboard/util/dashboardLayoutConverter.js
+++ b/superset/assets/src/dashboard/util/dashboardLayoutConverter.js
@@ -92,7 +92,7 @@ function getChartHolder(item) {
     if (code) {
       markdownContent = code;
     } else if (slice_name.trim()) {
-      markdownContent = `##### **${slice_name}**\n`;
+      markdownContent = `##### ${slice_name}`;
     }
 
     return {

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -188,6 +188,7 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
             'slice_id': self.id,
             'slice_name': self.slice_name,
             'slice_url': self.slice_url,
+            'modified': self.modified(),
         }
 
     @property

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -280,7 +280,7 @@ class AuditMixinNullable(AuditMixin):
         return Markup(
             '<span class="no-wrap">{}</span>'.format(self.changed_on))
 
-    @renders('changed_on')
+    @renders('modified')
     def modified(self):
         s = humanize.naturaltime(datetime.now() - self.changed_on)
         return Markup('<span class="no-wrap">{}</span>'.format(s))


### PR DESCRIPTION
UI fixes for dash builder:
- combine markdown code and markdown slice name
- allow dynamic height for slice picker cell


![screen_shot_2018-06-13_at_5_59_05_pm](https://user-images.githubusercontent.com/27990562/41386619-2e983078-6f37-11e8-9431-99aeef2b1b6b.jpg)
