### PR TITLE
Fixes to the play slider

### DIFF
--- a/superset/assets/src/visualizations/PlaySlider.css
+++ b/superset/assets/src/visualizations/PlaySlider.css
@@ -1,8 +1,7 @@
 .play-slider {
     position: absolute;
-    bottom: -16px;
     height: 20px;
-    width: 100%;
+    width: 90%;
 }
 
 .slider-selection {
@@ -20,4 +19,8 @@
 .slider-button {
     color: #b3b3b3;
     margin-right: 5px;
+}
+
+div.tooltip.tooltip-main.top.in {
+    margin-left: 0 !important;
 }

--- a/superset/assets/src/visualizations/PlaySlider.css
+++ b/superset/assets/src/visualizations/PlaySlider.css
@@ -1,7 +1,8 @@
 .play-slider {
-    position: absolute;
+    position: relative;
     height: 20px;
-    width: 90%;
+    width: 100%;
+    margin: 0;
 }
 
 .slider-selection {

--- a/superset/assets/src/visualizations/PlaySlider.css
+++ b/superset/assets/src/visualizations/PlaySlider.css
@@ -21,6 +21,6 @@
     margin-right: 5px;
 }
 
-div.tooltip.tooltip-main.top.in {
+div.slider > div.tooltip.tooltip-main.top.in {
     margin-left: 0 !important;
 }

--- a/superset/assets/src/visualizations/PlaySlider.jsx
+++ b/superset/assets/src/visualizations/PlaySlider.jsx
@@ -86,19 +86,17 @@ export default class PlaySlider extends React.PureComponent {
     this.setState({ intervalId: null });
   }
   step() {
-    if (this.props.disabled) {
+    const { start, end, step, values, disabled } = this.props;
+
+    if (disabled) {
       return;
     }
-    let values = this.props.values;
-    if (!Array.isArray(values)) {
-      values = [values, values + this.props.step];
-    }
-    values = values.map(value => value + this.increment);
-    if (values[1] > this.props.end) {
-      const cr = values[0] - this.props.start;
-      values = values.map(value => value - cr);
-    }
-    this.props.onChange(values);
+
+    const currentValues = Array.isArray(values) ? values : [values, values + step];
+    const nextValues = currentValues.map(value => value + this.increment);
+    const carriageReturn = (nextValues[1] > end) ? (nextValues[0] - start) : 0;
+
+    this.props.onChange(nextValues.map(value => value - carriageReturn));
   }
   formatter(values) {
     if (this.props.disabled) {

--- a/superset/assets/src/visualizations/PlaySlider.jsx
+++ b/superset/assets/src/visualizations/PlaySlider.jsx
@@ -21,6 +21,7 @@ const propTypes = {
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   reversed: PropTypes.bool,
   disabled: PropTypes.bool,
+  range: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -30,6 +31,7 @@ const defaultProps = {
   orientation: 'horizontal',
   reversed: false,
   disabled: false,
+  range: true,
 };
 
 export default class PlaySlider extends React.PureComponent {
@@ -87,7 +89,11 @@ export default class PlaySlider extends React.PureComponent {
     if (this.props.disabled) {
       return;
     }
-    let values = this.props.values.map(value => value + this.increment);
+    let values = this.props.values;
+    if (!Array.isArray(values)) {
+      values = [values, values + this.props.step];
+    }
+    values = this.props.values.map(value => value + this.increment);
     if (values[1] > this.props.end) {
       const cr = values[0] - this.props.start;
       values = values.map(value => value - cr);
@@ -116,7 +122,8 @@ export default class PlaySlider extends React.PureComponent {
         </Col>
         <Col md={11} className="padded">
           <ReactBootstrapSlider
-            value={this.props.values}
+            value={this.props.range ? this.props.values : this.props.values[0]}
+            range={this.props.range}
             formatter={this.formatter}
             change={this.onChange}
             min={this.props.start}

--- a/superset/assets/src/visualizations/PlaySlider.jsx
+++ b/superset/assets/src/visualizations/PlaySlider.jsx
@@ -93,7 +93,7 @@ export default class PlaySlider extends React.PureComponent {
     if (!Array.isArray(values)) {
       values = [values, values + this.props.step];
     }
-    values = this.props.values.map(value => value + this.increment);
+    values = values.map(value => value + this.increment);
     if (values[1] > this.props.end) {
       const cr = values[0] - this.props.start;
       values = values.map(value => value - cr);
@@ -114,6 +114,7 @@ export default class PlaySlider extends React.PureComponent {
     return parts.map(value => (new Date(value)).toUTCString()).join(' : ');
   }
   render() {
+    const { start, end, step, orientation, reversed, disabled, range, values } = this.props;
     return (
       <Row className="play-slider">
         <Col md={1} className="padded">
@@ -122,16 +123,16 @@ export default class PlaySlider extends React.PureComponent {
         </Col>
         <Col md={11} className="padded">
           <ReactBootstrapSlider
-            value={this.props.range ? this.props.values : this.props.values[0]}
-            range={this.props.range}
+            value={range ? values : values[0]}
+            range={range}
             formatter={this.formatter}
             change={this.onChange}
-            min={this.props.start}
-            max={this.props.end}
-            step={this.props.step}
-            orientation={this.props.orientation}
-            reversed={this.props.reversed}
-            disabled={this.props.disabled ? 'disabled' : 'enabled'}
+            min={start}
+            max={end}
+            step={step}
+            orientation={orientation}
+            reversed={reversed}
+            disabled={disabled ? 'disabled' : 'enabled'}
           />
         </Col>
       </Row>

--- a/superset/assets/src/visualizations/deckgl/AnimatableDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/AnimatableDeckGLContainer.jsx
@@ -10,12 +10,14 @@ const propTypes = {
   end: PropTypes.number.isRequired,
   step: PropTypes.number.isRequired,
   values: PropTypes.array.isRequired,
+  aggregation: PropTypes.bool,
   disabled: PropTypes.bool,
   viewport: PropTypes.object.isRequired,
   children: PropTypes.node,
 };
 
 const defaultProps = {
+  aggregation: false,
   disabled: false,
   step: 1,
 };
@@ -26,9 +28,19 @@ export default class AnimatableDeckGLContainer extends React.Component {
     const { getLayers, start, end, step, values, disabled, viewport, ...other } = props;
     this.state = { values, viewport };
     this.other = other;
+    this.onChange = this.onChange.bind(this);
   }
   componentWillReceiveProps(nextProps) {
     this.setState({ values: nextProps.values, viewport: nextProps.viewport });
+  }
+  onChange(newValues) {
+    let values;
+    if (!Array.isArray(newValues)) {
+      values = [newValues, newValues + this.props.step];
+    } else {
+      values = newValues;
+    }
+    this.setState({ values });
   }
   render() {
     const layers = this.props.getLayers(this.state.values);
@@ -46,7 +58,8 @@ export default class AnimatableDeckGLContainer extends React.Component {
           end={this.props.end}
           step={this.props.step}
           values={this.state.values}
-          onChange={newValues => this.setState({ values: newValues })}
+          range={!this.props.aggregation}
+          onChange={this.onChange}
         />
         }
         {this.props.children}

--- a/superset/assets/src/visualizations/deckgl/AnimatableDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/AnimatableDeckGLContainer.jsx
@@ -34,35 +34,35 @@ export default class AnimatableDeckGLContainer extends React.Component {
     this.setState({ values: nextProps.values, viewport: nextProps.viewport });
   }
   onChange(newValues) {
-    let values;
-    if (!Array.isArray(newValues)) {
-      values = [newValues, newValues + this.props.step];
-    } else {
-      values = newValues;
-    }
-    this.setState({ values });
+    this.setState({
+      values: Array.isArray(newValues)
+        ? newValues
+        : [newValues, newValues + this.props.step],
+    });
   }
   render() {
-    const layers = this.props.getLayers(this.state.values);
+    const { start, end, step, disabled, aggregation, children, getLayers } = this.props;
+    const { values, viewport } = this.state;
+    const layers = getLayers(values);
     return (
       <div>
         <DeckGLContainer
           {...this.other}
-          viewport={this.state.viewport}
+          viewport={viewport}
           layers={layers}
           onViewportChange={newViewport => this.setState({ viewport: newViewport })}
         />
-        {!this.props.disabled &&
+        {!disabled &&
         <PlaySlider
-          start={this.props.start}
-          end={this.props.end}
-          step={this.props.step}
-          values={this.state.values}
-          range={!this.props.aggregation}
+          start={start}
+          end={end}
+          step={step}
+          values={values}
+          range={!aggregation}
           onChange={this.onChange}
         />
         }
-        {this.props.children}
+        {children}
       </div>
     );
   }

--- a/superset/assets/src/visualizations/deckgl/layers/screengrid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/screengrid.jsx
@@ -110,6 +110,7 @@ class DeckGLScreenGrid extends React.PureComponent {
           mapboxApiAccessToken={this.props.payload.data.mapboxApiKey}
           mapStyle={this.props.slice.formData.mapbox_style}
           setControlValue={this.props.setControlValue}
+          aggregation
         />
       </div>
     );


### PR DESCRIPTION
Some fixes to the CSS:

- Removed negative bottom position, since the slider was disappearing.
- Made with smaller so it looks better (see screenshot).
- Fixed tooltip position that was off-centered to the left.

More importantly, added a props called `aggregation` to `AnimatableDeckGLContainer`. When true, the play slider will not allow selecting a wider period than the time granularity. This means that for the scatter plot or GeoJSON visualizations (which show just features) the user can select a wider period and see all the features combined. But for screengrid this doesn't make sense, so it users will be able to only step through the granularity.

<img width="1680" alt="screen shot 2018-08-18 at 12 55 45 pm" src="https://user-images.githubusercontent.com/1534870/44302848-0c756c80-a2e6-11e8-848d-cd8f02b1e59c.png">
