### PR TITLE
ImpalaEngineSpec inherits HiveEngineSpec

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1408,7 +1408,8 @@ class BQEngineSpec(BaseEngineSpec):
 class ImpalaEngineSpec(HiveEngineSpec):
     """
     Engine spec for Cloudera's Impala
-    Impala overlaps heavily with HiveServer2, importing HiveEngineSpec improves maintainibility
+    Impala overlaps heavily with HiveServer2,
+    importing HiveEngineSpec improves maintainibility
     """
 
     engine = 'impala'

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1405,8 +1405,11 @@ class BQEngineSpec(BaseEngineSpec):
         return data
 
 
-class ImpalaEngineSpec(BaseEngineSpec):
-    """Engine spec for Cloudera's Impala"""
+class ImpalaEngineSpec(HiveEngineSpec):
+    """
+    Engine spec for Cloudera's Impala
+    Impala overlaps heavily with HiveServer2, importing HiveEngineSpec improves maintainibility
+    """
 
     engine = 'impala'
 


### PR DESCRIPTION
Impala maintains compatibility with Hive. Inheriting `HiveEngineSpec` makes it easy to share functionality and override when necessary. 