### PR TITLE
Adding 52 weeks to time compare option

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1561,6 +1561,7 @@ export const controls = {
       '1 week',
       '28 days',
       '30 days',
+      '52 weeks',
       '1 year',
     ]),
     description: t('Overlay one or more timeseries from a ' +


### PR DESCRIPTION
A user mentioned that they prefer a YoY calculated as 364 days so that they compare YoY the same day of week (Monday-Monday). 1 year is currently calculated as 365 days. They can enter in 364 days as freeform, but if it's a common pattern we may want to just add it to the list of options. 

@john-bodley @betodealmeida 