### PR TITLE
[migrations] Cleaning up migration logic

### DIFF
--- a/superset/migrations/versions/f231d82b9b26_.py
+++ b/superset/migrations/versions/f231d82b9b26_.py
@@ -59,9 +59,6 @@ def downgrade():
         )
 
     # Remove the previous missing uniqueness constraints.
-    bind = op.get_bind()
-    insp = sa.engine.reflection.Inspector.from_engine(bind)
-
     for table, column in names.items():
         with op.batch_alter_table(table, naming_convention=conv) as batch_op:
             batch_op.drop_constraint(


### PR DESCRIPTION
This PR removes duplicate logic (which is originally defined on lines 49-50). It seems like this was added twice in two separate PRs to resolve a prior issue. 

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 