### PR TITLE
Bump botocore to 1.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bleach==2.1.2
 boto3==1.4.7
-botocore==1.7.48
+botocore==1.9.0
 celery==4.2.0
 colorama==0.3.9
 cryptography==1.9
@@ -40,4 +40,3 @@ thrift-sasl==0.3.0
 unicodecsv==0.14.1
 unidecode==1.0.22
 contextlib2==0.5.5
-

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         'bleach',
         'boto3>=1.4.6',
-        'botocore>=1.7.0, <1.8.0',
+        'botocore>=1.8.15, <1.9.0',
         'celery>=4.2.0',
         'colorama',
         'contextlib2',


### PR DESCRIPTION
Needed bump for boto3 upgrade:
`boto3 1.5.1 has requirement botocore<1.9.0,>=1.8.15, but you'll have botocore 1.10.45 which is incompatible.`

@john-bodley @mistercrunch @timifasubaa 