### PR TITLE
Make Pypi upload support markdown

### DIFF
--- a/pypi_push.sh
+++ b/pypi_push.sh
@@ -3,5 +3,6 @@ rm superset/assets/dist/*
 cd superset/assets/
 npm run build
 cd ../..
-python setup.py sdist upload
+python setup.py sdist
+echo "RUN: twine upload dist/superset-{VERSION}.tar.gz"
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     description=(
         'A modern, enterprise-ready business intelligence web application'),
     long_description=long_description,
+    long_description_content_type='text/markdown',
     version=version_string,
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Moving to using Twine to upload to pypi and fixing up the markdown
support so that the page on Pypi looks like the README on Github.

This has been tested on the 0.26 branch starting 0.26.3

👀 @hughhhh @betodealmeida 