### PR TITLE
[bug fix] Fixed forced percentage format on tooltips and bubble chart tooltips format.

### DIFF
--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -324,13 +324,15 @@ export default function nvd3Vis(slice, payload) {
         chart.showDistY(true);
         chart.tooltip.contentGenerator(function (obj) {
           const p = obj.point;
+          const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
+          const xAxisFormatter = d3FormatPreset(fd.x_axis_format);
           let s = '<table>';
           s += (
             `<tr><td style="color: ${p.color};">` +
               `<strong>${p[fd.entity]}</strong> (${p.group})` +
             '</td></tr>');
-          s += row(fd.x, formatter(p.x));
-          s += row(fd.y, formatter(p.y));
+          s += row(fd.x, xAxisFormatter(p.x));
+          s += row(fd.y, yAxisFormatter(p.y));
           s += row(fd.size, formatter(p.size));
           s += '</table>';
           return s;
@@ -412,15 +414,13 @@ export default function nvd3Vis(slice, payload) {
       chart.xAxis.tickFormat(xAxisFormatter);
     }
 
-    const yAxisFormatter = d3FormatPreset(fd.y_axis_format);
+    let yAxisFormatter = d3FormatPreset(fd.y_axis_format);
     if (chart.yAxis && chart.yAxis.tickFormat) {
       if (fd.contribution || fd.comparison_type === 'percentage') {
         // When computing a "Percentage" or "Contribution" selected, we force a percentage format
-        const percentageFormat = d3.format('.1%');
-        chart.yAxis.tickFormat(percentageFormat);
-      } else {
-        chart.yAxis.tickFormat(yAxisFormatter);
+        yAxisFormatter = d3.format('.1%');
       }
+      chart.yAxis.tickFormat(yAxisFormatter);
     }
     if (chart.y2Axis && chart.y2Axis.tickFormat) {
       chart.y2Axis.tickFormat(yAxisFormatter);


### PR DESCRIPTION
Bug 1: For line charts, when the y-axis is force to set as percentage (hen computing a "Percentage" or "Contribution" selected, we force a percentage format), the tooltip is not correctly reflected on this change. 

Before:

<img width="642" alt="screen shot 2018-08-14 at 1 32 03 pm" src="https://user-images.githubusercontent.com/2024960/44116864-866aa12c-9fc6-11e8-9b7e-649c39a29e4b.png">

After:

<img width="703" alt="screen shot 2018-08-14 at 1 29 32 pm" src="https://user-images.githubusercontent.com/2024960/44116873-8da8b7ee-9fc6-11e8-8afd-324de2b7da04.png">


Bug 2: For bubble chart, the format of tooltip is not correct reflect on the x and y tick formats.

Before:

<img width="946" alt="screen shot 2018-08-14 at 1 31 44 pm" src="https://user-images.githubusercontent.com/2024960/44116921-acb5377a-9fc6-11e8-941e-95a1beebd02a.png">

After:

<img width="559" alt="screen shot 2018-08-14 at 1 30 56 pm" src="https://user-images.githubusercontent.com/2024960/44116947-bd5a6e2e-9fc6-11e8-8960-f866593545c4.png">

cc: @john-bodley @michellethomas @williaster 