### PR TITLE
[ad-hoc filters] Remove legacy split in /explore

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1280,10 +1280,9 @@ class Superset(BaseSupersetView):
 
         form_data['datasource'] = str(datasource_id) + '__' + datasource_type
 
-        # On explore, merge extra filters into the form data
+        # On explore, merge legacy and extra filters into the form data
         utils.convert_legacy_filters_into_adhoc(form_data)
         merge_extra_filters(form_data)
-        utils.split_adhoc_filters_into_base_filters(form_data)
 
         # merge request url params
         if request.method == 'GET':


### PR DESCRIPTION
This PR removes the unnecessary step of splitting ad-hoc filters into legacy filters for the `/explore` endpoint. This merely unnecessarily pollutes (in a non-harmful way) the form-data (including that in the URL) with legacy constructs. These clauses are ignored given that the `adhoc_filters` field is guaranteed to exist (by construction). 

Note the only place we currently need to split ad-hoc filters to legacy (base) filters in the `BaseViz.query_obj(...)` as the query logic still uses the legacy constructs. Note a migration is not needed here given the code correctly converts and then removes the legacy constructs, but could be merited for cleaning up erroneous fields in the form-data.

to: @GabeLoins @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 