### PR TITLE
Clarify title when importing a table

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -156,7 +156,7 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
 
     list_title = _('List Tables')
     show_title = _('Show Table')
-    add_title = _('Add Table')
+    add_title = _('Import a table definition')
     edit_title = _('Edit Table')
 
     list_columns = [


### PR DESCRIPTION
The flow to import a table definition in Superset is confusing, user may
think they are creating a table or what not. This makes the flow a bit
more clear.
<img width="955" alt="screen shot 2018-07-20 at 4 32 22 pm" src="https://user-images.githubusercontent.com/487433/43029341-84a83100-8c3a-11e8-9b9e-558873365a99.png">
