### PR TITLE
Moving homogenize_types to after no data exception

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1331,10 +1331,10 @@ class DruidDatasource(Model, BaseDatasource):
             client=client, query_obj=query_obj, phase=2)
         df = client.export_pandas()
 
-        df = self.homogenize_types(df, query_obj.get('groupby', []))
-
         if df is None or df.size == 0:
             raise Exception(_('No data was returned.'))
+
+        df = self.homogenize_types(df, query_obj.get('groupby', []))
         df.columns = [
             DTTM_ALIAS if c in ('timestamp', '__time') else c
             for c in df.columns


### PR DESCRIPTION
If a chart has a group by and no data it will error on homogenize_types with `'NoneType' object is not subscriptable`. This will show the No data exception before it hits the error.

@mistercrunch @john-bodley 