### PR TITLE
Update expansion carets to have up/down orientation

### DIFF
--- a/superset/assets/src/CRUD/CollectionTable.jsx
+++ b/superset/assets/src/CRUD/CollectionTable.jsx
@@ -162,7 +162,7 @@ export default class CRUDCollection extends React.PureComponent {
       tds.push(
         <td key="__expand" className="expand">
           <i
-            className={`fa fa-caret-${isExpanded ? 'down' : 'right'} text-primary pointer`}
+            className={`fa fa-caret-${isExpanded ? 'up' : 'down'} text-primary pointer`}
             onClick={this.toggleExpand.bind(this, record.id)}
           />
         </td>);

--- a/superset/assets/src/explore/components/ControlPanelSection.jsx
+++ b/superset/assets/src/explore/components/ControlPanelSection.jsx
@@ -32,7 +32,7 @@ export default class ControlPanelSection extends React.Component {
       label &&
         <div>
           <i
-            className={`text-primary expander fa fa-caret-${this.state.expanded ? 'down' : 'right'}`}
+            className={`text-primary expander fa fa-caret-${this.state.expanded ? 'up' : 'down'}`}
             onClick={this.toggleExpand.bind(this)}
           />
           {' '}


### PR DESCRIPTION
Closes #5713 
This change updates carets used in expandable sections to express intent instead:
Before: unexpanded = right, expanded = down
Now: unexpanded = down, expanded = up