### PR TITLE
Match viz dataframe column case to form_data fields for Snowflake, Oracle and Redshift

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -41,12 +41,12 @@ def dedup(l, suffix='__', case_sensitive=True):
     new_l = []
     seen = {}
     for s in l:
-        s2 = s if case_sensitive else s.lower()
-        if s2 in seen:
-            seen[s2] += 1
-            s += suffix + str(seen[s2])
+        s_fixed_case = s if case_sensitive else s.lower()
+        if s_fixed_case in seen:
+            seen[s_fixed_case] += 1
+            s += suffix + str(seen[s_fixed_case])
         else:
-            seen[s2] = 0
+            seen[s_fixed_case] = 0
         new_l.append(s)
     return new_l
 

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -73,7 +73,8 @@ class SupersetDataFrame(object):
         if cursor_description:
             column_names = [col[0] for col in cursor_description]
 
-        self.column_names = dedup(column_names, case_sensitive=False)
+        dedup_case_sensitive = db_engine_spec.dedup_case_sensitive
+        self.column_names = dedup(column_names, case_sensitive=dedup_case_sensitive)
 
         data = data or []
         self.df = (

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -73,8 +73,8 @@ class SupersetDataFrame(object):
         if cursor_description:
             column_names = [col[0] for col in cursor_description]
 
-        dedup_case_sensitive = db_engine_spec.dedup_case_sensitive
-        self.column_names = dedup(column_names, case_sensitive=dedup_case_sensitive)
+        self.column_names = dedup(column_names,
+                                  case_sensitive=db_engine_spec.case_sensitive_cols)
 
         data = data or []
         self.df = (

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -46,7 +46,7 @@ def dedup(l, suffix='__', case_sensitive=True):
             seen[s2] += 1
             s += suffix + str(seen[s2])
         else:
-            seen[s] = 0
+            seen[s2] = 0
         new_l.append(s)
     return new_l
 

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -73,8 +73,9 @@ class SupersetDataFrame(object):
         if cursor_description:
             column_names = [col[0] for col in cursor_description]
 
+        case_sensitive = db_engine_spec.consistent_case_sensitivity
         self.column_names = dedup(column_names,
-                                  case_sensitive=db_engine_spec.case_sensitive_cols)
+                                  case_sensitive=case_sensitive)
 
         data = data or []
         self.df = (

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -27,21 +27,24 @@ INFER_COL_TYPES_THRESHOLD = 95
 INFER_COL_TYPES_SAMPLE_SIZE = 100
 
 
-def dedup(l, suffix='__'):
+def dedup(l, suffix='__', case_sensitive=True):
     """De-duplicates a list of string by suffixing a counter
 
     Always returns the same number of entries as provided, and always returns
-    unique values.
+    unique values. Case sensitive comparison by default.
 
-    >>> print(','.join(dedup(['foo', 'bar', 'bar', 'bar'])))
-    foo,bar,bar__1,bar__2
+    >>> print(','.join(dedup(['foo', 'bar', 'bar', 'bar', 'Bar'])))
+    foo,bar,bar__1,bar__2,Bar
+    >>> print(','.join(dedup(['foo', 'bar', 'bar', 'bar', 'Bar'], case_sensitive=False)))
+    foo,bar,bar__1,bar__2,Bar__3
     """
     new_l = []
     seen = {}
     for s in l:
-        if s in seen:
-            seen[s] += 1
-            s += suffix + str(seen[s])
+        s2 = s if case_sensitive else s.lower()
+        if s2 in seen:
+            seen[s2] += 1
+            s += suffix + str(seen[s2])
         else:
             seen[s] = 0
         new_l.append(s)
@@ -70,7 +73,7 @@ class SupersetDataFrame(object):
         if cursor_description:
             column_names = [col[0] for col in cursor_description]
 
-        self.column_names = dedup(column_names)
+        self.column_names = dedup(column_names, case_sensitive=False)
 
         data = data or []
         self.df = (

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -372,18 +372,15 @@ class BaseEngineSpec(object):
 
         Usually sqla engines return column names whose case matches that of the
         original query. For example:
-
             SELECT 1 as col1, 2 as COL2, 3 as Col_3
-
         will usually result in the following df.columns:
-
             ['col1', 'COL2', 'Col_3'].
-
-        For these engines there is no need to adjust the dataframe column names.
-        However, some engines (at least Snowflake, Oracle and Redshift) return column
-        names with different case than in the original query, usually all uppercase.
-        For these the column names need to be adjusted to correspond to the case of
-        the fields specified in the form data. This adjustment can be done here.
+        For these engines there is no need to adjust the dataframe column names
+        (default behavior). However, some engines (at least Snowflake, Oracle and
+        Redshift) return column names with different case than in the original query,
+        usually all uppercase. For these the column names need to be adjusted to
+        correspond to the case of the fields specified in the form data for Viz
+        to work properly. This adjustment can be done here.
         """
         return df
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -319,7 +319,6 @@ class BaseEngineSpec(object):
 
         if show_cols:
             fields = [sqla.column(c.get('name')) for c in cols]
-        full_table_name = table_name
         quote = engine.dialect.identifier_preparer.quote
         if schema:
             full_table_name = quote(schema) + '.' + quote(table_name)

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -509,6 +509,7 @@ class RedshiftEngineSpec(PostgresBaseEngineSpec):
     engine = 'redshift'
     case_sensitive_cols = False
 
+
 class OracleEngineSpec(PostgresBaseEngineSpec):
     engine = 'oracle'
     limit_method = LimitMethod.WRAP_SQL

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -101,7 +101,7 @@ class BaseEngineSpec(object):
     time_secondary_columns = False
     inner_joins = True
     allows_subquery = True
-    consistent_case_sensitivity = True # do query results have same case for column names?
+    consistent_case_sensitivity = True  # do results have same case as qry for col names?
 
     @classmethod
     def get_time_grains(cls):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -101,7 +101,7 @@ class BaseEngineSpec(object):
     time_secondary_columns = False
     inner_joins = True
     allows_subquery = True
-    case_sensitive_cols = True
+    consistent_case_sensitivity = True # do query results have same case for column names?
 
     @classmethod
     def get_time_grains(cls):
@@ -382,7 +382,7 @@ class BaseEngineSpec(object):
         correspond to the case of the fields specified in the form data for Viz
         to work properly. This adjustment can be done here.
         """
-        if cls.case_sensitive_cols:
+        if cls.consistent_case_sensitivity:
             return df
         else:
             return cls.align_df_col_names_with_form_data(df, fd, other_cols)
@@ -470,7 +470,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
 
 class SnowflakeEngineSpec(PostgresBaseEngineSpec):
     engine = 'snowflake'
-    case_sensitive_cols = False
+    consistent_case_sensitivity = False
     time_grain_functions = {
         None: '{col}',
         'PT1S': "DATE_TRUNC('SECOND', {col})",
@@ -507,13 +507,13 @@ class VerticaEngineSpec(PostgresBaseEngineSpec):
 
 class RedshiftEngineSpec(PostgresBaseEngineSpec):
     engine = 'redshift'
-    case_sensitive_cols = False
+    consistent_case_sensitivity = False
 
 
 class OracleEngineSpec(PostgresBaseEngineSpec):
     engine = 'oracle'
     limit_method = LimitMethod.WRAP_SQL
-    case_sensitive_cols = False
+    consistent_case_sensitivity = False
 
     time_grain_functions = {
         None: '{col}',

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from collections import defaultdict, namedtuple
-from superset import utils
 import inspect
 import logging
 import os

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -181,7 +181,7 @@ class BaseViz(object):
 
     def handle_nulls(self, df):
         fillna = self.get_fillna_for_columns(df.columns)
-        df = df.fillna(fillna)
+        return df.fillna(fillna)
 
     def get_fillna_for_col(self, col):
         """Returns the value to use as filler for a specific Column.type"""
@@ -245,7 +245,7 @@ class BaseViz(object):
                 self.df_metrics_to_num(df, query_obj.get('metrics') or [])
 
             df.replace([np.inf, -np.inf], np.nan)
-            self.handle_nulls(df)
+            df = self.handle_nulls(df)
 
         return df
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -218,7 +218,6 @@ class BaseViz(object):
 
             df.replace([np.inf, -np.inf], np.nan)
             df = self.handle_nulls(df)
-
         return df
 
     @staticmethod

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -382,9 +382,10 @@ class BaseViz(object):
         if query_obj and not is_loaded:
             try:
                 df = self.get_df(query_obj)
-                db_engine_spec = self.datasource.database.db_engine_spec
-                df = db_engine_spec.adjust_df_column_names(df, self.form_data,
-                                                           [DTTM_ALIAS])
+                if hasattr(self.datasource.database, 'db_engine_spec'):
+                    db_engine_spec = self.datasource.database.db_engine_spec
+                    df = db_engine_spec.adjust_df_column_names(df, self.form_data,
+                                                               [DTTM_ALIAS])
                 if self.status != utils.QueryStatus.FAILED:
                     stats_logger.incr('loaded_from_source')
                     is_loaded = True

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -382,7 +382,9 @@ class BaseViz(object):
         if query_obj and not is_loaded:
             try:
                 df = self.get_df(query_obj)
-                df = self.fix_df_column_case(df)
+                db_engine_spec = self.datasource.database.db_engine_spec
+                df = db_engine_spec.adjust_df_column_names(df, self.form_data,
+                                                           [DTTM_ALIAS])
                 if self.status != utils.QueryStatus.FAILED:
                     stats_logger.incr('loaded_from_source')
                     is_loaded = True

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -470,36 +470,6 @@ class BaseViz(object):
     def json_data(self):
         return json.dumps(self.data)
 
-    def fix_df_column_case(self, df):
-        """Helper function to rename columns that have changed case during query.
-        This usually happens when a sqla engine does Oracle-like uppercasing of
-        lowercase column names."""
-
-        form_fields = ['metrics', 'groupby']
-        other_cols = [DTTM_ALIAS]
-
-        columns = set()
-        lowercase_mapping = {}
-
-        for field in form_fields:
-            for col in self.form_data.get(field, []):
-                col_str = str(col)
-                columns.add(col_str)
-                lowercase_mapping[col_str.lower()] = col_str
-
-        for col in other_cols:
-            columns.add(col)
-            lowercase_mapping[col.lower()] = col
-
-        rename_cols = {}
-        for col in df.columns:
-            if col not in columns:
-                orig_col = lowercase_mapping.get(col.lower())
-                if orig_col:
-                    rename_cols[col] = orig_col
-
-        return df.rename(index=str, columns=rename_cols)
-
 
 class TableViz(BaseViz):
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -384,8 +384,7 @@ class BaseViz(object):
                 df = self.get_df(query_obj)
                 if hasattr(self.datasource.database, 'db_engine_spec'):
                     db_engine_spec = self.datasource.database.db_engine_spec
-                    df = db_engine_spec.adjust_df_column_names(df, self.form_data,
-                                                               [DTTM_ALIAS])
+                    df = db_engine_spec.adjust_df_column_names(df, self.form_data)
                 if self.status != utils.QueryStatus.FAILED:
                     stats_logger.incr('loaded_from_source')
                     is_loaded = True

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -16,12 +16,16 @@ class SupersetDataFrameTestCase(SupersetTestCase):
             ['foo', 'bar'],
         )
         self.assertEquals(
-            dedup(['foo', 'bar', 'foo', 'bar']),
-            ['foo', 'bar', 'foo__1', 'bar__1'],
+            dedup(['foo', 'bar', 'foo', 'bar', 'Foo']),
+            ['foo', 'bar', 'foo__1', 'bar__1', 'Foo'],
         )
         self.assertEquals(
-            dedup(['foo', 'bar', 'bar', 'bar']),
-            ['foo', 'bar', 'bar__1', 'bar__2'],
+            dedup(['foo', 'bar', 'bar', 'bar', 'Bar']),
+            ['foo', 'bar', 'bar__1', 'bar__2', 'Bar'],
+        )
+        self.assertEquals(
+            dedup(['foo', 'bar', 'bar', 'bar', 'Bar'], case_sensitive=False),
+            ['foo', 'bar', 'bar__1', 'bar__2', 'Bar__3'],
         )
 
     def test_get_columns_basic(self):


### PR DESCRIPTION
This might be slightly hacky, but I feel SQL Alchemy gives so much latitude to engines that Superset might need to be slightly more forgiving if a query result has different case compared to the datasource/form metadata. A brief summary of what this PR does:

Adjust dataframe column case, by performing _case-sensitive_ comparison of all colums in central fields in form_data (metrics, groupby) with column names in dataframe:
- Leave all matches untouched.
- Replace all dataframe columns with whichever _case-insensitive_ variant is present in form_data.

Examples:
- form_data: `__timestamp`, dataframe: `__timestamp` -> Do nothing.
- form_data: `__timestamp`, dataframe: `__TIMESTAMP` -> Rename dataframe column name to `__timestamp`.
- form_data: `__timeSTAMP`, dataframe: `__TIMESTAMP` -> Rename dataframe column name to `__timeSTAMP`.

The dataframe is adjusted prior to caching in `BaseViz.get_df_payload()`, with the logic for adjustments located in `db_engine_specs`, which is controlled by the `consistent_case_sensitivity` attribute. To minimize risk of collisions, dedup has been changed to be able to perform deduping both in a case-sensitive and case-insensitive manner. Default handling would now be case-sensitive, as before, but for affected engines (Snowflake, Oracle, Redshift) handling will be case-insensitive. Example from test case (note the last Bar which is seen as a duplicate despite different case):

```
>>> print(','.join(dedup(['foo', 'bar', 'bar', 'bar', 'Bar'], case_sensitive=False)))
foo,bar,bar__1,bar__2,Bar__3
```

Other changes:
- Add schema URI insertion for Snowflake db_engine_spec
- Fix what seemed to be a small bug in how `handle_nulls()` was implemented
 - Remove a redundant `full_table_name` row in db_engine_spec

Feel free to try it out, and don't feel shy to give feedback/critique. Like stated above, this might be borderline hacky, but seems to work fairly well, and might make it easier to add new engines later on. This fix should also be backwards compatible (except for the handle_nulls()-part, which was recently added), at least `0.26` and `0.25`.