### PR TITLE
Restrict pandas version (0.26 branch)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'humanize',
         'idna',
         'markdown',
-        'pandas',
+        'pandas<0.23',
         'parsedatetime',
         'pathlib2',
         'polyline',


### PR DESCRIPTION
Superset 0.26 uses deprecated pandas functions that were removed in Pandas 0.23.  See PR #5328 which fixes deprecated function calls in master branch.