### PR TITLE
Make brush send events

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1481,6 +1481,14 @@ export const controls = {
     description: t('Whether to display the legend (toggles)'),
   },
 
+  send_time_range: {
+    type: 'CheckboxControl',
+    label: t('Propagate'),
+    renderTrigger: true,
+    default: false,
+    description: t('Send range filter events to other charts'),
+  },
+
   show_labels: {
     type: 'CheckboxControl',
     label: t('Show Labels'),

--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -179,7 +179,7 @@ export const visTypes = {
         expanded: true,
         controlSetRows: [
           ['color_scheme'],
-          ['show_brush', 'show_legend'],
+          ['show_brush', 'send_time_range', 'show_legend'],
           ['rich_tooltip', 'show_markers'],
           ['line_interpolation'],
         ],

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -363,6 +363,13 @@ export default function nvd3Vis(slice, payload) {
         throw new Error('Unrecognized visualization for nvd3' + vizType);
     }
 
+    if (isTruthy(fd.show_brush) && isTruthy(fd.send_time_range)) {
+      chart.focus.dispatch.on('brush', (event) => {
+        const timeRange = event.extent.map(d => d.toISOString().slice(0, -1)).join(' : ');
+        slice.addFilter('__time_range', timeRange, false, true);
+      });
+    }
+
     if (chart.xAxis && chart.xAxis.staggerLabels) {
       chart.xAxis.staggerLabels(staggerLabels);
     }

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -365,7 +365,11 @@ export default function nvd3Vis(slice, payload) {
 
     if (isTruthy(fd.show_brush) && isTruthy(fd.send_time_range)) {
       chart.focus.dispatch.on('brush', (event) => {
-        const timeRange = event.extent.map(d => d.toISOString().slice(0, -1)).join(' : ');
+        const extent = event.extent;
+        if (extent.some(d => d.toISOString === undefined)) {
+          return;
+        }
+        const timeRange = extent.map(d => d.toISOString().slice(0, -1)).join(' : ');
         slice.addFilter('__time_range', timeRange, false, true);
       });
     }

--- a/superset/assets/src/visualizations/nvd3_vis.js
+++ b/superset/assets/src/visualizations/nvd3_vis.js
@@ -370,7 +370,7 @@ export default function nvd3Vis(slice, payload) {
           return;
         }
         const timeRange = extent.map(d => d.toISOString().slice(0, -1)).join(' : ');
-        slice.addFilter('__time_range', timeRange, false, true);
+        event.brush.on('brushend', () => slice.addFilter('__time_range', timeRange, false, true));
       });
     }
 


### PR DESCRIPTION
I added a new option to time series, allowing the time brush (range filter) to send the selection to other charts:

<img width="534" alt="screen shot 2018-08-17 at 2 51 12 pm" src="https://user-images.githubusercontent.com/1534870/44290426-85fd5400-a22d-11e8-9fdc-4a987bb80f66.png">

Demo:

![brush_events_dashboard](https://user-images.githubusercontent.com/1534870/44290437-8eee2580-a22d-11e8-9dbc-a6dd8e0c6918.gif)
