### PR TITLE
[bugfix] Fix Tableviz metrics column disorder

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -100,16 +100,9 @@ class BaseViz(object):
         self.process_metrics()
 
     def process_metrics(self):
-<<<<<<< HEAD
         # metrics in TableViz is order sensitive, so metric_dict should be
         # OrderedDict
         self.metric_dict = OrderedDict()
-=======
-        # metrics in TableViz is order sensitive,
-        # so all_metrics and metric_labels should be list
-        self.all_metrics = []
-        self.metric_labels = []
->>>>>>> lint code
         fd = self.form_data
         for mkey in METRIC_KEYS:
             val = fd.get(mkey)
@@ -124,6 +117,8 @@ class BaseViz(object):
 
         # Cast to list needed to return serializable object in py3
         self.all_metrics = list(self.metric_dict.values())
+        self.metric_labels = list(self.metric_dict.keys())
+
     def get_metric_label(self, metric):
         if isinstance(metric, string_types):
             return metric

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -100,6 +100,8 @@ class BaseViz(object):
         self.process_metrics()
 
     def process_metrics(self):
+        # metrics in TableViz is order sensitive, so metric_dict should be
+        # OrderedDict
         self.metric_dict = OrderedDict()
         fd = self.form_data
         for mkey in METRIC_KEYS:
@@ -115,8 +117,6 @@ class BaseViz(object):
 
         # Cast to list needed to return serializable object in py3
         self.all_metrics = list(self.metric_dict.values())
-        self.metric_labels = list(self.metric_dict.keys())
-
     def get_metric_label(self, metric):
         if isinstance(metric, string_types):
             return metric

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -100,9 +100,16 @@ class BaseViz(object):
         self.process_metrics()
 
     def process_metrics(self):
+<<<<<<< HEAD
         # metrics in TableViz is order sensitive, so metric_dict should be
         # OrderedDict
         self.metric_dict = OrderedDict()
+=======
+        # metrics in TableViz is order sensitive,
+        # so all_metrics and metric_labels should be list
+        self.all_metrics = []
+        self.metric_labels = []
+>>>>>>> lint code
         fd = self.form_data
         for mkey in METRIC_KEYS:
             val = fd.get(mkey)

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -29,59 +29,59 @@ class BaseVizTestCase(SupersetTestCase):
     def test_process_metrics(self):
         # test TableViz metrics in correct order
         form_data = {
-            "url_params": {},
-            "row_limit": 500,
-            "metric": "sum__SP_POP_TOTL",
-            "entity": "country_code",
-            "secondary_metric": "sum__SP_POP_TOTL",
-            "granularity_sqla": "year",
-            "page_length": 0,
-            "all_columns": [],
-            "viz_type": "table",
-            "since": "2014-01-01",
-            "until": "2014-01-02",
-            "metrics": [
-                "sum__SP_POP_TOTL",
-                "SUM(SE_PRM_NENR_MA)",
+            'url_params': {},
+            'row_limit': 500,
+            'metric': 'sum__SP_POP_TOTL',
+            'entity': 'country_code',
+            'secondary_metric': 'sum__SP_POP_TOTL',
+            'granularity_sqla': 'year',
+            'page_length': 0,
+            'all_columns': [],
+            'viz_type': 'table',
+            'since': '2014-01-01',
+            'until': '2014-01-02',
+            'metrics': [
+                'sum__SP_POP_TOTL',
+                'SUM(SE_PRM_NENR_MA)',
                 {
-                    "hasCustomLabel": False,
-                    "expressionType": "SIMPLE",
-                    "fromFormData": True,
-                    "label": "SUM(SH_DTH_IMRT)",
-                    "column": {
-                        "optionName": "_col_SH_DTH_IMRT",
-                        "description": None,
-                        "filterable": False,
-                        "expression": "",
-                        "is_dttm": False,
-                        "verbose_name": None,
-                        "type": "FLOAT",
-                        "groupby": False,
-                        "column_name": "SH_DTH_IMRT"
+                    'hasCustomLabel': False,
+                    'expressionType': 'SIMPLE',
+                    'fromFormData': True,
+                    'label': 'SUM(SH_DTH_IMRT)',
+                    'column': {
+                        'optionName': '_col_SH_DTH_IMRT',
+                        'description': None,
+                        'filterable': False,
+                        'expression': '',
+                        'is_dttm': False,
+                        'verbose_name': None,
+                        'type': 'FLOAT',
+                        'groupby': False,
+                        'column_name': 'SH_DTH_IMRT',
                     },
-                    "sqlExpression": None,
-                    "aggregate": "SUM",
-                    "optionName": "metric_hww53ilkph_jo8b2fyt8rs"
+                    'sqlExpression': None,
+                    'aggregate': 'SUM',
+                    'optionName': 'metric_hww53ilkph_jo8b2fyt8rs',
                 },
-                "SUM(SP_URB_TOTL)"
+                'SUM(SP_URB_TOTL)',
             ],
-            "country_fieldtype": "cca3",
-            "percent_metrics": [
-                "count"
+            'country_fieldtype': 'cca3',
+            'percent_metrics': [
+                'count',
             ],
-            "slice_id": 74,
-            "time_grain_sqla": None,
-            "order_by_cols": [],
-            "groupby": [
-                "country_name"
+            'slice_id': 74,
+            'time_grain_sqla': None,
+            'order_by_cols': [],
+            'groupby': [
+                'country_name',
             ],
-            "compare_lag": "10",
-            "limit": "25",
-            "datasource": "2__table",
-            "table_timestamp_format": "%Y-%m-%d %H:%M:%S",
-            "markup_type": "markdown",
-            "where": "",
-            "compare_suffix": "o10Y"
+            'compare_lag': '10',
+            'limit': '25',
+            'datasource': '2__table',
+            'table_timestamp_format': '%Y-%m-%d %H:%M:%S',
+            'markup_type': 'markdown',
+            'where': '',
+            'compare_suffix': 'o10Y',
         }
         datasource = {'type': 'table'}
         test_viz = viz.BaseViz(datasource, form_data)

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -26,6 +26,94 @@ class BaseVizTestCase(SupersetTestCase):
         with self.assertRaises(Exception):
             viz.BaseViz(datasource, form_data)
 
+    def test_process_metrics(self):
+        # test TableViz metrics in correct order
+        form_data = {
+            "url_params": {},
+            "row_limit": 500,
+            "metric": "sum__SP_POP_TOTL",
+            "entity": "country_code",
+            "secondary_metric": "sum__SP_POP_TOTL",
+            "granularity_sqla": "year",
+            "page_length": 0,
+            "all_columns": [],
+            "viz_type": "table",
+            "since": "2014-01-01",
+            "until": "2014-01-02",
+            "metrics": [
+                "sum__SP_POP_TOTL",
+                "SUM(SE_PRM_NENR_MA)",
+                {
+                    "hasCustomLabel": False,
+                    "expressionType": "SIMPLE",
+                    "fromFormData": True,
+                    "label": "SUM(SH_DTH_IMRT)",
+                    "column": {
+                        "optionName": "_col_SH_DTH_IMRT",
+                        "description": None,
+                        "filterable": False,
+                        "expression": "",
+                        "is_dttm": False,
+                        "verbose_name": None,
+                        "type": "FLOAT",
+                        "groupby": False,
+                        "column_name": "SH_DTH_IMRT"
+                    },
+                    "sqlExpression": None,
+                    "aggregate": "SUM",
+                    "optionName": "metric_hww53ilkph_jo8b2fyt8rs"
+                },
+                "SUM(SP_URB_TOTL)"
+            ],
+            "country_fieldtype": "cca3",
+            "percent_metrics": [
+                "count"
+            ],
+            "slice_id": 74,
+            "time_grain_sqla": None,
+            "order_by_cols": [],
+            "groupby": [
+                "country_name"
+            ],
+            "compare_lag": "10",
+            "limit": "25",
+            "datasource": "2__table",
+            "table_timestamp_format": "%Y-%m-%d %H:%M:%S",
+            "markup_type": "markdown",
+            "where": "",
+            "compare_suffix": "o10Y"
+        }
+        datasource = {'type': 'table'}
+        test_viz = viz.BaseViz(datasource, form_data)
+        expect_metric_labels = [u'sum__SP_POP_TOTL',
+                                u'SUM(SE_PRM_NENR_MA)',
+                                u'SUM(SH_DTH_IMRT)',
+                                u'SUM(SP_URB_TOTL)',
+                                u'count']
+        self.assertEqual(test_viz.metric_labels, expect_metric_labels)
+        expect_all_metrics = [u'sum__SP_POP_TOTL',
+                              u'SUM(SE_PRM_NENR_MA)',
+                              {u'label': u'SUM(SH_DTH_IMRT)',
+                               u'column':
+                                   {u'filterable': False,
+                                    u'description': None,
+                                    u'type': u'FLOAT',
+                                    u'expression': u'',
+                                    u'optionName': u'_col_SH_DTH_IMRT',
+                                    u'is_dttm': False,
+                                    u'verbose_name': None,
+                                    u'column_name': u'SH_DTH_IMRT',
+                                    u'groupby': False},
+                               u'aggregate': u'SUM',
+                               u'fromFormData': True,
+                               u'hasCustomLabel': False,
+                               u'expressionType': u'SIMPLE',
+                               u'sqlExpression': None,
+                               u'optionName': u'metric_hww53ilkph_jo8b2fyt8rs'},
+                              u'SUM(SP_URB_TOTL)',
+                              u'count']
+        self.assertEqual(test_viz.all_metrics, expect_all_metrics)
+
     def test_get_fillna_returns_default_on_null_columns(self):
         form_data = {
             'viz_type': 'table',

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -43,26 +43,6 @@ class BaseVizTestCase(SupersetTestCase):
             'metrics': [
                 'sum__SP_POP_TOTL',
                 'SUM(SE_PRM_NENR_MA)',
-                {
-                    'hasCustomLabel': False,
-                    'expressionType': 'SIMPLE',
-                    'fromFormData': True,
-                    'label': 'SUM(SH_DTH_IMRT)',
-                    'column': {
-                        'optionName': '_col_SH_DTH_IMRT',
-                        'description': None,
-                        'filterable': False,
-                        'expression': '',
-                        'is_dttm': False,
-                        'verbose_name': None,
-                        'type': 'FLOAT',
-                        'groupby': False,
-                        'column_name': 'SH_DTH_IMRT',
-                    },
-                    'sqlExpression': None,
-                    'aggregate': 'SUM',
-                    'optionName': 'metric_hww53ilkph_jo8b2fyt8rs',
-                },
                 'SUM(SP_URB_TOTL)',
             ],
             'country_fieldtype': 'cca3',
@@ -83,36 +63,16 @@ class BaseVizTestCase(SupersetTestCase):
             'where': '',
             'compare_suffix': 'o10Y',
         }
-        datasource = {'type': 'table'}
+        datasource = Mock()
+        datasource.type = 'table'
         test_viz = viz.BaseViz(datasource, form_data)
         expect_metric_labels = [u'sum__SP_POP_TOTL',
                                 u'SUM(SE_PRM_NENR_MA)',
-                                u'SUM(SH_DTH_IMRT)',
                                 u'SUM(SP_URB_TOTL)',
-                                u'count']
+                                u'count',
+                                ]
         self.assertEqual(test_viz.metric_labels, expect_metric_labels)
-        expect_all_metrics = [u'sum__SP_POP_TOTL',
-                              u'SUM(SE_PRM_NENR_MA)',
-                              {u'label': u'SUM(SH_DTH_IMRT)',
-                               u'column':
-                                   {u'filterable': False,
-                                    u'description': None,
-                                    u'type': u'FLOAT',
-                                    u'expression': u'',
-                                    u'optionName': u'_col_SH_DTH_IMRT',
-                                    u'is_dttm': False,
-                                    u'verbose_name': None,
-                                    u'column_name': u'SH_DTH_IMRT',
-                                    u'groupby': False},
-                               u'aggregate': u'SUM',
-                               u'fromFormData': True,
-                               u'hasCustomLabel': False,
-                               u'expressionType': u'SIMPLE',
-                               u'sqlExpression': None,
-                               u'optionName': u'metric_hww53ilkph_jo8b2fyt8rs'},
-                              u'SUM(SP_URB_TOTL)',
-                              u'count']
-        self.assertEqual(test_viz.all_metrics, expect_all_metrics)
+        self.assertEqual(test_viz.all_metrics, expect_metric_labels)
 
     def test_get_fillna_returns_default_on_null_columns(self):
         form_data = {


### PR DESCRIPTION
Fixes #5373
The cause of metrics disorder in Table View is located in function `BaseViz. process_metrics`.
This function was introduced from https://github.com/apache/incubator-superset/pull/4914/files


This fix also works for percentage metrics.