### PR TITLE
[sqllab] fix unexpected keyword argument 'ignore_nan'

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -3,13 +3,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import datetime
-import json
 import logging
 from time import sleep
 import uuid
 
 from celery.exceptions import SoftTimeLimitExceeded
 from contextlib2 import contextmanager
+import simplejson as json
 import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool


### PR DESCRIPTION
fixes issue introduced by https://github.com/apache/incubator-superset/pull/5413
@john-bodley @timifasubaa 