### PR TITLE
[metric] Fixing ad-hoc metric for dual-line chart

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1317,6 +1317,7 @@ class NVD3DualLineViz(NVD3Viz):
             self.form_data.get('metric_2'),
         ]
         for i, m in enumerate(metrics):
+            m = utils.get_metric_name(m)
             ys = series[m]
             if df[m].dtype.kind not in 'biufc':
                 continue


### PR DESCRIPTION
This PR fixes ad-hoc metrics for the dual-line axis chart where `m` is expected to be the metric name.

to: @GabeLoins @michellethomas @mistercrunch 
