### PR TITLE
Stop pretty printing dashboard json

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1641,7 +1641,7 @@ class Superset(BaseSupersetView):
                 session.merge(slc)
                 session.flush()
 
-        dashboard.position_json = json.dumps(positions, indent=4, sort_keys=True)
+        dashboard.position_json = json.dumps(positions, sort_keys=True)
         md = dashboard.params_dict
         dashboard.css = data.get('css')
         dashboard.dashboard_title = data['dashboard_title']
@@ -1658,7 +1658,7 @@ class Superset(BaseSupersetView):
             {key: v for key, v in default_filters_data.items()
              if int(key) in slice_ids}
         md['default_filters'] = json.dumps(applicable_filters)
-        dashboard.json_metadata = json.dumps(md, indent=4)
+        dashboard.json_metadata = json.dumps(md)
 
     @api
     @has_access_api


### PR DESCRIPTION
We don't need to pretty print the dashboard json, and removing this will save space in the db.

Testing
Opened a dashboard that's at the size limit and added more to it, checked that json was not pretty printed and the position_json is under the size limit.

@john-bodley @graceguo-supercat 

