### PR TITLE
Fix time shift

### DIFF
--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -65,7 +65,13 @@ export function getControlsState(state, form_data) {
       : formData[k];
 
     // If the value is not valid anymore based on choices, clear it
-    if (control.type === 'SelectControl' && !control.freeForm && control.choices && k !== 'datasource' && formData[k]) {
+    if (
+      control.type === 'SelectControl' &&
+      !control.freeForm &&
+      control.choices &&
+      k !== 'datasource' &&
+      formData[k]
+    ) {
       const choiceValues = control.choices.map(c => c[0]);
       if (control.multi && formData[k].length > 0) {
         formData[k] = formData[k].filter(el => choiceValues.indexOf(el) > -1);

--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -65,11 +65,11 @@ export function getControlsState(state, form_data) {
       : formData[k];
 
     // If the value is not valid anymore based on choices, clear it
-    if (control.type === 'SelectControl' && control.choices && k !== 'datasource' && formData[k]) {
+    if (control.type === 'SelectControl' && !control.freeForm && control.choices && k !== 'datasource' && formData[k]) {
       const choiceValues = control.choices.map(c => c[0]);
-      if (control.multi && !control.freeForm && formData[k].length > 0 && choiceValues.indexOf(formData[k][0]) < 0) {
-        delete formData[k];
-      } else if (!control.multi && !control.freeForm && choiceValues.indexOf(formData[k]) < 0) {
+      if (control.multi && formData[k].length > 0) {
+        formData[k] = formData[k].filter(el => choiceValues.indexOf(el) > -1);
+      } else if (!control.multi && choiceValues.indexOf(formData[k]) < 0) {
         delete formData[k];
       }
     }

--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -67,7 +67,7 @@ export function getControlsState(state, form_data) {
     // If the value is not valid anymore based on choices, clear it
     if (control.type === 'SelectControl' && control.choices && k !== 'datasource' && formData[k]) {
       const choiceValues = control.choices.map(c => c[0]);
-      if (control.multi && formData[k].length > 0 && choiceValues.indexOf(formData[k][0]) < 0) {
+      if (control.multi && !control.freeForm && formData[k].length > 0 && choiceValues.indexOf(formData[k][0]) < 0) {
         delete formData[k];
       } else if (!control.multi && !control.freeForm && choiceValues.indexOf(formData[k]) < 0) {
         delete formData[k];


### PR DESCRIPTION
`SelectControl` is not working correctly when `multi` and `freeForm` are both true — the freeform value is being deleted from the list of choices.

I also improved the code. Currently, for multi it only checks if the **first** value is not present in the choices, and deletes everything if that's true. I changed it so that only values not present in the choices are erased.

This fixes https://github.com/apache/incubator-superset/issues/5520.