### PR TITLE
Set ignore NaN as true for TableViz

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -578,7 +578,10 @@ class TableViz(BaseViz):
     def json_dumps(self, obj, sort_keys=False):
         if self.form_data.get('all_columns'):
             return json.dumps(
-                obj, default=utils.json_iso_dttm_ser, sort_keys=sort_keys, ignore_nan=True)
+                obj,
+                default=utils.json_iso_dttm_ser,
+                sort_keys=sort_keys,
+                ignore_nan=True)
         else:
             return super(TableViz, self).json_dumps(obj)
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -578,7 +578,7 @@ class TableViz(BaseViz):
     def json_dumps(self, obj, sort_keys=False):
         if self.form_data.get('all_columns'):
             return json.dumps(
-                obj, default=utils.json_iso_dttm_ser, sort_keys=sort_keys)
+                obj, default=utils.json_iso_dttm_ser, sort_keys=sort_keys, ignore_nan=True)
         else:
             return super(TableViz, self).json_dumps(obj)
 


### PR DESCRIPTION
Fixing bug for `lyft/geoviz` where we get a  `NaN` in a json. Adding this param to `json.dumps` makes sure that value is converted to `null`

@mistercrunch 