### PR TITLE
Add 'Last weekday' time range preset

### DIFF
--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -35,6 +35,7 @@ const RELATIVE_TIME_OPTIONS = Object.freeze({
 });
 const COMMON_TIME_FRAMES = [
   'Last day',
+  'Last weekday',
   'Last week',
   'Last month',
   'Last quarter',

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -905,6 +905,7 @@ def get_since_until(form_data):
     Additionally, for `time_range` (these specify both `since` and `until`):
 
         - Last day
+        - Last weekday
         - Last week
         - Last month
         - Last quarter
@@ -916,8 +917,10 @@ def get_since_until(form_data):
     """
     separator = ' : '
     today = parse_human_datetime('today')
+    weekday_offset = [3, 1, 1, 1, 1, 2, 3][today.weekday()]
     common_time_frames = {
         'Last day': (today - relativedelta(days=1), today),
+        'Last weekday': (today - relativedelta(days=weekday_offset), today),
         'Last week': (today - relativedelta(weeks=1), today),
         'Last month': (today - relativedelta(months=1), today),
         'Last quarter': (today - relativedelta(months=3), today),

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -609,6 +609,11 @@ class UtilsTestCase(unittest.TestCase):
         expected = datetime(2015, 11, 7), datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
+        form_data = {'time_range': 'Last weekday'}
+        result = get_since_until(form_data)
+        expected = datetime(2016, 11, 4), datetime(2016, 11, 7)
+        self.assertEqual(result, expected)
+
         form_data = {'time_range': 'Last 5 months'}
         result = get_since_until(form_data)
         expected = datetime(2016, 6, 7), datetime(2016, 11, 7)


### PR DESCRIPTION
This allows displaying the previous Friday's data on Monday.

"Who would need this?" We need this, badly. We're just now adopting Superset, and virtually all of our batch jobs run against the previous weekday's activity (we're a trading firm). I don't know of any workaround.