### PR TITLE
[security] add datasource sources

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -157,6 +157,10 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
         pass
 
     @property
+    def datasource_sources(self):
+        pass
+
+    @property
     def data(self):
         """Data representation of the datasource sent to the frontend"""
         order_by_choices = []

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -526,6 +526,10 @@ class DruidDatasource(Model, BaseDatasource):
         return Markup('<a href="{self.url}">{name}</a>').format(**locals())
 
     @property
+    def datasource_sources(self):
+        return '{}.{}'.format(self.cluster_name, self.datasource_name)
+
+    @property
     def full_name(self):
         return utils.get_datasource_full_name(
             self.cluster_name, self.datasource_name)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -23,7 +23,7 @@ from sqlalchemy.sql import column, literal_column, table, text
 from sqlalchemy.sql.expression import TextAsFrom
 import sqlparse
 
-from superset import db, import_util, security_manager, utils
+from superset import db, import_util, security_manager, sql_parse, utils
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
 from superset.jinja_context import get_template_processor
 from superset.models.annotations import Annotation
@@ -323,6 +323,10 @@ class SqlaTable(Model, BaseDatasource):
         if not self.schema:
             return self.table_name
         return '{}.{}'.format(self.schema, self.table_name)
+
+    @property
+    def datasource_sources(self):
+        return sql_parse.SupersetQuery(self.sql).tables
 
     @property
     def full_name(self):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1093,8 +1093,10 @@ class Superset(BaseSupersetView):
                 stacktrace=traceback.format_exc())
 
         if not security_manager.datasource_access(viz_obj.datasource, g.user):
+            print("this is where the good error message happens")
+            ERR_MSG = 'You don\'t have access to the following tables \n' + ', \n'.join([i[0] for i in security_manager.get_gandalf_denied_tables(g.user, viz_obj.datasource)])
             return json_error_response(
-                DATASOURCE_ACCESS_ERR, status=404, link=config.get(
+                ERR_MSG, status=404, link=config.get(
                     'PERMISSION_INSTRUCTIONS_LINK'))
 
         if csv:
@@ -1262,13 +1264,21 @@ class Superset(BaseSupersetView):
 
         if not security_manager.datasource_access(datasource):
             flash(
-                __(get_datasource_access_error_msg(datasource.name)),
+                __('You do not have access to the following tables: {}'.format(
+                    security_manager.get_gandalf_denied_tables(g.user, datasource))),
                 'danger')
-            return redirect(
-                'superset/request_access/?'
-                'datasource_type={datasource_type}&'
-                'datasource_id={datasource_id}&'
-                ''.format(**locals()))
+            print("~~~~~~!!!~~~~~~~~")
+            if config.get("ENABLE_ACCESS_REQUEST"):
+                #err=json_error_response(
+                #DATASOURCE_ACCESS_ERR, status=404, link=config.get(
+                #    'PERMISSION_INSTRUCTIONS_LINK'))
+                #print(err)
+                #flash(__(err))
+                return redirect(
+                    'superset/request_access/?'
+                    'datasource_type={datasource_type}&'
+                    'datasource_id={datasource_id}&'
+                    ''.format(**locals()))
 
         viz_type = form_data.get('viz_type')
         if not viz_type and datasource.default_endpoint:


### PR DESCRIPTION
This PR provides the concept of a datasource source which is a key abstraction for identifying the tables or druid datasources that a superset datasource derives its data from. This will be useful for people who override the security manager to identify the underlying tables and check if the person trying to access a slice has access to the underlying table. 

@john-bodley 