### PR TITLE
[SIP-4][superset-client] add `SupersetClient`, refactor app

### DIFF
--- a/superset/assets/.eslintrc
+++ b/superset/assets/.eslintrc
@@ -8,6 +8,7 @@
   },
   "globals": {
     "document": true,
+    "window": true,
   },
   "rules": {
     "prefer-template": 0,
@@ -26,7 +27,7 @@
     "no-mixed-operators": 0,
     "no-continue": 0,
     "no-bitwise": 0,
-    "no-undef": 0,
+    "no-undef": 1,
     "no-multi-assign": 0,
     "react/no-array-index-key": 0,
     "no-restricted-properties": 0,
@@ -42,8 +43,5 @@
     "indent": 0,
     "no-multi-spaces": 0,
     "padded-blocks": 0,
-  },
-  "settings": {
-    "import/resolver": "webpack"
   }
 }

--- a/superset/assets/.eslintrc
+++ b/superset/assets/.eslintrc
@@ -42,5 +42,8 @@
     "indent": 0,
     "no-multi-spaces": 0,
     "padded-blocks": 0,
+  },
+  "settings": {
+    "import/resolver": "webpack"
   }
 }

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -43,10 +43,12 @@
   },
   "homepage": "http://superset.apache.org/",
   "dependencies": {
-    "@data-ui/event-flow": "^0.0.54",
+    "@data-ui/event-flow": "^0.0.62",
     "@data-ui/sparkline": "^0.0.54",
     "@data-ui/xy-chart": "^0.0.61",
     "@vx/responsive": "0.0.153",
+    "abortcontroller-polyfill": "^1.1.9",
+    "aphrodite": "^1.2.0",
     "babel-register": "^6.24.1",
     "bootstrap": "^3.3.6",
     "bootstrap-slider": "^10.0.0",
@@ -120,7 +122,8 @@
     "supercluster": "https://github.com/georgeke/supercluster/tarball/ac3492737e7ce98e07af679623aad452373bbc40",
     "underscore": "^1.8.3",
     "urijs": "^1.18.10",
-    "viewport-mercator-project": "^5.0.0"
+    "viewport-mercator-project": "^5.0.0",
+    "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
@@ -140,6 +143,7 @@
     "eslint": "^4.19.0",
     "eslint-config-airbnb": "^15.0.1",
     "eslint-config-prettier": "^2.9.0",
+    "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-prettier": "^2.6.0",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -67,6 +67,7 @@
     "dnd-core": "^2.6.0",
     "dompurify": "^1.0.3",
     "fastdom": "^1.0.6",
+    "formdata-polyfill": "^3.0.11",
     "geojson-extent": "^0.3.2",
     "geolib": "^2.0.24",
     "immutable": "^3.8.2",
@@ -122,6 +123,7 @@
     "supercluster": "https://github.com/georgeke/supercluster/tarball/ac3492737e7ce98e07af679623aad452373bbc40",
     "underscore": "^1.8.3",
     "urijs": "^1.18.10",
+    "url-search-params-polyfill": "^4.0.1",
     "viewport-mercator-project": "^5.0.0",
     "whatwg-fetch": "^2.0.4"
   },
@@ -148,6 +150,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.0.1",
     "exports-loader": "^0.7.0",
+    "fetch-mock": "^6.5.2",
     "file-loader": "^1.1.11",
     "github-changes": "^1.0.4",
     "ignore-styles": "^5.0.1",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -143,7 +143,6 @@
     "eslint": "^4.19.0",
     "eslint-config-airbnb": "^15.0.1",
     "eslint-config-prettier": "^2.9.0",
-    "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-prettier": "^2.6.0",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -43,12 +43,11 @@
   },
   "homepage": "http://superset.apache.org/",
   "dependencies": {
-    "@data-ui/event-flow": "^0.0.62",
+    "@data-ui/event-flow": "^0.0.54",
     "@data-ui/sparkline": "^0.0.54",
     "@data-ui/xy-chart": "^0.0.61",
     "@vx/responsive": "0.0.153",
     "abortcontroller-polyfill": "^1.1.9",
-    "aphrodite": "^1.2.0",
     "babel-register": "^6.24.1",
     "bootstrap": "^3.3.6",
     "bootstrap-slider": "^10.0.0",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -67,7 +67,6 @@
     "dnd-core": "^2.6.0",
     "dompurify": "^1.0.3",
     "fastdom": "^1.0.6",
-    "formdata-polyfill": "^3.0.11",
     "geojson-extent": "^0.3.2",
     "geolib": "^2.0.24",
     "immutable": "^3.8.2",

--- a/superset/assets/spec/helpers/browser.js
+++ b/superset/assets/spec/helpers/browser.js
@@ -2,7 +2,7 @@
 import 'babel-polyfill';
 import chai from 'chai';
 import jsdom from 'jsdom';
-import SupersetClient from '../../src/packages/core/src';
+import { SupersetClient } from '../../src/packages/core/src';
 import fetchMock from 'fetch-mock'; // eslint-disable-line import/first
 
 require('babel-register')({
@@ -53,7 +53,7 @@ global.$ = require('jquery')(global.window);
 // The following are needed to mock out SupersetClient requests
 // including CSRF authentication and initialization
 global.FormData = window.FormData;
-fetchMock.get(/superset\/csrf_token/, { csrf_token: '1234' });
+fetchMock.get('glob:*superset/csrf_token/*', { csrf_token: '1234' });
 SupersetClient.configure({ protocol: 'http', host: 'localhost' })
   .init()
   .then(() => fetchMock.reset()); // remove this call from mocks

--- a/superset/assets/spec/helpers/browser.js
+++ b/superset/assets/spec/helpers/browser.js
@@ -2,7 +2,7 @@
 import 'babel-polyfill';
 import chai from 'chai';
 import jsdom from 'jsdom';
-import { SupersetClient } from '../../src/packages/core/src';
+import SupersetClient from '../../src/packages/core/src';
 import fetchMock from 'fetch-mock'; // eslint-disable-line import/first
 
 require('babel-register')({
@@ -54,6 +54,6 @@ global.$ = require('jquery')(global.window);
 // including CSRF authentication and initialization
 global.FormData = window.FormData;
 fetchMock.get(/superset\/csrf_token/, { csrf_token: '1234' });
-SupersetClient.getInstance({ protocol: 'http', host: 'localhost' })
+SupersetClient.configure({ protocol: 'http', host: 'localhost' })
   .init()
   .then(() => fetchMock.reset()); // remove this call from mocks

--- a/superset/assets/spec/helpers/browser.js
+++ b/superset/assets/spec/helpers/browser.js
@@ -2,6 +2,8 @@
 import 'babel-polyfill';
 import chai from 'chai';
 import jsdom from 'jsdom';
+import { SupersetClient } from '../../src/packages/core/src';
+import fetchMock from 'fetch-mock'; // eslint-disable-line import/first
 
 require('babel-register')({
   // NOTE: If `dynamic-import-node` is in .babelrc alongside
@@ -47,3 +49,11 @@ global.window.XMLHttpRequest = global.XMLHttpRequest;
 global.window.location = { href: 'about:blank' };
 global.window.performance = { now: () => new Date().getTime() };
 global.$ = require('jquery')(global.window);
+
+// The following are needed to mock out SupersetClient requests
+// including CSRF authentication and initialization
+global.FormData = window.FormData;
+fetchMock.get(/superset\/csrf_token/, { csrf_token: '1234' });
+SupersetClient.getInstance({ protocol: 'http', host: 'localhost' })
+  .init()
+  .then(() => fetchMock.reset()); // remove this call from mocks

--- a/superset/assets/spec/javascripts/dashboard/reducers/sliceEntities_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/reducers/sliceEntities_spec.js
@@ -26,7 +26,7 @@ describe('sliceEntities reducer', () => {
   it('should set slices', () => {
     const result = sliceEntitiesReducer(
       { slices: { a: {} } },
-      { type: SET_ALL_SLICES, slices: { 1: {}, 2: {} } },
+      { type: SET_ALL_SLICES, payload: { slices: { 1: {}, 2: {} } } },
     );
 
     expect(result.slices).to.deep.equal({
@@ -42,7 +42,7 @@ describe('sliceEntities reducer', () => {
       {},
       {
         type: FETCH_ALL_SLICES_FAILED,
-        error: { responseJSON: { message: 'errorrr' } },
+        error: 'errorrr',
       },
     );
     expect(result.isLoading).to.equal(false);

--- a/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -3,16 +3,15 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, afterEach, beforeEach } from 'mocha';
 import { shallow, mount } from 'enzyme';
 import { Modal, Button, Radio } from 'react-bootstrap';
 import sinon from 'sinon';
+import fetchMock from 'fetch-mock';
 
 import * as exploreUtils from '../../../../src/explore/exploreUtils';
 import * as saveModalActions from '../../../../src/explore/actions/saveModalActions';
 import SaveModal from '../../../../src/explore/components/SaveModal';
-
-const $ = window.$ = require('jquery');
 
 describe('SaveModal', () => {
   const middlewares = [thunk];
@@ -46,9 +45,11 @@ describe('SaveModal', () => {
     },
     value: 'mock value',
   };
-  const getWrapper = () => (shallow(<SaveModal {...defaultProps} />, {
-    context: { store },
-  }).dive());
+
+  const getWrapper = () =>
+    shallow(<SaveModal {...defaultProps} />, {
+      context: { store },
+    }).dive();
 
   it('renders a Modal with 7 inputs and 2 buttons', () => {
     const wrapper = getWrapper();
@@ -117,14 +118,28 @@ describe('SaveModal', () => {
 
   describe('saveOrOverwrite', () => {
     beforeEach(() => {
-      sinon.stub(exploreUtils, 'getExploreUrlAndPayload').callsFake(() => ({ url: 'mockURL', payload: defaultProps.form_data }));
-      sinon.stub(saveModalActions, 'saveSlice').callsFake(() => {
-        const d = $.Deferred();
-        d.resolve('done');
-        return d.promise();
+      // this must be non-null when saveOrOverwrite(gotodash = true) is called
+      Object.defineProperty(window.location, 'origin', {
+        writable: true,
+        value: 'http://localhost',
       });
+
+      sinon
+        .stub(exploreUtils, 'getExploreUrlAndPayload')
+        .callsFake(() => ({ url: 'mockURL', payload: defaultProps.form_data }));
+
+      sinon
+        .stub(saveModalActions, 'saveSlice')
+        .callsFake(() =>
+          Promise.resolve({ data: { dashboard: '/mock/', slice: { slice_url: '/mock/' } } }),
+        );
     });
+
     afterEach(() => {
+      Object.defineProperty(window.location, 'origin', {
+        writable: true,
+        value: null,
+      });
       exploreUtils.getExploreUrlAndPayload.restore();
       saveModalActions.saveSlice.restore();
     });
@@ -135,6 +150,7 @@ describe('SaveModal', () => {
       const args = saveModalActions.saveSlice.getCall(0).args;
       expect(args[0]).to.deep.equal(defaultProps.form_data);
     });
+
     it('existing dashboard', () => {
       const wrapper = getWrapper();
       const saveToDashboardId = 100;
@@ -148,6 +164,7 @@ describe('SaveModal', () => {
       const args = saveModalActions.saveSlice.getCall(0).args;
       expect(args[1].save_to_dashboard_id).to.equal(saveToDashboardId);
     });
+
     it('new dashboard', () => {
       const wrapper = getWrapper();
       const newDashboardName = 'new dashboard name';
@@ -163,53 +180,64 @@ describe('SaveModal', () => {
     });
   });
 
-  describe('should fetchDashboards', () => {
+  describe('fetchDashboards', () => {
     let dispatch;
     let request;
-    let ajaxStub;
     const userID = 1;
+
+    const mockDashboardData = {
+      pks: ['id'],
+      result: [{ id: 'id', dashboard_title: 'dashboard title' }],
+    };
+
+    const saveEndpoint = `glob:*/dashboardasync/api/read?_flt_0_owners=${1}`;
+    fetchMock.get(saveEndpoint, mockDashboardData);
+
     beforeEach(() => {
       dispatch = sinon.spy();
-      ajaxStub = sinon.stub($, 'ajax');
     });
     afterEach(() => {
-      ajaxStub.restore();
+      fetchMock.reset();
     });
-    const mockDashboardData = {
-      pks: ['value'],
-      result: [
-        { dashboard_title: 'dashboard title' },
-      ],
-    };
+
     const makeRequest = () => {
       request = saveModalActions.fetchDashboards(userID);
       request(dispatch);
     };
 
-    it('makes the ajax request', () => {
+    it('makes the fetch request', (done) => {
       makeRequest();
-      expect(ajaxStub.callCount).to.equal(1);
+
+      setTimeout(() => {
+        expect(fetchMock.calls(saveEndpoint)).to.have.lengthOf(1);
+        done();
+      }, 0);
     });
 
-    it('calls correct url', () => {
-      const url = '/dashboardasync/api/read?_flt_0_owners=' + userID;
+    it('calls correct actions on success', (done) => {
       makeRequest();
-      expect(ajaxStub.getCall(0).args[0].url).to.be.equal(url);
+
+      setTimeout(() => {
+        expect(dispatch.callCount).to.equal(1);
+        expect(dispatch.getCall(0).args[0].type).to.equal(
+          saveModalActions.FETCH_DASHBOARDS_SUCCEEDED,
+        );
+        done();
+      }, 0);
     });
 
-    it('calls correct actions on error', () => {
-      ajaxStub.yieldsTo('error', { responseJSON: { error: 'error text' } });
-      makeRequest();
-      expect(dispatch.callCount).to.equal(1);
-      expect(dispatch.getCall(0).args[0].type).to.equal(saveModalActions.FETCH_DASHBOARDS_FAILED);
-    });
+    it('calls correct actions on error', (done) => {
+      fetchMock.get(saveEndpoint, { throws: 'errorz' }, { overwriteRoutes: true });
 
-    it('calls correct actions on success', () => {
-      ajaxStub.yieldsTo('success', mockDashboardData);
       makeRequest();
-      expect(dispatch.callCount).to.equal(1);
-      expect(dispatch.getCall(0).args[0].type)
-        .to.equal(saveModalActions.FETCH_DASHBOARDS_SUCCEEDED);
+
+      setTimeout(() => {
+        expect(dispatch.callCount).to.equal(1);
+        expect(dispatch.getCall(0).args[0].type).to.equal(saveModalActions.FETCH_DASHBOARDS_FAILED);
+
+        fetchMock.get(saveEndpoint, mockDashboardData, { overwriteRoutes: true });
+        done();
+      }, 0);
     });
   });
 

--- a/superset/assets/spec/javascripts/logger_spec.js
+++ b/superset/assets/spec/javascripts/logger_spec.js
@@ -1,7 +1,6 @@
-import $ from 'jquery';
-import { describe, it } from 'mocha';
+import { describe, it, afterEach } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import fetchMock from 'fetch-mock';
 
 import { Logger, ActionLog } from '../../src/logger';
 
@@ -46,6 +45,13 @@ describe('ActionLog', () => {
 });
 
 describe('Logger', () => {
+  const logEndpoint = 'glob:*/superset/log/*';
+  fetchMock.post(logEndpoint, 'success');
+
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
   it('should add events when .append(eventName, eventBody) is called', () => {
     const eventName = 'testEvent';
     const eventBody = { test: 'event' };
@@ -58,13 +64,6 @@ describe('Logger', () => {
   });
 
   describe('.send()', () => {
-    beforeEach(() => {
-      sinon.spy($, 'ajax');
-    });
-    afterEach(() => {
-      $.ajax.restore();
-    });
-
     const eventNames = ['test'];
 
     function setup(overrides = {}) {
@@ -72,16 +71,17 @@ describe('Logger', () => {
       return log;
     }
 
-    it('should POST an event to /superset/log/ when called', () => {
+    it('should POST an event to /superset/log/ when called', (done) => {
       const log = setup();
       Logger.start(log);
       Logger.append(eventNames[0], { test: 'event' });
       expect(log.events[eventNames[0]]).to.have.length(1);
       Logger.end(log);
-      expect($.ajax.calledOnce).to.equal(true);
-      const args = $.ajax.getCall(0).args[0];
-      expect(args.url).to.equal('/superset/log/');
-      expect(args.method).to.equal('POST');
+
+      setTimeout(() => {
+        expect(fetchMock.calls(logEndpoint)).to.have.lengthOf(1);
+        done();
+      }, 0);
     });
 
     it("should flush the log's events", () => {
@@ -94,13 +94,14 @@ describe('Logger', () => {
       expect(log.events).to.deep.equal({});
     });
 
-    it('should include ts, start_offset, event_name, impression_id, source, and source_id in every event', () => {
+    it('should include ts, start_offset, event_name, impression_id, source, and source_id in every event', (done) => {
       const config = {
         eventNames: ['event1', 'event2'],
         impressionId: 'impress_me',
         source: 'superset',
         sourceId: 'lolz',
       };
+
       const log = setup(config);
 
       Logger.start(log);
@@ -108,36 +109,46 @@ describe('Logger', () => {
       Logger.append('event2', { foo: 'bar' });
       Logger.end(log);
 
-      const args = $.ajax.getCall(0).args[0];
-      const events = JSON.parse(args.data.events);
+      setTimeout(() => {
+        const calls = fetchMock.calls(logEndpoint);
+        expect(calls).to.have.lengthOf(1);
+        const options = calls[0][1];
+        const events = JSON.parse(options.body.get('events'));
 
-      expect(events).to.have.length(2);
-      expect(events[0]).to.deep.include({
-        key: 'value',
-        event_name: 'event1',
-        impression_id: config.impressionId,
-        source: config.source,
-        source_id: config.sourceId,
-      });
-      expect(events[1]).to.deep.include({
-        foo: 'bar',
-        event_name: 'event2',
-        impression_id: config.impressionId,
-        source: config.source,
-        source_id: config.sourceId,
-      });
-      expect(typeof events[0].ts).to.equal('number');
-      expect(typeof events[1].ts).to.equal('number');
-      expect(typeof events[0].start_offset).to.equal('number');
-      expect(typeof events[1].start_offset).to.equal('number');
+        expect(events).to.have.length(2);
+        expect(events[0]).to.deep.include({
+          key: 'value',
+          event_name: 'event1',
+          impression_id: config.impressionId,
+          source: config.source,
+          source_id: config.sourceId,
+        });
+        expect(events[1]).to.deep.include({
+          foo: 'bar',
+          event_name: 'event2',
+          impression_id: config.impressionId,
+          source: config.source,
+          source_id: config.sourceId,
+        });
+        expect(typeof events[0].ts).to.equal('number');
+        expect(typeof events[1].ts).to.equal('number');
+        expect(typeof events[0].start_offset).to.equal('number');
+        expect(typeof events[1].start_offset).to.equal('number');
+
+        done();
+      }, 0);
     });
 
-    it('should send() a log immediately if .append() is called with sendNow=true', () => {
+    it('should send() a log immediately if .append() is called with sendNow=true', (done) => {
       const log = setup();
       Logger.start(log);
       Logger.append(eventNames[0], { test: 'event' }, true);
-      expect($.ajax.calledOnce).to.equal(true);
-      Logger.end(log);
+
+      setTimeout(() => {
+        expect(fetchMock.calls(logEndpoint)).to.have.lengthOf(1);
+        Logger.end(log);
+        done();
+      }, 0);
     });
   });
 });

--- a/superset/assets/spec/javascripts/sqllab/actions_spec.js
+++ b/superset/assets/spec/javascripts/sqllab/actions_spec.js
@@ -1,132 +1,181 @@
 /* eslint-disable no-unused-expressions */
-import { it, describe } from 'mocha';
+import { it, describe, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import $ from 'jquery';
+import fetchMock from 'fetch-mock';
+
 import * as actions from '../../../src/SqlLab/actions';
 import { query } from './fixtures';
 
 describe('async actions', () => {
-  let ajaxStub;
   let dispatch;
 
   beforeEach(() => {
     dispatch = sinon.spy();
-    ajaxStub = sinon.stub($, 'ajax');
   });
-  afterEach(() => {
-    ajaxStub.restore();
-  });
+
+  afterEach(fetchMock.reset);
 
   describe('saveQuery', () => {
-    it('makes the ajax request', () => {
+    const saveQueryEndpoint = 'glob:*/savedqueryviewapi/api/create';
+    fetchMock.post(saveQueryEndpoint, 'ok');
+
+    it('posts to the correct url', (done) => {
       const thunk = actions.saveQuery(query);
       thunk((/* mockDispatch */) => {});
-      expect(ajaxStub.calledOnce).to.be.true;
+      setTimeout(() => {
+        expect(fetchMock.calls(saveQueryEndpoint)).to.have.lengthOf(1);
+        done();
+      });
     });
 
-    it('calls correct url', () => {
-      const url = '/savedqueryviewapi/api/create';
+    it('posts the correct query object', (done) => {
       const thunk = actions.saveQuery(query);
       thunk((/* mockDispatch */) => {});
-      expect(ajaxStub.getCall(0).args[0].url).to.equal(url);
+      setTimeout(() => {
+        const call = fetchMock.calls(saveQueryEndpoint)[0];
+        const formData = call[1].body;
+        Object.keys(query).forEach((key) => {
+          expect(formData.get(key)).to.not.be.undefined;
+        });
+        done();
+      });
     });
   });
 
   describe('fetchQueryResults', () => {
+    const fetchQueryEndpoint = 'glob:*/superset/results/*';
+    fetchMock.get(fetchQueryEndpoint, { data: '' });
+
     const makeRequest = () => {
       const request = actions.fetchQueryResults(query);
       request(dispatch);
     };
 
-    it('makes the ajax request', () => {
+    it('makes the fetch request', (done) => {
       makeRequest();
-      expect(ajaxStub.calledOnce).to.be.true;
+      setTimeout(() => {
+        expect(fetchMock.calls(fetchQueryEndpoint)).to.have.lengthOf(1);
+        done();
+      });
     });
 
-    it('calls correct url', () => {
-      const url = `/superset/results/${query.resultsKey}/`;
+    it('calls requestQueryResults', (done) => {
       makeRequest();
-      expect(ajaxStub.getCall(0).args[0].url).to.equal(url);
+      setTimeout(() => {
+        expect(dispatch.args[0][0].type).to.equal(actions.REQUEST_QUERY_RESULTS);
+        done();
+      });
     });
 
-    it('calls requestQueryResults', () => {
+    it('calls querySuccess on fetch success', (done) => {
       makeRequest();
-      expect(dispatch.args[0][0].type).to.equal(actions.REQUEST_QUERY_RESULTS);
+      setTimeout(() => {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.getCall(1).args[0].type).to.equal(actions.QUERY_SUCCESS);
+        done();
+      });
     });
 
-    it('calls querySuccess on ajax success', () => {
-      ajaxStub.yieldsTo('success', { data: '' });
-      makeRequest();
-      expect(dispatch.callCount).to.equal(2);
-      expect(dispatch.getCall(1).args[0].type).to.equal(actions.QUERY_SUCCESS);
-    });
+    it('calls queryFailed on fetch error', (done) => {
+      fetchMock.get(
+        fetchQueryEndpoint,
+        { throws: { error: 'error text' } },
+        { overwriteRoutes: true },
+      );
 
-    it('calls queryFailed on ajax error', () => {
-      ajaxStub.yieldsTo('error', { responseJSON: { error: 'error text' } });
       makeRequest();
-      expect(dispatch.callCount).to.equal(2);
-      expect(dispatch.getCall(1).args[0].type).to.equal(actions.QUERY_FAILED);
+      setTimeout(() => {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.getCall(1).args[0].type).to.equal(actions.QUERY_FAILED);
+        done();
+      });
     });
   });
 
   describe('runQuery', () => {
+    const runQueryEndpoint = 'glob:*/superset/sql_json/*';
+    fetchMock.post(runQueryEndpoint, { data: '' });
+
     const makeRequest = () => {
       const request = actions.runQuery(query);
       request(dispatch);
     };
 
-    it('makes the ajax request', () => {
+    it('makes the fetch request', (done) => {
       makeRequest();
-      expect(ajaxStub.calledOnce).to.be.true;
+      setTimeout(() => {
+        expect(fetchMock.calls(runQueryEndpoint)).to.have.lengthOf(1);
+        done();
+      });
     });
 
-    it('calls startQuery', () => {
+    it('calls startQuery', (done) => {
       makeRequest();
-      expect(dispatch.args[0][0].type).to.equal(actions.START_QUERY);
+      setTimeout(() => {
+        expect(dispatch.args[0][0].type).to.equal(actions.START_QUERY);
+        done();
+      });
     });
 
-    it('calls querySuccess on ajax success', () => {
-      ajaxStub.yieldsTo('success', { data: '' });
+    it('calls querySuccess on fetch success', (done) => {
       makeRequest();
-      expect(dispatch.callCount).to.equal(2);
-      expect(dispatch.getCall(1).args[0].type).to.equal(actions.QUERY_SUCCESS);
+      setTimeout(() => {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.getCall(1).args[0].type).to.equal(actions.QUERY_SUCCESS);
+        done();
+      });
     });
 
-    it('calls queryFailed on ajax error', () => {
-      ajaxStub.yieldsTo('error', { responseJSON: { error: 'error text' } });
+    it('calls queryFailed on fetch error', (done) => {
+      fetchMock.post(
+        runQueryEndpoint,
+        { throws: { error: 'error text' } },
+        { overwriteRoutes: true },
+      );
+
       makeRequest();
-      expect(dispatch.callCount).to.equal(2);
-      expect(dispatch.getCall(1).args[0].type).to.equal(actions.QUERY_FAILED);
+      setTimeout(() => {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.getCall(1).args[0].type).to.equal(actions.QUERY_FAILED);
+        done();
+      });
     });
   });
 
   describe('postStopQuery', () => {
+    const stopQueryEndpoint = 'glob:*/superset/stop_query/*';
+    fetchMock.post(stopQueryEndpoint, { data: '' });
+
     const makeRequest = () => {
       const request = actions.postStopQuery(query);
       request(dispatch);
     };
 
-    it('makes the ajax request', () => {
+    it('makes the fetch request', (done) => {
       makeRequest();
-      expect(ajaxStub.calledOnce).to.be.true;
+      setTimeout(() => {
+        expect(fetchMock.calls(stopQueryEndpoint)).to.have.lengthOf(1);
+        done();
+      });
     });
 
-    it('calls stopQuery', () => {
+    it('calls stopQuery', (done) => {
       makeRequest();
-      expect(dispatch.args[0][0].type).to.equal(actions.STOP_QUERY);
+      setTimeout(() => {
+        expect(dispatch.getCall(0).args[0].type).to.equal(actions.STOP_QUERY);
+        // expect(dispatch.args[0][0].type).to.equal(actions.STOP_QUERY);
+        done();
+      });
     });
 
-    it('calls the correct url', () => {
-      const url = '/superset/stop_query/';
+    it('sends the correct data', (done) => {
       makeRequest();
-      expect(ajaxStub.getCall(0).args[0].url).to.equal(url);
-    });
-
-    it('sends the correct data', () => {
-      const data = { client_id: query.id };
-      makeRequest();
-      expect(ajaxStub.getCall(0).args[0].data).to.deep.equal(data);
+      setTimeout(() => {
+        const call = fetchMock.calls(stopQueryEndpoint)[0];
+        expect(call[1].body.get('client_id')).to.equal(query.id);
+        done();
+      });
     });
   });
 });

--- a/superset/assets/spec/javascripts/sqllab/fixtures.js
+++ b/superset/assets/spec/javascripts/sqllab/fixtures.js
@@ -20,32 +20,24 @@ export const table = {
   indexes: [
     {
       unique: true,
-      column_names: [
-        'username',
-      ],
+      column_names: ['username'],
       type: 'UNIQUE',
       name: 'username',
     },
     {
       unique: true,
-      column_names: [
-        'email',
-      ],
+      column_names: ['email'],
       type: 'UNIQUE',
       name: 'email',
     },
     {
       unique: false,
-      column_names: [
-        'created_by_fk',
-      ],
+      column_names: ['created_by_fk'],
       name: 'created_by_fk',
     },
     {
       unique: false,
-      column_names: [
-        'changed_by_fk',
-      ],
+      column_names: ['changed_by_fk'],
       name: 'changed_by_fk',
     },
   ],
@@ -70,13 +62,9 @@ export const table = {
       name: 'first_name',
       keys: [
         {
-          column_names: [
-            'first_name',
-          ],
+          column_names: ['first_name'],
           name: 'slices_ibfk_1',
-          referred_columns: [
-            'id',
-          ],
+          referred_columns: ['id'],
           referred_table: 'datasources',
           type: 'fk',
           referred_schema: 'carapal',
@@ -84,9 +72,7 @@ export const table = {
         },
         {
           unique: false,
-          column_names: [
-            'druid_datasource_id',
-          ],
+          column_names: ['druid_datasource_id'],
           type: 'index',
           name: 'druid_datasource_id',
         },
@@ -205,21 +191,21 @@ export const queries = [
     serverId: 141,
     resultsKey: null,
     results: {
-      columns: [{
-        is_date: true,
-        is_dim: false,
-        name: 'ds',
-        type: 'STRING',
-      }, {
-        is_date: false,
-        is_dim: true,
-        name: 'gender',
-        type: 'STRING',
-      }],
-      data: [
-        { col1: 0, col2: 1 },
-        { col1: 2, col2: 3 },
+      columns: [
+        {
+          is_date: true,
+          is_dim: false,
+          name: 'ds',
+          type: 'STRING',
+        },
+        {
+          is_date: false,
+          is_dim: true,
+          name: 'gender',
+          type: 'STRING',
+        },
       ],
+      data: [{ col1: 0, col2: 1 }, { col1: 2, col2: 3 }],
     },
   },
   {
@@ -237,12 +223,11 @@ export const queries = [
     changedOn: 1476910572000,
     tempTable: null,
     userId: 1,
-    executedSql: (
+    executedSql:
       'SELECT * \nFROM (SELECT created_on, changed_on, id, slice_name, ' +
       'druid_datasource_id, table_id, datasource_type, datasource_name, ' +
       'viz_type, params, created_by_fk, changed_by_fk, description, ' +
-      'cache_timeout, perm\nFROM superset.slices) AS inner_qry \n LIMIT 1000'
-    ),
+      'cache_timeout, perm\nFROM superset.slices) AS inner_qry \n LIMIT 1000',
     changed_on: '2016-10-19T20:56:12',
     rows: 42,
     endDttm: 1476910579693,
@@ -261,72 +246,86 @@ export const queryWithBadColumns = {
   ...queries[0],
   results: {
     data: queries[0].results.data,
-    columns: [{
-      is_date: true,
-      is_dim: false,
-      name: 'COUNT(*)',
-      type: 'STRING',
-    }, {
-      is_date: false,
-      is_dim: true,
-      name: 'this_col_is_ok',
-      type: 'STRING',
-    }, {
-      is_date: false,
-      is_dim: true,
-      name: 'a',
-      type: 'STRING',
-    }, {
-      is_date: false,
-      is_dim: true,
-      name: '1',
-      type: 'STRING',
-    }, {
-      is_date: false,
-      is_dim: true,
-      name: '123',
-      type: 'STRING',
-    }, {
-      is_date: false,
-      is_dim: true,
-      name: 'CASE WHEN 1=1 THEN 1 ELSE 0 END',
-      type: 'STRING',
-    }],
+    columns: [
+      {
+        is_date: true,
+        is_dim: false,
+        name: 'COUNT(*)',
+        type: 'STRING',
+      },
+      {
+        is_date: false,
+        is_dim: true,
+        name: 'this_col_is_ok',
+        type: 'STRING',
+      },
+      {
+        is_date: false,
+        is_dim: true,
+        name: 'a',
+        type: 'STRING',
+      },
+      {
+        is_date: false,
+        is_dim: true,
+        name: '1',
+        type: 'STRING',
+      },
+      {
+        is_date: false,
+        is_dim: true,
+        name: '123',
+        type: 'STRING',
+      },
+      {
+        is_date: false,
+        is_dim: true,
+        name: 'CASE WHEN 1=1 THEN 1 ELSE 0 END',
+        type: 'STRING',
+      },
+    ],
   },
 };
 export const databases = {
-  result: [{
-    allow_ctas: true,
-    allow_dml: true,
-    allow_run_async: false,
-    allow_run_sync: true,
-    database_name: 'main',
-    expose_in_sqllab: true,
-    force_ctas_schema: '',
-    id: 1,
-  }, {
-    allow_ctas: true,
-    allow_dml: false,
-    allow_run_async: true,
-    allow_run_sync: true,
-    database_name: 'Presto - Gold',
-    expose_in_sqllab: true,
-    force_ctas_schema: 'tmp',
-    id: 208,
-  }],
+  result: [
+    {
+      allow_ctas: true,
+      allow_dml: true,
+      allow_run_async: false,
+      allow_run_sync: true,
+      database_name: 'main',
+      expose_in_sqllab: true,
+      force_ctas_schema: '',
+      id: 1,
+    },
+    {
+      allow_ctas: true,
+      allow_dml: false,
+      allow_run_async: true,
+      allow_run_sync: true,
+      database_name: 'Presto - Gold',
+      expose_in_sqllab: true,
+      force_ctas_schema: 'tmp',
+      id: 208,
+    },
+  ],
 };
 export const tables = {
   tableLength: 3,
-  options: [{
-    value: 'birth_names',
-    label: 'birth_names',
-  }, {
-    value: 'energy_usage',
-    label: 'energy_usage',
-  }, {
-    value: 'wb_health_population',
-    label: 'wb_health_population',
-  }],
+  options: [
+    {
+      value: 'birth_names',
+      label: 'birth_names',
+    },
+    {
+      value: 'energy_usage',
+      label: 'energy_usage',
+    },
+    {
+      value: 'wb_health_population',
+      label: 'wb_health_population',
+    },
+  ],
 };
 
 export const stoppedQuery = {
@@ -371,6 +370,7 @@ export const initialState = {
 };
 
 export const query = {
+  id: 'clientId2353',
   dbId: 1,
   sql: 'SELECT * FROM something',
   sqlEditorId: defaultQueryEditor.id,

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -1,7 +1,8 @@
 /* global window */
 /* eslint no-undef: 2 */
-import $ from 'jquery';
 import shortid from 'shortid';
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+
 import { now } from '../modules/dates';
 import { t } from '../locales';
 import {
@@ -43,7 +44,6 @@ export const QUERY_FAILED = 'QUERY_FAILED';
 export const CLEAR_QUERY_RESULTS = 'CLEAR_QUERY_RESULTS';
 export const REMOVE_DATA_PREVIEW = 'REMOVE_DATA_PREVIEW';
 export const CHANGE_DATA_PREVIEW_ID = 'CHANGE_DATA_PREVIEW_ID';
-export const SAVE_QUERY = 'SAVE_QUERY';
 
 export const CREATE_DATASOURCE_STARTED = 'CREATE_DATASOURCE_STARTED';
 export const CREATE_DATASOURCE_SUCCESS = 'CREATE_DATASOURCE_SUCCESS';
@@ -59,20 +59,14 @@ export function resetState() {
 
 export function saveQuery(query) {
   return (dispatch) => {
-    const url = '/savedqueryviewapi/api/create';
-    $.ajax({
-      type: 'POST',
-      url,
-      data: query,
-      success: () => {
-        dispatch(addSuccessToast(t('Your query was saved')));
-      },
-      error: () => {
-        dispatch(addDangerToast(t('Your query could not be saved')));
-      },
-      dataType: 'json',
-    });
-    return { type: SAVE_QUERY };
+    SupersetClient.getInstance()
+      .post({
+        endpoint: '/savedqueryviewapi/api/create',
+        postPayload: query,
+        stringify: false,
+      })
+      .then(() => dispatch(addSuccessToast(t('Your query was saved'))))
+      .catch(() => dispatch(addDangerToast(t('Your query could not be saved'))));
   };
 }
 
@@ -81,7 +75,7 @@ export function startQuery(query) {
     id: query.id ? query.id : shortid.generate(),
     progress: 0,
     startDttm: now(),
-    state: (query.runAsync) ? 'pending' : 'running',
+    state: query.runAsync ? 'pending' : 'running',
     cached: false,
   });
   return { type: START_QUERY, query };
@@ -122,29 +116,25 @@ function getErrorLink(err) {
 export function fetchQueryResults(query) {
   return function (dispatch) {
     dispatch(requestQueryResults(query));
-    const sqlJsonUrl = `/superset/results/${query.resultsKey}/`;
-    $.ajax({
-      type: 'GET',
-      dataType: 'json',
-      url: sqlJsonUrl,
-      success(results) {
-        dispatch(querySuccess(query, results));
-      },
-      error(err) {
-        let msg = t('Failed at retrieving results from the results backend');
-        if (err.responseJSON && err.responseJSON.error) {
-          msg = err.responseJSON.error;
-        }
-        dispatch(queryFailed(query, msg, getErrorLink(err)));
-      },
-    });
+
+    return SupersetClient.getInstance()
+      .get({ endpoint: `/superset/results/${query.resultsKey}/` })
+      .then(({ json }) => dispatch(querySuccess(query, json)))
+      .catch((error) => {
+        const message =
+          error.error ||
+          error.statusText ||
+          t('Failed at retrieving results from the results backend');
+
+        return dispatch(queryFailed(query, message, error.link));
+      });
   };
 }
 
 export function runQuery(query) {
   return function (dispatch) {
     dispatch(startQuery(query));
-    const sqlJsonRequest = {
+    const postPayload = {
       client_id: query.id,
       database_id: query.dbId,
       json: true,
@@ -157,59 +147,39 @@ export function runQuery(query) {
       select_as_cta: query.ctas,
       templateParams: query.templateParams,
     };
-    const sqlJsonUrl = '/superset/sql_json/' + window.location.search;
-    $.ajax({
-      type: 'POST',
-      dataType: 'json',
-      url: sqlJsonUrl,
-      data: sqlJsonRequest,
-      success(results) {
+
+    SupersetClient.getInstance()
+      .post({
+        endpoint: `/superset/sql_json/${window.location.search}`,
+        postPayload,
+        stringify: false,
+      })
+      .then(({ json }) => {
         if (!query.runAsync) {
-          dispatch(querySuccess(query, results));
+          dispatch(querySuccess(query, json));
         }
-      },
-      error(err, textStatus, errorThrown) {
-        let msg;
-        try {
-          msg = err.responseJSON.error;
-        } catch (e) {
-          if (err.responseText !== undefined) {
-            msg = err.responseText;
-          }
+      })
+      .catch((error) => {
+        let message = error.error || error.statusText || t('Unknown error');
+        if (message.includes('CSRF token')) {
+          message = COMMON_ERR_MESSAGES.SESSION_TIMED_OUT;
         }
-        if (msg === null) {
-          if (errorThrown) {
-            msg = `[${textStatus}] ${errorThrown}`;
-          } else {
-            msg = t('Unknown error');
-          }
-        }
-        if (msg.indexOf('CSRF token') > 0) {
-          msg = COMMON_ERR_MESSAGES.SESSION_TIMED_OUT;
-        }
-        dispatch(queryFailed(query, msg, getErrorLink(err)));
-      },
-    });
+        // @TODO how to verify link?
+        dispatch(queryFailed(query, message, error.link));
+      });
   };
 }
 
 export function postStopQuery(query) {
   return function (dispatch) {
-    const stopQueryUrl = '/superset/stop_query/';
-    const stopQueryRequestData = { client_id: query.id };
-    dispatch(stopQuery(query));
-    $.ajax({
-      type: 'POST',
-      dataType: 'json',
-      url: stopQueryUrl,
-      data: stopQueryRequestData,
-      success() {
-        dispatch(addSuccessToast(t('Query was stopped.')));
-      },
-      error() {
-        dispatch(addDangerToast(t('Failed at stopping query.')));
-      },
-    });
+    return SupersetClient.getInstance()
+      .post({
+        endpoint: '/superset/stop_query/',
+        postPayload: { client_id: query.id },
+        stringify: false,
+      })
+      .then(() => dispatch(addSuccessToast(t('Query was stopped.'))))
+      .catch(() => dispatch(addDangerToast(t('Failed at stopping query. ') + `'${query.id}'`)));
   };
 }
 
@@ -279,59 +249,69 @@ export function mergeTable(table, query) {
 
 export function addTable(query, tableName, schemaName) {
   return function (dispatch) {
-    let table = {
+    const table = {
       dbId: query.dbId,
       queryEditorId: query.id,
       schema: schemaName,
       name: tableName,
     };
-    dispatch(mergeTable(Object.assign({}, table, {
-      isMetadataLoading: true,
-      isExtraMetadataLoading: true,
-      expanded: false,
-    })));
+    dispatch(
+      mergeTable({
+        ...table,
+        isMetadataLoading: true,
+        isExtraMetadataLoading: true,
+        expanded: false,
+      }),
+    );
 
-    let url = `/superset/table/${query.dbId}/${tableName}/${schemaName}/`;
-    $.get(url, (data) => {
-      const dataPreviewQuery = {
-        id: shortid.generate(),
-        dbId: query.dbId,
-        sql: data.selectStar,
-        tableName,
-        sqlEditorId: null,
-        tab: '',
-        runAsync: false,
-        ctas: false,
-      };
-      // Merge table to tables in state
-      const newTable = Object.assign({}, table, data, {
-        expanded: true,
-        isMetadataLoading: false,
-      });
-      dispatch(mergeTable(newTable, dataPreviewQuery));
-      // Run query to get preview data for table
-      dispatch(runQuery(dataPreviewQuery));
-    })
-    .fail(() => {
-      const newTable = Object.assign({}, table, {
-        isMetadataLoading: false,
-      });
-      dispatch(mergeTable(newTable));
-      dispatch(addDangerToast(t('Error occurred while fetching table metadata')));
-    });
+    SupersetClient.getInstance()
+      .get({ endpoint: `/superset/table/${query.dbId}/${tableName}/${schemaName}/` })
+      .then(({ json }) => {
+        const dataPreviewQuery = {
+          id: shortid.generate(),
+          dbId: query.dbId,
+          sql: json.selectStar,
+          tableName,
+          sqlEditorId: null,
+          tab: '',
+          runAsync: false,
+          ctas: false,
+        };
+        const newTable = {
+          ...table,
+          ...json,
+          expanded: true,
+          isMetadataLoading: false,
+        };
 
-    url = `/superset/extra_table_metadata/${query.dbId}/${tableName}/${schemaName}/`;
-    $.get(url, (data) => {
-      table = Object.assign({}, table, data, { isExtraMetadataLoading: false });
-      dispatch(mergeTable(table));
-    })
-    .fail(() => {
-      const newTable = Object.assign({}, table, {
-        isExtraMetadataLoading: false,
-      });
-      dispatch(mergeTable(newTable));
-      dispatch(addDangerToast(t('Error occurred while fetching table metadata')));
-    });
+        return Promise.all([
+          dispatch(mergeTable(newTable, dataPreviewQuery)), // Merge table to tables in state
+          dispatch(runQuery(dataPreviewQuery)), // Run query to get preview data for table
+        ]);
+      })
+      .catch(() =>
+        Promise.all([
+          dispatch(
+            mergeTable({
+              ...table,
+              isMetadataLoading: false,
+            }),
+          ),
+          dispatch(addDangerToast(t('Error occurred while fetching table metadata'))),
+        ]),
+      );
+
+    SupersetClient.getInstance()
+      .get({ endpoint: `/superset/extra_table_metadata/${query.dbId}/${tableName}/${schemaName}/` })
+      .then(({ json }) =>
+        dispatch(mergeTable({ ...table, ...json, isExtraMetadataLoading: false })),
+      )
+      .catch(() =>
+        Promise.all([
+          dispatch(mergeTable({ ...table, isExtraMetadataLoading: false })),
+          dispatch(addDangerToast(t('Error occurred while fetching table metadata'))),
+        ]),
+      );
   };
 }
 
@@ -378,75 +358,63 @@ export function persistEditorHeight(queryEditor, currentHeight) {
 
 export function popStoredQuery(urlId) {
   return function (dispatch) {
-    $.ajax({
-      type: 'GET',
-      url: `/kv/${urlId}`,
-      success: (data) => {
-        const newQuery = JSON.parse(data);
-        const queryEditorProps = {
-          title: newQuery.title ? newQuery.title : t('shared query'),
-          dbId: newQuery.dbId ? parseInt(newQuery.dbId, 10) : null,
-          schema: newQuery.schema ? newQuery.schema : null,
-          autorun: newQuery.autorun ? newQuery.autorun : false,
-          sql: newQuery.sql ? newQuery.sql : 'SELECT ...',
-        };
-        dispatch(addQueryEditor(queryEditorProps));
-      },
-      error: () => {
-        dispatch(addDangerToast(t('The query couldn\'t be loaded')));
-      },
-    });
+    return SupersetClient.getInstance()
+      .get({ endpoint: `/kv/${urlId}` })
+      .then(({ json }) =>
+        dispatch(
+          addQueryEditor({
+            title: json.title ? json.title : t('Sjsonhared query'),
+            dbId: json.dbId ? parseInt(json.dbId, 10) : null,
+            schema: json.schema ? json.schema : null,
+            autorun: json.autorun ? json.autorun : false,
+            sql: json.sql ? json.sql : 'SELECT ...',
+          }),
+        ),
+      )
+      .catch(() => dispatch(addDangerToast(t("The query couldn't be loaded"))));
   };
 }
 export function popSavedQuery(saveQueryId) {
   return function (dispatch) {
-    $.ajax({
-      type: 'GET',
-      url: `/savedqueryviewapi/api/get/${saveQueryId}`,
-      success: (data) => {
-        const sq = data.result;
+    return SupersetClient.getInstance()
+      .get({ endpoint: `/savedqueryviewapi/api/get/${saveQueryId}` })
+      .then(({ json }) => {
+        const { result } = json;
         const queryEditorProps = {
-          title: sq.label,
-          dbId: sq.db_id ? parseInt(sq.db_id, 10) : null,
-          schema: sq.schema,
+          title: result.label,
+          dbId: result.db_id ? parseInt(result.db_id, 10) : null,
+          schema: result.schema,
           autorun: false,
-          sql: sq.sql,
+          sql: result.sql,
         };
-        dispatch(addQueryEditor(queryEditorProps));
-      },
-      error: () => {
-        dispatch(addDangerToast(t('The query couldn\'t be loaded')));
-      },
-    });
+        return dispatch(addQueryEditor(queryEditorProps));
+      })
+      .catch(() => dispatch(addDangerToast(t("The query couldn't be loaded"))));
   };
 }
 export function popDatasourceQuery(datasourceKey, sql) {
   return function (dispatch) {
-    $.ajax({
-      type: 'GET',
-      url: `/superset/fetch_datasource_metadata?datasourceKey=${datasourceKey}`,
-      success: (metadata) => {
-        const queryEditorProps = {
-          title: 'Query ' + metadata.name,
-          dbId: metadata.database.id,
-          schema: metadata.schema,
-          autorun: sql !== undefined,
-          sql: sql || metadata.select_star,
-        };
-        dispatch(addQueryEditor(queryEditorProps));
-      },
-      error: () => {
-        dispatch(addDangerToast(t("The datasource couldn't be loaded")));
-      },
-    });
+    return SupersetClient.getInstance()
+      .get({ endpoint: `/superset/fetch_datasource_metadata?datasourceKey=${datasourceKey}` })
+      .then(({ json }) =>
+        dispatch(
+          addQueryEditor({
+            title: 'Query ' + json.name,
+            dbId: json.database.id,
+            schema: json.schema,
+            autorun: sql !== undefined,
+            sql: sql || json.select_star,
+          }),
+        ),
+      )
+      .catch(() => dispatch(addDangerToast(t("The datasource couldn't be loaded"))));
   };
 }
 
 export function createDatasourceStarted() {
   return { type: CREATE_DATASOURCE_STARTED };
 }
-export function createDatasourceSuccess(response) {
-  const data = JSON.parse(response);
+export function createDatasourceSuccess(data) {
   const datasource = `${data.table_id}__table`;
   return { type: CREATE_DATASOURCE_SUCCESS, datasource };
 }
@@ -454,25 +422,24 @@ export function createDatasourceFailed(err) {
   return { type: CREATE_DATASOURCE_FAILED, err };
 }
 
-export function createDatasource(vizOptions, context) {
+export function createDatasource(vizOptions) {
   return (dispatch) => {
     dispatch(createDatasourceStarted());
+    return SupersetClient.getInstance()
+      .post({
+        endpoint: '/suddperset/sqllab_viz/',
+        postPayload: { data: vizOptions },
+      })
+      .then(({ json }) => {
+        const data = JSON.parse(json);
+        dispatch(createDatasourceSuccess(data));
 
-    return $.ajax({
-      type: 'POST',
-      url: '/superset/sqllab_viz/',
-      async: false,
-      data: {
-        data: JSON.stringify(vizOptions),
-      },
-      context,
-      dataType: 'json',
-      success: (resp) => {
-        dispatch(createDatasourceSuccess(resp));
-      },
-      error: () => {
+        return Promise.resolve(data);
+      })
+      .catch(() => {
         dispatch(createDatasourceFailed(t('An error occurred while creating the data source')));
-      },
-    });
+
+        return Promise.reject();
+      });
   };
 }

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -1,5 +1,5 @@
 import shortid from 'shortid';
-import { SupersetClient } from '../packages/core/src';
+import SupersetClient from '../packages/core/src';
 
 import { now } from '../modules/dates';
 import { t } from '../locales';
@@ -57,12 +57,11 @@ export function resetState() {
 
 export function saveQuery(query) {
   return (dispatch) => {
-    SupersetClient.getInstance()
-      .post({
-        endpoint: '/savedqueryviewapi/api/create',
-        postPayload: query,
-        stringify: false,
-      })
+    SupersetClient.post({
+      endpoint: '/savedqueryviewapi/api/create',
+      postPayload: query,
+      stringify: false,
+    })
       .then(() => dispatch(addSuccessToast(t('Your query was saved'))))
       .catch(() => dispatch(addDangerToast(t('Your query could not be saved'))));
   };
@@ -107,8 +106,7 @@ export function fetchQueryResults(query) {
   return function (dispatch) {
     dispatch(requestQueryResults(query));
 
-    return SupersetClient.getInstance()
-      .get({ endpoint: `/superset/results/${query.resultsKey}/` })
+    return SupersetClient.get({ endpoint: `/superset/results/${query.resultsKey}/` })
       .then(({ json }) => dispatch(querySuccess(query, json)))
       .catch((error) => {
         const message =
@@ -138,12 +136,11 @@ export function runQuery(query) {
       templateParams: query.templateParams,
     };
 
-    SupersetClient.getInstance()
-      .post({
-        endpoint: `/superset/sql_json/${window.location.search}`,
-        postPayload,
-        stringify: false,
-      })
+    SupersetClient.post({
+      endpoint: `/superset/sql_json/${window.location.search}`,
+      postPayload,
+      stringify: false,
+    })
       .then(({ json }) => {
         if (!query.runAsync) {
           dispatch(querySuccess(query, json));
@@ -162,12 +159,11 @@ export function runQuery(query) {
 
 export function postStopQuery(query) {
   return function (dispatch) {
-    return SupersetClient.getInstance()
-      .post({
-        endpoint: '/superset/stop_query/',
-        postPayload: { client_id: query.id },
-        stringify: false,
-      })
+    return SupersetClient.post({
+      endpoint: '/superset/stop_query/',
+      postPayload: { client_id: query.id },
+      stringify: false,
+    })
       .then(() => dispatch(stopQuery(query)))
       .then(() => dispatch(addSuccessToast(t('Query was stopped.'))))
       .catch(() => dispatch(addDangerToast(t('Failed at stopping query. ') + `'${query.id}'`)));
@@ -255,8 +251,7 @@ export function addTable(query, tableName, schemaName) {
       }),
     );
 
-    SupersetClient.getInstance()
-      .get({ endpoint: `/superset/table/${query.dbId}/${tableName}/${schemaName}/` })
+    SupersetClient.get({ endpoint: `/superset/table/${query.dbId}/${tableName}/${schemaName}/` })
       .then(({ json }) => {
         const dataPreviewQuery = {
           id: shortid.generate(),
@@ -292,8 +287,9 @@ export function addTable(query, tableName, schemaName) {
         ]),
       );
 
-    SupersetClient.getInstance()
-      .get({ endpoint: `/superset/extra_table_metadata/${query.dbId}/${tableName}/${schemaName}/` })
+    SupersetClient.get({
+      endpoint: `/superset/extra_table_metadata/${query.dbId}/${tableName}/${schemaName}/`,
+    })
       .then(({ json }) =>
         dispatch(mergeTable({ ...table, ...json, isExtraMetadataLoading: false })),
       )
@@ -349,8 +345,7 @@ export function persistEditorHeight(queryEditor, currentHeight) {
 
 export function popStoredQuery(urlId) {
   return function (dispatch) {
-    return SupersetClient.getInstance()
-      .get({ endpoint: `/kv/${urlId}` })
+    return SupersetClient.get({ endpoint: `/kv/${urlId}` })
       .then(({ json }) =>
         dispatch(
           addQueryEditor({
@@ -367,8 +362,7 @@ export function popStoredQuery(urlId) {
 }
 export function popSavedQuery(saveQueryId) {
   return function (dispatch) {
-    return SupersetClient.getInstance()
-      .get({ endpoint: `/savedqueryviewapi/api/get/${saveQueryId}` })
+    return SupersetClient.get({ endpoint: `/savedqueryviewapi/api/get/${saveQueryId}` })
       .then(({ json }) => {
         const { result } = json;
         const queryEditorProps = {
@@ -385,8 +379,9 @@ export function popSavedQuery(saveQueryId) {
 }
 export function popDatasourceQuery(datasourceKey, sql) {
   return function (dispatch) {
-    return SupersetClient.getInstance()
-      .get({ endpoint: `/superset/fetch_datasource_metadata?datasourceKey=${datasourceKey}` })
+    return SupersetClient.get({
+      endpoint: `/superset/fetch_datasource_metadata?datasourceKey=${datasourceKey}`,
+    })
       .then(({ json }) =>
         dispatch(
           addQueryEditor({
@@ -416,11 +411,10 @@ export function createDatasourceFailed(err) {
 export function createDatasource(vizOptions) {
   return (dispatch) => {
     dispatch(createDatasourceStarted());
-    return SupersetClient.getInstance()
-      .post({
-        endpoint: '/superset/sqllab_viz/',
-        postPayload: { data: vizOptions },
-      })
+    return SupersetClient.post({
+      endpoint: '/superset/sqllab_viz/',
+      postPayload: { data: vizOptions },
+    })
       .then(({ json }) => {
         const data = JSON.parse(json);
         dispatch(createDatasourceSuccess(data));

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -168,6 +168,7 @@ export function postStopQuery(query) {
         postPayload: { client_id: query.id },
         stringify: false,
       })
+      .then(() => dispatch(stopQuery(query)))
       .then(() => dispatch(addSuccessToast(t('Query was stopped.'))))
       .catch(() => dispatch(addDangerToast(t('Failed at stopping query. ') + `'${query.id}'`)));
   };

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -1,7 +1,5 @@
-/* global window */
-/* eslint no-undef: 2 */
 import shortid from 'shortid';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../packages/core/src';
 
 import { now } from '../modules/dates';
 import { t } from '../locales';

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -418,7 +418,7 @@ export function createDatasource(vizOptions) {
     dispatch(createDatasourceStarted());
     return SupersetClient.getInstance()
       .post({
-        endpoint: '/suddperset/sqllab_viz/',
+        endpoint: '/superset/sqllab_viz/',
         postPayload: { data: vizOptions },
       })
       .then(({ json }) => {

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -1,5 +1,5 @@
 import shortid from 'shortid';
-import SupersetClient from '../packages/core/src';
+import { SupersetClient } from '../packages/core/src';
 
 import { now } from '../modules/dates';
 import { t } from '../locales';

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -105,14 +105,6 @@ export function requestQueryResults(query) {
   return { type: REQUEST_QUERY_RESULTS, query };
 }
 
-function getErrorLink(err) {
-  let link = '';
-  if (err.responseJSON && err.responseJSON.link) {
-    link = err.responseJSON.link;
-  }
-  return link;
-}
-
 export function fetchQueryResults(query) {
   return function (dispatch) {
     dispatch(requestQueryResults(query));

--- a/superset/assets/src/SqlLab/components/CopyQueryTabUrl.jsx
+++ b/superset/assets/src/SqlLab/components/CopyQueryTabUrl.jsx
@@ -1,3 +1,4 @@
+/* eslint no-alert: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import CopyToClipboard from '../../components/CopyToClipboard';
@@ -9,6 +10,11 @@ const propTypes = {
 };
 
 export default class CopyQueryTabUrl extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.getUrl = this.getUrl.bind(this);
+  }
+
   getUrl(callback) {
     const qe = this.props.queryEditor;
     const sharedQuery = {
@@ -18,21 +24,34 @@ export default class CopyQueryTabUrl extends React.PureComponent {
       autorun: qe.autorun,
       sql: qe.sql,
     };
-    storeQuery(sharedQuery, callback);
+
+    // the fetch call to get a url is async, but execCommand('copy') must be sync
+    // get around this with 2 timeouts. calling a timeout from within a timeout is not considered
+    // a short-lived, user-initiated sync event
+    let url;
+    storeQuery(sharedQuery).then((shareUrl) => { url = shareUrl; });
+    const longTimeout = setTimeout(() => { if (url) callback(url); }, 750);
+    setTimeout(() => {
+      if (url) {
+        callback(url);
+        clearTimeout(longTimeout);
+      }
+    }, 150);
+
   }
 
   render() {
     return (
       <CopyToClipboard
         inMenu
-        copyNode={(
+        copyNode={
           <div>
             <i className="fa fa-clipboard" /> <span>{t('share query')}</span>
           </div>
-        )}
+        }
         tooltipText={t('copy URL to clipboard')}
         shouldShowText={false}
-        getText={this.getUrl.bind(this)}
+        getText={this.getUrl}
       />
     );
   }

--- a/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 2 */
 import moment from 'moment';
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
@@ -58,9 +58,7 @@ class ExploreResultsButton extends React.PureComponent {
       this.dialog.show({
         title: t('Explore'),
         body: msg,
-        actions: [
-          Dialog.DefaultAction('Ok', () => {}, 'btn-danger'),
-        ],
+        actions: [Dialog.DefaultAction('Ok', () => {}, 'btn-danger')],
         bsSize: 'large',
         bsStyle: 'warning',
         onHide: (dialog) => {
@@ -107,10 +105,10 @@ class ExploreResultsButton extends React.PureComponent {
     };
   }
   visualize() {
-    this.props.actions.createDatasource(this.buildVizOptions(), this)
-      .done((resp) => {
+    this.props.actions
+      .createDatasource(this.buildVizOptions())
+      .then((data) => {
         const columns = this.getColumns();
-        const data = JSON.parse(resp);
         const formData = {
           datasource: `${data.table_id}__table`,
           metrics: [],
@@ -120,28 +118,28 @@ class ExploreResultsButton extends React.PureComponent {
           all_columns: columns.map(c => c.name),
           row_limit: 1000,
         };
+
         this.props.actions.addInfoToast(t('Creating a data source and creating a new tab'));
 
         // open new window for data visualization
         exportChart(formData);
       })
-      .fail(() => {
-        this.props.actions.addDangerToast(this.props.errorMessage);
+      .catch(() => {
+        this.props.actions.addDangerToast(this.props.errorMessage || t('An error occurred'));
       });
   }
   renderTimeoutWarning() {
     return (
       <Alert bsStyle="warning">
-        {
-          t('This query took %s seconds to run, ', Math.round(this.getQueryDuration())) +
+        {t('This query took %s seconds to run, ', Math.round(this.getQueryDuration())) +
           t('and the explore view times out at %s seconds ', this.props.timeout) +
           t('following this flow will most likely lead to your query timing out. ') +
           t('We recommend your summarize your data further before following that flow. ') +
-          t('If activated you can use the ')
-        }
+          t('If activated you can use the ')}
         <strong>CREATE TABLE AS </strong>
         {t('feature to store a summarized data set that you can then explore.')}
-      </Alert>);
+      </Alert>
+    );
   }
   renderInvalidColumnMessage() {
     const invalidColumns = this.getInvalidColumns();
@@ -151,13 +149,16 @@ class ExploreResultsButton extends React.PureComponent {
     return (
       <div>
         {t('Column name(s) ')}
-        <code><strong>{invalidColumns.join(', ')} </strong></code>
+        <code>
+          <strong>{invalidColumns.join(', ')} </strong>
+        </code>
         {t('cannot be used as a column name. Please use aliases (as in ')}
-        <code>SELECT count(*)
+        <code>
+          SELECT count(*)
           <strong>AS my_alias</strong>
-        </code>){' '}
-        {t('limited to alphanumeric characters and underscores')}
-      </div>);
+        </code>) {t('limited to alphanumeric characters and underscores')}
+      </div>
+    );
   }
   render() {
     return (
@@ -172,12 +173,9 @@ class ExploreResultsButton extends React.PureComponent {
             this.dialog = el;
           }}
         />
-        <InfoTooltipWithTrigger
-          icon="line-chart"
-          placement="top"
-          label="explore"
-        /> {t('Explore')}
-      </Button>);
+        <InfoTooltipWithTrigger icon="line-chart" placement="top" label="explore" /> {t('Explore')}
+      </Button>
+    );
   }
 }
 ExploreResultsButton.propTypes = propTypes;
@@ -197,4 +195,7 @@ function mapDispatchToProps(dispatch) {
 }
 
 export { ExploreResultsButton };
-export default connect(mapStateToProps, mapDispatchToProps)(ExploreResultsButton);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ExploreResultsButton);

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { SupersetClient } from '../../packages/core/src';
+import SupersetClient from '../../packages/core/src';
 
 import * as Actions from '../actions';
 
@@ -42,15 +42,13 @@ class QueryAutoRefresh extends React.PureComponent {
   stopwatch() {
     // only poll /superset/queries/ if there are started or running queries
     if (this.shouldCheckForQueries()) {
-      SupersetClient.getInstance()
-        .get({
-          endpoint: `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`,
-        })
-        .then(({ json }) => {
-          if (Object.keys(json).length > 0) {
-            this.props.actions.refreshQueries(json);
-          }
-        });
+      SupersetClient.get({
+        endpoint: `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`,
+      }).then(({ json }) => {
+        if (Object.keys(json).length > 0) {
+          this.props.actions.refreshQueries(json);
+        }
+      });
     }
   }
   render() {

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import * as Actions from '../actions';
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 
-const $ = require('jquery');
+import * as Actions from '../actions';
 
 const QUERY_UPDATE_FREQ = 2000;
 const QUERY_UPDATE_BUFFER_MS = 5000;
@@ -19,14 +19,15 @@ class QueryAutoRefresh extends React.PureComponent {
   }
   shouldCheckForQueries() {
     // if there are started or running queries, this method should return true
-    const { queries } = this.props;
+    const { queries, queriesLastUpdate } = this.props;
     const now = new Date().getTime();
-    return Object.values(queries).some(
-      q =>
-        (['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 &&
-          now - q.startDttm < MAX_QUERY_AGE_TO_POLL &&
-          console.log(q)) ||
-        now - q.startDttm,
+    return (
+      queriesLastUpdate > 0 &&
+      Object.values(queries).some(
+        q =>
+          ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 &&
+          now - q.startDttm < MAX_QUERY_AGE_TO_POLL,
+      )
     );
   }
   startTimer() {
@@ -41,12 +42,15 @@ class QueryAutoRefresh extends React.PureComponent {
   stopwatch() {
     // only poll /superset/queries/ if there are started or running queries
     if (this.shouldCheckForQueries()) {
-      const url = `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`;
-      $.getJSON(url, (data) => {
-        if (Object.keys(data).length > 0) {
-          this.props.actions.refreshQueries(data);
-        }
-      });
+      SupersetClient.getInstance()
+        .get({
+          endpoint: `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`,
+        })
+        .then(({ json }) => {
+          if (Object.keys(json).length > 0) {
+            this.props.actions.refreshQueries(json);
+          }
+        });
     }
   }
   render() {

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import SupersetClient from '../../packages/core/src';
+import { SupersetClient } from '../../packages/core/src';
 
 import * as Actions from '../actions';
 

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -21,14 +21,16 @@ class QueryAutoRefresh extends React.PureComponent {
     // if there are started or running queries, this method should return true
     const { queries } = this.props;
     const now = new Date().getTime();
-    return Object.values(queries)
-      .some(
-        q => ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 &&
-        now - q.startDttm < MAX_QUERY_AGE_TO_POLL,
-      );
+    return Object.values(queries).some(
+      q =>
+        (['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 &&
+          now - q.startDttm < MAX_QUERY_AGE_TO_POLL &&
+          console.log(q)) ||
+        now - q.startDttm,
+    );
   }
   startTimer() {
-    if (!(this.timer)) {
+    if (!this.timer) {
       this.timer = setInterval(this.stopwatch.bind(this), QUERY_UPDATE_FREQ);
     }
   }
@@ -70,4 +72,7 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(QueryAutoRefresh);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(QueryAutoRefresh);

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../../packages/core/src';
 
 import * as Actions from '../actions';
 

--- a/superset/assets/src/SqlLab/components/ShareQuery.jsx
+++ b/superset/assets/src/SqlLab/components/ShareQuery.jsx
@@ -5,7 +5,7 @@ import CopyQueryTabUrl from './CopyQueryTabUrl';
 import Button from '../../components/Button';
 import { t } from '../../locales';
 
-export default class ShareQueryBtn extends CopyQueryTabUrl {
+export default class ShareQuery extends CopyQueryTabUrl {
   render() {
     return (
       <CopyToClipboard
@@ -16,7 +16,7 @@ export default class ShareQueryBtn extends CopyQueryTabUrl {
       )}
         tooltipText={t('copy URL to clipboard')}
         shouldShowText={false}
-        getText={this.getUrl.bind(this)}
+        getText={this.getUrl}
       />);
   }
 }

--- a/superset/assets/src/SqlLab/getInitialState.js
+++ b/superset/assets/src/SqlLab/getInitialState.js
@@ -22,7 +22,7 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
       queryEditors: [defaultQueryEditor],
       tabHistory: [defaultQueryEditor.id],
       tables: [],
-      queriesLastUpdate: 0,
+      queriesLastUpdate: Date.now(),
       activeSouthPaneTab: 'Results',
       ...restBootstrapData,
     },

--- a/superset/assets/src/SqlLab/index.jsx
+++ b/superset/assets/src/SqlLab/index.jsx
@@ -27,7 +27,7 @@ const store = createStore(
   state,
   compose(
     applyMiddleware(thunkMiddleware),
-    initEnhancer(false),
+    initEnhancer(),
   ),
 );
 

--- a/superset/assets/src/SqlLab/index.jsx
+++ b/superset/assets/src/SqlLab/index.jsx
@@ -27,7 +27,7 @@ const store = createStore(
   state,
   compose(
     applyMiddleware(thunkMiddleware),
-    initEnhancer(),
+    initEnhancer(false),
   ),
 );
 

--- a/superset/assets/src/SqlLab/reducers.js
+++ b/superset/assets/src/SqlLab/reducers.js
@@ -23,13 +23,14 @@ export const sqlLabReducer = function (state = {}, action) {
       return addToArr(newState, 'queryEditors', action.queryEditor);
     },
     [actions.CLONE_QUERY_TO_NEW_TAB]() {
-      const progenitor = state.queryEditors.find(qe =>
-          qe.id === state.tabHistory[state.tabHistory.length - 1]);
+      const progenitor = state.queryEditors.find(
+        qe => qe.id === state.tabHistory[state.tabHistory.length - 1],
+      );
       const qe = {
         id: shortid.generate(),
         title: t('Copy of %s', progenitor.title),
-        dbId: (action.query.dbId) ? action.query.dbId : null,
-        schema: (action.query.schema) ? action.query.schema : null,
+        dbId: action.query.dbId ? action.query.dbId : null,
+        schema: action.query.schema ? action.query.schema : null,
         autorun: true,
         sql: action.query.sql,
       };
@@ -65,10 +66,11 @@ export const sqlLabReducer = function (state = {}, action) {
       let existingTable;
       state.tables.forEach((xt) => {
         if (
-            xt.dbId === at.dbId &&
-            xt.queryEditorId === at.queryEditorId &&
-            xt.schema === at.schema &&
-            xt.name === at.name) {
+          xt.dbId === at.dbId &&
+          xt.queryEditorId === at.queryEditorId &&
+          xt.schema === at.schema &&
+          xt.name === at.name
+        ) {
           existingTable = xt;
         }
       });
@@ -94,8 +96,7 @@ export const sqlLabReducer = function (state = {}, action) {
       const queries = Object.assign({}, state.queries);
       delete queries[action.table.dataPreviewQueryId];
       const newState = alterInArr(state, 'tables', action.table, { dataPreviewQueryId: null });
-      return Object.assign(
-       {}, newState, { queries });
+      return Object.assign({}, newState, { queries });
     },
     [actions.CHANGE_DATA_PREVIEW_ID]() {
       const queries = Object.assign({}, state.queries);
@@ -109,8 +110,11 @@ export const sqlLabReducer = function (state = {}, action) {
           newTables.push(xt);
         }
       });
-      return Object.assign(
-       {}, state, { queries, tables: newTables, activeSouthPaneTab: action.newQuery.id });
+      return Object.assign({}, state, {
+        queries,
+        tables: newTables,
+        activeSouthPaneTab: action.newQuery.id,
+      });
     },
     [actions.COLLAPSE_TABLE]() {
       return alterInArr(state, 'tables', action.table, { expanded: false });
@@ -123,8 +127,10 @@ export const sqlLabReducer = function (state = {}, action) {
       if (action.query.sqlEditorId) {
         const qe = getFromArr(state.queryEditors, action.query.sqlEditorId);
         if (qe.latestQueryId && state.queries[qe.latestQueryId]) {
-          const newResults = Object.assign(
-            {}, state.queries[qe.latestQueryId].results, { data: [], query: null });
+          const newResults = Object.assign({}, state.queries[qe.latestQueryId].results, {
+            data: [],
+            query: null,
+          });
           const q = Object.assign({}, state.queries[qe.latestQueryId], { results: newResults });
           const queries = Object.assign({}, state.queries, { [q.id]: q });
           newState = Object.assign({}, state, { queries });
@@ -200,7 +206,9 @@ export const sqlLabReducer = function (state = {}, action) {
       return alterInArr(state, 'queryEditors', action.queryEditor, { sql: action.sql });
     },
     [actions.QUERY_EDITOR_SET_TEMPLATE_PARAMS]() {
-      return alterInArr(state, 'queryEditors', action.queryEditor, { templateParams: action.templateParams });
+      return alterInArr(state, 'queryEditors', action.queryEditor, {
+        templateParams: action.templateParams,
+      });
     },
     [actions.QUERY_EDITOR_SET_SELECTED_TEXT]() {
       return alterInArr(state, 'queryEditors', action.queryEditor, { selectedText: action.sql });
@@ -209,7 +217,9 @@ export const sqlLabReducer = function (state = {}, action) {
       return alterInArr(state, 'queryEditors', action.queryEditor, { autorun: action.autorun });
     },
     [actions.QUERY_EDITOR_PERSIST_HEIGHT]() {
-      return alterInArr(state, 'queryEditors', action.queryEditor, { height: action.currentHeight });
+      return alterInArr(state, 'queryEditors', action.queryEditor, {
+        height: action.currentHeight,
+      });
     },
     [actions.SET_DATABASES]() {
       const databases = {};
@@ -225,8 +235,7 @@ export const sqlLabReducer = function (state = {}, action) {
       let queriesLastUpdate = state.queriesLastUpdate;
       for (const id in action.alteredQueries) {
         const changedQuery = action.alteredQueries[id];
-        if (!state.queries.hasOwnProperty(id) ||
-            state.queries[id].state !== 'stopped') {
+        if (!state.queries.hasOwnProperty(id) || state.queries[id].state !== 'stopped') {
           if (changedQuery.changedOn > queriesLastUpdate) {
             queriesLastUpdate = changedQuery.changedOn;
           }

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -33,7 +33,6 @@ const propTypes = {
   chartUpdateEndTime: PropTypes.number,
   chartUpdateStartTime: PropTypes.number,
   latestQueryFormData: PropTypes.object,
-  queryRequest: PropTypes.object,
   queryResponse: PropTypes.object,
   lastRendered: PropTypes.number,
   triggerQuery: PropTypes.bool,

--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -1,6 +1,6 @@
 /* global window, AbortController */
 /* eslint no-undef: 'error' */
-import SupersetClient from '../packages/core/src';
+import { SupersetClient } from '../packages/core/src';
 import { getExploreUrlAndPayload, getAnnotationJsonUrl } from '../explore/exploreUtils';
 import { requiresQuery, ANNOTATION_SOURCE_TYPES } from '../modules/AnnotationTypes';
 import { addDangerToast } from '../messageToasts/actions';

--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -1,14 +1,16 @@
+/* global window, AbortController */
+/* eslint no-undef: 'error' */
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 import { getExploreUrlAndPayload, getAnnotationJsonUrl } from '../explore/exploreUtils';
 import { requiresQuery, ANNOTATION_SOURCE_TYPES } from '../modules/AnnotationTypes';
+import { addDangerToast } from '../messageToasts/actions';
 import { Logger, LOG_ACTIONS_LOAD_CHART } from '../logger';
 import { COMMON_ERR_MESSAGES } from '../common';
 import { t } from '../locales';
 
-const $ = (window.$ = require('jquery'));
-
 export const CHART_UPDATE_STARTED = 'CHART_UPDATE_STARTED';
-export function chartUpdateStarted(queryRequest, latestQueryFormData, key) {
-  return { type: CHART_UPDATE_STARTED, queryRequest, latestQueryFormData, key };
+export function chartUpdateStarted(queryController, latestQueryFormData, key) {
+  return { type: CHART_UPDATE_STARTED, queryController, latestQueryFormData, key };
 }
 
 export const CHART_UPDATE_SUCCEEDED = 'CHART_UPDATE_SUCCEEDED';
@@ -52,8 +54,8 @@ export function annotationQuerySuccess(annotation, queryResponse, key) {
 }
 
 export const ANNOTATION_QUERY_STARTED = 'ANNOTATION_QUERY_STARTED';
-export function annotationQueryStarted(annotation, queryRequest, key) {
-  return { type: ANNOTATION_QUERY_STARTED, annotation, queryRequest, key };
+export function annotationQueryStarted(annotation, queryController, key) {
+  return { type: ANNOTATION_QUERY_STARTED, annotation, queryController, key };
 }
 
 export const ANNOTATION_QUERY_FAILED = 'ANNOTATION_QUERY_FAILED';
@@ -83,18 +85,22 @@ export function runAnnotationQuery(annotation, timeout = 60, formData = null, ke
     );
     const isNative = annotation.sourceType === ANNOTATION_SOURCE_TYPES.NATIVE;
     const url = getAnnotationJsonUrl(annotation.value, sliceFormData, isNative);
-    const queryRequest = $.ajax({
-      url,
-      dataType: 'json',
-      timeout: timeout * 1000,
-    });
-    dispatch(annotationQueryStarted(annotation, queryRequest, sliceKey));
-    return queryRequest
-      .then(queryResponse => dispatch(annotationQuerySuccess(annotation, queryResponse, sliceKey)))
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    dispatch(annotationQueryStarted(annotation, controller, sliceKey));
+
+    return SupersetClient.getInstance()
+      .get({
+        url,
+        signal,
+        timeout: timeout * 1000,
+      })
+      .then(({ json }) => dispatch(annotationQuerySuccess(annotation, json, sliceKey)))
       .catch((err) => {
         if (err.statusText === 'timeout') {
           dispatch(annotationQueryFailed(annotation, { error: 'Query Timeout' }, sliceKey));
-        } else if ((err.responseJSON.error || '').toLowerCase().startsWith('no data')) {
+        } else if ((err.responseJSON.error || '').toLowerCase().includes('no data')) {
           dispatch(annotationQuerySuccess(annotation, err, sliceKey));
         } else if (err.statusText !== 'abort') {
           dispatch(annotationQueryFailed(annotation, err.responseJSON, sliceKey));
@@ -133,30 +139,31 @@ export function runQuery(formData, force = false, timeout = 60, key) {
       force,
     });
     const logStart = Logger.getTimestamp();
-    const queryRequest = $.ajax({
-      type: 'POST',
-      url,
-      dataType: 'json',
-      data: {
-        form_data: JSON.stringify(payload),
-      },
-      timeout: timeout * 1000,
-    });
-    const queryPromise = Promise.resolve(dispatch(chartUpdateStarted(queryRequest, payload, key)))
-      .then(() => queryRequest)
-      .then((queryResponse) => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    dispatch(chartUpdateStarted(controller, payload, key));
+
+    const queryPromise = SupersetClient.getInstance()
+      .post({
+        url,
+        postPayload: { form_data: payload },
+        signal,
+        timeout: timeout * 1000,
+      })
+      .then(({ json }) => {
         Logger.append(LOG_ACTIONS_LOAD_CHART, {
           slice_id: key,
-          is_cached: queryResponse.is_cached,
+          is_cached: json.is_cached,
           force_refresh: force,
-          row_count: queryResponse.rowcount,
+          row_count: json.rowcount,
           datasource: formData.datasource,
           start_offset: logStart,
           duration: Logger.getTimestamp() - logStart,
           has_extra_filters: formData.extra_filters && formData.extra_filters.length > 0,
           viz_type: formData.viz_type,
         });
-        return dispatch(chartUpdateSucceeded(queryResponse, key));
+        return dispatch(chartUpdateSucceeded(json, key));
       })
       .catch((err) => {
         Logger.append(LOG_ACTIONS_LOAD_CHART, {
@@ -168,7 +175,7 @@ export function runQuery(formData, force = false, timeout = 60, key) {
         });
         if (err.statusText === 'timeout') {
           dispatch(chartUpdateTimeout(err.statusText, timeout, key));
-        } else if (err.statusText === 'abort') {
+        } else if (err.statusText === 'AbortError') {
           dispatch(chartUpdateStopped(key));
         } else {
           let errObject;
@@ -191,7 +198,9 @@ export function runQuery(formData, force = false, timeout = 60, key) {
           dispatch(chartUpdateFailed(errObject, key));
         }
       });
+
     const annotationLayers = formData.annotation_layers || [];
+
     return Promise.all([
       queryPromise,
       dispatch(triggerQuery(false, key)),
@@ -202,23 +211,21 @@ export function runQuery(formData, force = false, timeout = 60, key) {
 }
 
 export function redirectSQLLab(formData) {
-  return function () {
+  return (dispatch) => {
     const { url } = getExploreUrlAndPayload({ formData, endpointType: 'query' });
-    $.ajax({
-      type: 'GET',
-      url,
-      success: (response) => {
+    return SupersetClient.getInstance()
+      .get({ url })
+      .then(({ json }) => {
         const redirectUrl = new URL(window.location);
         redirectUrl.pathname = '/superset/sqllab';
-        for (const k of redirectUrl.searchParams.keys()) {
-          redirectUrl.searchParams.delete(k);
+        for (const key of redirectUrl.searchParams.keys()) {
+          redirectUrl.searchParams.delete(key);
         }
         redirectUrl.searchParams.set('datasourceKey', formData.datasource);
-        redirectUrl.searchParams.set('sql', response.query);
+        redirectUrl.searchParams.set('sql', json.query);
         window.open(redirectUrl.href, '_blank');
-      },
-      error: () => notify.error(t("The SQL couldn't be loaded")),
-    });
+      })
+      .catch(() => dispatch(addDangerToast(t('An error occurred while loading the SQL'))));
   };
 }
 

--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -1,6 +1,6 @@
 /* global window, AbortController */
 /* eslint no-undef: 'error' */
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../packages/core/src';
 import { getExploreUrlAndPayload, getAnnotationJsonUrl } from '../explore/exploreUtils';
 import { requiresQuery, ANNOTATION_SOURCE_TYPES } from '../modules/AnnotationTypes';
 import { addDangerToast } from '../messageToasts/actions';

--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -1,6 +1,6 @@
 /* global window, AbortController */
 /* eslint no-undef: 'error' */
-import { SupersetClient } from '../packages/core/src';
+import SupersetClient from '../packages/core/src';
 import { getExploreUrlAndPayload, getAnnotationJsonUrl } from '../explore/exploreUtils';
 import { requiresQuery, ANNOTATION_SOURCE_TYPES } from '../modules/AnnotationTypes';
 import { addDangerToast } from '../messageToasts/actions';
@@ -90,12 +90,11 @@ export function runAnnotationQuery(annotation, timeout = 60, formData = null, ke
 
     dispatch(annotationQueryStarted(annotation, controller, sliceKey));
 
-    return SupersetClient.getInstance()
-      .get({
-        url,
-        signal,
-        timeout: timeout * 1000,
-      })
+    return SupersetClient.get({
+      url,
+      signal,
+      timeout: timeout * 1000,
+    })
       .then(({ json }) => dispatch(annotationQuerySuccess(annotation, json, sliceKey)))
       .catch((err) => {
         if (err.statusText === 'timeout') {
@@ -144,13 +143,12 @@ export function runQuery(formData, force = false, timeout = 60, key) {
 
     dispatch(chartUpdateStarted(controller, payload, key));
 
-    const queryPromise = SupersetClient.getInstance()
-      .post({
-        url,
-        postPayload: { form_data: payload },
-        signal,
-        timeout: timeout * 1000,
-      })
+    const queryPromise = SupersetClient.post({
+      url,
+      postPayload: { form_data: payload },
+      signal,
+      timeout: timeout * 1000,
+    })
       .then(({ json }) => {
         Logger.append(LOG_ACTIONS_LOAD_CHART, {
           slice_id: key,
@@ -213,8 +211,7 @@ export function runQuery(formData, force = false, timeout = 60, key) {
 export function redirectSQLLab(formData) {
   return (dispatch) => {
     const { url } = getExploreUrlAndPayload({ formData, endpointType: 'query' });
-    return SupersetClient.getInstance()
-      .get({ url })
+    return SupersetClient.get({ url })
       .then(({ json }) => {
         const redirectUrl = new URL(window.location);
         redirectUrl.pathname = '/superset/sqllab';

--- a/superset/assets/src/chart/chartReducer.js
+++ b/superset/assets/src/chart/chartReducer.js
@@ -10,7 +10,7 @@ export const chart = {
   chartUpdateEndTime: null,
   chartUpdateStartTime: now(),
   latestQueryFormData: {},
-  queryRequest: null,
+  queryController: null,
   queryResponse: null,
   triggerQuery: true,
   lastRendered: 0,
@@ -25,52 +25,61 @@ export default function chartReducer(charts = {}, action) {
       };
     },
     [actions.CHART_UPDATE_SUCCEEDED](state) {
-      return { ...state,
+      return {
+        ...state,
         chartStatus: 'success',
         queryResponse: action.queryResponse,
         chartUpdateEndTime: now(),
       };
     },
     [actions.CHART_UPDATE_STARTED](state) {
-      return { ...state,
+      return {
+        ...state,
         chartStatus: 'loading',
         chartAlert: null,
         chartUpdateEndTime: null,
         chartUpdateStartTime: now(),
-        queryRequest: action.queryRequest,
+        queryController: action.queryController,
       };
     },
     [actions.CHART_UPDATE_STOPPED](state) {
-      return { ...state,
+      return {
+        ...state,
         chartStatus: 'stopped',
         chartAlert: t('Updating chart was stopped'),
       };
     },
     [actions.CHART_RENDERING_SUCCEEDED](state) {
-      return { ...state,
+      return {
+        ...state,
         chartStatus: 'rendered',
       };
     },
     [actions.CHART_RENDERING_FAILED](state) {
-      return { ...state,
+      return {
+        ...state,
         chartStatus: 'failed',
         chartAlert: t('An error occurred while rendering the visualization: %s', action.error),
       };
     },
     [actions.CHART_UPDATE_TIMEOUT](state) {
-      return { ...state,
+      return {
+        ...state,
         chartStatus: 'failed',
-        chartAlert: (
+        chartAlert:
           `${t('Query timeout')} - ` +
           t(`visualization queries are set to timeout at ${action.timeout} seconds. `) +
-          t('Perhaps your data has grown, your database is under unusual load, ' +
-            'or you are simply querying a data source that is too large ' +
-            'to be processed within the timeout range. ' +
-            'If that is the case, we recommend that you summarize your data further.')),
+          t(
+            'Perhaps your data has grown, your database is under unusual load, ' +
+              'or you are simply querying a data source that is too large ' +
+              'to be processed within the timeout range. ' +
+              'If that is the case, we recommend that you summarize your data further.',
+          ),
       };
     },
     [actions.CHART_UPDATE_FAILED](state) {
-      return { ...state,
+      return {
+        ...state,
         chartStatus: 'failed',
         chartAlert: action.queryResponse ? action.queryResponse.error : t('Network error.'),
         chartUpdateEndTime: now(),
@@ -87,13 +96,16 @@ export default function chartReducer(charts = {}, action) {
       return { ...state, latestQueryFormData: action.value };
     },
     [actions.ANNOTATION_QUERY_STARTED](state) {
-      if (state.annotationQuery &&
-        state.annotationQuery[action.annotation.name]) {
-        state.annotationQuery[action.annotation.name].abort();
+      if (
+        state.annotationQuery &&
+        state.annotationQuery[action.annotation.name] &&
+        state.annotationQuery[action.annotation.name].queryController
+      ) {
+        state.annotationQuery[action.annotation.name].queryController.abort();
       }
       const annotationQuery = {
         ...state.annotationQuery,
-        [action.annotation.name]: action.queryRequest,
+        [action.annotation.name]: { queryController: action.queryController },
       };
       return {
         ...state,
@@ -121,8 +133,9 @@ export default function chartReducer(charts = {}, action) {
       delete annotationData[action.annotation.name];
       const annotationError = {
         ...state.annotationError,
-        [action.annotation.name]: action.queryResponse ?
-          action.queryResponse.error : t('Network error.'),
+        [action.annotation.name]: action.queryResponse
+          ? action.queryResponse.error
+          : t('Network error.'),
       };
       const annotationQuery = { ...state.annotationQuery };
       delete annotationQuery[action.annotation.name];

--- a/superset/assets/src/common.js
+++ b/superset/assets/src/common.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 import $ from 'jquery';
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
-import SupersetClient from './packages/core/src';
+import { SupersetClient } from './packages/core/src';
 import { t } from './locales';
 
 const utils = require('./modules/utils');

--- a/superset/assets/src/common.js
+++ b/superset/assets/src/common.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 import $ from 'jquery';
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
-import { SupersetClient } from './packages/core/src';
+import SupersetClient from './packages/core/src';
 import { t } from './locales';
 
 const utils = require('./modules/utils');
@@ -20,12 +20,11 @@ document.addEventListener('DOMContentLoaded', () => {
   languagePickerLinks.forEach((elem) => {
     elem.addEventListener('click', (event) => {
       event.preventDefault();
-      const client = SupersetClient.getInstance();
       const currLocation = window.location.href;
 
       // this seems to be called twice (jQuery thing? the second time it's not authenticated)
-      if (client.authorized()) {
-        client.get({ url: event.currentTarget.href }).then(() => {
+      if (SupersetClient.authorized()) {
+        SupersetClient.get({ url: event.currentTarget.href }).then(() => {
           window.location = currLocation;
         });
       }
@@ -41,11 +40,7 @@ export function appSetup() {
   require('bootstrap');
 
   // configure and initialize the JS client which makes all requests, handles auth, etc.
-  const client = SupersetClient.getInstance({
-    host: window.location && window.location.host,
-  });
-
-  client.init();
+  SupersetClient.configure({ host: window.location && window.location.host }).init();
 }
 
 // Error messages used in many places across applications

--- a/superset/assets/src/common.js
+++ b/superset/assets/src/common.js
@@ -1,8 +1,7 @@
 /* eslint-disable global-require */
 import $ from 'jquery';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
-
+import { SupersetClient } from './packages/core/src';
 import { t } from './locales';
 
 const utils = require('./modules/utils');
@@ -22,12 +21,12 @@ document.addEventListener('DOMContentLoaded', () => {
     elem.addEventListener('click', (event) => {
       event.preventDefault();
       const client = SupersetClient.getInstance();
-      const currLocation = location.href;
+      const currLocation = window.location.href;
 
       // this seems to be called twice (jQuery thing? the second time it's not authenticated)
       if (client.authorized()) {
         client.get({ url: event.currentTarget.href }).then(() => {
-          location = currLocation;
+          window.location = currLocation;
         });
       }
     });

--- a/superset/assets/src/components/CopyToClipboard.jsx
+++ b/superset/assets/src/components/CopyToClipboard.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip, OverlayTrigger, MenuItem } from 'react-bootstrap';
+
 import { t } from '../locales';
 
 const propTypes = {
@@ -28,7 +29,6 @@ export default class CopyToClipboard extends React.Component {
       hasCopied: false,
     };
 
-    // bindings
     this.copyToClipboard = this.copyToClipboard.bind(this);
     this.resetTooltipText = this.resetTooltipText.bind(this);
     this.onMouseOut = this.onMouseOut.bind(this);
@@ -41,7 +41,9 @@ export default class CopyToClipboard extends React.Component {
 
   onClick() {
     if (this.props.getText) {
-      this.props.getText((d) => { this.copyToClipboard(d); });
+      this.props.getText((d) => {
+        this.copyToClipboard(d);
+      });
     } else {
       this.copyToClipboard(this.props.text);
     }
@@ -72,7 +74,11 @@ export default class CopyToClipboard extends React.Component {
         throw new Error(t('Not successful'));
       }
     } catch (err) {
-      window.alert(t('Sorry, your browser does not support copying. Use Ctrl / Cmd + C!')); // eslint-disable-line
+      // eslint-disable-next-line no-alert
+      window.prompt(
+        t('Sorry, your browser does not support copying. Use Ctrl / Cmd + C!'),
+        textToCopy,
+      );
     }
 
     document.body.removeChild(span);
@@ -96,12 +102,12 @@ export default class CopyToClipboard extends React.Component {
   renderLink() {
     return (
       <span>
-        {this.props.shouldShowText &&
+        {this.props.shouldShowText && (
           <span>
             {this.props.text}
             &nbsp;&nbsp;&nbsp;&nbsp;
           </span>
-        }
+        )}
         <OverlayTrigger
           placement="top"
           style={{ cursor: 'pointer' }}
@@ -121,10 +127,7 @@ export default class CopyToClipboard extends React.Component {
     return (
       <OverlayTrigger placement="top" overlay={this.renderTooltip()} trigger={['hover']}>
         <MenuItem>
-          <span
-            onClick={this.onClick.bind(this)}
-            onMouseOut={this.onMouseOut}
-          >
+          <span onClick={this.onClick.bind(this)} onMouseOut={this.onMouseOut}>
             {this.props.copyNode}
           </span>
         </MenuItem>
@@ -133,11 +136,7 @@ export default class CopyToClipboard extends React.Component {
   }
 
   renderTooltip() {
-    return (
-      <Tooltip id="copy-to-clipboard-tooltip">
-        {this.tooltipText()}
-      </Tooltip>
-    );
+    return <Tooltip id="copy-to-clipboard-tooltip">{this.tooltipText()}</Tooltip>;
   }
 
   render() {

--- a/superset/assets/src/components/URLShortLinkButton.jsx
+++ b/superset/assets/src/components/URLShortLinkButton.jsx
@@ -30,7 +30,12 @@ class URLShortLinkButton extends React.Component {
   }
 
   getCopyUrl() {
-    getShortUrl(this.props.url, this.onShortUrlSuccess, this.props.addDangerToast);
+    getShortUrl(this.props.url)
+      .then(this.onShortUrlSuccess)
+      .catch((response) => {
+        this.props.addDangerToast(response.error);
+        this.onShortUrlSuccess(this.props.url); // fallback to long url
+      });
   }
 
   renderPopover() {

--- a/superset/assets/src/components/URLShortLinkModal.jsx
+++ b/superset/assets/src/components/URLShortLinkModal.jsx
@@ -38,7 +38,12 @@ class URLShortLinkModal extends React.Component {
   }
 
   getCopyUrl() {
-    getShortUrl(this.props.url, this.onShortUrlSuccess, this.props.addDangerToast);
+    getShortUrl(this.props.url)
+      .then(this.onShortUrlSuccess)
+      .catch((response) => {
+        this.props.addDangerToast(response.error);
+        this.onShortUrlSuccess(this.props.url); // fallback to long url
+      });
   }
 
   render() {

--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -1,7 +1,7 @@
 /* eslint camelcase: 0 */
 import $ from 'jquery';
 import { ActionCreators as UndoActionCreators } from 'redux-undo';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../../packages/core/src';
 
 import { addChart, removeChart, refreshChart } from '../../chart/chartAction';
 import { chart as initChart } from '../../chart/chartReducer';

--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -1,7 +1,7 @@
 /* eslint camelcase: 0 */
 import $ from 'jquery';
 import { ActionCreators as UndoActionCreators } from 'redux-undo';
-import SupersetClient from '../../packages/core/src';
+import { SupersetClient } from '../../packages/core/src';
 
 import { addChart, removeChart, refreshChart } from '../../chart/chartAction';
 import { chart as initChart } from '../../chart/chartReducer';

--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -1,7 +1,7 @@
 /* eslint camelcase: 0 */
 import $ from 'jquery';
 import { ActionCreators as UndoActionCreators } from 'redux-undo';
-import { SupersetClient } from '../../packages/core/src';
+import SupersetClient from '../../packages/core/src';
 
 import { addChart, removeChart, refreshChart } from '../../chart/chartAction';
 import { chart as initChart } from '../../chart/chartReducer';
@@ -111,14 +111,12 @@ export function saveDashboardRequestSuccess() {
 
 export function saveDashboardRequest(data, id, saveType) {
   const path = saveType === SAVE_TYPE_OVERWRITE ? 'save_dash' : 'copy_dash';
-  const client = SupersetClient.getInstance();
 
   return dispatch =>
-    client
-      .post({
-        endpoint: `/superset/${path}/${id}/`,
-        postPayload: { data },
-      })
+    SupersetClient.post({
+      endpoint: `/superset/${path}/${id}/`,
+      postPayload: { data },
+    })
       .then(response =>
         Promise.all([
           Promise.resolve(response),

--- a/superset/assets/src/dashboard/actions/datasources.js
+++ b/superset/assets/src/dashboard/actions/datasources.js
@@ -1,4 +1,4 @@
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../../packages/core/src';
 import { getAjaxErrorMsg } from '../../modules/utils';
 
 export const SET_DATASOURCE = 'SET_DATASOURCE';
@@ -25,9 +25,7 @@ export function fetchDatasourceMetadata(key) {
       return dispatch(setDatasource(datasource, key));
     }
 
-    const client = SupersetClient.getInstance();
-
-    return client
+    return SupersetClient.getInstance()
       .get({
         endpoint: `/superset/fetch_datasource_metadata?datasourceKey=${key}`,
       })

--- a/superset/assets/src/dashboard/actions/datasources.js
+++ b/superset/assets/src/dashboard/actions/datasources.js
@@ -1,4 +1,5 @@
-import $ from 'jquery';
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { getAjaxErrorMsg } from '../../modules/utils';
 
 export const SET_DATASOURCE = 'SET_DATASOURCE';
 export function setDatasource(datasource, key) {
@@ -24,13 +25,15 @@ export function fetchDatasourceMetadata(key) {
       return dispatch(setDatasource(datasource, key));
     }
 
-    const url = `/superset/fetch_datasource_metadata?datasourceKey=${key}`;
-    return $.ajax({
-      type: 'GET',
-      url,
-      success: data => dispatch(setDatasource(data, key)),
-      error: error =>
-        dispatch(fetchDatasourceFailed(error.responseJSON.error, key)),
-    });
+    const client = SupersetClient.getInstance();
+
+    return client
+      .get({
+        endpoint: `/superset/fetch_datasource_metadata?datasourceKey=${key}`,
+      })
+      .then(data => dispatch(data, key))
+      .catch(error =>
+        dispatch(fetchDatasourceFailed(getAjaxErrorMsg(error), key)),
+      );
   };
 }

--- a/superset/assets/src/dashboard/actions/datasources.js
+++ b/superset/assets/src/dashboard/actions/datasources.js
@@ -1,4 +1,4 @@
-import { SupersetClient } from '../../packages/core/src';
+import SupersetClient from '../../packages/core/src';
 import { getAjaxErrorMsg } from '../../modules/utils';
 
 export const SET_DATASOURCE = 'SET_DATASOURCE';
@@ -25,10 +25,9 @@ export function fetchDatasourceMetadata(key) {
       return dispatch(setDatasource(datasource, key));
     }
 
-    return SupersetClient.getInstance()
-      .get({
-        endpoint: `/superset/fetch_datasource_metadata?datasourceKey=${key}`,
-      })
+    return SupersetClient.get({
+      endpoint: `/superset/fetch_datasource_metadata?datasourceKey=${key}`,
+    })
       .then(data => dispatch(data, key))
       .catch(error =>
         dispatch(fetchDatasourceFailed(getAjaxErrorMsg(error), key)),

--- a/superset/assets/src/dashboard/actions/datasources.js
+++ b/superset/assets/src/dashboard/actions/datasources.js
@@ -1,4 +1,4 @@
-import SupersetClient from '../../packages/core/src';
+import { SupersetClient } from '../../packages/core/src';
 import { getAjaxErrorMsg } from '../../modules/utils';
 
 export const SET_DATASOURCE = 'SET_DATASOURCE';

--- a/superset/assets/src/dashboard/actions/sliceEntities.js
+++ b/superset/assets/src/dashboard/actions/sliceEntities.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../../packages/core/src';
 
 import { addDangerToast } from '../../messageToasts/actions';
 import { t } from '../../locales';

--- a/superset/assets/src/dashboard/actions/sliceEntities.js
+++ b/superset/assets/src/dashboard/actions/sliceEntities.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */
-import { SupersetClient } from '../../packages/core/src';
+import SupersetClient from '../../packages/core/src';
 
 import { addDangerToast } from '../../messageToasts/actions';
 import { t } from '../../locales';
@@ -26,10 +26,9 @@ export function fetchAllSlices(userId) {
     if (sliceEntities.lastUpdated === 0) {
       dispatch(fetchAllSlicesStarted());
 
-      return SupersetClient.getInstance()
-        .get({
-          endpoint: `/sliceaddview/api/read?_flt_0_created_by=${userId}`,
-        })
+      return SupersetClient.get({
+        endpoint: `/sliceaddview/api/read?_flt_0_created_by=${userId}`,
+      })
         .then(({ json }) => {
           const slices = {};
           json.result.forEach(slice => {

--- a/superset/assets/src/dashboard/actions/sliceEntities.js
+++ b/superset/assets/src/dashboard/actions/sliceEntities.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */
-import SupersetClient from '../../packages/core/src';
+import { SupersetClient } from '../../packages/core/src';
 
 import { addDangerToast } from '../../messageToasts/actions';
 import { t } from '../../locales';

--- a/superset/assets/src/dashboard/actions/sliceEntities.js
+++ b/superset/assets/src/dashboard/actions/sliceEntities.js
@@ -67,7 +67,13 @@ export function fetchAllSlices(userId) {
         })
         .catch(error =>
           Promise.all([
-            dispatch(fetchAllSlicesFailed(error)),
+            dispatch(
+              fetchAllSlicesFailed(
+                error.error ||
+                  error.statusText ||
+                  t('Could not fetch all saved charts'),
+              ),
+            ),
             dispatch(
               addDangerToast(
                 t('Sorry there was an error fetching saved charts: ') +

--- a/superset/assets/src/dashboard/components/SaveModal.jsx
+++ b/superset/assets/src/dashboard/components/SaveModal.jsx
@@ -93,9 +93,14 @@ class SaveModal extends React.PureComponent {
         t('You must pick a name for the new dashboard'),
       );
     } else {
-      this.onSave(data, dashboardId, saveType).done(resp => {
-        if (saveType === SAVE_TYPE_NEWDASHBOARD) {
-          window.location = `/superset/dashboard/${resp.id}/`;
+      this.onSave(data, dashboardId, saveType).then(([resp]) => {
+        if (
+          saveType === SAVE_TYPE_NEWDASHBOARD &&
+          resp &&
+          resp.json &&
+          resp.json.id
+        ) {
+          window.location = `/superset/dashboard/${resp.json.id}/`;
         }
       });
       this.modal.close();

--- a/superset/assets/src/dashboard/components/SliceAdder.jsx
+++ b/superset/assets/src/dashboard/components/SliceAdder.jsx
@@ -226,8 +226,6 @@ class SliceAdder extends React.Component {
 
         {this.props.isLoading && <Loading />}
 
-        {this.props.errorMessage && <div>{this.props.errorMessage}</div>}
-
         {!this.props.isLoading &&
           this.state.filteredSlices.length > 0 && (
             <List
@@ -242,6 +240,10 @@ class SliceAdder extends React.Component {
               selectedSliceIds={this.props.selectedSliceIds}
             />
           )}
+
+        {this.props.errorMessage && (
+          <div className="error-message">{this.props.errorMessage}</div>
+        )}
 
         {/* Drag preview is just a single fixed-position element */}
         <AddSliceDragPreview slices={this.state.filteredSlices} />

--- a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
@@ -233,7 +233,7 @@ class Chart extends React.Component {
             latestQueryFormData={chart.latestQueryFormData}
             lastRendered={chart.lastRendered}
             queryResponse={chart.queryResponse}
-            queryRequest={chart.queryRequest}
+            queryController={chart.queryController}
             triggerQuery={chart.triggerQuery}
           />
         </div>

--- a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
@@ -168,6 +168,7 @@ class Chart extends React.Component {
     const isCached = queryResponse && queryResponse.is_cached;
     const cachedDttm = queryResponse && queryResponse.cached_dttm;
     const isOverflowable = OVERFLOWABLE_VIZ_TYPES.has(slice && slice.viz_type);
+    debugger;
 
     return (
       <div>

--- a/superset/assets/src/dashboard/reducers/sliceEntities.js
+++ b/superset/assets/src/dashboard/reducers/sliceEntities.js
@@ -37,7 +37,7 @@ export default function sliceEntitiesReducer(
         ...state,
         isLoading: false,
         lastUpdated: new Date().getTime(),
-        errorMessage: t('Could not fetch all saved charts'),
+        errorMessage: action.error || t('Could not fetch all saved charts'),
       };
     },
   };

--- a/superset/assets/src/dashboard/reducers/sliceEntities.js
+++ b/superset/assets/src/dashboard/reducers/sliceEntities.js
@@ -3,6 +3,7 @@ import {
   FETCH_ALL_SLICES_STARTED,
   SET_ALL_SLICES,
 } from '../actions/sliceEntities';
+
 import { t } from '../../locales';
 
 export const initSliceEntities = {
@@ -27,22 +28,16 @@ export default function sliceEntitiesReducer(
       return {
         ...state,
         isLoading: false,
-        slices: { ...state.slices, ...action.slices }, // append more slices
+        slices: { ...state.slices, ...action.payload.slices },
         lastUpdated: new Date().getTime(),
       };
     },
     [FETCH_ALL_SLICES_FAILED]() {
-      const respJSON = action.error.responseJSON;
-      const errorMessage =
-        t('Sorry, there was an error fetching slices: ') +
-        (respJSON && respJSON.message)
-          ? respJSON.message
-          : action.error.responseText;
       return {
         ...state,
         isLoading: false,
-        errorMessage,
         lastUpdated: new Date().getTime(),
+        errorMessage: t('Could not fetch all saved charts'),
       };
     },
   };

--- a/superset/assets/src/dashboard/stylesheets/builder-sidepane.less
+++ b/superset/assets/src/dashboard/stylesheets/builder-sidepane.less
@@ -127,6 +127,13 @@
   }
 
   .slice-adder-container {
+    position: relative;
+    min-height: 200px; /* for loader positioning */
+
+    .error-message {
+      padding: 16px;
+    }
+
     .controls {
       display: flex;
       padding: 16px;

--- a/superset/assets/src/dashboard/util/propShapes.jsx
+++ b/superset/assets/src/dashboard/util/propShapes.jsx
@@ -27,7 +27,7 @@ export const chartPropShape = PropTypes.shape({
   chartUpdateEndTime: PropTypes.number,
   chartUpdateStartTime: PropTypes.number,
   latestQueryFormData: PropTypes.object,
-  queryRequest: PropTypes.object,
+  queryController: PropTypes.shape({ abort: PropTypes.func }),
   queryResponse: PropTypes.object,
   triggerQuery: PropTypes.bool,
   lastRendered: PropTypes.number,

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Badge, Col, Label, Tabs, Tab, Well } from 'react-bootstrap';
 import shortid from 'shortid';
-import { SupersetClient } from '../packages/core/src';
+import SupersetClient from '../packages/core/src';
 import { t } from '../locales';
 
 import Button from '../components/Button';
@@ -248,10 +248,9 @@ export class DatasourceEditor extends React.PureComponent {
   syncMetadata() {
     const { datasource } = this.state;
     this.setState({ metadataLoading: true });
-    SupersetClient.getInstance()
-      .get({
-        endpoint: `/datasource/external_metadata/${datasource.type}/${datasource.id}/`,
-      })
+    SupersetClient.get({
+      endpoint: `/datasource/external_metadata/${datasource.type}/${datasource.id}/`,
+    })
       .then(({ json }) => {
         this.mergeColumns(json);
         this.props.addSuccessToast(t('Metadata has been synced'));
@@ -400,7 +399,11 @@ export class DatasourceEditor extends React.PureComponent {
           itemRenderers={{
             name: (d, onChange) => <EditableTitle canEdit title={d} onSaveTitle={onChange} />,
             config: (v, onChange) => (
-              <SpatialControl value={v} onChange={onChange} choices={datasource.all_cols} />
+              <SpatialControl
+                value={v}
+                onChange={onChange}
+                choices={this.state.datasource.all_cols}
+              />
             ),
           }}
         />

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Badge, Col, Label, Tabs, Tab, Well } from 'react-bootstrap';
 import shortid from 'shortid';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../packages/core/src';
 import { t } from '../locales';
 
 import Button from '../components/Button';

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Badge, Col, Label, Tabs, Tab, Well } from 'react-bootstrap';
 import shortid from 'shortid';
-import SupersetClient from '../packages/core/src';
+import { SupersetClient } from '../packages/core/src';
 import { t } from '../locales';
 
 import Button from '../components/Button';

--- a/superset/assets/src/datasource/DatasourceModal.jsx
+++ b/superset/assets/src/datasource/DatasourceModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Button, Modal } from 'react-bootstrap';
 import Dialog from 'react-bootstrap-dialog';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../packages/core/src';
 
 import { t } from '../locales';
 import DatasourceEditor from '../datasource/DatasourceEditor';

--- a/superset/assets/src/datasource/DatasourceModal.jsx
+++ b/superset/assets/src/datasource/DatasourceModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Button, Modal } from 'react-bootstrap';
 import Dialog from 'react-bootstrap-dialog';
-import { SupersetClient } from '../packages/core/src';
+import SupersetClient from '../packages/core/src';
 
 import { t } from '../locales';
 import DatasourceEditor from '../datasource/DatasourceEditor';
@@ -52,13 +52,12 @@ class DatasourceModal extends React.PureComponent {
     });
   }
   onConfirmSave() {
-    SupersetClient.getInstance()
-      .post({
-        endpoint: '/datasource/save/',
-        postPayload: {
-          data: this.state.datasource,
-        },
-      })
+    SupersetClient.post({
+      endpoint: '/datasource/save/',
+      postPayload: {
+        data: this.state.datasource,
+      },
+    })
       .then(({ json }) => {
         this.props.addSuccessToast(t('The datasource has been saved'));
         this.props.onDatasourceSave(json);

--- a/superset/assets/src/datasource/DatasourceModal.jsx
+++ b/superset/assets/src/datasource/DatasourceModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Button, Modal } from 'react-bootstrap';
 import Dialog from 'react-bootstrap-dialog';
-import SupersetClient from '../packages/core/src';
+import { SupersetClient } from '../packages/core/src';
 
 import { t } from '../locales';
 import DatasourceEditor from '../datasource/DatasourceEditor';

--- a/superset/assets/src/explore/actions/exploreActions.js
+++ b/superset/assets/src/explore/actions/exploreActions.js
@@ -1,5 +1,5 @@
-/* eslint no-undef: 'error', camelcase: 0 */
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+/* eslint camelcase: 0 */
+import { SupersetClient } from '../../packages/core/src';
 import { addDangerToast } from '../../messageToasts/actions';
 import { t } from '../../locales';
 

--- a/superset/assets/src/explore/actions/exploreActions.js
+++ b/superset/assets/src/explore/actions/exploreActions.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */
-import SupersetClient from '../../packages/core/src';
+import { SupersetClient } from '../../packages/core/src';
 import { addDangerToast } from '../../messageToasts/actions';
 import { t } from '../../locales';
 

--- a/superset/assets/src/explore/actions/exploreActions.js
+++ b/superset/assets/src/explore/actions/exploreActions.js
@@ -1,5 +1,7 @@
-/* eslint camelcase: 0 */
-const $ = window.$ = require('jquery');
+/* eslint no-undef: 'error', camelcase: 0 */
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { addDangerToast } from '../../messageToasts/actions';
+import { t } from '../../locales';
 
 const FAVESTAR_BASE_URL = '/superset/favstar/slice';
 
@@ -44,24 +46,6 @@ export function resetControls() {
   return { type: RESET_FIELDS };
 }
 
-export function fetchDatasources() {
-  return function (dispatch) {
-    dispatch(fetchDatasourcesStarted());
-    const url = '/superset/datasources/';
-    $.ajax({
-      type: 'GET',
-      url,
-      success: (data) => {
-        dispatch(setDatasources(data));
-        dispatch(fetchDatasourcesSucceeded());
-      },
-      error(error) {
-        dispatch(fetchDatasourcesFailed(error.responseJSON.error));
-      },
-    });
-  };
-}
-
 export const TOGGLE_FAVE_STAR = 'TOGGLE_FAVE_STAR';
 export function toggleFaveStar(isStarred) {
   return { type: TOGGLE_FAVE_STAR, isStarred };
@@ -70,12 +54,13 @@ export function toggleFaveStar(isStarred) {
 export const FETCH_FAVE_STAR = 'FETCH_FAVE_STAR';
 export function fetchFaveStar(sliceId) {
   return function (dispatch) {
-    const url = `${FAVESTAR_BASE_URL}/${sliceId}/count`;
-    $.get(url, (data) => {
-      if (data.count > 0) {
-        dispatch(toggleFaveStar(true));
-      }
-    });
+    SupersetClient.getInstance()
+      .get({ endpoint: `${FAVESTAR_BASE_URL}/${sliceId}/count` })
+      .then(({ json }) => {
+        if (json.count > 0) {
+          dispatch(toggleFaveStar(true));
+        }
+      });
   };
 }
 
@@ -83,9 +68,10 @@ export const SAVE_FAVE_STAR = 'SAVE_FAVE_STAR';
 export function saveFaveStar(sliceId, isStarred) {
   return function (dispatch) {
     const urlSuffix = isStarred ? 'unselect' : 'select';
-    const url = `${FAVESTAR_BASE_URL}/${sliceId}/${urlSuffix}/`;
-    $.get(url);
-    dispatch(toggleFaveStar(!isStarred));
+    SupersetClient.getInstance()
+      .get({ endpoint: `${FAVESTAR_BASE_URL}/${sliceId}/${urlSuffix}/` })
+      .then(() => dispatch(toggleFaveStar(!isStarred)))
+      .catch(() => dispatch(addDangerToast(t('An error occurred while starring this chart'))));
   };
 }
 

--- a/superset/assets/src/explore/actions/exploreActions.js
+++ b/superset/assets/src/explore/actions/exploreActions.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */
-import { SupersetClient } from '../../packages/core/src';
+import SupersetClient from '../../packages/core/src';
 import { addDangerToast } from '../../messageToasts/actions';
 import { t } from '../../locales';
 
@@ -54,13 +54,11 @@ export function toggleFaveStar(isStarred) {
 export const FETCH_FAVE_STAR = 'FETCH_FAVE_STAR';
 export function fetchFaveStar(sliceId) {
   return function (dispatch) {
-    SupersetClient.getInstance()
-      .get({ endpoint: `${FAVESTAR_BASE_URL}/${sliceId}/count` })
-      .then(({ json }) => {
-        if (json.count > 0) {
-          dispatch(toggleFaveStar(true));
-        }
-      });
+    SupersetClient.get({ endpoint: `${FAVESTAR_BASE_URL}/${sliceId}/count` }).then(({ json }) => {
+      if (json.count > 0) {
+        dispatch(toggleFaveStar(true));
+      }
+    });
   };
 }
 
@@ -68,8 +66,7 @@ export const SAVE_FAVE_STAR = 'SAVE_FAVE_STAR';
 export function saveFaveStar(sliceId, isStarred) {
   return function (dispatch) {
     const urlSuffix = isStarred ? 'unselect' : 'select';
-    SupersetClient.getInstance()
-      .get({ endpoint: `${FAVESTAR_BASE_URL}/${sliceId}/${urlSuffix}/` })
+    SupersetClient.get({ endpoint: `${FAVESTAR_BASE_URL}/${sliceId}/${urlSuffix}/` })
       .then(() => dispatch(toggleFaveStar(!isStarred)))
       .catch(() => dispatch(addDangerToast(t('An error occurred while starring this chart'))));
   };

--- a/superset/assets/src/explore/actions/saveModalActions.js
+++ b/superset/assets/src/explore/actions/saveModalActions.js
@@ -1,4 +1,4 @@
-import { SupersetClient } from '../../packages/core/src';
+import SupersetClient from '../../packages/core/src';
 import { getExploreUrlAndPayload } from '../exploreUtils';
 
 export const FETCH_DASHBOARDS_SUCCEEDED = 'FETCH_DASHBOARDS_SUCCEEDED';
@@ -13,10 +13,9 @@ export function fetchDashboardsFailed(userId) {
 
 export function fetchDashboards(userId) {
   return function fetchDashboardsThunk(dispatch) {
-    return SupersetClient.getInstance()
-      .get({
-        endpoint: `/dashboardasync/api/read?_flt_0_owners=${userId}`,
-      })
+    return SupersetClient.get({
+      endpoint: `/dashboardasync/api/read?_flt_0_owners=${userId}`,
+    })
       .then(({ json }) => {
         const choices = json.pks.map((id, index) => ({
           value: id,
@@ -53,8 +52,7 @@ export function saveSlice(formData, requestParams) {
       requestParams,
     });
 
-    return SupersetClient.getInstance()
-      .post({ url, postPayload: { form_data: payload } })
+    return SupersetClient.post({ url, postPayload: { form_data: payload } })
       .then(({ json }) => dispatch(saveSliceSuccess(json)))
       .catch(() => dispatch(saveSliceFailed()));
   };

--- a/superset/assets/src/explore/actions/saveModalActions.js
+++ b/superset/assets/src/explore/actions/saveModalActions.js
@@ -1,5 +1,4 @@
-/* eslint no-undef: 'error' */
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../../packages/core/src';
 import { getExploreUrlAndPayload } from '../exploreUtils';
 
 export const FETCH_DASHBOARDS_SUCCEEDED = 'FETCH_DASHBOARDS_SUCCEEDED';

--- a/superset/assets/src/explore/actions/saveModalActions.js
+++ b/superset/assets/src/explore/actions/saveModalActions.js
@@ -1,4 +1,4 @@
-import SupersetClient from '../../packages/core/src';
+import { SupersetClient } from '../../packages/core/src';
 import { getExploreUrlAndPayload } from '../exploreUtils';
 
 export const FETCH_DASHBOARDS_SUCCEEDED = 'FETCH_DASHBOARDS_SUCCEEDED';

--- a/superset/assets/src/explore/actions/saveModalActions.js
+++ b/superset/assets/src/explore/actions/saveModalActions.js
@@ -1,6 +1,6 @@
+/* eslint no-undef: 'error' */
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 import { getExploreUrlAndPayload } from '../exploreUtils';
-
-const $ = window.$ = require('jquery');
 
 export const FETCH_DASHBOARDS_SUCCEEDED = 'FETCH_DASHBOARDS_SUCCEEDED';
 export function fetchDashboardsSucceeded(choices) {
@@ -13,22 +13,20 @@ export function fetchDashboardsFailed(userId) {
 }
 
 export function fetchDashboards(userId) {
-  return function (dispatch) {
-    const url = '/dashboardasync/api/read?_flt_0_owners=' + userId;
-    return $.ajax({
-      type: 'GET',
-      url,
-      success: (data) => {
-        const choices = [];
-        for (let i = 0; i < data.pks.length; i++) {
-          choices.push({ value: data.pks[i], label: data.result[i].dashboard_title });
-        }
-        dispatch(fetchDashboardsSucceeded(choices));
-      },
-      error: () => {
-        dispatch(fetchDashboardsFailed(userId));
-      },
-    });
+  return function fetchDashboardsThunk(dispatch) {
+    return SupersetClient.getInstance()
+      .get({
+        endpoint: `/dashboardasync/api/read?_flt_0_owners=${userId}`,
+      })
+      .then(({ json }) => {
+        const choices = json.pks.map((id, index) => ({
+          value: id,
+          label: (json.result[index] || {}).dashboard_title,
+        }));
+
+        return dispatch(fetchDashboardsSucceeded(choices));
+      })
+      .catch(() => dispatch(fetchDashboardsFailed(userId)));
   };
 }
 
@@ -55,18 +53,10 @@ export function saveSlice(formData, requestParams) {
       curUrl: null,
       requestParams,
     });
-    return $.ajax({
-      type: 'POST',
-      url,
-      data: {
-        form_data: JSON.stringify(payload),
-      },
-      success: ((data) => {
-        dispatch(saveSliceSuccess(data));
-      }),
-      error: (() => {
-        dispatch(saveSliceFailed());
-      }),
-    });
+
+    return SupersetClient.getInstance()
+      .post({ url, postPayload: { form_data: payload } })
+      .then(({ json }) => dispatch(saveSliceSuccess(json)))
+      .catch(() => dispatch(saveSliceFailed()));
   };
 }

--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'react-bootstrap';
 import VirtualizedSelect from 'react-virtualized-select';
-import { SupersetClient } from '../../packages/core/src';
+import SupersetClient from '../../packages/core/src';
 
 import AdhocFilter, { EXPRESSION_TYPES, CLAUSES } from '../AdhocFilter';
 import adhocMetricType from '../propTypes/adhocMetricType';
@@ -180,14 +180,12 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
       const { signal } = controller;
       this.setState({ abortActiveRequest: controller.abort });
 
-      SupersetClient.getInstance()
-        .get({
-          signal,
-          endpoint: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
-        })
-        .then(({ json }) => {
-          this.setState(() => ({ suggestions: json, abortActiveRequest: null }));
-        });
+      SupersetClient.get({
+        signal,
+        endpoint: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
+      }).then(({ json }) => {
+        this.setState(() => ({ suggestions: json, abortActiveRequest: null }));
+      });
     }
   }
 

--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -1,10 +1,9 @@
 /* global AbortController */
-/* eslint no-undef: 'error' */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'react-bootstrap';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 import VirtualizedSelect from 'react-virtualized-select';
+import { SupersetClient } from '../../packages/core/src';
 
 import AdhocFilter, { EXPRESSION_TYPES, CLAUSES } from '../AdhocFilter';
 import adhocMetricType from '../propTypes/adhocMetricType';

--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -1,6 +1,9 @@
+/* global AbortController */
+/* eslint no-undef: 'error' */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'react-bootstrap';
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 import VirtualizedSelect from 'react-virtualized-select';
 
 import AdhocFilter, { EXPRESSION_TYPES, CLAUSES } from '../AdhocFilter';
@@ -19,16 +22,16 @@ import OnPasteSelect from '../../components/OnPasteSelect';
 import SelectControl from './controls/SelectControl';
 import VirtualizedRendererWrap from '../../components/VirtualizedRendererWrap';
 
-const $ = require('jquery');
-
 const propTypes = {
   adhocFilter: PropTypes.instanceOf(AdhocFilter).isRequired,
   onChange: PropTypes.func.isRequired,
-  options: PropTypes.arrayOf(PropTypes.oneOfType([
-    columnType,
-    PropTypes.shape({ saved_metric_name: PropTypes.string.isRequired }),
-    adhocMetricType,
-  ])).isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      columnType,
+      PropTypes.shape({ saved_metric_name: PropTypes.string.isRequired }),
+      adhocMetricType,
+    ]),
+  ).isRequired,
   onHeightChange: PropTypes.func.isRequired,
   datasource: PropTypes.object,
 };
@@ -64,6 +67,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     this.state = {
       suggestions: [],
       multiComparatorHeight: SINGLE_LINE_SELECT_CONTROL_HEIGHT,
+      abortActiveRequest: null,
     };
 
     this.selectProps = {
@@ -102,11 +106,13 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
       subject = option.saved_metric_name || option.label;
       clause = CLAUSES.HAVING;
     }
-    this.props.onChange(this.props.adhocFilter.duplicateWith({
-      subject,
-      clause,
-      expressionType: EXPRESSION_TYPES.SIMPLE,
-    }));
+    this.props.onChange(
+      this.props.adhocFilter.duplicateWith({
+        subject,
+        clause,
+        expressionType: EXPRESSION_TYPES.SIMPLE,
+      }),
+    );
   }
 
   onOperatorChange(operator) {
@@ -115,17 +121,19 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     // convert between list of comparators and individual comparators
     // (e.g. `in ('North America', 'Africa')` to `== 'North America'`)
     if (MULTI_OPERATORS.indexOf(operator.operator) >= 0) {
-      newComparator = Array.isArray(currentComparator) ?
-        currentComparator :
-        [currentComparator].filter(element => element);
+      newComparator = Array.isArray(currentComparator)
+        ? currentComparator
+        : [currentComparator].filter(element => element);
     } else {
       newComparator = Array.isArray(currentComparator) ? currentComparator[0] : currentComparator;
     }
-    this.props.onChange(this.props.adhocFilter.duplicateWith({
-      operator: operator && operator.operator,
-      comparator: newComparator,
-      expressionType: EXPRESSION_TYPES.SIMPLE,
-    }));
+    this.props.onChange(
+      this.props.adhocFilter.duplicateWith({
+        operator: operator && operator.operator,
+        comparator: newComparator,
+        expressionType: EXPRESSION_TYPES.SIMPLE,
+      }),
+    );
   }
 
   onInputComparatorChange(event) {
@@ -133,23 +141,26 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
   }
 
   onComparatorChange(comparator) {
-    this.props.onChange(this.props.adhocFilter.duplicateWith({
-      comparator,
-      expressionType: EXPRESSION_TYPES.SIMPLE,
-    }));
+    this.props.onChange(
+      this.props.adhocFilter.duplicateWith({
+        comparator,
+        expressionType: EXPRESSION_TYPES.SIMPLE,
+      }),
+    );
   }
 
   handleMultiComparatorInputHeightChange() {
     if (this.multiComparatorComponent) {
       /* eslint-disable no-underscore-dangle */
-      const multiComparatorDOMNode = this.multiComparatorComponent._selectRef &&
+      const multiComparatorDOMNode =
+        this.multiComparatorComponent._selectRef &&
         this.multiComparatorComponent._selectRef.select &&
         this.multiComparatorComponent._selectRef.select.control;
       if (multiComparatorDOMNode) {
         if (multiComparatorDOMNode.clientHeight !== this.state.multiComparatorHeight) {
-          this.props.onHeightChange((
-            multiComparatorDOMNode.clientHeight - this.state.multiComparatorHeight
-          ));
+          this.props.onHeightChange(
+            multiComparatorDOMNode.clientHeight - this.state.multiComparatorHeight,
+          );
           this.setState({ multiComparatorHeight: multiComparatorDOMNode.clientHeight });
         }
       }
@@ -162,16 +173,22 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     const having = this.props.adhocFilter.clause === CLAUSES.HAVING;
 
     if (col && datasource && datasource.filter_select && !having) {
-      if (this.state.activeRequest) {
-        this.state.activeRequest.abort();
+      if (this.state.abortActiveRequest) {
+        this.state.abortActiveRequest();
       }
-      this.setState({
-        activeRequest: $.ajax({
-          type: 'GET',
-          url: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
-          success: data => this.setState({ suggestions: data, activeRequest: null }),
-        }),
-      });
+
+      const controller = new AbortController();
+      const { signal } = controller;
+      this.setState({ abortActiveRequest: controller.abort });
+
+      SupersetClient.getInstance()
+        .get({
+          signal,
+          endpoint: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
+        })
+        .then(({ json }) => {
+          this.setState(() => ({ suggestions: json, abortActiveRequest: null }));
+        });
     }
   }
 
@@ -179,10 +196,8 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     return !(
       (this.props.datasource.type === 'druid' && TABLE_ONLY_OPERATORS.indexOf(operator) >= 0) ||
       (this.props.datasource.type === 'table' && DRUID_ONLY_OPERATORS.indexOf(operator) >= 0) ||
-      (
-        this.props.adhocFilter.clause === CLAUSES.HAVING &&
-        HAVING_OPERATORS.indexOf(operator) === -1
-      )
+      (this.props.adhocFilter.clause === CLAUSES.HAVING &&
+        HAVING_OPERATORS.indexOf(operator) === -1)
     );
   }
 
@@ -204,9 +219,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     let subjectSelectProps = {
       value: adhocFilter.subject ? { value: adhocFilter.subject } : undefined,
       onChange: this.onSubjectChange,
-      optionRenderer: VirtualizedRendererWrap(option => (
-        <FilterDefinitionOption option={option} />
-      )),
+      optionRenderer: VirtualizedRendererWrap(option => <FilterDefinitionOption option={option} />),
       valueRenderer: option => <span>{option.value}</span>,
       valueKey: 'filterOptionName',
       noResultsText: t('No such column found. To filter on a metric, try the Custom SQL tab.'),
@@ -224,28 +237,23 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
       // becomes a rather complicated problem)
       subjectSelectProps = {
         ...subjectSelectProps,
-        placeholder: adhocFilter.clause === CLAUSES.WHERE ?
-          t('%s column(s)', options.length) :
-          t('To filter on a metric, use Custom SQL tab.'),
+        placeholder:
+          adhocFilter.clause === CLAUSES.WHERE
+            ? t('%s column(s)', options.length)
+            : t('To filter on a metric, use Custom SQL tab.'),
         options: options.filter(option => option.column_name),
       };
     }
 
     const operatorSelectProps = {
       placeholder: t('%s operators(s)', Object.keys(OPERATORS).length),
-      options: Object.keys(OPERATORS).filter(this.isOperatorRelevant).map((
-        operator => ({ operator })
-      )),
+      options: Object.keys(OPERATORS)
+        .filter(this.isOperatorRelevant)
+        .map(operator => ({ operator })),
       value: adhocFilter.operator,
       onChange: this.onOperatorChange,
-      optionRenderer: VirtualizedRendererWrap((
-        operator => translateOperator(operator.operator)
-      )),
-      valueRenderer: operator => (
-        <span>
-          {translateOperator(operator.operator)}
-        </span>
-      ),
+      optionRenderer: VirtualizedRendererWrap(operator => translateOperator(operator.operator)),
+      valueRenderer: operator => <span>{translateOperator(operator.operator)}</span>,
       valueKey: 'operator',
     };
 
@@ -258,33 +266,33 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
           <OnPasteSelect {...this.selectProps} {...operatorSelectProps} />
         </FormGroup>
         <FormGroup>
-          {
-            (
-              MULTI_OPERATORS.indexOf(adhocFilter.operator) >= 0 ||
-              this.state.suggestions.length > 0
-            ) ?
-              <SelectControl
-                multi={MULTI_OPERATORS.indexOf(adhocFilter.operator) >= 0}
-                freeForm
-                name="filter-comparator-value"
-                value={adhocFilter.comparator}
-                isLoading={false}
-                choices={this.state.suggestions}
-                onChange={this.onComparatorChange}
-                showHeader={false}
-                noResultsText={t('type a value here')}
-                refFunc={this.multiComparatorRef}
-                disabled={adhocFilter.operator === 'IS NOT NULL' || adhocFilter.operator === 'IS NULL'}
-              /> :
-              <input
-                ref={this.focusComparator}
-                type="text"
-                onChange={this.onInputComparatorChange}
-                value={adhocFilter.comparator || ''}
-                className="form-control input-sm"
-                placeholder={t('Filter value')}
-              />
-          }
+          {MULTI_OPERATORS.indexOf(adhocFilter.operator) >= 0 ||
+          this.state.suggestions.length > 0 ? (
+            <SelectControl
+              multi={MULTI_OPERATORS.indexOf(adhocFilter.operator) >= 0}
+              freeForm
+              name="filter-comparator-value"
+              value={adhocFilter.comparator}
+              isLoading={false}
+              choices={this.state.suggestions}
+              onChange={this.onComparatorChange}
+              showHeader={false}
+              noResultsText={t('type a value here')}
+              refFunc={this.multiComparatorRef}
+              disabled={
+                adhocFilter.operator === 'IS NOT NULL' || adhocFilter.operator === 'IS NULL'
+              }
+            />
+          ) : (
+            <input
+              ref={this.focusComparator}
+              type="text"
+              onChange={this.onInputComparatorChange}
+              value={adhocFilter.comparator || ''}
+              className="form-control input-sm"
+              placeholder={t('Filter value')}
+            />
+          )}
         </FormGroup>
       </span>
     );

--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'react-bootstrap';
 import VirtualizedSelect from 'react-virtualized-select';
-import SupersetClient from '../../packages/core/src';
+import { SupersetClient } from '../../packages/core/src';
 
 import AdhocFilter, { EXPRESSION_TYPES, CLAUSES } from '../AdhocFilter';
 import adhocMetricType from '../propTypes/adhocMetricType';

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -1,10 +1,12 @@
+/* eslint no-undef: 'error' */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/light';
-import html from 'react-syntax-highlighter/languages/hljs/htmlbars';
-import markdown from 'react-syntax-highlighter/languages/hljs/markdown';
-import sql from 'react-syntax-highlighter/languages/hljs/sql';
-import json from 'react-syntax-highlighter/languages/hljs/json';
+import htmlSyntax from 'react-syntax-highlighter/languages/hljs/htmlbars';
+import markdownSyntax from 'react-syntax-highlighter/languages/hljs/markdown';
+import sqlSyntax from 'react-syntax-highlighter/languages/hljs/sql';
+import jsonSyntax from 'react-syntax-highlighter/languages/hljs/json';
 import github from 'react-syntax-highlighter/styles/hljs/github';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
@@ -18,12 +20,10 @@ import ModalTrigger from './../../components/ModalTrigger';
 import Button from '../../components/Button';
 import { t } from '../../locales';
 
-registerLanguage('markdown', markdown);
-registerLanguage('html', html);
-registerLanguage('sql', sql);
-registerLanguage('json', json);
-
-const $ = (window.$ = require('jquery'));
+registerLanguage('markdown', markdownSyntax);
+registerLanguage('html', htmlSyntax);
+registerLanguage('sql', sqlSyntax);
+registerLanguage('json', jsonSyntax);
 
 const propTypes = {
   onOpenInEditor: PropTypes.func,
@@ -56,28 +56,26 @@ export default class DisplayQueryButton extends React.PureComponent {
       formData: this.props.latestQueryFormData,
       endpointType: 'query',
     });
-    $.ajax({
-      type: 'POST',
-      url,
-      data: {
-        form_data: JSON.stringify(payload),
-      },
-      success: (data) => {
+    SupersetClient.getInstance()
+      .post({
+        url,
+        postPayload: { form_data: payload },
+      })
+      .then(({ json }) => {
         this.setState({
-          language: data.language,
-          query: data.query,
-          data: data.data,
+          language: json.language,
+          query: json.query,
+          data: json.data,
           isLoading: false,
           error: null,
         });
-      },
-      error: (data) => {
+      })
+      .catch((error) => {
         this.setState({
-          error: data.responseJSON ? data.responseJSON.error : t('Error...'),
+          error: error.error || error.statusText || t('Sorry, An error occurred'),
           isLoading: false,
         });
-      },
-    });
+      });
   }
   redirectSQLLab() {
     this.props.onOpenInEditor(this.props.latestQueryFormData);
@@ -109,11 +107,7 @@ export default class DisplayQueryButton extends React.PureComponent {
   }
   renderResultsModalBody() {
     if (this.state.isLoading) {
-      return (<img
-        className="loading"
-        alt="Loading..."
-        src="/static/assets/images/loading.gif"
-      />);
+      return <Loading />;
     } else if (this.state.error) {
       return <pre>{this.state.error}</pre>;
     } else if (this.state.data) {
@@ -121,16 +115,12 @@ export default class DisplayQueryButton extends React.PureComponent {
         return 'No data';
       }
       const headers = Object.keys(this.state.data[0]).map((k, i) => (
-        <TableHeaderColumn key={k} dataField={k} isKey={i === 0} dataSort>{k}</TableHeaderColumn>
+        <TableHeaderColumn key={k} dataField={k} isKey={i === 0} dataSort>
+          {k}
+        </TableHeaderColumn>
       ));
       return (
-        <BootstrapTable
-          height="auto"
-          data={this.state.data}
-          striped
-          hover
-          condensed
-        >
+        <BootstrapTable height="auto" data={this.state.data} striped hover condensed>
           {headers}
         </BootstrapTable>
       );
@@ -160,12 +150,11 @@ export default class DisplayQueryButton extends React.PureComponent {
           modalBody={this.renderResultsModalBody()}
           eventKey="2"
         />
-        {this.state.sqlSupported && <MenuItem
-          eventKey="3"
-          onClick={this.redirectSQLLab.bind(this)}
-        >
-          {t('Run in SQL Lab')}
-        </MenuItem>}
+        {this.state.sqlSupported && (
+          <MenuItem eventKey="3" onClick={this.redirectSQLLab.bind(this)}>
+            {t('Run in SQL Lab')}
+          </MenuItem>
+        )}
       </DropdownButton>
     );
   }

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -9,7 +9,7 @@ import github from 'react-syntax-highlighter/styles/hljs/github';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import 'react-bootstrap-table/css/react-bootstrap-table.css';
-import { SupersetClient } from '../../packages/core/src';
+import SupersetClient from '../../packages/core/src';
 
 import CopyToClipboard from './../../components/CopyToClipboard';
 import { getExploreUrlAndPayload } from '../exploreUtils';
@@ -55,11 +55,10 @@ export default class DisplayQueryButton extends React.PureComponent {
       formData: this.props.latestQueryFormData,
       endpointType: 'query',
     });
-    SupersetClient.getInstance()
-      .post({
-        url,
-        postPayload: { form_data: payload },
-      })
+    SupersetClient.post({
+      url,
+      postPayload: { form_data: payload },
+    })
       .then(({ json }) => {
         this.setState({
           language: json.language,

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -1,7 +1,5 @@
-/* eslint no-undef: 'error' */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/light';
 import htmlSyntax from 'react-syntax-highlighter/languages/hljs/htmlbars';
 import markdownSyntax from 'react-syntax-highlighter/languages/hljs/markdown';
@@ -11,6 +9,7 @@ import github from 'react-syntax-highlighter/styles/hljs/github';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import 'react-bootstrap-table/css/react-bootstrap-table.css';
+import { SupersetClient } from '../../packages/core/src';
 
 import CopyToClipboard from './../../components/CopyToClipboard';
 import { getExploreUrlAndPayload } from '../exploreUtils';

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -9,7 +9,7 @@ import github from 'react-syntax-highlighter/styles/hljs/github';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import 'react-bootstrap-table/css/react-bootstrap-table.css';
-import SupersetClient from '../../packages/core/src';
+import { SupersetClient } from '../../packages/core/src';
 
 import CopyToClipboard from './../../components/CopyToClipboard';
 import { getExploreUrlAndPayload } from '../exploreUtils';

--- a/superset/assets/src/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/src/explore/components/ExploreChartPanel.jsx
@@ -62,7 +62,7 @@ class ExploreChartPanel extends React.PureComponent {
         latestQueryFormData={chart.latestQueryFormData}
         lastRendered={chart.lastRendered}
         queryResponse={chart.queryResponse}
-        queryRequest={chart.queryRequest}
+        queryController={chart.queryController}
         triggerQuery={chart.triggerQuery}
       />
     );

--- a/superset/assets/src/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/src/explore/components/ExploreViewContainer.jsx
@@ -53,6 +53,9 @@ class ExploreViewContainer extends React.Component {
     this.addHistory = this.addHistory.bind(this);
     this.handleResize = this.handleResize.bind(this);
     this.handlePopstate = this.handlePopstate.bind(this);
+    this.onStop = this.onStop.bind(this);
+    this.onQuery = this.onQuery.bind(this);
+    this.toggleModal = this.toggleModal.bind(this);
   }
 
   componentDidMount() {
@@ -123,7 +126,9 @@ class ExploreViewContainer extends React.Component {
   }
 
   onStop() {
-    return this.props.chart.queryRequest.abort();
+    if (this.props.chart && this.props.chart.queryController) {
+      this.props.chart.queryController.abort();
+    }
   }
 
   getWidth() {
@@ -256,7 +261,7 @@ class ExploreViewContainer extends React.Component {
       >
         {this.state.showModal && (
           <SaveModal
-            onHide={this.toggleModal.bind(this)}
+            onHide={this.toggleModal}
             actions={this.props.actions}
             form_data={this.props.form_data}
           />
@@ -265,9 +270,9 @@ class ExploreViewContainer extends React.Component {
           <div className="col-sm-4">
             <QueryAndSaveBtns
               canAdd="True"
-              onQuery={this.onQuery.bind(this)}
-              onSave={this.toggleModal.bind(this)}
-              onStop={this.onStop.bind(this)}
+              onQuery={this.onQuery}
+              onSave={this.toggleModal}
+              onStop={this.onStop}
               loading={this.props.chart.chartStatus === 'loading'}
               chartIsStale={this.state.chartIsStale}
               errorMessage={this.renderErrorMessage()}

--- a/superset/assets/src/explore/components/SaveModal.jsx
+++ b/superset/assets/src/explore/components/SaveModal.jsx
@@ -85,7 +85,7 @@ class SaveModal extends React.Component {
     sliceParams.add_to_dash = addToDash;
     let dashboard = null;
     switch (addToDash) {
-      case ('existing'):
+      case 'existing':
         dashboard = this.state.saveToDashboardId;
         if (!dashboard) {
           this.setState({ alert: t('Please select a dashboard') });
@@ -93,7 +93,7 @@ class SaveModal extends React.Component {
         }
         sliceParams.save_to_dashboard_id = dashboard;
         break;
-      case ('new'):
+      case 'new':
         dashboard = this.state.newDashboardName;
         if (dashboard === '') {
           this.setState({ alert: t('Please enter a dashboard name') });
@@ -106,15 +106,14 @@ class SaveModal extends React.Component {
     }
     sliceParams.goto_dash = gotodash;
 
-    this.props.actions.saveSlice(this.props.form_data, sliceParams)
-      .then((data) => {
-        // Go to new slice url or dashboard url
-        if (gotodash) {
-          window.location = supersetURL(data.dashboard);
-        } else {
-          window.location = data.slice.slice_url;
-        }
-      });
+    this.props.actions.saveSlice(this.props.form_data, sliceParams).then(({ data }) => {
+      // Go to new slice url or dashboard url
+      if (gotodash) {
+        window.location = supersetURL(data.dashboard);
+      } else {
+        window.location = data.slice.slice_url;
+      }
+    });
     this.props.onHide();
   }
   removeAlert() {
@@ -126,18 +125,12 @@ class SaveModal extends React.Component {
   render() {
     const canNotSaveToDash = EXPLORE_ONLY_VIZ_TYPE.indexOf(this.state.vizType) > -1;
     return (
-      <Modal
-        show
-        onHide={this.props.onHide}
-        bsStyle="large"
-      >
+      <Modal show onHide={this.props.onHide} bsStyle="large">
         <Modal.Header closeButton>
-          <Modal.Title>
-            {t('Save A Chart')}
-          </Modal.Title>
+          <Modal.Title>{t('Save A Chart')}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {(this.state.alert || this.props.alert) &&
+          {(this.state.alert || this.props.alert) && (
             <Alert>
               {this.state.alert ? this.state.alert : this.props.alert}
               <i
@@ -146,8 +139,8 @@ class SaveModal extends React.Component {
                 style={{ cursor: 'pointer' }}
               />
             </Alert>
-          }
-          {this.props.slice &&
+          )}
+          {this.props.slice && (
             <Radio
               id="overwrite-radio"
               disabled={!this.props.can_overwrite}
@@ -156,14 +149,16 @@ class SaveModal extends React.Component {
             >
               {t('Overwrite chart %s', this.props.slice.slice_name)}
             </Radio>
-          }
+          )}
 
           <Radio
             id="saveas-radio"
             inline
             checked={this.state.action === 'saveas'}
             onChange={this.changeAction.bind(this, 'saveas')}
-          > {t('Save as')} &nbsp;
+          >
+            {' '}
+            {t('Save as')} &nbsp;
           </Radio>
           <input
             name="new_slice_name"
@@ -171,7 +166,6 @@ class SaveModal extends React.Component {
             onChange={this.onChange.bind(this, 'newSliceName')}
             onFocus={this.changeAction.bind(this, 'saveas')}
           />
-
 
           <br />
           <hr />
@@ -215,7 +209,6 @@ class SaveModal extends React.Component {
             onFocus={this.changeDash.bind(this, 'new')}
             placeholder={t('[dashboard name]')}
           />
-
         </Modal.Body>
 
         <Modal.Footer>
@@ -256,4 +249,7 @@ function mapStateToProps({ explore, saveModal }) {
 }
 
 export { SaveModal };
-export default connect(mapStateToProps, () => ({}))(SaveModal);
+export default connect(
+  mapStateToProps,
+  () => ({}),
+)(SaveModal);

--- a/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
@@ -1,12 +1,10 @@
-/* eslint no-undef: 'error' */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { CompactPicker } from 'react-color';
 import { Button } from 'react-bootstrap';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 import mathjs from 'mathjs';
 
+import { SupersetClient } from '../../../packages/core/src';
 import SelectControl from './SelectControl';
 import TextControl from './TextControl';
 import CheckboxControl from './CheckboxControl';

--- a/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
@@ -4,7 +4,7 @@ import { CompactPicker } from 'react-color';
 import { Button } from 'react-bootstrap';
 import mathjs from 'mathjs';
 
-import SupersetClient from '../../../packages/core/src';
+import { SupersetClient } from '../../../packages/core/src';
 import SelectControl from './SelectControl';
 import TextControl from './TextControl';
 import CheckboxControl from './CheckboxControl';

--- a/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
@@ -4,7 +4,7 @@ import { CompactPicker } from 'react-color';
 import { Button } from 'react-bootstrap';
 import mathjs from 'mathjs';
 
-import { SupersetClient } from '../../../packages/core/src';
+import SupersetClient from '../../../packages/core/src';
 import SelectControl from './SelectControl';
 import TextControl from './TextControl';
 import CheckboxControl from './CheckboxControl';
@@ -210,31 +210,27 @@ export default class AnnotationLayer extends React.PureComponent {
   fetchOptions(annotationType, sourceType, isLoadingOptions) {
     if (isLoadingOptions === true) {
       if (sourceType === ANNOTATION_SOURCE_TYPES.NATIVE) {
-        SupersetClient.getInstance()
-          .get({ endpoint: '/annotationlayermodelview/api/read?' })
-          .then(({ json }) => {
-            const layers = json
-              ? json.result.map(layer => ({
-                  value: layer.id,
-                  label: layer.name,
-                }))
-              : [];
-            this.setState({
-              isLoadingOptions: false,
-              valueOptions: layers,
-            });
+        SupersetClient.get({ endpoint: '/annotationlayermodelview/api/read?' }).then(({ json }) => {
+          const layers = json
+            ? json.result.map(layer => ({
+                value: layer.id,
+                label: layer.name,
+              }))
+            : [];
+          this.setState({
+            isLoadingOptions: false,
+            valueOptions: layers,
           });
+        });
       } else if (requiresQuery(sourceType)) {
-        SupersetClient.getInstance()
-          .get({ endpoint: '/superset/user_slices' })
-          .then(({ json }) =>
-            this.setState({
-              isLoadingOptions: false,
-              valueOptions: json
-                .filter(x => getSupportedSourceTypes(annotationType).find(v => v === x.viz_type))
-                .map(x => ({ value: x.id, label: x.title, slice: x })),
-            }),
-          );
+        SupersetClient.get({ endpoint: '/superset/user_slices' }).then(({ json }) =>
+          this.setState({
+            isLoadingOptions: false,
+            valueOptions: json
+              .filter(x => getSupportedSourceTypes(annotationType).find(v => v === x.viz_type))
+              .map(x => ({ value: x.id, label: x.title, slice: x })),
+          }),
+        );
       } else {
         this.setState({
           isLoadingOptions: false,

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, Collapse, Label, OverlayTrigger, Row, Tooltip, Well } from 'react-bootstrap';
-import { SupersetClient } from '../../../packages/core/src';
+import SupersetClient from '../../../packages/core/src';
 
 import ControlHeader from '../ControlHeader';
 import { t } from '../../../locales';
@@ -47,8 +47,7 @@ class DatasourceControl extends React.PureComponent {
       this.searchRef.focus();
     }
     if (!this.state.datasources) {
-      SupersetClient.getInstance()
-        .get({ endpoint: '/superset/datasources/' })
+      SupersetClient.get({ endpoint: '/superset/datasources/' })
         .then(({ json }) => {
           const datasources = json.map(ds => ({
             rawName: ds.name,

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -1,8 +1,7 @@
-/* eslint no-undef: 2 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, Collapse, Label, OverlayTrigger, Row, Tooltip, Well } from 'react-bootstrap';
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+import { SupersetClient } from '../../../packages/core/src';
 
 import ControlHeader from '../ControlHeader';
 import { t } from '../../../locales';

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, Collapse, Label, OverlayTrigger, Row, Tooltip, Well } from 'react-bootstrap';
-import SupersetClient from '../../../packages/core/src';
+import { SupersetClient } from '../../../packages/core/src';
 
 import ControlHeader from '../ControlHeader';
 import { t } from '../../../locales';

--- a/superset/assets/src/explore/index.jsx
+++ b/superset/assets/src/explore/index.jsx
@@ -56,7 +56,7 @@ const initState = {
       chartUpdateStartTime: now(),
       latestQueryFormData: getFormDataFromControls(controls),
       sliceFormData,
-      queryRequest: null,
+      queryController: null,
       queryResponse: null,
       triggerQuery: true,
       lastRendered: 0,

--- a/superset/assets/src/logger.js
+++ b/superset/assets/src/logger.js
@@ -1,6 +1,5 @@
-/* global window */
-/* eslint no-undef: 'error', no-console: 0 */
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+/* eslint no-console: 0 */
+import { SupersetClient } from './packages/core/src';
 
 // This creates an association between an eventName and the ActionLog instance so that
 // Logger.append calls do not have to know about the appropriate ActionLog instance

--- a/superset/assets/src/logger.js
+++ b/superset/assets/src/logger.js
@@ -1,5 +1,5 @@
 /* eslint no-console: 0 */
-import SupersetClient from './packages/core/src';
+import { SupersetClient } from './packages/core/src';
 
 // This creates an association between an eventName and the ActionLog instance so that
 // Logger.append calls do not have to know about the appropriate ActionLog instance

--- a/superset/assets/src/logger.js
+++ b/superset/assets/src/logger.js
@@ -1,6 +1,6 @@
-/* eslint no-console: 0 */
-
-import $ from 'jquery';
+/* global window */
+/* eslint no-undef: 'error', no-console: 0 */
+import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
 
 // This creates an association between an eventName and the ActionLog instance so that
 // Logger.append calls do not have to know about the appropriate ActionLog instance
@@ -41,13 +41,13 @@ export const Logger = {
 
   send(log) {
     const { impressionId, source, sourceId, events } = log;
-    let url = '/superset/log/';
+    let endpoint = '/superset/log/?explode=events';
 
     // backend logs treat these request params as first-class citizens
     if (source === 'dashboard') {
-      url += `?dashboard_id=${sourceId}`;
+      endpoint += `&dashboard_id=${sourceId}`;
     } else if (source === 'slice') {
-      url += `?slice_id=${sourceId}`;
+      endpoint += `&slice_id=${sourceId}`;
     }
 
     const eventData = [];
@@ -63,14 +63,9 @@ export const Logger = {
       });
     }
 
-    $.ajax({
-      url,
-      method: 'POST',
-      dataType: 'json',
-      data: {
-        explode: 'events',
-        events: JSON.stringify(eventData),
-      },
+    SupersetClient.getInstance().post({
+      endpoint,
+      postPayload: { events: eventData },
     });
 
     // flush events for this logger

--- a/superset/assets/src/logger.js
+++ b/superset/assets/src/logger.js
@@ -1,5 +1,5 @@
 /* eslint no-console: 0 */
-import { SupersetClient } from './packages/core/src';
+import SupersetClient from './packages/core/src';
 
 // This creates an association between an eventName and the ActionLog instance so that
 // Logger.append calls do not have to know about the appropriate ActionLog instance
@@ -62,7 +62,7 @@ export const Logger = {
       });
     }
 
-    SupersetClient.getInstance().post({
+    SupersetClient.post({
       endpoint,
       postPayload: { events: eventData },
     });

--- a/superset/assets/src/modules/utils.js
+++ b/superset/assets/src/modules/utils.js
@@ -56,10 +56,12 @@ export function wrapSvgText(text, width, adjustedY) {
     const x = d3Text.attr('x');
     const y = d3Text.attr('y');
     const dy = parseFloat(d3Text.attr('dy'));
-    let tspan =
-      d3Text.text(null).append('tspan').attr('x', x)
-            .attr('y', y)
-            .attr('dy', dy + 'em');
+    let tspan = d3Text
+      .text(null)
+      .append('tspan')
+      .attr('x', x)
+      .attr('y', y)
+      .attr('dy', dy + 'em');
 
     let didWrap = false;
     for (let i = 0; i < words.length; i++) {
@@ -71,10 +73,12 @@ export function wrapSvgText(text, width, adjustedY) {
         // remove word that pushes over the limit
         tspan.text(line.join(' '));
         line = [word];
-        tspan =
-          d3Text.append('tspan').attr('x', x).attr('y', y)
-                .attr('dy', ++lineNumber * lineHeight + dy + 'em')
-                .text(word);
+        tspan = d3Text
+          .append('tspan')
+          .attr('x', x)
+          .attr('y', y)
+          .attr('dy', ++lineNumber * lineHeight + dy + 'em')
+          .text(word);
         didWrap = true;
       }
     }
@@ -107,16 +111,16 @@ export function showModal(options) {
   $(options.modalSelector).modal('show');
 }
 
-
 function showApiMessage(resp) {
   const template =
     '<div class="alert"> ' +
     '<button type="button" class="close" ' +
     'data-dismiss="alert">\xD7</button> </div>';
   const severity = resp.severity || 'info';
-  $(template).addClass('alert-' + severity)
-             .append(resp.message)
-             .appendTo($('#alert-container'));
+  $(template)
+    .addClass('alert-' + severity)
+    .append(resp.message)
+    .appendTo($('#alert-container'));
 }
 
 export function toggleCheckbox(apiUrlPrefix, selector) {
@@ -137,8 +141,10 @@ export const fixDataTableBodyHeight = function ($tableDom, height) {
   const filterHeight = $tableDom.find('.dataTables_filter').height() || 0;
   const pageLengthHeight = $tableDom.find('.dataTables_length').height() || 0;
   const paginationHeight = $tableDom.find('.dataTables_paginate').height() || 0;
-  const controlsHeight = (pageLengthHeight > filterHeight) ? pageLengthHeight : filterHeight;
-  $tableDom.find('.dataTables_scrollBody').css('max-height', height - headHeight - controlsHeight - paginationHeight);
+  const controlsHeight = pageLengthHeight > filterHeight ? pageLengthHeight : filterHeight;
+  $tableDom
+    .find('.dataTables_scrollBody')
+    .css('max-height', height - headHeight - controlsHeight - paginationHeight);
 };
 
 export function d3format(format, number) {
@@ -181,25 +187,25 @@ export function formatSelectOptionsForRange(start, end) {
 }
 
 export function formatSelectOptions(options) {
-  return options.map(opt =>
-     [opt, opt.toString()],
-  );
+  return options.map(opt => [opt, opt.toString()]);
 }
 
 export function slugify(string) {
   // slugify('My Neat Label! '); returns 'my-neat-label'
   return string
-          .toString()
-          .toLowerCase()
-          .trim()
-          .replace(/[\s\W-]+/g, '-') // replace spaces, non-word chars, w/ a single dash (-)
-          .replace(/-$/, ''); // remove last floating dash
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/[\s\W-]+/g, '-') // replace spaces, non-word chars, w/ a single dash (-)
+    .replace(/-$/, ''); // remove last floating dash
 }
 
 export function getAjaxErrorMsg(error) {
-  const respJSON = error.responseJSON;
-  return (respJSON && respJSON.error) ? respJSON.error :
-          error.responseText;
+  if (error && error.responseJSON) {
+    return respJSON && respJSON.error ? respJSON.error : error.responseText;
+  }
+
+  return error && error.error ? error.error : error;
 }
 
 export function getDatasourceParameter(datasourceId, datasourceType) {
@@ -212,17 +218,19 @@ export function customizeToolTip(chart, xAxisFormatter, yAxisFormatters) {
     const tooltipTitle = xAxisFormatter(d.value);
     let tooltip = '';
 
-    tooltip += "<table><thead><tr><td colspan='3'>"
-      + `<strong class='x-value'>${tooltipTitle}</strong>`
-      + '</td></tr></thead><tbody>';
+    tooltip +=
+      "<table><thead><tr><td colspan='3'>" +
+      `<strong class='x-value'>${tooltipTitle}</strong>` +
+      '</td></tr></thead><tbody>';
 
     d.series.forEach((series, i) => {
       const yAxisFormatter = yAxisFormatters[i];
       const value = yAxisFormatter(series.value);
-      tooltip += "<tr><td class='legend-color-guide'>"
-        + `<div style="background-color: ${series.color};"></div></td>`
-        + `<td class='key'>${series.key}</td>`
-        + `<td class='value'>${value}</td></tr>`;
+      tooltip +=
+        "<tr><td class='legend-color-guide'>" +
+        `<div style="background-color: ${series.color};"></div></td>` +
+        `<td class='key'>${series.key}</td>` +
+        `<td class='value'>${value}</td></tr>`;
     });
 
     tooltip += '</tbody></table>';

--- a/superset/assets/src/packages/core/README.md
+++ b/superset/assets/src/packages/core/README.md
@@ -1,0 +1,21 @@
+## @superset/core
+
+### SupersetClient
+
+Example usage
+
+Configuration
+
+const { protocol = 'http', host = '', headers = {}, mode = 'same-origin', timeout, signal } = config;
+
+- timeout can be per request, or globally
+- can cancel requests via AbortController, queryRequest => 'queryController' which has abort method
+- once init is called, csrf token will be fetched and all other reuquests will be queued after that response
+
+@TODO should i18n be included in core? useful for error messages, or supersetclient could import i18n ...
+
+test
+
+- async/sync ajax (for document.execCommand('copy'))
+- copy text (sync ajax based)
+- not sure how to test the link

--- a/superset/assets/src/packages/core/src/SupersetClient.js
+++ b/superset/assets/src/packages/core/src/SupersetClient.js
@@ -44,14 +44,14 @@ export default class SupersetClient {
         }
 
         if (!this.csrfToken) {
-          return this.ensureAuth();
+          return Promise.reject({ error: 'Failed to fetch CSRF token' });
         }
 
         this.requestingCsrf = false;
 
         return response;
       })
-      .catch(error => Promise.reject(new Error(error)));
+      .catch(error => Promise.reject(error));
   }
 
   getUrlFromEndpoint(endpoint) {
@@ -113,36 +113,6 @@ export default class SupersetClient {
         timeout: timeout || this.timeout,
         signal,
         stringify,
-      }),
-    );
-  }
-
-  put({ url, endpoint, headers, body, postPayload, timeout, signal, stringify }) {
-    return this.ensureAuth().then(() =>
-      callApi({
-        method: 'PUT',
-        url: url || this.getUrlFromEndpoint(endpoint),
-        headers: { ...this.headers, ...headers },
-        body,
-        postPayload,
-        stringify,
-        mode: this.mode,
-        timeout: timeout || this.timeout,
-        signal,
-      }),
-    );
-  }
-
-  destroy({ url, endpoint, headers, body, timeout, signal }) {
-    return this.ensureAuth().then(() =>
-      callApi({
-        method: 'DELETE',
-        url: url || this.getUrlFromEndpoint(endpoint),
-        headers: { ...this.headers, ...headers },
-        body,
-        mode: this.mode,
-        timeout: timeout || this.timeout,
-        signal,
       }),
     );
   }

--- a/superset/assets/src/packages/core/src/SupersetClient.js
+++ b/superset/assets/src/packages/core/src/SupersetClient.js
@@ -1,0 +1,160 @@
+import callApi from './callApi';
+
+export default class SupersetClient {
+  constructor(config) {
+    const { protocol = 'http', host = '', headers = {}, mode = 'same-origin', timeout } = config;
+
+    this.headers = headers;
+    this.host = host.slice(-1) === '/' ? host.slice(0, -1) : host; // no backslash
+    this.mode = mode;
+    this.timeout = timeout;
+    this.protocol = protocol;
+    this.csrfToken = null;
+    this.didAuthSuccessfully = false;
+    this.requestingCsrf = false;
+  }
+
+  authorized() {
+    return this.didAuthSuccessfully;
+  }
+
+  init() {
+    return this.getCSRFToken();
+  }
+
+  getCSRFToken() {
+    this.requestingCsrf = true;
+
+    // If we can request this resource successfully, it means that the user has
+    // authenticated. If not we throw an error prompting to authenticate.
+    return callApi({
+      url: this.getUrlFromEndpoint('superset/csrf_token/'),
+      method: 'GET',
+      headers: {
+        ...this.headers,
+      },
+      mode: this.mode,
+      timeout: this.timeout,
+    })
+      .then((response) => {
+        if (response.json) {
+          this.csrfToken = response.json.csrf_token;
+          this.headers = { ...this.headers, 'X-CSRFToken': this.csrfToken };
+          this.didAuthSuccessfully = !!this.csrfToken;
+        }
+
+        if (!this.csrfToken) {
+          return this.ensureAuth();
+        }
+
+        this.requestingCsrf = false;
+
+        return response;
+      })
+      .catch(error => Promise.reject(new Error(error)));
+  }
+
+  getUrlFromEndpoint(endpoint) {
+    return `${this.protocol}://${this.host}/${endpoint[0] === '/' ? endpoint.slice(1) : endpoint}`;
+  }
+
+  getUnauthorizedError() {
+    return {
+      error: `No CSRF token, ensure you called client.init() or try logging into Superset instance at ${
+        this.host
+      }/login`,
+    };
+  }
+
+  ensureAuth() {
+    return new Promise((resolve, reject) => {
+      if (this.didAuthSuccessfully) {
+        return resolve();
+      } else if (this.requestingCsrf) {
+        const waitForCSRF = () => {
+          if (!this.requestingCsrf && this.didAuthSuccessfully) {
+            return resolve();
+          } else if (!this.requestingCsrf && !this.didAuthSuccessfully) {
+            return reject(this.getUnauthorizedError());
+          }
+          setTimeout(waitForCSRF, 30);
+          return null;
+        };
+        return waitForCSRF();
+      }
+
+      return reject(this.getUnauthorizedError());
+    });
+  }
+
+  get({ url, endpoint, headers, body, timeout, signal }) {
+    return this.ensureAuth().then(() =>
+      callApi({
+        method: 'GET',
+        url: url || this.getUrlFromEndpoint(endpoint),
+        headers: { ...this.headers, ...headers },
+        body,
+        mode: this.mode,
+        timeout: timeout || this.timeout,
+        signal,
+      }),
+    );
+  }
+
+  post({ url, body, endpoint, headers, postPayload, timeout, signal, stringify }) {
+    return this.ensureAuth().then(() =>
+      callApi({
+        method: 'POST',
+        url: url || this.getUrlFromEndpoint(endpoint),
+        headers: { ...this.headers, ...headers },
+        body,
+        postPayload,
+        mode: this.mode,
+        timeout: timeout || this.timeout,
+        signal,
+        stringify,
+      }),
+    );
+  }
+
+  put({ url, endpoint, headers, body, postPayload, timeout, signal, stringify }) {
+    return this.ensureAuth().then(() =>
+      callApi({
+        method: 'PUT',
+        url: url || this.getUrlFromEndpoint(endpoint),
+        headers: { ...this.headers, ...headers },
+        body,
+        postPayload,
+        stringify,
+        mode: this.mode,
+        timeout: timeout || this.timeout,
+        signal,
+      }),
+    );
+  }
+
+  destroy({ url, endpoint, headers, body, timeout, signal }) {
+    return this.ensureAuth().then(() =>
+      callApi({
+        method: 'DELETE',
+        url: url || this.getUrlFromEndpoint(endpoint),
+        headers: { ...this.headers, ...headers },
+        body,
+        mode: this.mode,
+        timeout: timeout || this.timeout,
+        signal,
+      }),
+    );
+  }
+}
+
+// enforce a singleton
+let client;
+
+SupersetClient.getInstance = function getInstance(config = {}) {
+  if (!client) {
+    client = new SupersetClient(config || {});
+  }
+
+  return client;
+};

--- a/superset/assets/src/packages/core/src/callApi.js
+++ b/superset/assets/src/packages/core/src/callApi.js
@@ -1,6 +1,9 @@
+/* global FormData, fetch */
 import 'whatwg-fetch';
+import 'abortcontroller-polyfill';
+import 'url-search-params-polyfill';
 
-const DEFAULT_HEADERS = {}; // { 'Content-Type': 'application/json' };
+const DEFAULT_HEADERS = {};
 
 // This function fetches an API response and returns the corresponding json
 export function callApi({
@@ -29,9 +32,11 @@ export function callApi({
       }
     });
 
+    // console.log(formData);
+
     request = {
       ...request,
-      body: new URLSearchParams(formData), // @TODO polyfill
+      body: formData, // new URLSearchParams(formData),
     };
   }
 
@@ -58,7 +63,7 @@ export function callApi({
         }
 
         return Promise.reject({
-          error: error.error || error.message || 'An error occurred', // @TODO how to use t()?
+          error: error.error || error.message || 'An error occurred',
           status: error.status || error.code,
           statusText: error.statusText || error.name,
           link: error.link,
@@ -68,7 +73,7 @@ export function callApi({
     .then(({ response, json, text }) => {
       if (!response.ok) {
         return Promise.reject({
-          error: (json && json.error) || text || 'An error occurred', // @TODO how to use t()?
+          error: (json && json.error) || text || 'An error occurred',
           status: response.status,
           statusText: response.statusText,
         });
@@ -86,7 +91,7 @@ export function callApi({
 // We pass the timeoutId to callApi so that it can clear it
 export default function callApiWithTimeout({ timeout, ...rest }) {
   let timeoutId;
-
+  console.log('callapi', rest.url);
   return Promise.race([
     callApi({ ...rest, timeoutId }),
     new Promise((_, reject) => {

--- a/superset/assets/src/packages/core/src/callApi.js
+++ b/superset/assets/src/packages/core/src/callApi.js
@@ -23,7 +23,10 @@ export function callApi({
   if (method === 'POST' && typeof postPayload === 'object') {
     const formData = new FormData();
     Object.keys(postPayload).forEach((key) => {
-      formData.append(key, stringify ? JSON.stringify(postPayload[key]) : postPayload[key]);
+      const value = postPayload[key];
+      if (typeof value !== 'undefined') {
+        formData.append(key, stringify ? JSON.stringify(postPayload[key]) : postPayload[key]);
+      }
     });
 
     request = {

--- a/superset/assets/src/packages/core/src/callApi.js
+++ b/superset/assets/src/packages/core/src/callApi.js
@@ -11,7 +11,7 @@ export function callApi({
   method = 'GET', // GET, POST, PUT, DELETE
   mode = 'same-origin', // no-cors, cors, same-origin
   cache = 'default', // default, no-cache, reload, force-cache, only-if-cached
-  credentials = 'include', // include, same-origin, omit
+  credentials = 'same-origin', // include, same-origin, omit
   headers: partialHeaders,
   body,
   postPayload,

--- a/superset/assets/src/packages/core/src/callApi.js
+++ b/superset/assets/src/packages/core/src/callApi.js
@@ -1,0 +1,102 @@
+import 'whatwg-fetch';
+
+const DEFAULT_HEADERS = {}; // { 'Content-Type': 'application/json' };
+
+// This function fetches an API response and returns the corresponding json
+export function callApi({
+  url,
+  method = 'GET', // GET, POST, PUT, DELETE
+  mode = 'same-origin', // no-cors, cors, same-origin
+  cache = 'default', // default, no-cache, reload, force-cache, only-if-cached
+  credentials = 'include', // include, same-origin, omit
+  headers: partialHeaders,
+  body,
+  postPayload,
+  stringify = true,
+  redirect = 'follow', // manual, follow, error
+  timeoutId,
+  signal, // used for aborting
+}) {
+  const headers = { ...DEFAULT_HEADERS, ...partialHeaders };
+  let request = { method, mode, cache, credentials, redirect, headers, body, signal };
+
+  if (method === 'POST' && typeof postPayload === 'object') {
+    const formData = new FormData();
+    Object.keys(postPayload).forEach((key) => {
+      formData.append(key, stringify ? JSON.stringify(postPayload[key]) : postPayload[key]);
+    });
+
+    request = {
+      ...request,
+      body: new URLSearchParams(formData), // @TODO polyfill
+    };
+  }
+
+  return fetch(url, request)
+    .then(
+      (response) => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
+        return response
+          .clone()
+          .json() // first try to parse as json, fall back to text
+          .catch(() => /* jsonParseError */ response.text().then(textPayload => ({ textPayload })))
+          .then(json => ({
+            response,
+            text: json.textPayload,
+            json: json.textPayload ? null : json,
+          }));
+      },
+      (error) => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
+        return Promise.reject({
+          error: error.error || error.message || 'An error occurred', // @TODO how to use t()?
+          status: error.status || error.code,
+          statusText: error.statusText || error.name,
+          link: error.link,
+        });
+      },
+    )
+    .then(({ response, json, text }) => {
+      if (!response.ok) {
+        return Promise.reject({
+          error: (json && json.error) || text || 'An error occurred', // @TODO how to use t()?
+          status: response.status,
+          statusText: response.statusText,
+        });
+      }
+
+      if (typeof text !== 'undefined') {
+        return { response, text };
+      }
+
+      return { response, json };
+    });
+}
+
+// Fetch does not support timeout natively, so we add a layer with it.
+// We pass the timeoutId to callApi so that it can clear it
+export default function callApiWithTimeout({ timeout, ...rest }) {
+  let timeoutId;
+
+  return Promise.race([
+    callApi({ ...rest, timeoutId }),
+    new Promise((_, reject) => {
+      if (typeof timeout === 'number') {
+        timeoutId = setTimeout(
+          () =>
+            reject({
+              error: 'Request timed out',
+              statusText: 'timeout',
+            }),
+          timeout,
+        );
+      }
+    }),
+  ]);
+}

--- a/superset/assets/src/packages/core/src/callApi.js
+++ b/superset/assets/src/packages/core/src/callApi.js
@@ -32,8 +32,6 @@ export function callApi({
       }
     });
 
-    // console.log(formData);
-
     request = {
       ...request,
       body: formData, // new URLSearchParams(formData),
@@ -91,7 +89,7 @@ export function callApi({
 // We pass the timeoutId to callApi so that it can clear it
 export default function callApiWithTimeout({ timeout, ...rest }) {
   let timeoutId;
-  console.log('callapi', rest.url);
+
   return Promise.race([
     callApi({ ...rest, timeoutId }),
     new Promise((_, reject) => {

--- a/superset/assets/src/packages/core/src/index.js
+++ b/superset/assets/src/packages/core/src/index.js
@@ -1,0 +1,2 @@
+export { default as callApi } from './callApi';
+export { default as SupersetClient } from './SupersetClient';

--- a/superset/assets/src/packages/core/src/index.js
+++ b/superset/assets/src/packages/core/src/index.js
@@ -1,4 +1,2 @@
-import SupersetClient from './SupersetClient';
-
 export { default as callApi } from './callApi';
-export default SupersetClient;
+export { default as SupersetClient } from './SupersetClient';

--- a/superset/assets/src/packages/core/src/index.js
+++ b/superset/assets/src/packages/core/src/index.js
@@ -1,2 +1,4 @@
+import SupersetClient from './SupersetClient';
+
 export { default as callApi } from './callApi';
-export { default as SupersetClient } from './SupersetClient';
+export default SupersetClient;

--- a/superset/assets/src/packages/core/tests/SupersetClient_spec.js
+++ b/superset/assets/src/packages/core/tests/SupersetClient_spec.js
@@ -1,0 +1,300 @@
+/* eslint import/no-extraneous-dependencies: 0 */
+import { it, describe, before, after, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import fetchMock from 'fetch-mock';
+
+import PublicAPI, { SupersetClient } from '../src/SupersetClient';
+
+const LOGIN_GLOB = 'glob:*superset/csrf_token/*';
+
+describe('SupersetClient', () => {
+  before(() => {
+    // clear the base config for Superset tests
+    PublicAPI.reset();
+  });
+
+  afterEach(() => {
+    PublicAPI.reset();
+  });
+
+  after(() => {
+    // this is the base config for Superset tests, remove when moved to separate package
+    fetchMock.get('glob:*superset/csrf_token/*', { csrf_token: '1234' }, { overwriteRoutes: true });
+    PublicAPI.configure({ protocol: 'http', host: 'localhost' })
+      .init()
+      .then(() => fetchMock.reset());
+  });
+
+  describe('API', () => {
+    it('exposes reset, configure, init, get, post, isAuthenticated, and reAuthenticate methods', () => {
+      expect(typeof PublicAPI.configure).to.equal('function');
+      expect(typeof PublicAPI.init).to.equal('function');
+      expect(typeof PublicAPI.get).to.equal('function');
+      expect(typeof PublicAPI.post).to.equal('function');
+      expect(typeof PublicAPI.isAuthenticated).to.equal('function');
+      expect(typeof PublicAPI.reAuthenticate).to.equal('function');
+      expect(typeof PublicAPI.reset).to.equal('function');
+    });
+
+    it('throws if you call init, get, post, isAuthenticated, or reAuthenticate before configure', () => {
+      expect(PublicAPI.init).to.throw();
+      expect(PublicAPI.get).to.throw();
+      expect(PublicAPI.post).to.throw();
+      expect(PublicAPI.isAuthenticated).to.throw();
+      expect(PublicAPI.reAuthenticate).to.throw();
+
+      expect(PublicAPI.configure).to.not.throw();
+    });
+
+    // this also tests that the ^above doesn't throw if configure is called appropriately
+    it('calls appropriate SupersetClient methods when configured', () => {
+      const initSpy = sinon.stub(SupersetClient.prototype, 'init');
+      const getSpy = sinon.stub(SupersetClient.prototype, 'get');
+      const postSpy = sinon.stub(SupersetClient.prototype, 'post');
+      const authenticatedSpy = sinon.stub(SupersetClient.prototype, 'isAuthenticated');
+      const csrfSpy = sinon.stub(SupersetClient.prototype, 'getCSRFToken');
+
+      PublicAPI.configure({});
+      PublicAPI.init();
+      PublicAPI.get({});
+      PublicAPI.post({});
+      PublicAPI.isAuthenticated();
+      PublicAPI.reAuthenticate({});
+
+      expect(initSpy.callCount).to.equal(1);
+      expect(getSpy.callCount).to.equal(1);
+      expect(postSpy.callCount).to.equal(1);
+      expect(authenticatedSpy.callCount).to.equal(1);
+      expect(csrfSpy.callCount).to.equal(1); // from reAuthenticate()
+
+      initSpy.restore();
+      getSpy.restore();
+      postSpy.restore();
+      authenticatedSpy.restore();
+      csrfSpy.restore();
+    });
+  });
+
+  describe('SupersetClient', () => {
+    describe('CSRF', () => {
+      afterEach(fetchMock.reset);
+
+      it('calls superset/csrf_token/ upon initialization', (done) => {
+        const successSpy = sinon.spy();
+        const errorSpy = sinon.spy();
+        const client = new SupersetClient({});
+        client.init().then(successSpy, errorSpy);
+
+        setTimeout(() => {
+          expect(fetchMock.calls(LOGIN_GLOB)).to.have.lengthOf(1);
+          expect(successSpy.callCount).to.equal(1);
+          expect(errorSpy.callCount).to.equal(0);
+          done();
+        });
+      });
+
+      it('isAuthenticated() returns true if there is a token and false if not', (done) => {
+        const client = new SupersetClient({});
+        expect(client.isAuthenticated()).to.equal(false);
+        client.init();
+        setTimeout(() => {
+          expect(client.isAuthenticated()).to.equal(true);
+          done();
+        });
+      });
+
+      it('throws if superset/csrf_token/ does not return a token', (done) => {
+        fetchMock.get(LOGIN_GLOB, () => Promise.reject({ status: 403 }), {
+          overwriteRoutes: true,
+        });
+
+        const successSpy = sinon.spy();
+        const errorSpy = sinon.spy();
+        const client = new SupersetClient({});
+        client.init().then(successSpy, errorSpy);
+
+        setTimeout(() => {
+          expect(successSpy.callCount).to.equal(0);
+          expect(errorSpy.callCount).to.equal(1);
+
+          // reset
+          fetchMock.get(
+            LOGIN_GLOB,
+            { csrf_token: 1234 },
+            {
+              overwriteRoutes: true,
+            },
+          );
+          done();
+        });
+      });
+    });
+
+    describe('requests', () => {
+      afterEach(fetchMock.reset);
+      const protocol = 'PROTOCOL';
+      const host = 'HOST';
+      const mockGetEndpoint = '/get/url';
+      const mockPostEndpoint = '/post/url';
+      const mockGetUrl = `${protocol}://${host}${mockGetEndpoint}`;
+      const mockPostUrl = `${protocol}://${host}${mockPostEndpoint}`;
+
+      fetchMock.get(mockGetUrl, 'Ok');
+      fetchMock.post(mockPostUrl, 'Ok');
+
+      it('checks for authentication before every get and post request', (done) => {
+        const authSpy = sinon.stub(SupersetClient.prototype, 'ensureAuth').resolves();
+        const client = new SupersetClient({ protocol, host });
+        client.init();
+        client.get({ url: mockGetUrl });
+        client.post({ url: mockPostUrl });
+
+        setTimeout(() => {
+          expect(fetchMock.calls(mockGetUrl)).to.have.lengthOf(1);
+          expect(fetchMock.calls(mockPostUrl)).to.have.lengthOf(1);
+          expect(authSpy.callCount).to.equal(2);
+          done();
+        });
+      });
+
+      it('sets protocol, host, headers, mode, and credentials from config', (done) => {
+        const clientConfig = {
+          host,
+          protocol,
+          mode: 'a la mode',
+          credentials: 'mad cred',
+          headers: { my: 'header' },
+        };
+
+        const client = new SupersetClient(clientConfig);
+        client.init();
+        client.get({ url: mockGetUrl });
+
+        setTimeout(() => {
+          const fetchRequest = fetchMock.calls(mockGetUrl)[0][1];
+          expect(fetchRequest.mode).to.equal(clientConfig.mode);
+          expect(fetchRequest.credentials).to.equal(clientConfig.credentials);
+          expect(fetchRequest.headers).to.deep.equal(clientConfig.headers);
+          done();
+        });
+      });
+
+      describe('GET', () => {
+        it('makes a request using url or endpoint', (done) => {
+          const client = new SupersetClient({ protocol, host });
+          client.init();
+          client.get({ url: mockGetUrl });
+          client.get({ endpoint: mockGetEndpoint });
+          setTimeout(() => {
+            expect(fetchMock.calls(mockGetUrl)).to.have.lengthOf(2);
+            done();
+          });
+        });
+
+        it('allows overriding host, headers, mode, and credentials per-request', (done) => {
+          const clientConfig = {
+            host,
+            protocol,
+            mode: 'a la mode',
+            credentials: 'mad cred',
+            headers: { my: 'header' },
+          };
+
+          const overrideConfig = {
+            host: 'override_host',
+            mode: 'override mode',
+            credentials: 'override credentials',
+            headers: { my: 'override', another: 'header' },
+          };
+
+          const client = new SupersetClient(clientConfig);
+          client.init();
+          client.get({ url: mockGetUrl, ...overrideConfig });
+
+          setTimeout(() => {
+            const fetchRequest = fetchMock.calls(mockGetUrl)[0][1];
+            expect(fetchRequest.mode).to.equal(overrideConfig.mode);
+            expect(fetchRequest.credentials).to.equal(overrideConfig.credentials);
+            expect(fetchRequest.headers).to.deep.equal(overrideConfig.headers);
+            done();
+          });
+        });
+      });
+
+      describe('POST', () => {
+        it('makes a request using url or endpoint', (done) => {
+          const client = new SupersetClient({ protocol, host });
+          client.init();
+          client.post({ url: mockPostUrl });
+          client.post({ endpoint: mockPostEndpoint });
+          setTimeout(() => {
+            expect(fetchMock.calls(mockPostUrl)).to.have.lengthOf(2);
+            done();
+          });
+        });
+
+        it('allows overriding host, headers, mode, and credentials per-request', (done) => {
+          const clientConfig = {
+            host,
+            protocol,
+            mode: 'a la mode',
+            credentials: 'mad cred',
+            headers: { my: 'header' },
+          };
+
+          const overrideConfig = {
+            host: 'override_host',
+            mode: 'override mode',
+            credentials: 'override credentials',
+            headers: { my: 'override', another: 'header' },
+          };
+
+          const client = new SupersetClient(clientConfig);
+          client.init();
+          client.post({ url: mockPostUrl, ...overrideConfig });
+
+          setTimeout(() => {
+            const fetchRequest = fetchMock.calls(mockPostUrl)[0][1];
+            expect(fetchRequest.mode).to.equal(overrideConfig.mode);
+            expect(fetchRequest.credentials).to.equal(overrideConfig.credentials);
+            expect(fetchRequest.headers).to.deep.equal(overrideConfig.headers);
+            done();
+          });
+        });
+
+        it('passes postPayload key,values in the body', (done) => {
+          const postPayload = { number: 123, array: [1, 2, 3] };
+          const client = new SupersetClient({ protocol, host });
+          client.init();
+          client.post({ url: mockPostUrl, postPayload });
+          setTimeout(() => {
+            const formData = fetchMock.calls(mockPostUrl)[0][1].body;
+            expect(fetchMock.calls(mockPostUrl)).to.have.lengthOf(1);
+            Object.keys(postPayload).forEach((key) => {
+              expect(formData.get(key)).to.equal(JSON.stringify(postPayload[key]));
+            });
+
+            done();
+          });
+        });
+
+        it('respects the stringify parameter for postPayload key,values', (done) => {
+          const postPayload = { number: 123, array: [1, 2, 3] };
+          const client = new SupersetClient({ protocol, host });
+          client.init();
+          client.post({ url: mockPostUrl, postPayload, stringify: false });
+          setTimeout(() => {
+            const formData = fetchMock.calls(mockPostUrl)[0][1].body;
+            expect(fetchMock.calls(mockPostUrl)).to.have.lengthOf(1);
+            Object.keys(postPayload).forEach((key) => {
+              expect(formData.get(key)).to.equal(String(postPayload[key]));
+            });
+
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/superset/assets/src/packages/core/tests/callApi_spec.js
+++ b/superset/assets/src/packages/core/tests/callApi_spec.js
@@ -1,0 +1,248 @@
+/* eslint import/no-extraneous-dependencies: 0 */
+import { it, describe, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import fetchMock from 'fetch-mock';
+
+import { callApi } from '../src';
+
+describe('callApi', () => {
+  const mockGetUrl = '/mock/get/url';
+  const mockPostUrl = '/mock/post/url';
+  const mockGetPayload = { get: 'payload' };
+  const mockPostPayload = { post: 'payload' };
+  fetchMock.get(mockGetUrl, mockGetPayload);
+  fetchMock.post(mockPostUrl, mockPostPayload);
+
+  afterEach(fetchMock.reset);
+
+  describe('request config', () => {
+    it('calls the right url with the specified method', (done) => {
+      callApi({ url: mockGetUrl, method: 'GET' });
+      callApi({ url: mockPostUrl, method: 'POST' });
+
+      setTimeout(() => {
+        expect(fetchMock.calls(mockGetUrl)).to.have.lengthOf(1);
+        expect(fetchMock.calls(mockPostUrl)).to.have.lengthOf(1);
+        done();
+      });
+    });
+
+    it('passes along mode, cache, credentials, headers, body, signal, and redirect parameters in the request', (done) => {
+      const mockRequest = {
+        url: mockGetUrl,
+        mode: 'my-mode',
+        cache: 'cash money',
+        credentials: 'mad cred',
+        headers: {
+          custom: 'header',
+        },
+        redirect: 'no thanks',
+        signal: () => {},
+        body: 'BODY',
+      };
+
+      callApi(mockRequest);
+
+      setTimeout(() => {
+        const calls = fetchMock.calls(mockGetUrl);
+        const fetchParams = calls[0][1];
+        expect(calls).to.have.lengthOf(1);
+        expect(fetchParams.mode).to.equal(mockRequest.mode);
+        expect(fetchParams.cache).to.equal(mockRequest.cache);
+        expect(fetchParams.credentials).to.equal(mockRequest.credentials);
+        expect(fetchParams.headers).to.deep.equal(mockRequest.headers);
+        expect(fetchParams.redirect).to.equal(mockRequest.redirect);
+        expect(fetchParams.signal).to.equal(mockRequest.signal);
+        expect(fetchParams.body).to.equal(mockRequest.body);
+
+        done();
+      });
+    });
+  });
+
+  describe('POST requests', () => {
+    it('encodes key,value pairs from postPayload', (done) => {
+      const postPayload = { key: 'value', anotherKey: 1237 };
+      callApi({ url: mockPostUrl, method: 'POST', postPayload });
+
+      setTimeout(() => {
+        const calls = fetchMock.calls(mockPostUrl);
+        expect(calls).to.have.lengthOf(1);
+
+        const fetchParams = calls[0][1];
+        const { body } = fetchParams;
+
+        Object.keys(postPayload).forEach((key) => {
+          expect(body.get(key)).to.equal(JSON.stringify(postPayload[key]));
+        });
+
+        done();
+      });
+    });
+
+    // the reason for this is to omit strings like 'undefined' from making their way to the backend
+    it('omits key,value pairs from postPayload that have undefined values', (done) => {
+      const postPayload = { key: 'value', noValue: undefined };
+      callApi({ url: mockPostUrl, method: 'POST', postPayload });
+
+      setTimeout(() => {
+        const calls = fetchMock.calls(mockPostUrl);
+        expect(calls).to.have.lengthOf(1);
+
+        const fetchParams = calls[0][1];
+        const { body } = fetchParams;
+        expect(body.get('key')).to.equal(JSON.stringify(postPayload.key));
+        expect(body.get('noValue')).to.equal(null);
+
+        done();
+      });
+    });
+
+    it('respects the stringify flag in POST requests', (done) => {
+      const postPayload = {
+        string: 'value',
+        number: 1237,
+        array: [1, 2, 3],
+        object: { a: 'a', 1: 1 },
+        null: null,
+        emptyString: '',
+      };
+
+      callApi({ url: mockPostUrl, method: 'POST', postPayload });
+      callApi({ url: mockPostUrl, method: 'POST', postPayload, stringify: false });
+
+      setTimeout(() => {
+        const calls = fetchMock.calls(mockPostUrl);
+        expect(calls).to.have.lengthOf(2);
+
+        const stringified = calls[0][1].body;
+        const unstringified = calls[1][1].body;
+
+        Object.keys(postPayload).forEach((key) => {
+          expect(stringified.get(key)).to.equal(JSON.stringify(postPayload[key]));
+          expect(unstringified.get(key)).to.equal(String(postPayload[key]));
+        });
+
+        done();
+      });
+    });
+  });
+
+  describe('Promises', () => {
+    let promiseResolveSpy;
+    let promiseRejectSpy;
+
+    beforeEach(() => {
+      promiseResolveSpy = sinon.spy(Promise, 'resolve');
+      promiseRejectSpy = sinon.spy(Promise, 'reject');
+    });
+
+    afterEach(() => {
+      promiseResolveSpy.restore();
+      promiseRejectSpy.restore();
+    });
+
+    it('resolves to { json, response } if the request succeeds', (done) => {
+      callApi({ url: mockGetUrl, method: 'GET' });
+
+      setTimeout(() => {
+        expect(fetchMock.calls(mockGetUrl)).to.have.lengthOf(1);
+
+        // 1. fetch resolves
+        // 2. timeout promise (unresolved)
+        // 3. final resolve with json payload
+        expect(promiseResolveSpy.callCount).to.equal(3);
+        expect(promiseRejectSpy.callCount).to.equal(0);
+        const finalPromiseArgs = promiseResolveSpy.getCall(2).args[0];
+        expect(finalPromiseArgs).to.have.keys(['response', 'json']);
+        expect(finalPromiseArgs.json).to.deep.equal(mockGetPayload);
+
+        done();
+      });
+    });
+
+    it('resolves to { text, response } if the request succeeds with text response', (done) => {
+      const mockTextUrl = '/mock/text/url';
+      const mockTextResponse =
+        '<html><head></head><body>I could be a stack trace or something</body></html>';
+      fetchMock.get(mockTextUrl, mockTextResponse);
+
+      callApi({ url: mockTextUrl, method: 'GET' });
+
+      setTimeout(() => {
+        expect(fetchMock.calls(mockTextUrl)).to.have.lengthOf(1);
+
+        // 1. fetch resolves
+        // 2. timeout promise (unresolved)
+        // 3. (error) json parse fails => rejects
+        // 4. final resolve with text payload
+        expect(promiseResolveSpy.callCount).to.equal(3);
+        expect(promiseRejectSpy.callCount).to.equal(1);
+
+        const finalPromiseArgs = promiseResolveSpy.getCall(2).args[0];
+        expect(finalPromiseArgs).to.have.keys(['response', 'text']);
+        expect(finalPromiseArgs.text).to.deep.equal(mockTextResponse);
+
+        done();
+      });
+    });
+
+    it('rejects if the request throws', (done) => {
+      const mockErrorUrl = '/mock/error/url';
+      const mockResponse = { status: 500, statusText: 'Internal errorz!' };
+      fetchMock.get(mockErrorUrl, () => Promise.reject(mockResponse));
+
+      let thrownError;
+      callApi({ url: mockErrorUrl, method: 'GET' })
+        .then(() => {})
+        .catch((error) => {
+          thrownError = error;
+        });
+
+      setTimeout(() => {
+        expect(fetchMock.calls(mockErrorUrl)).to.have.lengthOf(1);
+
+        // 1. fetch resolves
+        // 2. timeout promise (unresolved)
+        // 3. reject above
+        // 3. rejects from fetch error
+        expect(promiseResolveSpy.callCount).to.equal(2);
+        expect(promiseRejectSpy.callCount).to.equal(2);
+
+        expect(thrownError.status).to.equal(mockResponse.status);
+        expect(thrownError.statusText).to.equal(mockResponse.statusText);
+
+        done();
+      });
+    });
+
+    it('rejects if the request exceeds the timeout passed', (done) => {
+      const mockTimeoutUrl = '/mock/timeout/url';
+      const unresolvingPromise = new Promise(() => {});
+
+      fetchMock.get(mockTimeoutUrl, () => unresolvingPromise);
+
+      let error;
+      callApi({ url: mockTimeoutUrl, method: 'GET', timeout: 0 })
+        .then(() => {})
+        .catch((timeoutError) => {
+          error = timeoutError;
+        });
+
+      setTimeout(() => {
+        expect(fetchMock.calls(mockTimeoutUrl)).to.have.lengthOf(1);
+
+        // 1. unresolved fetch
+        // 2. Promise.race resolves with timeout error, not seen in reject spy because it calls
+        //    reject not Promise.reject. We assert this via the error closure above.
+        expect(promiseResolveSpy.callCount).to.equal(2);
+        expect(promiseRejectSpy.callCount).to.equal(0);
+        expect(error).to.have.keys(['error', 'statusText']);
+        expect(error.statusText).to.equal('timeout');
+
+        done();
+      }, 10);
+    });
+  });
+});

--- a/superset/assets/src/reduxUtils.js
+++ b/superset/assets/src/reduxUtils.js
@@ -66,7 +66,7 @@ export function addToArr(state, arrKey, obj) {
 
 export function initEnhancer(persist = true) {
   let enhancer = persist ? compose(persistState()) : compose();
-  if (process.env.NODE_ENV === 'dev') {
+  if (process.env.NODE_ENV !== 'production') {
     /* eslint-disable-next-line no-underscore-dangle */
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
     enhancer = persist ? composeEnhancers(persistState()) : composeEnhancers();

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -1,5 +1,5 @@
 /* eslint global-require: 0 */
-import { SupersetClient } from '../packages/core/src';
+import SupersetClient from '../packages/core/src';
 
 const d3 = require('d3');
 
@@ -44,17 +44,15 @@ export function getParamFromQuery(query, param) {
 }
 
 export function storeQuery(query) {
-  return SupersetClient.getInstance()
-    .post({
-      endpoint: '/kv/store/',
-      postPayload: { data: query },
-    })
-    .then((response) => {
-      const baseUrl = window.location.origin + window.location.pathname;
-      const url = `${baseUrl}?id=${response.json.id}`;
+  return SupersetClient.post({
+    endpoint: '/kv/store/',
+    postPayload: { data: query },
+  }).then((response) => {
+    const baseUrl = window.location.origin + window.location.pathname;
+    const url = `${baseUrl}?id=${response.json.id}`;
 
-      return Promise.resolve(url);
-    });
+    return Promise.resolve(url);
+  });
 }
 
 export function getParamsFromUrl() {
@@ -70,12 +68,10 @@ export function getParamsFromUrl() {
 }
 
 export function getShortUrl(longUrl) {
-  return SupersetClient.getInstance()
-    .post({
-      endpoint: '/r/shortner/',
-      postPayload: { data: `/${longUrl}` }, // note: url should contain 2x '/' to redirect properly
-    })
-    .then(response => Promise.resolve(response.text));
+  return SupersetClient.post({
+    endpoint: '/r/shortner/',
+    postPayload: { data: `/${longUrl}` }, // note: url should contain 2x '/' to redirect properly
+  }).then(response => Promise.resolve(response.text));
 }
 
 export function supersetURL(rootUrl, getParams = {}) {

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -1,5 +1,5 @@
 /* eslint global-require: 0 */
-import SupersetClient from '../packages/core/src';
+import { SupersetClient } from '../packages/core/src';
 
 const d3 = require('d3');
 

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -1,7 +1,5 @@
-/* global window */
-
-/* eslint global-require: 0, no-undef: 'error' */
-import { SupersetClient } from '@superset/core'; // eslint-disable-line import/no-extraneous-dependencies
+/* eslint global-require: 0 */
+import { SupersetClient } from '../packages/core/src';
 
 const d3 = require('d3');
 

--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -39,9 +39,6 @@ const config = {
   },
   resolve: {
     extensions: ['.js', '.jsx'],
-    alias: {
-      '@superset/core': path.resolve(__dirname, './src/packages/core/src'),
-    },
   },
   module: {
     // uglyfying mapbox-gl results in undefined errors, see

--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -39,6 +39,9 @@ const config = {
   },
   resolve: {
     extensions: ['.js', '.jsx'],
+    alias: {
+      '@superset/core': path.resolve(__dirname, './src/packages/core/src'),
+    },
   },
   module: {
     // uglyfying mapbox-gl results in undefined errors, see

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -1833,6 +1833,15 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-plugin-webpack-alias@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-webpack-alias/-/babel-plugin-webpack-alias-2.1.2.tgz#05a1ba23c28595660fb6ea5736424fc596b4a247"
+  dependencies:
+    babel-types "^6.14.0"
+    find-up "^2.0.0"
+    lodash.some "^4.5.1"
+    lodash.template "^4.3.0"
+
 babel-polyfill@^6.23.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
@@ -2015,7 +2024,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.14.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -6366,6 +6375,10 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
+lodash._reinterpolate@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
+
 lodash._root@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
@@ -6470,9 +6483,22 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
 
-lodash.some@^4.4.0:
+lodash.some@^4.4.0, lodash.some@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash.template@^4.3.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
+    lodash.templatesettings "^4.0.0"
+
+lodash.templatesettings@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
 
 lodash.throttle@^4.1.1:
   version "4.1.1"

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -93,13 +93,13 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
-"@data-ui/event-flow@^0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@data-ui/event-flow/-/event-flow-0.0.54.tgz#bb03e1fd2b5634248655b8df9d3c6c38a747e65e"
+"@data-ui/event-flow@^0.0.62":
+  version "0.0.62"
+  resolved "https://registry.yarnpkg.com/@data-ui/event-flow/-/event-flow-0.0.62.tgz#bddbc8d0b37146a364110079f0d66b7e67fb2ca1"
   dependencies:
-    "@data-ui/forms" "0.0.50"
-    "@data-ui/radial-chart" "0.0.54"
-    "@data-ui/theme" "0.0.48"
+    "@data-ui/forms" "^0.0.61"
+    "@data-ui/radial-chart" "^0.0.62"
+    "@data-ui/theme" "^0.0.62"
     "@vx/axis" "0.0.140"
     "@vx/bounds" "0.0.140"
     "@vx/clip-path" "0.0.140"
@@ -126,24 +126,25 @@
     react-with-styles-interface-aphrodite "^1.2.0"
     recompose "^0.23.5"
 
-"@data-ui/forms@0.0.50":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@data-ui/forms/-/forms-0.0.50.tgz#c55a699ee4b7cf44ff263d30784299c38d939932"
+"@data-ui/forms@^0.0.61":
+  version "0.0.61"
+  resolved "https://registry.yarnpkg.com/@data-ui/forms/-/forms-0.0.61.tgz#6a6d8c6dfba4ba16fca5972ffab23ad5031560f7"
   dependencies:
     prop-types "^15.5.10"
     react-select "^1.0.0-rc.5"
 
-"@data-ui/radial-chart@0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@data-ui/radial-chart/-/radial-chart-0.0.54.tgz#0d28b07681d9b6027d9ac23b729241827d513001"
+"@data-ui/radial-chart@^0.0.62":
+  version "0.0.62"
+  resolved "https://registry.yarnpkg.com/@data-ui/radial-chart/-/radial-chart-0.0.62.tgz#49e50d7735fc23811769b663d3d9cb0b6b938056"
   dependencies:
-    "@data-ui/shared" "0.0.54"
-    "@data-ui/theme" "0.0.48"
+    "@data-ui/shared" "^0.0.62"
+    "@data-ui/theme" "^0.0.62"
     "@vx/event" "0.0.140"
     "@vx/group" "0.0.140"
     "@vx/scale" "0.0.140"
     "@vx/shape" "0.0.140"
     "@vx/tooltip" "0.0.140"
+    babel-runtime "^6.26.0"
     prop-types "^15.5.10"
 
 "@data-ui/shared@0.0.54":
@@ -163,6 +164,19 @@
   resolved "https://registry.yarnpkg.com/@data-ui/shared/-/shared-0.0.61.tgz#717a1a1f7bd606c0f51573e65b6acdda51a1252b"
   dependencies:
     "@data-ui/theme" "^0.0.61"
+    "@vx/event" "^0.0.165"
+    "@vx/group" "^0.0.165"
+    "@vx/shape" "^0.0.168"
+    "@vx/tooltip" "0.0.165"
+    babel-runtime "^6.26.0"
+    d3-array "^1.2.1"
+    prop-types "^15.5.10"
+
+"@data-ui/shared@^0.0.62":
+  version "0.0.62"
+  resolved "https://registry.yarnpkg.com/@data-ui/shared/-/shared-0.0.62.tgz#6d4e14e03ab37060e6f6afdd5f831df88cd3c5aa"
+  dependencies:
+    "@data-ui/theme" "^0.0.62"
     "@vx/event" "^0.0.165"
     "@vx/group" "^0.0.165"
     "@vx/shape" "^0.0.168"
@@ -202,6 +216,12 @@
 "@data-ui/theme@^0.0.61":
   version "0.0.61"
   resolved "https://registry.yarnpkg.com/@data-ui/theme/-/theme-0.0.61.tgz#2a792da6c384d08553d1794bdb16ce633bc02cbd"
+  dependencies:
+    babel-runtime "^6.26.0"
+
+"@data-ui/theme@^0.0.62":
+  version "0.0.62"
+  resolved "https://registry.yarnpkg.com/@data-ui/theme/-/theme-0.0.62.tgz#a7f50bb796fd6ea90171cb2c7f958f3bb24fe6d9"
   dependencies:
     babel-runtime "^6.26.0"
 
@@ -799,6 +819,10 @@ abbrev@1.0.x, abbrev@~1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
+abortcontroller-polyfill@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.1.9.tgz#9fefe359fda2e9e0932dc85e6106453ac393b2da"
+
 acorn-dynamic-import@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
@@ -1026,6 +1050,10 @@ array-differ@^1.0.0:
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
+array-find@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
 
 array-flatten@^2.1.0:
   version "2.1.1"
@@ -3733,6 +3761,14 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
+enhanced-resolve@~0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz#4d6e689b3725f86090927ccc86cd9f1635b89e2e"
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.2.0"
+    tapable "^0.1.8"
+
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
@@ -3885,6 +3921,21 @@ eslint-import-resolver-node@^0.3.1:
   dependencies:
     debug "^2.6.9"
     resolve "^1.5.0"
+
+eslint-import-resolver-webpack@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.10.1.tgz#4cbceed2c0c43e488a74775c30861e58e00fb290"
+  dependencies:
+    array-find "^1.0.0"
+    debug "^2.6.8"
+    enhanced-resolve "~0.9.0"
+    find-root "^1.1.0"
+    has "^1.0.1"
+    interpret "^1.0.0"
+    lodash "^4.17.4"
+    node-libs-browser "^1.0.0 || ^2.0.0"
+    resolve "^1.4.0"
+    semver "^5.3.0"
 
 eslint-module-utils@^2.2.0:
   version "2.2.0"
@@ -4312,6 +4363,10 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
 
 find-up@1.1.2, find-up@^1.0.0:
   version "1.1.2"
@@ -6683,6 +6738,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memory-fs@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -7028,7 +7087,7 @@ node-gyp@~3.4.0:
     tar "^2.0.0"
     which "1"
 
-node-libs-browser@^2.0.0:
+"node-libs-browser@^1.0.0 || ^2.0.0", node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
   dependencies:
@@ -9232,7 +9291,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.1.0, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.0, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -9980,6 +10039,10 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
+tapable@^0.1.8:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
+
 tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
@@ -10714,7 +10777,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.19"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -1051,10 +1051,6 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
-array-find@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
-
 array-flatten@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
@@ -1833,15 +1829,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-webpack-alias@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-webpack-alias/-/babel-plugin-webpack-alias-2.1.2.tgz#05a1ba23c28595660fb6ea5736424fc596b4a247"
-  dependencies:
-    babel-types "^6.14.0"
-    find-up "^2.0.0"
-    lodash.some "^4.5.1"
-    lodash.template "^4.3.0"
-
 babel-polyfill@^6.23.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
@@ -2024,7 +2011,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.14.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -3770,14 +3757,6 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
-enhanced-resolve@~0.9.0:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz#4d6e689b3725f86090927ccc86cd9f1635b89e2e"
-  dependencies:
-    graceful-fs "^4.1.2"
-    memory-fs "^0.2.0"
-    tapable "^0.1.8"
-
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
@@ -3930,21 +3909,6 @@ eslint-import-resolver-node@^0.3.1:
   dependencies:
     debug "^2.6.9"
     resolve "^1.5.0"
-
-eslint-import-resolver-webpack@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.10.1.tgz#4cbceed2c0c43e488a74775c30861e58e00fb290"
-  dependencies:
-    array-find "^1.0.0"
-    debug "^2.6.8"
-    enhanced-resolve "~0.9.0"
-    find-root "^1.1.0"
-    has "^1.0.1"
-    interpret "^1.0.0"
-    lodash "^4.17.4"
-    node-libs-browser "^1.0.0 || ^2.0.0"
-    resolve "^1.4.0"
-    semver "^5.3.0"
 
 eslint-module-utils@^2.2.0:
   version "2.2.0"
@@ -4308,6 +4272,14 @@ fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fetch-mock@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-6.5.2.tgz#b3842b305c13ea0f81c85919cfaa7de387adfa3e"
+  dependencies:
+    babel-polyfill "^6.26.0"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -4372,10 +4344,6 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
-
-find-root@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
 
 find-up@1.1.2, find-up@^1.0.0:
   version "1.1.2"
@@ -4477,6 +4445,10 @@ form-data@~2.3.1:
 format@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+
+formdata-polyfill@^3.0.11:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-3.0.11.tgz#c82b4b4bea3356c0a6752219e54ce1edb2a7fb5b"
 
 fraction.js@4.0.4:
   version "4.0.4"
@@ -4806,6 +4778,10 @@ glob-parent@^3.1.0:
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
 
 glob@5.x:
   version "5.0.15"
@@ -6375,10 +6351,6 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
-lodash._reinterpolate@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-
 lodash._root@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
@@ -6483,22 +6455,9 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
 
-lodash.some@^4.4.0, lodash.some@^4.5.1:
+lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
-
-lodash.template@^4.3.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
-  dependencies:
-    lodash._reinterpolate "~3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
-  dependencies:
-    lodash._reinterpolate "~3.0.0"
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -6763,10 +6722,6 @@ mem@^1.1.0:
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
-
-memory-fs@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -7113,7 +7068,7 @@ node-gyp@~3.4.0:
     tar "^2.0.0"
     which "1"
 
-"node-libs-browser@^1.0.0 || ^2.0.0", node-libs-browser@^2.0.0:
+node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
   dependencies:
@@ -7825,6 +7780,10 @@ path-to-regexp@^1.7.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -9317,7 +9276,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.1.0, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.0, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -10065,10 +10024,6 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tapable@^0.1.8:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
-
 tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
@@ -10507,6 +10462,10 @@ url-parse-lax@^3.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
   dependencies:
     prepend-http "^2.0.0"
+
+url-search-params-polyfill@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-4.0.1.tgz#4eda68a5689eda19aff2287e65d98d6fb5f6bc11"
 
 url-to-options@^1.0.1:
   version "1.0.1"

--- a/superset/config.py
+++ b/superset/config.py
@@ -189,8 +189,8 @@ CACHE_CONFIG = {'CACHE_TYPE': 'null'}
 TABLE_NAMES_CACHE_CONFIG = {'CACHE_TYPE': 'null'}
 
 # CORS Options
-ENABLE_CORS = False
-CORS_OPTIONS = {}
+ENABLE_CORS = True
+CORS_OPTIONS = { "resources": { "*": {"origins": "http://localhost:9001", "supports_credentials": True } }}
 
 # Allowed format types for upload on Database view
 # TODO: Add processing of other spreadsheet formats (xls, xlsx etc)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2377,7 +2377,7 @@ class Superset(BaseSupersetView):
         database_id = request.form.get('database_id')
         schema = request.form.get('schema') or None
         template_params = json.loads(
-            request.form.get('templateParams', '{}'))
+            request.form.get('templateParams') or '{}')
 
         session = db.session()
         mydb = session.query(models.Database).filter_by(id=database_id).first()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -710,15 +710,22 @@ class R(BaseSupersetView):
     def index(self, url_id):
         url = db.session.query(models.Url).filter_by(id=url_id).first()
         if url:
+            # return redirect(
+            #     '{scheme}://{request.headers[Host]}/{url}'.format(
+            #         scheme=request.scheme,
+            #         request=request,
+            #         url=url.url
+            #     )
+            # )
             return redirect('/' + url.url)
         else:
             flash('URL to nowhere...', 'danger')
             return redirect('/')
 
     @log_this
-    @expose('/shortner/', methods=['POST', 'GET'])
+    @expose('/shortner/', methods=['POST'])
     def shortner(self):
-        url = request.form.get('data')
+        url = json.loads(request.form.get('data'))
         obj = models.Url(url=url)
         db.session.add(obj)
         db.session.commit()
@@ -2370,13 +2377,13 @@ class Superset(BaseSupersetView):
         database_id = request.form.get('database_id')
         schema = request.form.get('schema') or None
         template_params = json.loads(
-            request.form.get('templateParams') or '{}')
+            request.form.get('templateParams', '{}'))
 
         session = db.session()
         mydb = session.query(models.Database).filter_by(id=database_id).first()
 
         if not mydb:
-            json_error_response(
+            return json_error_response(
                 'Database with id {} is missing.'.format(database_id))
 
         rejected_tables = security_manager.rejected_datasources(sql, mydb, schema)


### PR DESCRIPTION
This PR implements [SIP-4](https://github.com/apache/incubator-superset/issues/5667), replacing all JS ajax calls with a new `SupersetClient` that handles all async requests using `fetch` 🎉  

It's a big PR due to the ajax refactoring, so here's an higher-altitude summary:

#### `SupersetClient` usage*

```javascript
// appSetup.js
import SupersetClient from `@superset-ui/core`;

SupersetClient.configure(...clientConfig);
SupersetClient.init(); // CSRF auth, can also chain `.configure().init();

// anotherFile.js
import SupersetClient from `@superset-ui/core`;

SupersetClient.post(...requestConfig)
  .then(({ request, json }) => ...)
  .catch((error) => ...);
```

*this is currently in `src/packages/core/src` which will become `@superset-ui/core`

#### `SupersetClient` handles:
- `CSRF` token authentication 
    - it also queues requests in the case that another request is made before the token is received
    - it checks for a token before every request, an external app that uses this can detect this by catching errors, or explicitly checking `SupersetClient.isAuthorized()`
- timeouts (not supported by default in fetch)
- query aborts (also not supported by default in fetch, uses `AbortController` polyfill)
- supports the following configuration options: 
    - `protocol = 'http'`
    - `host`
    - `headers`
    - `credentials = 'same-origin'` (`include` for non-Superset apps)
    - `mode = 'same-origin'`  (`cors` for non-Superset apps)
    - `timeout`
- supports `get`s and `post`s. I considered adding `put`s/`delete`s but no existing ajax calls of this type are currently made
- a given request supports the following options, which met the need of every async call in the app:
  - `url` or `endpoint`
  - `headers`
  - `body`
  - `timeout`
  - `signal` (for aborting, from `const { signal } = (new AbortController())`)
  - for posts
    - `postPayload` (key values are added to a `new FormData()`)
    - `stringify` whether to call `JSON.stringify` on `postPayload` values

#### New dependencies
It introduces the following new packages:
- `abortcontroller-polyfill`
- `whatwg-fetch`
- `fetch-mock` for testing

#### How was this tested?
- attempted to test success + failure of every endpoint that was refactored in the browser
- updated broken / ajax-containing tests
- (TODO) add `SupersetClient` tests 

#### Next steps
0. finish todos
1. merge this PR, test in staging, fix any immediate bugs
2. move `packages/core` to `superset-ui` repo
3. update imports to pull from `@superset-ui/core`

#### TODO
- [x] implement `SupersetClient`
- [x] refactor all ajax calls to use `SupersetClient` / `fetch`
- [x] refactor / fix all ajax-containing tests
- [x] debug SQL lab polling
- [x] remove unused `SupersetClient` methods like `put` and `destroy`
- [x] refactor API
- [ ] rebase
- [ ] add `SupersetClient` tests
- [ ] add API documentation to package readme
- [ ] verify sqllab error links

@mistercrunch @kristw @conglei @graceguo-supercat @hughhhh @betodealmeida @michellethomas 