### PR TITLE
[pie] improvements to pie charts

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -206,6 +206,7 @@ export const controls = {
   percent_metrics: {
     ...metrics,
     multi: true,
+    default: [],
     label: t('Percentage Metrics'),
     validators: [],
     description: t('Metrics for which percentage of total are to be displayed'),
@@ -1472,6 +1473,16 @@ export const controls = {
     renderTrigger: true,
     default: true,
     description: t('Whether to display the legend (toggles)'),
+  },
+
+  show_labels: {
+    type: 'CheckboxControl',
+    label: t('Show Labels'),
+    renderTrigger: true,
+    default: true,
+    description: t(
+      'Whether to display the labels. Note that the label only displays when the the 5% ' +
+      'threshold.'),
   },
 
   show_values: {

--- a/superset/assets/src/explore/visTypes.js
+++ b/superset/assets/src/explore/visTypes.js
@@ -164,7 +164,7 @@ export const visTypes = {
           ['metric'],
           ['adhoc_filters'],
           ['groupby'],
-          ['limit'],
+          ['row_limit'],
         ],
       },
       {
@@ -173,11 +173,16 @@ export const visTypes = {
         controlSetRows: [
           ['pie_label_type'],
           ['donut', 'show_legend'],
-          ['labels_outside'],
+          ['show_labels', 'labels_outside'],
           ['color_scheme'],
         ],
       },
     ],
+    controlOverrides: {
+      row_limit: {
+        default: 25,
+      },
+    },
   },
 
   line: {

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -272,6 +272,7 @@ export default function nvd3Vis(slice, payload) {
         if (fd.donut) {
           chart.donut(true);
         }
+        chart.showLabels(fd.show_labels);
         chart.labelsOutside(fd.labels_outside);
         chart.labelThreshold(0.05);  // Configure the minimum slice size for labels to show up
         if (fd.pie_label_type !== 'key_percent' && fd.pie_label_type !== 'key_value') {


### PR DESCRIPTION
Pie chart was using `limit` instead of `row_limit` which didn't work. Also set a lower default limit to 25 to prevent the chart from getting super crowded.

Added `show_labels` to formatting options and a tooltip message making it clear that <5% won't show labels.

Unrelated drive-by fix of setting "percentage metric" to default to `[]`

closes https://github.com/apache/incubator-superset/issues/5210

@betodealmeida 👀 