### PR TITLE
Fix broken cache_key

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -331,9 +331,7 @@ class BaseViz(object):
         for k in ['from_dttm', 'to_dttm']:
             del cache_dict[k]
 
-        for k in ['since', 'until']:
-            cache_dict[k] = self.form_data.get(k)
-
+        cache_dict['time_range'] = self.form_data.get('time_range')
         cache_dict['datasource'] = self.datasource.uid
         json_data = self.json_dumps(cache_dict, sort_keys=True)
         return hashlib.md5(json_data.encode('utf-8')).hexdigest()


### PR DESCRIPTION
The new time filter broke the cache key. This PR fixes it.

Tested with a dashboard, changing the time range in the filter box now correctly refreshes charts.