### PR TITLE
bug: don't show query overlay when panning mapbox maps

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1815,6 +1815,8 @@ export const controls = {
     isFloat: true,
     description: t('Latitude of default viewport'),
     places: 8,
+    // Viewport latitude changes shouldn't prompt user to re-run query
+    dontRefreshOnChange: true,
   },
 
   viewport_longitude: {
@@ -1824,6 +1826,8 @@ export const controls = {
     isFloat: true,
     description: t('Longitude of default viewport'),
     places: 8,
+    // Viewport longitude changes shouldn't prompt user to re-run query
+    dontRefreshOnChange: true,
   },
 
   render_while_dragging: {

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1806,6 +1806,8 @@ export const controls = {
     default: 11,
     description: t('Zoom level of the map'),
     places: 8,
+    // Viewport zoom shouldn't prompt user to re-run query
+    dontRefreshOnChange: true,
   },
 
   viewport_latitude: {


### PR DESCRIPTION
Since we don't want to prompt user to rerun query every time they pan a map, prevent the query overlay from showing by setting dontRefreshOnChange in for viewport_latitude and viewport_longitude controls.

👀 @mistercrunch @betodealmeida 