### PR TITLE
[contributing.md] swap cypress command order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,9 +346,9 @@ We use [Mocha](https://mochajs.org/), [Chai](http://chaijs.com/) and [Enzyme](ht
 We use [Cypress](https://www.cypress.io/) for integration tests. Tests can be run by `tox -e cypress`. To open Cypress and explore tests first setup and run test server:
 
     export SUPERSET_CONFIG=tests.superset_test_config
-    superset load_test_users
     superset db upgrade
     superset init
+    superset load_test_users
     superset load_examples
     superset runserver
 


### PR DESCRIPTION
@michellethomas running the commands in the previous order failed for me, but worked after first running `db upgrade` (this seems to mirror other parts of the `contributing.md` + `cypress_build.sh` files as well)