### PR TITLE
Simplifying docker contrib

### DIFF
--- a/contrib/docker/docker-build.sh
+++ b/contrib/docker/docker-build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-
-docker build -t apache/incubator-superset -f Dockerfile .

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   redis:
     image: redis:3.2
     restart: always
-    ports:
-      - 6379:6379
     volumes:
       - redis:/data
   postgres:
@@ -14,12 +12,10 @@ services:
       POSTGRES_DB: superset
       POSTGRES_PASSWORD: superset
       POSTGRES_USER: superset
-    ports:
-      - 5432:5432
     volumes:
       - postgres:/var/lib/postgresql/data
   superset:
-    image: apache/incubator-superset
+    build: .
     restart: always
     environment:
       POSTGRES_DB: superset

--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -5,6 +5,10 @@ if [ "$#" -ne 0 ]; then
     exec "$@"
 elif [ "$SUPERSET_ENV" = "local" ]; then
     superset runserver -d
+elif [ "$SUPERSET_ENV" = "development" ]; then
+    superset runserver -d &
+    cd /home/work/incubator-superset/superset/assets
+    npm run dev
 elif [ "$SUPERSET_ENV" = "production" ]; then
     superset runserver -a 0.0.0.0 -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1))
 else

--- a/contrib/docker/docker-init.sh
+++ b/contrib/docker/docker-init.sh
@@ -13,12 +13,3 @@ superset load_examples
 
 # Create default roles and permissions
 superset init
-
-# Need to run `npm run build` when enter contains for first time
-cd superset/assets && npm run build && cd ../../
-
-# Start superset worker for SQL Lab
-superset worker &
-
-# To start a development web server, use the -d switch
-superset runserver -d

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,9 +43,8 @@ initialize development environment: ::
 
     git clone https://github.com/apache/incubator-superset/
     cd incubator-superset
-    cp contrib/docker/{docker-build.sh,docker-compose.yml,docker-entrypoint.sh,docker-init.sh,Dockerfile} .
+    cp contrib/docker/{docker-compose.yml,docker-entrypoint.sh,docker-init.sh,Dockerfile} .
     cp contrib/docker/superset_config.py superset/
-    bash -x docker-build.sh
     docker-compose up -d
     docker-compose exec superset bash
     bash docker-init.sh


### PR DESCRIPTION
1) Removing docker-build.sh step and building superset container with docker-compose (build command)
2) Removing exposed ports for psql and redis. 
3) Adding new SUPERSET_ENV development that also runs npm watcher
4) Removing npm and superset runserver/worker from docker-init. Dockerfile already builds assets and  starts superset. 