### PR TITLE
[dev] fix redux devtools

### DIFF
--- a/superset/assets/src/reduxUtils.js
+++ b/superset/assets/src/reduxUtils.js
@@ -70,7 +70,7 @@ export function addToArr(state, arrKey, obj, prepend = false) {
 
 export function initEnhancer(persist = true) {
   let enhancer = persist ? compose(persistState()) : compose();
-  if (process.env.NODE_ENV === 'dev') {
+  if (process.env.WEBPACK_MODE === 'development') {
     /* eslint-disable-next-line no-underscore-dangle */
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
     enhancer = persist ? composeEnhancers(persistState()) : composeEnhancers();

--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -35,6 +35,11 @@ const plugins = [
 
   // create fresh dist/ upon build
   new CleanWebpackPlugin(['dist']),
+
+  // expose mode variable to other modules
+  new webpack.DefinePlugin({
+    'process.env.WEBPACK_MODE': JSON.stringify(mode),
+  }),
 ];
 
 if (isDevMode) {


### PR DESCRIPTION
This PR fixes redux dev tools which broke due to the webpack 4 upgrade. 

The `process.node. NODE_ENV` variable is no longer defined, so I define the new `WEBPACK_MODE` variable and use its value to set redux dev tools or not.

@kristw @mistercrunch @xtinec @michellethomas @graceguo-supercat 