### PR TITLE
[setup] Include README in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include README.md
 recursive-include superset/data *
 recursive-include superset/migrations *
 recursive-include superset/static *


### PR DESCRIPTION
Since we've added `README` content to the setup description (in https://github.com/apache/incubator-superset/pull/5226), `README.md` must be in `MANIFEST.in`.

@xrmx @mistercrunch 