### PR TITLE
[bugfix] 'No numeric types to aggregate' in NVD3 chart

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -225,15 +225,15 @@ class BaseViz(object):
                 df[DTTM_ALIAS] += self.time_shift
 
             if self.enforce_numerical_metrics:
-                self.df_metrics_to_num(df, query_obj.get('metrics') or [])
+                self.df_metrics_to_num(df)
 
             df.replace([np.inf, -np.inf], np.nan)
             df = self.handle_nulls(df)
         return df
 
-    @staticmethod
-    def df_metrics_to_num(df, metrics):
+    def df_metrics_to_num(self, df):
         """Converting metrics to numeric when pandas.read_sql cannot"""
+        metrics = self.metric_labels
         for col, dtype in df.dtypes.items():
             if dtype.type == np.object_ and col in metrics:
                 df[col] = pd.to_numeric(df[col], errors='coerce')


### PR DESCRIPTION
Another bug related to old vs new metric format. This one here prevented the `enforce_numerical_metrics = True`-related logic to execute