### PR TITLE
[bug fix] Fixed adhoc metric is not working for WordCloud

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1309,7 +1309,7 @@ export const controls = {
     label: t('Rotation'),
     choices: formatSelectOptions(['random', 'flat', 'square']),
     renderTrigger: true,
-    default: 'square',
+    default: 'flat',
     description: t('Rotation to apply to words in the cloud'),
   },
 

--- a/superset/assets/src/visualizations/wordcloud/WordCloud.js
+++ b/superset/assets/src/visualizations/wordcloud/WordCloud.js
@@ -35,7 +35,7 @@ function wordCloud(element, props) {
 
   const chart = d3.select(element);
   const size = [width, height];
-  const rotationFn = ROTATION[rotation] || ROTATION.random;
+  const rotationFn = ROTATION[rotation] || ROTATION.flat;
 
   const scale = d3.scale.linear()
     .range(sizeRange)

--- a/superset/assets/src/visualizations/wordcloud/WordCloud.js
+++ b/superset/assets/src/visualizations/wordcloud/WordCloud.js
@@ -86,7 +86,7 @@ function transform(data, formData) {
 
   const transformedData = data.map(datum => ({
     text: datum[series],
-    size: datum[metric],
+    size: datum[metric.label || metric],
   }));
 
   return transformedData;


### PR DESCRIPTION
#5857 

This PR is to fix the issue that adhoc metrics don't work for wordcloud.  The root cause is the inconsistent metric formats between normal metrics and adhoc metrics.  @villebro 


The inconsistency is pretty annoying, and we should, imo, make it consistent in a long term when refactoring the formdata part. 

@john-bodley @williaster @mistercrunch @kristw 