### PR TITLE
[bugfix] De-dup <script> tags. #5883

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -68,11 +68,13 @@ def get_css_manifest_files(filename):
     entry_files = manifest.get(filename, {})
     return entry_files.get('css', [])
 
+
 def filter_loaded_chunks(files, loaded_chunks):
     filtered_files = [f for f in files if f not in loaded_chunks]
     for f in filtered_files:
         loaded_chunks.add(f)
     return filtered_files
+
 
 parse_manifest_json()
 

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -69,7 +69,7 @@ def get_css_manifest_files(filename):
     return entry_files.get('css', [])
 
 
-def filter_loaded_chunks(files, loaded_chunks):
+def get_unloaded_chunks(files, loaded_chunks):
     filtered_files = [f for f in files if f not in loaded_chunks]
     for f in filtered_files:
         loaded_chunks.add(f)
@@ -83,7 +83,7 @@ parse_manifest_json()
 def get_manifest():
     return dict(
         loaded_chunks=set(),
-        filter_loaded_chunks=filter_loaded_chunks,
+        get_unloaded_chunks=get_unloaded_chunks,
         js_manifest=get_js_manifest_files,
         css_manifest=get_css_manifest_files,
     )

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -68,6 +68,11 @@ def get_css_manifest_files(filename):
     entry_files = manifest.get(filename, {})
     return entry_files.get('css', [])
 
+def filter_loaded_chunks(files, loaded_chunks):
+    filtered_files = [f for f in files if f not in loaded_chunks]
+    for f in filtered_files:
+        loaded_chunks.add(f)
+    return filtered_files
 
 parse_manifest_json()
 
@@ -75,6 +80,8 @@ parse_manifest_json()
 @app.context_processor
 def get_manifest():
     return dict(
+        loaded_chunks=set(),
+        filter_loaded_chunks=filter_loaded_chunks,
         js_manifest=get_js_manifest_files,
         css_manifest=get_css_manifest_files,
     )

--- a/superset/templates/superset/base.html
+++ b/superset/templates/superset/base.html
@@ -3,21 +3,21 @@
   {% block head_css %}
     {{super()}}
     <link rel="icon" type="image/png" href="/static/assets/images/favicon.png">
-    {% for entry in css_manifest('theme') %}
+    {% for entry in filter_loaded_chunks(css_manifest('theme'), loaded_chunks) %}
       <link rel="stylesheet" type="text/css" href="{{ entry }}" />
     {% endfor %}
   {% endblock %}
 
   {% block head_js %}
     {{super()}}
-    {% for entry in js_manifest('theme') %}
+    {% for entry in filter_loaded_chunks(js_manifest('theme'), loaded_chunks) %}
       <script src="{{ entry }}"></script>
     {% endfor %}
   {% endblock %}
 
   {% block tail_js %}
     {{super()}}
-    {% for entry in js_manifest('common') %}
+    {% for entry in filter_loaded_chunks(js_manifest('common'), loaded_chunks) %}
       <script src="{{ entry }}"></script>
     {% endfor %}
   {% endblock %}

--- a/superset/templates/superset/base.html
+++ b/superset/templates/superset/base.html
@@ -3,21 +3,21 @@
   {% block head_css %}
     {{super()}}
     <link rel="icon" type="image/png" href="/static/assets/images/favicon.png">
-    {% for entry in filter_loaded_chunks(css_manifest('theme'), loaded_chunks) %}
+    {% for entry in get_unloaded_chunks(css_manifest('theme'), loaded_chunks) %}
       <link rel="stylesheet" type="text/css" href="{{ entry }}" />
     {% endfor %}
   {% endblock %}
 
   {% block head_js %}
     {{super()}}
-    {% for entry in filter_loaded_chunks(js_manifest('theme'), loaded_chunks) %}
+    {% for entry in get_unloaded_chunks(js_manifest('theme'), loaded_chunks) %}
       <script src="{{ entry }}"></script>
     {% endfor %}
   {% endblock %}
 
   {% block tail_js %}
     {{super()}}
-    {% for entry in filter_loaded_chunks(js_manifest('common'), loaded_chunks) %}
+    {% for entry in get_unloaded_chunks(js_manifest('common'), loaded_chunks) %}
       <script src="{{ entry }}"></script>
     {% endfor %}
   {% endblock %}

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -16,23 +16,23 @@
       <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/flags/flags16.css" />
       <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/font-awesome.min.css">
 
-      {% for entry in css_manifest('theme') %}
+      {% for entry in filter_loaded_chunks(css_manifest('theme'), loaded_chunks) %}
         <link rel="stylesheet" type="text/css" href="{{ entry }}" />
       {% endfor %}
 
       {% if entry %}
         {% set entry_files = css_manifest(entry) %}
-        {% for entry in entry_files %}
+        {% for entry in filter_loaded_chunks(entry_files, loaded_chunks) %}
           <link rel="stylesheet" type="text/css" href="{{ entry }}" />
         {% endfor %}
       {% endif %}
 
     {% endblock %}
 
-    {% for entry in js_manifest('theme') %}
+    {% for entry in filter_loaded_chunks(js_manifest('theme'), loaded_chunks) %}
       <script src="{{ entry }}"></script>
     {% endfor %}
-    {% for entry in js_manifest('common') %}
+    {% for entry in filter_loaded_chunks(js_manifest('common'), loaded_chunks) %}
       <script src="{{ entry }}"></script>
     {% endfor %}
 
@@ -80,7 +80,7 @@
     {% block tail_js %}
       {% if entry %}
         {% set entry_files = js_manifest(entry) %}
-        {% for entry in entry_files %}
+        {% for entry in filter_loaded_chunks(entry_files, loaded_chunks) %}
           <script src="{{ entry }}"></script>
         {% endfor %}
       {% endif %}

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -16,23 +16,23 @@
       <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/flags/flags16.css" />
       <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/font-awesome.min.css">
 
-      {% for entry in filter_loaded_chunks(css_manifest('theme'), loaded_chunks) %}
+      {% for entry in get_unloaded_chunks(css_manifest('theme'), loaded_chunks) %}
         <link rel="stylesheet" type="text/css" href="{{ entry }}" />
       {% endfor %}
 
       {% if entry %}
         {% set entry_files = css_manifest(entry) %}
-        {% for entry in filter_loaded_chunks(entry_files, loaded_chunks) %}
+        {% for entry in get_unloaded_chunks(entry_files, loaded_chunks) %}
           <link rel="stylesheet" type="text/css" href="{{ entry }}" />
         {% endfor %}
       {% endif %}
 
     {% endblock %}
 
-    {% for entry in filter_loaded_chunks(js_manifest('theme'), loaded_chunks) %}
+    {% for entry in get_unloaded_chunks(js_manifest('theme'), loaded_chunks) %}
       <script src="{{ entry }}"></script>
     {% endfor %}
-    {% for entry in filter_loaded_chunks(js_manifest('common'), loaded_chunks) %}
+    {% for entry in get_unloaded_chunks(js_manifest('common'), loaded_chunks) %}
       <script src="{{ entry }}"></script>
     {% endfor %}
 
@@ -80,7 +80,7 @@
     {% block tail_js %}
       {% if entry %}
         {% set entry_files = js_manifest(entry) %}
-        {% for entry in filter_loaded_chunks(entry_files, loaded_chunks) %}
+        {% for entry in get_unloaded_chunks(entry_files, loaded_chunks) %}
           <script src="{{ entry }}"></script>
         {% endfor %}
       {% endif %}

--- a/superset/templates/superset/partials/_script_tag.html
+++ b/superset/templates/superset/partials/_script_tag.html
@@ -1,5 +1,5 @@
 {% block tail_js %}
-  {% for entry in js_manifest(filename) %}
+  {% for entry in filter_loaded_chunks(js_manifest(filename), loaded_chunks) %}
     <script src="{{ entry }}"></script>
   {% endfor %}
 {% endblock %}

--- a/superset/templates/superset/partials/_script_tag.html
+++ b/superset/templates/superset/partials/_script_tag.html
@@ -1,5 +1,5 @@
 {% block tail_js %}
-  {% for entry in filter_loaded_chunks(js_manifest(filename), loaded_chunks) %}
+  {% for entry in get_unloaded_chunks(js_manifest(filename), loaded_chunks) %}
     <script src="{{ entry }}"></script>
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
This fixes #5883 

> There are duplicate <script> tags for the shared chunks. If you view page source, there will be multiple vendors-addSlice-common-dashboard-explore-profile-sqllab-theme-welcome.xxx.chunk.js

@john-bodley @mistercrunch @graceguo-supercat @michellethomas 