### PR TITLE
[celery] Using preferred configuration proceedure

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -710,7 +710,8 @@ def get_celery_app(config):
     global _celery_app
     if _celery_app:
         return _celery_app
-    _celery_app = celery.Celery(config_source=config.get('CELERY_CONFIG'))
+    _celery_app = celery.Celery()
+    _celery_app.config_from_object(config.get('CELERY_CONFIG'))
     return _celery_app
 
 


### PR DESCRIPTION
We've been using the [celery_statsd](https://github.com/lyst/celery-statsd) for additional Celery monitoring but have recently noticed issues with the config parsing, i.e.,  
```
>>> from celery import Celery 
>>> 
>>> 
>>> class Config:
...     STATSD_HOST = 'localhost'
... 
>>> app = Celery(source_config=Config)
>>> app.conf.STATSD_HOST
Traceback (most recent call last):
  File ".../celery/utils/collections.py", line 130, in __getattr__
    return self[k]
  File ".../celery/utils/collections.py", line 436, in __getitem__
    return self.__missing__(key)
  File ".../celery/utils/collections.py", line 269, in __missing__
    raise KeyError(key)
KeyError: 'STATSD_HOST'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../celery/utils/collections.py", line 134, in __getattr__
    type(self).__name__, k))
AttributeError: 'Settings' object has no attribute 'STATSD_HOST'
```

According to the [documentation](http://docs.celeryproject.org/en/latest/userguide/application.html#config-from-object) it seems like the `config_from_object` is the suggested approach, which provides the correct behavior,
```
>>> app = Celery()
>>> app.config_from_object(Config)
>>> app.conf.STATSD_HOST
'localhost'
>>> 
```

to: @graceguo-supercat @kristw @michellethomas @mistercrunch @timifasubaa 