### PR TITLE
Remove unused functions and jquery dependency

### DIFF
--- a/superset/assets/src/chart/ChartBody.jsx
+++ b/superset/assets/src/chart/ChartBody.jsx
@@ -10,14 +10,6 @@ const propTypes = {
 };
 
 class ChartBody extends React.PureComponent {
-  html(data) {
-    this.el.innerHTML = data;
-  }
-
-  css(property, value) {
-    this.el.style[property] = value;
-  }
-
   height() {
     return this.props.height();
   }

--- a/superset/assets/src/chart/ChartBody.jsx
+++ b/superset/assets/src/chart/ChartBody.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import $ from 'jquery';
 
 const propTypes = {
   containerId: PropTypes.string.isRequired,
@@ -17,18 +16,6 @@ class ChartBody extends React.PureComponent {
 
   css(property, value) {
     this.el.style[property] = value;
-  }
-
-  get(n) {
-    return $(this.el).get(n);
-  }
-
-  find(classname) {
-    return $(this.el).find(classname);
-  }
-
-  show() {
-    return $(this.el).show();
   }
 
   height() {


### PR DESCRIPTION
Functions `get`, `find` and `show` are not used any more after the SIP-5 refactor. 

@williaster @conglei @graceguo-supercat 