### PR TITLE
change datetime format prior to json dump

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -514,6 +514,12 @@ class DruidDatasource(Model, BaseDatasource):
         """Returns schema permission if present, cluster one otherwise."""
         return security_manager.get_schema_perm(self.cluster, self.schema)
 
+    def get_col(self, col_name):
+        columns = self.columns
+        for col in columns:
+            if col_name == col.column_name:
+                return col
+
     def get_perm(self):
         return (
             '[{obj.cluster_name}].[{obj.datasource_name}]'

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1123,6 +1123,12 @@ class Superset(BaseSupersetView):
         ):
             status = 400
 
+        time_cols = [col for col in payload['form_data']['groupby'] if viz_obj.datasource.get_col(col).is_time]
+        if time_cols:
+            for col in time_cols:
+                for record in payload['data']['records']:
+                    record[col] = str(record[col])      
+                    
         return json_success(viz_obj.json_dumps(payload), status=status)
 
     @log_this

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1125,8 +1125,12 @@ class Superset(BaseSupersetView):
 
         # ensures proper formatting for creating tables
         if 'groupby' in payload['form_data'].keys() and viz_obj.viz_type == 'table':
-            time_cols = [viz_obj.datasource.get_col(col) for col in payload['form_data']['groupby']]
-            time_cols = [col.column_name for col in time_cols if col is not None and col.is_time]
+            time_cols = [
+                viz_obj.datasource.get_col(col).column_name 
+                for col in payload['form_data']['groupby'] 
+                if viz_obj.datasource.get_col(col) is not None and \
+                viz_obj.datasource.get_col(col).is_time
+            ]
             if time_cols:
                 for col in time_cols:
                     for record in payload['data']['records']:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1123,16 +1123,15 @@ class Superset(BaseSupersetView):
         ):
             status = 400
 
-        if 'groupby' in payload['form_data'].keys():
-            time_cols = [
-                col for col in payload['form_data']['groupby'] if viz_obj.datasource.get_col(col)
-            ]
-            time_cols = [col for col in time_cols if hasattr(col, 'is_time') and col.is_time]
+        # ensures proper formatting for creating tables
+        if 'groupby' in payload['form_data'].keys() and viz_obj.viz_type == 'table':
+            time_cols = [viz_obj.datasource.get_col(col) for col in payload['form_data']['groupby']]
+            time_cols = [col.column_name for col in time_cols if col is not None and col.is_time]
             if time_cols:
                 for col in time_cols:
                     for record in payload['data']['records']:
-                        record[col] = str(record[col])      
-                    
+                        record[col] = str(record[col])
+
         return json_success(viz_obj.json_dumps(payload), status=status)
 
     @log_this

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1123,11 +1123,15 @@ class Superset(BaseSupersetView):
         ):
             status = 400
 
-        time_cols = [col for col in payload['form_data']['groupby'] if viz_obj.datasource.get_col(col).is_time]
-        if time_cols:
-            for col in time_cols:
-                for record in payload['data']['records']:
-                    record[col] = str(record[col])      
+        if 'groupby' in payload['form_data'].keys():
+            time_cols = [
+                col for col in payload['form_data']['groupby'] if viz_obj.datasource.get_col(col)
+            ]
+            time_cols = [col for col in time_cols if hasattr(col, 'is_time') and col.is_time]
+            if time_cols:
+                for col in time_cols:
+                    for record in payload['data']['records']:
+                        record[col] = str(record[col])      
                     
         return json_success(viz_obj.json_dumps(payload), status=status)
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1126,9 +1126,9 @@ class Superset(BaseSupersetView):
         # ensures proper formatting for creating tables
         if 'groupby' in payload['form_data'].keys() and viz_obj.viz_type == 'table':
             time_cols = [
-                viz_obj.datasource.get_col(col).column_name 
-                for col in payload['form_data']['groupby'] 
-                if viz_obj.datasource.get_col(col) is not None and \
+                viz_obj.datasource.get_col(col).column_name
+                for col in payload['form_data']['groupby']
+                if viz_obj.datasource.get_col(col) is not None and
                 viz_obj.datasource.get_col(col).is_time
             ]
             if time_cols:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1123,19 +1123,6 @@ class Superset(BaseSupersetView):
         ):
             status = 400
 
-        # ensures proper formatting for creating tables
-        if 'groupby' in payload['form_data'].keys() and viz_obj.viz_type == 'table':
-            time_cols = [
-                viz_obj.datasource.get_col(col).column_name
-                for col in payload['form_data']['groupby']
-                if viz_obj.datasource.get_col(col) is not None and
-                viz_obj.datasource.get_col(col).is_time
-            ]
-            if time_cols:
-                for col in time_cols:
-                    for record in payload['data']['records']:
-                        record[col] = str(record[col])
-
         return json_success(viz_obj.json_dumps(payload), status=status)
 
     @log_this

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -573,6 +573,18 @@ class TableViz(BaseViz):
                 columns=list(df.columns),
             ))
 
+        # Reformat dates and datetime groupbys 
+        if fd.get('groupby'):
+            time_cols = [
+                self.datasource.get_col(col).column_name
+                for col in fd.get('groupby')
+                if self.datasource.get_col(col).is_time
+            ]
+            if time_cols:
+                for col in time_cols:
+                    for record in data['records']:
+                        record[col] = str(record[col])
+
         return data
 
     def json_dumps(self, obj, sort_keys=False):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -573,7 +573,7 @@ class TableViz(BaseViz):
                 columns=list(df.columns),
             ))
 
-        # Reformat dates and datetime groupbys 
+        # Reformat dates and datetime groupbys
         if fd.get('groupby'):
             time_cols = [
                 self.datasource.get_col(col).column_name


### PR DESCRIPTION
This is to address the issue with datetime objects being converted to UNIX time stamps when being serialized. This occurs when the temporal column is used as the group by key. 

This is discussed [here](https://github.com/apache/incubator-superset/issues/4931) and [here](https://github.com/apache/incubator-superset/issues/5312).