### PR TITLE
[Adhoc Filters] fixing regex displaying as undefined in the pill

### DIFF
--- a/superset/assets/src/explore/AdhocFilter.js
+++ b/superset/assets/src/explore/AdhocFilter.js
@@ -20,6 +20,7 @@ const OPERATORS_TO_SQL = {
   in: 'in',
   'not in': 'not in',
   LIKE: 'like',
+  regex: 'regex',
 };
 
 function translateToSql(adhocMetric, { useSimple } = {}) {


### PR DESCRIPTION
When the regex operation was used in a filter, the filter's label was not printing properly.

Before:
![image](https://user-images.githubusercontent.com/2455694/41752132-6e33abd8-757a-11e8-98ce-dd4b70eae873.png)


After:
![image](https://user-images.githubusercontent.com/2455694/41752023-a591041e-7579-11e8-8500-bc695057716c.png)

test plan:
made those screenshots

reviewers:
@michellethomas @john-bodley @graceguo-supercat @mistercrunch 