### PR TITLE
fix sqllab querysearch typeahead permission issue

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -377,7 +377,9 @@ class SupersetSecurityManager(SecurityManager):
             pvm.permission.name in {
                 'can_sql_json', 'can_csv', 'can_search_queries', 'can_sqllab_viz',
                 'can_sqllab',
-            })
+            } or
+            (pvm.view_menu.name == 'UserDBModelView' and
+             pvm.permission.name == 'can_list'))
 
     def is_granter_pvm(self, pvm):
         return pvm.permission.name in {


### PR DESCRIPTION
Query search for users only has type ahead for `admin` role but not `alpha` role or `sql_lab` role. This is a permission issue because `/users/api/read` endpoint is not open to `sql_lab` users.
```
            <AsyncSelect
              dataEndpoint="/users/api/read"
              mutator={this.userMutator}
              value={this.state.userId}
              onChange={this.changeUser}
            />
``` 

Adding the specific permission to `sql_lab` role should fix the bug.