### PR TITLE
Make sure there is a val to be set for existing filters

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -737,7 +737,7 @@ def merge_extra_filters(form_data):
             return f['col'] + '__' + f['op']
         existing_filters = {}
         for existing in form_data['filters']:
-            if existing['col'] is not None:
+            if existing['col'] is not None and existing['val'] is not None:
                 existing_filters[get_filter_key(existing)] = existing['val']
         for filtr in form_data['extra_filters']:
             # Pull out time filters/options and merge into form data


### PR DESCRIPTION
Found a bug on having filter set in the explore view effecting renders in the dashboard. Added a safe check to make sure `val` is an actual key before throwing an `KeyError` exception in the dashboard

@mistercrunch 