### PR TITLE
[security] Moving set/merge perm to security manager

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -41,7 +41,7 @@ from superset import conf, db, import_util, security_manager, utils
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
 from superset.exceptions import MetricPermException, SupersetException
 from superset.models.helpers import (
-    AuditMixinNullable, ImportMixin, QueryResult, set_perm,
+    AuditMixinNullable, ImportMixin, QueryResult,
 )
 from superset.utils import (
     DimSelector, DTTM_ALIAS, flasher,
@@ -1601,5 +1601,5 @@ class DruidDatasource(Model, BaseDatasource):
         ]
 
 
-sa.event.listen(DruidDatasource, 'after_insert', set_perm)
-sa.event.listen(DruidDatasource, 'after_update', set_perm)
+sa.event.listen(DruidDatasource, 'after_insert', security_manager.set_perm)
+sa.event.listen(DruidDatasource, 'after_update', security_manager.set_perm)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -29,7 +29,6 @@ from superset.jinja_context import get_template_processor
 from superset.models.annotations import Annotation
 from superset.models.core import Database
 from superset.models.helpers import QueryResult
-from superset.models.helpers import set_perm
 from superset.utils import DTTM_ALIAS, QueryStatus
 
 config = app.config
@@ -892,5 +891,5 @@ class SqlaTable(Model, BaseDatasource):
         return qry.filter_by(is_sqllab_view=False)
 
 
-sa.event.listen(SqlaTable, 'after_insert', set_perm)
-sa.event.listen(SqlaTable, 'after_update', set_perm)
+sa.event.listen(SqlaTable, 'after_insert', security_manager.set_perm)
+sa.event.listen(SqlaTable, 'after_update', security_manager.set_perm)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -39,7 +39,7 @@ import sqlparse
 from superset import app, db, db_engine_specs, security_manager, utils
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.legacy import update_time_range
-from superset.models.helpers import AuditMixinNullable, ImportMixin, set_perm
+from superset.models.helpers import AuditMixinNullable, ImportMixin
 from superset.models.user_attributes import UserAttribute
 from superset.utils import MediumText
 from superset.viz import viz_types
@@ -959,8 +959,8 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         return sqla_url.get_dialect()()
 
 
-sqla.event.listen(Database, 'after_insert', set_perm)
-sqla.event.listen(Database, 'after_update', set_perm)
+sqla.event.listen(Database, 'after_insert', security_manager.set_perm)
+sqla.event.listen(Database, 'after_update', security_manager.set_perm)
 
 
 class Log(Model):


### PR DESCRIPTION
This PR refactors (copy and paste) the helper `set_perm` and `merge_perm` methods to be encompassed within the security manager which ensures that the manager controls all reads/writes related to data permissions. 

Note the `helpers.merge_perm` logic is part of `SupersetSecurityManager.set_perm` as there already exists a `SupersetSecurityManager.merge_perm` method. Though the logic is similar the database connection logic differs. When I tried to use the later, though I was able to read, writes failed with the following exception,
```
sqlalchemy.exc.ResourceClosedError: This transaction is closed
```
hence the reason for simply copy-and-pasting the current logic. The one exception is the `permission` and `view_menu` should only be refreshed only if updated.

Finally I'm also perplexed as to why the `pylint` warnings are present (which I've ignored). 

to: @jeffreythewang @mistercrunch @timifasubaa 