### PR TITLE
Increase number of pylint jobs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -23,7 +23,7 @@ persistent=yes
 load-plugins=
 
 # Use multiple processes to speed up Pylint.
-jobs=1
+jobs=2
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.


### PR DESCRIPTION
`pylint` unit tests keep failing after spending more than 10 minutes without producing any output. I tested locally, and doubling the number of jobs will approximately half that time. Testing if it works with Travis.