### PR TITLE
[ad-hoc filters] Fixing issue with legacy filters

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -713,17 +713,42 @@ def get_celery_app(config):
     return _celery_app
 
 
+def to_adhoc(filt, expressionType='SIMPLE', clause='where'):
+    result = {
+        'clause': clause.upper(),
+        'expressionType': expressionType,
+        'filterOptionName': str(uuid.uuid4()),
+    }
+
+    if expressionType == 'SIMPLE':
+        result.update({
+            'comparator': filt['val'],
+            'operator': filt['op'],
+            'subject': filt['col'],
+        })
+    elif expressionType == 'SQL':
+        result.update({
+            'sqlExpression': filt[clause],
+        })
+
+    return result
+
+
 def merge_extra_filters(form_data):
-    # extra_filters are temporary/contextual filters that are external
-    # to the slice definition. We use those for dynamic interactive
-    # filters like the ones emitted by the "Filter Box" visualization
+    # extra_filters are temporary/contextual filters (using the legacy constructs)
+    # that are external to the slice definition. We use those for dynamic
+    # interactive filters like the ones emitted by the "Filter Box" visualization.
+    # Note extra_filters only support simple filters.
     if 'extra_filters' in form_data:
         # __form and __to are special extra_filters that target time
         # boundaries. The rest of extra_filters are simple
         # [column_name in list_of_values]. `__` prefix is there to avoid
         # potential conflicts with column that would be named `from` or `to`
-        if 'filters' not in form_data:
-            form_data['filters'] = []
+        if (
+            'adhoc_filters' not in form_data or
+            not isinstance(form_data['adhoc_filters'], list)
+        ):
+            form_data['adhoc_filters'] = []
         date_options = {
             '__time_range': 'time_range',
             '__time_col': 'granularity_sqla',
@@ -734,11 +759,20 @@ def merge_extra_filters(form_data):
         # Grab list of existing filters 'keyed' on the column and operator
 
         def get_filter_key(f):
-            return f['col'] + '__' + f['op']
+            if 'expressionType' in f:
+                return '{}__{}'.format(f['subject'], f['operator'])
+            else:
+                return '{}__{}'.format(f['col'], f['op'])
+
         existing_filters = {}
-        for existing in form_data['filters']:
-            if existing['col'] is not None and existing['val'] is not None:
-                existing_filters[get_filter_key(existing)] = existing['val']
+        for existing in form_data['adhoc_filters']:
+            if (
+                existing['expressionType'] == 'SIMPLE' and
+                existing['comparator'] is not None and
+                existing['subject'] is not None
+            ):
+                existing_filters[get_filter_key(existing)] = existing['comparator']
+
         for filtr in form_data['extra_filters']:
             # Pull out time filters/options and merge into form data
             if date_options.get(filtr['col']):
@@ -757,16 +791,16 @@ def merge_extra_filters(form_data):
                                 sorted(existing_filters[filter_key]) !=
                                 sorted(filtr['val'])
                             ):
-                                form_data['filters'] += [filtr]
+                                form_data['adhoc_filters'].append(to_adhoc(filtr))
                         else:
-                            form_data['filters'] += [filtr]
+                            form_data['adhoc_filters'].append(to_adhoc(filtr))
                     else:
                         # Do not add filter if same value already exists
                         if filtr['val'] != existing_filters[filter_key]:
-                            form_data['filters'] += [filtr]
+                            form_data['adhoc_filters'].append(to_adhoc(filtr))
                 else:
                     # Filter not found, add it
-                    form_data['filters'] += [filtr]
+                    form_data['adhoc_filters'].append(to_adhoc(filtr))
         # Remove extra filters from the form data since no longer needed
         del form_data['extra_filters']
 
@@ -921,6 +955,25 @@ def since_until_to_time_range(form_data):
     form_data['time_range'] = ' : '.join((since, until))
 
 
+def convert_legacy_filters_into_adhoc(fd):
+    mapping = {'having': 'having_filters', 'where': 'filters'}
+
+    if 'adhoc_filters' not in fd:
+        fd['adhoc_filters'] = []
+
+        for clause, filters in mapping.items():
+            if clause in fd and fd[clause] != '':
+                fd['adhoc_filters'].append(to_adhoc(fd, 'SQL', clause))
+
+            if filters in fd:
+                for filt in fd[filters]:
+                    fd['adhoc_filters'].append(to_adhoc(filt, 'SIMPLE', clause))
+
+    for key in ('filters', 'having', 'having_filters', 'where'):
+        if key in fd:
+            del fd[key]
+
+
 def split_adhoc_filters_into_base_filters(fd):
     """
     Mutates form data to restructure the adhoc filters in the form of the four base
@@ -928,7 +981,7 @@ def split_adhoc_filters_into_base_filters(fd):
     free form where sql, free form having sql, structured where clauses and structured
     having clauses.
     """
-    adhoc_filters = fd.get('adhoc_filters', None)
+    adhoc_filters = fd.get('adhoc_filters')
     if isinstance(adhoc_filters, list):
         simple_where_filters = []
         simple_having_filters = []

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1281,8 +1281,9 @@ class Superset(BaseSupersetView):
         form_data['datasource'] = str(datasource_id) + '__' + datasource_type
 
         # On explore, merge extra filters into the form data
-        utils.split_adhoc_filters_into_base_filters(form_data)
+        utils.convert_legacy_filters_into_adhoc(form_data)
         merge_extra_filters(form_data)
+        utils.split_adhoc_filters_into_base_filters(form_data)
 
         # merge request url params
         if request.method == 'GET':

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -246,10 +246,9 @@ class BaseViz(object):
         # extras are used to query elements specific to a datasource type
         # for instance the extra where clause that applies only to Tables
 
-        utils.split_adhoc_filters_into_base_filters(form_data)
-
+        utils.convert_legacy_filters_into_adhoc(form_data)
         merge_extra_filters(form_data)
-
+        utils.split_adhoc_filters_into_base_filters(form_data)
         granularity = (
             form_data.get('granularity') or
             form_data.get('granularity_sqla')

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -264,33 +264,6 @@ class TableVizTestCase(unittest.TestCase):
         self.assertEqual('(value3 in (\'North America\'))', query_obj['extras']['where'])
         self.assertEqual('', query_obj['extras']['having'])
 
-    def test_legacy_filters_still_appear_without_adhoc_filters(self):
-        form_data = {
-            'metrics': [{
-                'expressionType': 'SIMPLE',
-                'aggregate': 'SUM',
-                'label': 'SUM(value1)',
-                'column': {'column_name': 'value1', 'type': 'DOUBLE'},
-            }],
-            'having': 'SUM(value1) > 5',
-            'where': 'value3 in (\'North America\')',
-            'filters': [{'col': 'value2', 'val': '100', 'op': '>'}],
-            'having_filters': [{'op': '<', 'val': '10', 'col': 'SUM(value1)'}],
-        }
-        datasource = Mock()
-        test_viz = viz.TableViz(datasource, form_data)
-        query_obj = test_viz.query_obj()
-        self.assertEqual(
-            [{'col': 'value2', 'val': '100', 'op': '>'}],
-            query_obj['filter'],
-        )
-        self.assertEqual(
-            [{'op': '<', 'val': '10', 'col': 'SUM(value1)'}],
-            query_obj['extras']['having_druid'],
-        )
-        self.assertEqual('value3 in (\'North America\')', query_obj['extras']['where'])
-        self.assertEqual('SUM(value1) > 5', query_obj['extras']['having'])
-
     @patch('superset.viz.BaseViz.query_obj')
     def test_query_obj_merges_percent_metrics(self, super_query_obj):
         datasource = Mock()


### PR DESCRIPTION
This PR fixes an issue with https://github.com/apache/incubator-superset/pull/5206. Previously dashboard filters (`extra_filters` in the form-data defined via the legacy definition) and saved URLs with legacy filter definitions wouldn't be correctly handled in the explorer UI as they weren't included in as part of the ad-hoc filters. 

The solution is to convert these filters to ad-hoc filters (be it by transform legacy filters or merging the extra filters) to ensure they're correctly handled in the UI. These filters are then split into the base filters (like previously) to ensure correct handling by the various engines. Note in the future we should migrate away from having legacy filters defined anywhere. 

to: @GabeLoins @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 