### PR TITLE
Autofocus aggregation in metric control

### DIFF
--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -256,6 +256,7 @@ export default class AdhocMetricEditPopover extends React.Component {
             bsSize="small"
             className="m-r-5"
             onClick={this.onSave}
+            autoFocus
           >
             Save
           </Button>

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -221,7 +221,7 @@ export default class AdhocMetricEditPopover extends React.Component {
             </FormGroup>
             <FormGroup>
               <ControlLabel><strong>aggregate</strong></ControlLabel>
-              <OnPasteSelect {...this.selectProps} {...aggregateSelectProps} />
+              <OnPasteSelect autoFocus {...this.selectProps} {...aggregateSelectProps} />
             </FormGroup>
           </Tab>
           <Tab className="adhoc-metric-edit-tab" eventKey={EXPRESSION_TYPES.SQL} title="Custom SQL">
@@ -256,7 +256,6 @@ export default class AdhocMetricEditPopover extends React.Component {
             bsSize="small"
             className="m-r-5"
             onClick={this.onSave}
-            autoFocus
           >
             Save
           </Button>


### PR DESCRIPTION
This makes the aggregation select be focused when the overlay shows up:

<img width="644" alt="screen shot 2018-08-23 at 11 42 18 pm" src="https://user-images.githubusercontent.com/1534870/44569147-48696100-a72e-11e8-8c49-4c7c3fa67bfd.png">

The user can then press tab+enter to accept, or enter to choose a different aggregation.