### PR TITLE
[feature] Allow min/max value for the sparkline in time series table

### DIFF
--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -173,17 +173,6 @@ export default class TimeSeriesColumnControl extends React.Component {
             />,
           )}
           {this.state.colType === 'spark' && this.formRow(
-            'Y-axis bounds',
-            (
-              'Manually set min/max values for the y-axis.'
-            ),
-            'y-axis-bounds',
-            <BoundsControl
-              value={this.state.yAxisBounds}
-              onChange={this.onYAxisBoundsChange.bind(this)}
-            />,
-          )}
-          {this.state.colType === 'spark' && this.formRow(
             'Show Y-axis',
             (
               'Show Y-axis on the sparkline. Will display the manually set min/max if set or min/max values in the data otherwise.'
@@ -192,6 +181,17 @@ export default class TimeSeriesColumnControl extends React.Component {
             <CheckboxControl
               value={this.state.showYAxis}
               onChange={this.onCheckboxChange.bind(this, 'showYAxis')}
+            />,
+          )}
+          {this.state.colType === 'spark' && this.formRow(
+            'Y-axis bounds',
+            (
+              'Manually set min/max values for the y-axis.'
+            ),
+            'y-axis-bounds',
+            <BoundsControl
+              value={this.state.yAxisBounds}
+              onChange={this.onYAxisBoundsChange.bind(this)}
             />,
           )}
           {this.state.colType !== 'spark' && this.formRow(

--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -184,14 +184,14 @@ export default class TimeSeriesColumnControl extends React.Component {
             />,
           )}
           {this.state.colType === 'spark' && this.formRow(
-            'Show bounds',
+            'Show Y-axis',
             (
-              'Show Y-axis bounds as dotted line on the sparkline'
+              'Show Y-axis on the sparkline. Will display the manually set min/max if set or min/max values in the data otherwise.'
             ),
             'show-y-axis-bounds',
             <CheckboxControl
-              value={this.state.showYAxisBounds}
-              onChange={this.onCheckboxChange.bind(this, 'showYAxisBounds')}
+              value={this.state.showYAxis}
+              onChange={this.onCheckboxChange.bind(this, 'showYAxis')}
             />,
           )}
           {this.state.colType !== 'spark' && this.formRow(

--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -7,6 +7,7 @@ import Select from 'react-select';
 
 import InfoTooltipWithTrigger from '../../../components/InfoTooltipWithTrigger';
 import BoundsControl from './BoundsControl';
+import CheckboxControl from './CheckboxControl';
 
 const propTypes = {
   onChange: PropTypes.func,
@@ -46,6 +47,9 @@ export default class TimeSeriesColumnControl extends React.Component {
   }
   onTextInputChange(attr, event) {
     this.setState({ [attr]: event.target.value }, this.onChange);
+  }
+  onCheckboxChange(attr, value) {
+    this.setState({ [attr]: value }, this.onChange);
   }
   onBoundsChange(bounds) {
     this.setState({ bounds }, this.onChange);
@@ -177,6 +181,17 @@ export default class TimeSeriesColumnControl extends React.Component {
             <BoundsControl
               value={this.state.yAxisBounds}
               onChange={this.onYAxisBoundsChange.bind(this)}
+            />,
+          )}
+          {this.state.colType === 'spark' && this.formRow(
+            'Show bounds',
+            (
+              'Show Y-axis bounds as dotted line on the sparkline'
+            ),
+            'show-y-axis-bounds',
+            <CheckboxControl
+              value={this.state.showYAxisBounds}
+              onChange={this.onCheckboxChange.bind(this, 'showYAxisBounds')}
             />,
           )}
           {this.state.colType !== 'spark' && this.formRow(

--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -50,6 +50,9 @@ export default class TimeSeriesColumnControl extends React.Component {
   onBoundsChange(bounds) {
     this.setState({ bounds }, this.onChange);
   }
+  onYAxisBoundsChange(yAxisBounds) {
+    this.setState({ yAxisBounds }, this.onChange);
+  }
   setType() {
   }
   textSummary() {
@@ -163,6 +166,17 @@ export default class TimeSeriesColumnControl extends React.Component {
               clearable={false}
               onChange={this.onSelectChange.bind(this, 'comparisonType')}
               options={comparisonTypeOptions}
+            />,
+          )}
+          {this.state.colType === 'spark' && this.formRow(
+            'Y-axis bounds',
+            (
+              'Manually set min/max values for the y-axis.'
+            ),
+            'y-axis-bounds',
+            <BoundsControl
+              value={this.state.yAxisBounds}
+              onChange={this.onYAxisBoundsChange.bind(this)}
             />,
           )}
           {this.state.colType !== 'spark' && this.formRow(

--- a/superset/assets/src/modules/visUtils.js
+++ b/superset/assets/src/modules/visUtils.js
@@ -18,7 +18,7 @@ export function getTextDimension({
   }
 
   if (isDefined(style)) {
-    ['font', 'fontWeight', 'fontStyle', 'fontSize', 'fontFamily']
+    ['font', 'fontWeight', 'fontStyle', 'fontSize', 'fontFamily', 'letterSpacing']
       .filter(field => isDefined(style[field]))
       .forEach((field) => {
         textNode.style[field] = style[field];

--- a/superset/assets/src/visualizations/SparklineCell.jsx
+++ b/superset/assets/src/visualizations/SparklineCell.jsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Sparkline, LineSeries, PointSeries, HorizontalReferenceLine, VerticalReferenceLine, WithTooltip } from '@data-ui/sparkline';
+import { d3format } from '../modules/utils';
+import { getTextDimension } from '../modules/visUtils';
+
+const propTypes = {
+  className: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  data: PropTypes.array.isRequired,
+  ariaLabel: PropTypes.string,
+  numberFormat: PropTypes.string,
+  yAxisBounds: PropTypes.array,
+  showYAxisBounds: PropTypes.bool,
+  renderTooltip: PropTypes.func,
+};
+const defaultProps = {
+  className: '',
+  width: 300,
+  height: 50,
+  ariaLabel: '',
+  numberFormat: undefined,
+  yAxisBounds: [null, null],
+  showYAxisBounds: false,
+  renderTooltip() { return <div />; },
+};
+
+const SPARKLINE_MARGIN = {
+  top: 8,
+  right: 8,
+  bottom: 8,
+  left: 8,
+};
+const sparklineTooltipProps = {
+  style: {
+    opacity: 0.8,
+  },
+  offsetTop: 0,
+};
+
+function getSparklineTextWidth(text) {
+  return getTextDimension({
+    text,
+    style: {
+      fontSize: '12px',
+      fontWeight: 200,
+      letterSpacing: 0.4,
+    },
+  }).width + 5;
+}
+
+function isValidBoundValue(value) {
+  return value !== null && value !== undefined && value !== '' && !Number.isNaN(value);
+}
+
+class SparklineCell extends React.Component {
+  renderLine() {
+
+  }
+
+  render() {
+    const {
+      width,
+      height,
+      data,
+      ariaLabel,
+      numberFormat,
+      yAxisBounds,
+      showYAxisBounds,
+      renderTooltip,
+    } = this.props;
+
+    const yScale = {};
+    let hasMin = false;
+    let hasMax = false;
+    let minLabel = '';
+    let maxLabel = '';
+    let labelLength = 0;
+    if (yAxisBounds) {
+      const [min, max] = yAxisBounds;
+      hasMin = isValidBoundValue(min);
+      if (hasMin) {
+        yScale.min = min;
+        minLabel = d3format(numberFormat, yScale.min);
+        labelLength = getSparklineTextWidth(minLabel);
+      }
+      hasMax = isValidBoundValue(max);
+      if (hasMax) {
+        yScale.max = max;
+        maxLabel = d3format(numberFormat, yScale.max);
+        labelLength = Math.max(labelLength, getSparklineTextWidth(maxLabel));
+      }
+    }
+    const margin = {
+      ...SPARKLINE_MARGIN,
+      right: SPARKLINE_MARGIN.right + labelLength,
+    };
+
+    return (
+      <WithTooltip
+        tooltipProps={sparklineTooltipProps}
+        hoverStyles={null}
+        renderTooltip={renderTooltip}
+      >
+        {({ onMouseLeave, onMouseMove, tooltipData }) => (
+          <Sparkline
+            ariaLabel={ariaLabel}
+            width={width}
+            height={height}
+            margin={margin}
+            data={data}
+            onMouseLeave={onMouseLeave}
+            onMouseMove={onMouseMove}
+            {...yScale}
+          >
+            {showYAxisBounds && hasMin &&
+              <HorizontalReferenceLine
+                reference={yScale.min}
+                labelPosition="right"
+                renderLabel={() => minLabel}
+                stroke="#bbb"
+                strokeDasharray="3 3"
+                strokeWidth={1}
+              />}
+            {showYAxisBounds && hasMax &&
+              <HorizontalReferenceLine
+                reference={yScale.max}
+                labelPosition="right"
+                renderLabel={() => maxLabel}
+                stroke="#bbb"
+                strokeDasharray="3 3"
+                strokeWidth={1}
+              />}
+            <LineSeries
+              showArea={false}
+              stroke="#767676"
+            />
+            {tooltipData &&
+              <VerticalReferenceLine
+                reference={tooltipData.index}
+                strokeDasharray="3 3"
+                strokeWidth={1}
+              />}
+            {tooltipData &&
+              <PointSeries
+                points={[tooltipData.index]}
+                fill="#767676"
+                strokeWidth={1}
+              />}
+          </Sparkline>
+        )}
+      </WithTooltip>
+    );
+  }
+}
+
+SparklineCell.propTypes = propTypes;
+SparklineCell.defaultProps = defaultProps;
+
+export default SparklineCell;

--- a/superset/assets/src/visualizations/time_table.jsx
+++ b/superset/assets/src/visualizations/time_table.jsx
@@ -94,6 +94,16 @@ function viz(slice, payload) {
           }
         }
         const formatDate = formatDateThunk(column.dateFormat);
+        const yScale = {};
+        if (column.yAxisBounds) {
+          const [min, max] = column.yAxisBounds;
+          if (min !== null && min !== undefined && min !== '') {
+            yScale.min = min;
+          }
+          if (max !== null && max !== undefined && max !== '') {
+            yScale.max = max;
+          }
+        }
         row[column.key] = {
           data: sparkData[sparkData.length - 1],
           display: (
@@ -116,6 +126,7 @@ function viz(slice, payload) {
                   data={sparkData}
                   onMouseLeave={onMouseLeave}
                   onMouseMove={onMouseMove}
+                  {...yScale}
                 >
                   <LineSeries
                     showArea={false}

--- a/superset/assets/src/visualizations/time_table.jsx
+++ b/superset/assets/src/visualizations/time_table.jsx
@@ -132,14 +132,14 @@ function viz(slice, payload) {
                   onMouseMove={onMouseMove}
                   {...yScale}
                 >
-                  {hasMin &&
+                  {column.showYAxisBounds && hasMin &&
                     <HorizontalReferenceLine
                       reference={yScale.min}
                       stroke="#bbb"
                       strokeDasharray="3 3"
                       strokeWidth={1}
                     />}
-                  {hasMax &&
+                  {column.showYAxisBounds && hasMax &&
                     <HorizontalReferenceLine
                       reference={yScale.max}
                       stroke="#bbb"

--- a/superset/assets/src/visualizations/time_table.jsx
+++ b/superset/assets/src/visualizations/time_table.jsx
@@ -93,7 +93,7 @@ function viz(slice, payload) {
               ariaLabel={`spark-${metricLabel}`}
               numberFormat={column.d3format}
               yAxisBounds={column.yAxisBounds}
-              showYAxisBounds={column.showYAxisBounds}
+              showYAxis={column.showYAxis}
               renderTooltip={({ index }) => (
                 <div>
                   <strong>{d3format(column.d3Format, sparkData[index])}</strong>

--- a/superset/assets/src/visualizations/time_table.jsx
+++ b/superset/assets/src/visualizations/time_table.jsx
@@ -4,7 +4,7 @@ import propTypes from 'prop-types';
 import { Table, Thead, Th, Tr, Td } from 'reactable';
 import d3 from 'd3';
 import Mustache from 'mustache';
-import { Sparkline, LineSeries, PointSeries, VerticalReferenceLine, WithTooltip } from '@data-ui/sparkline';
+import { Sparkline, LineSeries, PointSeries, HorizontalReferenceLine, VerticalReferenceLine, WithTooltip } from '@data-ui/sparkline';
 
 import MetricOption from '../components/MetricOption';
 import { d3format } from '../modules/utils';
@@ -95,12 +95,16 @@ function viz(slice, payload) {
         }
         const formatDate = formatDateThunk(column.dateFormat);
         const yScale = {};
+        let hasMin = false;
+        let hasMax = false;
         if (column.yAxisBounds) {
           const [min, max] = column.yAxisBounds;
-          if (min !== null && min !== undefined && min !== '') {
+          hasMin = min !== null && min !== undefined && min !== '';
+          if (hasMin) {
             yScale.min = min;
           }
-          if (max !== null && max !== undefined && max !== '') {
+          hasMax = max !== null && max !== undefined && max !== '';
+          if (hasMax) {
             yScale.max = max;
           }
         }
@@ -128,6 +132,20 @@ function viz(slice, payload) {
                   onMouseMove={onMouseMove}
                   {...yScale}
                 >
+                  {hasMin &&
+                    <HorizontalReferenceLine
+                      reference={yScale.min}
+                      stroke="#bbb"
+                      strokeDasharray="3 3"
+                      strokeWidth={1}
+                    />}
+                  {hasMax &&
+                    <HorizontalReferenceLine
+                      reference={yScale.max}
+                      stroke="#bbb"
+                      strokeDasharray="3 3"
+                      strokeWidth={1}
+                    />}
                   <LineSeries
                     showArea={false}
                     stroke="#767676"

--- a/superset/assets/src/visualizations/time_table.jsx
+++ b/superset/assets/src/visualizations/time_table.jsx
@@ -108,6 +108,9 @@ function viz(slice, payload) {
             yScale.max = max;
           }
         }
+        const margin = column.showYAxisBounds && (hasMin || hasMax)
+          ? { ...SPARKLINE_MARGIN, right: SPARKLINE_MARGIN.right + 30 }
+          : SPARKLINE_MARGIN;
         row[column.key] = {
           data: sparkData[sparkData.length - 1],
           display: (
@@ -126,7 +129,7 @@ function viz(slice, payload) {
                   ariaLabel={`spark-${metricLabel}`}
                   width={parseInt(column.width, 10) || 300}
                   height={parseInt(column.height, 10) || 50}
-                  margin={SPARKLINE_MARGIN}
+                  margin={margin}
                   data={sparkData}
                   onMouseLeave={onMouseLeave}
                   onMouseMove={onMouseMove}
@@ -135,6 +138,8 @@ function viz(slice, payload) {
                   {column.showYAxisBounds && hasMin &&
                     <HorizontalReferenceLine
                       reference={yScale.min}
+                      labelPosition="right"
+                      renderLabel={() => d3format(column.d3format, yScale.min)}
                       stroke="#bbb"
                       strokeDasharray="3 3"
                       strokeWidth={1}
@@ -142,6 +147,8 @@ function viz(slice, payload) {
                   {column.showYAxisBounds && hasMax &&
                     <HorizontalReferenceLine
                       reference={yScale.max}
+                      labelPosition="right"
+                      renderLabel={() => d3format(column.d3format, yScale.max)}
                       stroke="#bbb"
                       strokeDasharray="3 3"
                       strokeWidth={1}


### PR DESCRIPTION
- User can set a fixed y-min/max
- User can choose to display y-axis for the sparkline
- Refactor and extract Sparkline logic from `time_table` into `SparklineCell`

![debug-time-series-table-4](https://user-images.githubusercontent.com/1659771/44049384-cf79aad6-9ee8-11e8-934b-8c863cf18944.png)

@williaster @graceguo-supercat 