### PR TITLE
No exception on no data

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1351,7 +1351,6 @@ class DruidDatasource(Model, BaseDatasource):
                 df=pandas.DataFrame([]),
                 query=query_str,
                 duration=datetime.now() - qry_start_dttm)
-            raise Exception(_('No data was returned.'))
 
         df = self.homogenize_types(df, query_obj.get('groupby', []))
         df.columns = [

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -20,6 +20,7 @@ from flask import escape, Markup
 from flask_appbuilder import Model
 from flask_appbuilder.models.decorators import renders
 from flask_babel import lazy_gettext as _
+import pandas
 from pydruid.client import PyDruid
 from pydruid.utils.aggregators import count
 from pydruid.utils.dimensions import MapLookupExtraction, RegexExtraction
@@ -1346,6 +1347,10 @@ class DruidDatasource(Model, BaseDatasource):
         df = client.export_pandas()
 
         if df is None or df.size == 0:
+            return QueryResult(
+                df=pandas.DataFrame([]),
+                query=query_str,
+                duration=datetime.now() - qry_start_dttm)
             raise Exception(_('No data was returned.'))
 
         df = self.homogenize_types(df, query_obj.get('groupby', []))

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -793,9 +793,14 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
                 self.db_engine_spec.execute(cursor, sqls[-1])
 
+                if cursor.description is not None:
+                    columns = [col_desc[0] for col_desc in cursor.description]
+                else:
+                    columns = []
+
                 df = pd.DataFrame.from_records(
                     data=list(cursor.fetchall()),
-                    columns=[col_desc[0] for col_desc in cursor.description],
+                    columns=columns,
                     coerce_float=True,
                 )
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -179,7 +179,6 @@ class BaseViz(object):
             return None
 
         self.error_msg = ''
-        self.results = None
 
         timestamp_format = None
         if self.datasource.type == 'table':


### PR DESCRIPTION
When trying to replicate a bug I found out to the backend is raising exceptions when no data is returned, both in Druid (explicitly) and in SQLAlchemy (iterating over a `cursor.description` that is `None`).

I think the SQLAlchemy bug happens only in conjunction with the `druid` backend, and I recently fixed it (https://github.com/druid-io/pydruid/pull/133/). But it's better to be on the safe side here.