### PR TITLE
[slice] Adding slice owners to SliceFilter

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -146,7 +146,16 @@ class SliceFilter(SupersetFilter):
             return query
         perms = self.get_view_menus('datasource_access')
         # TODO(bogdan): add `schema_access` support here
-        return query.filter(self.model.perm.in_(perms))
+        return query.filter(
+            or_(
+                models.Slice.perm.in_(perms),
+                models.Slice.id.in_(
+                    db.session.query(models.Slice.id)
+                    .join(models.Slice.owners)
+                    .filter(security_manager.user_model.id == g.user.get_id()),
+                ),
+            ),
+        )
 
 
 class DashboardFilter(SupersetFilter):


### PR DESCRIPTION
Similar to https://github.com/apache/incubator-superset/pull/4520 this PR adds owners of a slice to the `SliceFilter` method which ensures that owners can view the slices they own irrelevant of the permission. 

Note this really is a temporary partial fix as the current `DashboardFilter`, `DatasourceFilter`, and `SliceFilter` do not currently correctly apply the correct permission logic, i.e., for users without all-datasource-access the filters merely check if the corresponding datasource permission is explicitly defined for their roles, however it does not take into account indirect schema access, database access etc.

to: @graceguo-supercat @jeffreythewang @michellethomas @mistercrunch @timifasubaa 