### PR TITLE
allow selection of dbs where csv can be uploaded to

### DIFF
--- a/superset/forms.py
+++ b/superset/forms.py
@@ -49,8 +49,10 @@ def filter_not_empty_values(value):
 
 class CsvToDatabaseForm(DynamicForm):
     # pylint: disable=E0211
-    def all_db_items():
-        return db.session.query(models.Database)
+    def csv_enabled_dbs():
+        return db.session.query(
+            models.Database).filter_by(
+                allow_csv_upload=True).all()
 
     name = StringField(
         _('Table Name'),
@@ -64,7 +66,7 @@ class CsvToDatabaseForm(DynamicForm):
             FileRequired(), FileAllowed(['csv'], _('CSV Files Only!'))])
     con = QuerySelectField(
         _('Database'),
-        query_factory=all_db_items,
+        query_factory=csv_enabled_dbs,
         get_pk=lambda a: a.id, get_label=lambda a: a.database_name)
     sep = StringField(
         _('Delimiter'),

--- a/superset/migrations/versions/1d9e835a84f9_.py
+++ b/superset/migrations/versions/1d9e835a84f9_.py
@@ -1,0 +1,29 @@
+"""empty message
+
+Revision ID: 1d9e835a84f9
+Revises: 3dda56f1c4c6
+Create Date: 2018-07-16 18:04:07.764659
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1d9e835a84f9'
+down_revision = '3dda56f1c4c6'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import expression
+
+
+def upgrade():
+    op.add_column(
+    	'dbs',
+    	sa.Column(
+    		'allow_csv_upload',
+    		sa.Boolean(),
+    		nullable=False,
+    		server_default=expression.true()))
+
+def downgrade():
+    op.drop_column('dbs', 'allow_csv_upload')
+ 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -619,6 +619,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     expose_in_sqllab = Column(Boolean, default=False)
     allow_run_sync = Column(Boolean, default=True)
     allow_run_async = Column(Boolean, default=False)
+    allow_csv_upload = Column(Boolean, default=True)
     allow_ctas = Column(Boolean, default=False)
     allow_dml = Column(Boolean, default=False)
     force_ctas_schema = Column(String(250))
@@ -634,7 +635,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     impersonate_user = Column(Boolean, default=False)
     export_fields = ('database_name', 'sqlalchemy_uri', 'cache_timeout',
                      'expose_in_sqllab', 'allow_run_sync', 'allow_run_async',
-                     'allow_ctas', 'extra')
+                     'allow_ctas', 'allow_csv_upload', 'extra')
     export_children = ['tables']
 
     def __repr__(self):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -193,14 +193,14 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
 
     list_columns = [
         'database_name', 'backend', 'allow_run_sync', 'allow_run_async',
-        'allow_dml', 'creator', 'modified']
+        'allow_dml', 'allow_csv_upload', 'creator', 'modified']
     order_columns = [
         'database_name', 'allow_run_sync', 'allow_run_async', 'allow_dml',
-        'modified',
+        'modified', 'allow_csv_upload',
     ]
     add_columns = [
         'database_name', 'sqlalchemy_uri', 'cache_timeout', 'extra',
-        'expose_in_sqllab', 'allow_run_sync', 'allow_run_async',
+        'expose_in_sqllab', 'allow_run_sync', 'allow_run_async', 'allow_csv_upload',
         'allow_ctas', 'allow_dml', 'force_ctas_schema', 'impersonate_user',
         'allow_multi_schema_metadata_fetch',
     ]
@@ -326,7 +326,7 @@ class DatabaseAsync(DatabaseView):
         'id', 'database_name',
         'expose_in_sqllab', 'allow_ctas', 'force_ctas_schema',
         'allow_run_async', 'allow_run_sync', 'allow_dml',
-        'allow_multi_schema_metadata_fetch',
+        'allow_multi_schema_metadata_fetch', 'allow_csv_upload',
     ]
 
 


### PR DESCRIPTION
Right now, all databases are listed when the user tries to upload to CSV. 
This PR allows the administrator select which databases people can upload CSV to. I set it to True by default so there is no breakage upon deploy. 

@john-bodley @mistercrunch 