### PR TITLE
[schema] Updating the datasources schema

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -21,11 +21,17 @@ under the License.
 This file documents any backwards-incompatible changes in Superset and
 assists people when migrating to a new version.
 
+## Superset 0.34.0
+
+* [5451](https://github.com/apache/incubator-superset/pull/5451): a change
+which adds missing non-nullable fields to the `datasources` table. Depending on
+the integrity of the data, manual intervention may be required.
+
 ## Superset 0.32.0
 
 * `npm run backend-sync` is deprecated and no longer needed, will fail if called
-* [5445](https://github.com/apache/incubator-superset/pull/5445) : a change 
-which prevents encoding of empty string from form data in the datanbase. 
+* [5445](https://github.com/apache/incubator-superset/pull/5445): a change
+which prevents encoding of empty string from form data in the database.
 This involves a non-schema changing migration which does potentially impact
 a large number of records. Scheduled downtime may be advised.
 

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -417,7 +417,7 @@ class DruidDatasource(Model, BaseDatasource):
     baselink = 'druiddatasourcemodelview'
 
     # Columns
-    datasource_name = Column(String(255))
+    datasource_name = Column(String(255), nullable=False)
     is_hidden = Column(Boolean, default=False)
     filter_select_enabled = Column(Boolean, default=True)  # override default
     fetch_values_from = Column(String(100))
@@ -427,7 +427,6 @@ class DruidDatasource(Model, BaseDatasource):
         'DruidCluster', backref='datasources', foreign_keys=[cluster_name])
     owners = relationship(owner_class, secondary=druiddatasource_user,
                           backref='druiddatasources')
-    UniqueConstraint('cluster_name', 'datasource_name')
 
     export_fields = (
         'datasource_name', 'is_hidden', 'description', 'default_endpoint',

--- a/superset/migrations/versions/937d04c16b64_update_datasources.py
+++ b/superset/migrations/versions/937d04c16b64_update_datasources.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""update datasources
+
+Revision ID: 937d04c16b64
+Revises: d94d33dbe938
+Create Date: 2018-07-20 16:08:10.195843
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '937d04c16b64'
+down_revision = 'd94d33dbe938'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+
+    # Enforce that the datasource_name column be non-nullable.
+    with op.batch_alter_table('datasources') as batch_op:
+        batch_op.alter_column(
+            'datasource_name',
+            nullable=False,
+            type_=sa.String(255),
+        )
+
+
+def downgrade():
+
+    # Forego that the datasource_name column be non-nullable.
+    with op.batch_alter_table('datasources') as batch_op:
+        batch_op.alter_column(
+            'datasource_name',
+            nullable=True,
+            type_=sa.String(255),
+        )


### PR DESCRIPTION
We've noticed a number of anomalies in our database caused by ill-defined forms and/or table schema definitions. This PR ensures that the `datasources.datasource_name` column is non-NULL. 

Note this migration _will_ fail if the `datasource_name` column is NULL. One *must* manually fix these records as programmatically trying to remedy these invalid records is difficult as the intent is unclear and the tables may function (from a query standpoint) if SQL is provided. The following query determines which records are problematic:
```
SELECT 
    *
FROM 
   datasources
WHERE 
   datasource_name IS NULL
```

Note this PR is gated by https://github.com/apache/incubator-superset/pull/5445 and https://github.com/apache/incubator-superset/pull/7084 which ensure that empty strings associated with form-data wont persist in the database and is necessary for ensuring that the relevant entries are non-NULL.

to: @fabianmenges @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 