### PR TITLE
[get_df] Fix datetime conversion

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -197,13 +197,11 @@ class BaseViz(object):
         # be considered as the default ISO date format
         # If the datetime format is unix, the parse will use the corresponding
         # parsing logic.
-        if df is None or df.empty:
-            return pd.DataFrame()
-        else:
+        if not df.empty:
             if DTTM_ALIAS in df.columns:
                 if timestamp_format in ('epoch_s', 'epoch_ms'):
-                    df[DTTM_ALIAS] = pd.to_datetime(
-                        df[DTTM_ALIAS], utc=False, unit=timestamp_format[6:])
+                    # Column has already been formatted as a timestamp.
+                    df[DTTM_ALIAS] = df[DTTM_ALIAS].apply(pd.Timestamp)
                 else:
                     df[DTTM_ALIAS] = pd.to_datetime(
                         df[DTTM_ALIAS], utc=False, format=timestamp_format)


### PR DESCRIPTION
This PR fixes an issue where epoch time columns which have [already been converted](https://github.com/apache/incubator-superset/blob/master/superset/connectors/sqla/models.py#L127) to a timestamp (of type string) in the query are trying to be coerced in Pandas as a timestamp under the assumption that these values are still in the epoch format. Given these are already timestamps one merely needs to cast them to a `pandas.Timestamp` object.

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 