### PR TITLE
[time table] fix sorting on missing values

### DIFF
--- a/superset/assets/src/visualizations/time_table.jsx
+++ b/superset/assets/src/visualizations/time_table.jsx
@@ -123,6 +123,7 @@ function viz(slice, payload) {
           } else if (column.comparisonType === 'perc_change') {
             v = (recent / v) - 1;
           }
+          v = v || 0;
         } else if (column.colType === 'contrib') {
           // contribution to column total
           v = recent / Object.keys(reversedData[0])


### PR DESCRIPTION
Empty cells would show as `0` and sort randomly.