### PR TITLE
Fix broken dedup and remove redundant db_spec logic

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -70,12 +70,11 @@ class SupersetDataFrame(object):
         if cursor_description:
             column_names = [col[0] for col in cursor_description]
 
-        self.column_names = dedup(
-            db_engine_spec.get_normalized_column_names(cursor_description))
+        self.column_names = dedup(column_names)
 
         data = data or []
         self.df = (
-            pd.DataFrame(list(data), columns=column_names).infer_objects())
+            pd.DataFrame(list(data), columns=self.column_names).infer_objects())
 
         self._type_dict = {}
         try:

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -321,15 +321,6 @@ class BaseEngineSpec(object):
         """
         return {}
 
-    @classmethod
-    def get_normalized_column_names(cls, cursor_description):
-        columns = cursor_description if cursor_description else []
-        return [cls.normalize_column_name(col[0]) for col in columns]
-
-    @staticmethod
-    def normalize_column_name(column_name):
-        return column_name
-
     @staticmethod
     def execute(cursor, query, async=False):
         cursor.execute(query)
@@ -402,10 +393,6 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         Grain('year', _('year'), "DATE_TRUNC('YEAR', {col})", 'P1Y'),
     )
 
-    @staticmethod
-    def normalize_column_name(column_name):
-        return column_name.lower()
-
 
 class VerticaEngineSpec(PostgresBaseEngineSpec):
     engine = 'vertica'
@@ -413,10 +400,6 @@ class VerticaEngineSpec(PostgresBaseEngineSpec):
 
 class RedshiftEngineSpec(PostgresBaseEngineSpec):
     engine = 'redshift'
-
-    @staticmethod
-    def normalize_column_name(column_name):
-        return column_name.lower()
 
 
 class OracleEngineSpec(PostgresBaseEngineSpec):
@@ -439,10 +422,6 @@ class OracleEngineSpec(PostgresBaseEngineSpec):
         return (
             """TO_TIMESTAMP('{}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""
         ).format(dttm.isoformat())
-
-    @staticmethod
-    def normalize_column_name(column_name):
-        return column_name.lower()
 
 
 class Db2EngineSpec(BaseEngineSpec):

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -113,3 +113,15 @@ class SupersetDataFrameTestCase(SupersetTestCase):
                 },
             ],
         )
+
+    def test_dedup_with_data(self):
+        data = [
+            ('a', 1),
+            ('a', 2),
+        ]
+        cursor_descr = (
+            ('a', 'string'),
+            ('a', 'string'),
+        )
+        cdf = SupersetDataFrame(data, cursor_descr, BaseEngineSpec)
+        self.assertListEqual(cdf.column_names, ['a', 'a__1'])


### PR DESCRIPTION
Fixes regression introduced by PR #4724 that broke column name deduplication. Also remove column name lowercasing logic from db_engine_spec that was made redundant by PR #5178.