### PR TITLE
fetch datasources from broker endpoint when refresh new datasources

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -126,6 +126,11 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
             self.coordinator_host, self.coordinator_port)
         return '{base_url}/{self.coordinator_endpoint}'.format(**locals())
 
+    def get_base_broker_url(self):
+        base_url = self.get_base_url(
+            self.broker_host, self.broker_port)
+        return '{base_url}/{self.broker_endpoint}'.format(**locals())
+
     def get_pydruid_client(self):
         cli = PyDruid(
             self.get_base_url(self.broker_host, self.broker_port),
@@ -133,7 +138,7 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
         return cli
 
     def get_datasources(self):
-        endpoint = self.get_base_coordinator_url() + '/datasources'
+        endpoint = self.get_base_broker_url() + '/datasources'
         return json.loads(requests.get(endpoint).text)
 
     def get_druid_version(self):

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -121,11 +121,6 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
         url = '{0}:{1}'.format(host, port) if port else host
         return url
 
-    def get_base_coordinator_url(self):
-        base_url = self.get_base_url(
-            self.coordinator_host, self.coordinator_port)
-        return '{base_url}/{self.coordinator_endpoint}'.format(**locals())
-
     def get_base_broker_url(self):
         base_url = self.get_base_url(
             self.broker_host, self.broker_port)

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -94,6 +94,7 @@ class DruidTests(SupersetTestCase):
             coordinator_port=7979,
             broker_host='localhost',
             broker_port=7980,
+            broker_endpoint='druid/v2',
             metadata_last_refreshed=datetime.now())
 
     def get_cluster(self, PyDruid):

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -456,8 +456,8 @@ class DruidTests(SupersetTestCase):
             'https://localhost:9999')
 
         self.assertEquals(
-            cluster.get_base_coordinator_url(),
-            'http://localhost:7979/druid/coordinator/v1/metadata')
+            cluster.get_base_broker_url(),
+            'http://localhost:7980/druid/v2')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We should fetch all datasources from broker endpoint when refresh new datasources.
Otherwise superset will not scan out new datasource unitl  new druid supervisor task publish first segment file. 