### PR TITLE
Should technically document step using pip3

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -89,7 +89,7 @@ that the required dependencies are installed: ::
 **OSX**, system python is not recommended. brew's python also ships with pip  ::
 
     brew install pkg-config libffi openssl python
-    env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install cryptography==1.9
+    env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip3 install cryptography==1.9
 
 **Windows** isn't officially supported at this point, but if you want to
 attempt it, download `get-pip.py <https://bootstrap.pypa.io/get-pip.py>`_, and run ``python get-pip.py`` which may need admin access. Then run the following: ::


### PR DESCRIPTION
I'm not entirely sure about this one, perhaps two separate blocks are called for. But technically if someone _today_ were to `brew install python`, which is inline with the recommendation to not use system python on OSX, then they would actually use `pip3`, and in fact, not have `pip` in their path.