### PR TITLE
use_slice_data in slice_json

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1105,7 +1105,7 @@ class Superset(BaseSupersetView):
     @expose('/slice_json/<slice_id>')
     def slice_json(self, slice_id):
         try:
-            form_data, slc = self.get_form_data(slice_id)
+            form_data, slc = self.get_form_data(slice_id, use_slice_data=True)
             datasource_type = slc.datasource.type
             datasource_id = slc.datasource.id
 


### PR DESCRIPTION
We should be explicitly making sure use_slice_json is true when slice_json calls get_form_data. 

@john-bodley @graceguo-supercat  