### PR TITLE
Time filter fixes

### DIFF
--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -38,6 +38,7 @@ const COMMON_TIME_FRAMES = [
   'Last month',
   'Last quarter',
   'Last year',
+  'No filter',
 ];
 const TIME_GRAIN_OPTIONS = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'];
 

--- a/superset/data/__init__.py
+++ b/superset/data/__init__.py
@@ -197,6 +197,7 @@ def load_world_bank_health_n_pop():
         "row_limit": config.get("ROW_LIMIT"),
         "since": "2014-01-01",
         "until": "2014-01-02",
+        "time_range": "2014-01-01 : 2014-01-02",
         "where": "",
         "markup_type": "markdown",
         "country_fieldtype": "cca3",

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -861,10 +861,12 @@ def get_since_until(form_data):
 
     Additionally, for `time_range` (these specify both `since` and `until`):
 
-        - Yesterday
+        - Last day
         - Last week
         - Last month
+        - Last quarter
         - Last year
+        - No filter
         - Last X seconds/minutes/hours/days/weeks/months/years
         - Next X seconds/minutes/hours/days/weeks/months/years
 
@@ -872,9 +874,10 @@ def get_since_until(form_data):
     separator = ' : '
     today = parse_human_datetime('today')
     common_time_frames = {
-        'Yesterday': (today - relativedelta(days=1), today),
+        'Last day': (today - relativedelta(days=1), today),
         'Last week': (today - relativedelta(weeks=1), today),
         'Last month': (today - relativedelta(months=1), today),
+        'Last quarter': (today - relativedelta(months=3), today),
         'Last year': (today - relativedelta(years=1), today),
     }
 
@@ -886,6 +889,8 @@ def get_since_until(form_data):
             until = parse_human_datetime(until)
         elif time_range in common_time_frames:
             since, until = common_time_frames[time_range]
+        elif time_range == 'No filter':
+            since = until = None
         else:
             rel, num, grain = time_range.split()
             if rel == 'Last':


### PR DESCRIPTION
A PR with small fixes for the new time filter:

- World's Bank Data now initializes correctly.
- Added a new option "No filter" (see screenshot).
- Added "Last quarter" to list of default time ranges.
- Updated backend to handle "Last day" and "Last quarter".

<img width="426" alt="screen shot 2018-07-20 at 1 21 05 pm" src="https://user-images.githubusercontent.com/1534870/43023454-cd188cfc-8c1f-11e8-8797-b9dc162a16be.png">
