### PR TITLE
Restrict pandas version (0.25 branch)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'humanize',
         'idna',
         'markdown',
-        'pandas',
+        'pandas<0.23',
         'parsedatetime',
         'pathlib2',
         'polyline',


### PR DESCRIPTION
(Not sure if the 0.25 branch is still maintained, but just in case)
Superset 0.25 uses deprecated pandas functions that were removed in Pandas 0.23. See PR #5328 which fixes deprecated function calls in master branch.