### PR TITLE
[bubble] Fixing ad-hoc metric labels

### DIFF
--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -329,9 +329,9 @@ export default function nvd3Vis(slice, payload) {
             `<tr><td style="color: ${p.color};">` +
               `<strong>${p[fd.entity]}</strong> (${p.group})` +
             '</td></tr>');
-          s += row(fd.x, formatter(p.x));
-          s += row(fd.y, formatter(p.y));
-          s += row(fd.size, formatter(p.size));
+          s += row(fd.x.label || fd.x, formatter(p.x));
+          s += row(fd.y.label || fd.y, formatter(p.y));
+          s += row(fd.size.label || fd.size, formatter(p.size));
           s += '</table>';
           return s;
         });


### PR DESCRIPTION
This PR fixes the bubble chart labels which previously rendered as `[object Object]` if the metric was an ad-hoc metric.

to: @GabeLoins @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 