### PR TITLE
Enable Teradata

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1489,10 +1489,12 @@ class KylinEngineSpec(BaseEngineSpec):
                 dttm.strftime('%Y-%m-%d %H:%M:%S'))
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
+
 class TeradataEngineSpec(BaseEngineSpec):
+    """Dialect for Teradata DB."""
     engine = 'teradata'
     limit_method = LimitMethod.WRAP_SQL
-    
+
     time_grains = (
         Grain('Time Column', _('Time Column'), '{col}', None),
         Grain('minute', _('minute'), "TRUNC(CAST({col} as DATE), 'MI')", 'PT1M'),
@@ -1503,7 +1505,8 @@ class TeradataEngineSpec(BaseEngineSpec):
         Grain('quarter', _('quarter'), "TRUNC(CAST({col} as DATE), 'Q')", 'P0.25Y'),
         Grain('year', _('year'), "TRUNC(CAST({col} as DATE), 'YEAR')", 'P1Y'),
     )
-    
+
+
 engines = {
     o.engine: o for o in globals().values()
     if inspect.isclass(o) and issubclass(o, BaseEngineSpec)}

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1489,7 +1489,21 @@ class KylinEngineSpec(BaseEngineSpec):
                 dttm.strftime('%Y-%m-%d %H:%M:%S'))
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
-
+class TeradataEngineSpec(BaseEngineSpec):
+    engine = 'teradata'
+    limit_method = LimitMethod.WRAP_SQL
+    
+    time_grains = (
+        Grain('Time Column', _('Time Column'), '{col}', None),
+        Grain('minute', _('minute'), "TRUNC(CAST({col} as DATE), 'MI')", 'PT1M'),
+        Grain('hour', _('hour'), "TRUNC(CAST({col} as DATE), 'HH')", 'PT1H'),
+        Grain('day', _('day'), "TRUNC(CAST({col} as DATE), 'DDD')", 'P1D'),
+        Grain('week', _('week'), "TRUNC(CAST({col} as DATE), 'WW')", 'P1W'),
+        Grain('month', _('month'), "TRUNC(CAST({col} as DATE), 'MONTH')", 'P1M'),
+        Grain('quarter', _('quarter'), "TRUNC(CAST({col} as DATE), 'Q')", 'P0.25Y'),
+        Grain('year', _('year'), "TRUNC(CAST({col} as DATE), 'YEAR')", 'P1Y'),
+    )
+    
 engines = {
     o.engine: o for o in globals().values()
     if inspect.isclass(o) and issubclass(o, BaseEngineSpec)}


### PR DESCRIPTION
New DB engine spec for Teradata:
- LimitMethod should be WRAP_SQL since Teradata does not supporting "LIMIT" clause  (TOP) - without this change sqllab does not work
- Timegrains for Teradata are added