### PR TITLE
Add option for BigNumber to not start y-axis at 0

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1479,6 +1479,14 @@ export const controls = {
     description: t('Whether to display the trend line'),
   },
 
+  do_not_start_y_axis_at_zero: {
+    type: 'CheckboxControl',
+    label: t('Do not start y-axis at 0'),
+    renderTrigger: true,
+    default: false,
+    description: t('Start y-axis range at minimum value in the data, instead of 0'),
+  },
+
   x_axis_showminmax: {
     type: 'CheckboxControl',
     label: t('X bounds'),

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1479,12 +1479,12 @@ export const controls = {
     description: t('Whether to display the trend line'),
   },
 
-  do_not_start_y_axis_at_zero: {
+  start_y_axis_at_zero: {
     type: 'CheckboxControl',
-    label: t('Do not start y-axis at 0'),
+    label: t('Start y-axis at 0'),
     renderTrigger: true,
-    default: false,
-    description: t('Start y-axis range at minimum value in the data, instead of 0'),
+    default: true,
+    description: t('Start y-axis at zero. Uncheck to start y-axis at minimum value in the data.'),
   },
 
   x_axis_showminmax: {

--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -1251,7 +1251,7 @@ export const visTypes = {
         controlSetRows: [
           ['compare_lag', 'compare_suffix'],
           ['y_axis_format', null],
-          ['show_trend_line', 'do_not_start_y_axis_at_zero'],
+          ['show_trend_line', 'start_y_axis_at_zero'],
         ],
       },
     ],

--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -1251,7 +1251,7 @@ export const visTypes = {
         controlSetRows: [
           ['compare_lag', 'compare_suffix'],
           ['y_axis_format', null],
-          ['show_trend_line', null],
+          ['show_trend_line', 'do_not_start_y_axis_at_zero'],
         ],
       },
     ],

--- a/superset/assets/src/visualizations/BigNumber.jsx
+++ b/superset/assets/src/visualizations/BigNumber.jsx
@@ -53,6 +53,7 @@ const propTypes = {
   formatBigNumber: PropTypes.func,
   subheader: PropTypes.string,
   showTrendline: PropTypes.bool,
+  doNotStartYAxisAtZero: PropTypes.bool,
   trendlineData: PropTypes.array,
   mainColor: PropTypes.string,
   gradientId: PropTypes.string,
@@ -63,6 +64,7 @@ const defaultProps = {
   formatBigNumber: identity,
   subheader: '',
   showTrendline: false,
+  doNotStartYAxisAtZero: false,
   trendlineData: null,
   mainColor: brandColor,
   gradientId: '',
@@ -152,12 +154,16 @@ class BigNumberVis extends React.Component {
       subheader,
       renderTooltip,
       gradientId,
+      doNotStartYAxisAtZero,
     } = this.props;
     return (
       <XYChart
         ariaLabel={`Big number visualization ${subheader}`}
         xScale={{ type: 'timeUtc' }}
-        yScale={{ type: 'linear' }}
+        yScale={{
+          type: 'linear',
+          includeZero: !doNotStartYAxisAtZero,
+        }}
         width={width}
         height={maxHeight}
         margin={CHART_MARGIN}
@@ -227,6 +233,7 @@ function adaptor(slice, payload) {
   const compareLag = Number(payload.data.compare_lag);
   const supportTrendline = formData.viz_type === 'big_number';
   const showTrendline = supportTrendline && formData.show_trend_line;
+  const doNotStartYAxisAtZero = formData.do_not_start_y_axis_at_zero;
   const formatValue = d3FormatPreset(formData.y_axis_format);
   const bigNumber = supportTrendline ? data[data.length - 1][1] : data[0][0];
 
@@ -262,6 +269,7 @@ function adaptor(slice, payload) {
       formatBigNumber={formatValue}
       subheader={formattedSubheader}
       showTrendline={showTrendline}
+      doNotStartYAxisAtZero={doNotStartYAxisAtZero}
       trendlineData={trendlineData}
       mainColor={brandColor}
       gradientId={`big_number_${containerId}`}

--- a/superset/assets/src/visualizations/BigNumber.jsx
+++ b/superset/assets/src/visualizations/BigNumber.jsx
@@ -53,7 +53,7 @@ const propTypes = {
   formatBigNumber: PropTypes.func,
   subheader: PropTypes.string,
   showTrendline: PropTypes.bool,
-  doNotStartYAxisAtZero: PropTypes.bool,
+  startYAxisAtZero: PropTypes.bool,
   trendlineData: PropTypes.array,
   mainColor: PropTypes.string,
   gradientId: PropTypes.string,
@@ -64,7 +64,7 @@ const defaultProps = {
   formatBigNumber: identity,
   subheader: '',
   showTrendline: false,
-  doNotStartYAxisAtZero: false,
+  startYAxisAtZero: true,
   trendlineData: null,
   mainColor: brandColor,
   gradientId: '',
@@ -154,7 +154,7 @@ class BigNumberVis extends React.Component {
       subheader,
       renderTooltip,
       gradientId,
-      doNotStartYAxisAtZero,
+      startYAxisAtZero,
     } = this.props;
     return (
       <XYChart
@@ -162,7 +162,7 @@ class BigNumberVis extends React.Component {
         xScale={{ type: 'timeUtc' }}
         yScale={{
           type: 'linear',
-          includeZero: !doNotStartYAxisAtZero,
+          includeZero: startYAxisAtZero,
         }}
         width={width}
         height={maxHeight}
@@ -233,7 +233,7 @@ function adaptor(slice, payload) {
   const compareLag = Number(payload.data.compare_lag);
   const supportTrendline = formData.viz_type === 'big_number';
   const showTrendline = supportTrendline && formData.show_trend_line;
-  const doNotStartYAxisAtZero = formData.do_not_start_y_axis_at_zero;
+  const startYAxisAtZero = formData.start_y_axis_at_zero;
   const formatValue = d3FormatPreset(formData.y_axis_format);
   const bigNumber = supportTrendline ? data[data.length - 1][1] : data[0][0];
 
@@ -269,7 +269,7 @@ function adaptor(slice, payload) {
       formatBigNumber={formatValue}
       subheader={formattedSubheader}
       showTrendline={showTrendline}
-      doNotStartYAxisAtZero={doNotStartYAxisAtZero}
+      startYAxisAtZero={startYAxisAtZero}
       trendlineData={trendlineData}
       mainColor={brandColor}
       gradientId={`big_number_${containerId}`}


### PR DESCRIPTION
With the recent change to `BigNumber`, the BigNumber with trend line will start y-axis at 0 by default. However, this behavior may be not desirable in some situation, so this PR add an option to overwrite that and start y-axis at min value instead.

![image](https://user-images.githubusercontent.com/1659771/43733159-91d1fc54-9968-11e8-9ee2-57822b513b38.png)

![image](https://user-images.githubusercontent.com/1659771/43733143-83c842a8-9968-11e8-91da-c692b4a31b5a.png)

@graceguo-supercat @williaster 