### PR TITLE
[druid] remove reliance on coordinator

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -85,18 +85,13 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
     verbose_name = Column(String(250), unique=True)
     # short unique name, used in permissions
     cluster_name = Column(String(250), unique=True)
-    coordinator_host = Column(String(255))
-    coordinator_port = Column(Integer, default=8081)
-    coordinator_endpoint = Column(
-        String(255), default='druid/coordinator/v1/metadata')
     broker_host = Column(String(255))
     broker_port = Column(Integer, default=8082)
     broker_endpoint = Column(String(255), default='druid/v2')
     metadata_last_refreshed = Column(DateTime)
     cache_timeout = Column(Integer)
 
-    export_fields = ('cluster_name', 'coordinator_host', 'coordinator_port',
-                     'coordinator_endpoint', 'broker_host', 'broker_port',
+    export_fields = ('cluster_name', 'broker_host', 'broker_port',
                      'broker_endpoint', 'cache_timeout')
     export_children = ['datasources']
 
@@ -139,7 +134,7 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
 
     def get_druid_version(self):
         endpoint = self.get_base_url(
-            self.coordinator_host, self.coordinator_port) + '/status'
+            self.broker_host, self.broker_port) + '/status'
         return json.loads(requests.get(endpoint).text)['version']
 
     def refresh_datasources(

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -160,8 +160,7 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):  #
     edit_title = _('Edit Druid Cluster')
 
     add_columns = [
-        'verbose_name', 'coordinator_host', 'coordinator_port',
-        'coordinator_endpoint', 'broker_host', 'broker_port',
+        'verbose_name', 'broker_host', 'broker_port',
         'broker_endpoint', 'cache_timeout', 'cluster_name',
     ]
     edit_columns = add_columns
@@ -169,9 +168,6 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):  #
     search_columns = ('cluster_name',)
     label_columns = {
         'cluster_name': _('Cluster'),
-        'coordinator_host': _('Coordinator Host'),
-        'coordinator_port': _('Coordinator Port'),
-        'coordinator_endpoint': _('Coordinator Endpoint'),
         'broker_host': _('Broker Host'),
         'broker_port': _('Broker Port'),
         'broker_endpoint': _('Broker Endpoint'),

--- a/superset/migrations/versions/b6192189340e_.py
+++ b/superset/migrations/versions/b6192189340e_.py
@@ -1,0 +1,22 @@
+"""empty message
+
+Revision ID: b6192189340e
+Revises: ('c48871eed6ca', 'bddc498dd179')
+Create Date: 2018-07-16 09:35:50.038797
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b6192189340e'
+down_revision = ('c48871eed6ca', 'bddc498dd179')
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/superset/migrations/versions/c48871eed6ca_removing_druid_coordinator_from_cluster_.py
+++ b/superset/migrations/versions/c48871eed6ca_removing_druid_coordinator_from_cluster_.py
@@ -1,0 +1,45 @@
+"""Removing Druid coordinator from cluster conf
+
+Revision ID: c48871eed6ca
+Revises: afb7730f6a9c
+Create Date: 2018-06-13 08:26:26.362939
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = 'c48871eed6ca'
+down_revision = 'afb7730f6a9c'
+
+
+def upgrade():
+    with op.batch_alter_table('clusters') as bop:
+        bop.drop_column('coordinator_endpoint')
+        bop.drop_column('coordinator_host')
+        bop.drop_column('coordinator_port')
+
+
+def downgrade():
+    with op.batch_alter_table('clusters') as bop:
+        bop.add_column(
+            sa.Column(
+                'coordinator_port',
+                mysql.INTEGER(display_width=11),
+                autoincrement=False, nullable=True,
+            )
+        )
+        bop.add_column(
+            sa.Column(
+                'coordinator_host',
+                mysql.VARCHAR(length=255),
+                nullable=True,
+            ),
+        )
+        bop.add_column(
+            sa.Column(
+                'coordinator_endpoint',
+                mysql.VARCHAR(length=255), nullable=True,
+            )
+        )

--- a/superset/migrations/versions/e83de60ac8dc_.py
+++ b/superset/migrations/versions/e83de60ac8dc_.py
@@ -1,0 +1,22 @@
+"""empty message
+
+Revision ID: e83de60ac8dc
+Revises: ('b6192189340e', '1d9e835a84f9')
+Create Date: 2018-07-22 08:15:47.146340
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e83de60ac8dc'
+down_revision = ('b6192189340e', '1d9e835a84f9')
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -89,9 +89,6 @@ class DruidTests(SupersetTestCase):
     def get_test_cluster_obj(self):
         return DruidCluster(
             cluster_name='test_cluster',
-            coordinator_host='localhost',
-            coordinator_endpoint='druid/coordinator/v1/metadata',
-            coordinator_port=7979,
             broker_host='localhost',
             broker_port=7980,
             broker_endpoint='druid/v2',
@@ -316,8 +313,6 @@ class DruidTests(SupersetTestCase):
 
         cluster = DruidCluster(
             cluster_name='test_cluster',
-            coordinator_host='localhost',
-            coordinator_port=7979,
             broker_host='localhost',
             broker_port=7980,
             metadata_last_refreshed=datetime.now())


### PR DESCRIPTION
It turns out all of the endpoints we use against the coordinator are
also available on the broker.