### PR TITLE
Add option to run query with ctrl+enter

### DIFF
--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -99,8 +99,14 @@ class SqlEditor extends React.PureComponent {
   getHotkeyConfig() {
     return [
       {
-        name: 'runQuery',
+        name: 'runQuery1',
         key: 'ctrl+r',
+        descr: 'Run query',
+        func: this.runQuery,
+      },
+      {
+        name: 'runQuery2',
+        key: 'ctrl+enter',
         descr: 'Run query',
         func: this.runQuery,
       },


### PR DESCRIPTION
Add `ctrl+enter` as an option to run query. `ctrl+r` still works.