### PR TITLE
[celery] setting default

### DIFF
--- a/superset/utils.py
+++ b/superset/utils.py
@@ -712,6 +712,7 @@ def get_celery_app(config):
         return _celery_app
     _celery_app = celery.Celery()
     _celery_app.config_from_object(config.get('CELERY_CONFIG'))
+    _celery_app.set_default()
     return _celery_app
 
 


### PR DESCRIPTION
This PR remedies an issue we've been seeing with `celery_statsd` where `celery.current_app` refers to the default rather than the app instance. Per [this](https://stackoverflow.com/questions/26527214/why-celery-current-app-refers-the-default-instance-inside-flask-view-functions) thread it seems like enforcing the app to be the default for all threads remedies the issue, which I verified via testing locally. 

to: @michellethomas @mistercrunch @timifasubaa 