### PR TITLE
[SQL lab] Fixed limit issue

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -114,8 +114,7 @@ class BaseEngineSpec(object):
                 (?ix)          # case insensitive, verbose
                 \s+            # whitespace
                 LIMIT\s+(\d+)  # LIMIT $ROWS
-                ;?             # optional semi-colon
-                (\s|;)*$       # remove trailing spaces tabs or semicolons
+                (\s|;|.)*$     # remove the reset of the chars
                 """)
         matches = limit_pattern.findall(sql)
         if matches:
@@ -127,8 +126,7 @@ class BaseEngineSpec(object):
                 (?ix)        # case insensitive, verbose
                 \s+          # whitespace
                 LIMIT\s+\d+  # LIMIT $ROWS
-                ;?           # optional semi-colon
-                (\s|;)*$     # remove trailing spaces tabs or semicolons
+                (\s|;|.)*$   # remove the reset of the chars
                 """, '', sql)
 
     @staticmethod


### PR DESCRIPTION
This PR is to fix the issue https://github.com/apache/incubator-superset/issues/5272

The original Regular Expression cannot catch the LIMIT statement when there are extra statements after LIMIT. 

Note, the proposed solution is not perfect either..  Currently all the corner case I can think of: 

* 'LIMIT' inside quotes, which causes the false setting of query.limit
`SELECT "LIMIT 100" as C, id from aTable`

* LIMIT number is set larger than `SQL_MAX_ROW`, which causes the additional limit clause added
`SELECT * FROM atable LIMIT 10000001 OFFSET 1`

* `get_query_without_limit` function is broken too for the cases shown above. 