### PR TITLE
[dashboard] Fix save issue at Force_V2_Edit mode

### DIFF
--- a/superset/assets/src/dashboard/deprecated/v1/components/Controls.jsx
+++ b/superset/assets/src/dashboard/deprecated/v1/components/Controls.jsx
@@ -144,6 +144,7 @@ class Controls extends React.PureComponent {
             }
           />
           {dashboard.dash_save_perm &&
+            dashboard.force_v2_edit &&
             <SaveModal
               dashboard={dashboard}
               filters={filters}

--- a/superset/assets/src/dashboard/deprecated/v1/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/deprecated/v1/components/Dashboard.jsx
@@ -10,6 +10,7 @@ import {
   Logger,
   ActionLog,
   DASHBOARD_EVENT_NAMES,
+  LOG_ACTIONS_PREVIEW_V2,
   LOG_ACTIONS_MOUNT_DASHBOARD,
   LOG_ACTIONS_EXPLORE_DASHBOARD_CHART,
   LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART,
@@ -68,6 +69,7 @@ class Dashboard extends React.PureComponent {
       unsavedChanges: false,
     };
     this.handleSetEditMode = this.handleSetEditMode.bind(this);
+    this.handleConvertToV2 = this.handleConvertToV2.bind(this);
 
     this.rerenderCharts = this.rerenderCharts.bind(this);
     this.updateDashboardTitle = this.updateDashboardTitle.bind(this);
@@ -346,6 +348,21 @@ class Dashboard extends React.PureComponent {
     exportChart(formData, 'csv');
   }
 
+  handleConvertToV2(editMode) {
+    Logger.append(
+      LOG_ACTIONS_PREVIEW_V2,
+      {
+        force_v2_edit: this.props.dashboard.forceV2Edit,
+        edit_mode: editMode === true,
+      },
+      true,
+    );
+    const url = new URL(window.location); // eslint-disable-line
+    url.searchParams.set('version', 'v2');
+    if (editMode === true) url.searchParams.set('edit', true);
+    window.location = url; // eslint-disable-line
+  }
+
   handleSetEditMode(nextEditMode) {
     if (this.props.dashboard.forceV2Edit) {
       this.handleConvertToV2(true);
@@ -386,6 +403,7 @@ class Dashboard extends React.PureComponent {
             addSlicesToDashboard={this.addSlicesToDashboard}
             editMode={this.props.editMode}
             setEditMode={this.handleSetEditMode}
+            handleConvertToV2={this.handleConvertToV2}
           />
         </div>
         <div id="grid-container" className="slice-grid gridster">

--- a/superset/assets/src/dashboard/deprecated/v1/components/Header.jsx
+++ b/superset/assets/src/dashboard/deprecated/v1/components/Header.jsx
@@ -9,7 +9,6 @@ import InfoTooltipWithTrigger from '../../../../components/InfoTooltipWithTrigge
 import PromptV2ConversionModal from '../../PromptV2ConversionModal';
 import {
   Logger,
-  LOG_ACTIONS_PREVIEW_V2,
   LOG_ACTIONS_DISMISS_V2_PROMPT,
   LOG_ACTIONS_SHOW_V2_INFO_PROMPT,
 } from '../../../../logger';
@@ -31,6 +30,7 @@ const propTypes = {
   updateDashboardTitle: PropTypes.func,
   editMode: PropTypes.bool.isRequired,
   setEditMode: PropTypes.func.isRequired,
+  handleConvertToV2: PropTypes.func.isRequired,
   unsavedChanges: PropTypes.bool.isRequired,
 };
 
@@ -43,24 +43,9 @@ class Header extends React.PureComponent {
       showV2PromptModal: props.dashboard.promptV2Conversion,
     };
     this.toggleShowV2PromptModal = this.toggleShowV2PromptModal.bind(this);
-    this.handleConvertToV2 = this.handleConvertToV2.bind(this);
   }
   handleSaveTitle(title) {
     this.props.updateDashboardTitle(title);
-  }
-  handleConvertToV2(editMode) {
-    Logger.append(
-      LOG_ACTIONS_PREVIEW_V2,
-      {
-        force_v2_edit: this.props.dashboard.forceV2Edit,
-        edit_mode: editMode === true,
-      },
-      true,
-    );
-    const url = new URL(window.location); // eslint-disable-line
-    url.searchParams.set('version', 'v2');
-    if (editMode === true) url.searchParams.set('edit', true);
-    window.location = url; // eslint-disable-line
   }
   toggleEditMode() {
     this.props.setEditMode(!this.props.editMode);
@@ -169,7 +154,7 @@ class Header extends React.PureComponent {
           !this.props.editMode && (
             <PromptV2ConversionModal
               onClose={this.toggleShowV2PromptModal}
-              handleConvertToV2={this.handleConvertToV2}
+              handleConvertToV2={this.props.handleConvertToV2}
               forceV2Edit={dashboard.forceV2Edit}
               v2AutoConvertDate={dashboard.v2AutoConvertDate}
               v2FeedbackUrl={dashboard.v2FeedbackUrl}

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2169,6 +2169,8 @@ class Superset(BaseSupersetView):
             else:
                 dashboard_view = 'v1'
                 prompt_v2_conversion = not force_v1
+                if force_v2_edit:
+                    dash_edit_perm = False
 
         # Hack to log the dashboard_id properly, even when getting a slug
         @log_this


### PR DESCRIPTION

<img width="1252" alt="screen shot 2018-07-05 at 3 06 00 pm" src="https://user-images.githubusercontent.com/27990562/42406230-f0404f1c-8157-11e8-9d74-8e3b92b5b4e3.png">


Fix 2 issues for dashboard when set config
`CAN_FALLBACK_TO_DASH_V1_EDIT_MODE = False`

if dashboard is still in v1 mode:
- for dashboard owner/viewer, can see/edit dashboard in v1 mode.
- for dashboard owner/viewer, cannot save/save-as dashboard to v1 mode.
- for dashboard owner, if they click on `Edit dashboard` button in V1 mode,  we will show dashboard in v2 preview mode, and user can convert and save dashboard to v2 mode.