### PR TITLE
make filters use security manager

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -85,15 +85,6 @@ class SupersetSecurityManager(SecurityManager):
         if schema:
             return '[{}].[{}]'.format(database, schema)
 
-    def always_list_all_dashboards(self):
-        return False
-
-    def always_list_all_slices(self):
-        return False
-
-    def always_list_all_datasources(self):
-        return False
-
     def can_access(self, permission_name, view_name, user=None):
         """Protecting from has_access failing from missing perms/view"""
         if not user:

--- a/superset/security.py
+++ b/superset/security.py
@@ -85,6 +85,15 @@ class SupersetSecurityManager(SecurityManager):
         if schema:
             return '[{}].[{}]'.format(database, schema)
 
+    def always_list_all_dashboards(self):
+        return False
+
+    def always_list_all_slices(self):
+        return False
+
+    def always_list_all_datasources(self):
+        return False
+
     def can_access(self, permission_name, view_name, user=None):
         """Protecting from has_access failing from missing perms/view"""
         if not user:

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -251,8 +251,7 @@ class SupersetFilter(BaseFilter):
 
 class DatasourceFilter(SupersetFilter):
     def apply(self, query, func):  # noqa
-        if (security_manager.all_datasource_access() or
-                security_manager.always_list_all_datasources()):
+        if security_manager.all_datasource_access():
             return query
         perms = self.get_view_menus('datasource_access')
         # TODO(bogdan): add `schema_access` support here

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -248,15 +248,11 @@ class SupersetFilter(BaseFilter):
                 vm.add(vm_name)
         return vm
 
-    def has_all_datasource_access(self):
-        return (
-            self.has_role(['Admin', 'Alpha']) or
-            self.has_perm('all_datasource_access', 'all_datasource_access'))
-
 
 class DatasourceFilter(SupersetFilter):
     def apply(self, query, func):  # noqa
-        if self.has_all_datasource_access():
+        if (security_manager.all_datasource_access() or
+                security_manager.always_list_all_datasources()):
             return query
         perms = self.get_view_menus('datasource_access')
         # TODO(bogdan): add `schema_access` support here

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -136,8 +136,7 @@ def check_ownership(obj, raise_if_false=True):
 
 class SliceFilter(SupersetFilter):
     def apply(self, query, func):  # noqa
-        if (security_manager.all_datasource_access() or
-                security_manager.always_list_all_slices()):
+        if security_manager.all_datasource_access():
             return query
         perms = self.get_view_menus('datasource_access')
         # TODO(bogdan): add `schema_access` support here
@@ -149,8 +148,7 @@ class DashboardFilter(SupersetFilter):
     """List dashboards for which users have access to at least one slice or are owners"""
 
     def apply(self, query, func):  # noqa
-        if (security_manager.all_datasource_access() or
-                security_manager.always_list_all_dashboards()):
+        if security_manager.all_datasource_access():
             return query
         Slice = models.Slice  # noqa
         Dash = models.Dashboard  # noqa

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -136,7 +136,8 @@ def check_ownership(obj, raise_if_false=True):
 
 class SliceFilter(SupersetFilter):
     def apply(self, query, func):  # noqa
-        if self.has_all_datasource_access():
+        if (security_manager.all_datasource_access() or
+                security_manager.always_list_all_slices()):
             return query
         perms = self.get_view_menus('datasource_access')
         # TODO(bogdan): add `schema_access` support here
@@ -148,7 +149,8 @@ class DashboardFilter(SupersetFilter):
     """List dashboards for which users have access to at least one slice or are owners"""
 
     def apply(self, query, func):  # noqa
-        if self.has_all_datasource_access():
+        if (security_manager.all_datasource_access() or
+                security_manager.always_list_all_dashboards()):
             return query
         Slice = models.Slice  # noqa
         Dash = models.Dashboard  # noqa


### PR DESCRIPTION
This PR removes the redundant has_all_datasource_access method and uses the security manager's all_datasource_access method. It also makes superset filters configurable via the security manager. 

Longer term, it will be nicer to make the whole method configurable so different deployments can decide their own mechanisms to filter the dashboards. 

@john-bodley  @michellethomas  @mistercrunch 