### PR TITLE
fix sqllab logging

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -100,7 +100,7 @@ def execute_sql(
     user_name=None, session=None, start_time=None,
 ):
     """Executes the sql query returns the results."""
-    if store_results:
+    if store_results and start_time:
         # only asynchronous queries
         stats_logger.timing(
             'sqllab.query.time_pending', utils.now_as_float() - start_time)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2338,7 +2338,7 @@ class Superset(BaseSupersetView):
         blob = results_backend.get(key)
         stats_logger.timing(
             'sqllab.query.results_backend_read',
-            read_from_results_backend_start - utils.now_as_float(),
+            utils.now_as_float() - read_from_results_backend_start,
         )
         if not blob:
             return json_error_response(


### PR DESCRIPTION
This PR fixes a case in sqllab celery worker where run query is called in the asynchronous case but not with the query. (It ensures there is a start_time specified before subtracting) 
It also fixes a minor bug where I flipped the operands beside the minus sign

@john-bodley 