### PR TITLE
remove redundant default from control to fix build

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -208,7 +208,6 @@ export const controls = {
     multi: true,
     default: [],
     label: t('Percentage Metrics'),
-    default: [],
     validators: [],
     description: t('Metrics for which percentage of total are to be displayed'),
   },


### PR DESCRIPTION
This PR fixes the js error that's currently breaking the CI build. 
It removes the redundant default field from controls. 

@michellethomas @graceguo-supercat 