### PR TITLE
[hive-csv] Infer schema from csv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ six==1.11.0
 sqlalchemy==1.2.2
 sqlalchemy-utils==0.32.21
 sqlparse==0.2.4
+tableschema==1.1.0
 thrift==0.11.0
 thrift-sasl==0.3.0
 unicodecsv==0.14.1

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         'sqlalchemy',
         'sqlalchemy-utils',
         'sqlparse',
+        'tableschema',
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',
         'unicodecsv',


### PR DESCRIPTION
Previously all column types were string. This PR leverages the tableschema package to get a more precise column type and uses it in the table creation. 

@john-bodley @mistercrunch 