### PR TITLE
[explore] fix the 'altered' tag false positive

### DIFF
--- a/superset/assets/src/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/src/explore/components/ExploreViewContainer.jsx
@@ -293,12 +293,6 @@ ExploreViewContainer.propTypes = propTypes;
 
 function mapStateToProps({ explore, charts, impressionId }) {
   const form_data = getFormDataFromControls(explore.controls);
-  // fill in additional params stored in form_data but not used by control
-  Object.keys(explore.rawFormData).forEach((key) => {
-    if (form_data[key] === undefined) {
-      form_data[key] = explore.rawFormData[key];
-    }
-  });
   const chartKey = Object.keys(charts)[0];
   const chart = charts[chartKey];
   return {

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1888,6 +1888,13 @@ export const controls = {
     description: t('The number of seconds before expiring the cache'),
   },
 
+  url_params: {
+    type: 'HiddenControl',
+    label: t('URL Parameters'),
+    hidden: true,
+    description: t('Captures extra URL params'),
+  },
+
   order_by_entity: {
     type: 'CheckboxControl',
     label: t('Order by entity id'),

--- a/superset/assets/src/explore/index.jsx
+++ b/superset/assets/src/explore/index.jsx
@@ -41,11 +41,8 @@ const bootstrappedState = {
   isDatasourceMetaLoading: false,
   isStarred: false,
 };
-const slice = bootstrappedState.slice;
-const sliceFormData = slice
-  ? getFormDataFromControls(getControlsState(bootstrapData, slice.form_data))
-  : null;
 const chartKey = getChartKey(bootstrappedState);
+const formData = getFormDataFromControls(controls);
 const initState = {
   charts: {
     [chartKey]: {
@@ -54,8 +51,8 @@ const initState = {
       chartStatus: 'loading',
       chartUpdateEndTime: null,
       chartUpdateStartTime: now(),
-      latestQueryFormData: getFormDataFromControls(controls),
-      sliceFormData,
+      latestQueryFormData: formData,
+      sliceFormData: bootstrappedState.slice ? formData : null,
       queryRequest: null,
       queryResponse: null,
       triggerQuery: true,

--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -24,6 +24,7 @@ export const sections = {
       ['datasource'],
       ['viz_type'],
       ['slice_id', 'cache_timeout'],
+      ['url_params'],
     ],
   },
   colorScheme: {


### PR DESCRIPTION
The altered tag shows up in many cases where it shouldn't. First
it's common for the loaded examples to have extra keys in their
form_data, they were designed that way knowing extra keys get removed
along the way (only the form_data relevant to a particular viz type
makes it through).

Though then there was a few lines added to allow for `url_params`
through, but brought back the kitchen sink as it merged all other
bad keys. This also creates problems around metrics and such as
switching viz types.

As an alternative approach, I added `url_params` as a HiddenControl so
that it can flow using the common form_data flow.

Note that:
* `url_params` will get saved with the chart metadata, but overriden on
explore. It appears that the logic that bakes the `url_params` applies
only to explore, not dashboards, meaning unless we call
`merge_request_params` on the dashobard endpoint, the `url_params` would
show as saved on the chart.
* I cleaned up some dup logic in index.js
* I can't test that very much as I don't fully understand the use case,
it appears url_params never worked with dashboards for instance

@michellethomas @graceguo-supercat let me know what you think