### PR TITLE
[Table Viz] Table columns not match with group_by control

### DIFF
--- a/superset/assets/src/explore/components/controls/MetricsControl.jsx
+++ b/superset/assets/src/explore/components/controls/MetricsControl.jsx
@@ -139,6 +139,12 @@ export default class MetricsControl extends React.PureComponent {
   }
 
   onChange(opts) {
+    // if clear out options
+    if (opts === null) {
+      this.props.onChange(null);
+      return;
+    }
+
     let transformedOpts = opts;
     if (!this.props.multi) {
       transformedOpts = [opts].filter(option => option);

--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -73,7 +73,13 @@ export function getControlsState(state, form_data) {
       control.default = control.default(control);
     }
     control.validationErrors = [];
-    control.value = formData[k] !== undefined ? formData[k] : control.default;
+    control.value = control.default;
+    // formData[k]'s type should match control value type
+    if (formData[k] !== undefined &&
+      (Array.isArray(formData[k]) && control.multi || !control.multi)
+    ) {
+      control.value = formData[k];
+    }
     controlsState[k] = control;
   });
   if (viz.onInit) {

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -509,7 +509,7 @@ class TableViz(BaseViz):
                 'Choose either fields to [Group By] and [Metrics] or '
                 '[Columns], not both'))
 
-        sort_by = fd.get('timeseries_limit_metric') or []
+        sort_by = fd.get('timeseries_limit_metric')
         if fd.get('all_columns'):
             d['columns'] = fd.get('all_columns')
             d['groupby'] = []


### PR DESCRIPTION
![screen_shot_2018-07-02_at_11_07_48_pm](https://user-images.githubusercontent.com/27990562/42201540-3689939c-7e4d-11e8-8b68-c5ce67f5d83b.jpg)

`timeseries_limit_metric` parameter is supposed to be single value but in the slice record I see `timeseries_limit_metric=[]`. This caused table viz dropped last column.

@michellethomas @GabeLoins 