### PR TITLE
[WiP] Build LICENSE file dynamically

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,7 @@ flake8-mypy==17.8.0
 flake8==3.7.7
 flask-cors==3.0.7
 ipdb==0.12
+liccheck
 mypy==0.670
 nose==1.3.7
 pip-tools==3.7.0

--- a/scripts/build_license.py
+++ b/scripts/build_license.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import json
-import os
+from pprint import pprint
 import subprocess
 
 LICENSE_MAP = {
@@ -25,9 +25,11 @@ LICENSE_MAP = {
     'CC-BY-3.0': 'CC-BY-3.0',
     'CC-BY-4.0': 'CC-BY-4.0',
     'CC0-1.0': 'CC0-1.0',
-    'Custom: http://badges.github.io/stability-badges/dist/stable.svg': 'Custom: http://badges.github.io/stability-badges/dist/stable.svg',
+    'Custom: http://badges.github.io/stability-badges/dist/stable.svg':
+        'Custom: http://badges.github.io/stability-badges/dist/stable.svg',
     'Custom: http://i.imgur.com/goJdO.png': 'Custom: http://i.imgur.com/goJdO.png',
-    'Custom: https://github.com/tmcw/jsonlint': 'Custom: https://github.com/tmcw/jsonlint',
+    'Custom: https://github.com/tmcw/jsonlint':
+        'Custom: https://github.com/tmcw/jsonlint',
     'Custom: https://ppl.family': 'Custom: https://ppl.family',
     'GNU Library General Public License': 'GNU Library General Public License',
     'ISC': 'ISC',
@@ -45,8 +47,10 @@ LICENSE_MAP = {
 
 
 def build_license():
-    # os.system('npm install -g license-check')
-    result = subprocess.run(['license-checker', '--json', '--production'], stdout=subprocess.PIPE)
+    result = subprocess.run(
+        ['license-checker', '--json', '--production'],
+        stdout=subprocess.PIPE,
+    )
     packages = json.loads(result.stdout)
     license_dict = defaultdict(set)
     for npm_short, package_details in packages.items():
@@ -59,7 +63,6 @@ def build_license():
             lic = LICENSE_MAP.get(lic) or lic or 'UNKNOWN'
             license_dict[lic].add(npm_short)
 
-    from pprint import pprint
     pprint(license_dict)
 
 

--- a/scripts/build_license.py
+++ b/scripts/build_license.py
@@ -1,0 +1,67 @@
+from collections import defaultdict
+import json
+import os
+import subprocess
+
+LICENSE_MAP = {
+    '(BSD-2-Clause OR MIT OR Apache-2.0)': '(BSD-2-Clause OR MIT OR Apache-2.0)',
+    '(BSD-2-Clause OR MIT)': '(BSD-2-Clause OR MIT)',
+    '(GPL-2.0 OR MIT)': '(GPL-2.0 OR MIT)',
+    '(MIT AND BSD-3-Clause)': '(MIT AND BSD-3-Clause)',
+    '(MIT AND CC-BY-3.0)': '(MIT AND CC-BY-3.0)',
+    '(MIT AND Zlib)': '(MIT AND Zlib)',
+    '(MIT OR Apache-2.0)': '(MIT OR Apache-2.0)',
+    '(WTFPL OR MIT)': '(WTFPL OR MIT)',
+    'AFLv2.1': 'AFLv2.1',
+    'Apache License, Version 2.0': 'Apache License, Version 2.0',
+    'Apache*': 'Apache*',
+    'Apache-2.0': 'Apache-2.0',
+    'Artistic-2.0': 'Artistic-2.0',
+    'BSD': 'BSD',
+    'BSD*': 'BSD*',
+    'BSD-2-Clause': 'BSD-2-Clause',
+    'BSD-3-Clause OR MIT': 'BSD-3-Clause OR MIT',
+    'BSD-3-Clause': 'BSD-3-Clause',
+    'CC-BY-3.0': 'CC-BY-3.0',
+    'CC-BY-4.0': 'CC-BY-4.0',
+    'CC0-1.0': 'CC0-1.0',
+    'Custom: http://badges.github.io/stability-badges/dist/stable.svg': 'Custom: http://badges.github.io/stability-badges/dist/stable.svg',
+    'Custom: http://i.imgur.com/goJdO.png': 'Custom: http://i.imgur.com/goJdO.png',
+    'Custom: https://github.com/tmcw/jsonlint': 'Custom: https://github.com/tmcw/jsonlint',
+    'Custom: https://ppl.family': 'Custom: https://ppl.family',
+    'GNU Library General Public License': 'GNU Library General Public License',
+    'ISC': 'ISC',
+    'MIT OR GPL-2.0': 'MIT OR GPL-2.0',
+    'MIT': 'MIT',
+    'MIT*': 'MIT*',
+    'MPL-2.0 OR Apache-2.0': 'MPL-2.0 OR Apache-2.0',
+    'Public Domain': 'Public Domain',
+    'The MIT License': 'The MIT License',
+    'UNKNOWN': 'UNKNOWN',
+    'Unlicense': 'Unlicense',
+    'WTFPL': 'WTFPL',
+    'Zlib': 'Zlib',
+}
+
+
+def build_license():
+    # os.system('npm install -g license-check')
+    result = subprocess.run(['license-checker', '--json', '--production'], stdout=subprocess.PIPE)
+    packages = json.loads(result.stdout)
+    license_dict = defaultdict(set)
+    for npm_short, package_details in packages.items():
+        if '@' in npm_short:
+            npm_short = npm_short.split('@')[0]
+        licenses = package_details.get('licenses')
+        if not isinstance(licenses, list):
+            licenses = [licenses]
+        for lic in licenses:
+            lic = LICENSE_MAP.get(lic) or lic or 'UNKNOWN'
+            license_dict[lic].add(npm_short)
+
+    from pprint import pprint
+    pprint(license_dict)
+
+
+if __name__ == '__main__':
+    build_license()

--- a/scripts/build_license.py
+++ b/scripts/build_license.py
@@ -1,89 +1,99 @@
 from collections import defaultdict
 import json
-from pprint import pprint
 import subprocess
 
 LICENSE_MAP = {
-    '(BSD-2-Clause OR MIT OR Apache-2.0)': 'MIT',
-    '(BSD-2-Clause OR MIT)': 'MIT',
-    '(GPL-2.0 OR MIT)': 'MIT',
-    '(MIT AND BSD-3-Clause)': '(MIT AND BSD-3-Clause)',
-    '(MIT AND CC-BY-3.0)': '(MIT AND CC-BY-3.0)',
-    '(MIT AND Zlib)': '(MIT AND Zlib)',
-    '(MIT OR Apache-2.0)': 'MIT',
-    '(WTFPL OR MIT)': 'MIT',
-    'AFLv2.1': 'AFLv2.1',
-    'Apache License, Version 2.0': 'Apache License, Version 2.0',
-    'Apache*': 'Apache*',
-    'Apache-2.0': 'Apache-2.0',
-    'Artistic-2.0': 'Artistic-2.0',
-    'BSD': 'BSD',
-    'BSD*': 'BSD*',
-    'BSD-2-Clause': 'BSD-2-Clause',
-    'BSD-3-Clause OR MIT': 'BSD-3-Clause OR MIT',
-    'BSD-3-Clause': 'BSD-3-Clause',
-    'CC-BY-3.0': 'CC-BY-3.0',
-    'CC-BY-4.0': 'CC-BY-4.0',
-    'CC0-1.0': 'CC0-1.0',
-    'Custom: http://badges.github.io/stability-badges/dist/stable.svg':
-        'Custom: http://badges.github.io/stability-badges/dist/stable.svg',
-    'Custom: http://i.imgur.com/goJdO.png': 'Custom: http://i.imgur.com/goJdO.png',
-    'Custom: https://github.com/tmcw/jsonlint':
-        'Custom: https://github.com/tmcw/jsonlint',
-    'Custom: https://ppl.family': 'Custom: https://ppl.family',
-    'GNU Library General Public License': 'GNU Library General Public License',
-    'ISC': 'ISC',
-    'MIT OR GPL-2.0': 'MIT',
-    'MIT': 'MIT',
-    'MIT*': 'MIT*',
-    'MPL-2.0 OR Apache-2.0': 'Apache-2.0',
-    'Public Domain': 'Public Domain',
-    'The MIT License': 'The MIT License',
-    'UNKNOWN': 'UNKNOWN',
-    'Unlicense': 'Unlicense',
-    'WTFPL': 'WTFPL',
-    'Zlib': 'Zlib',
+    "(BSD-2-Clause OR MIT OR Apache-2.0)": "MIT",
+    "(BSD-2-Clause OR MIT)": "MIT",
+    "(GPL-2.0 OR MIT)": "MIT",
+    "(MIT AND BSD-3-Clause)": "(MIT AND BSD-3-Clause)",
+    "(MIT AND CC-BY-3.0)": "(MIT AND CC-BY-3.0)",
+    "(MIT AND Zlib)": "(MIT AND Zlib)",
+    "(MIT OR Apache-2.0)": "MIT",
+    "(WTFPL OR MIT)": "MIT",
+    "AFLv2.1": "AFLv2.1",
+    "Apache License, Version 2.0": "Apache License, Version 2.0",
+    "Apache*": "Apache*",
+    "Apache-2.0": "Apache-2.0",
+    "Artistic-2.0": "Artistic-2.0",
+    "BSD": "BSD",
+    "BSD*": "BSD*",
+    "BSD-2-Clause": "BSD-2-Clause",
+    "BSD-3-Clause OR MIT": "BSD-3-Clause OR MIT",
+    "BSD-3-Clause": "BSD-3-Clause",
+    "CC-BY-3.0": "CC-BY-3.0",
+    "CC-BY-4.0": "CC-BY-4.0",
+    "CC0-1.0": "CC0-1.0",
+    "Custom: http://badges.github.io/stability-badges/dist/stable.svg": "Custom: http://badges.github.io/stability-badges/dist/stable.svg",
+    "Custom: http://i.imgur.com/goJdO.png": "Custom: http://i.imgur.com/goJdO.png",
+    "Custom: https://github.com/tmcw/jsonlint": "Custom: https://github.com/tmcw/jsonlint",
+    "Custom: https://ppl.family": "Custom: https://ppl.family",
+    "GNU Library General Public License": "GNU Library General Public License",
+    "ISC": "ISC",
+    "MIT OR GPL-2.0": "MIT",
+    "MIT": "MIT",
+    "MIT*": "MIT*",
+    "MPL-2.0 OR Apache-2.0": "Apache-2.0",
+    "Public Domain": "Public Domain",
+    "The MIT License": "The MIT License",
+    "UNKNOWN": "UNKNOWN",
+    "Unlicense": "Unlicense",
+    "WTFPL": "WTFPL",
+    "Zlib": "Zlib",
 }
 
 COMPATIBLE_LICENSES = {
-    'Apache-2.0',
-    'BSD',
-    'BSD-2-Clause',
-    'BSD-3-Clause',
-    'ISC',
-    'MIT',
-    'Zlib',
+    "Apache-2.0",
+    "BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "Zlib",
 }
 LIB_WHITELIST = {
+    # https://github.com/mapbox/mapbox-gl-js#license
+    "mapbox-gl",
     # AFL or BSD 3-Clause: https://github.com/kriszyp/json-schema
-    'json-schema',
+    "json-schema",
+    # https://github.com/josdejong/typed-function/blob/master/LICENSE
+    "typed-function",
+    # https://github.com/substack/node-optimist/blob/master/LICENSE
+    "optimist",
+    # https://github.com/Automattic/expect.js/
+    "expect.js",
+    # https://github.com/Automattic/expect.js/
+    "split",
 }
 
 
 def build_license():
     result = subprocess.run(
-        ['license-checker', '--json', '--production'],
-        stdout=subprocess.PIPE,
+        ["license-checker", "--json", "--production"], stdout=subprocess.PIPE
     )
     packages = json.loads(result.stdout)
     license_dict = defaultdict(set)
     for npm_short, package_details in packages.items():
-        if '@' in npm_short:
-            npm_short = npm_short.split('@')[0]
-        licenses = package_details.get('licenses')
+        if "@" in npm_short:
+            npm_short = npm_short.split("@")[0]
+        licenses = package_details.get("licenses")
         if not isinstance(licenses, list):
             licenses = [licenses]
         for lic in licenses:
-            lic = LICENSE_MAP.get(lic) or lic or 'UNKNOWN'
+            lic = LICENSE_MAP.get(lic) or lic or "UNKNOWN"
             license_dict[lic].add(npm_short)
 
-    incompatible_dict = {
-        k: [lib for lib in v if lib not in LIB_WHITELIST]
-        for k, v in license_dict.items()
-        if k not in COMPATIBLE_LICENSES
-    }
+    incompatible_dict = {}
+    for license, libs in license_dict.items():
+        if license not in COMPATIBLE_LICENSES:
+            bad_libs = []
+            for lib in libs:
+                if lib and lib not in LIB_WHITELIST:
+                    bad_libs.append(lib)
+            if bad_libs:
+                incompatible_dict[license] = bad_libs
     print(json.dumps(incompatible_dict, indent=2))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     build_license()

--- a/scripts/build_license.py
+++ b/scripts/build_license.py
@@ -4,14 +4,14 @@ from pprint import pprint
 import subprocess
 
 LICENSE_MAP = {
-    '(BSD-2-Clause OR MIT OR Apache-2.0)': '(BSD-2-Clause OR MIT OR Apache-2.0)',
-    '(BSD-2-Clause OR MIT)': '(BSD-2-Clause OR MIT)',
-    '(GPL-2.0 OR MIT)': '(GPL-2.0 OR MIT)',
+    '(BSD-2-Clause OR MIT OR Apache-2.0)': 'MIT',
+    '(BSD-2-Clause OR MIT)': 'MIT',
+    '(GPL-2.0 OR MIT)': 'MIT',
     '(MIT AND BSD-3-Clause)': '(MIT AND BSD-3-Clause)',
     '(MIT AND CC-BY-3.0)': '(MIT AND CC-BY-3.0)',
     '(MIT AND Zlib)': '(MIT AND Zlib)',
-    '(MIT OR Apache-2.0)': '(MIT OR Apache-2.0)',
-    '(WTFPL OR MIT)': '(WTFPL OR MIT)',
+    '(MIT OR Apache-2.0)': 'MIT',
+    '(WTFPL OR MIT)': 'MIT',
     'AFLv2.1': 'AFLv2.1',
     'Apache License, Version 2.0': 'Apache License, Version 2.0',
     'Apache*': 'Apache*',
@@ -33,16 +33,30 @@ LICENSE_MAP = {
     'Custom: https://ppl.family': 'Custom: https://ppl.family',
     'GNU Library General Public License': 'GNU Library General Public License',
     'ISC': 'ISC',
-    'MIT OR GPL-2.0': 'MIT OR GPL-2.0',
+    'MIT OR GPL-2.0': 'MIT',
     'MIT': 'MIT',
     'MIT*': 'MIT*',
-    'MPL-2.0 OR Apache-2.0': 'MPL-2.0 OR Apache-2.0',
+    'MPL-2.0 OR Apache-2.0': 'Apache-2.0',
     'Public Domain': 'Public Domain',
     'The MIT License': 'The MIT License',
     'UNKNOWN': 'UNKNOWN',
     'Unlicense': 'Unlicense',
     'WTFPL': 'WTFPL',
     'Zlib': 'Zlib',
+}
+
+COMPATIBLE_LICENSES = {
+    'Apache-2.0',
+    'BSD',
+    'BSD-2-Clause',
+    'BSD-3-Clause',
+    'ISC',
+    'MIT',
+    'Zlib',
+}
+LIB_WHITELIST = {
+    # AFL or BSD 3-Clause: https://github.com/kriszyp/json-schema
+    'json-schema',
 }
 
 
@@ -63,7 +77,12 @@ def build_license():
             lic = LICENSE_MAP.get(lic) or lic or 'UNKNOWN'
             license_dict[lic].add(npm_short)
 
-    pprint(license_dict)
+    incompatible_dict = {
+        k: [lib for lib in v if lib not in LIB_WHITELIST]
+        for k, v in license_dict.items()
+        if k not in COMPATIBLE_LICENSES
+    }
+    print(json.dumps(incompatible_dict, indent=2))
 
 
 if __name__ == '__main__':

--- a/scripts/liccheck.ini
+++ b/scripts/liccheck.ini
@@ -1,0 +1,25 @@
+# Authorized and unauthorized licenses in LOWER CASE
+[Licenses]
+authorized_licenses:
+        bsd
+        new bsd
+        bsd license
+        new bsd license
+        simplified bsd
+        apache
+        apache 2.0
+        apache software license
+        gnu lgpl
+        lgpl with exceptions or zpl
+        isc license
+        isc license (iscl)
+        mit
+        mit license
+        python software foundation license
+        zpl 2.1
+
+unauthorized_licenses:
+        gpl v3
+
+[Authorized Packages]
+# Python software license (see http://zesty.ca/python/uuid.README.txt)

--- a/scripts/liccheck.ini
+++ b/scripts/liccheck.ini
@@ -9,8 +9,6 @@ authorized_licenses:
         apache
         apache 2.0
         apache software license
-        gnu lgpl
-        lgpl with exceptions or zpl
         isc license
         isc license (iscl)
         mit

--- a/scripts/liccheck.sh
+++ b/scripts/liccheck.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+liccheck -l STANDARD -s ./liccheck.ini -r ../requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -118,5 +118,9 @@ setup(
     download_url=(
         "https://dist.apache.org/repos/dist/release/superset/" + version_string
     ),
-    classifiers=["Programming Language :: Python :: 3.6"],
+    classifiers=[
+        'Programming Language :: Python :: 3.6',
+        'License :: OSI Approved :: Apache Software License',
+    ],
+    license='Apache License 2.0',
 )


### PR DESCRIPTION
Some early work on license. Here's the output of the script that fetches license information from npm and organizes package by license:

Updated may 29th 2019
```
{
  "Custom: https://github.com/tmcw/jsonlint": [
    ""
  ],
  "MIT*": [
    "optimist",
    "exif-parser",
    "mapbox-gl",
    "expect.js",
    "split",
    "process",
    "trim",
    "typed-function"
  ],
  "Custom: https://github.com/IonicaBizau/node-blah": [
    "typpy",
    "flat-colors"
  ],
  "Custom: http://badges.github.io/stability-badges/dist/stable.svg": [
    "gl-vec2",
    "gl-mat3",
    "gl-vec3"
  ],
  "AFLv2.1": [],
  "Apache-2.0 WITH LLVM-exception": [
    "mousetrap"
  ],
  "CC0-1.0": [
    "string-hash"
  ],
  "Unlicense": [
    "tweetnacl"
  ]
}
```