### PR TITLE
[sql_json] allow not specifying client_id

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -1016,3 +1016,7 @@ def get_username():
 
 def MediumText():
     return Text().with_variant(MEDIUMTEXT(), 'mysql')
+
+
+def shortid():
+    return '{}'.format(uuid.uuid4())[-12:]

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2395,6 +2395,8 @@ class Superset(BaseSupersetView):
                 tmp_table_name,
             )
 
+        client_id = request.form.get('client_id') or utils.shortid()
+
         query = Query(
             database_id=int(database_id),
             limit=mydb.db_engine_spec.get_limit_from_sql(sql),
@@ -2406,8 +2408,8 @@ class Superset(BaseSupersetView):
             status=QueryStatus.PENDING if async_ else QueryStatus.RUNNING,
             sql_editor_id=request.form.get('sql_editor_id'),
             tmp_table_name=tmp_table_name,
-            user_id=int(g.user.get_id()),
-            client_id=request.form.get('client_id'),
+            user_id=int(g.user.get_id()) if g.user and g.user.get_id() else None,
+            client_id=client_id,
         )
         session.add(query)
         session.flush()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2408,7 +2408,7 @@ class Superset(BaseSupersetView):
             status=QueryStatus.PENDING if async_ else QueryStatus.RUNNING,
             sql_editor_id=request.form.get('sql_editor_id'),
             tmp_table_name=tmp_table_name,
-            user_id=int(g.user.get_id()) if g.user and g.user.get_id() else None,
+            user_id=g.user.get_id() if g.user else None,
             client_id=client_id,
         )
         session.add(query)


### PR DESCRIPTION
We're opening the sql_json endpoint at Lyft to other apps leveraging
Superset as a data-access layer that enforces authentication and our data
access policy.

Currently sql_json requires the client to pass a `client_id` parameter
that uniquely identifies the query, that can then be used for polling
when in async mode. This PR makes it such that you don't have to define
a client_id anymore. It just gets generated when not passed.