### PR TITLE
[get_df] Updating multi-statement logic

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -738,8 +738,12 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
         with closing(engine.raw_connection()) as conn:
             with closing(conn.cursor()) as cursor:
-                for sql in sqls:
+                for sql in sqls[:-1]:
                     self.db_engine_spec.execute(cursor, sql)
+                    cursor.fetchall()
+
+                self.db_engine_spec.execute(cursor, sqls[-1])
+
                 df = pd.DataFrame.from_records(
                     data=list(cursor.fetchall()),
                     columns=[col_desc[0] for col_desc in cursor.description],


### PR DESCRIPTION
This PR fixes an issue we've been running into with multi-statements in Presto which is asynchronous. When using the cursor associated with a raw connection using multiple statements, i.e.,  
```
cursor = engine.raw_connection().cursor()
cursor.execute(...)
cursor.execute(...)
```
for Presto it wouldn't poll to check that the first statement had finished before executing the second. It seems that some DB-API's have the `nextset` method (though this isn't universal) but reading through code snippets it seems the best way to ensure that multi-statements execute sequentially for all engine types is to simply call `fetchall` from the cursor which waits until the statement is done, i.e., [here's](https://github.com/dropbox/PyHive/blob/master/pyhive/common.py#L105) the logic for Presto.

The other option is to call `db_engine_spec.handle_cursor` after every statement (which is what SQL Lab does) which polls when necessary, however this logic is very much configured for SQL Lab queries.

Note that when using the `sqlalchemy.engine.base.Connection` (without a cursor) the following would works. I believe the reason is because `execute` returns a result set which enforces syncronicity:
```
conn = engine.connect()
conn.execute(...)
conn.execute(...)
```
However this approach isn't viable as we need to use the cursor to execute queries via `db_engine_spec.execute`. 

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 