### PR TITLE
[bugfix] IS NOT NULL filter triggers KeyError: 'val'

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -724,13 +724,13 @@ def to_adhoc(filt, expressionType='SIMPLE', clause='where'):
 
     if expressionType == 'SIMPLE':
         result.update({
-            'comparator': filt['val'],
-            'operator': filt['op'],
-            'subject': filt['col'],
+            'comparator': filt.get('val'),
+            'operator': filt.get('op'),
+            'subject': filt.get('col'),
         })
     elif expressionType == 'SQL':
         result.update({
-            'sqlExpression': filt[clause],
+            'sqlExpression': filt.get(clause),
         })
 
     return result


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/superset/models/core.py", line 1018, in wrapper
    value = f(*args, **kwargs)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask_appbuilder/security/decorators.py", line 26, in wraps
    return f(self, *args, **kwargs)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/superset/views/core.py", line 1264, in explore
    utils.convert_legacy_filters_into_adhoc(form_data)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/superset/utils.py", line 962, in convert_legacy_filters_into_adhoc
    fd['adhoc_filters'].append(to_adhoc(filt, 'SIMPLE', clause))
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/superset/utils.py", line 726, in to_adhoc
    'comparator': filt['val'],
KeyError: 'val'
```