### PR TITLE
[bugfix] making secondary_metric optional

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -533,6 +533,7 @@ export const controls = {
     ...metric,
     label: t('Color Metric'),
     default: null,
+    validators: [],
     description: t('A metric to use for color'),
   },
   select_country: {
@@ -1430,6 +1431,7 @@ export const controls = {
     type: 'CheckboxControl',
     label: t('Data Table'),
     default: false,
+    renderTrigger: true,
     description: t('Whether to display the interactive data table'),
   },
 

--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -1511,6 +1511,7 @@ export const visTypes = {
           ['country_fieldtype'],
           ['metric'],
           ['adhoc_filters'],
+          ['row_limit'],
         ],
       },
       {
@@ -1590,13 +1591,15 @@ export const visTypes = {
           ['metrics'],
           ['secondary_metric'],
           ['adhoc_filters'],
-          ['limit'],
+          ['limit', 'row_limit'],
         ],
       },
       {
         label: t('Options'),
+        expanded: true,
         controlSetRows: [
           ['show_datatable', 'include_series'],
+          ['linear_color_scheme'],
         ],
       },
     ],

--- a/superset/assets/src/visualizations/sunburst.js
+++ b/superset/assets/src/visualizations/sunburst.js
@@ -3,7 +3,7 @@ import d3 from 'd3';
 import { getColorFromScheme } from '../modules/colors';
 import { wrapSvgText } from '../modules/utils';
 
-require('./sunburst.css');
+import './sunburst.css';
 
 // Modified from http://bl.ocks.org/kerryrodden/7090426
 function sunburstVis(slice, payload) {
@@ -250,7 +250,7 @@ function sunburstVis(slice, payload) {
       let currentNode = root;
       for (let level = 0; level < levels.length; level++) {
         const children = currentNode.children || [];
-        const nodeName = levels[level];
+        const nodeName = levels[level].toString();
         // If the next node has the name '0', it will
         const isLeafNode = (level >= levels.length - 1) || levels[level + 1] === 0;
         let childNode;

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1724,8 +1724,6 @@ class WorldMapViz(BaseViz):
 
     def query_obj(self):
         qry = super(WorldMapViz, self).query_obj()
-        qry['metrics'] = [
-            self.form_data['metric'], self.form_data['secondary_metric']]
         qry['groupby'] = [self.form_data['entity']]
         return qry
 
@@ -1735,6 +1733,7 @@ class WorldMapViz(BaseViz):
         cols = [fd.get('entity')]
         metric = self.get_metric_label(fd.get('metric'))
         secondary_metric = self.get_metric_label(fd.get('secondary_metric'))
+        columns = ['country', 'm1', 'm2']
         if metric == secondary_metric:
             ndf = df[cols]
             # df[metric] will be a DataFrame
@@ -1742,10 +1741,14 @@ class WorldMapViz(BaseViz):
             ndf['m1'] = df[metric].iloc[:, 0]
             ndf['m2'] = ndf['m1']
         else:
-            cols += [metric, secondary_metric]
+            if secondary_metric:
+                cols += [metric, secondary_metric]
+            else:
+                cols += [metric]
+                columns = ['country', 'm1']
             ndf = df[cols]
         df = ndf
-        df.columns = ['country', 'm1', 'm2']
+        df.columns = columns
         d = df.to_dict(orient='records')
         for row in d:
             country = None
@@ -1843,10 +1846,6 @@ class ParallelCoordinatesViz(BaseViz):
     def query_obj(self):
         d = super(ParallelCoordinatesViz, self).query_obj()
         fd = self.form_data
-        d['metrics'] = copy.copy(fd.get('metrics'))
-        second = fd.get('secondary_metric')
-        if second not in d['metrics']:
-            d['metrics'] += [second]
         d['groupby'] = [fd.get('series')]
         return d
 


### PR DESCRIPTION
I noticed that `secondary_metric` was required in the chart that uses
it, namely sunburst, parallel coordinates, and world_map.

I set the control as allowing null, and found related bugs in the
process:
* parallel coordinates did not have support for the new MetricControl
* added color scheme support for parallel coordinates
* added option to set row_limit on these viz types
* sunburst to support numeric columns (number would show as blank)