### PR TITLE
Prevent deleting databases that have attached tables

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -261,7 +261,7 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
             raise SupersetException(Markup(
                 'Cannot delete a database that has tables attached. '
                 "Here's the list of associated tables: " +
-                ''.join(['{}'.format(o) for o in obj.tables])))
+                ', '.join('{}'.format(o) for o in obj.tables)))
 
     def _delete(self, pk):
         DeleteMixin._delete(self, pk)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -256,6 +256,13 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
     def pre_update(self, db):
         self.pre_add(db)
 
+    def pre_delete(self, obj):
+        if obj.tables:
+            raise SupersetException(Markup(
+                'Cannot delete a database that has tables attached. '
+                "Here's the list of associated tables: " +
+                ''.join(['{}'.format(o) for o in obj.tables])))
+
     def _delete(self, pk):
         DeleteMixin._delete(self, pk)
 


### PR DESCRIPTION

<img width="1051" alt="screen shot 2018-08-27 at 5 41 32 pm" src="https://user-images.githubusercontent.com/487433/44694175-e310bb00-aa20-11e8-84d6-0956e128f964.png">
Similar to logic preventing deleting tables that have charts attached.