### PR TITLE
[sql lab] fix Hive 'Transport' not open issue

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -191,7 +191,7 @@ def execute_sql(
         return handle_error(db_engine_spec.extract_error_message(e))
 
     logging.info('Fetching cursor description')
-
+    cursor_description = cursor.description
     if conn is not None:
         conn.commit()
         conn.close()
@@ -199,7 +199,7 @@ def execute_sql(
     if query.status == utils.QueryStatus.STOPPED:
         return handle_error('The query has been stopped')
 
-    cdf = dataframe.SupersetDataFrame(data, cursor.description, db_engine_spec)
+    cdf = dataframe.SupersetDataFrame(data, cursor_description, db_engine_spec)
 
     query.rows = cdf.size
     query.progress = 100


### PR DESCRIPTION
Somehow other dbapi drivers are ok with this, but pyhive requires that the connection is still alive when reading from `cursor.description`.