### PR TITLE
Repoint .istambul.yml to the right location

### DIFF
--- a/superset/assets/.istanbul.yml
+++ b/superset/assets/.istanbul.yml
@@ -1,6 +1,6 @@
 verbose: true
 instrumentation:
-    root: './javascripts'
+    root: './src'
     extensions: ['.js', '.jsx']
     excludes: [
         'dist/**'


### PR DESCRIPTION
Never did this when I renamed the folder. `npm run cover` currently
doesn't generate a proper coverage report, this fixes it