### PR TITLE
Fix CSS theme flickering on FAB pages

### DIFF
--- a/superset/templates/superset/base.html
+++ b/superset/templates/superset/base.html
@@ -8,11 +8,15 @@
     {% endfor %}
   {% endblock %}
 
-  {% block tail_js %}
+  {% block head_js %}
     {{super()}}
     {% for entry in js_manifest('theme') %}
       <script src="{{ entry }}"></script>
     {% endfor %}
+  {% endblock %}
+
+  {% block tail_js %}
+    {{super()}}
     {% for entry in js_manifest('common') %}
       <script src="{{ entry }}"></script>
     {% endfor %}


### PR DESCRIPTION
Since the recent PRs around webpack 4 and reloading, FAB pages have been
flickering on load, where a themeless Superset is shown for a fraction
of a second until the bootstrap theme gets loaded up.

This addresses it by moving the theme JS to the head section of the html
page.

related to https://github.com/apache/incubator-superset/pull/5813

@williaster @kristw @betodealmeida 