### PR TITLE
feat: ensure to check a permission in SQL Lab regardless parsing results of SQL

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2379,6 +2379,9 @@ class Superset(BaseSupersetView):
             json_error_response(
                 'Database with id {} is missing.'.format(database_id))
 
+        if not security_manager.database_access(mydb):
+            return json_error_response('database access denied')
+
         rejected_tables = security_manager.rejected_datasources(sql, mydb, schema)
         if rejected_tables:
             return json_error_response(


### PR DESCRIPTION
At Udemy, my colleague reported a bug about the security of SQL lab. The report is permissions doesn't work properly against DML queries. Let's say there's `analytics.dummy_table` on one database, the symptoms are like this.

```
-- do not have permission to run this command.
SELECT COUNT(*) FROM analytics.dummy_table;

-- have permission to run this command.
CREATE TABLE analytics.dummy_table (
    id BIGINT
);

-- have permission to run this command.
DROP TABLE analytics.dummy_table;
```

The root cause is `security_manager.rejected_datasources` method relied on parsing results of SQL. Most simple select cases will work but complex queries won't work properly and DML is same. This PR is ensuring permission in SQL lab regardless parsing results of SQL, all `/sql_json/` requests will be checking database permission first and then call downstream.