### PR TITLE
Implement rolling api introduced in pandas 0.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
 markdown==2.6.11
-pandas==0.22.0
+pandas==0.23.1
 parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'humanize',
         'idna',
         'markdown',
-        'pandas',
+        'pandas>=0.18',
         'parsedatetime',
         'pathlib2',
         'polyline',

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'humanize',
         'idna',
         'markdown',
-        'pandas>=0.18',
+        'pandas>=0.18.0',
         'parsedatetime',
         'pathlib2',
         'polyline',

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1175,15 +1175,14 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
         if rolling_type in ('mean', 'std', 'sum') and rolling_periods:
             kwargs = dict(
-                arg=df,
                 window=rolling_periods,
                 min_periods=min_periods)
             if rolling_type == 'mean':
-                df = pd.rolling_mean(**kwargs)
+                df = df.rolling(**kwargs).mean()
             elif rolling_type == 'std':
-                df = pd.rolling_std(**kwargs)
+                df = df.rolling(**kwargs).std()
             elif rolling_type == 'sum':
-                df = pd.rolling_sum(**kwargs)
+                df = df.rolling(**kwargs).sum()
         elif rolling_type == 'cumsum':
             df = df.cumsum()
         if min_periods:


### PR DESCRIPTION
The deprecated `rolling_` functions were removed in the current stable pandas version (0.23). Also bump pandas to `0.23.1` in `requirements.txt`. Fixes #5324.