### PR TITLE
[sql lab] always use NullPool

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -165,7 +165,7 @@ def execute_sql(
     try:
         engine = database.get_sqla_engine(
             schema=query.schema,
-            nullpool=not ctask.request.called_directly,
+            nullpool=True,
             user_name=user_name,
         )
         conn = engine.raw_connection()


### PR DESCRIPTION
I think that the only place where we want db connection pooling would be
to talk to the metadata database. SQL Lab should close its connections
and never pool them.
Given that each Gunicorn worker will create its own pool that can lead
to way too many connections opened.

closes https://github.com/apache/incubator-superset/issues/4666

@john-bodley @betodealmeida 