### PR TITLE
pass error message separately

### DIFF
--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -221,7 +221,6 @@ class Chart extends React.PureComponent {
         <StackTraceMessage
           message={this.props.chartAlert}
           queryResponse={this.props.queryResponse}
-          resolutionLink={this.props.resolutionLink}
         />
         }
 

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -221,6 +221,7 @@ class Chart extends React.PureComponent {
         <StackTraceMessage
           message={this.props.chartAlert}
           queryResponse={this.props.queryResponse}
+          resolutionLink={this.props.resolutionLink}
         />
         }
 

--- a/superset/assets/src/components/StackTraceMessage.jsx
+++ b/superset/assets/src/components/StackTraceMessage.jsx
@@ -7,11 +7,9 @@ const propTypes = {
   message: PropTypes.string,
   queryResponse: PropTypes.object,
   showStackTrace: PropTypes.bool,
-  resolutionLink: PropTypes.string,
 };
 const defaultProps = {
   showStackTrace: false,
-  resolutionLink: '',
 };
 
 class StackTraceMessage extends React.PureComponent {

--- a/superset/assets/src/components/StackTraceMessage.jsx
+++ b/superset/assets/src/components/StackTraceMessage.jsx
@@ -7,9 +7,11 @@ const propTypes = {
   message: PropTypes.string,
   queryResponse: PropTypes.object,
   showStackTrace: PropTypes.bool,
+  resolutionLink: PropTypes.string,
 };
 const defaultProps = {
   showStackTrace: false,
+  resolutionLink: '',
 };
 
 class StackTraceMessage extends React.PureComponent {
@@ -25,6 +27,10 @@ class StackTraceMessage extends React.PureComponent {
     return this.props.queryResponse && this.props.queryResponse.stacktrace;
   }
 
+  hasLink() {
+    return this.props.queryResponse && this.props.queryResponse.link;
+  }
+
   render() {
     return (
       <div className={`stack-trace-container${this.hasTrace() ? ' has-trace' : ''}`}>
@@ -33,6 +39,9 @@ class StackTraceMessage extends React.PureComponent {
           onClick={() => this.setState({ showStackTrace: !this.state.showStackTrace })}
         >
           {this.props.message}
+          {this.hasLink() &&
+          <a href={this.props.queryResponse.link}> (Request Access) </a>
+       }
         </Alert>
         {this.hasTrace() &&
           <Collapse in={this.state.showStackTrace}>

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -41,11 +41,13 @@ def get_error_msg():
     return error_msg
 
 
-def json_error_response(msg=None, status=500, stacktrace=None, payload=None):
+def json_error_response(msg=None, status=500, stacktrace=None, payload=None, link=None):
     if not payload:
         payload = {'error': str(msg)}
         if stacktrace:
             payload['stacktrace'] = stacktrace
+        if link:
+            payload['link'] = link
     return Response(
         json.dumps(payload, default=utils.json_iso_dttm_ser),
         status=status, mimetype='application/json')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1083,9 +1083,9 @@ class Superset(BaseSupersetView):
                 stacktrace=traceback.format_exc())
 
         if not security_manager.datasource_access(viz_obj.datasource, g.user):
-            perms_instruction_link = config.get('PERMISSION_INSTRUCTIONS_LINK')
             return json_error_response(
-                DATASOURCE_ACCESS_ERR, status=404, link=perms_instruction_link)
+                DATASOURCE_ACCESS_ERR, status=404, link=config.get(
+                    'PERMISSION_INSTRUCTIONS_LINK'))
 
         if csv:
             return CsvResponse(
@@ -2703,7 +2703,9 @@ class Superset(BaseSupersetView):
         """
         viz_obj = self.get_viz(slice_id)
         if not security_manager.datasource_access(viz_obj.datasource):
-            return json_error_response(DATASOURCE_ACCESS_ERR, status=401)
+            return json_error_response(
+                DATASOURCE_ACCESS_ERR, status=401, link=config.get(
+                    'PERMISSION_INSTRUCTIONS_LINK'))
         return self.get_query_string_response(viz_obj)
 
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -68,14 +68,7 @@ DATASOURCE_MISSING_ERR = __('The datasource seems to have been deleted')
 ACCESS_REQUEST_MISSING_ERR = __(
     'The access requests seem to have been deleted')
 USER_MISSING_ERR = __('The user seems to have been deleted')
-perms_instruction_link = config.get('PERMISSION_INSTRUCTIONS_LINK')
-if perms_instruction_link:
-    DATASOURCE_ACCESS_ERR = __(
-        "You don't have access to this datasource. <a href='{}'>(Gain access)</a>"
-        .format(perms_instruction_link),
-    )
-else:
-    DATASOURCE_ACCESS_ERR = __("You don't have access to this datasource")
+DATASOURCE_ACCESS_ERR = __("You don't have access to this datasource")
 
 FORM_DATA_KEY_BLACKLIST = []
 if not config.get('ENABLE_JAVASCRIPT_CONTROLS'):
@@ -1090,7 +1083,9 @@ class Superset(BaseSupersetView):
                 stacktrace=traceback.format_exc())
 
         if not security_manager.datasource_access(viz_obj.datasource, g.user):
-            return json_error_response(DATASOURCE_ACCESS_ERR, status=404)
+            perms_instruction_link = config.get('PERMISSION_INSTRUCTIONS_LINK')
+            return json_error_response(
+                DATASOURCE_ACCESS_ERR, status=404, link=perms_instruction_link)
 
         if csv:
             return CsvResponse(


### PR DESCRIPTION
This PR changes the way error messages are passed to the frontend. In the past the HTML was sent from the backend but now it is passed separately in the JSON response.

@graceguo-supercat @michellethomas 