### PR TITLE
Fetch a batch of rows from bigquery

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1367,6 +1367,15 @@ class BQEngineSpec(BaseEngineSpec):
     As contributed by @mxmzdlv on issue #945"""
     engine = 'bigquery'
 
+    """
+    https://www.python.org/dev/peps/pep-0249/#arraysize
+    raw_connections bypass the pybigquery query execution context and deal with
+    raw dbapi connection directly.
+    If this value is not set, the default value is set to 1, as described here,
+    https://googlecloudplatform.github.io/google-cloud-python/latest/_modules/google/cloud/bigquery/dbapi/cursor.html#Cursor
+    """
+    arraysize = 5000
+
     time_grain_functions = {
         None: '{col}',
         'PT1S': 'TIMESTAMP_TRUNC({col}, SECOND)',
@@ -1388,6 +1397,7 @@ class BQEngineSpec(BaseEngineSpec):
 
     @classmethod
     def fetch_data(cls, cursor, limit):
+        cursor.arraysize = 5000
         data = super(BQEngineSpec, cls).fetch_data(cursor, limit)
         if len(data) != 0 and type(data[0]).__name__ == 'Row':
             data = [r.values() for r in data]

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1397,7 +1397,7 @@ class BQEngineSpec(BaseEngineSpec):
 
     @classmethod
     def fetch_data(cls, cursor, limit):
-        cursor.arraysize = 5000
+        cursor.arraysize = BQEngineSpec.arraysize
         data = super(BQEngineSpec, cls).fetch_data(cursor, limit)
         if len(data) != 0 and type(data[0]).__name__ == 'Row':
             data = [r.values() for r in data]


### PR DESCRIPTION
While running superset with Google BigQuery as the database I found that the queries are very slow. To fetch 1000 rows, it was taking approx. ~2 minutes. On further investigation I found that, they way our cursor is configured, it makes an REST API call for every row fetched, instead of one API call to fetch a batch of rows. pybigquery handles this batch fetch configuration, however, it does not work with cursor from the raw_connection used in superset.  

After my change, the query to fetch 1000 rows from BigQuery takes ~1.5 seconds in Superset, down from ~120seconds. Which is on par with the query runtime, when run from BigQuery query editor.