### PR TITLE
Handling bigquery dialect when previewing data

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1414,17 +1414,19 @@ class BQEngineSpec(BaseEngineSpec):
             data = [r.values() for r in data]
         return data
 
-    """
-    BigQuery dialect requires us to not use backtick in the fieldname which are
-    nested.
-    Using literal_column handles that issue.
-    http://docs.sqlalchemy.org/en/latest/core/tutorial.html#using-more-specific-text-with-table-literal-column-and-column
-    Also explicility specifying column names so we don't encounter duplicate
-    column names in the result.
-    """
     @classmethod
     def _get_fields(cls, cols):
-        return [sqla.literal_column(c.get('name') + ' as ' + c.get('name').replace('.','__')) for c in cols]
+        """
+        BigQuery dialect requires us to not use backtick in the fieldname which are
+        nested.
+        Using literal_column handles that issue.
+        http://docs.sqlalchemy.org/en/latest/core/tutorial.html#using-more-specific-text-with-table-literal-column-and-column
+        Also explicility specifying column names so we don't encounter duplicate
+        column names in the result.
+        """
+        return [sqla.literal_column(c.get('name')).label(
+                        c.get('name').replace('.','__')
+                    ) for c in cols]
 
 
 class ImpalaEngineSpec(BaseEngineSpec):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -312,6 +312,10 @@ class BaseEngineSpec(object):
         return False
 
     @classmethod
+    def _get_fields(cls, cols):
+        return [sqla.column(c.get('name')) for c in cols]
+
+    @classmethod
     def select_star(cls, my_db, table_name, engine, schema=None, limit=100,
                     show_cols=False, indent=True, latest_partition=True,
                     cols=None):
@@ -321,7 +325,7 @@ class BaseEngineSpec(object):
             cols = my_db.get_columns(table_name, schema)
 
         if show_cols:
-            fields = [sqla.column(c.get('name')) for c in cols]
+            fields = cls._get_fields(cols)
         quote = engine.dialect.identifier_preparer.quote
         if schema:
             full_table_name = quote(schema) + '.' + quote(table_name)
@@ -1409,6 +1413,18 @@ class BQEngineSpec(BaseEngineSpec):
         if len(data) != 0 and type(data[0]).__name__ == 'Row':
             data = [r.values() for r in data]
         return data
+
+    """
+    BigQuery dialect requires us to not use backtick in the fieldname which are
+    nested.
+    Using literal_column handles that issue.
+    http://docs.sqlalchemy.org/en/latest/core/tutorial.html#using-more-specific-text-with-table-literal-column-and-column
+    Also explicility specifying column names so we don't encounter duplicate
+    column names in the result.
+    """
+    @classmethod
+    def _get_fields(cls, cols):
+        return [sqla.literal_column(c.get('name') + ' as ' + c.get('name').replace('.','__')) for c in cols]
 
 
 class ImpalaEngineSpec(BaseEngineSpec):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1424,9 +1424,8 @@ class BQEngineSpec(BaseEngineSpec):
         Also explicility specifying column names so we don't encounter duplicate
         column names in the result.
         """
-        return [sqla.literal_column(c.get('name')).label(
-                        c.get('name').replace('.','__')
-                    ) for c in cols]
+        return [sqla.literal_column(c.get('name')).label(c.get('name').replace('.', '__'))
+                for c in cols]
 
 
 class ImpalaEngineSpec(BaseEngineSpec):


### PR DESCRIPTION
BigQuery dialect does not like the use of backtick character in the column name when it is nested field/record type.
