### PR TITLE
Improve support for BigQuery, Redshift, Oracle, Db2, Snowflake

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -95,8 +95,8 @@ class TableColumn(Model, BaseColumn):
     export_parent = 'table'
 
     def get_sqla_col(self, label=None):
-        db_engine_spec = self.table.database.db_engine_spec
-        label = db_engine_spec.make_label_compatible(label if label else self.column_name)
+        label = label if label else self.column_name
+        label = self.table.mutate_label(label)
         if not self.expression:
             col = column(self.column_name).label(label)
         else:
@@ -118,10 +118,12 @@ class TableColumn(Model, BaseColumn):
 
     def get_timestamp_expression(self, time_grain):
         """Getting the time component of the query"""
+        label = self.table.mutate_label(utils.DTTM_ALIAS)
+
         pdf = self.python_date_format
         is_epoch = pdf in ('epoch_s', 'epoch_ms')
         if not self.expression and not time_grain and not is_epoch:
-            return column(self.column_name, type_=DateTime).label(utils.DTTM_ALIAS)
+            return column(self.column_name, type_=DateTime).label(label)
 
         expr = self.expression or self.column_name
         if is_epoch:
@@ -135,7 +137,7 @@ class TableColumn(Model, BaseColumn):
             grain = self.table.database.grains_dict().get(time_grain)
             if grain:
                 expr = grain.function.format(col=expr)
-        return literal_column(expr, type_=DateTime).label(utils.DTTM_ALIAS)
+        return literal_column(expr, type_=DateTime).label(label)
 
     @classmethod
     def import_obj(cls, i_column):
@@ -227,8 +229,8 @@ class SqlMetric(Model, BaseMetric):
     export_parent = 'table'
 
     def get_sqla_col(self, label=None):
-        db_engine_spec = self.table.database.db_engine_spec
-        label = db_engine_spec.make_label_compatible(label if label else self.metric_name)
+        label = label if label else self.metric_name
+        label = self.table.mutate_label(label)
         return literal_column(self.expression).label(label)
 
     @property
@@ -301,6 +303,16 @@ class SqlaTable(Model, BaseDatasource):
         'MIN': sa.func.MIN,
         'MAX': sa.func.MAX,
     }
+
+    mutated_label_cache = {}
+
+    def mutate_label(self, label):
+        db_engine_spec = self.database.db_engine_spec
+        original_label = label
+        label, sqla_label = db_engine_spec.make_label_compatible(original_label)
+        if original_label != label:
+            self.mutated_label_cache[label] = original_label
+        return sqla_label
 
     def __repr__(self):
         return self.name
@@ -501,8 +513,8 @@ class SqlaTable(Model, BaseDatasource):
         :rtype: sqlalchemy.sql.column
         """
         expression_type = metric.get('expressionType')
-        db_engine_spec = self.database.db_engine_spec
-        label = db_engine_spec.make_label_compatible(metric.get('label'))
+        label = utils.get_metric_name(metric)
+        label = self.mutate_label(label)
 
         if expression_type == utils.ADHOC_METRIC_EXPRESSION_TYPES['SIMPLE']:
             column_name = metric.get('column').get('column_name')
@@ -555,6 +567,9 @@ class SqlaTable(Model, BaseDatasource):
         template_processor = self.get_template_processor(**template_kwargs)
         db_engine_spec = self.database.db_engine_spec
 
+        # Reset cache when retrieving new sqla query
+        self.mutated_label_cache = {}
+
         orderby = orderby or []
 
         # For backward compatibility
@@ -584,8 +599,8 @@ class SqlaTable(Model, BaseDatasource):
         if metrics_exprs:
             main_metric_expr = metrics_exprs[0]
         else:
-            main_metric_expr = literal_column('COUNT(*)').label(
-                db_engine_spec.make_label_compatible('count'))
+            label = self.mutate_label('ccount')
+            main_metric_expr = literal_column('COUNT(*)').label(label)
 
         select_exprs = []
         groupby_exprs = []
@@ -710,7 +725,8 @@ class SqlaTable(Model, BaseDatasource):
                 # some sql dialects require for order by expressions
                 # to also be in the select clause -- others, e.g. vertica,
                 # require a unique inner alias
-                inner_main_metric_expr = main_metric_expr.label('mme_inner__')
+                label = self.mutate_label('mme_inner__')
+                inner_main_metric_expr = main_metric_expr.label(label)
                 inner_select_exprs += [inner_main_metric_expr]
                 subq = select(inner_select_exprs)
                 subq = subq.select_from(tbl)
@@ -738,8 +754,11 @@ class SqlaTable(Model, BaseDatasource):
 
                 on_clause = []
                 for i, gb in enumerate(groupby):
-                    on_clause.append(
-                        groupby_exprs[i] == column(gb + '__'))
+                    # in this case the column name, not the alias, needs to be
+                    # conditionally mutated, as it refers to the column alias in
+                    # the inner query
+                    col_name = self.mutate_label(gb + '__')
+                    on_clause.append(groupby_exprs[i] == column(col_name))
 
                 tbl = tbl.join(subq.alias(), and_(*on_clause))
             else:
@@ -791,6 +810,9 @@ class SqlaTable(Model, BaseDatasource):
         df = None
         try:
             df = self.database.get_df(sql, self.schema)
+            mutated_labels = self.mutated_label_cache
+            if len(mutated_labels) > 0:
+                df = df.rename(index=str, columns=mutated_labels)
         except Exception as e:
             status = utils.QueryStatus.FAILED
             logging.exception(e)
@@ -833,7 +855,6 @@ class SqlaTable(Model, BaseDatasource):
             .filter(or_(TableColumn.column_name == col.name
                         for col in table.columns)))
         dbcols = {dbcol.column_name: dbcol for dbcol in dbcols}
-        db_engine_spec = self.database.db_engine_spec
 
         for col in table.columns:
             try:
@@ -866,9 +887,6 @@ class SqlaTable(Model, BaseDatasource):
         ))
         if not self.main_dttm_col:
             self.main_dttm_col = any_date_col
-        for metric in metrics:
-            metric.metric_name = db_engine_spec.mutate_expression_label(
-                metric.metric_name)
         self.add_missing_metrics(metrics)
         db.session.merge(self)
         db.session.commit()

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -304,9 +304,16 @@ class SqlaTable(Model, BaseDatasource):
         'MAX': sa.func.MAX,
     }
 
+    # cache for storing labels that are mutated to be compatible with db engine
     mutated_label_cache = {}
 
     def mutate_label(self, label):
+        """Conditionally mutate a label to conform to db engine requirements
+
+        :param label: original label
+        :return: Either a string or sqlalchemy.sql.elements.quoted_name if required
+        by db engine
+        """
         db_engine_spec = self.database.db_engine_spec
         original_label = label
         label, sqla_label = db_engine_spec.make_label_compatible(original_label)

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1455,7 +1455,7 @@ class BQEngineSpec(BaseEngineSpec):
         :param str label: the original label which might include unsupported characters
         :return: String that is supported by the database
         """
-        hashed_label = hashlib.md5(label.encode('utf-8')).hexdigest()
+        hashed_label = '_' + hashlib.md5(label.encode('utf-8')).hexdigest()
 
         # if label starts with number, add underscore as first character
         label = '_' + label if re.match('^\d', label) else label
@@ -1464,7 +1464,7 @@ class BQEngineSpec(BaseEngineSpec):
         mutated_label = re.sub('[^\w]+', '_', label)
         if mutated_label != label:
             # add md5 hash to label to avoid possible collisions
-            mutated_label += '_' + hashed_label
+            mutated_label += hashed_label
 
         # return only hash if length of final label exceeds 128 chars
         return mutated_label if len(mutated_label) <= 128 else hashed_label

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -378,13 +378,14 @@ class BaseEngineSpec(object):
     @classmethod
     def make_label_compatible(cls, label):
         """
-        Return a tuple containing the mutated label and a
-        sqlalchemy.sql.elements.quoted_name if the engine requires quoting of aliases
-        to ensure that select query and query results have same case.
+        Conditionally mutate and/or quote a sql column/expression label. If
+        force_column_alias_quotes is set to True, return the label as a
+        sqlalchemy.sql.elements.quoted_name object to ensure that the select query
+        and query results have same case. Otherwise return the mutated label as a
+        regular string.
         """
         label = cls.mutate_label(label)
-        sqla_label = quoted_name(label, True) if cls.force_column_alias_quotes else label
-        return label, sqla_label
+        return quoted_name(label, True) if cls.force_column_alias_quotes else label
 
     @staticmethod
     def mutate_label(label):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1461,10 +1461,10 @@ class BQEngineSpec(BaseEngineSpec):
         hashed_label = '_' + hashlib.md5(label.encode('utf-8')).hexdigest()
 
         # if label starts with number, add underscore as first character
-        mutated_label = '_' + label if re.match('^\d', label) else label
+        mutated_label = '_' + label if re.match(r'^\d', label) else label
 
         # replace non-alphanumeric characters with underscores
-        mutated_label = re.sub('[^\w]+', '_', mutated_label)
+        mutated_label = re.sub(r'[^\w]+', '_', mutated_label)
         if mutated_label != label:
             # add md5 hash to label to avoid possible collisions
             mutated_label += hashed_label

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -13,6 +13,7 @@ at all. The classes here will use a common interface to specify all this.
 The general idea is to use static classes and an inheritance scheme.
 """
 from collections import namedtuple
+import hashlib
 import inspect
 import logging
 import os
@@ -377,16 +378,23 @@ class BaseEngineSpec(object):
     @classmethod
     def make_label_compatible(cls, label):
         """
-        Return a sqlalchemy.sql.elements.quoted_name if the engine requires
-        quoting of aliases to ensure that select query and query results
-        have same case.
+        Return a tuple containing the mutated label and a
+        sqlalchemy.sql.elements.quoted_name if the engine requires quoting of aliases
+        to ensure that select query and query results have same case.
         """
-        if cls.force_column_alias_quotes is True:
-            return quoted_name(label, True)
-        return label
+        label = cls.mutate_label(label)
+        sqla_label = quoted_name(label, True) if cls.force_column_alias_quotes else label
+        return label, sqla_label
 
     @staticmethod
-    def mutate_expression_label(label):
+    def mutate_label(label):
+        """
+        Most engines support mixed case aliases that can include numbers
+        and special characters, like commas, parentheses etc. For engines that
+        have restrictions on what types of aliases are supported, this method
+        can be overridden to ensure that labels conform to the engine's
+        limitations.
+        """
         return label
 
 
@@ -475,7 +483,15 @@ class VerticaEngineSpec(PostgresBaseEngineSpec):
 
 class RedshiftEngineSpec(PostgresBaseEngineSpec):
     engine = 'redshift'
-    force_column_alias_quotes = True
+
+    @staticmethod
+    def mutate_label(label):
+        """
+        Redshift only supports lowercase column names and aliases.
+        :param str label: Original label which might include uppercase letters
+        :return: String that is supported by the database
+        """
+        return label.lower()
 
 
 class OracleEngineSpec(PostgresBaseEngineSpec):
@@ -501,11 +517,26 @@ class OracleEngineSpec(PostgresBaseEngineSpec):
             """TO_TIMESTAMP('{}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""
         ).format(dttm.isoformat())
 
+    @staticmethod
+    def mutate_label(label):
+        """
+        Oracle 12.1 and earlier support a maximum of 30 byte length object names, which
+        usually means 30 characters.
+        :param str label: Original label which might include unsupported characters
+        :return: String that is supported by the database
+        """
+        if len(label) > 30:
+            hashed_label = hashlib.md5(label.encode('utf-8')).hexdigest()
+            # truncate the hash to first 30 characters
+            return hashed_label[:30]
+        return label
+
 
 class Db2EngineSpec(BaseEngineSpec):
     engine = 'ibm_db_sa'
     limit_method = LimitMethod.WRAP_SQL
     force_column_alias_quotes = True
+
     time_grain_functions = {
         None: '{col}',
         'PT1S': 'CAST({col} as TIMESTAMP)'
@@ -538,6 +569,20 @@ class Db2EngineSpec(BaseEngineSpec):
     @classmethod
     def convert_dttm(cls, target_type, dttm):
         return "'{}'".format(dttm.strftime('%Y-%m-%d-%H.%M.%S'))
+
+    @staticmethod
+    def mutate_label(label):
+        """
+        Db2 for z/OS supports a maximum of 30 byte length object names, which usually
+        means 30 characters.
+        :param str label: Original label which might include unsupported characters
+        :return: String that is supported by the database
+        """
+        if len(label) > 30:
+            hashed_label = hashlib.md5(label.encode('utf-8')).hexdigest()
+            # truncate the hash to first 30 characters
+            return hashed_label[:30]
+        return label
 
 
 class SqliteEngineSpec(BaseEngineSpec):
@@ -1399,16 +1444,30 @@ class BQEngineSpec(BaseEngineSpec):
         return data
 
     @staticmethod
-    def mutate_expression_label(label):
+    def mutate_label(label):
+        """
+        BigQuery field_name should start with a letter or underscore, contain only
+        alphanumeric characters and be at most 128 characters long. Labels that start
+        with a number are prefixed with an underscore. Any unsupported characters are
+        replaced with underscores and an md5 hash is added to the end of the label to
+        avoid possible collisions. If the resulting label exceeds 128 characters, only
+        the md5 sum is returned.
+        :param str label: the original label which might include unsupported characters
+        :return: String that is supported by the database
+        """
+        hashed_label = hashlib.md5(label.encode('utf-8')).hexdigest()
+
+        # if label starts with number, add underscore as first character
+        label = '_' + label if re.match('^\d', label) else label
+
+        # replace non-alphanumeric characters with underscores
         mutated_label = re.sub('[^\w]+', '_', label)
-        if not re.match('^[a-zA-Z_]+.*', mutated_label):
-            raise SupersetTemplateException('BigQuery field_name used is invalid {}, '
-                                            'should start with a letter or '
-                                            'underscore'.format(mutated_label))
-        if len(mutated_label) > 128:
-            raise SupersetTemplateException('BigQuery field_name {}, should be atmost '
-                                            '128 characters'.format(mutated_label))
-        return mutated_label
+        if mutated_label != label:
+            # add md5 hash to label to avoid possible collisions
+            mutated_label += '_' + hashed_label
+
+        # return only hash if length of final label exceeds 128 chars
+        return mutated_label if len(mutated_label) <= 128 else hashed_label
 
     @classmethod
     def extra_table_metadata(cls, database, table_name, schema_name):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1461,10 +1461,10 @@ class BQEngineSpec(BaseEngineSpec):
         hashed_label = '_' + hashlib.md5(label.encode('utf-8')).hexdigest()
 
         # if label starts with number, add underscore as first character
-        label = '_' + label if re.match('^\d', label) else label
+        mutated_label = '_' + label if re.match('^\d', label) else label
 
         # replace non-alphanumeric characters with underscores
-        mutated_label = re.sub('[^\w]+', '_', label)
+        mutated_label = re.sub('[^\w]+', '_', mutated_label)
         if mutated_label != label:
             # add md5 hash to label to avoid possible collisions
             mutated_label += hashed_label

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -394,7 +394,9 @@ class BaseEngineSpec(object):
         and special characters, like commas, parentheses etc. For engines that
         have restrictions on what types of aliases are supported, this method
         can be overridden to ensure that labels conform to the engine's
-        limitations.
+        limitations. Mutated labels should be deterministic (input label A always
+        yields output label X) and unique (input labels A and B don't yield the same
+        output label X).
         """
         return label
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2362,7 +2362,7 @@ class DeckPathViz(BaseDeckGLViz):
         return d
 
     def get_data(self, df):
-        self.metric_label = self.get_metric_label(self.metric)
+        self.metric_label = utils.get_metric_name(self.metric)
         return super(DeckPathViz, self).get_data(df)
 
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -105,26 +105,12 @@ class BaseViz(object):
                 if not isinstance(val, list):
                     val = [val]
                 for o in val:
-                    label = self.get_metric_label(o)
-                    if isinstance(o, dict):
-                        o['label'] = label
+                    label = utils.get_metric_name(o)
                     self.metric_dict[label] = o
 
         # Cast to list needed to return serializable object in py3
         self.all_metrics = list(self.metric_dict.values())
         self.metric_labels = list(self.metric_dict.keys())
-
-    def get_metric_label(self, metric):
-        if isinstance(metric, str):
-            return metric
-
-        if isinstance(metric, dict):
-            metric = metric.get('label')
-
-        if self.datasource.type == 'table':
-            db_engine_spec = self.datasource.database.db_engine_spec
-            metric = db_engine_spec.mutate_expression_label(metric)
-        return metric
 
     @staticmethod
     def handle_js_int_overflow(data):
@@ -561,7 +547,7 @@ class TableViz(BaseViz):
 
         # Sum up and compute percentages for all percent metrics
         percent_metrics = fd.get('percent_metrics') or []
-        percent_metrics = [self.get_metric_label(m) for m in percent_metrics]
+        percent_metrics = [utils.get_metric_name(m) for m in percent_metrics]
 
         if len(percent_metrics):
             percent_metrics = list(filter(lambda m: m in df, percent_metrics))
@@ -579,7 +565,7 @@ class TableViz(BaseViz):
                 df[m_name] = pd.Series(metric_percents[m], name=m_name)
             # Remove metrics that are not in the main metrics list
             metrics = fd.get('metrics') or []
-            metrics = [self.get_metric_label(m) for m in metrics]
+            metrics = [utils.get_metric_name(m) for m in metrics]
             for m in filter(
                 lambda m: m not in metrics and m in df.columns,
                 percent_metrics,
@@ -682,7 +668,7 @@ class PivotTableViz(BaseViz):
         df = df.pivot_table(
             index=self.form_data.get('groupby'),
             columns=self.form_data.get('columns'),
-            values=[self.get_metric_label(m) for m in self.form_data.get('metrics')],
+            values=[utils.get_metric_name(m) for m in self.form_data.get('metrics')],
             aggfunc=self.form_data.get('pandas_aggfunc'),
             margins=self.form_data.get('pivot_margins'),
         )
@@ -1017,7 +1003,7 @@ class BulletViz(NVD3Viz):
 
     def get_data(self, df):
         df = df.fillna(0)
-        df['metric'] = df[[self.get_metric_label(self.metric)]]
+        df['metric'] = df[[utils.get_metric_name(self.metric)]]
         values = df['metric'].values
         return {
             'measures': values.tolist(),
@@ -1137,6 +1123,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
         df = df.fillna(0)
         if fd.get('granularity') == 'all':
             raise Exception(_('Pick a time granularity for your time series'))
+
         if not aggregate:
             df = df.pivot_table(
                 index=DTTM_ALIAS,
@@ -1352,8 +1339,8 @@ class NVD3DualLineViz(NVD3Viz):
         if self.form_data.get('granularity') == 'all':
             raise Exception(_('Pick a time granularity for your time series'))
 
-        metric = self.get_metric_label(fd.get('metric'))
-        metric_2 = self.get_metric_label(fd.get('metric_2'))
+        metric = utils.get_metric_name(fd.get('metric'))
+        metric_2 = utils.get_metric_name(fd.get('metric_2'))
         df = df.pivot_table(
             index=DTTM_ALIAS,
             values=[metric, metric_2])
@@ -1404,7 +1391,7 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
         df = df.pivot_table(
             index=DTTM_ALIAS,
             columns='series',
-            values=self.get_metric_label(fd.get('metric')))
+            values=utils.get_metric_name(fd.get('metric')))
         chart_data = self.to_series(df)
         for serie in chart_data:
             serie['rank'] = rank_lookup[serie['key']]
@@ -1576,8 +1563,8 @@ class SunburstViz(BaseViz):
     def get_data(self, df):
         fd = self.form_data
         cols = fd.get('groupby')
-        metric = self.get_metric_label(fd.get('metric'))
-        secondary_metric = self.get_metric_label(fd.get('secondary_metric'))
+        metric = utils.get_metric_name(fd.get('metric'))
+        secondary_metric = utils.get_metric_name(fd.get('secondary_metric'))
         if metric == secondary_metric or secondary_metric is None:
             df.columns = cols + ['m1']
             df['m2'] = df['m1']
@@ -1678,7 +1665,7 @@ class ChordViz(BaseViz):
         qry = super(ChordViz, self).query_obj()
         fd = self.form_data
         qry['groupby'] = [fd.get('groupby'), fd.get('columns')]
-        qry['metrics'] = [self.get_metric_label(fd.get('metric'))]
+        qry['metrics'] = [utils.get_metric_name(fd.get('metric'))]
         return qry
 
     def get_data(self, df):
@@ -1744,8 +1731,8 @@ class WorldMapViz(BaseViz):
         from superset.data import countries
         fd = self.form_data
         cols = [fd.get('entity')]
-        metric = self.get_metric_label(fd.get('metric'))
-        secondary_metric = self.get_metric_label(fd.get('secondary_metric'))
+        metric = utils.get_metric_name(fd.get('metric'))
+        secondary_metric = utils.get_metric_name(fd.get('secondary_metric'))
         columns = ['country', 'm1', 'm2']
         if metric == secondary_metric:
             ndf = df[cols]
@@ -2267,7 +2254,7 @@ class DeckScatterViz(BaseDeckGLViz):
     def get_data(self, df):
         fd = self.form_data
         self.metric_label = \
-            self.get_metric_label(self.metric) if self.metric else None
+            utils.get_metric_name(self.metric) if self.metric else None
         self.point_radius_fixed = fd.get('point_radius_fixed')
         self.fixed_value = None
         self.dim = self.form_data.get('dimension')
@@ -2298,7 +2285,7 @@ class DeckScreengrid(BaseDeckGLViz):
         }
 
     def get_data(self, df):
-        self.metric_label = self.get_metric_label(self.metric)
+        self.metric_label = utils.get_metric_name(self.metric)
         return super(DeckScreengrid, self).get_data(df)
 
 
@@ -2317,7 +2304,7 @@ class DeckGrid(BaseDeckGLViz):
         }
 
     def get_data(self, df):
-        self.metric_label = self.get_metric_label(self.metric)
+        self.metric_label = utils.get_metric_name(self.metric)
         return super(DeckGrid, self).get_data(df)
 
 
@@ -2423,7 +2410,7 @@ class DeckHex(BaseDeckGLViz):
         }
 
     def get_data(self, df):
-        self.metric_label = self.get_metric_label(self.metric)
+        self.metric_label = utils.get_metric_name(self.metric)
         return super(DeckHex, self).get_data(df)
 
 


### PR DESCRIPTION
A continuation of PR #5686 for databases that have non-standard handling of column/alias names. The purpose of this PR is to make all engines 'just work' regardless of connector quirks or database restrictions. Based on available documentation and empirical experience, the following holds for dbapi1 query results used by Superset:
- **BigQuery**: Column names can be no longer than 128 characters, must start with a letter and can contain only letters, numbers and underscores. Mixed case.
- **Redshift**: Column names in query results are all lowercase, even if mixed-case alias is quoted.
- **Oracle**: Column names have a maximum length 30 characters.
- **DB2**: Same as Oracle.
- **Snowflake**: Lowercase aliases that are unquoted result in all uppercase column names. In addition 256 character limit on column names.

This PR changes the following:
- No functional changes to any existing databases; the PR only modifies behavior of the five databases mentioned above.
- Centralizes all label mutation and quoting logic in `/connectors/sqla/models.py`, which modifies labels as necessary on the fly and returns a dataframe with the original column headers, irrespective of database type. All SQL Alchemy specific logic removed from `viz.py`.
- Extends the work started in #5641 where engines with special restrictions for labels can provide a custom `mutate_label` method in `db_engine_specs.py` to change the label as needed. For BigQuery the logic is as follows:
   1) If the label contains unsupported characters, replace all characters in violation with underscores and add an md5 hash to the end of the column to avoid collisions.
   2) Return the new label from 1) if the new column name is less than 128 characters long, otherwise return only the hash.
- Other engines, use a similar approach as described above: Redshift lowercases everything, while Oracle and DB2 restricts the column length to 30 characters. If a label is mutated, the original and mutated labels are listed in the View Query view.

Below some examples of before and after this PR.

## BigQuery

Currently BigQuery mutates column names to comply with the minimum requirements. This causes funny column names where e.g. parentheses are replaced by underscores:

<img width="1254" alt="bigquery before" src="https://user-images.githubusercontent.com/33317356/49801461-ebcc9900-fd52-11e8-99fd-f486079170d5.png">

This PR changes the columns back to their original state:

<img width="1264" alt="bigquery after" src="https://user-images.githubusercontent.com/33317356/49801494-043cb380-fd53-11e8-9c90-39ad94da55d3.png">

Looking at the query one can see that a hash has been added to the mutated column to avoid collisions, .e.g. if the columns `SUM(x)`and `SUM[x]` are present.

<img width="886" alt="bigquery after query" src="https://user-images.githubusercontent.com/33317356/49802052-8679a780-fd54-11e8-970c-e3d419a0e7b0.png">

## Redshift

Currently Redshift shows all lowercase column names in tables:

<img width="1255" alt="redshift before table" src="https://user-images.githubusercontent.com/33317356/49801591-46fe8b80-fd53-11e8-85a3-9601897bd52a.png">

On the other hand timeseries don't work at all:

<img width="1259" alt="redshift before timeseries" src="https://user-images.githubusercontent.com/33317356/49801730-a0ff5100-fd53-11e8-95c8-e78fd90d1905.png">

After this PR timeseries work just fine:

<img width="1252" alt="redshift after timeseries" src="https://user-images.githubusercontent.com/33317356/49801746-b1afc700-fd53-11e8-88ed-2bd1e8897ffb.png">

## Oracle

Currently column names that exceed 30 characters don't work:

<img width="1252" alt="oracle before" src="https://user-images.githubusercontent.com/33317356/49801841-f89dbc80-fd53-11e8-9892-3785fcead853.png">

This PR makes it possible to use arbitrarily long column names:

<img width="1265" alt="oracle after" src="https://user-images.githubusercontent.com/33317356/49801859-0bb08c80-fd54-11e8-9769-1ea9a2fab1b9.png">

This is done by changing the column names that exceed 30 chars to the first 30 chars from a MD5 hash in the query:

<img width="897" alt="oracle after query" src="https://user-images.githubusercontent.com/33317356/49801891-21be4d00-fd54-11e8-863d-ca8b551bd6ef.png">

## Snowflake

Currently timeseries graphs don't work due to forced quotes being missing from temporal column names (my bad, I forgot to add it to the original PR):

<img width="1256" alt="snowflake before" src="https://user-images.githubusercontent.com/33317356/49801960-516d5500-fd54-11e8-9106-b32754d1cea1.png">

After this PR timeseries work fine:

<img width="1258" alt="snowflake after" src="https://user-images.githubusercontent.com/33317356/49801985-5fbb7100-fd54-11e8-868a-a9f6423af02d.png">

## Db2

Not tested at all, but should work similar to Oracle.