### PR TITLE
[SIP-5] Remove unused function #easy-review

### DIFF
--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -170,10 +170,6 @@ class Chart extends React.PureComponent {
     this.props.actions.chartRenderingFailed(e, this.props.chartId);
   }
 
-  verboseMetricName(metric) {
-    return this.props.datasource.verbose_map[metric] || metric;
-  }
-
   renderTooltip() {
     if (this.state.tooltip) {
       return (

--- a/superset/assets/src/visualizations/table.js
+++ b/superset/assets/src/visualizations/table.js
@@ -288,10 +288,6 @@ function adaptor(slice, payload) {
     orderDesc,
     pageLength: pageLength && parseInt(pageLength, 10),
     percentMetrics,
-    // Aug 22, 2018
-    // Perhaps this `tableFilter` field can be removed as there is
-    // no code left in repo to set tableFilter to true.
-    // which make `onAddFilter` will never be called as well.
     tableFilter,
     tableTimestampFormat,
     timeseriesLimitMetric,


### PR DESCRIPTION
- This function `verboseMetricName` is not used anywhere after the chart refactor.
- Remove comment in `table.js` as I misunderstood something and found where the `tableFilter` field is used. 