### PR TITLE
[WIP] Allow admin restrict chart dbs

### DIFF
--- a/superset/migrations/versions/6400c588de5e_.py
+++ b/superset/migrations/versions/6400c588de5e_.py
@@ -1,0 +1,21 @@
+"""empty message
+
+Revision ID: 6400c588de5e
+Revises: bddc498dd179
+Create Date: 2018-07-13 17:10:00.156708
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '6400c588de5e'
+down_revision = 'bddc498dd179'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('dbs', sa.Column('allow_csv_upload', sa.Boolean(), nullable=True))
+
+def downgrade():
+    op.drop_column('dbs', 'allow_csv_upload')

--- a/superset/migrations/versions/af91471628d4_add_allow_charts.py
+++ b/superset/migrations/versions/af91471628d4_add_allow_charts.py
@@ -1,0 +1,31 @@
+"""empty message
+
+Revision ID: af91471628d4
+Revises: 55e910a74826
+Create Date: 2018-09-06 02:04:06.340732
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'af91471628d4'
+down_revision = '55e910a74826'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from sqlalchemy.sql import expression
+
+
+def upgrade():
+    op.add_column(
+    	'dbs',
+    	sa.Column(
+    		'allow_charts',
+    		sa.Boolean(),
+    		nullable=False,
+    		server_default=expression.true()))
+
+def downgrade():
+    op.drop_column('dbs', 'allow_charts')
+

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -638,6 +638,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     expose_in_sqllab = Column(Boolean, default=False)
     allow_run_sync = Column(Boolean, default=True)
     allow_run_async = Column(Boolean, default=False)
+    allow_charts = Column(Boolean, default=True)
     allow_csv_upload = Column(Boolean, default=True)
     allow_ctas = Column(Boolean, default=False)
     allow_dml = Column(Boolean, default=False)
@@ -654,7 +655,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     impersonate_user = Column(Boolean, default=False)
     export_fields = ('database_name', 'sqlalchemy_uri', 'cache_timeout',
                      'expose_in_sqllab', 'allow_run_sync', 'allow_run_async',
-                     'allow_ctas', 'allow_csv_upload', 'extra')
+                     'allow_ctas', 'allow_charts', 'allow_csv_upload', 'extra')
     export_children = ['tables']
 
     def __repr__(self):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -148,16 +148,16 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
 
     list_columns = [
         'database_name', 'backend', 'allow_run_sync', 'allow_run_async',
-        'allow_dml', 'allow_csv_upload', 'creator', 'modified']
+        'allow_dml', 'allow_charts', 'allow_csv_upload', 'creator', 'modified']
     order_columns = [
         'database_name', 'allow_run_sync', 'allow_run_async', 'allow_dml',
-        'modified', 'allow_csv_upload',
+        'modified', 'allow_charts', 'allow_csv_upload',
     ]
     add_columns = [
         'database_name', 'sqlalchemy_uri', 'cache_timeout', 'extra',
-        'expose_in_sqllab', 'allow_run_sync', 'allow_run_async', 'allow_csv_upload',
-        'allow_ctas', 'allow_dml', 'force_ctas_schema', 'impersonate_user',
-        'allow_multi_schema_metadata_fetch',
+        'expose_in_sqllab', 'allow_run_sync', 'allow_run_async', 'allow_charts',
+        'allow_csv_upload', 'allow_ctas', 'allow_dml', 'force_ctas_schema', 
+        'impersonate_user', 'allow_multi_schema_metadata_fetch',
     ]
     search_exclude_columns = (
         'password', 'tables', 'created_by', 'changed_by', 'queries',
@@ -240,6 +240,7 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
         'allow_run_sync': _('Allow Run Sync'),
         'allow_run_async': _('Allow Run Async'),
         'impersonate_user': _('Impersonate the logged on user'),
+        'allow_charts': _('Allow users make charts backed by this db'),
         'allow_csv_upload': _('Allow Csv Upload'),
         'modified': _('Modified'),
         'allow_multi_schema_metadata_fetch': _('Allow Multi Schema Metadata Fetch'),
@@ -292,8 +293,8 @@ class DatabaseAsync(DatabaseView):
         'id', 'database_name',
         'expose_in_sqllab', 'allow_ctas', 'force_ctas_schema',
         'allow_run_async', 'allow_run_sync', 'allow_dml',
-        'allow_multi_schema_metadata_fetch', 'allow_csv_upload',
-        'allows_subquery',
+        'allow_multi_schema_metadata_fetch', 'allow_charts', 
+        'allow_csv_upload', 'allows_subquery',
     ]
 
 


### PR DESCRIPTION
This PR allows the admin restrict what databases a user can create slices from. 
I still need to follow-up with changes to the visualize flow and the db dropdowns for slices. 