### PR TITLE
[NVD3] Set max width for tooltips

### DIFF
--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -89,6 +89,18 @@ function hideTooltips() {
   $('.nvtooltip').css({ opacity: 0 });
 }
 
+function wrapTooltip(chart, container) {
+  const tooltipLayer = chart.useInteractiveGuideline && chart.useInteractiveGuideline() ?
+    chart.interactiveLayer : chart;
+  const tooltipGeneratorFunc = tooltipLayer.tooltip.contentGenerator();
+  tooltipLayer.tooltip.contentGenerator((d) => {
+    let tooltip = `<div style="max-width: ${container.width() * 0.5}px">`;
+    tooltip += tooltipGeneratorFunc(d);
+    tooltip += '</div>';
+    return tooltip;
+  });
+}
+
 function getMaxLabelSize(container, axisClass) {
   // axis class = .nv-y2  // second y axis on dual line chart
   // axis class = .nv-x  // x axis on time series line chart
@@ -844,6 +856,8 @@ export default function nvd3Vis(slice, payload) {
           .call(chart);
       }
     }
+
+    wrapTooltip(chart, slice.container);
     return chart;
   };
 


### PR DESCRIPTION
This sets a width limit on tooltips in visualizations equal to half the width of the slice container such that the tooltip should never overflow unreasonably out of the container.

We've had issues where grouping key values were too long, or too many grouping keys were in the query, which made for wide, unwrapped tooltips.

**Before:**
![screen shot 2018-07-26 at 10 13 53 pm](https://user-images.githubusercontent.com/3317634/43297840-68c4f3b0-9121-11e8-8ed6-6f299ac5e914.png)

**After:**
![screen shot 2018-07-26 at 10 15 13 pm](https://user-images.githubusercontent.com/3317634/43297844-6d3275e4-9121-11e8-9a11-11b400a34d21.png)

With multiple series involved, and interactive guideline:
<img width="953" alt="screen shot 2018-07-26 at 10 19 22 pm" src="https://user-images.githubusercontent.com/3317634/43297975-0a8cf24c-9122-11e8-9b0e-4965895e3ab5.png">

@graceguo-supercat @mistercrunch 