### PR TITLE
fix panada version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
 markdown==2.6.11
-pandas==0.23.1
+pandas==0.22.0
 parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         'humanize',
         'idna',
         'markdown',
-        'pandas>=0.18.0',
+        'pandas>=0.18.0, <=0.22.0',
         'parsedatetime',
         'pathlib2',
         'polyline',


### PR DESCRIPTION
when create a charts , the charts sql include three column for "group by"
it is the error:
```
2018-07-19 18:51:18,950:ERROR:root:u'the label [\u5176\u4ed6] is not in the [index]'
Traceback (most recent call last):
  File "/data/superset/venv/lib/python2.7/site-packages/superset/views/core.py", line 1107, in generate_json
    payload = viz_obj.get_payload()
  File "/data/superset/venv/lib/python2.7/site-packages/superset/viz.py", line 329, in get_payload
    payload['data'] = self.get_data(df)
  File "/data/superset/venv/lib/python2.7/site-packages/superset/viz.py", line 722, in get_data
    for metric in df.columns]
  File "/data/superset/venv/lib/python2.7/site-packages/superset/viz.py", line 716, in _nest
    for l in df.index.levels[0]]
  File "/data/superset/venv/lib/python2.7/site-packages/superset/viz.py", line 716, in _nest
    for l in df.index.levels[0]]
  File "/data/superset/venv/lib/python2.7/site-packages/pandas/core/indexing.py", line 1478, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
  File "/data/superset/venv/lib/python2.7/site-packages/pandas/core/indexing.py", line 1911, in _getitem_axis
    self._validate_key(key, axis)
  File "/data/superset/venv/lib/python2.7/site-packages/pandas/core/indexing.py", line 1798, in _validate_key
    error()
  File "/data/superset/venv/lib/python2.7/site-packages/pandas/core/indexing.py", line 1785, in error
    axis=self.obj._get_axis_name(axis)))
KeyError: u'the label [\u5176\u4ed6] is not in the [index]'
```
because the pandas version is "0.23.x"
so it need update pandas version to "0.22.0".

