### PR TITLE
fix: Pivot table not sorting formatted numeric column properly

### DIFF
--- a/superset/assets/src/visualizations/pivot_table.js
+++ b/superset/assets/src/visualizations/pivot_table.js
@@ -35,7 +35,7 @@ module.exports = function (slice, payload) {
       const tdText = $(this)[0].textContent;
       if (!isNaN(tdText) && tdText !== '') {
         $(this)[0].textContent = d3format(format, tdText);
-        $(this).attr('data-sort', tdText );
+        $(this).attr('data-sort', tdText);
       }
     });
   });

--- a/superset/assets/src/visualizations/pivot_table.js
+++ b/superset/assets/src/visualizations/pivot_table.js
@@ -35,6 +35,7 @@ module.exports = function (slice, payload) {
       const tdText = $(this)[0].textContent;
       if (!isNaN(tdText) && tdText !== '') {
         $(this)[0].textContent = d3format(format, tdText);
+        $(this).attr('data-sort', tdText );
       }
     });
   });


### PR DESCRIPTION
Added the sorting fix similar to visual table.js

Now DataTable will use metric values to sort. 

This PR fixes #5674 