### PR TITLE
Return 403 on no authorization

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2340,7 +2340,7 @@ class Superset(BaseSupersetView):
             query.sql, query.database, query.schema)
         if rejected_tables:
             return json_error_response(security_manager.get_table_access_error_msg(
-                '{}'.format(rejected_tables)), status=401)
+                '{}'.format(rejected_tables)), status=403)
 
         return json_success(utils.zlib_decompress_to_string(blob))
 
@@ -2384,7 +2384,7 @@ class Superset(BaseSupersetView):
             return json_error_response(
                 security_manager.get_table_access_error_msg(rejected_tables),
                 link=security_manager.get_table_access_link(rejected_tables),
-                status=401)
+                status=403)
         session.commit()
 
         select_as_cta = request.form.get('select_as_cta') == 'true'

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2340,7 +2340,7 @@ class Superset(BaseSupersetView):
             query.sql, query.database, query.schema)
         if rejected_tables:
             return json_error_response(security_manager.get_table_access_error_msg(
-                '{}'.format(rejected_tables)))
+                '{}'.format(rejected_tables)), status=401)
 
         return json_success(utils.zlib_decompress_to_string(blob))
 
@@ -2383,7 +2383,8 @@ class Superset(BaseSupersetView):
         if rejected_tables:
             return json_error_response(
                 security_manager.get_table_access_error_msg(rejected_tables),
-                link=security_manager.get_table_access_link(rejected_tables))
+                link=security_manager.get_table_access_link(rejected_tables),
+                status=401)
         session.commit()
 
         select_as_cta = request.form.get('select_as_cta') == 'true'


### PR DESCRIPTION
When a user has no permission to access a table we should return a 403:

> 403 Forbidden The server understood the request, but is refusing to fulfill it. Authorization will not help and the request SHOULD NOT be repeated.