### PR TITLE
[sqllab] remove limiting at the display level

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -226,7 +226,8 @@ def execute_sql(
     if store_results:
         key = '{}'.format(uuid.uuid4())
         logging.info('Storing results in results backend, key: {}'.format(key))
-        json_payload = json.dumps(payload, default=utils.json_iso_dttm_ser)
+        json_payload = json.dumps(
+            payload, default=utils.json_iso_dttm_ser, ignore_nan=True)
         cache_timeout = database.cache_timeout
         if cache_timeout is None:
             cache_timeout = config.get('CACHE_DEFAULT_TIMEOUT', 0)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2481,14 +2481,7 @@ class Superset(BaseSupersetView):
             return json_error_response(get_datasource_access_error_msg(
                 '{}'.format(rejected_tables)))
 
-        payload = utils.zlib_decompress_to_string(blob)
-        display_limit = app.config.get('SQL_MAX_ROW', None)
-        if display_limit:
-            payload_json = json.loads(payload)
-            payload_json['data'] = payload_json['data'][:display_limit]
-        return json_success(
-            json.dumps(
-                payload_json, default=utils.json_iso_dttm_ser, ignore_nan=True))
+        return json_success(utils.zlib_decompress_to_string(blob))
 
     @has_access_api
     @expose('/stop_query/', methods=['POST'])


### PR DESCRIPTION
Especially as we now enforce the limit into the query(https://github.com/apache/incubator-superset/pull/5295), there is no longer a need to reduce the payload before sending to the frontend. This PR removes that logic. 

This should also improve performance as we no longer need to json.loads and dumps the data in the middle. 
@john-bodley @mistercrunch 