### PR TITLE
[bug] 'an error has ooccured' when saving datasource

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -307,7 +307,7 @@ def check_ownership(obj, raise_if_false=True):
     if hasattr(orig_obj, 'created_by'):
         owners += [orig_obj.created_by]
 
-    owner_names = [o.username for o in owners]
+    owner_names = [o.username for o in owners if o]
 
     if (
             g.user and hasattr(g.user, 'username') and

--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -9,6 +9,7 @@ import json
 
 from flask import request
 from flask_appbuilder import expose
+from flask_appbuilder.security.decorators import has_access_api
 from flask_babel import gettext as __
 
 from superset import appbuilder, db
@@ -19,6 +20,7 @@ from .base import BaseSupersetView, check_ownership, json_error_response
 class Datasource(BaseSupersetView):
     """Datasource-related views"""
     @expose('/save/', methods=['POST'])
+    @has_access_api
     def save(self):
         datasource = json.loads(request.form.get('data'))
         datasource_id = datasource.get('id')


### PR DESCRIPTION
The check_ownership was failing when Alpha user was saving a datasource
from the datasource editor.