### PR TITLE
[CRUD] disable user change slices from dashboardmodelview

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -530,9 +530,9 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
     list_columns = ['dashboard_link', 'creator', 'modified']
     order_columns = ['modified']
     edit_columns = [
-        'dashboard_title', 'slug', 'slices', 'owners', 'position_json', 'css',
+        'dashboard_title', 'slug', 'owners', 'position_json', 'css',
         'json_metadata']
-    show_columns = edit_columns + ['table_names']
+    show_columns = edit_columns + ['table_names', 'slices']
     search_columns = ('dashboard_title', 'slug', 'owners')
     add_columns = edit_columns
     base_order = ('changed_on', 'desc')
@@ -555,10 +555,6 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
         'owners': _('Owners is a list of users who can alter the dashboard.'),
     }
     base_filters = [['slice', DashboardFilter, lambda: []]]
-    add_form_query_rel_fields = {
-        'slices': [['slices', SliceFilter, None]],
-    }
-    edit_form_query_rel_fields = add_form_query_rel_fields
     label_columns = {
         'dashboard_link': _('Dashboard'),
         'dashboard_title': _('Title'),


### PR DESCRIPTION
similar to #5136, disable charts dropdown list (and filter function call) from dashboardmodelview, to improve the page load time for dashboard metadata edit page. Also for dashboard v2, we want to see user add/remove charts from dashboard builder as much as possible.

@michellethomas @mistercrunch @john-bodley 