### PR TITLE
Add monkey patch for --console-log dev env

### DIFF
--- a/superset/bin/superset
+++ b/superset/bin/superset
@@ -5,6 +5,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import gevent.monkey
+gevent.monkey.patch_all()
+
 import warnings
 from flask.exthook import ExtDeprecationWarning
 warnings.simplefilter('ignore', ExtDeprecationWarning)


### PR DESCRIPTION
Running `superset runserver --console-log` would return the following error:
```
/Users/hmiles/src/incubator-superset/superset/cli.py:22: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6.
It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): ['b
otocore.vendored.requests.packages.urllib3.util.ssl_ (/Users/hmiles/src/incubator-superset/venv/lib/python3.6/site-packages/botocore/vendored/requests/packages/urllib3/util/ssl_.py)', 'botocore
.vendored.requests.packages.urllib3.util (/Users/hmiles/src/incubator-superset/venv/lib/python3.6/site-packages/botocore/vendored/requests/packages/urllib3/util/__init__.py)', 'urllib3.util.ssl
_ (/Users/hmiles/src/incubator-superset/venv/lib/python3.6/site-packages/urllib3/util/ssl_.py)', 'urllib3.util (/Users/hmiles/src/incubator-superset/venv/lib/python3.6/site-packages/urllib3/uti
l/__init__.py)'].
  gevent.monkey.patch_all()
```

With this i've added the monkey patch code to our bin and now things are working normally

@betodealmeida 