### PR TITLE
Add row_limit control to line chart

### DIFF
--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -58,6 +58,7 @@ export const sections = {
         ['groupby'],
         ['limit', 'timeseries_limit_metric'],
         ['order_desc', 'contribution'],
+        ['row_limit', null],
       ],
     },
     {


### PR DESCRIPTION
Somehow it's not possible to set the row_limit for a line chart,
resulting to a 10k cap in our environment. In some cases the user may
want more than that.

@betodealmeida @hughhhh 