### PR TITLE
Fix checkbox is fails When disable Druid datasource

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1449,10 +1449,8 @@ class Superset(BaseSupersetView):
     def checkbox(self, model_view, id_, attr, value):
         """endpoint for checking/unchecking any boolean in a sqla model"""
         modelview_to_model = {
-            'TableColumnInlineView':
-                ConnectorRegistry.sources['table'].column_class,
-            'DruidColumnInlineView':
-                ConnectorRegistry.sources['druid'].column_class,
+            '{}ColumnInlineView'.format(name.capitalize()): source.column_class
+            for name, source in ConnectorRegistry.sources.items()
         }
         model = modelview_to_model[model_view]
         col = db.session.query(model).filter_by(id=id_).first()


### PR DESCRIPTION
As subject mentioned, when disable Druid datasource, the checkbox is fails. 
