### PR TITLE
Filter out null locations by default

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -680,6 +680,13 @@ export const controls = {
     }),
   },
 
+  filter_nulls: {
+    type: 'CheckboxControl',
+    label: t('Ignore null locations'),
+    default: true,
+    description: t('Whether to ignore locations that are null'),
+  },
+
   geojson: {
     type: 'SelectControl',
     label: t('GeoJson Column'),

--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -503,7 +503,7 @@ export const visTypes = {
         expanded: true,
         controlSetRows: [
           ['spatial', 'size'],
-          ['row_limit', null],
+          ['row_limit', 'filter_nulls'],
           ['adhoc_filters'],
         ],
       },
@@ -542,7 +542,7 @@ export const visTypes = {
         expanded: true,
         controlSetRows: [
           ['spatial', 'size'],
-          ['row_limit', null],
+          ['row_limit', 'filter_nulls'],
           ['adhoc_filters'],
         ],
       },
@@ -582,7 +582,7 @@ export const visTypes = {
         expanded: true,
         controlSetRows: [
           ['line_column', 'line_type'],
-          ['row_limit', null],
+          ['row_limit', 'filter_nulls'],
           ['adhoc_filters'],
         ],
       },
@@ -616,7 +616,7 @@ export const visTypes = {
         expanded: true,
         controlSetRows: [
           ['spatial', 'size'],
-          ['row_limit', null],
+          ['row_limit', 'filter_nulls'],
           ['adhoc_filters'],
         ],
       },
@@ -662,7 +662,8 @@ export const visTypes = {
         label: t('Query'),
         expanded: true,
         controlSetRows: [
-          ['geojson', 'row_limit'],
+          ['geojson', null],
+          ['row_limit', 'filter_nulls'],
           ['adhoc_filters'],
         ],
       },
@@ -703,7 +704,7 @@ export const visTypes = {
         expanded: true,
         controlSetRows: [
           ['line_column', 'line_type'],
-          ['row_limit', null],
+          ['row_limit', 'filter_nulls'],
           ['adhoc_filters'],
         ],
       },
@@ -744,7 +745,7 @@ export const visTypes = {
         expanded: true,
         controlSetRows: [
           ['start_spatial', 'end_spatial'],
-          ['row_limit', null],
+          ['row_limit', 'filter_nulls'],
           ['adhoc_filters'],
         ],
       },
@@ -793,7 +794,8 @@ export const visTypes = {
         label: t('Query'),
         expanded: true,
         controlSetRows: [
-          ['spatial', 'row_limit'],
+          ['spatial', null],
+          ['row_limit', 'filter_nulls'],
           ['adhoc_filters'],
         ],
       },

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -39,7 +39,12 @@ from six.moves import cPickle as pkl, reduce
 
 from superset import app, cache, get_css_manifest_files, utils
 from superset.exceptions import NullValueException, SpatialException
-from superset.utils import DTTM_ALIAS, JS_MAX_INTEGER, merge_extra_filters
+from superset.utils import (
+    DTTM_ALIAS,
+    JS_MAX_INTEGER,
+    merge_extra_filters,
+    to_adhoc,
+)
 
 
 config = app.config
@@ -2073,14 +2078,16 @@ class BaseDeckGLViz(BaseViz):
         spatial = self.form_data.get(key)
         if spatial is None:
             raise ValueError(_('Bad spatial key'))
+        group_by.extend(self.get_spatial_columns(key))
 
+    def get_spatial_columns(self, key):
+        spatial = self.form_data.get(key)
         if spatial.get('type') == 'latlong':
-            group_by += [spatial.get('lonCol')]
-            group_by += [spatial.get('latCol')]
+            return [spatial.get('lonCol'), spatial.get('latCol')]
         elif spatial.get('type') == 'delimited':
-            group_by += [spatial.get('lonlatCol')]
+            return [spatial.get('lonlatCol')]
         elif spatial.get('type') == 'geohash':
-            group_by += [spatial.get('geohashCol')]
+            return [spatial.get('geohashCol')]
 
     @staticmethod
     def parse_coordinates(s):
@@ -2124,8 +2131,24 @@ class BaseDeckGLViz(BaseViz):
         return df
 
     def query_obj(self):
-        d = super(BaseDeckGLViz, self).query_obj()
         fd = self.form_data
+
+        # add NULL filters
+        if fd.get('filter_nulls'):
+            spatial_columns = set()
+            for key in self.spatial_control_keys:
+                for column in self.get_spatial_columns(key):
+                    spatial_columns.add(column)
+
+            for column in spatial_columns:
+                filter_ = to_adhoc({
+                    'col': column,
+                    'op': 'IS NOT NULL',
+                    'val': '',
+                })
+                fd['adhoc_filters'].append(filter_)
+
+        d = super(BaseDeckGLViz, self).query_obj()
         gb = []
 
         for key in self.spatial_control_keys:
@@ -2144,6 +2167,7 @@ class BaseDeckGLViz(BaseViz):
             d['columns'] = []
         else:
             d['columns'] = gb
+
         return d
 
     def get_js_columns(self, d):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2075,13 +2075,13 @@ class BaseDeckGLViz(BaseViz):
         return [self.metric] if self.metric else []
 
     def process_spatial_query_obj(self, key, group_by):
-        spatial = self.form_data.get(key)
-        if spatial is None:
-            raise ValueError(_('Bad spatial key'))
         group_by.extend(self.get_spatial_columns(key))
 
     def get_spatial_columns(self, key):
         spatial = self.form_data.get(key)
+        if spatial is None:
+            raise ValueError(_('Bad spatial key'))
+
         if spatial.get('type') == 'latlong':
             return [spatial.get('lonCol'), spatial.get('latCol')]
         elif spatial.get('type') == 'delimited':
@@ -2167,7 +2167,6 @@ class BaseDeckGLViz(BaseViz):
             d['columns'] = []
         else:
             d['columns'] = gb
-
         return d
 
     def get_js_columns(self, d):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2130,23 +2130,29 @@ class BaseDeckGLViz(BaseViz):
                                        please consider filtering those out'))
         return df
 
+    def add_null_filters(self):
+        spatial_columns = set()
+        for key in self.spatial_control_keys:
+            for column in self.get_spatial_columns(key):
+                spatial_columns.add(column)
+
+        if self.form_data.get('adhoc_filters') is None:
+            self.form_data['adhoc_filters'] = []
+
+        for column in spatial_columns:
+            filter_ = to_adhoc({
+                'col': column,
+                'op': 'IS NOT NULL',
+                'val': '',
+            })
+            self.form_data['adhoc_filters'].append(filter_)
+
     def query_obj(self):
         fd = self.form_data
 
         # add NULL filters
         if fd.get('filter_nulls'):
-            spatial_columns = set()
-            for key in self.spatial_control_keys:
-                for column in self.get_spatial_columns(key):
-                    spatial_columns.add(column)
-
-            for column in spatial_columns:
-                filter_ = to_adhoc({
-                    'col': column,
-                    'op': 'IS NOT NULL',
-                    'val': '',
-                })
-                fd['adhoc_filters'].append(filter_)
+            self.add_null_filters()
 
         d = super(BaseDeckGLViz, self).query_obj()
         gb = []

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2139,7 +2139,7 @@ class BaseDeckGLViz(BaseViz):
         if self.form_data.get('adhoc_filters') is None:
             self.form_data['adhoc_filters'] = []
 
-        for column in spatial_columns:
+        for column in sorted(spatial_columns):
             filter_ = to_adhoc({
                 'col': column,
                 'op': 'IS NOT NULL',


### PR DESCRIPTION
I added a checkbox to all spatial visualizations allowing null locations to be filtered out by default. Currently, they are shown as `0, 0`, which is confusing.

My original approach to solving this was by filtering the data on `viz.py`, but at that point we don't know if a zero is a valid location or not (Druid return zeros for null, IIRC). Adding the extra filters to the form data has the benefit that the data is filtered in the database, and in a consistent way.

Here's how the `flights` dataset currently looks like — note all the arcs with an edge at the Equator/Greenwich:

<img width="1680" alt="screen shot 2018-08-15 at 4 04 11 pm" src="https://user-images.githubusercontent.com/1534870/44178187-1446ce00-a0a6-11e8-9927-9dc70c17613a.png">

When we toggle "Ignore null locations" they are removed:

<img width="1680" alt="screen shot 2018-08-15 at 4 04 20 pm" src="https://user-images.githubusercontent.com/1534870/44178186-1446ce00-a0a6-11e8-9f99-034a3572b161.png">


