### PR TITLE
Avoid expensive select_star on dashboard bootstrap data

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -371,7 +371,10 @@ class SqlaTable(Model, BaseDatasource):
 
     @property
     def select_star(self):
-        return self.database.select_star(self.name, show_cols=True)
+        # show_cols and latest_partition set to false to avoid
+        # the expensive cost of inspecting the DB
+        return self.database.select_star(
+            self.name, show_cols=False, latest_partition=False)
 
     def get_col(self, col_name):
         columns = self.columns

--- a/superset/data/__init__.py
+++ b/superset/data/__init__.py
@@ -17,7 +17,7 @@ from sqlalchemy import BigInteger, Date, DateTime, Float, String, Text
 import geohash
 import polyline
 
-from superset import app, db, security_manager, utils
+from superset import app, db, utils
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.models import TableColumn
 from superset.models import core as models

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -775,7 +775,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
     def select_star(
             self, table_name, schema=None, limit=100, show_cols=False,
-            indent=True, latest_partition=True, cols=None):
+            indent=True, latest_partition=False, cols=None):
         """Generates a ``select *`` statement in the proper dialect"""
         eng = self.get_sqla_engine(schema=schema)
         return self.db_engine_spec.select_star(


### PR DESCRIPTION
The dashboard page bootstrap data currently attempts to generate the
`SELECT` statement with column name details for each table represented
in the dash. This means it calls the database(s) and waits for column
details prior to returning any HTML.

This makes the default select_star property generate a simple
`SELECT *` with no column details instead, which doesn't require
interogating the DBs.

@betodealmeida 