### PR TITLE
[cache] Providing a mechanism for disabling the datasource/database cache

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -176,6 +176,11 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):  #
         'broker_port': _('Broker Port'),
         'broker_endpoint': _('Broker Endpoint'),
     }
+    description_columns = {
+        'cache_timeout': _(
+            'Duration (in seconds) of the caching timeout for this cluster. '
+            'Note this defaults to the global timeout if undefined.'),
+    }
 
     def pre_add(self, cluster):
         security_manager.merge_perm('database_access', cluster.perm)
@@ -249,6 +254,9 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin
         'default_endpoint': _(
             'Redirects to this endpoint when clicking on the datasource '
             'from the datasource list'),
+        'cache_timeout': _(
+            'Duration (in seconds) of the caching timeout for this datasource. '
+            'Note this defaults to the cluster timeout if undefined.'),
     }
     base_filters = [['id', DatasourceFilter, lambda: []]]
     label_columns = {

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -219,6 +219,9 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
         'template_params': _(
             'A set of parameters that become available in the query using '
             'Jinja templating syntax'),
+        'cache_timeout': _(
+            'Duration (in seconds) of the caching timeout for this table. '
+            'Note this defaults to the database timeout if undefined.'),
     }
     label_columns = {
         'slices': _('Associated Charts'),

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -266,6 +266,9 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
             'Allow SQL Lab to fetch a list of all tables and all views across '
             'all database schemas. For large data warehouse with thousands of '
             'tables, this can be expensive and put strain on the system.'),
+        'cache_timeout': _(
+            'Duration (in seconds) of the caching timeout for this database. '
+            'Note this defaults to the global timeout if undefined.'),
     }
     label_columns = {
         'expose_in_sqllab': _('Expose in SQL Lab'),
@@ -450,7 +453,8 @@ class SliceModelView(SupersetModelView, DeleteMixin):  # noqa
             'want to alter specific parameters.',
         ),
         'cache_timeout': _(
-            'Duration (in seconds) of the caching timeout for this chart.'),
+            'Duration (in seconds) of the caching timeout for this chart. '
+            'Note this defaults to the datasource/table timeout if undefined.'),
     }
     base_filters = [['id', SliceFilter, lambda: []]]
     label_columns = {

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -310,13 +310,13 @@ class BaseViz(object):
 
     @property
     def cache_timeout(self):
-        if self.form_data.get('cache_timeout'):
+        if self.form_data.get('cache_timeout') is not None:
             return int(self.form_data.get('cache_timeout'))
-        if self.datasource.cache_timeout:
+        if self.datasource.cache_timeout is not None:
             return self.datasource.cache_timeout
         if (
                 hasattr(self.datasource, 'database') and
-                self.datasource.database.cache_timeout):
+                self.datasource.database.cache_timeout) is not None:
             return self.datasource.database.cache_timeout
         return config.get('CACHE_DEFAULT_TIMEOUT')
 

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -10,6 +10,7 @@ import unittest
 from mock import Mock, patch
 import pandas as pd
 
+from superset import app
 from superset.utils import DTTM_ALIAS
 import superset.viz as viz
 from .utils import load_fixture
@@ -101,13 +102,21 @@ class BaseVizTestCase(unittest.TestCase):
 
     def test_cache_timeout(self):
         datasource = Mock()
+        datasource.cache_timeout = 0
+        test_viz = viz.BaseViz(datasource, form_data={})
+        self.assertEqual(0, test_viz.cache_timeout)
         datasource.cache_timeout = 156
         test_viz = viz.BaseViz(datasource, form_data={})
         self.assertEqual(156, test_viz.cache_timeout)
         datasource.cache_timeout = None
         datasource.database = Mock()
+        datasource.database.cache_timeout = 0
+        self.assertEqual(0, test_viz.cache_timeout)
         datasource.database.cache_timeout = 1666
         self.assertEqual(1666, test_viz.cache_timeout)
+        datasource.database.cache_timeout = None
+        test_viz = viz.BaseViz(datasource, form_data={})
+        self.assertEqual(app.config['CACHE_DEFAULT_TIMEOUT'], test_viz.cache_timeout)
 
 
 class TableVizTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR updates the cache-timeout delegation logic which previously checked whether the datasource or database` cache_timeout` evaluated to `True` rather than whether it was `None`. The distinction here is you should be able to set a cache-timeout of zero at the datasource/database level to indicate that the slice will not timeout. 

I've also updated the form descriptions which explicitly mention the timeout is in seconds and what the fall back logic is, i.e., 

chart: 
![screen shot 2018-07-02 at 11 23 05 am](https://user-images.githubusercontent.com/4567245/42181811-0f5e2b36-7df1-11e8-9f4e-bdd5ad25738e.png)

table: 
![screen shot 2018-07-02 at 11 22 13 am](https://user-images.githubusercontent.com/4567245/42181812-0f784ebc-7df1-11e8-9c2c-019f152f9bf5.png)

database:
![screen shot 2018-07-02 at 11 29 45 am](https://user-images.githubusercontent.com/4567245/42181810-0f47907e-7df1-11e8-8b0c-924a55fce065.png)

datasource: 
![screen shot 2018-07-02 at 11 21 48 am](https://user-images.githubusercontent.com/4567245/42181813-0f94413a-7df1-11e8-825f-23837c0474fc.png)

cluster:
![screen shot 2018-07-02 at 11 30 05 am](https://user-images.githubusercontent.com/4567245/42181809-0f2ecc56-7df1-11e8-8bed-7589a2e61a0e.png)


to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 