### PR TITLE
[bubble-chart] Fixing issue w/ metric names

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -947,9 +947,9 @@ class BubbleViz(NVD3Viz):
         return d
 
     def get_data(self, df):
-        df['x'] = df[[self.x_metric]]
-        df['y'] = df[[self.y_metric]]
-        df['size'] = df[[self.z_metric]]
+        df['x'] = df[[utils.get_metric_name(self.x_metric)]]
+        df['y'] = df[[utils.get_metric_name(self.y_metric)]]
+        df['size'] = df[[utils.get_metric_name(self.z_metric)]]
         df['shape'] = 'circle'
         df['group'] = df[[self.series]]
 


### PR DESCRIPTION
The bubble chart doesn't correctly handle ad-hoc metrics, i.e., `self.x_metric` etc. could be a dictionary representing the serialized ad-hoc metric state, and thus when getting the data from the resulting Pandas dataframe one needs to use the correct name which is achieved via the `utils.get_metric_name(...)` utility method.

Note this is a similar change to https://github.com/apache/incubator-superset/pull/5080.

to: @GabeLoins @michellethomas @mistercrunch 