### PR TITLE
[sqllab] reduce the asynchronous query progress

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -203,7 +203,7 @@ def execute_sql(
     cdf = dataframe.SupersetDataFrame(data, cursor.description, db_engine_spec)
 
     query.rows = cdf.size
-    query.progress = 100
+    query.progress = 95
     query.status = QueryStatus.SUCCESS
     if query.select_as_cta:
         query.select_sql = '{}'.format(


### PR DESCRIPTION
We show 100 percent progress before we write the celery results to the backend. Writing to the backend might take some time and the users get frustrated with this because we claim 100 percent. This PR sets it to 95 percent. 
@john-bodley 