### PR TITLE
Fix superset error message flow

### DIFF
--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -187,7 +187,7 @@ export function runQuery(query) {
         if (msg.indexOf('CSRF token') > 0) {
           msg = COMMON_ERR_MESSAGES.SESSION_TIMED_OUT;
         }
-        dispatch(queryFailed(query, msg, getErrorLink(msg)));
+        dispatch(queryFailed(query, msg, getErrorLink(err)));
       },
     });
   };

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -161,7 +161,7 @@ export default class ResultSet extends React.PureComponent {
       return (
         <Alert bsStyle="danger">
           {query.errorMessage}
-          {query.link && <a href={query.link}> {t('(Common errors and their resolutions)')} </a>}
+          {query.link && <a href={query.link}> {t('(Request Access)')} </a>}
         </Alert>);
     } else if (query.state === 'success' && query.ctas) {
       return (

--- a/superset/security.py
+++ b/superset/security.py
@@ -129,6 +129,10 @@ class SupersetSecurityManager(SecurityManager):
         return """You need access to the following tables: {}, all database access or
               `all_datasource_access` permission""".format(table_name)
 
+    def get_table_access_link(self, tables):
+        from superset import conf
+        return conf.get('PERMISSION_INSTRUCTIONS_LINK')
+
     def datasource_access_by_name(
             self, database, datasource_name, schema=None):
         from superset import db
@@ -147,15 +151,19 @@ class SupersetSecurityManager(SecurityManager):
                 return True
         return False
 
-    def datasource_access_by_fullname(
-            self, database, full_table_name, schema):
-        table_name_pieces = full_table_name.split('.')
+    def get_schema_and_table(self, table_in_query, schema):
+        table_name_pieces = table_in_query.split('.')
         if len(table_name_pieces) == 2:
             table_schema = table_name_pieces[0]
             table_name = table_name_pieces[1]
         else:
             table_schema = schema
             table_name = table_name_pieces[0]
+        return (table_schema, table_name)
+
+    def datasource_access_by_fullname(
+            self, database, table_in_query, schema):
+        table_schema, table_name = self.get_schema_and_table(table_in_query, schema)
         return self.datasource_access_by_name(
             database, table_name, schema=table_schema)
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -46,8 +46,9 @@ def json_error_response(msg=None, status=500, stacktrace=None, payload=None, lin
         payload = {'error': str(msg)}
         if stacktrace:
             payload['stacktrace'] = stacktrace
-        if link:
-            payload['link'] = link
+    if link:
+        payload['link'] = link
+
     return Response(
         json.dumps(payload, default=utils.json_iso_dttm_ser),
         status=status, mimetype='application/json')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2426,9 +2426,8 @@ class Superset(BaseSupersetView):
         rejected_tables = security_manager.rejected_datasources(sql, mydb, schema)
         if rejected_tables:
             return json_error_response(
-                security_manager.get_datasource_access_error_msg('{}'.format(
-                    rejected_tables)),
-                link=security_manager.get_table_error_link(rejected_tables))
+                security_manager.get_table_access_error_msg(rejected_tables),
+                link=security_manager.get_table_access_link(rejected_tables))
         session.commit()
 
         select_as_cta = request.form.get('select_as_cta') == 'true'


### PR DESCRIPTION
This PR fixes several minor issues in the access request flow and the process of allowing the security manager provide the information for error messages.

1. Changes the link on sqllab errors to be access request as opposed to 'common error messages'.
2. Fixes a bug with passing the link to the frontend. 

I will follow up with a PR that allows administrators fully customize the links added beside error message. This will allow them control both the url and the text to be clicked.

@graceguo-supercat @john-bodley @michellethomas 