### PR TITLE
[cleanup] Remove `deep-equal` npm dependency and use `_.isEqual` instead

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -61,7 +61,6 @@
     "datamaps": "^0.5.8",
     "datatables.net-bs": "^1.10.15",
     "deck.gl": "^5.1.4",
-    "deep-equal": "^1.0.1",
     "distributions": "^1.0.0",
     "dnd-core": "^2.6.0",
     "dompurify": "^1.0.3",

--- a/superset/assets/src/reduxUtils.js
+++ b/superset/assets/src/reduxUtils.js
@@ -1,7 +1,7 @@
 import shortid from 'shortid';
 import { compose } from 'redux';
 import persistState from 'redux-localstorage';
-import equals from 'deep-equal';
+import { isEqual } from 'underscore';
 
 export function addToObject(state, arrKey, obj) {
   const newObject = Object.assign({}, state[arrKey]);
@@ -95,5 +95,5 @@ export function areArraysShallowEqual(arr1, arr2) {
 }
 
 export function areObjectsEqual(obj1, obj2) {
-  return equals(obj1, obj2, true);
+  return isEqual(obj1, obj2);
 }

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -3420,10 +3420,6 @@ deep-eql@^3.0.0:
   dependencies:
     type-detect "^4.0.0"
 
-deep-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"


### PR DESCRIPTION
Remove package `deep-equal` dependency and use `_.isEqual` instead to compute deep equality.
https://underscorejs.org/#isEqual

Tested locally.