### PR TITLE
make access request open new tab

### DIFF
--- a/superset/assets/src/components/StackTraceMessage.jsx
+++ b/superset/assets/src/components/StackTraceMessage.jsx
@@ -38,7 +38,13 @@ class StackTraceMessage extends React.PureComponent {
         >
           {this.props.message}
           {this.hasLink() &&
-          <a href={this.props.queryResponse.link}> (Request Access) </a>
+          <a
+            href={this.props.queryResponse.link}
+            target="_blank" 
+            rel="noopener noreferrer"
+          >
+            (Request Access)
+          </a>
        }
         </Alert>
         {this.hasTrace() &&

--- a/superset/assets/src/components/StackTraceMessage.jsx
+++ b/superset/assets/src/components/StackTraceMessage.jsx
@@ -40,7 +40,7 @@ class StackTraceMessage extends React.PureComponent {
           {this.hasLink() &&
           <a
             href={this.props.queryResponse.link}
-            target="_blank" 
+            target="_blank"
             rel="noopener noreferrer"
           >
             (Request Access)


### PR DESCRIPTION
This PR makes request access links open a new tab, as opposed to changing the page from Superset. 

@graceguo-supercat @michellethomas 