### PR TITLE
[react16] fix React type checking

### DIFF
--- a/superset/assets/src/CRUD/utils.js
+++ b/superset/assets/src/CRUD/utils.js
@@ -7,7 +7,7 @@ export function recurseReactClone(children, type, propExtender) {
    */
   return React.Children.map(children, (child) => {
     let newChild = child;
-    if (child && child.type === type) {
+    if (child && child.type.name === type.name) {
       newChild = React.cloneElement(child, propExtender(child));
     }
     if (newChild && newChild.props.children) {


### PR DESCRIPTION
Somehow checking the type of a JSX-defined React component is not
straightforward and changes through versions of React.

Using the `name` attr addresses the issue for now.