### PR TITLE
Allow removing legend

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -259,6 +259,7 @@ export const controls = {
     clearable: false,
     default: 'tr',
     choices: [
+      [null, 'None'],
       ['tl', 'Top left'],
       ['tr', 'Top right'],
       ['bl', 'Bottom left'],

--- a/superset/assets/src/visualizations/Legend.jsx
+++ b/superset/assets/src/visualizations/Legend.jsx
@@ -7,7 +7,7 @@ const propTypes = {
   categories: PropTypes.object,
   toggleCategory: PropTypes.func,
   showSingleCategory: PropTypes.func,
-  position: PropTypes.oneOf(['tl', 'tr', 'bl', 'br']),
+  position: PropTypes.oneOf([null, 'tl', 'tr', 'bl', 'br']),
 };
 
 const defaultProps = {
@@ -19,7 +19,7 @@ const defaultProps = {
 
 export default class Legend extends React.PureComponent {
   render() {
-    if (Object.keys(this.props.categories).length === 0) {
+    if (Object.keys(this.props.categories).length === 0 || this.props.position === null) {
       return null;
     }
 
@@ -27,7 +27,7 @@ export default class Legend extends React.PureComponent {
       const style = { color: 'rgba(' + v.color.join(', ') + ')' };
       const icon = v.enabled ? '\u25CF' : '\u25CB';
       return (
-        <li>
+        <li key={k}>
           <a
             href="#"
             onClick={() => this.props.toggleCategory(k)}


### PR DESCRIPTION
The deck.gl scatter and screengrid visualizations have a custom legend for group bys. I added an option to hide the legend.