### PR TITLE
normalize column names for Redshift

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -424,6 +424,10 @@ class VerticaEngineSpec(PostgresBaseEngineSpec):
 class RedshiftEngineSpec(PostgresBaseEngineSpec):
     engine = 'redshift'
 
+    @staticmethod
+    def normalize_column_name(column_name):
+        return column_name.lower()
+
 
 class OracleEngineSpec(PostgresBaseEngineSpec):
     engine = 'oracle'


### PR DESCRIPTION
This fixes an error with column names when using RedShift, issue is detailed here https://github.com/apache/incubator-superset/issues/5308.