### PR TITLE
SQL Lab can now query tables with spaces in the name

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -843,10 +843,12 @@ class SqlaTable(Model, BaseDatasource):
     @classmethod
     def query_datasources_by_name(
             cls, session, database, datasource_name, schema=None):
+        unquote = db.engine.dialect.identifier_preparer.unformat_identifiers
+        unformatted_ds = unquote(datasource_name)[0]
         query = (
             session.query(cls)
             .filter_by(database_id=database.id)
-            .filter_by(table_name=datasource_name)
+            .filter_by(table_name=unformatted_ds)
         )
         if schema:
             query = query.filter_by(schema=schema)


### PR DESCRIPTION
The datasources names in the DB are not quoted, and the user can't surround the datasource name with quotes from the UI (receives a 'table not found' error). This fix will simply strip off the dialect-specific formatting before looking up the datasource for permissions things and other things.

*EDIT*:
To clarify, I was receiving a 500 error when submitting a query to the `sql_json` endpoint:
https://github.com/apache/incubator-superset/blob/bea0a0aa1590d073365ecf74d75a054643dbe3b7/superset/views/core.py#L2521-L2524

Which was comparing the table names in the submitted query to a list of tables the user has access to:
https://github.com/apache/incubator-superset/blob/bea0a0aa1590d073365ecf74d75a054643dbe3b7/superset/security.py#L150-L154

The datasource access list is eventually conjured from the security manager's `datasource_access_by_name` function, using the `ConnectorRegistry`:
https://github.com/apache/incubator-superset/blob/bea0a0aa1590d073365ecf74d75a054643dbe3b7/superset/security.py#L131-L136

At this point, the table name is being passed to the `ConnectorRegistry.query_datasources_by_name` function with the quotes on it, because of the changes made in https://github.com/apache/incubator-superset/pull/5195. This is where the point of failure is, since the quoted table name has no matches and the tables my user has authorization to view are not returned.

This issue is only reproducible if the user has datasource-only access. As soon as I give the user database  access, querying works since the `datasource_access_by_name` function short-circuits.