### PR TITLE
[bugfix] ignore history.pushState errors

### DIFF
--- a/superset/assets/src/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/src/explore/components/ExploreViewContainer.jsx
@@ -170,10 +170,15 @@ class ExploreViewContainer extends React.Component {
   addHistory({ isReplace = false, title }) {
     const { payload } = getExploreUrlAndPayload({ formData: this.props.form_data });
     const longUrl = getExploreLongUrl(this.props.form_data);
-    if (isReplace) {
-      history.replaceState(payload, title, longUrl);
-    } else {
-      history.pushState(payload, title, longUrl);
+    try {
+      if (isReplace) {
+        history.replaceState(payload, title, longUrl);
+      } else {
+        history.pushState(payload, title, longUrl);
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed at altering browser history', payload, title, longUrl);
     }
 
     // it seems some browsers don't support pushState title attribute


### PR DESCRIPTION
Ignoring history.pushState handling errors as they are impredictable and
crash the application hard.

I'm thinking this may be because the payload object is too big and the
browser is unhappy about it. I'm not sure if the payload/state is ever
used (when hitting back?). The error seem to stop when replacing payload
by an empty object.

Related, about state size limits in browsers: https://stackoverflow.com/questions/6460377/html5-history-api-what-is-the-max-size-the-state-object-can-be

