### PR TITLE
Compact time filter tabs in dashboard

### DIFF
--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -109,3 +109,11 @@
     margin-right: 8px;
   }
 }
+
+.time-filter-tabs > .nav-tabs {
+  margin-bottom: 8px;
+}
+
+.time-filter-tabs > .nav-tabs > li > a {
+  padding: 4px;
+}


### PR DESCRIPTION
Fix CSS for time filter in dashboards.

How it looks like in the explore view:

<img width="408" alt="screen shot 2018-08-15 at 2 51 44 pm" src="https://user-images.githubusercontent.com/1534870/44175358-c6789880-a09a-11e8-97d6-3279a9f1f252.png">

How it currently looks like in dashboards:

<img width="415" alt="screen shot 2018-08-15 at 2 53 15 pm" src="https://user-images.githubusercontent.com/1534870/44175435-02136280-a09b-11e8-9345-18d5b96f2a02.png">

With this change:

<img width="415" alt="screen shot 2018-08-15 at 2 52 19 pm" src="https://user-images.githubusercontent.com/1534870/44175399-e60fc100-a09a-11e8-83f7-58125192b162.png">