### PR TITLE
[bugfix] don't cache empty dataframe

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -396,8 +396,9 @@ class BaseViz(object):
                     is_loaded and
                     cache_key and
                     cache and
-                    not df.empty and
-                    self.status != utils.QueryStatus.FAILED):
+                    self.status != utils.QueryStatus.FAILED and
+                    not df.empty
+            ):
                 try:
                     cache_value = dict(
                         dttm=cached_dttm,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -396,6 +396,7 @@ class BaseViz(object):
                     is_loaded and
                     cache_key and
                     cache and
+                    not df.empty and
                     self.status != utils.QueryStatus.FAILED):
                 try:
                     cache_value = dict(


### PR DESCRIPTION
"No data" used to raise exceptions, which would make it such that
data would not be cached. Another unrelated bug highlighted this to me
and I feel like the right approach is to not cache an empty df.

@john-bodley what do you think?