### PR TITLE
[Explore] Enable Rich tooltip by default

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1506,7 +1506,7 @@ export const controls = {
     type: 'CheckboxControl',
     label: t('Rich Tooltip'),
     renderTrigger: true,
-    default: false,
+    default: true,
     description: t('The rich tooltip shows a list of all series for that ' +
     'point in time'),
   },


### PR DESCRIPTION
per our data scientist requested, want to enable chart's rich tooltip by default.


@mistercrunch @timifasubaa @michellethomas 