### PR TITLE
[bugfix] FilterBox crashes after React 16 update

### DIFF
--- a/superset/assets/src/components/VirtualizedRendererWrap.jsx
+++ b/superset/assets/src/components/VirtualizedRendererWrap.jsx
@@ -35,7 +35,7 @@ export default function VirtualizedRendererWrap(renderer) {
       <div
         className={className.join(' ')}
         key={key}
-        style={Object.assign(option.style || {}, style)}
+        style={{ ...(option.style || {}), ...style }}
         title={option.title}
         {...events}
       >


### PR DESCRIPTION
Fix `Object.assign` try to write to read-only `option.style`

@graceguo-supercat 