### PR TITLE
Adds a new macro to allow getting filter values easily

### DIFF
--- a/docs/sqllab.rst
+++ b/docs/sqllab.rst
@@ -67,6 +67,8 @@ Superset's Jinja context:
 
 .. autofunction:: superset.jinja_context.url_param
 
+.. autofunction:: superset.jinja_context.filter_values
+
 Extending macros
 ''''''''''''''''
 

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -61,8 +61,47 @@ def current_username():
         return g.user.username
 
 
-class BaseTemplateProcessor(object):
+def filter_values(column, default=None):
+    """ Gets a values for a particular filter as a list
 
+    This is useful if:
+        - you want to use a filter box to filter a query where the name of filter box
+          column doesn't match the one in the select statement
+        - you want to have the ability for filter inside the main query for speed purposes
+
+    This searches for "filters" and "extra_filters" in form_data for a match
+
+    Usage example:
+        * SELECT action, count(*) as times
+        FROM logs
+        WHERE action in ( {{ "'" + "','".join(filter_values('action_type')) + "'" )
+        GROUP BY 1
+
+    :param column: column/filter name to lookup
+    :type column: str
+    :param default: default value to return if there's no matching columns
+    :type default: str
+    :return: returns a list of filter values
+    :rtype: list
+    """
+    form_data = json.loads(request.form.get('form_data'))
+    return_val = []
+    for filter_type in ['filters', 'extra_filters']:
+        if filter_type not in form_data:
+            continue
+
+        for f in form_data[filter_type]:
+            if f['col'] == column:
+                for v in f['val']:
+                    return_val.append(v)
+
+    if return_val:
+        return return_val
+
+    return default
+
+
+class BaseTemplateProcessor(object):
     """Base class for database-specific jinja context
 
     There's this bit of magic in ``process_template`` that instantiates only
@@ -90,6 +129,7 @@ class BaseTemplateProcessor(object):
             'url_param': url_param,
             'current_user_id': current_user_id,
             'current_username': current_username,
+            'filter_values': filter_values,
             'form_data': {},
         }
         self.context.update(kwargs)

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -84,7 +84,7 @@ def filter_values(column, default=None):
     :return: returns a list of filter values
     :rtype: list
     """
-    form_data = json.loads(request.form.get('form_data'))
+    form_data = json.loads(request.form.get('form_data', '{}'))
     return_val = []
     for filter_type in ['filters', 'extra_filters']:
         if filter_type not in form_data:
@@ -98,7 +98,10 @@ def filter_values(column, default=None):
     if return_val:
         return return_val
 
-    return default
+    if default:
+        return [default]
+    else:
+        return []
 
 
 class BaseTemplateProcessor(object):

--- a/tests/macro_tests.py
+++ b/tests/macro_tests.py
@@ -50,7 +50,7 @@ class MacroTestCase(SupersetTestCase):
             self.assertEqual(filter_values, ['bar'])
 
             filter_values = jinja_context.filter_values('')
-            self.assertEqual(filter_values, None)
+            self.assertEqual(filter_values, [])
 
         with app.test_request_context(data=data2):
             filter_values = jinja_context.filter_values('my_special_filter')
@@ -59,3 +59,7 @@ class MacroTestCase(SupersetTestCase):
         with app.test_request_context(data=data3):
             filter_values = jinja_context.filter_values('my_special_filter')
             self.assertEqual(filter_values, ['savage', 'foo', 'bar'])
+
+        with app.test_request_context():
+            filter_values = jinja_context.filter_values('nonexistent_filter', 'foo')
+            self.assertEqual(filter_values, ['foo'])

--- a/tests/macro_tests.py
+++ b/tests/macro_tests.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from flask import json
+from tests.base_tests import SupersetTestCase
+
+from superset import app
+from superset import jinja_context
+
+
+class MacroTestCase(SupersetTestCase):
+
+    def test_filter_values_macro(self):
+        form_data1 = {
+            'extra_filters': [
+                {'col': 'my_special_filter', 'op': 'in', 'val': ['foo']},
+            ],
+            'filters': [
+                {'col': 'my_special_filter2', 'op': 'in', 'val': ['bar']},
+            ],
+        }
+
+        form_data2 = {
+            'extra_filters': [
+                {'col': 'my_special_filter', 'op': 'in', 'val': ['foo', 'bar']},
+            ],
+        }
+
+        form_data3 = {
+            'extra_filters': [
+                {'col': 'my_special_filter', 'op': 'in', 'val': ['foo', 'bar']},
+            ],
+            'filters': [
+                {'col': 'my_special_filter', 'op': 'in', 'val': ['savage']},
+            ],
+        }
+
+        data1 = {'form_data': json.dumps(form_data1)}
+        data2 = {'form_data': json.dumps(form_data2)}
+        data3 = {'form_data': json.dumps(form_data3)}
+
+        with app.test_request_context(data=data1):
+            filter_values = jinja_context.filter_values('my_special_filter')
+            self.assertEqual(filter_values, ['foo'])
+
+            filter_values = jinja_context.filter_values('my_special_filter2')
+            self.assertEqual(filter_values, ['bar'])
+
+            filter_values = jinja_context.filter_values('')
+            self.assertEqual(filter_values, None)
+
+        with app.test_request_context(data=data2):
+            filter_values = jinja_context.filter_values('my_special_filter')
+            self.assertEqual(filter_values, ['foo', 'bar'])
+
+        with app.test_request_context(data=data3):
+            filter_values = jinja_context.filter_values('my_special_filter')
+            self.assertEqual(filter_values, ['savage', 'foo', 'bar'])


### PR DESCRIPTION
We've added a new macro `filter_values` to make it easy to grab the values of a filter box when writing dynamic filter dependent queries.

Usage:
```
SELECT action,
count(*) as times
FROM logs
WHERE action in ( {{ "'" + "','".join(filter_values('action_type')) + "'" }} )
GROUP BY 1
```

Returns:
```
SELECT action,
count(*) as times
FROM logs
WHERE action in ( "dashboard", "log" )
GROUP BY 1
```

When filter box is like this:
![sc 2018-08-02 at 8 42 35 pm](https://user-images.githubusercontent.com/158554/43579306-f23c0494-9694-11e8-8310-3e28a311f94e.png)

Fixes #1996