### PR TITLE
Fix TableViz column order

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -593,8 +593,6 @@ class TableViz(BaseViz):
             ):
                 del df[m]
 
-        columns = self.get_column_names(df)
-
         data = self.handle_js_int_overflow(
             dict(
                 records=df.to_dict(orient='records'),

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -523,23 +523,37 @@ class TableViz(BaseViz):
 
     def get_column_names(self, df):
         fd = self.form_data
-        groupby_columns = fd.get('groupby') or []
 
-        metrics_columns = fd.get('metrics') or []
-        metrics_columns = [self.get_metric_label(m) for m in metrics_columns]
-        
-        percent_metrics_columns = fd.get('percent_metrics') or []
-        percent_metrics_columns = ['%'+self.get_metric_label(m) for m in percent_metrics_columns]
-        
-        timeseries_limit_metric_column = fd.get('timeseries_limit_metric') or None
-        if timeseries_limit_metric_column:
-            timeseries_limit_metric_column = [self.get_metric_label(timeseries_limit_metric_column)]
-        else:
-            timeseries_limit_metric_column = []
+        all_columns = fd.get('all_columns') or []
+
+        if len(all_columns):
+            return list(filter(lambda c: c in df, all_columns))
 
         columns = OrderedDict()
-        for c in groupby_columns + metrics_columns + percent_metrics_columns + timeseries_limit_metric_column:
-            columns[c] = c
+
+        groupby_columns = fd.get('groupby') or []
+
+        for column_name in groupby_columns:
+            columns[column_name] = column_name
+
+        if fd.get('include_time'):
+            columns['__timestamp'] = '__timestamp'
+
+        metrics_columns = fd.get('metrics') or []
+
+        for metric in metrics_columns:
+            column_name = self.get_metric_label(metric)
+            columns[column_name] = column_name
+        
+        percent_metrics_columns = fd.get('percent_metrics') or []
+        for metric in percent_metrics_columns:
+            column_name = '%'+self.get_metric_label(metric)
+            columns[column_name] = column_name
+
+        timeseries_limit_metric_column = fd.get('timeseries_limit_metric') or None
+        if timeseries_limit_metric_column:
+            column_name = self.get_metric_label(timeseries_limit_metric_column)
+            columns[column_name] = column_name
         
         return list(filter(lambda c: c in df, columns))
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -544,17 +544,17 @@ class TableViz(BaseViz):
         for metric in metrics_columns:
             column_name = self.get_metric_label(metric)
             columns[column_name] = column_name
-        
+
         percent_metrics_columns = fd.get('percent_metrics') or []
         for metric in percent_metrics_columns:
-            column_name = '%'+self.get_metric_label(metric)
+            column_name = '%' + self.get_metric_label(metric)
             columns[column_name] = column_name
 
         timeseries_limit_metric_column = fd.get('timeseries_limit_metric') or None
         if timeseries_limit_metric_column:
             column_name = self.get_metric_label(timeseries_limit_metric_column)
             columns[column_name] = column_name
-        
+
         return list(filter(lambda c: c in df, columns))
 
     def get_data(self, df):

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -121,8 +121,43 @@ class BaseVizTestCase(unittest.TestCase):
 
 
 class TableVizTestCase(unittest.TestCase):
+    def test_get_data_maintains_column_order(self):
+        form_data = {
+            'groupby': ['groupA', 'groupB'],
+            'percent_metrics': [{
+                'expressionType': 'SIMPLE',
+                'aggregate': 'SUM',
+                'label': 'SUM(value1)',
+                'column': {'column_name': 'value1', 'type': 'DOUBLE'},
+            }, 'avg__B'],
+            'metrics': [{
+                'expressionType': 'SIMPLE',
+                'aggregate': 'SUM',
+                'label': 'SUM(value1)',
+                'column': {'column_name': 'value1', 'type': 'DOUBLE'},
+            }, 'count', 'avg__C'],
+        }
+        datasource = Mock()
+        raw = {}
+        raw['SUM(value1)'] = [15, 20, 25, 40]
+        raw['avg__B'] = [10, 20, 5, 15]
+        raw['avg__C'] = [11, 22, 33, 44]
+        raw['count'] = [6, 7, 8, 9]
+        raw['groupA'] = ['A', 'B', 'C', 'C']
+        raw['groupB'] = ['x', 'x', 'y', 'z']
+        df = pd.DataFrame(raw)
+        test_viz = viz.TableViz(datasource, form_data)
+        data = test_viz.get_data(df)
+        # Check method correctly transforms data and computes percents
+        self.assertEqual(list([
+            'groupA', 'groupB',
+            'SUM(value1)', 'count', 'avg__C',
+            '%SUM(value1)', '%avg__B',
+        ]), data['columns'])
+    
     def test_get_data_applies_percentage(self):
         form_data = {
+            'groupby': ['groupA', 'groupB'],
             'percent_metrics': [{
                 'expressionType': 'SIMPLE',
                 'aggregate': 'SUM',

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -121,7 +121,51 @@ class BaseVizTestCase(unittest.TestCase):
 
 
 class TableVizTestCase(unittest.TestCase):
-    def test_get_data_maintains_column_order(self):
+    def test_get_data_maintains_column_order_all_columns(self):
+        form_data = {
+            'all_columns': ['groupB'],
+            'percent_metrics': [],
+            'metrics': [],
+        }
+        datasource = Mock()
+        raw = {}
+        raw['SUM(value1)'] = [15, 20, 25, 40]
+        raw['avg__B'] = [10, 20, 5, 15]
+        raw['avg__C'] = [11, 22, 33, 44]
+        raw['count'] = [6, 7, 8, 9]
+        raw['groupA'] = ['A', 'B', 'C', 'C']
+        raw['groupB'] = ['x', 'x', 'y', 'z']
+        df = pd.DataFrame(raw)
+        test_viz = viz.TableViz(datasource, form_data)
+        data = test_viz.get_data(df)
+        # Check method correctly transforms data and computes percents
+        self.assertEqual(list(['groupB']), data['columns'])
+    
+    def test_get_data_maintains_column_order_with_timestamp(self):
+        form_data = {
+            'groupby': ['groupA'],
+            'include_time': True,
+            'granularity_sqla': 'ds',
+            'time_grain_sqla':"P1D",
+            'metrics': ['count', 'avg__C'],
+        }
+
+        datasource = Mock()
+        raw = {}
+        raw['SUM(value1)'] = [15, 20, 25, 40]
+        raw['avg__B'] = [10, 20, 5, 15]
+        raw['avg__C'] = [11, 22, 33, 44]
+        raw['count'] = [6, 7, 8, 9]
+        raw['__timestamp'] = [6, 7, 8, 9]
+        raw['groupA'] = ['A', 'B', 'C', 'C']
+        raw['groupB'] = ['x', 'x', 'y', 'z']
+        df = pd.DataFrame(raw)
+        test_viz = viz.TableViz(datasource, form_data)
+        data = test_viz.get_data(df)
+        # Check method correctly transforms data and computes percents
+        self.assertEqual(list(['groupA', '__timestamp', 'count', 'avg__C']), data['columns'])
+
+    def test_get_data_maintains_column_order_grouped(self):
         form_data = {
             'groupby': ['groupA', 'groupB'],
             'percent_metrics': [{

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -164,7 +164,7 @@ class TableVizTestCase(unittest.TestCase):
         data = test_viz.get_data(df)
         # Check method correctly transforms data and computes percents
         self.assertEqual(list([
-            'groupA', '__timestamp', 'count', 'avg__C'
+            'groupA', '__timestamp', 'count', 'avg__C',
         ]), data['columns'])
 
     def test_get_data_maintains_column_order_grouped(self):

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -140,13 +140,13 @@ class TableVizTestCase(unittest.TestCase):
         data = test_viz.get_data(df)
         # Check method correctly transforms data and computes percents
         self.assertEqual(list(['groupB']), data['columns'])
-    
+
     def test_get_data_maintains_column_order_with_timestamp(self):
         form_data = {
             'groupby': ['groupA'],
             'include_time': True,
             'granularity_sqla': 'ds',
-            'time_grain_sqla':"P1D",
+            'time_grain_sqla': 'P1D',
             'metrics': ['count', 'avg__C'],
         }
 
@@ -163,7 +163,9 @@ class TableVizTestCase(unittest.TestCase):
         test_viz = viz.TableViz(datasource, form_data)
         data = test_viz.get_data(df)
         # Check method correctly transforms data and computes percents
-        self.assertEqual(list(['groupA', '__timestamp', 'count', 'avg__C']), data['columns'])
+        self.assertEqual(list([
+            'groupA', '__timestamp', 'count', 'avg__C'
+        ]), data['columns'])
 
     def test_get_data_maintains_column_order_grouped(self):
         form_data = {
@@ -198,7 +200,7 @@ class TableVizTestCase(unittest.TestCase):
             'SUM(value1)', 'count', 'avg__C',
             '%SUM(value1)', '%avg__B',
         ]), data['columns'])
-    
+
     def test_get_data_applies_percentage(self):
         form_data = {
             'groupby': ['groupA', 'groupB'],


### PR DESCRIPTION
Fixes  #5373 

Column names maintain the order which they are defined in form_data with the following hierarchy:

For Non-Grouped:
 The all_columns list is returned

For Grouped:
 - groupby columns
 - timestamp if needed
- metrics
- percent_metrics
- timeseries_limit_metric



