### PR TITLE
[dashboard fix]: Fix default_filters validation

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1637,7 +1637,11 @@ class Superset(BaseSupersetView):
             if 'filter_immune_slice_fields' not in md:
                 md['filter_immune_slice_fields'] = {}
             md['expanded_slices'] = data['expanded_slices']
-            md['default_filters'] = data.get('default_filters', '')
+            default_filters_data = json.loads(data.get('default_filters', '{}'))
+            applicable_filters =\
+                {key: v for key, v in default_filters_data.items()
+                 if int(key) in slice_ids}
+            md['default_filters'] = json.dumps(applicable_filters)
             dashboard.json_metadata = json.dumps(md, indent=4)
             return
 
@@ -1681,10 +1685,10 @@ class Superset(BaseSupersetView):
             md['filter_immune_slice_fields'] = {}
         md['expanded_slices'] = data['expanded_slices']
         default_filters_data = json.loads(data.get('default_filters', '{}'))
-        for key in default_filters_data.keys():
-            if int(key) not in slice_ids:
-                del default_filters_data[key]
-        md['default_filters'] = json.dumps(default_filters_data)
+        applicable_filters = \
+            {key: v for key, v in default_filters_data.items()
+             if int(key) in slice_ids}
+        md['default_filters'] = json.dumps(applicable_filters)
         dashboard.json_metadata = json.dumps(md, indent=4)
 
     @api

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -98,6 +98,31 @@ class DashboardTests(SupersetTestCase):
         resp = self.get_resp(new_url)
         self.assertIn('North America', resp)
 
+    def test_save_dash_with_invalid_filters(self, username='admin'):
+        self.login(username=username)
+        dash = db.session.query(models.Dashboard).filter_by(
+            slug='world_health').first()
+
+        # add an invalid filter slice
+        filters = {str(99999): {'region': ['North America']}}
+        default_filters = json.dumps(filters)
+        data = {
+            'css': '',
+            'expanded_slices': {},
+            'positions': dash.position_array,
+            'dashboard_title': dash.dashboard_title,
+            'default_filters': default_filters,
+        }
+
+        url = '/superset/save_dash/{}/'.format(dash.id)
+        resp = self.get_resp(url, data=dict(data=json.dumps(data)))
+        self.assertIn('SUCCESS', resp)
+
+        updatedDash = db.session.query(models.Dashboard).filter_by(
+            slug='world_health').first()
+        new_url = updatedDash.url
+        self.assertNotIn('region', new_url)
+
     def test_save_dash_with_dashboard_title(self, username='admin'):
         self.login(username=username)
         dash = (


### PR DESCRIPTION
if user update dashboard default_filters metadata with invalid slice_id (a slice not included in the dashboard), we should not add this slice id into dashboard metadata. This PR is to fix `error dictionary changed size during iteration` in python3

@williaster @john-bodley  @mistercrunch 