### PR TITLE
[bugfix] form_data - fix empty metrics

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -555,7 +555,7 @@ class TableViz(BaseViz):
                 m_name = '%' + m
                 df[m_name] = pd.Series(metric_percents[m], name=m_name)
             # Remove metrics that are not in the main metrics list
-            metrics = fd.get('metrics', [])
+            metrics = fd.get('metrics') or []
             metrics = [self.get_metric_label(m) for m in metrics]
             for m in filter(
                 lambda m: m not in metrics and m in df.columns,


### PR DESCRIPTION
This change introduced a regression (https://github.com/apache/incubator-superset/pull/5026) 

Sometimes metrics can be set to None and the function assumes wrongly that if the metrics variable is specified, it must be a list. This PR fixes the regression.

@john-bodley @michellethomas  