### PR TITLE
[tests] fix sqllab/TableElement_spec

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -54,8 +54,6 @@ describe('TableElement', () => {
     expect(wrapper.state().expanded).to.equal(true);
     wrapper.find('.table-remove').simulate('click');
     expect(wrapper.state().expanded).to.equal(false);
-    setTimeout(() => {
-      expect(mockedActions.removeTable.called).to.equal(true);
-    }, 10);
+    expect(mockedActions.removeDataPreview.called).to.equal(true);
   });
 });


### PR DESCRIPTION
This PR fixes a JS test that I encountered locally and seems to be failing others (e.g., [failed build here](https://travis-ci.org/apache/incubator-superset/jobs/427507093#L4728) from #5865, #5869, etc.)

I'm not sure how this test passed before TBH. According to git blame [`removeDataPreview`](https://github.com/apache/incubator-superset/blame/master/superset/assets/src/SqlLab/components/TableElement.jsx#L57) (not  `removeTable`) has been called for ~2 years. My only thought is that this async test didn't properly call the `done()` callback, so maybe it was getting skipped most of the time 🤔 

@mistercrunch @kristw @conglei @graceguo-supercat @michellethomas 