### PR TITLE
Convert dttm to utc to avoid errors with different timezones

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -356,8 +356,9 @@ def pessimistic_json_iso_dttm_ser(obj):
 
 def datetime_to_epoch(dttm):
     if dttm.tzinfo:
+        dttmutc = dttm.astimezone(pytz.utc)
         epoch_with_tz = pytz.utc.localize(EPOCH)
-        return (dttm - epoch_with_tz).total_seconds() * 1000
+        return (dttmutc - epoch_with_tz).total_seconds() * 1000
     return (dttm - EPOCH).total_seconds() * 1000
 
 


### PR DESCRIPTION
Working with PostgreSQL I had some problems with the datetimes with time zone. When I tried to query these types I got an error:  *{TypeError}Timestamp subtraction must have the same timezones or no timezones*

This pull request fix an error in the  datetime_to_epoch method from superset\utils.py to avoid make operations with diferent timezones.