### PR TITLE
fixed modal close issue

### DIFF
--- a/superset/assets/src/components/ModalTrigger.jsx
+++ b/superset/assets/src/components/ModalTrigger.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, MenuItem } from 'react-bootstrap';
 import cx from 'classnames';
@@ -82,31 +82,37 @@ export default class ModalTrigger extends React.Component {
       'btn btn-default btn-sm': this.props.isButton,
     });
     if (this.props.isButton) {
-      return [
-        <Button
-          className="modal-trigger"
-          tooltip={this.props.tooltip}
-          onClick={this.open}
-        >
-          {this.props.triggerNode}
-        </Button>,
-        this.renderModal(),
-      ];
+      return (
+        <Fragment>
+          <Button
+            className="modal-trigger"
+            tooltip={this.props.tooltip}
+            onClick={this.open}
+          >
+            {this.props.triggerNode}
+          </Button>
+          {this.renderModal()}
+        </Fragment>
+      );
     } else if (this.props.isMenuItem) {
-      return [
-        <MenuItem onClick={this.open}>
-          {this.props.triggerNode}
-        </MenuItem>,
-        this.renderModal(),
-      ];
+      return (
+        <Fragment>
+          <MenuItem onClick={this.open}>
+            {this.props.triggerNode}
+          </MenuItem>
+          {this.renderModal()}
+        </Fragment>
+      );
     }
     /* eslint-disable jsx-a11y/interactive-supports-focus */
-    return [
-      <span className={classNames} onClick={this.open} role="button">
-        {this.props.triggerNode}
-      </span>,
-      this.renderModal(),
-    ];
+    return (
+      <Fragment>
+        <span className={classNames} onClick={this.open} role="button">
+          {this.props.triggerNode}
+        </span>
+        {this.renderModal()}
+      </Fragment>
+    );
   }
 }
 

--- a/superset/assets/src/components/ModalTrigger.jsx
+++ b/superset/assets/src/components/ModalTrigger.jsx
@@ -82,31 +82,31 @@ export default class ModalTrigger extends React.Component {
       'btn btn-default btn-sm': this.props.isButton,
     });
     if (this.props.isButton) {
-      return (
+      return [
         <Button
           className="modal-trigger"
           tooltip={this.props.tooltip}
           onClick={this.open}
         >
           {this.props.triggerNode}
-          {this.renderModal()}
-        </Button>
-      );
+        </Button>,
+        this.renderModal(),
+      ];
     } else if (this.props.isMenuItem) {
-      return (
+      return [
         <MenuItem onClick={this.open}>
           {this.props.triggerNode}
-          {this.renderModal()}
-        </MenuItem>
-      );
+        </MenuItem>,
+        this.renderModal(),
+      ];
     }
     /* eslint-disable jsx-a11y/interactive-supports-focus */
-    return (
+    return [
       <span className={classNames} onClick={this.open} role="button">
         {this.props.triggerNode}
-        {this.renderModal()}
-      </span>
-    );
+      </span>,
+      this.renderModal(),
+    ];
   }
 }
 


### PR DESCRIPTION
This PR is to fix the issue that the modal generated by `ModelTrigger` cannot be closed properly.  

Credit to @williaster for finding the bug!

The root cause is `this.open` will be trigger since the modal literally is inside the parent dom which has `this.open` binded with `onClick`. 

![model_close_bug](https://user-images.githubusercontent.com/2024960/45400594-ac7e9700-b601-11e8-9d63-a56f2a8a6c1f.gif)

