### PR TITLE
[ad-hoc filters] Fixing legacy conversion

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -949,7 +949,7 @@ def get_since_until(form_data):
 def convert_legacy_filters_into_adhoc(fd):
     mapping = {'having': 'having_filters', 'where': 'filters'}
 
-    if 'adhoc_filters' not in fd:
+    if not fd.get('adhoc_filters'):
         fd['adhoc_filters'] = []
 
         for clause, filters in mapping.items():

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -702,14 +702,45 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEquals(form_data, expected)
 
     @patch('superset.utils.to_adhoc', mock_to_adhoc)
-    def test_convert_legacy_filters_into_adhoc_existing(self):
+    def test_convert_legacy_filters_into_adhoc_present_and_empty(self):
         form_data = {
             'adhoc_filters': [],
+            'where': 'a = 1',
+        }
+        expected = {
+            'adhoc_filters': [
+                {
+                    'clause': 'WHERE',
+                    'expressionType': 'SQL',
+                    'sqlExpression': 'a = 1',
+                },
+            ],
+        }
+        convert_legacy_filters_into_adhoc(form_data)
+        self.assertEquals(form_data, expected)
+
+    @patch('superset.utils.to_adhoc', mock_to_adhoc)
+    def test_convert_legacy_filters_into_adhoc_present_and_nonempty(self):
+        form_data = {
+            'adhoc_filters': [
+                {
+                    'clause': 'WHERE',
+                    'expressionType': 'SQL',
+                    'sqlExpression': 'a = 1',
+                },
+            ],
             'filters': [{'col': 'a', 'op': 'in', 'val': 'someval'}],
             'having': 'COUNT(1) = 1',
             'having_filters': [{'col': 'COUNT(1)', 'op': '==', 'val': 1}],
-            'where': 'a = 1',
         }
-        expected = {'adhoc_filters': []}
+        expected = {
+            'adhoc_filters': [
+                {
+                    'clause': 'WHERE',
+                    'expressionType': 'SQL',
+                    'sqlExpression': 'a = 1',
+                },
+            ],
+        }
         convert_legacy_filters_into_adhoc(form_data)
         self.assertEquals(form_data, expected)


### PR DESCRIPTION
This PR fixes an issue where previously the assumption was that the presence of the `adhhoc_filters` field in the form data informed that it should trump (and remove) any legacy filters, however it's been brought to our attention that the field could have been previously defined. 

The solution is to convert legacy filters if i) the `adhoc_filters` field is undefined or ii) the associated value is `None` or an empty list, i.e., falsy.

to: @GabeLoins @graceguo-supercat @michellethomas @mistercrunch
