### PR TITLE
Field names in big query can contain only alphanumeric and underscore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.swp
 yarn-error.log
 _modules
 superset/assets/coverage/*

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -566,8 +566,6 @@ class SqlaTable(Model, BaseDatasource):
             raise Exception(_('Empty query?'))
         metrics_exprs = []
         for m in metrics:
-            if isinstance(m, dict) and 'label' in m:
-                m['label'] = db_engine_spec.mutate_expression_label(m['label'])
             if utils.is_adhoc_metric(m):
                 metrics_exprs.append(self.adhoc_metric_to_sa(m, cols))
             elif m in metrics_dict:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -566,6 +566,8 @@ class SqlaTable(Model, BaseDatasource):
             raise Exception(_('Empty query?'))
         metrics_exprs = []
         for m in metrics:
+            if isinstance(m, dict) and 'label' in m:
+                m['label'] = db_engine_spec.mutate_expression_label(m['label'])
             if utils.is_adhoc_metric(m):
                 metrics_exprs.append(self.adhoc_metric_to_sa(m, cols))
             elif m in metrics_dict:

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -422,6 +422,10 @@ class BaseEngineSpec(object):
 
         return df.rename(index=str, columns=rename_cols)
 
+    @staticmethod
+    def mutate_expression_label(label):
+        return label
+
 
 class PostgresBaseEngineSpec(BaseEngineSpec):
     """ Abstract class for Postgres 'like' databases """
@@ -1409,6 +1413,18 @@ class BQEngineSpec(BaseEngineSpec):
         if len(data) != 0 and type(data[0]).__name__ == 'Row':
             data = [r.values() for r in data]
         return data
+
+    @staticmethod
+    def mutate_expression_label(label):
+        mutated_label = re.sub('[^\w]+', '_', label)
+        if not re.match("^[a-zA-Z_]+.*", mutated_label):
+            raise SupersetTemplateException('BigQuery field_name used is invalid {}, '
+                                            'should start with a letter or '
+                                            'underscore'.format(mutated_label))
+        if len(mutated_label) > 128:
+            raise SupersetTemplateException('BigQuery field_name {}, should be atmost '
+                                            '128 characters'.format(mutated_label))
+        return mutated_label
 
 
 class ImpalaEngineSpec(BaseEngineSpec):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1417,7 +1417,7 @@ class BQEngineSpec(BaseEngineSpec):
     @staticmethod
     def mutate_expression_label(label):
         mutated_label = re.sub('[^\w]+', '_', label)
-        if not re.match("^[a-zA-Z_]+.*", mutated_label):
+        if not re.match('^[a-zA-Z_]+.*', mutated_label):
             raise SupersetTemplateException('BigQuery field_name used is invalid {}, '
                                             'should start with a letter or '
                                             'underscore'.format(mutated_label))

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1442,7 +1442,7 @@ class BQEngineSpec(BaseEngineSpec):
         """
         return [sqla.literal_column(c.get('name')).label(c.get('name').replace('.', '__'))
                 for c in cols]
-      
+
 
 class ImpalaEngineSpec(BaseEngineSpec):
     """Engine spec for Cloudera's Impala"""

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -108,7 +108,10 @@ class BaseViz(object):
                 if not isinstance(val, list):
                     val = [val]
                 for o in val:
-                    self.metric_dict[self.get_metric_label(o)] = o
+                    label = self.get_metric_label(o)
+                    if isinstance(o, dict):
+                        o['label'] = label
+                    self.metric_dict[label] = o
 
         # Cast to list needed to return serializable object in py3
         self.all_metrics = list(self.metric_dict.values())

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -118,7 +118,8 @@ class BaseViz(object):
         if isinstance(metric, string_types):
             return metric
         if isinstance(metric, dict):
-            return self.datasource.database.db_engine_spec.mutate_expression_label(metric.get('label'))
+            return self.datasource.database.db_engine_spec.mutate_expression_label(
+                    metric.get('label'))
 
     @staticmethod
     def handle_js_int_overflow(data):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -113,7 +113,7 @@ class BaseViz(object):
         if isinstance(metric, string_types):
             return metric
         if isinstance(metric, dict):
-            return metric.get('label')
+            return self.datasource.database.db_engine_spec.mutate_expression_label(metric.get('label'))
 
     @staticmethod
     def handle_js_int_overflow(data):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -122,7 +122,7 @@ class BaseViz(object):
             return metric
         if isinstance(metric, dict):
             return self.datasource.database.db_engine_spec.mutate_expression_label(
-                    metric.get('label'))
+                metric.get('label'))
 
     @staticmethod
     def handle_js_int_overflow(data):

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -121,6 +121,20 @@ class BaseVizTestCase(unittest.TestCase):
 
 
 class TableVizTestCase(unittest.TestCase):
+
+    class DBEngineSpecMock:
+        @staticmethod
+        def mutate_expression_label(label):
+            return label
+
+    class DatabaseMock:
+        def __init__(self):
+            self.db_engine_spec = TableVizTestCase.DBEngineSpecMock()
+
+    class DatasourceMock:
+        def __init__(self):
+            self.database = TableVizTestCase.DatabaseMock()
+
     def test_get_data_applies_percentage(self):
         form_data = {
             'percent_metrics': [{
@@ -136,7 +150,7 @@ class TableVizTestCase(unittest.TestCase):
                 'column': {'column_name': 'value1', 'type': 'DOUBLE'},
             }, 'count', 'avg__C'],
         }
-        datasource = Mock()
+        datasource = TableVizTestCase.DatasourceMock()
         raw = {}
         raw['SUM(value1)'] = [15, 20, 25, 40]
         raw['avg__B'] = [10, 20, 5, 15]


### PR DESCRIPTION
When we try to use explore view to plot charts against a BigQuery dataset, superset was used some characters in the field name which BigQuery syntax did not like.

Here, is the error returned by BigQuery
`Invalid field name "AVG(lat)". Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be at most 128 characters long`

This PR, fixes this issue so that we can plot charts against big query dataset.