### PR TITLE
remove getColorFromScheme usage in histogram

### DIFF
--- a/superset/assets/src/visualizations/Histogram.jsx
+++ b/superset/assets/src/visualizations/Histogram.jsx
@@ -6,7 +6,7 @@ import { chartTheme } from '@data-ui/theme';
 import { LegendOrdinal } from '@vx/legend';
 import { scaleOrdinal } from '@vx/scale';
 import WithLegend from './WithLegend';
-import { getColorFromScheme } from '../modules/colors';
+import { getScale } from '../modules/CategoricalColorNamespace';
 
 const propTypes = {
   className: PropTypes.string,
@@ -48,10 +48,11 @@ class CustomHistogram extends React.PureComponent {
       yAxisLabel,
     } = this.props;
 
+    const colorFn = getScale(colorScheme).toFunction();
     const keys = data.map(d => d.key);
     const colorScale = scaleOrdinal({
       domain: keys,
-      range: keys.map(key => getColorFromScheme(key, colorScheme)),
+      range: keys.map(colorFn),
     });
 
     return (


### PR DESCRIPTION
in favor of `CategoricalColorNamespace`'s `getScale()`

@williaster @graceguo-supercat @conglei 