### PR TITLE
hotfix - pass link not error message

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1090,7 +1090,8 @@ class Superset(BaseSupersetView):
             return json_error_response(
                 security_manager.get_datasource_access_error_msg(viz_obj.datasource),
                 status=404,
-                link=security_manager.security_manager.get_datasource_error_link(viz_obj.datasource))
+                link=security_manager.security_manager.get_datasource_error_link(
+                    viz_obj.datasource))
 
         if csv:
             return CsvResponse(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1090,7 +1090,7 @@ class Superset(BaseSupersetView):
             return json_error_response(
                 security_manager.get_datasource_access_error_msg(viz_obj.datasource),
                 status=404,
-                link=security_manager.get_datasource_access_error_msg(viz_obj.datasource))
+                link=security_manager.security_manager.get_datasource_error_link(viz_obj.datasource))
 
         if csv:
             return CsvResponse(


### PR DESCRIPTION
Earlier PR passed the error message as a link instead of the link. This PR corrects that and passes the link. 