### PR TITLE
Fix multilayer geoviz and color picker error

### DIFF
--- a/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
@@ -104,7 +104,7 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
       data = data.filter(d => this.state.categories[d.cat_color].enabled);
     }
 
-    let payload = this.props.payload;
+    const payload = this.props.payload;
     payload.data.features = data;
     return [this.props.getLayer(fd, payload, this.props.slice)];
   }

--- a/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
@@ -79,8 +79,9 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
     });
   }
   getLayers(values) {
-    const fd = this.props.slice.formData;
-    let data = [...this.props.payload.data.features];
+    const { getLayer, payload, slice } = this.props;
+    const fd = slice.formData;
+    let data = [...payload.data.features];
 
     // Add colors from categories or fixed color
     data = this.addColor(data, fd);
@@ -103,9 +104,8 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
       data = data.filter(d => this.state.categories[d.cat_color].enabled);
     }
 
-    const payload = this.props.payload;
     payload.data.features = data;
-    return [this.props.getLayer(fd, payload, this.props.slice)];
+    return [getLayer(fd, payload, slice)];
   }
   toggleCategory(category) {
     const categoryState = this.state.categories[category];

--- a/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
@@ -35,6 +35,7 @@ const propTypes = {
   setControlValue: PropTypes.func.isRequired,
   viewport: PropTypes.object.isRequired,
   getLayer: PropTypes.func.isRequired,
+  payload: PropTypes.object.isRequired,
 };
 
 export default class CategoricalDeckGLContainer extends React.PureComponent {
@@ -103,7 +104,9 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
       data = data.filter(d => this.state.categories[d.cat_color].enabled);
     }
 
-    return [this.props.getLayer(fd, data, this.props.slice)];
+    let payload = this.props.payload;
+    payload.data.features = data;
+    return [this.props.getLayer(fd, payload, this.props.slice)];
   }
   toggleCategory(category) {
     const categoryState = this.state.categories[category];

--- a/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
@@ -30,7 +30,6 @@ function getCategories(fd, data) {
 
 const propTypes = {
   slice: PropTypes.object.isRequired,
-  data: PropTypes.array.isRequired,
   mapboxApiKey: PropTypes.string.isRequired,
   setControlValue: PropTypes.func.isRequired,
   viewport: PropTypes.object.isRequired,
@@ -51,9 +50,9 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
     const fd = nextProps.slice.formData;
 
     const timeGrain = fd.time_grain_sqla || fd.granularity || 'PT1M';
-    const timestamps = nextProps.data.map(f => f.__timestamp);
+    const timestamps = nextProps.payload.data.features.map(f => f.__timestamp);
     const { start, end, step, values, disabled } = getPlaySliderParams(timestamps, timeGrain);
-    const categories = getCategories(fd, nextProps.data);
+    const categories = getCategories(fd, nextProps.payload.data.features);
 
     return { start, end, step, values, disabled, categories };
   }
@@ -81,7 +80,7 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
   }
   getLayers(values) {
     const fd = this.props.slice.formData;
-    let data = [...this.props.data];
+    let data = [...this.props.payload.data.features];
 
     // Add colors from categories or fixed color
     data = this.addColor(data, fd);

--- a/superset/assets/src/visualizations/deckgl/layers/arc.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/arc.jsx
@@ -47,7 +47,6 @@ function deckArc(slice, payload, setControlValue) {
   ReactDOM.render(
     <CategoricalDeckGLContainer
       slice={slice}
-      data={payload.data.features}
       mapboxApiKey={payload.data.mapboxApiKey}
       setControlValue={setControlValue}
       viewport={viewport}

--- a/superset/assets/src/visualizations/deckgl/layers/arc.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/arc.jsx
@@ -19,7 +19,7 @@ function getPoints(data) {
 }
 
 function getLayer(fd, payload, slice) {
-  let data = payload.data.features;
+  const data = payload.data.features;
   const sc = fd.color_picker;
   const tc = fd.target_color_picker;
   return new ArcLayer({

--- a/superset/assets/src/visualizations/deckgl/layers/arc.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/arc.jsx
@@ -18,7 +18,8 @@ function getPoints(data) {
   return points;
 }
 
-function getLayer(fd, data, slice) {
+function getLayer(fd, payload, slice) {
+  let data = payload.data.features;
   const sc = fd.color_picker;
   const tc = fd.target_color_picker;
   return new ArcLayer({
@@ -40,17 +41,18 @@ function deckArc(slice, payload, setControlValue) {
   };
 
   if (fd.autozoom) {
-    viewport = common.fitViewport(viewport, getPoints(payload.data.arcs));
+    viewport = common.fitViewport(viewport, getPoints(payload.data.features));
   }
 
   ReactDOM.render(
     <CategoricalDeckGLContainer
       slice={slice}
-      data={payload.data.arcs}
+      data={payload.data.features}
       mapboxApiKey={payload.data.mapboxApiKey}
       setControlValue={setControlValue}
       viewport={viewport}
       getLayer={getLayer}
+      payload={payload}
     />,
     document.getElementById(slice.containerId),
   );

--- a/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
@@ -22,11 +22,10 @@ function getLayer(fd, payload, slice) {
     }
     if (d.color) {
       return { ...d, radius };
-    } else {
-      const c = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };
-      let color = [c.r, c.g, c.b, c.a * 255];
-      return { ...d, radius, color };
     }
+    const c = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };
+    const color = [c.r, c.g, c.b, c.a * 255];
+    return { ...d, radius, color };
   });
 
   return new ScatterplotLayer({

--- a/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
@@ -14,13 +14,19 @@ function getPoints(data) {
   return data.map(d => d.position);
 }
 
-function getLayer(fd, data, slice) {
-  const dataWithRadius = data.map((d) => {
+function getLayer(fd, payload, slice) {
+  const dataWithRadius = payload.data.features.map((d) => {
     let radius = unitToRadius(fd.point_unit, d.radius) || 10;
     if (fd.multiplier) {
       radius *= fd.multiplier;
     }
-    return { ...d, radius };
+    if (d.color) {
+      return { ...d, radius };
+    } else {
+      const c = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };
+      let color = [c.r, c.g, c.b, c.a * 255];
+      return { ...d, radius, color };
+    }
   });
 
   return new ScatterplotLayer({
@@ -54,6 +60,7 @@ function deckScatter(slice, payload, setControlValue) {
       setControlValue={setControlValue}
       viewport={viewport}
       getLayer={getLayer}
+      payload={payload}
     />,
     document.getElementById(slice.containerId),
   );

--- a/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
@@ -54,7 +54,6 @@ function deckScatter(slice, payload, setControlValue) {
   ReactDOM.render(
     <CategoricalDeckGLContainer
       slice={slice}
-      data={payload.data.features}
       mapboxApiKey={payload.data.mapboxApiKey}
       setControlValue={setControlValue}
       viewport={viewport}

--- a/superset/assets/src/visualizations/deckgl/multi.jsx
+++ b/superset/assets/src/visualizations/deckgl/multi.jsx
@@ -33,7 +33,13 @@ function deckMulti(slice, payload, setControlValue) {
     // Filters applied to multi_deck are passed down to underlying charts
     // note that dashboard contextual information (filter_immune_slices and such) aren't
     // taken into consideration here
-    let filters = subslice.form_data.filters.concat(fd.filters);
+    let filters = [];
+    if (subslice.form_data.filters) {
+      filters = filters.concat(subslice.form_data.filters);
+    }
+    if (fd.filters) {
+      filters = filters.concat(fd.filters);
+    }
     if (fd.extra_filters) {
       filters = filters.concat(fd.extra_filters);
     }

--- a/superset/assets/src/visualizations/deckgl/multi.jsx
+++ b/superset/assets/src/visualizations/deckgl/multi.jsx
@@ -33,16 +33,11 @@ function deckMulti(slice, payload, setControlValue) {
     // Filters applied to multi_deck are passed down to underlying charts
     // note that dashboard contextual information (filter_immune_slices and such) aren't
     // taken into consideration here
-    let filters = [];
-    if (subslice.form_data.filters) {
-      filters = filters.concat(subslice.form_data.filters);
-    }
-    if (fd.filters) {
-      filters = filters.concat(fd.filters);
-    }
-    if (fd.extra_filters) {
-      filters = filters.concat(fd.extra_filters);
-    }
+    const filters = [
+      ...(subslice.form_data.filters || []),
+      ...(fd.filters || []),
+      ...(fd.extra_filters || []),
+    ];
     const subsliceCopy = {
       ...subslice,
       form_data: {

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2161,7 +2161,7 @@ class BaseDeckGLViz(BaseViz):
         fd = self.form_data
 
         # add NULL filters
-        if fd.get('filter_nulls'):
+        if fd.get('filter_nulls', True):
             self.add_null_filters()
 
         d = super(BaseDeckGLViz, self).query_obj()
@@ -2409,10 +2409,9 @@ class DeckArc(BaseDeckGLViz):
 
     def get_data(self, df):
         d = super(DeckArc, self).get_data(df)
-        arcs = d['features']
 
         return {
-            'arcs': arcs,
+            'features': d['features'],
             'mapboxApiKey': config.get('MAPBOX_API_KEY'),
         }
 


### PR DESCRIPTION
Several improvements and bug fixes in this PR.

1. The `multilayer geoviz` was unable to be rendered because queries did not filter out null locations by default. Changing `if fd.get('filter_nulls')` to `if fd.get('filter_nulls', True)` fixed the issue.
2. `getLayer()` function in `scatter.jsx` is also called by `multilayer geoviz` directly. After introducing component `CategoricalDeckGLContainer`, the `getLayer()` interface got changed so scatterplot failed to be rendered in `multilayer geoviz`.
3. `color picker` does not work with scatter plot and it is always showing black point. This issue is fixed as well.

<img width="1524" alt="screen shot 2018-08-28 at 4 02 10 pm" src="https://user-images.githubusercontent.com/26216756/44755602-bf5e7b00-aadb-11e8-8821-0b38adcb011a.png">
