### PR TITLE
[dashboards] Increasing position_json to MEDIUMTEXT for MySQL

### DIFF
--- a/superset/migrations/versions/1a1d627ebd8e_position_json.py
+++ b/superset/migrations/versions/1a1d627ebd8e_position_json.py
@@ -1,0 +1,36 @@
+"""position_json
+
+Revision ID: 1a1d627ebd8e
+Revises: 0c5070e96b57
+Create Date: 2018-08-13 11:30:07.101702
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1a1d627ebd8e'
+down_revision = '0c5070e96b57'
+
+from alembic import op
+import sqlalchemy as sa
+
+from superset.utils import MediumText
+
+
+def upgrade():
+    with op.batch_alter_table('dashboards') as batch_op:
+        batch_op.alter_column(
+            'position_json',
+            existing_type=sa.Text(),
+            type_=MediumText(),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('dashboards') as batch_op:
+        batch_op.alter_column(
+            'position_json',
+            existing_type=MediumText(),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -41,6 +41,7 @@ from superset.connectors.connector_registry import ConnectorRegistry
 from superset.legacy import update_time_range
 from superset.models.helpers import AuditMixinNullable, ImportMixin, set_perm
 from superset.models.user_attributes import UserAttribute
+from superset.utils import MediumText
 from superset.viz import viz_types
 install_aliases()
 from urllib import parse  # noqa
@@ -364,7 +365,7 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
     __tablename__ = 'dashboards'
     id = Column(Integer, primary_key=True)
     dashboard_title = Column(String(500))
-    position_json = Column(Text)
+    position_json = Column(MediumText())
     description = Column(Text)
     css = Column(Text)
     json_metadata = Column(Text)

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -39,7 +39,8 @@ from past.builtins import basestring
 from pydruid.utils.having import Having
 import pytz
 import sqlalchemy as sa
-from sqlalchemy import event, exc, select
+from sqlalchemy import event, exc, select, Text
+from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.types import TEXT, TypeDecorator
 
 from superset.exceptions import SupersetException, SupersetTimeoutException
@@ -1011,3 +1012,7 @@ def get_username():
         return g.user.username
     except Exception:
         pass
+
+
+def MediumText():
+    return Text().with_variant(MEDIUMTEXT(), 'mysql')


### PR DESCRIPTION
Most SQLA engines are unbounded for the `TEXT` type however for MySQL it's restricted to ~ 64 kB which can cause overflow for the `dashboards.position_json` column for the V2 layout.

This PR ensures that for MySQL engines the `TEXT` column is changed from `TEXT`(~ 64 kB) to `MEDIUMTEXT` (~ 16 MB). All other engines remained unchanged.

to: @graceguo-supercat @michellethomas @mistercrunch @williaster  