### PR TITLE
Fix redirect to SQL Lab

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -1,3 +1,5 @@
+import URI from 'urijs';
+
 import { getExploreUrlAndPayload, getAnnotationJsonUrl } from '../explore/exploreUtils';
 import { requiresQuery, ANNOTATION_SOURCE_TYPES } from '../modules/AnnotationTypes';
 import { Logger, LOG_ACTIONS_LOAD_CHART } from '../logger';
@@ -201,23 +203,28 @@ export function runQuery(formData, force = false, timeout = 60, key) {
   };
 }
 
+export const SQLLAB_REDIRECT_FAILED = 'SQLLAB_REDIRECT_FAILED';
+export function sqllabRedirectFailed(error, key) {
+  return { type: SQLLAB_REDIRECT_FAILED, error, key };
+}
+
 export function redirectSQLLab(formData) {
-  return function () {
-    const { url } = getExploreUrlAndPayload({ formData, endpointType: 'query' });
+  return function (dispatch) {
+    const { url, payload } = getExploreUrlAndPayload({ formData, endpointType: 'query' });
     $.ajax({
-      type: 'GET',
+      type: 'POST',
       url,
-      success: (response) => {
-        const redirectUrl = new URL(window.location);
-        redirectUrl.pathname = '/superset/sqllab';
-        for (const k of redirectUrl.searchParams.keys()) {
-          redirectUrl.searchParams.delete(k);
-        }
-        redirectUrl.searchParams.set('datasourceKey', formData.datasource);
-        redirectUrl.searchParams.set('sql', response.query);
-        window.open(redirectUrl.href, '_blank');
+      data: {
+        form_data: JSON.stringify(payload),
       },
-      error: () => notify.error(t("The SQL couldn't be loaded")),
+      success: (response) => {
+        const redirectUrl = new URI(window.location);
+        redirectUrl
+          .pathname('/superset/sqllab')
+          .search({ datasourceKey: formData.datasource, sql: response.query });
+        window.open(redirectUrl.href(), '_blank');
+      },
+      error: (xhr, status, error) => dispatch(sqllabRedirectFailed(error, formData.slice_id)),
     });
   };
 }

--- a/superset/assets/src/chart/chartReducer.js
+++ b/superset/assets/src/chart/chartReducer.js
@@ -133,6 +133,12 @@ export default function chartReducer(charts = {}, action) {
         annotationQuery,
       };
     },
+    [actions.SQLLAB_REDIRECT_FAILED](state) {
+      return { ...state,
+        chartStatus: 'failed',
+        chartAlert: t('An error occurred while redirecting to SQL Lab: %s', action.error),
+      };
+    },
   };
 
   /* eslint-disable no-param-reassign */


### PR DESCRIPTION
This PR fix a few things:

1. The SQL Lab redirect was not working correctly, since changes to the form controls were not being picked up. Instead, the auto-populated query corresponded to the **saved** chart, not the one being visualized.
2. The redirect code was using the [URL interface](https://developer.mozilla.org/en-US/docs/Web/API/URL) without a polyfill. I changed the code to use `uri.js`, which is a dependency.
3. The error message was using the `notify` code that was removed. I changed it to use the chart alerting instead.