### PR TITLE
Pin boto3 to 1.4.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     scripts=['superset/bin/superset'],
     install_requires=[
         'bleach',
-        'boto3>=1.4.6',
+        'boto3==1.4.7',
         'botocore>=1.7.0, <1.8.0',
         'celery>=4.2.0',
         'colorama',


### PR DESCRIPTION
Since `botocore` is pinned to `botocore>=1.7.0, <1.8.0` as per #5184 , `boto3` should also be pinned, as `boto3==1.4.6` depends on `botocore>=1.6.0, <1.7.0` and `boto3==1.4.8` depends on `botocore>=1.8.0, <1.9.0`.

cc: @mistercrunch @ledor473 @john-bodley 