### PR TITLE
fix sqlab progress bar and status inconsistency

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -23,7 +23,7 @@ class QueryAutoRefresh extends React.PureComponent {
     const now = new Date().getTime();
     return Object.values(queries)
       .some(
-        q => ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 &&
+        q => ['running', 'started', 'pending', 'fetching', 'rendering'].indexOf(q.state) >= 0 &&
         now - q.startDttm < MAX_QUERY_AGE_TO_POLL,
       );
   }

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -200,7 +200,7 @@ export default class ResultSet extends React.PureComponent {
     }
     let progressBar;
     let trackingUrl;
-    if (query.progress > 0 && query.state === 'running') {
+    if (query.progress > 0) {
       progressBar = (
         <ProgressBar
           striped

--- a/superset/assets/src/SqlLab/constants.js
+++ b/superset/assets/src/SqlLab/constants.js
@@ -4,6 +4,7 @@ export const STATE_BSSTYLE_MAP = {
   fetching: 'info',
   running: 'warning',
   stopped: 'danger',
+  rendering: 'info',
   success: 'success',
 };
 

--- a/superset/assets/src/SqlLab/reducers.js
+++ b/superset/assets/src/SqlLab/reducers.js
@@ -157,7 +157,7 @@ export const sqlLabReducer = function (state = {}, action) {
         progress: 100,
         results: action.results,
         rows,
-        state: action.query.state,
+        state: 'rendering',
         errorMessage: null,
         cached: false,
       };


### PR DESCRIPTION
This is an example that progress bar says 100% finished, but status still says running
<img width="1149" alt="screen shot 2018-09-10 at 3 13 56 pm" src="https://user-images.githubusercontent.com/26216756/45327380-2af90d00-b50c-11e8-8389-9148d13526f9.png">
This is because there is one more round of rendering going on in `sqllab` app to show data after it gets the query result. 

In this PR, I introduced one more state regarding query status which is `rendering`. After query succeeds, the progress bar will now show `100%` and the status will show `rendering`. It is more user friendly. This is what it looks like now:
<img width="1145" alt="screen shot 2018-09-10 at 3 24 01 pm" src="https://user-images.githubusercontent.com/26216756/45327734-94c5e680-b50d-11e8-80dc-132fd3083cf8.png">
