### PR TITLE
[bugfix] Fix react-syntax-highlighter import

### DIFF
--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/light';
+import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/dist/light';
 import html from 'react-syntax-highlighter/languages/hljs/htmlbars';
 import markdown from 'react-syntax-highlighter/languages/hljs/markdown';
 import sql from 'react-syntax-highlighter/languages/hljs/sql';


### PR DESCRIPTION
Wrong path in `import` that caused page to sometimes crash