### PR TITLE
[Druid] Improving performance by disabling editing Associated Chart

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -211,7 +211,7 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin
     order_columns = ['datasource_link', 'modified']
     related_views = [DruidColumnInlineView, DruidMetricInlineView]
     edit_columns = [
-        'datasource_name', 'cluster', 'slices', 'description', 'owner',
+        'datasource_name', 'cluster', 'description', 'owner',
         'is_hidden',
         'filter_select_enabled', 'fetch_values_from',
         'default_endpoint', 'offset', 'cache_timeout']
@@ -219,7 +219,7 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin
         'datasource_name', 'cluster', 'description', 'owner',
     )
     add_columns = edit_columns
-    show_columns = add_columns + ['perm']
+    show_columns = add_columns + ['perm', 'slices']
     page_size = 500
     base_order = ('datasource_name', 'asc')
     description_columns = {


### PR DESCRIPTION
Similar to https://github.com/apache/incubator-superset/pull/5136 this PR helps to improve the performance of datasource CRUD view by removing the slices (Associated Charts) column from the edit view (it's still present for show).

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa