### PR TITLE
[druid] Adding verbose_name to editable columns

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -38,7 +38,7 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
     list_widget = ListWidgetWithCheckboxes
 
     edit_columns = [
-        'column_name', 'description', 'dimension_spec_json', 'datasource',
+        'column_name', 'verbose_name', 'description', 'dimension_spec_json', 'datasource',
         'groupby', 'filterable', 'count_distinct', 'sum', 'min', 'max']
     add_columns = edit_columns
     list_columns = [


### PR DESCRIPTION
This PR adds the Druid column verbose name as an editable column, inline with SQLA columns.

![screen shot 2018-06-19 at 2 03 49 pm](https://user-images.githubusercontent.com/4567245/41624353-4e006268-73ca-11e8-85ee-0ea2d4a2e2d6.png)

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 