### PR TITLE
[fix] Enforcing main dttm column

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -832,22 +832,23 @@ export const controls = {
     'column in the table. Also note that the ' +
     'filter below is applied against this column or ' +
     'expression'),
-    default: (c) => {
-      if (c.options && c.options.length > 0) {
-        return c.options[0].column_name;
-      }
-      return null;
-    },
+    default: control => control.default,
     clearable: false,
     optionRenderer: c => <ColumnOption column={c} showType />,
     valueRenderer: c => <ColumnOption column={c} />,
     valueKey: 'column_name',
     mapStateToProps: (state) => {
-      const newState = {};
+      const props = {};
       if (state.datasource) {
-        newState.options = state.datasource.columns.filter(c => c.is_dttm);
+        props.options = state.datasource.columns.filter(c => c.is_dttm);
+        props.default = null;
+        if (state.datasource.main_dttm_col) {
+          props.default = state.datasource.main_dttm_col;
+        } else if (props.options && props.options.length > 0) {
+          props.default = props.options[0].column_name;
+        }
       }
-      return newState;
+      return props;
     },
   },
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -410,6 +410,7 @@ class SqlaTable(Model, BaseDatasource):
                 grains = [(g.duration, g.name) for g in grains]
             d['granularity_sqla'] = utils.choicify(self.dttm_cols)
             d['time_grain_sqla'] = grains
+            d['main_dttm_col'] = self.main_dttm_col
         return d
 
     def values_for_column(self, column_name, limit=10000):


### PR DESCRIPTION
This PR ensures that if defined the "Main Datetime Column" is used as the default value. Previously this value was being ignored and thus for datasource with multiple temporal columns a sub-optimal choice may occur, i.e., using a non-partitioned column.

to: @GabeLoins @graceguo-supercat @michellethomas @mistercrunch  @williaster 

closes #3629