### PR TITLE
[Bug Fix] Fixed the wrong icon for Source -> Table

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -328,7 +328,7 @@ appbuilder.add_link(
     'Tables',
     label=__('Tables'),
     href='/tablemodelview/list/?_flt_1_is_sqllab_view=y',
-    icon='fa-upload',
+    icon='fa-table',
     category='Sources',
     category_label=__('Sources'),
     category_icon='fa-table')


### PR DESCRIPTION
The icon for Source -> Table was wrong. 

Before:

<img width="230" alt="screen shot 2018-08-06 at 5 08 27 pm" src="https://user-images.githubusercontent.com/2024960/43746837-76e666fe-999b-11e8-929f-6d3791f24657.png">


After:

<img width="223" alt="screen shot 2018-08-06 at 5 08 38 pm" src="https://user-images.githubusercontent.com/2024960/43746839-7d2ebb4c-999b-11e8-9ec6-6456dbce181c.png">
