### PR TITLE
[sqlparse] fix sqlparse bug

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -12,6 +12,7 @@ from sqlparse.sql import Identifier, IdentifierList
 from sqlparse.tokens import Keyword, Name
 
 RESULT_OPERATIONS = {'UNION', 'INTERSECT', 'EXCEPT'}
+ON_KEYWORD = 'ON'
 PRECEDES_TABLE_NAME = {'FROM', 'JOIN', 'DESC', 'DESCRIBE', 'WITH'}
 
 
@@ -128,7 +129,8 @@ class SupersetQuery(object):
                 continue
 
             if item.ttype in Keyword:
-                if self.__is_result_operation(item.value):
+                if (self.__is_result_operation(item.value) or
+                        item.value.upper() == ON_KEYWORD):
                     table_name_preceding_token = False
                     continue
                 # FROM clause is over

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -330,3 +330,11 @@ class SupersetTestCase(unittest.TestCase):
         self.assertEquals(
             {'my_l_table', 'my_b_table', 'my_t_table', 'inner_table'},
             self.extract_tables(query))
+
+    def test_complex_extract_tables2(self):
+        query = """SELECT *
+            FROM table_a AS a, table_b AS b, table_c as c
+            WHERE a.id = b.id and b.id = c.id"""
+        self.assertEquals(
+            {'table_a', 'table_b', 'table_c'},
+            self.extract_tables(query))

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -310,3 +310,23 @@ class SupersetTestCase(unittest.TestCase):
         self.assertEquals(True, sql.is_explain())
         self.assertEquals(False, sql.is_select())
         self.assertEquals(True, sql.is_readonly())
+
+    def test_complex_extract_tables(self):
+        query = """SELECT sum(m_examples) AS "sum__m_example"
+            FROM
+              (SELECT COUNT(DISTINCT id_userid) AS m_examples,
+                      some_more_info
+               FROM my_b_table b
+               JOIN my_t_table t ON b.ds=t.ds
+               JOIN my_l_table l ON b.uid=l.uid
+               WHERE b.rid IN
+                   (SELECT other_col
+                    FROM inner_table)
+                 AND l.bla IN ('x', 'y')
+               GROUP BY 2
+               ORDER BY 2 ASC) AS "meh"
+            ORDER BY "sum__m_example" DESC
+            LIMIT 10;"""
+        self.assertEquals(
+            {'my_l_table', 'my_b_table', 'my_t_table', 'inner_table'},
+            self.extract_tables(query))


### PR DESCRIPTION
superset's sql_parse implementation fails when there are more than two tables in a join. 
This causes problems when we use this method to extract tables to determine if a user can access all the tables in a sqllab query. 

This PR addresses the issue by preventing it from stopping early. I also added a test. 

@john-bodley @mistercrunch 