### PR TITLE
Fix dashboard export:

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -577,22 +577,11 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
     def mulexport(self, items):
         if not isinstance(items, list):
             items = [items]
-        ids = ''.join('&id={}'.format(d.id) for d in items)
-        return redirect(
-            '/dashboard/export_dashboards_form?{}'.format(ids[1:]))
 
-    @expose('/export_dashboards_form')
-    def download_dashboards(self):
-        if request.args.get('action') == 'go':
-            ids = request.args.getlist('id')
-            return Response(
-                models.Dashboard.export_dashboards(ids),
-                headers=generate_download_headers('json'),
-                mimetype='application/text')
-        return self.render_template(
-            'superset/export_dashboards.html',
-            dashboards_url='/dashboard/list',
-        )
+        return Response(
+            models.Dashboard.export_dashboards([i.id for i in items]),
+            headers=generate_download_headers('json'),
+            mimetype='application/json')
 
 
 appbuilder.add_view(

--- a/tests/import_export_tests.py
+++ b/tests/import_export_tests.py
@@ -9,6 +9,7 @@ import json
 import unittest
 
 from sqlalchemy.orm.session import make_transient
+from werkzeug.datastructures import MultiDict
 
 from superset import db, utils
 from superset.connectors.druid.models import (
@@ -205,11 +206,9 @@ class ImportExportTests(SupersetTestCase):
 
     def test_export_1_dashboard(self):
         birth_dash = self.get_dash_by_slug('births')
-        export_dash_url = (
-            '/dashboard/export_dashboards_form?id={}&action=go'
-            .format(birth_dash.id)
-        )
-        resp = self.client.get(export_dash_url)
+        resp = self.client.post(
+            '/dashboard/action_post',
+            data=dict(action='mulexport', rowid=birth_dash.id))
         exported_dashboards = json.loads(
             resp.data.decode('utf-8'),
             object_hook=utils.decode_dashboards,
@@ -234,10 +233,9 @@ class ImportExportTests(SupersetTestCase):
     def test_export_2_dashboards(self):
         birth_dash = self.get_dash_by_slug('births')
         world_health_dash = self.get_dash_by_slug('world_health')
-        export_dash_url = (
-            '/dashboard/export_dashboards_form?id={}&id={}&action=go'
-            .format(birth_dash.id, world_health_dash.id))
-        resp = self.client.get(export_dash_url)
+        resp = self.client.post(
+            '/dashboard/action_post',
+            data=MultiDict([('action', 'mulexport'), ('rowid', birth_dash.id), ('rowid', world_health_dash.id)]))
         exported_dashboards = sorted(
             json.loads(
                 resp.data.decode('utf-8'),


### PR DESCRIPTION
The "Export" action on the dashboard list is broken on current Chrome, since the user is redirected right after the popup is blocked