### PR TITLE
[sql lab] extract Hive error messages

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1051,10 +1051,10 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     @classmethod
     def extract_error_message(cls, e):
-        try:
-            msg = e.message.status.errorMessage
-        except Exception:
-            msg = str(e)
+        msg = str(e)
+        match = re.search('errorMessage="(.*)", ', msg)
+        if match:
+            msg = match.group(1)
         return msg
 
     @classmethod


### PR DESCRIPTION
So `pyhive` returns an exception object with a stringified thrift error
object. This PR uses a regex to extract the errorMessage portion of that
string.