### PR TITLE
Bump Celery to 4.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ geopy==1.11.0
 gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
+kombu==4.1.0
 markdown==2.6.11
 pandas==0.22.0
 parsedatetime==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bleach==2.1.2
 boto3==1.4.7
-celery==4.1.1
+celery==4.1.0
 colorama==0.3.9
 cryptography==1.9
 flask==0.12.2
@@ -17,7 +17,7 @@ geopy==1.11.0
 gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
-kombu==4.1.0
+kombu<4.2
 markdown==2.6.11
 pandas==0.22.0
 parsedatetime==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ geopy==1.11.0
 gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
-kombu<4.2
 markdown==2.6.11
 pandas==0.22.0
 parsedatetime==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bleach==2.1.2
 boto3==1.4.7
-celery==4.1.0
+celery==4.2.0
 colorama==0.3.9
 cryptography==1.9
 flask==0.12.2
@@ -17,7 +17,6 @@ geopy==1.11.0
 gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
-kombu==4.1.0
 markdown==2.6.11
 pandas==0.22.0
 parsedatetime==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         'bleach',
         'boto3>=1.4.6',
-        'celery>=4.1.1',
+        'celery==4.1.0',
         'colorama',
         'contextlib2',
         'cryptography',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         'bleach',
         'boto3>=1.4.6',
-        'celery==4.1.0',
+        'celery>=4.2.0',
         'colorama',
         'contextlib2',
         'cryptography',


### PR DESCRIPTION
More background can be found in https://github.com/celery/kombu/issues/870, `Celery` needs to be fixed at `4.1.0` until `Kombu 4.2.2` arrives. Fixes #5221.
