### PR TITLE
handle exception and set dtype value to JSON, when column type JSON

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2252,6 +2252,8 @@ class Superset(BaseSupersetView):
             try:
                 dtype = '{}'.format(col['type'])
             except Exception:
+                if isinstance(col['type'], sqla.types.JSON):
+                    dtype = 'JSON'
                 pass
             payload_columns.append({
                 'name': col['name'],

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2250,10 +2250,9 @@ class Superset(BaseSupersetView):
         for col in columns:
             dtype = ''
             try:
-                dtype = '{}'.format(col['type'])
+                # sqla.types.JSON __str__ has a bug, so using __class__.
+                dtype = col['type'].__class__.__name__
             except Exception:
-                if isinstance(col['type'], sqla.types.JSON):
-                    dtype = 'JSON'
                 pass
             payload_columns.append({
                 'name': col['name'],

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2250,9 +2250,10 @@ class Superset(BaseSupersetView):
         for col in columns:
             dtype = ''
             try:
+                dtype = '{}'.format(col['type'])
+            except Exception:
                 # sqla.types.JSON __str__ has a bug, so using __class__.
                 dtype = col['type'].__class__.__name__
-            except Exception:
                 pass
             payload_columns.append({
                 'name': col['name'],


### PR DESCRIPTION
Because we pass the exception for sqlachemy.types.JSON type, in the UI when we list columns in the table we do not show the correct type.

ERROR:root:Compiler <sqlalchemy.sql.compiler.GenericTypeCompiler object at 0x7fc5aa6cad90> can't render element of type <class 'sqlalchemy.sql.sqltypes.JSON'> 
