### PR TITLE
[bugfix] Fix percent metric display and check for string columns in table

### DIFF
--- a/superset/assets/src/visualizations/table.js
+++ b/superset/assets/src/visualizations/table.js
@@ -136,6 +136,7 @@ function TableVis(element, props) {
       if (key[0] === '%') {
         html = formatPercent(val);
       }
+
       return {
         col: key,
         val,

--- a/superset/assets/src/visualizations/table.js
+++ b/superset/assets/src/visualizations/table.js
@@ -77,7 +77,7 @@ function TableVis(element, props) {
     // Add percent metrics
     .concat((percentMetrics || []).map(m => '%' + m))
     // Removing metrics (aggregates) that are strings
-    .filter(m => !Number.isNaN(data[0][m]));
+    .filter(m => (typeof data[0][m]) === 'number');
 
   function col(c) {
     const arr = [];

--- a/superset/assets/src/visualizations/table.js
+++ b/superset/assets/src/visualizations/table.js
@@ -46,6 +46,7 @@ const propTypes = {
 };
 
 const formatValue = d3.format('0,000');
+const formatPercent = d3.format('.3p');
 function NOOP() {}
 
 function TableVis(element, props) {
@@ -131,8 +132,9 @@ function TableVis(element, props) {
       }
       if (isMetric) {
         html = d3.format(format || '0.3s')(val);
-      } else if (key[0] === '%') {
-        html = d3.format('.3p')(val);
+      }
+      if (key[0] === '%') {
+        html = formatPercent(val);
       }
       return {
         col: key,


### PR DESCRIPTION
SUPERSET-695

> For the visualization type `Table View`, this slice, used to automatically convert some values into %s (e.g., `55%`) because the column names (like `% Visit` had the phrase `%` in it. This was ideal for my use case.

> However, now I noticed that these values’ format recently auto-changed to `mm`, e.g., 550mm. Is there a way to change these values back to the former percentages?

This was fixed by reverting the inadvertent change made during refactor (`if` => `else if`)

As well as another bug to filter out columns that are not numbers.

Reference: 
https://github.com/apache/incubator-superset/pull/5707/files

@graceguo-supercat 