### PR TITLE
[bugfix] TypeError: adhocMetric.comparator.join is not a function

### DIFF
--- a/superset/assets/src/explore/AdhocFilter.js
+++ b/superset/assets/src/explore/AdhocFilter.js
@@ -30,7 +30,7 @@ function translateToSql(adhocMetric, { useSimple } = {}) {
     const isMulti = MULTI_OPERATORS.indexOf(adhocMetric.operator) >= 0;
     const subject = adhocMetric.subject;
     const operator = OPERATORS_TO_SQL[adhocMetric.operator];
-    const comparator = isMulti ? adhocMetric.comparator.join("','") : adhocMetric.comparator;
+    const comparator = Array.isArray(adhocMetric.comparator) ? adhocMetric.comparator.join("','") : adhocMetric.comparator;
     return `${subject} ${operator} ${isMulti ? '(\'' : ''}${comparator}${isMulti ? '\')' : ''}`;
   } else if (adhocMetric.expressionType === EXPRESSION_TYPES.SQL) {
     return adhocMetric.sqlExpression;


### PR DESCRIPTION
Somehow we have a "IN" filter where the filter is a string, not an
array. While this may need to get fixed upstream as well, this prevents
the explore view from completely crashing.

Side note: this function looked somewhat brittle, I'm assuming it's used to keep
the free form SQL tab in sync and not used to generate the actual SQL
being executed.

@betodealmeida @GabeLoins @graceguo-supercat 