### PR TITLE
[bugfix] Fix slice width calculation in dashboard 

### DIFF
--- a/superset/assets/src/dashboard/components/gridComponents/ChartHolder.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/ChartHolder.jsx
@@ -12,6 +12,7 @@ import {
   GRID_MIN_COLUMN_COUNT,
   GRID_MIN_ROW_UNITS,
   GRID_BASE_UNIT,
+  GRID_GUTTER_SIZE,
 } from '../../util/constants';
 
 const CHART_MARGIN = 32;
@@ -131,8 +132,14 @@ class ChartHolder extends React.Component {
             >
               <Chart
                 id={component.meta.chartId}
-                width={widthMultiple * columnWidth - CHART_MARGIN / 2}
-                height={component.meta.height * GRID_BASE_UNIT - CHART_MARGIN}
+                width={Math.floor(
+                  widthMultiple * columnWidth +
+                    (widthMultiple - 1) * GRID_GUTTER_SIZE -
+                    CHART_MARGIN,
+                )}
+                height={Math.floor(
+                  component.meta.height * GRID_BASE_UNIT - CHART_MARGIN,
+                )}
                 sliceName={component.meta.sliceName || ''}
                 updateSliceName={this.handleUpdateSliceName}
               />


### PR DESCRIPTION
My previous fix (https://github.com/apache/incubator-superset/pull/5839) was incorrect. 
It only works for slices that spans 1-2 columns, but compute less width than it should be for the slices that span >2 columns. 

The previous formula did not take `GRID_GUTTER_SIZE` into account. A slice with `n` columns also contains `n-1` gutter. 

The formula for width is updated to 
```js
widthMultiple * columnWidth + (widthMultiple - 1) * GRID_GUTTER_SIZE - CHART_MARGIN
```

@john-bodley @graceguo-supercat 
