### PR TITLE
[SIP-5] Revise markup.js and iframe.js

### DIFF
--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -1,7 +1,6 @@
 /* eslint no-undef: 2 */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Mustache from 'mustache';
 import { Tooltip } from 'react-bootstrap';
 
 import { d3format } from '../modules/utils';
@@ -181,15 +180,6 @@ class Chart extends React.PureComponent {
 
   verboseMetricName(metric) {
     return this.props.datasource.verbose_map[metric] || metric;
-  }
-
-  // eslint-disable-next-line camelcase
-  render_template(s) {
-    const context = {
-      width: this.width(),
-      height: this.height(),
-    };
-    return Mustache.render(s, context);
   }
 
   renderTooltip() {

--- a/superset/assets/src/visualizations/iframe.js
+++ b/superset/assets/src/visualizations/iframe.js
@@ -1,12 +1,20 @@
-const $ = require('jquery');
+import Mustache from 'mustache';
 
-function iframeWidget(slice) {
-  $('#code').attr('rows', '15');
-  const url = slice.render_template(slice.formData.url);
-  slice.container.html('<iframe style="width:100%;"></iframe>');
-  const iframe = slice.container.find('iframe');
-  iframe.css('height', slice.height());
-  iframe.attr('src', url);
+export default function iframeWidget(slice) {
+  const { selector, formData } = slice;
+  const { url } = formData;
+  const width = slice.width();
+  const height = slice.height();
+  const container = document.querySelector(selector);
+
+  const completedUrl = Mustache.render(url, {
+    width,
+    height,
+  });
+
+  const iframe = document.createElement('iframe');
+  iframe.style.width = '100%';
+  iframe.style.height = height;
+  iframe.setAttribute('src', completedUrl);
+  container.appendChild(iframe);
 }
-
-module.exports = iframeWidget;

--- a/superset/assets/src/visualizations/markup.js
+++ b/superset/assets/src/visualizations/markup.js
@@ -1,6 +1,5 @@
+import srcdoc from 'srcdoc-polyfill';
 import './markup.css';
-
-const srcdoc = require('srcdoc-polyfill');
 
 function markupWidget(slice, payload) {
   const { selector } = slice;
@@ -8,11 +7,6 @@ function markupWidget(slice, payload) {
   const headerHeight = slice.headerHeight();
   const vizType = slice.props.vizType;
   const { data } = payload;
-
-  // Old code not working. There is no #code element.
-  // $('#code').attr('rows', '15');
-  // document.getElementById('brace-editor')
-  //   .setAttribute('rows', 15);
 
   const container = document.querySelector(selector);
   container.style.overflow = 'auto';

--- a/superset/assets/src/visualizations/markup.js
+++ b/superset/assets/src/visualizations/markup.js
@@ -14,10 +14,6 @@ function markupWidget(slice, payload) {
   // document.getElementById('brace-editor')
   //   .setAttribute('rows', 15);
 
-  // const jqdiv = slice.container;
-  // jqdiv.css({
-  //   overflow: 'auto',
-  // });
   const container = document.querySelector(selector);
   container.style.overflow = 'auto';
 
@@ -25,12 +21,6 @@ function markupWidget(slice, payload) {
   const iframeHeight = vizType === 'separator'
     ? height - 20
     : height + headerHeight;
-
-  // let iframeHeight = height - 20;
-  // if (vizType === 'separator') {
-  //   // separator height is the entire chart container: slice height + header
-  //   iframeHeight = height + headerHeight;
-  // }
 
   const html = `
     <html>
@@ -50,15 +40,6 @@ function markupWidget(slice, payload) {
   iframe.setAttribute('sandbox', 'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation');
   container.appendChild(iframe);
 
-  // jqdiv.html(`
-  //   <iframe id="${iframeId}"
-  //     frameborder="0"
-  //     height="${iframeHeight}"
-  //     sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation">
-  //   </iframe>
-  // `);
-
-  // const iframe = document.getElementById(iframeId);
   srcdoc.set(iframe, html);
 }
 

--- a/superset/assets/src/visualizations/markup.js
+++ b/superset/assets/src/visualizations/markup.js
@@ -3,7 +3,7 @@ import './markup.css';
 const srcdoc = require('srcdoc-polyfill');
 
 function markupWidget(slice, payload) {
-  const { selector, containerId } = slice;
+  const { selector } = slice;
   const height = slice.height();
   const headerHeight = slice.headerHeight();
   const vizType = slice.props.vizType;
@@ -32,7 +32,6 @@ function markupWidget(slice, payload) {
   //   iframeHeight = height + headerHeight;
   // }
 
-  const iframeId = `if__${containerId}`;
   const html = `
     <html>
       <head>
@@ -46,7 +45,6 @@ function markupWidget(slice, payload) {
     </html>`;
 
   const iframe = document.createElement('iframe');
-  iframe.setAttribute('id', iframeId);
   iframe.setAttribute('frameborder', 0);
   iframe.setAttribute('height', iframeHeight);
   iframe.setAttribute('sandbox', 'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation');
@@ -59,8 +57,8 @@ function markupWidget(slice, payload) {
   //     sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation">
   //   </iframe>
   // `);
-  // const iframe = document.getElementById(iframeId);
 
+  // const iframe = document.getElementById(iframeId);
   srcdoc.set(iframe, html);
 }
 

--- a/superset/assets/src/visualizations/markup.js
+++ b/superset/assets/src/visualizations/markup.js
@@ -1,44 +1,67 @@
+import './markup.css';
+
 const srcdoc = require('srcdoc-polyfill');
 
-require('./markup.css');
-
 function markupWidget(slice, payload) {
-  $('#code').attr('rows', '15');
-  const jqdiv = slice.container;
-  jqdiv.css({
-    overflow: 'auto',
-  });
+  const { selector, containerId } = slice;
+  const height = slice.height();
+  const headerHeight = slice.headerHeight();
+  const vizType = slice.props.vizType;
+  const { data } = payload;
+
+  // Old code not working. There is no #code element.
+  // $('#code').attr('rows', '15');
+  // document.getElementById('brace-editor')
+  //   .setAttribute('rows', 15);
+
+  // const jqdiv = slice.container;
+  // jqdiv.css({
+  //   overflow: 'auto',
+  // });
+  const container = document.querySelector(selector);
+  container.style.overflow = 'auto';
 
   // markup height is slice height - (marginTop + marginBottom)
-  let iframeHeight = slice.height() - 20;
-  if (slice.props.vizType === 'separator') {
-    // separator height is the entire chart container: slice height + header
-    iframeHeight = slice.height() + slice.headerHeight();
-  }
+  const iframeHeight = vizType === 'separator'
+    ? height - 20
+    : height + headerHeight;
 
-  const iframeId = `if__${slice.containerId}`;
-  const stylesheets = payload.data.theme_css.map(
-    href => `<link rel="stylesheet" type="text/css" href="${href}" />`,
-  );
+  // let iframeHeight = height - 20;
+  // if (vizType === 'separator') {
+  //   // separator height is the entire chart container: slice height + header
+  //   iframeHeight = height + headerHeight;
+  // }
+
+  const iframeId = `if__${containerId}`;
   const html = `
     <html>
       <head>
-        ${stylesheets}
+        ${data.theme_css.map(
+          href => `<link rel="stylesheet" type="text/css" href="${href}" />`,
+        )}
       </head>
       <body style="background-color: transparent;">
-        ${payload.data.html}
+        ${data.html}
       </body>
     </html>`;
-  jqdiv.html(`
-    <iframe id="${iframeId}"
-      frameborder="0"
-      height="${iframeHeight}"
-      sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation">
-    </iframe>
-  `);
 
-  const iframe = document.getElementById(iframeId);
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('id', iframeId);
+  iframe.setAttribute('frameborder', 0);
+  iframe.setAttribute('height', iframeHeight);
+  iframe.setAttribute('sandbox', 'allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation');
+  container.appendChild(iframe);
+
+  // jqdiv.html(`
+  //   <iframe id="${iframeId}"
+  //     frameborder="0"
+  //     height="${iframeHeight}"
+  //     sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation">
+  //   </iframe>
+  // `);
+  // const iframe = document.getElementById(iframeId);
+
   srcdoc.set(iframe, html);
 }
 
-module.exports = markupWidget;
+export default markupWidget;


### PR DESCRIPTION
- Remove calls to `slice.xxx`
- Construct `iframe` element in js and keep it for later use instead of setting `innerHTML` to create iframe and later lookup iframe by id. Remove iframe id.
- Remove code block `$('#code').attr('rows', '15')` because the element with id `code` does not exist so this block does nothing. Also make this component independent from jquery
- Use `import`/`export` instead of `require` and `module.exports`
- Fix the code to set style `overflow:auto`. The previous code has a bug and did not set the style successfully.
- Remove `render_template` and `Mustache` dependency from `Chart.jsx`

### Test

Ran a development instance with the code above and verified with production instance that they produce the same results.