### PR TITLE
[hive-csv] specify hive namespace for tables

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -314,6 +314,10 @@ CSV_TO_HIVE_UPLOAD_S3_BUCKET = None
 # contain all the external tables
 CSV_TO_HIVE_UPLOAD_DIRECTORY = 'EXTERNAL_HIVE_TABLES/'
 
+# The namespace within hive where the tables created from
+# uploading CSVs will be stored.
+UPLOADED_CSV_HIVE_NAMESPACE = None
+
 # A dictionary of items that gets merged into the Jinja context for
 # SQL Lab. The existing context gets updated with this dictionary,
 # meaning values for existing keys get overwritten by the content of this

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -978,6 +978,14 @@ class HiveEngineSpec(PrestoEngineSpec):
                 return next(unicodecsv.reader(f, encoding='utf-8-sig'))
 
         table_name = form.name.data
+        if config.get('UPLOADED_CSV_HIVE_NAMESPACE'):
+            if '.' in table_name:
+                raise Exception(
+                    "You can't specify a namespace. "
+                    'All tables will be uploaded to the `{}` namespace'.format(
+                        config.get('HIVE_NAMESPACE')))
+            table_name = '{}.{}'.format(
+                config.get('UPLOADED_CSV_HIVE_NAMESPACE'), table_name)
         filename = form.csv_file.data.filename
 
         bucket_path = app.config['CSV_TO_HIVE_UPLOAD_S3_BUCKET']


### PR DESCRIPTION
This PR gives the administrators the option of forcing uploaded CSVs into a specific namespace in Hive. 

@john-bodley @mistercrunch 
cc @paulbramsen