### PR TITLE
[big number] set start_y_axis_at_zero default to false

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1519,7 +1519,7 @@ export const controls = {
     type: 'CheckboxControl',
     label: t('Start y-axis at 0'),
     renderTrigger: true,
-    default: true,
+    default: false,
     description: t('Start y-axis at zero. Uncheck to start y-axis at minimum value in the data.'),
   },
 


### PR DESCRIPTION
To stick with the previous behavior and get the trend line to show the
trend by default.

@kristw @williaster 