### PR TITLE
[timeseries table] use verbose date in tooltip by default

### DIFF
--- a/superset/assets/src/modules/dates.js
+++ b/superset/assets/src/modules/dates.js
@@ -114,7 +114,7 @@ export const formatDateVerbose = function (dttm) {
 
 export const formatDateThunk = function (format) {
   if (!format) {
-    return formatDate;
+    return formatDateVerbose;
   }
 
   const formatter = d3.time.format(format);


### PR DESCRIPTION
When I updated the time series date formatting I failed to use the verbose form in the time series table tooltip.

@john-bodley 