### PR TITLE
[ad-hoc filters] Use SelectControl for groupable filters with filter select enabled

### DIFF
--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -57,6 +57,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     this.onOperatorChange = this.onOperatorChange.bind(this);
     this.onComparatorChange = this.onComparatorChange.bind(this);
     this.onInputComparatorChange = this.onInputComparatorChange.bind(this);
+    this.isColumnGroupable = this.isColumnGroupable.bind(this);
     this.isOperatorRelevant = this.isOperatorRelevant.bind(this);
     this.refreshComparatorSuggestions = this.refreshComparatorSuggestions.bind(this);
     this.multiComparatorRef = this.multiComparatorRef.bind(this);
@@ -161,7 +162,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     const col = this.props.adhocFilter.subject;
     const having = this.props.adhocFilter.clause === CLAUSES.HAVING;
 
-    if (col && datasource && datasource.filter_select && !having) {
+    if (col && datasource && datasource.filter_select && !having && this.isColumnGroupable(col)) {
       if (this.state.activeRequest) {
         this.state.activeRequest.abort();
       }
@@ -173,6 +174,11 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
         }),
       });
     }
+  }
+
+  isColumnGroupable(column) {
+    return this.props.datasource.gb_cols &&
+      this.props.datasource.gb_cols.map(col => col[0]).indexOf(column) > -1;
   }
 
   isOperatorRelevant(operator) {
@@ -261,14 +267,14 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
           {
             (
               MULTI_OPERATORS.indexOf(adhocFilter.operator) >= 0 ||
-              this.state.suggestions.length > 0
+              (datasource.filter_select && this.isColumnGroupable(adhocFilter.subject))
             ) ?
               <SelectControl
                 multi={MULTI_OPERATORS.indexOf(adhocFilter.operator) >= 0}
                 freeForm
                 name="filter-comparator-value"
                 value={adhocFilter.comparator}
-                isLoading={false}
+                isLoading={!!this.state.activeRequest}
                 choices={this.state.suggestions}
                 onChange={this.onComparatorChange}
                 showHeader={false}


### PR DESCRIPTION
Previously, whether the ad-hoc filter popover value field was a `SelectControl` or free form input was dependent on whether there are options to choose from. This creates some weird situations where the field is a free form input for a few seconds and then becomes a select control (because the request to pre-populate the options can take a while).

**Before** (the weird situation):
![adhoc-filter-delay](https://user-images.githubusercontent.com/3317634/43546907-c41908d4-95a7-11e8-8256-31a6ab1f40f2.gif)

Instead, I think `SelectControl` should be rendered if filter select is enabled and if the column is groupable (it doesn't make sense to query for 1000+ possible ID values, and calling filter select on a field like a sum just runs forever).

**After**:
![adhoc-filter-nodelay](https://user-images.githubusercontent.com/3317634/43547309-e40d9ea6-95a8-11e8-8675-2dd43bf6c5ec.gif)

If users do not want a pre-populated value, nor to wait for the pre-populate request to finish running, they can create an option the same way as they could before ad-hoc filters.

I'm not sure if this will conflict with deprecation of legacy filters.

@john-bodley @mistercrunch @michellethomas @GabeLoins @graceguo-supercat 