### PR TITLE
added hack to make time pivot chart working

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1376,6 +1376,7 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
         return d
 
     def get_data(self, df):
+        self.form_data['metrics'] = [self.form_data.get('metric')]
         fd = self.form_data
         df = self.process_data(df)
         freq = to_offset(fd.get('freq'))


### PR DESCRIPTION
guys

I noticed there is a bug in the chart time periodicity pivot. For example if you use the example birth data as the datasource/table ("birth_names), the chart return and error

`'NoneType' object is not iterable`

so I went down and dig in the code and realised there is some issue in getting the metrics values from metric. So I added that line below that make the chart working (try to use another data source with data time resolution of weeks or day to see the overlapping of all the lines as all the example data are with year minimum resolution hence can overlap them as there is no frequecy option higher than year).

I think the problem is that  in the class `NVD3TimePivotViz`, the method `query_obj` can't override the default method that is in the base class `BaseViz`.

Am I right?