### PR TITLE
[bugfix] Fix color scheme picker

### DIFF
--- a/superset/assets/src/explore/components/Control.jsx
+++ b/superset/assets/src/explore/components/Control.jsx
@@ -11,7 +11,10 @@ const propTypes = {
   type: PropTypes.oneOf(controlTypes).isRequired,
   hidden: PropTypes.bool,
   label: PropTypes.string.isRequired,
-  choices: PropTypes.arrayOf(PropTypes.array),
+  choices: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.array),
+    PropTypes.func,
+  ]),
   description: PropTypes.string,
   tooltipOnClick: PropTypes.func,
   places: PropTypes.number,
@@ -26,7 +29,8 @@ const propTypes = {
     PropTypes.object,
     PropTypes.bool,
     PropTypes.array,
-    PropTypes.func]),
+    PropTypes.func,
+  ]),
 };
 
 const defaultProps = {

--- a/superset/assets/src/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset/assets/src/explore/components/controls/ColorSchemeControl.jsx
@@ -49,7 +49,7 @@ export default class ColorSchemeControl extends React.PureComponent {
   renderOption(key) {
     const { schemes } = this.props;
     const schemeLookup = _.isFunction(schemes) ? schemes() : schemes;
-    const currentScheme = schemeLookup[key.value || defaultProps];
+    const currentScheme = schemeLookup[key.value || defaultProps.value];
 
     let colors = currentScheme;
     if (this.props.isLinear) {

--- a/superset/assets/src/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset/assets/src/explore/components/controls/ColorSchemeControl.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 import { Creatable } from 'react-select';
 import ControlHeader from '../ControlHeader';
-
 import { colorScalerFactory } from '../../../modules/colors';
 
 const propTypes = {
@@ -12,8 +12,14 @@ const propTypes = {
   onChange: PropTypes.func,
   value: PropTypes.string,
   default: PropTypes.string,
-  choices: PropTypes.arrayOf(PropTypes.array).isRequired,
-  schemes: PropTypes.object.isRequired,
+  choices: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.array),
+    PropTypes.func,
+  ]).isRequired,
+  schemes: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.func,
+  ]).isRequired,
   isLinear: PropTypes.bool,
 };
 
@@ -41,9 +47,9 @@ export default class ColorSchemeControl extends React.PureComponent {
   }
 
   renderOption(key) {
-    const currentScheme = key.value ?
-      this.props.schemes[key.value] :
-      this.props.schemes[defaultProps.value];
+    const { schemes } = this.props;
+    const schemeLookup = _.isFunction(schemes) ? schemes() : schemes;
+    const currentScheme = schemeLookup[key.value || defaultProps];
 
     let colors = currentScheme;
     if (this.props.isLinear) {
@@ -61,12 +67,16 @@ export default class ColorSchemeControl extends React.PureComponent {
   }
 
   render() {
+    const { choices } = this.props;
+    const options = (_.isFunction(choices) ? choices() : choices)
+      .map(choice => ({ value: choice[0], label: choice[1] }));
+
     const selectProps = {
       multi: false,
       name: `select-${this.props.name}`,
-      placeholder: `Select (${this.props.choices.length})`,
+      placeholder: `Select (${options.length})`,
       default: this.props.default,
-      options: this.props.choices.map(choice => ({ value: choice[0], label: choice[1] })),
+      options,
       value: this.props.value,
       autosize: false,
       clearable: false,

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -53,8 +53,6 @@ import { t } from '../locales';
 import { getAllSchemes } from '../modules/ColorSchemeManager';
 import sequentialSchemes from '../modules/colorSchemes/sequential';
 
-const ALL_COLOR_SCHEMES = getAllSchemes();
-
 const D3_FORMAT_DOCS = 'D3 format syntax: https://github.com/d3/d3-format';
 
 // input choices & options
@@ -1977,9 +1975,9 @@ export const controls = {
     label: t('Color Scheme'),
     default: 'bnbColors',
     renderTrigger: true,
-    choices: Object.keys(ALL_COLOR_SCHEMES).map(s => ([s, s])),
+    choices: () => Object.keys(getAllSchemes()).map(s => ([s, s])),
     description: t('The color scheme for rendering chart'),
-    schemes: ALL_COLOR_SCHEMES,
+    schemes: () => getAllSchemes(),
   },
 
   significance_level: {


### PR DESCRIPTION
Support dynamic choices by passing function instead of value to fix #5889 
This will ensure that the `ColorSchemeControl` will always get the latest schemes registered to `ColorSchemeManager`

@mistercrunch @williaster @graceguo-supercat 