### PR TITLE
Get 'Test Connection' button to take 'engine_params' into account

### DIFF
--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -1,7 +1,7 @@
 {% macro testconn() %}
   <script>
     $("#sqlalchemy_uri").parent()
-      .append('<button id="testconn" class="btn">{{ _("Test Connection") }}</button>');
+      .append('<button id="testconn" class="btn btn-sm btn-primary">{{ _("Test Connection") }}</button>');
     $("#testconn").click(function(e) {
       e.preventDefault();
       var url = "/superset/testconn";

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1701,16 +1701,16 @@ class Superset(BaseSupersetView):
                                                                   username),
                 )
 
-            connect_args = (
+            engine_params = (
                 request.json
                 .get('extras', {})
-                .get('engine_params', {})
-                .get('connect_args', {}))
+                .get('engine_params', {}))
+            connect_args = engine_params.get('connect_args')
 
             if configuration:
                 connect_args['configuration'] = configuration
 
-            engine = create_engine(uri, connect_args=connect_args)
+            engine = create_engine(uri, **engine_params)
             engine.connect()
             return json_success(json.dumps(engine.table_names(), indent=4))
         except Exception as e:


### PR DESCRIPTION
I was connecting BigQuery and realized that the 'Test Connection' was disregarding the `extras` parameters. This addressed it:
<img width="691" alt="screen shot 2018-09-05 at 10 19 33 pm" src="https://user-images.githubusercontent.com/487433/45136611-cd567080-b159-11e8-99f8-cffd020acb6e.png">
