### PR TITLE
[lint] turn no-undef back on, set browser, cypress, and mocha env's

### DIFF
--- a/superset/assets/.eslintrc
+++ b/superset/assets/.eslintrc
@@ -6,8 +6,8 @@
       "experimentalObjectRestSpread": true
     }
   },
-  "globals": {
-    "document": true,
+  "env": {
+    "browser": true
   },
   "rules": {
     "prefer-template": 0,
@@ -26,7 +26,6 @@
     "no-mixed-operators": 0,
     "no-continue": 0,
     "no-bitwise": 0,
-    "no-undef": 0,
     "no-multi-assign": 0,
     "react/no-array-index-key": 0,
     "no-restricted-properties": 0,

--- a/superset/assets/cypress/.eslintrc
+++ b/superset/assets/cypress/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "cypress"
+  ],
+  "env": {
+    "cypress/globals": true
+  }
+}

--- a/superset/assets/cypress/integration/dashboard/dashboard_tests.js
+++ b/superset/assets/cypress/integration/dashboard/dashboard_tests.js
@@ -1,5 +1,5 @@
-describe('Load dashboard', function () {
-  it('Load birth names dashboard', function () {
+describe('Load dashboard', () => {
+  it('Load birth names dashboard', () => {
     cy.server();
     cy.login();
 

--- a/superset/assets/cypress/integration/explore/control_tests.js
+++ b/superset/assets/cypress/integration/explore/control_tests.js
@@ -2,8 +2,8 @@
 // Tests for setting controls in the UI
 // ***********************************************
 
-describe('Groupby', function () {
-  it('Set groupby', function () {
+describe('Groupby', () => {
+  it('Set groupby', () => {
     cy.server();
     cy.login();
 
@@ -21,8 +21,8 @@ describe('Groupby', function () {
   });
 });
 
-describe('SimpleAdhocMetric', function () {
-  it('Clear metric and set simple adhoc metric', function () {
+describe('SimpleAdhocMetric', () => {
+  it('Clear metric and set simple adhoc metric', () => {
     cy.server();
     cy.login();
 
@@ -36,7 +36,9 @@ describe('SimpleAdhocMetric', function () {
       cy.get('.select-clear').click();
       cy.get('.Select-control').click({ force: true });
       cy.get('input').type('sum_girls', { force: true });
-      cy.get('.VirtualizedSelectFocusedOption').trigger('mousedown').click();
+      cy.get('.VirtualizedSelectFocusedOption')
+        .trigger('mousedown')
+        .click();
     });
 
     cy.get('#metrics-edit-popover').within(() => {
@@ -44,7 +46,9 @@ describe('SimpleAdhocMetric', function () {
         cy.get('span').click();
         cy.get('input').type(metricName);
       });
-      cy.get('button').contains('Save').click();
+      cy.get('button')
+        .contains('Save')
+        .click();
     });
 
     cy.get('button.query').click();
@@ -56,4 +60,3 @@ describe('SimpleAdhocMetric', function () {
     });
   });
 });
-

--- a/superset/assets/cypress/integration/explore/visualizations/big_number.js
+++ b/superset/assets/cypress/integration/explore/visualizations/big_number.js
@@ -2,10 +2,10 @@ import { FORM_DATA_DEFAULTS, NUM_METRIC } from './shared.helper';
 
 // Big Number Total
 
-describe('Big Number Total', function () {
+describe('Big Number Total', () => {
   const BIG_NUMBER_DEFAULTS = { ...FORM_DATA_DEFAULTS, viz_type: 'big_number_total' };
 
-  it('Test big number chart with adhoc metric', function () {
+  it('Test big number chart with adhoc metric', () => {
     cy.server();
     cy.login();
 
@@ -16,20 +16,22 @@ describe('Big Number Total', function () {
     cy.verifySliceSuccess({ waitAlias: '@getJson', querySubstring: NUM_METRIC.label });
   });
 
-  it('Test big number chart with simple filter', function () {
+  it('Test big number chart with simple filter', () => {
     cy.server();
     cy.login();
 
-    const filters = [{
-      expressionType: 'SIMPLE',
-      subject: 'name',
-      operator: 'in',
-      comparator: ['Aaron', 'Amy', 'Andrea'],
-      clause: 'WHERE',
-      sqlExpression: null,
-      fromFormData: true,
-      filterOptionName: 'filter_4y6teao56zs_ebjsvwy48c',
-    }];
+    const filters = [
+      {
+        expressionType: 'SIMPLE',
+        subject: 'name',
+        operator: 'in',
+        comparator: ['Aaron', 'Amy', 'Andrea'],
+        clause: 'WHERE',
+        sqlExpression: null,
+        fromFormData: true,
+        filterOptionName: 'filter_4y6teao56zs_ebjsvwy48c',
+      },
+    ];
 
     const formData = { ...BIG_NUMBER_DEFAULTS, metric: 'count', adhoc_filters: filters };
 
@@ -38,7 +40,7 @@ describe('Big Number Total', function () {
     cy.verifySliceSuccess({ waitAlias: '@getJson' });
   });
 
-  it('Test big number chart ignores groupby', function () {
+  it('Test big number chart ignores groupby', () => {
     cy.server();
     cy.login();
 

--- a/superset/assets/cypress/integration/explore/visualizations/line.js
+++ b/superset/assets/cypress/integration/explore/visualizations/line.js
@@ -1,9 +1,9 @@
 import { FORM_DATA_DEFAULTS, NUM_METRIC } from './shared.helper';
 
-describe('Line', function () {
+describe('Line', () => {
   const LINE_CHART_DEFAULTS = { ...FORM_DATA_DEFAULTS, viz_type: 'line' };
 
-  it('Test line chart with adhoc metric', function () {
+  it('Test line chart with adhoc metric', () => {
     cy.server();
     cy.login();
 
@@ -14,7 +14,7 @@ describe('Line', function () {
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
-  it('Test line chart with groupby', function () {
+  it('Test line chart with groupby', () => {
     cy.server();
     cy.login();
 
@@ -28,21 +28,23 @@ describe('Line', function () {
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
-  it('Test line chart with simple filter', function () {
+  it('Test line chart with simple filter', () => {
     cy.server();
     cy.login();
 
     const metrics = ['count'];
-    const filters = [{
-      expressionType: 'SIMPLE',
-      subject: 'name',
-      operator: 'in',
-      comparator: ['Aaron', 'Amy', 'Andrea'],
-      clause: 'WHERE',
-      sqlExpression: null,
-      fromFormData: true,
-      filterOptionName: 'filter_4y6teao56zs_ebjsvwy48c',
-    }];
+    const filters = [
+      {
+        expressionType: 'SIMPLE',
+        subject: 'name',
+        operator: 'in',
+        comparator: ['Aaron', 'Amy', 'Andrea'],
+        clause: 'WHERE',
+        sqlExpression: null,
+        fromFormData: true,
+        filterOptionName: 'filter_4y6teao56zs_ebjsvwy48c',
+      },
+    ];
 
     const formData = { ...LINE_CHART_DEFAULTS, metrics, adhoc_filters: filters };
 
@@ -51,7 +53,7 @@ describe('Line', function () {
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
-  it('Test line chart with series limit sort asc', function () {
+  it('Test line chart with series limit sort asc', () => {
     cy.server();
     cy.login();
 
@@ -68,7 +70,7 @@ describe('Line', function () {
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
-  it('Test line chart with series limit sort desc', function () {
+  it('Test line chart with series limit sort desc', () => {
     cy.server();
     cy.login();
 
@@ -86,7 +88,7 @@ describe('Line', function () {
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
-  it('Test line chart with rolling avg', function () {
+  it('Test line chart with rolling avg', () => {
     cy.server();
     cy.login();
 
@@ -99,39 +101,54 @@ describe('Line', function () {
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
-  it('Test line chart with time shift 1 year', function () {
+  it('Test line chart with time shift 1 year', () => {
     cy.server();
     cy.login();
 
     const metrics = [NUM_METRIC];
 
-    const formData = { ...LINE_CHART_DEFAULTS, metrics, time_compare: ['1+year'], comparison_type: 'values' };
+    const formData = {
+      ...LINE_CHART_DEFAULTS,
+      metrics,
+      time_compare: ['1+year'],
+      comparison_type: 'values',
+    };
 
     cy.route('POST', '/superset/explore_json/**').as('getJson');
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
-  it('Test line chart with time shift yoy', function () {
+  it('Test line chart with time shift yoy', () => {
     cy.server();
     cy.login();
 
     const metrics = [NUM_METRIC];
 
-    const formData = { ...LINE_CHART_DEFAULTS, metrics, time_compare: ['1+year'], comparison_type: 'ratio' };
+    const formData = {
+      ...LINE_CHART_DEFAULTS,
+      metrics,
+      time_compare: ['1+year'],
+      comparison_type: 'ratio',
+    };
 
     cy.route('POST', '/superset/explore_json/**').as('getJson');
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
-  it('Test line chart with time shift percentage change', function () {
+  it('Test line chart with time shift percentage change', () => {
     cy.server();
     cy.login();
 
     const metrics = [NUM_METRIC];
 
-    const formData = { ...LINE_CHART_DEFAULTS, metrics, time_compare: ['1+year'], comparison_type: 'percentage' };
+    const formData = {
+      ...LINE_CHART_DEFAULTS,
+      metrics,
+      time_compare: ['1+year'],
+      comparison_type: 'percentage',
+    };
 
     cy.route('POST', '/superset/explore_json/**').as('getJson');
     cy.visitChartByParams(JSON.stringify(formData));

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -150,6 +150,7 @@
     "eslint": "^4.19.0",
     "eslint-config-airbnb": "^15.0.1",
     "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-cypress": "^2.0.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-prettier": "^2.6.0",

--- a/superset/assets/spec/.eslintrc
+++ b/superset/assets/spec/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "mocha": true
+  },
   "rules": {
     "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
   }

--- a/superset/assets/spec/helpers/shim.js
+++ b/superset/assets/spec/helpers/shim.js
@@ -1,4 +1,4 @@
-/* eslint no-undef: 0, no-native-reassign: 0 */
+/* eslint no-native-reassign: 0 */
 import 'babel-polyfill';
 import chai from 'chai';
 import jsdom from 'jsdom';
@@ -55,4 +55,3 @@ global.window.XMLHttpRequest = global.XMLHttpRequest;
 global.window.location = { href: 'about:blank' };
 global.window.performance = { now: () => new Date().getTime() };
 global.$ = require('jquery')(global.window);
-

--- a/superset/assets/spec/javascripts/CRUD/CollectionTable_spec.jsx
+++ b/superset/assets/spec/javascripts/CRUD/CollectionTable_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 
 import CollectionTable from '../../../src/CRUD/CollectionTable';

--- a/superset/assets/spec/javascripts/addSlice/AddSliceContainer_spec.jsx
+++ b/superset/assets/spec/javascripts/addSlice/AddSliceContainer_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import { Button } from 'react-bootstrap';
 import Select from 'react-virtualized-select';

--- a/superset/assets/spec/javascripts/chart/Chart_spec.jsx
+++ b/superset/assets/spec/javascripts/chart/Chart_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/components/AlteredSliceTag_spec.jsx
+++ b/superset/assets/spec/javascripts/components/AlteredSliceTag_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { Table, Thead, Td, Th, Tr } from 'reactable';

--- a/superset/assets/spec/javascripts/components/AsyncSelect_spec.jsx
+++ b/superset/assets/spec/javascripts/components/AsyncSelect_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Select from 'react-select';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/components/CachedLabel_spec.jsx
+++ b/superset/assets/spec/javascripts/components/CachedLabel_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { Label } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/components/Checkbox_spec.jsx
+++ b/superset/assets/spec/javascripts/components/Checkbox_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 

--- a/superset/assets/spec/javascripts/components/ColumnOption_spec.jsx
+++ b/superset/assets/spec/javascripts/components/ColumnOption_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import ColumnOption from '../../../src/components/ColumnOption';

--- a/superset/assets/spec/javascripts/components/ColumnTypeLabel_spec.jsx
+++ b/superset/assets/spec/javascripts/components/ColumnTypeLabel_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import ColumnTypeLabel from '../../../src/components/ColumnTypeLabel';

--- a/superset/assets/spec/javascripts/components/CopyToClipboard_spec.jsx
+++ b/superset/assets/spec/javascripts/components/CopyToClipboard_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 
 import CopyToClipboard from '../../../src/components/CopyToClipboard';
 

--- a/superset/assets/spec/javascripts/components/FilterableTable/FilterableTable_spec.jsx
+++ b/superset/assets/spec/javascripts/components/FilterableTable/FilterableTable_spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import FilterableTable from '../../../../src/components/FilterableTable/FilterableTable';

--- a/superset/assets/spec/javascripts/components/MetricOption_spec.jsx
+++ b/superset/assets/spec/javascripts/components/MetricOption_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import MetricOption from '../../../src/components/MetricOption';

--- a/superset/assets/spec/javascripts/components/ModalTrigger_spec.jsx
+++ b/superset/assets/spec/javascripts/components/ModalTrigger_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 
 import ModalTrigger from '../../../src/components/ModalTrigger';
 

--- a/superset/assets/spec/javascripts/components/OnPasteSelect_spec.jsx
+++ b/superset/assets/spec/javascripts/components/OnPasteSelect_spec.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import VirtualizedSelect from 'react-virtualized-select';
 import Select, { Creatable } from 'react-select';
 

--- a/superset/assets/spec/javascripts/components/OptionDescription_spec.jsx
+++ b/superset/assets/spec/javascripts/components/OptionDescription_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import InfoTooltipWithTrigger from '../../../src/components/InfoTooltipWithTrigger';

--- a/superset/assets/spec/javascripts/components/PopoverSection_spec.jsx
+++ b/superset/assets/spec/javascripts/components/PopoverSection_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import PopoverSection from '../../../src/components/PopoverSection';

--- a/superset/assets/spec/javascripts/components/URLShortLinkButton_spec.jsx
+++ b/superset/assets/spec/javascripts/components/URLShortLinkButton_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import { OverlayTrigger } from 'react-bootstrap';

--- a/superset/assets/spec/javascripts/components/URLShortLinkModal_spec.jsx
+++ b/superset/assets/spec/javascripts/components/URLShortLinkModal_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import URLShortLinkModal from '../../../src/components/URLShortLinkModal';

--- a/superset/assets/spec/javascripts/components/VirtualizedRendererWrap_spec.jsx
+++ b/superset/assets/spec/javascripts/components/VirtualizedRendererWrap_spec.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import sinon from 'sinon';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import VirtualizedRendererWrap from '../../../src/components/VirtualizedRendererWrap';

--- a/superset/assets/spec/javascripts/dashboard/.eslintrc
+++ b/superset/assets/spec/javascripts/dashboard/.eslintrc
@@ -17,7 +17,6 @@
     "no-mixed-operators": 0,
     "no-continue": 2,
     "no-bitwise": 2,
-    "no-undef": 2,
     "no-multi-assign": 2,
     "no-restricted-properties": 2,
     "no-prototype-builtins": 2,

--- a/superset/assets/spec/javascripts/dashboard/actions/dashboardLayout_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/actions/dashboardLayout_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/CodeModal_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/CodeModal_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import CodeModal from '../../../../src/dashboard/components/CodeModal';

--- a/superset/assets/spec/javascripts/dashboard/components/CssEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/CssEditor_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import CssEditor from '../../../../src/dashboard/components/CssEditor';

--- a/superset/assets/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -1,7 +1,6 @@
 import { Provider } from 'react-redux';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import ParentSize from '@vx/responsive/build/components/ParentSize';

--- a/superset/assets/spec/javascripts/dashboard/components/DashboardGrid_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/DashboardGrid_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/Dashboard_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/Dashboard_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/HeaderActionsDropdown_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/HeaderActionsDropdown_spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { DropdownButton, MenuItem } from 'react-bootstrap';

--- a/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Header from '../../../../src/dashboard/components/Header';

--- a/superset/assets/spec/javascripts/dashboard/components/MissingChart_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/MissingChart_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import Loading from '../../../../src/components/Loading';

--- a/superset/assets/spec/javascripts/dashboard/components/RefreshIntervalModal_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/RefreshIntervalModal_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import RefreshIntervalModal from '../../../../src/dashboard/components/RefreshIntervalModal';

--- a/superset/assets/spec/javascripts/dashboard/components/SliceAdder_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/SliceAdder_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it, beforeEach, afterEach } from 'mocha';
 import sinon from 'sinon';
 import { expect } from 'chai';
 

--- a/superset/assets/spec/javascripts/dashboard/components/dnd/DragDroppable_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/dnd/DragDroppable_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
@@ -1,7 +1,6 @@
 import { Provider } from 'react-redux';
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Column_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Column_spec.jsx
@@ -1,7 +1,6 @@
 import { Provider } from 'react-redux';
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Divider_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Divider_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Header_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Header_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Markdown_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Markdown_spec.jsx
@@ -1,7 +1,6 @@
 import { Provider } from 'react-redux';
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import AceEditor from 'react-ace';

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Row_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Row_spec.jsx
@@ -1,7 +1,6 @@
 import { Provider } from 'react-redux';
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Tab_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Tab_spec.jsx
@@ -1,7 +1,6 @@
 import { Provider } from 'react-redux';
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
@@ -1,7 +1,6 @@
 import { Provider } from 'react-redux';
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { Tabs as BootstrapTabs, Tab as BootstrapTab } from 'react-bootstrap';

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/DraggableNewComponent_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/DraggableNewComponent_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import DragDroppable from '../../../../../../src/dashboard/components/dnd/DragDroppable';

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewColumn_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewColumn_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import DraggableNewComponent from '../../../../../../src/dashboard/components/gridComponents/new/DraggableNewComponent';

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewDivider_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewDivider_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import DraggableNewComponent from '../../../../../../src/dashboard/components/gridComponents/new/DraggableNewComponent';

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewHeader_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewHeader_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import DraggableNewComponent from '../../../../../../src/dashboard/components/gridComponents/new/DraggableNewComponent';

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewRow_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewRow_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import DraggableNewComponent from '../../../../../../src/dashboard/components/gridComponents/new/DraggableNewComponent';

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewTabs_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/new/NewTabs_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import DraggableNewComponent from '../../../../../../src/dashboard/components/gridComponents/new/DraggableNewComponent';

--- a/superset/assets/spec/javascripts/dashboard/components/menu/HoverMenu_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/menu/HoverMenu_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import HoverMenu from '../../../../../src/dashboard/components/menu/HoverMenu';

--- a/superset/assets/spec/javascripts/dashboard/components/menu/WithPopoverMenu_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/menu/WithPopoverMenu_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import WithPopoverMenu from '../../../../../src/dashboard/components/menu/WithPopoverMenu';

--- a/superset/assets/spec/javascripts/dashboard/components/resizable/ResizableContainer_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/resizable/ResizableContainer_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Resizable from 're-resizable';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import ResizableContainer from '../../../../../src/dashboard/components/resizable/ResizableContainer';

--- a/superset/assets/spec/javascripts/dashboard/components/resizable/ResizableHandle_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/resizable/ResizableHandle_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import ResizableHandle from '../../../../../src/dashboard/components/resizable/ResizableHandle';

--- a/superset/assets/spec/javascripts/dashboard/reducers/dashboardLayout_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/reducers/dashboardLayout_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import layoutReducer from '../../../../src/dashboard/reducers/dashboardLayout';

--- a/superset/assets/spec/javascripts/dashboard/reducers/dashboardState_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/reducers/dashboardState_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import {

--- a/superset/assets/spec/javascripts/dashboard/reducers/sliceEntities_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/reducers/sliceEntities_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import {

--- a/superset/assets/spec/javascripts/dashboard/util/componentIsResizable_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/componentIsResizable_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import componentIsResizable from '../../../../src/dashboard/util/componentIsResizable';

--- a/superset/assets/spec/javascripts/dashboard/util/dnd-reorder_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/dnd-reorder_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import reorderItem from '../../../../src/dashboard/util/dnd-reorder';

--- a/superset/assets/spec/javascripts/dashboard/util/dropOverflowsParent_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/dropOverflowsParent_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import dropOverflowsParent from '../../../../src/dashboard/util/dropOverflowsParent';

--- a/superset/assets/spec/javascripts/dashboard/util/findFirstParentContainer_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/findFirstParentContainer_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import findFirstParentContainerId from '../../../../src/dashboard/util/findFirstParentContainer';

--- a/superset/assets/spec/javascripts/dashboard/util/findParentId_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/findParentId_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import findParentId from '../../../../src/dashboard/util/findParentId';

--- a/superset/assets/spec/javascripts/dashboard/util/getChartIdsFromLayout_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getChartIdsFromLayout_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import getChartIdsFromLayout from '../../../../src/dashboard/util/getChartIdsFromLayout';

--- a/superset/assets/spec/javascripts/dashboard/util/getDashboardUrl_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getDashboardUrl_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import getDashboardUrl from '../../../../src/dashboard/util/getDashboardUrl';

--- a/superset/assets/spec/javascripts/dashboard/util/getDetailedComponentWidth_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getDetailedComponentWidth_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import getDetailedComponentWidth from '../../../../src/dashboard/util/getDetailedComponentWidth';

--- a/superset/assets/spec/javascripts/dashboard/util/getDropPosition_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getDropPosition_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import getDropPosition, {

--- a/superset/assets/spec/javascripts/dashboard/util/getFormDataWithExtraFilters_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getFormDataWithExtraFilters_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import getFormDataWithExtraFilters from '../../../../src/dashboard/util/charts/getFormDataWithExtraFilters';

--- a/superset/assets/spec/javascripts/dashboard/util/isValidChild_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/isValidChild_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import isValidChild from '../../../../src/dashboard/util/isValidChild';

--- a/superset/assets/spec/javascripts/dashboard/util/newComponentFactory_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/newComponentFactory_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import newComponentFactory from '../../../../src/dashboard/util/newComponentFactory';

--- a/superset/assets/spec/javascripts/dashboard/util/newEntitiesFromDrop_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/newEntitiesFromDrop_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import newEntitiesFromDrop from '../../../../src/dashboard/util/newEntitiesFromDrop';

--- a/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Tabs } from 'react-bootstrap';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import configureStore from 'redux-mock-store';
 import $ from 'jquery';

--- a/superset/assets/spec/javascripts/datasource/DatasourceModal_spec.jsx
+++ b/superset/assets/spec/javascripts/datasource/DatasourceModal_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import configureStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import $ from 'jquery';

--- a/superset/assets/spec/javascripts/explore/AdhocFilter_spec.js
+++ b/superset/assets/spec/javascripts/explore/AdhocFilter_spec.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 
 import AdhocFilter, { EXPRESSION_TYPES, CLAUSES } from '../../../src/explore/AdhocFilter';
 

--- a/superset/assets/spec/javascripts/explore/AdhocMetric_spec.js
+++ b/superset/assets/spec/javascripts/explore/AdhocMetric_spec.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 
 import AdhocMetric, { EXPRESSION_TYPES } from '../../../src/explore/AdhocMetric';
 import { AGGREGATES } from '../../../src/explore/constants';

--- a/superset/assets/spec/javascripts/explore/chartActions_spec.js
+++ b/superset/assets/spec/javascripts/explore/chartActions_spec.js
@@ -1,4 +1,3 @@
-import { it, describe } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import $ from 'jquery';

--- a/superset/assets/spec/javascripts/explore/components/AdhocFilterControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocFilterControl_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import AdhocFilter, { EXPRESSION_TYPES, CLAUSES } from '../../../../src/explore/AdhocFilter';

--- a/superset/assets/spec/javascripts/explore/components/AdhocFilterEditPopoverSimpleTabContent_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocFilterEditPopoverSimpleTabContent_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { FormGroup } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/AdhocFilterEditPopoverSqlTabContent_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocFilterEditPopoverSqlTabContent_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { FormGroup } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/AdhocFilterEditPopover_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocFilterEditPopover_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { Button, Popover, Tab, Tabs } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/AdhocFilterOption_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocFilterOption_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { Label, OverlayTrigger } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/AdhocMetricEditPopoverTitle_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocMetricEditPopoverTitle_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { OverlayTrigger } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { Button, FormGroup, Popover } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/AdhocMetricOption_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocMetricOption_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { Label, OverlayTrigger } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/AdhocMetricStaticOption_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AdhocMetricStaticOption_spec.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import AdhocMetricStaticOption from '../../../../src/explore/components/AdhocMetricStaticOption';

--- a/superset/assets/spec/javascripts/explore/components/AggregateOption_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/AggregateOption_spec.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import AggregateOption from '../../../../src/explore/components/AggregateOption';

--- a/superset/assets/spec/javascripts/explore/components/BoundsControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/BoundsControl_spec.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { FormControl } from 'react-bootstrap';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { mount } from 'enzyme';
 
 import BoundsControl from '../../../../src/explore/components/controls/BoundsControl';

--- a/superset/assets/spec/javascripts/explore/components/CheckboxControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/CheckboxControl_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 
 import CheckboxControl from '../../../../src/explore/components/controls/CheckboxControl';

--- a/superset/assets/spec/javascripts/explore/components/ColorPickerControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ColorPickerControl_spec.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import { OverlayTrigger } from 'react-bootstrap';
 import { SketchPicker } from 'react-color';

--- a/superset/assets/spec/javascripts/explore/components/ColorScheme_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ColorScheme_spec.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { mount } from 'enzyme';
 import { Creatable } from 'react-select';
 

--- a/superset/assets/spec/javascripts/explore/components/ControlPanelSection_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ControlPanelSection_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { Panel } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/ControlPanelsContainer_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ControlPanelsContainer_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import { getFormDataFromControls, defaultControls }
   from '../../../../src/explore/store';

--- a/superset/assets/spec/javascripts/explore/components/ControlRow_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ControlRow_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import ControlSetRow from '../../../../src/explore/components/ControlRow';
 

--- a/superset/assets/spec/javascripts/explore/components/DatasourceControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/DatasourceControl_spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import sinon from 'sinon';
 import configureStore from 'redux-mock-store';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import DatasourceModal from '../../../../src/datasource/DatasourceModal';
 import DatasourceControl from '../../../../src/explore/components/controls/DatasourceControl';

--- a/superset/assets/spec/javascripts/explore/components/DateFilterControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/DateFilterControl_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import { Button, Label } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/DisplayQueryButton_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/DisplayQueryButton_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { mount } from 'enzyme';
 import ModalTrigger from './../../../../src/components/ModalTrigger';
 

--- a/superset/assets/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow, mount } from 'enzyme';
 import { OverlayTrigger } from 'react-bootstrap';
 import sinon from 'sinon';

--- a/superset/assets/spec/javascripts/explore/components/ExploreActionButtons_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ExploreActionButtons_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import ExploreActionButtons from
   '../../../../src/explore/components/ExploreActionButtons';

--- a/superset/assets/spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import ExploreChartHeader from '../../../../src/explore/components/ExploreChartHeader';

--- a/superset/assets/spec/javascripts/explore/components/ExploreChartPanel_spec.js
+++ b/superset/assets/spec/javascripts/explore/components/ExploreChartPanel_spec.js
@@ -3,8 +3,7 @@
 
 // import React from 'react';
 // import { expect } from 'chai';
-// import { describe, it } from 'mocha';
-
+//
 // import ChartContainer from '../../../../src/explore/components/ChartContainer';
 
 // describe('ChartContainer', () => {

--- a/superset/assets/spec/javascripts/explore/components/ExploreViewContainer_spec.js
+++ b/superset/assets/spec/javascripts/explore/components/ExploreViewContainer_spec.js
@@ -3,8 +3,7 @@
 
 // import React from 'react';
 // import { expect } from 'chai';
-// import { describe, it } from 'mocha';
-// import { shallow } from 'enzyme';
+// // import { shallow } from 'enzyme';
 
 // import ExploreViewContainer
 //   from '../../../../src/explore/components/ExploreViewContainer';

--- a/superset/assets/spec/javascripts/explore/components/FilterDefinitionOption_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/FilterDefinitionOption_spec.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import FilterDefinitionOption from '../../../../src/explore/components/FilterDefinitionOption';

--- a/superset/assets/spec/javascripts/explore/components/FixedOrMetricControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/FixedOrMetricControl_spec.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import { OverlayTrigger } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/MetricDefinitionOption_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/MetricDefinitionOption_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import MetricDefinitionOption from '../../../../src/explore/components/MetricDefinitionOption';

--- a/superset/assets/spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import MetricDefinitionValue from '../../../../src/explore/components/MetricDefinitionValue';

--- a/superset/assets/spec/javascripts/explore/components/MetricsControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/MetricsControl_spec.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import MetricsControl from '../../../../src/explore/components/controls/MetricsControl';

--- a/superset/assets/spec/javascripts/explore/components/QueryAndSaveBtns_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/QueryAndSaveBtns_spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';

--- a/superset/assets/spec/javascripts/explore/components/RowCountLabel_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/RowCountLabel_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 import { Label } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/RunQueryActionButton_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/RunQueryActionButton_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 
 import RunQueryActionButton

--- a/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -3,7 +3,6 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow, mount } from 'enzyme';
 import { Modal, Button, Radio } from 'react-bootstrap';
 import sinon from 'sinon';

--- a/superset/assets/spec/javascripts/explore/components/SelectControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/SelectControl_spec.jsx
@@ -4,7 +4,6 @@ import Select, { Creatable } from 'react-select';
 import VirtualizedSelect from 'react-virtualized-select';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import OnPasteSelect from '../../../../src/components/OnPasteSelect';
 import VirtualizedRendererWrap from '../../../../src/components/VirtualizedRendererWrap';

--- a/superset/assets/spec/javascripts/explore/components/TextArea_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/TextArea_spec.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { FormControl } from 'react-bootstrap';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import AceEditor from 'react-ace';
 

--- a/superset/assets/spec/javascripts/explore/components/TimeSeriesColumnControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/TimeSeriesColumnControl_spec.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { FormControl, OverlayTrigger } from 'react-bootstrap';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 
 import TimeSeriesColumnControl from '../../../../src/explore/components/controls/TimeSeriesColumnControl';

--- a/superset/assets/spec/javascripts/explore/components/ViewportControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ViewportControl_spec.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import { OverlayTrigger, Label } from 'react-bootstrap';
 

--- a/superset/assets/spec/javascripts/explore/components/VizTypeControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/VizTypeControl_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
 import { shallow } from 'enzyme';
 import { Modal } from 'react-bootstrap';
 import VizTypeControl from '../../../../src/explore/components/controls/VizTypeControl';

--- a/superset/assets/spec/javascripts/explore/exploreActions_spec.js
+++ b/superset/assets/spec/javascripts/explore/exploreActions_spec.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-unused-expressions */
-import { it, describe } from 'mocha';
 import { expect } from 'chai';
 import { defaultState } from '../../../src/explore/store';
 import exploreReducer from '../../../src/explore/reducers/exploreReducer';

--- a/superset/assets/spec/javascripts/explore/utils_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/utils_spec.jsx
@@ -1,4 +1,3 @@
-import { it, describe } from 'mocha';
 import { expect } from 'chai';
 import URI from 'urijs';
 import { getExploreUrlAndPayload, getExploreLongUrl } from '../../../src/explore/exploreUtils';

--- a/superset/assets/spec/javascripts/logger_spec.js
+++ b/superset/assets/spec/javascripts/logger_spec.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/messageToasts/.eslintrc
+++ b/superset/assets/spec/javascripts/messageToasts/.eslintrc
@@ -17,7 +17,6 @@
     "no-mixed-operators": 0,
     "no-continue": 2,
     "no-bitwise": 2,
-    "no-undef": 2,
     "no-multi-assign": 2,
     "no-restricted-properties": 2,
     "no-prototype-builtins": 2,

--- a/superset/assets/spec/javascripts/messageToasts/components/ToastPresenter_spec.jsx
+++ b/superset/assets/spec/javascripts/messageToasts/components/ToastPresenter_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import mockMessageToasts from '../mockMessageToasts';

--- a/superset/assets/spec/javascripts/messageToasts/components/Toast_spec.jsx
+++ b/superset/assets/spec/javascripts/messageToasts/components/Toast_spec.jsx
@@ -1,7 +1,6 @@
 import { Alert } from 'react-bootstrap';
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import mockMessageToasts from '../mockMessageToasts';

--- a/superset/assets/spec/javascripts/messageToasts/reducers/messageToasts_spec.js
+++ b/superset/assets/spec/javascripts/messageToasts/reducers/messageToasts_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { ADD_TOAST, REMOVE_TOAST } from '../../../../src/messageToasts/actions';

--- a/superset/assets/spec/javascripts/messageToasts/utils/getToastsFromPyFlashMessages_spec.js
+++ b/superset/assets/spec/javascripts/messageToasts/utils/getToastsFromPyFlashMessages_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import {

--- a/superset/assets/spec/javascripts/modules/colors_spec.jsx
+++ b/superset/assets/spec/javascripts/modules/colors_spec.jsx
@@ -1,4 +1,3 @@
-import { it, describe, before } from 'mocha';
 import { expect } from 'chai';
 import { getColorFromScheme, hexToRGB } from '../../../src/modules/colors';
 import { getInstance } from '../../../src/modules/ColorSchemeManager';

--- a/superset/assets/spec/javascripts/modules/dates_spec.js
+++ b/superset/assets/spec/javascripts/modules/dates_spec.js
@@ -1,5 +1,4 @@
-import { it, describe } from 'mocha';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import {
   tickMultiFormat,
   formatDate,

--- a/superset/assets/spec/javascripts/modules/geo_spec.jsx
+++ b/superset/assets/spec/javascripts/modules/geo_spec.jsx
@@ -1,4 +1,3 @@
-import { it, describe } from 'mocha';
 import { expect } from 'chai';
 
 import { unitToRadius } from '../../../src/modules/geo';

--- a/superset/assets/spec/javascripts/modules/sandbox_spec.jsx
+++ b/superset/assets/spec/javascripts/modules/sandbox_spec.jsx
@@ -1,4 +1,3 @@
-import { it, describe } from 'mocha';
 import { expect } from 'chai';
 
 import sandboxedEval from '../../../src/modules/sandbox';

--- a/superset/assets/spec/javascripts/modules/time_spec.js
+++ b/superset/assets/spec/javascripts/modules/time_spec.js
@@ -1,5 +1,4 @@
-import { it, describe } from 'mocha';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 
 import moment from 'moment';
 import { getPlaySliderParams, truncate } from '../../../src/modules/time';

--- a/superset/assets/spec/javascripts/modules/utils_spec.jsx
+++ b/superset/assets/spec/javascripts/modules/utils_spec.jsx
@@ -1,5 +1,4 @@
-import { it, describe } from 'mocha';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import {
   tryNumify,
   slugify,

--- a/superset/assets/spec/javascripts/profile/App_spec.jsx
+++ b/superset/assets/spec/javascripts/profile/App_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Col, Row, Tab } from 'react-bootstrap';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { user } from './fixtures';

--- a/superset/assets/spec/javascripts/profile/CreatedContent_spec.jsx
+++ b/superset/assets/spec/javascripts/profile/CreatedContent_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { user } from './fixtures';
 import CreatedContent from '../../../src/profile/components/CreatedContent';

--- a/superset/assets/spec/javascripts/profile/EditableTitle_spec.jsx
+++ b/superset/assets/spec/javascripts/profile/EditableTitle_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import { expect } from 'chai';
 

--- a/superset/assets/spec/javascripts/profile/Favorites_spec.jsx
+++ b/superset/assets/spec/javascripts/profile/Favorites_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { user } from './fixtures';

--- a/superset/assets/spec/javascripts/profile/RecentActivity_spec.jsx
+++ b/superset/assets/spec/javascripts/profile/RecentActivity_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { user } from './fixtures';

--- a/superset/assets/spec/javascripts/profile/Security_spec.jsx
+++ b/superset/assets/spec/javascripts/profile/Security_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { user, userNoPerms } from './fixtures';

--- a/superset/assets/spec/javascripts/profile/UserInfo_spec.jsx
+++ b/superset/assets/spec/javascripts/profile/UserInfo_spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Gravatar from 'react-gravatar';
 import { Panel } from 'react-bootstrap';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { user } from './fixtures';

--- a/superset/assets/spec/javascripts/sqllab/App_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/App_spec.jsx
@@ -3,7 +3,6 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/sqllab/ColumnElement_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/ColumnElement_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { mockedActions, table } from './fixtures';

--- a/superset/assets/spec/javascripts/sqllab/CopyQueryTabUrl_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/CopyQueryTabUrl_spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { initialState } from './fixtures';
 

--- a/superset/assets/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
@@ -3,7 +3,6 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/sqllab/HighlightedSql_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/HighlightedSql_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { mount, shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import HighlightedSql from '../../../src/SqlLab/components/HighlightedSql';

--- a/superset/assets/spec/javascripts/sqllab/Link_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/Link_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import Link from '../../../src/SqlLab/components/Link';

--- a/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Select from 'react-select';
 import { Button } from 'react-bootstrap';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/sqllab/QueryStateLabel_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QueryStateLabel_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Label } from 'react-bootstrap';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import QueryStateLabel from '../../../src/SqlLab/components/QueryStateLabel';

--- a/superset/assets/spec/javascripts/sqllab/QueryTable_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QueryTable_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { Table } from 'reactable';
 

--- a/superset/assets/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/sqllab/SaveQuery_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SaveQuery_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { FormControl } from 'react-bootstrap';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import SaveQuery from '../../../src/SqlLab/components/SaveQuery';
 import ModalTrigger from '../../../src/components/ModalTrigger';

--- a/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import { expect } from 'chai';
 

--- a/superset/assets/spec/javascripts/sqllab/SqlEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditor_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { initialState, queries, table } from './fixtures';

--- a/superset/assets/spec/javascripts/sqllab/TabStatusIcon_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TabStatusIcon_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
 import { shallow } from 'enzyme';
 
 import TabStatusIcon from '../../../src/SqlLab/components/TabStatusIcon';

--- a/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
@@ -5,7 +5,6 @@ import URI from 'urijs';
 
 import { Tab } from 'react-bootstrap';
 import { shallow, mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import Link from '../../../src/SqlLab/components/Link';

--- a/superset/assets/spec/javascripts/sqllab/Timer_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/Timer_spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it, beforeEach } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/superset/assets/spec/javascripts/sqllab/actions_spec.js
+++ b/superset/assets/spec/javascripts/sqllab/actions_spec.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-unused-expressions */
-import { it, describe } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import $ from 'jquery';

--- a/superset/assets/spec/javascripts/sqllab/reducers_spec.js
+++ b/superset/assets/spec/javascripts/sqllab/reducers_spec.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import * as r from '../../../src/SqlLab/reducers';

--- a/superset/assets/spec/javascripts/utils/common_spec.jsx
+++ b/superset/assets/spec/javascripts/utils/common_spec.jsx
@@ -1,4 +1,3 @@
-import { it, describe } from 'mocha';
 import { expect } from 'chai';
 import { isTruthy, optionFromValue } from '../../../src/utils/common';
 

--- a/superset/assets/spec/javascripts/visualizations/nvd3_viz_spec.jsx
+++ b/superset/assets/spec/javascripts/visualizations/nvd3_viz_spec.jsx
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import { formatLabel } from '../../../src/visualizations/nvd3_vis';

--- a/superset/assets/spec/javascripts/visualizations/table_spec.jsx
+++ b/superset/assets/spec/javascripts/visualizations/table_spec.jsx
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import $ from 'jquery';
 import '../../helpers/shim';

--- a/superset/assets/spec/javascripts/welcome/DashboardTable_spec.jsx
+++ b/superset/assets/spec/javascripts/welcome/DashboardTable_spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import DashboardTable from '../../../src/welcome/DashboardTable';
 

--- a/superset/assets/spec/javascripts/welcome/Welcome_spec.jsx
+++ b/superset/assets/spec/javascripts/welcome/Welcome_spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Panel, Row, Tab } from 'react-bootstrap';
 import { shallow } from 'enzyme';
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import Welcome from '../../../src/welcome/Welcome';

--- a/superset/assets/src/SqlLab/App.jsx
+++ b/superset/assets/src/SqlLab/App.jsx
@@ -3,6 +3,7 @@ import { createStore, compose, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunkMiddleware from 'redux-thunk';
 import { hot } from 'react-hot-loader';
+import $ from 'jquery';
 
 import getInitialState from './getInitialState';
 import rootReducer from './reducers';

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -1,5 +1,3 @@
-/* global window */
-/* eslint no-undef: 2 */
 import $ from 'jquery';
 import shortid from 'shortid';
 import JSONbig from 'json-bigint';

--- a/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 2 */
 import moment from 'moment';
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/superset/assets/src/SqlLab/components/QuerySearch.jsx
+++ b/superset/assets/src/SqlLab/components/QuerySearch.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 2 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -1,5 +1,3 @@
-/* global window */
-/* eslint no-undef: 2 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import throttle from 'lodash.throttle';

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -1,5 +1,3 @@
-/* global window */
-/* eslint no-undef: 2 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ControlLabel, Button } from 'react-bootstrap';

--- a/superset/assets/src/SqlLab/getInitialState.js
+++ b/superset/assets/src/SqlLab/getInitialState.js
@@ -1,4 +1,3 @@
-/* eslint no-undef: 2 */
 import shortid from 'shortid';
 import { t } from '../locales';
 import getToastsFromPyFlashMessages from '../messageToasts/utils/getToastsFromPyFlashMessages';

--- a/superset/assets/src/SqlLab/reducers.js
+++ b/superset/assets/src/SqlLab/reducers.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import shortid from 'shortid';
 import messageToasts from '../messageToasts/reducers';
 
+import getInitialState from './getInitialState';
 import * as actions from './actions';
 import { now } from '../modules/dates';
 import {

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 2 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'react-bootstrap';

--- a/superset/assets/src/dashboard/.eslintrc
+++ b/superset/assets/src/dashboard/.eslintrc
@@ -17,7 +17,6 @@
     "no-mixed-operators": 0,
     "no-continue": 2,
     "no-bitwise": 2,
-    "no-undef": 2,
     "no-multi-assign": 2,
     "no-restricted-properties": 2,
     "no-prototype-builtins": 2,

--- a/superset/assets/src/dashboard/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/components/Dashboard.jsx
@@ -1,4 +1,3 @@
-/* global window */
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/superset/assets/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset/assets/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -1,4 +1,3 @@
-/* global window */
 import React from 'react';
 import PropTypes from 'prop-types';
 import $ from 'jquery';

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -394,7 +394,8 @@ export class DatasourceEditor extends React.PureComponent {
       </Fieldset>);
   }
   renderSpatialTab() {
-    const spatials = this.state.datasource.spatials;
+    const { datasource } = this.state;
+    const { spatials, all_cols: allCols } = datasource;
     return (
       <Tab
         title={<CollectionTabTitle collection={spatials} title={t('Spatial')} />}
@@ -414,7 +415,7 @@ export class DatasourceEditor extends React.PureComponent {
             name: (d, onChange) => (
               <EditableTitle canEdit title={d} onSaveTitle={onChange} />),
             config: (v, onChange) => (
-              <SpatialControl value={v} onChange={onChange} choices={datasource.all_cols} />
+              <SpatialControl value={v} onChange={onChange} choices={allCols} />
             ),
           }}
         />

--- a/superset/assets/src/explore/App.jsx
+++ b/superset/assets/src/explore/App.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 2 */
 import React from 'react';
 import { hot } from 'react-hot-loader';
 import { createStore, applyMiddleware, compose } from 'redux';

--- a/superset/assets/src/explore/actions/exploreActions.js
+++ b/superset/assets/src/explore/actions/exploreActions.js
@@ -34,6 +34,12 @@ export function fetchDatasourcesSucceeded() {
   return { type: FETCH_DATASOURCES_SUCCEEDED };
 }
 
+export const FETCH_DATASOURCES_FAILED = 'FETCH_DATASOURCES_FAILED';
+export function fetchDatasourcesFailed(error) {
+  return { type: FETCH_DATASOURCES_FAILED, error };
+}
+
+
 export const POST_DATASOURCES_FAILED = 'POST_DATASOURCES_FAILED';
 export function postDatasourcesFailed(error) {
   return { type: POST_DATASOURCES_FAILED, error };

--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import AceEditor from 'react-ace';
+import ace from 'brace';
 import 'brace/mode/sql';
 import 'brace/theme/github';
 import 'brace/ext/language_tools';

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, ControlLabel, FormGroup, Popover, Tab, Tabs } from 'react-bootstrap';
 import VirtualizedSelect from 'react-virtualized-select';
+import ace from 'brace';
 import AceEditor from 'react-ace';
 import 'brace/mode/sql';
 import 'brace/theme/github';

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 2 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/superset/assets/src/explore/components/controls/SelectAsyncControl.jsx
+++ b/superset/assets/src/explore/components/controls/SelectAsyncControl.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 2 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Select from '../../../components/AsyncSelect';

--- a/superset/assets/src/messageToasts/.eslintrc
+++ b/superset/assets/src/messageToasts/.eslintrc
@@ -17,7 +17,6 @@
     "no-mixed-operators": 0,
     "no-continue": 2,
     "no-bitwise": 2,
-    "no-undef": 2,
     "no-multi-assign": 2,
     "no-restricted-properties": 2,
     "no-prototype-builtins": 2,

--- a/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
+++ b/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { XYChart, AreaSeries, CrossHair, LinearGradient } from '@data-ui/xy-chart';
 
 import { brandColor } from '../../modules/colors';

--- a/superset/assets/src/visualizations/BigNumber/adaptor.jsx
+++ b/superset/assets/src/visualizations/BigNumber/adaptor.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import * as color from 'd3-color';
+import d3 from 'd3';
 
 import BigNumberVis, { renderTooltipFactory } from './BigNumber';
 import { d3FormatPreset } from '../../modules/utils';

--- a/superset/assets/src/visualizations/MapBox/MapBox.jsx
+++ b/superset/assets/src/visualizations/MapBox/MapBox.jsx
@@ -122,9 +122,9 @@ MapBox.defaultProps = defaultProps;
 function createReducer(aggregatorName, customMetric) {
   if (aggregatorName === 'sum' || !customMetric) {
     return (a, b) => a + b;
-  } else if (aggName === 'min') {
+  } else if (aggregatorName === 'min') {
     return Math.min;
-  } else if (aggName === 'max') {
+  } else if (aggregatorName === 'max') {
     return Math.max;
   }
   return function (a, b) {

--- a/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
@@ -150,7 +150,7 @@ class TimeTable extends React.PureComponent {
       const { timeLag } = column;
       const totalLag = Object.keys(reversedEntries).length;
       if (timeLag > totalLag) {
-        errorMsg = `The time lag set at ${timeLag} exceeds the length of data at ${reversedData.length}. No data available.`;
+        errorMsg = `The time lag set at ${timeLag} exceeds the length of data at ${reversedEntries.length}. No data available.`;
       } else {
         v = reversedEntries[timeLag][valueField];
       }

--- a/superset/assets/src/visualizations/deckgl/layers/common.js
+++ b/superset/assets/src/visualizations/deckgl/layers/common.js
@@ -1,5 +1,6 @@
 import dompurify from 'dompurify';
 import { fitBounds } from 'viewport-mercator-project';
+import d3 from 'd3';
 
 import sandboxedEval from '../../../modules/sandbox';
 

--- a/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
@@ -28,10 +28,10 @@ const alterProps = (props, propOverrides) => {
     }
   });
   if (typeof props.fillColor === 'string') {
-    newProps.fillColor = hexToRGB(p.fillColor);
+    newProps.fillColor = hexToRGB(props.fillColor);
   }
   if (typeof props.strokeColor === 'string') {
-    newProps.strokeColor = hexToRGB(p.strokeColor);
+    newProps.strokeColor = hexToRGB(props.strokeColor);
   }
   return {
     ...newProps,

--- a/superset/assets/src/visualizations/line_multi.js
+++ b/superset/assets/src/visualizations/line_multi.js
@@ -1,6 +1,7 @@
+import d3 from 'd3';
+
 import nvd3Vis from './nvd3_vis';
 import { getExploreLongUrl } from '../explore/exploreUtils';
-
 
 export default function lineMulti(slice, payload) {
   /*

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -4529,6 +4529,12 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-cypress@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.0.1.tgz#647e942cacbfd71b0f1a1ed6978472fbd475c60a"
+  dependencies:
+    globals "^11.0.1"
+
 eslint-plugin-import@^2.2.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"


### PR DESCRIPTION
This PR turns the `eslint no-undef` rule back on because it's one of the more dangerous ones to have turned off 😈 

This resulted in `eslint` complaining about various global variables, such as `window` (`env: browser`), `cy` (`env: cypress`), and `describe` (`env: mocha`). I added the appropriate `.eslintrc`s and `env` entries to set `env` as appropriate, and removed `mocha` imports from tests because they are unnecessary.

Also fixed ~10 bugs 🐛 from valid `no-undef` errors.

@kristw @mistercrunch @michellethomas @graceguo-supercat 