### PR TITLE
[sqllab] Fix sql lab resolution link

### DIFF
--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -148,6 +148,8 @@ export function runQuery(query) {
         }
       },
       error(err, textStatus, errorThrown) {
+        console.log(err, textStatus, errorThrown);
+        console.log("^^^");
         let msg;
         try {
           msg = err.responseJSON.error;

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -78,8 +78,8 @@ export function querySuccess(query, results) {
   return { type: QUERY_SUCCESS, query, results };
 }
 
-export function queryFailed(query, msg) {
-  return { type: QUERY_FAILED, query, msg };
+export function queryFailed(query, msg, link) {
+  return { type: QUERY_FAILED, query, msg, link };
 }
 
 export function stopQuery(query) {
@@ -114,7 +114,11 @@ export function fetchQueryResults(query) {
         if (err.responseJSON && err.responseJSON.error) {
           msg = err.responseJSON.error;
         }
-        dispatch(queryFailed(query, msg));
+        let link = '';
+        if (err.responseJSON && err.responseJSON.link) {
+          link = err.responseJSON.link;
+        }
+        dispatch(queryFailed(query, msg, link));
       },
     });
   };
@@ -148,8 +152,6 @@ export function runQuery(query) {
         }
       },
       error(err, textStatus, errorThrown) {
-        console.log(err, textStatus, errorThrown);
-        console.log("^^^");
         let msg;
         try {
           msg = err.responseJSON.error;
@@ -168,7 +170,11 @@ export function runQuery(query) {
         if (msg.indexOf('CSRF token') > 0) {
           msg = COMMON_ERR_MESSAGES.SESSION_TIMED_OUT;
         }
-        dispatch(queryFailed(query, msg));
+        let link = '';
+        if (err.responseJSON && err.responseJSON.link) {
+          link = err.responseJSON.link;
+        }
+        dispatch(queryFailed(query, msg, link));
       },
     });
   };

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -98,6 +98,14 @@ export function requestQueryResults(query) {
   return { type: REQUEST_QUERY_RESULTS, query };
 }
 
+function getErrorLink(err) {
+  let link = '';
+  if (err.responseJSON && err.responseJSON.link) {
+    link = err.responseJSON.link;
+  }
+  return link;
+}
+
 export function fetchQueryResults(query) {
   return function (dispatch) {
     dispatch(requestQueryResults(query));
@@ -114,11 +122,7 @@ export function fetchQueryResults(query) {
         if (err.responseJSON && err.responseJSON.error) {
           msg = err.responseJSON.error;
         }
-        let link = '';
-        if (err.responseJSON && err.responseJSON.link) {
-          link = err.responseJSON.link;
-        }
-        dispatch(queryFailed(query, msg, link));
+        dispatch(queryFailed(query, msg, getErrorLink(err)));
       },
     });
   };
@@ -170,11 +174,7 @@ export function runQuery(query) {
         if (msg.indexOf('CSRF token') > 0) {
           msg = COMMON_ERR_MESSAGES.SESSION_TIMED_OUT;
         }
-        let link = '';
-        if (err.responseJSON && err.responseJSON.link) {
-          link = err.responseJSON.link;
-        }
-        dispatch(queryFailed(query, msg, link));
+        dispatch(queryFailed(query, msg, getErrorLink(msg)));
       },
     });
   };

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -143,6 +143,7 @@ export default class ResultSet extends React.PureComponent {
     }
   }
   render() {
+    // {query.error && <a href={query.error.link}>(Common errors and their resolutions)</a>}
     const query = this.props.query;
     const height = Math.max(0,
       (this.props.search ? this.props.height - SEARCH_HEIGHT : this.props.height));
@@ -155,7 +156,8 @@ export default class ResultSet extends React.PureComponent {
     if (query.state === 'stopped') {
       return <Alert bsStyle="warning">Query was stopped</Alert>;
     } else if (query.state === 'failed') {
-      return <Alert bsStyle="danger">{query.errorMessage}</Alert>;
+      return true && <Alert bsStyle="danger">{query.errorMessage}
+      </Alert>;
     } else if (query.state === 'success' && query.ctas) {
       return (
         <div>

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -157,6 +157,8 @@ export default class ResultSet extends React.PureComponent {
       return <Alert bsStyle="warning">Query was stopped</Alert>;
     } else if (query.state === 'failed') {
       return true && <Alert bsStyle="danger">{query.errorMessage}
+        {query.link &&
+          <a href={query.link}> (Common errors and their resolutions)</a>}
       </Alert>;
     } else if (query.state === 'success' && query.ctas) {
       return (

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -143,7 +143,6 @@ export default class ResultSet extends React.PureComponent {
     }
   }
   render() {
-    // {query.error && <a href={query.error.link}>(Common errors and their resolutions)</a>}
     const query = this.props.query;
     const height = Math.max(0,
       (this.props.search ? this.props.height - SEARCH_HEIGHT : this.props.height));
@@ -156,10 +155,11 @@ export default class ResultSet extends React.PureComponent {
     if (query.state === 'stopped') {
       return <Alert bsStyle="warning">Query was stopped</Alert>;
     } else if (query.state === 'failed') {
-      return true && <Alert bsStyle="danger">{query.errorMessage}
-        {query.link &&
-          <a href={query.link}> (Common errors and their resolutions)</a>}
-      </Alert>;
+      return (
+        <Alert bsStyle="danger">
+          {query.errorMessage}
+          {query.link && <a href={query.link}> {t('(Common errors and their resolutions)')} </a>}
+        </Alert>);
     } else if (query.state === 'success' && query.ctas) {
       return (
         <div>

--- a/superset/assets/src/SqlLab/components/SouthPane.jsx
+++ b/superset/assets/src/SqlLab/components/SouthPane.jsx
@@ -51,7 +51,6 @@ class SouthPane extends React.PureComponent {
     } else {
       results = <Alert bsStyle="info">{t('Run a query to display results here')}</Alert>;
     }
-
     const dataPreviewTabs = props.dataPreviewQueries.map(query => (
       <Tab
         title={t('Preview for %s', query.tableName)}

--- a/superset/assets/src/SqlLab/reducers.js
+++ b/superset/assets/src/SqlLab/reducers.js
@@ -181,7 +181,12 @@ export const sqlLabReducer = function (state, action) {
       if (action.query.state === 'stopped') {
         return state;
       }
-      const alts = { state: 'failed', errorMessage: action.msg, endDttm: now() };
+      const alts = {
+        state: 'failed',
+        errorMessage: action.msg,
+        endDttm: now(),
+        link: action.link,
+      };
       return alterInObject(state, 'queries', action.query, alts);
     },
     [actions.SET_ACTIVE_QUERY_EDITOR]() {

--- a/superset/config.py
+++ b/superset/config.py
@@ -356,7 +356,7 @@ SILENCE_FAB = True
 
 # The link to a page containing common errors and their resolutions
 # It will be appended at the bottom of sql_lab errors.
-TROUBLESHOOTING_LINK = ''
+TROUBLESHOOTING_LINK = 'www.google.com'
 
 # CSRF token timeout, set to None for a token that never expires
 WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 7

--- a/superset/config.py
+++ b/superset/config.py
@@ -356,7 +356,7 @@ SILENCE_FAB = True
 
 # The link to a page containing common errors and their resolutions
 # It will be appended at the bottom of sql_lab errors.
-TROUBLESHOOTING_LINK = 'www.google.com'
+TROUBLESHOOTING_LINK = ''
 
 # CSRF token timeout, set to None for a token that never expires
 WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 7

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -152,9 +152,6 @@ def execute_sql(
     def handle_error(msg):
         """Local method handling error while processing the SQL"""
         troubleshooting_link = config['TROUBLESHOOTING_LINK']
-        msg = 'Error: {}. You can find common superset errors and their \
-            resolutions at: {}'.format(msg, troubleshooting_link) \
-            if troubleshooting_link else msg
         query.error_message = msg
         query.status = QueryStatus.FAILED
         query.tmp_table_name = None
@@ -163,6 +160,8 @@ def execute_sql(
             'status': query.status,
             'error': msg,
         })
+        if troubleshooting_link:
+            payload['link'] = troubleshooting_link
         return payload
 
     if store_results and not results_backend:


### PR DESCRIPTION
This PR makes the error resolution link get passed to the frontend separately in the payload as opposed to preformed html from the backend.

@graceguo-supercat @michellethomas @mistercrunch 