### PR TITLE
[bugfix] time filter on dashboard view

### DIFF
--- a/superset/legacy.py
+++ b/superset/legacy.py
@@ -86,6 +86,6 @@ def cast_form_data(form_data):
 
 def update_time_range(form_data):
     """Move since and until to time_range."""
-    form_data['time_range'] = '{} : {}'.format(
-        form_data.pop('since'), form_data.pop('until'))
-    return form_data
+    if 'since' in form_data or 'until' in form_data:
+        form_data['time_range'] = '{} : {}'.format(
+            form_data.pop('since', ''), form_data.pop('until', ''))

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -37,6 +37,7 @@ import sqlparse
 
 from superset import app, db, db_engine_specs, security_manager, utils
 from superset.connectors.connector_registry import ConnectorRegistry
+from superset.legacy import update_time_range
 from superset.models.helpers import AuditMixinNullable, ImportMixin, set_perm
 from superset.viz import viz_types
 install_aliases()
@@ -213,8 +214,10 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
             'datasource': '{}__{}'.format(
                 self.datasource_id, self.datasource_type),
         })
+
         if self.cache_timeout:
             form_data['cache_timeout'] = self.cache_timeout
+        update_time_range(form_data)
         return form_data
 
     def get_explore_url(self, base_url='/superset/explore', overrides=None):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1005,6 +1005,8 @@ class Superset(BaseSupersetView):
             slice_form_data.update(form_data)
             form_data = slice_form_data
 
+        update_time_range(form_data)
+
         return form_data, slc
 
     def get_viz(
@@ -1310,10 +1312,6 @@ class Superset(BaseSupersetView):
                 datasource_id,
                 datasource_type,
                 datasource.name)
-
-        # update to new time filter
-        if 'since' in form_data and 'until' in form_data:
-            form_data = update_time_range(form_data)
 
         standalone = request.args.get('standalone') == 'true'
         bootstrap_data = {


### PR DESCRIPTION
Example charts using the old since/until time filtering form_data format would only work in the Explore view, not on the dashboard view. The form_data was fixed in a db migration, but the examples have not been altered, so loading the examples after the db migration would cause problems.

@betodealmeida 