### PR TITLE
[sqllab] Include visual feedback that SQL Lab query is limited

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -156,6 +156,7 @@ def execute_sql(
     if (superset_query.is_select() and SQL_MAX_ROWS and
             (not query.limit or query.limit > SQL_MAX_ROWS)):
         query.limit = SQL_MAX_ROWS
+        query.limit_used = True
         executed_sql = database.apply_limit_to_sql(executed_sql, query.limit)
 
     # Hook to allow environment-specific mutation (usually comments) to the SQL

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -189,7 +189,8 @@ class CeleryTestCase(SupersetTestCase):
             "WHERE name='Admin' LIMIT 666", query.executed_sql)
         self.assertEqual(sql_where, query.sql)
         self.assertEqual(0, query.rows)
-        self.assertEqual(False, query.limit_used)
+        self.assertEqual(True, query.limit_used)
+        self.assertEqual(False, query.limit_reached)
         self.assertEqual(True, query.select_as_cta)
         self.assertEqual(True, query.select_as_cta_used)
 


### PR DESCRIPTION
As an extension to https://github.com/apache/incubator-superset/pull/5392, I think it makes sense to include visual feedback when the query has been limited on the backend.

<img width="715" alt="screen shot 2018-08-29 at 4 32 55 pm" src="https://user-images.githubusercontent.com/3317634/44814012-6230fb00-aba9-11e8-8368-e595218393e0.png">

@timifasubaa @villebro 