### PR TITLE
fix multilayer viz backend error

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -958,7 +958,7 @@ def convert_legacy_filters_into_adhoc(fd):
                 fd['adhoc_filters'].append(to_adhoc(fd, 'SQL', clause))
 
             if filters in fd:
-                for filt in fd[filters]:
+                for filt in filter(lambda x: x is not None, fd[filters]):
                     fd['adhoc_filters'].append(to_adhoc(filt, 'SIMPLE', clause))
 
     for key in ('filters', 'having', 'having_filters', 'where'):


### PR DESCRIPTION
Multilayers Geoviz is broken on master. Here is the stack trace:
```
Traceback (most recent call last):
  File "/Users/jundayang/fun/youngyjd-superset/superset/views/core.py", line 1085, in generate_json
    payload = viz_obj.get_payload()
  File "/Users/jundayang/fun/youngyjd-superset/superset/viz.py", line 340, in get_payload
    payload = self.get_df_payload(query_obj)
  File "/Users/jundayang/fun/youngyjd-superset/superset/viz.py", line 355, in get_df_payload
    query_obj = self.query_obj()
  File "/Users/jundayang/fun/youngyjd-superset/superset/viz.py", line 2128, in query_obj
    d = super(BaseDeckGLViz, self).query_obj()
  File "/Users/jundayang/fun/youngyjd-superset/superset/viz.py", line 247, in query_obj
    utils.convert_legacy_filters_into_adhoc(form_data)
  File "/Users/jundayang/fun/youngyjd-superset/superset/utils.py", line 962, in convert_legacy_filters_into_adhoc
    fd['adhoc_filters'].append(to_adhoc(filt, 'SIMPLE', clause))
  File "/Users/jundayang/fun/youngyjd-superset/superset/utils.py", line 726, in to_adhoc
    'comparator': filt['val'],
TypeError: 'NoneType' object is not subscriptable
```
The example form data sent to backend:
```
{'color_picker': {'a': 1, 'b': 0, 'g': 255, 'r': 14}, 'datasource': '5__table', 'extruded': True, 'filters': [None], 'granularity_sqla': 'dttm', 'grid_size': 120, 'groupby': [], 'having': '', 'mapbox_style': 'mapbox://styles/mapbox/satellite-streets-v9', 'point_radius': 'Auto', 'point_radius_fixed': {'type': 'fix', 'value': 2000}, 'point_radius_unit': 'Pixels', 'row_limit': 5000, 'size': 'count', 'spatial': {'latCol': 'LAT', 'lonCol': 'LON', 'type': 'latlong'}, 'time_grain_sqla': None, 'time_range': 'No filter', 'viewport': {'bearing': 155.80099696026355, 'latitude': 37.7942314882596, 'longitude': -122.42066918995666, 'pitch': 53.470800300695146, 'zoom': 12.699690845482069}, 'viz_type': 'deck_grid', 'where': '', 'slice_id': 69}
```
Need to filter out **None** value from **'filters': [None]**