### PR TITLE
[RfC] provide ways to hide controls on certain visualization types

### DIFF
--- a/superset/assets/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset/assets/src/explore/components/ControlPanelsContainer.jsx
@@ -45,7 +45,7 @@ class ControlPanelsContainer extends React.Component {
     return control;
   }
   sectionsToRender() {
-    return sectionsToRender(this.props.form_data.viz_type, this.props.datasource_type);
+    return sectionsToRender(this.props.form_data.viz_type, this.props.datasource_type, false);
   }
   removeAlert() {
     this.props.actions.removeControlPanelAlert();

--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -16,7 +16,7 @@ export function getControlNames(vizType, datasourceType) {
     section => section.controlSetRows.forEach(
       fsr => fsr.forEach(
         f => controlNames.push(f))));
-  return controlNames;
+  return controlNames.filter(s => s);
 }
 
 function handleDeprecatedControls(formData) {

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -136,7 +136,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
             [
                 (m.metric_name, m.verbose_name or m.metric_name)
                 for m in self.metrics],
-            key=lambda x: x[1])
+            key=lambda x: x[1] or '')
 
     @property
     def short_data(self):


### PR DESCRIPTION
Some "global" controls like datasource, time-granularity or even time
filtering don't make much sense for some visualizations.

For instance the Markup viz really should let you choose a datasource,
or a distribution bar chart shouldn't ask for a time granularity.

This PR shows an approach to hhide some of these controls.