### PR TITLE
[dashboard v2] add `<MissingChart />` component

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/components/MissingChart_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/MissingChart_spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import Loading from '../../../../src/components/Loading';
+import MissingChart from '../../../../src/dashboard/components/MissingChart';
+
+describe('MissingChart', () => {
+  function setup(overrideProps) {
+    const wrapper = shallow(<MissingChart height={100} {...overrideProps} />);
+    return wrapper;
+  }
+
+  it('renders a .missing-chart-container', () => {
+    const wrapper = setup();
+    expect(wrapper.find('.missing-chart-container')).to.have.length(1);
+  });
+
+  it('renders a .missing-chart-body', () => {
+    const wrapper = setup();
+    expect(wrapper.find('.missing-chart-body')).to.have.length(1);
+  });
+
+  it('renders a Loading', () => {
+    const wrapper = setup();
+    expect(wrapper.find(Loading)).to.have.length(1);
+  });
+});

--- a/superset/assets/src/SqlLab/components/QuerySearch.jsx
+++ b/superset/assets/src/SqlLab/components/QuerySearch.jsx
@@ -217,10 +217,10 @@ class QuerySearch extends React.PureComponent {
             </Button>
           </div>
         </div>
-        {this.state.queriesLoading ? (
-          <Loading />
-        ) : (
-          <div className="scrollbar-container">
+        <div className="scrollbar-container">
+          {this.state.queriesLoading ? (
+            <Loading />
+          ) : (
             <div className="scrollbar-content" style={{ height: this.props.height }}>
               <QueryTable
                 columns={['state', 'db', 'user', 'time', 'progress', 'rows', 'sql', 'querylink']}
@@ -230,8 +230,8 @@ class QuerySearch extends React.PureComponent {
                 actions={this.props.actions}
               />
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     );
   }

--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -209,6 +209,13 @@ export function addSliceToDashboard(id) {
   return (dispatch, getState) => {
     const { sliceEntities } = getState();
     const selectedSlice = sliceEntities.slices[id];
+    if (!selectedSlice) {
+      return dispatch(
+        addWarningToast(
+          'Sorry, there is no chart definition associated with the chart trying to be added.',
+        ),
+      );
+    }
     const form_data = selectedSlice.form_data;
     const newChart = {
       ...initChart,

--- a/superset/assets/src/dashboard/components/MissingChart.jsx
+++ b/superset/assets/src/dashboard/components/MissingChart.jsx
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Loading from '../../components/Loading';
+import { t } from '../../locales';
+
+const propTypes = {
+  height: PropTypes.number.isRequired,
+};
+
+export default function MissingChart({ height }) {
+  return (
+    <div className="missing-chart-container" style={{ height: height + 20 }}>
+      <div className="loading-container">
+        <Loading />
+      </div>
+      <div className="missing-chart-body">
+        {t(
+          'There is no chart definition associated with this component, could it have been deleted?',
+        )}
+        <br />
+        <br />
+        {t('Delete this container and save to remove this message.')}
+      </div>
+    </div>
+  );
+}
+
+MissingChart.propTypes = propTypes;

--- a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { exportChart } from '../../../explore/exploreUtils';
 import SliceHeader from '../SliceHeader';
 import ChartContainer from '../../../chart/ChartContainer';
+import MissingChart from '../MissingChart';
 import { chartPropType } from '../../../chart/chartReducer';
 import { slicePropShape } from '../../util/propShapes';
 import { VIZ_TYPES } from '../../../visualizations';
@@ -155,11 +156,14 @@ class Chart extends React.Component {
       sliceCanEdit,
     } = this.props;
 
-    // this should never happen but prevents throwing in the case that a gridComponent
-    // references a chart that is not associated with the dashboard
-    if (!chart || !slice) return null;
-
     const { width } = this.state;
+
+    // this prevents throwing in the case that a gridComponent
+    // references a chart that is not associated with the dashboard
+    if (!chart || !slice) {
+      return <MissingChart height={this.getChartHeight()} />;
+    }
+
     const { queryResponse, chartUpdateEndTime } = chart;
     const isCached = queryResponse && queryResponse.is_cached;
     const cachedDttm = queryResponse && queryResponse.cached_dttm;

--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -5,6 +5,22 @@
   background-color: white;
   position: relative;
   padding: 16px;
+
+  .missing-chart-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow-y: auto;
+
+    .missing-chart-body {
+      font-size: 12px;
+    }
+
+    .loading-container {
+      position: relative;
+      height: 40%;
+    }
+  }
 }
 
 .dashboard-chart {


### PR DESCRIPTION
This PR adds a `<MissingChart />` component that is shown in the case that a dashboard v2 `<Chart />` component has no slice definition. 

![deleted-chart-flow](https://user-images.githubusercontent.com/4496521/41956952-3b14e3ba-799a-11e8-9cd3-63844642c3a2.gif)

**Testing**
- verified that this works in the case that a layout references a chart that was deleted (and previously part of the dashboard)
- Added frontend tests for `<MissingChart />`
- Tested undo/redo of removing the empty chart, adds toast when we add a slice that has no definition to a dashboard

@graceguo-supercat 