### PR TITLE
[dashboard fix] force refresh charts under tabs

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -202,5 +202,10 @@ export function runQuery(formData, force = false, timeout = 60, key) {
 }
 
 export function refreshChart(chart, force, timeout) {
-  return dispatch => dispatch(runQuery(chart.latestQueryFormData, force, timeout, chart.id));
+  return (dispatch) => {
+    if (!chart.latestQueryFormData || Object.keys(chart.latestQueryFormData).length === 0) {
+      return;
+    }
+    dispatch(runQuery(chart.latestQueryFormData, force, timeout, chart.id));
+  };
 }


### PR DESCRIPTION
<img width="600" alt="screen shot 2018-06-26 at 11 19 05 am" src="https://user-images.githubusercontent.com/27990562/41931402-d1b65d84-7932-11e8-89d0-831cb9fa8fca.png">


when user created top level tabs and place charts under it, initial page load won't fetch those charts data. But if user force refresh dashboard, currently we force refresh all charts even not visible ones. It cause js exception because some attributes are not well initialized.

updated solution: when user force refresh whole dashboard, _don't fetch data_ for charts that haven't been rendered.