### PR TITLE
Allow user to force refresh metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,7 +332,7 @@ commands are invoked.
 We use [Mocha](https://mochajs.org/), [Chai](http://chaijs.com/) and [Enzyme](http://airbnb.io/enzyme/) to test Javascript. Tests can be run with:
 
 ```bash
-cd superset/assets/javascripts
+cd superset/assets/spec
 npm install
 npm run test
 ```

--- a/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
@@ -131,7 +131,7 @@ describe('SqlEditorLeftBar', () => {
         return d.promise();
       });
       wrapper.instance().fetchSchemas(1);
-      expect(ajaxStub.getCall(0).args[0]).to.equal('/superset/schemas/1/');
+      expect(ajaxStub.getCall(0).args[0]).to.equal('/superset/schemas/1/false/');
       expect(wrapper.state().schemaOptions).to.have.length(3);
     });
     it('should handle error', () => {

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ControlLabel, Button, Row, Col } from 'react-bootstrap';
+import { ControlLabel, Button} from 'react-bootstrap';
 import Select from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
 
@@ -40,7 +40,6 @@ class SqlEditorLeftBar extends React.PureComponent {
   }
   onDatabaseChange(db, force) {
     const val = db ? db.value : null;
-    const force_refresh = force || false;
     this.setState({ schemaOptions: [] });
     this.props.actions.queryEditorSetSchema(this.props.queryEditor, null);
     this.props.actions.queryEditorSetDb(this.props.queryEditor, val);
@@ -48,7 +47,7 @@ class SqlEditorLeftBar extends React.PureComponent {
       this.setState({ tableOptions: [] });
     } else {
       this.fetchTables(val, this.props.queryEditor.schema);
-      this.fetchSchemas(val, force_refresh);
+      this.fetchSchemas(val, force || false);
     }
   }
   getTableNamesBySubStr(input) {
@@ -116,12 +115,12 @@ class SqlEditorLeftBar extends React.PureComponent {
     this.props.actions.queryEditorSetSchema(this.props.queryEditor, schema);
     this.fetchTables(this.props.queryEditor.dbId, schema);
   }
-  fetchSchemas(dbId, force_refresh) {
+  fetchSchemas(dbId, force) {
     const actualDbId = dbId || this.props.queryEditor.dbId;
-    force_refresh = force_refresh || false;
+    const forceRefresh = force || false;
     if (actualDbId) {
       this.setState({ schemaLoading: true });
-      const url = `/superset/schemas/${actualDbId}/${force_refresh}/`;
+      const url = `/superset/schemas/${actualDbId}/${forceRefresh}/`;
       $.get(url).done((data) => {
         const schemaOptions = data.schemas.map(s => ({ value: s, label: s }));
         this.setState({ schemaOptions, schemaLoading: false });
@@ -193,11 +192,11 @@ class SqlEditorLeftBar extends React.PureComponent {
                 onChange={this.changeSchema.bind(this)}
               />
             </div>
-            <div className="col-md-1" style={{ paddingTop: '8px', paddingLeft: '0px'}}>
+            <div className="col-md-1" style={{ paddingTop: '8px', paddingLeft: '0px' }}>
               <RefreshLabel
                 onClick={this.onDatabaseChange.bind(
                     this, { value: database.id }, true)}
-                tooltipContent='refresh schema list'
+                tooltipContent="refresh schema list"
               />
             </div>
           </div>

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ControlLabel, Button} from 'react-bootstrap';
+import { ControlLabel, Button } from 'react-bootstrap';
 import Select from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
 

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -196,7 +196,7 @@ class SqlEditorLeftBar extends React.PureComponent {
               <RefreshLabel
                 onClick={this.onDatabaseChange.bind(
                     this, { value: database.id }, true)}
-                tooltipContent="refresh schema list"
+                tooltipContent="force refresh schema list"
               />
             </div>
           </div>

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -176,7 +176,7 @@ class SqlEditorLeftBar extends React.PureComponent {
         </div>
         <div className="m-t-5">
           <div className="row">
-            <div className="col-md-11" style={{ paddingRight: '2px' }}>
+            <div className="col-md-11 col-xs-11" style={{ paddingRight: '2px' }}>
               <Select
                 name="select-schema"
                 placeholder={t('Select a schema (%s)', this.state.schemaOptions.length)}
@@ -192,7 +192,7 @@ class SqlEditorLeftBar extends React.PureComponent {
                 onChange={this.changeSchema.bind(this)}
               />
             </div>
-            <div className="col-md-1" style={{ paddingTop: '8px', paddingLeft: '0px' }}>
+            <div className="col-md-1 col-xs-1" style={{ paddingTop: '8px', paddingLeft: '0px' }}>
               <RefreshLabel
                 onClick={this.onDatabaseChange.bind(
                     this, { value: database.id }, true)}

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ControlLabel, Button } from 'react-bootstrap';
+import { ControlLabel, Button, Row, Col } from 'react-bootstrap';
 import Select from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
 
 import TableElement from './TableElement';
 import AsyncSelect from '../../components/AsyncSelect';
+import RefreshLabel from '../../components/RefreshLabel';
 import { t } from '../../locales';
 
 const $ = require('jquery');
@@ -37,8 +38,9 @@ class SqlEditorLeftBar extends React.PureComponent {
     this.fetchSchemas(this.props.queryEditor.dbId);
     this.fetchTables(this.props.queryEditor.dbId, this.props.queryEditor.schema);
   }
-  onDatabaseChange(db) {
+  onDatabaseChange(db, force) {
     const val = db ? db.value : null;
+    const force_refresh = force || false;
     this.setState({ schemaOptions: [] });
     this.props.actions.queryEditorSetSchema(this.props.queryEditor, null);
     this.props.actions.queryEditorSetDb(this.props.queryEditor, val);
@@ -46,7 +48,7 @@ class SqlEditorLeftBar extends React.PureComponent {
       this.setState({ tableOptions: [] });
     } else {
       this.fetchTables(val, this.props.queryEditor.schema);
-      this.fetchSchemas(val);
+      this.fetchSchemas(val, force_refresh);
     }
   }
   getTableNamesBySubStr(input) {
@@ -114,11 +116,12 @@ class SqlEditorLeftBar extends React.PureComponent {
     this.props.actions.queryEditorSetSchema(this.props.queryEditor, schema);
     this.fetchTables(this.props.queryEditor.dbId, schema);
   }
-  fetchSchemas(dbId) {
+  fetchSchemas(dbId, force_refresh) {
     const actualDbId = dbId || this.props.queryEditor.dbId;
+    force_refresh = force_refresh || false;
     if (actualDbId) {
       this.setState({ schemaLoading: true });
-      const url = `/superset/schemas/${actualDbId}/`;
+      const url = `/superset/schemas/${actualDbId}/${force_refresh}/`;
       $.get(url).done((data) => {
         const schemaOptions = data.schemas.map(s => ({ value: s, label: s }));
         this.setState({ schemaOptions, schemaLoading: false });
@@ -144,6 +147,7 @@ class SqlEditorLeftBar extends React.PureComponent {
       tableSelectPlaceholder = t('Select table ');
       tableSelectDisabled = true;
     }
+    const database = this.props.database || {};
     return (
       <div className="clearfix sql-toolbar">
         <div>
@@ -172,20 +176,31 @@ class SqlEditorLeftBar extends React.PureComponent {
           />
         </div>
         <div className="m-t-5">
-          <Select
-            name="select-schema"
-            placeholder={t('Select a schema (%s)', this.state.schemaOptions.length)}
-            options={this.state.schemaOptions}
-            value={this.props.queryEditor.schema}
-            valueRenderer={o => (
-              <div>
-                <span className="text-muted">{t('Schema:')}</span> {o.label}
-              </div>
-            )}
-            isLoading={this.state.schemaLoading}
-            autosize={false}
-            onChange={this.changeSchema.bind(this)}
-          />
+          <div className="row">
+            <div className="col-md-11" style={{ paddingRight: '2px' }}>
+              <Select
+                name="select-schema"
+                placeholder={t('Select a schema (%s)', this.state.schemaOptions.length)}
+                options={this.state.schemaOptions}
+                value={this.props.queryEditor.schema}
+                valueRenderer={o => (
+                  <div>
+                    <span className="text-muted">{t('Schema:')}</span> {o.label}
+                  </div>
+                )}
+                isLoading={this.state.schemaLoading}
+                autosize={false}
+                onChange={this.changeSchema.bind(this)}
+              />
+            </div>
+            <div className="col-md-1" style={{ paddingTop: '8px', paddingLeft: '0px'}}>
+              <RefreshLabel
+                onClick={this.onDatabaseChange.bind(
+                    this, { value: database.id }, true)}
+                tooltipContent='refresh schema list'
+              />
+            </div>
+          </div>
         </div>
         <hr />
         <div className="m-t-5">

--- a/superset/assets/src/components/RefreshLabel.jsx
+++ b/superset/assets/src/components/RefreshLabel.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Label } from 'react-bootstrap';
+import TooltipWrapper from './TooltipWrapper';
+
+const propTypes = {
+  onClick: PropTypes.func,
+  className: PropTypes.string,
+  tooltipContent: PropTypes.string.isRequired,
+};
+
+class RefreshLabel extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hovered: false,
+    };
+  }
+
+  mouseOver() {
+    this.setState({ hovered: true });
+  }
+
+  mouseOut() {
+    this.setState({ hovered: false });
+  }
+
+  render() {
+    const labelStyle = this.state.hovered ? 'primary' : 'default';
+    const tooltip = 'Click to ' + this.props.tooltipContent;
+    return (
+      <TooltipWrapper
+        tooltip={tooltip}
+        label="cache-desc"
+      >
+        <Label
+          className={this.props.className}
+          bsStyle={labelStyle}
+          style={{ fontSize: '13px', marginRight: '5px', cursor: 'pointer' }}
+          onClick={this.props.onClick}
+          onMouseOver={this.mouseOver.bind(this)}
+          onMouseOut={this.mouseOut.bind(this)}
+        >
+        <i className="fa fa-refresh" />
+        </Label>
+      </TooltipWrapper>);
+  }
+}
+RefreshLabel.propTypes = propTypes;
+
+export default RefreshLabel;

--- a/superset/assets/src/components/RefreshLabel.jsx
+++ b/superset/assets/src/components/RefreshLabel.jsx
@@ -41,7 +41,7 @@ class RefreshLabel extends React.PureComponent {
           onMouseOver={this.mouseOver.bind(this)}
           onMouseOut={this.mouseOut.bind(this)}
         >
-        <i className="fa fa-refresh" />
+          <i className="fa fa-refresh" />
         </Label>
       </TooltipWrapper>);
   }

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 from flask import request
 
-from superset import tables_cache
+from superset import cache, tables_cache
 
 
 def view_cache_key(*unused_args, **unused_kwargs):
@@ -15,7 +15,7 @@ def view_cache_key(*unused_args, **unused_kwargs):
     return 'view/{}/{}'.format(request.path, args_hash)
 
 
-def memoized_func(timeout=5 * 60, key=view_cache_key):
+def memoized_func(timeout=5 * 60, key=view_cache_key, use_tables_cache=False):
     """Use this decorator to cache functions that have predefined first arg.
 
     memoized_func uses simple_cache and stored the data in memory.
@@ -23,14 +23,20 @@ def memoized_func(timeout=5 * 60, key=view_cache_key):
     returns the caching key.
     """
     def wrap(f):
-        if tables_cache:
+        selected_cache = None
+        if use_tables_cache and tables_cache:
+            selected_cache = tables_cache
+        elif cache:
+            selected_cache = cache
+
+        if selected_cache:
             def wrapped_f(cls, *args, **kwargs):
                 cache_key = key(*args, **kwargs)
-                o = tables_cache.get(cache_key)
+                o = selected_cache.get(cache_key)
                 if not kwargs['force'] and o is not None:
                     return o
                 o = f(cls, *args, **kwargs)
-                tables_cache.set(cache_key, o, timeout=timeout)
+                selected_cache.set(cache_key, o, timeout=timeout)
                 return o
         else:
             # noop

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -15,7 +15,11 @@ def view_cache_key(*unused_args, **unused_kwargs):
     return 'view/{}/{}'.format(request.path, args_hash)
 
 
-def memoized_func(timeout=5 * 60, key=view_cache_key, use_tables_cache=False):
+def default_timetout(*unused_args, **unused_kwargs):
+    return 5 * 60
+
+
+def memoized_func(timeout=default_timetout, key=view_cache_key, use_tables_cache=False):
     """Use this decorator to cache functions that have predefined first arg.
 
     memoized_func uses simple_cache and stored the data in memory.
@@ -36,7 +40,7 @@ def memoized_func(timeout=5 * 60, key=view_cache_key, use_tables_cache=False):
                 if not kwargs['force'] and o is not None:
                     return o
                 o = f(cls, *args, **kwargs)
-                selected_cache.set(cache_key, o, timeout=timeout)
+                selected_cache.set(cache_key, o, timeout=timeout(*args, **kwargs))
                 return o
         else:
             # noop

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -15,7 +15,7 @@ def view_cache_key(*unused_args, **unused_kwargs):
     return 'view/{}/{}'.format(request.path, args_hash)
 
 
-def default_timetout(*unused_args, **unused_kwargs):
+def default_timeout(*unused_args, **unused_kwargs):
     return 5 * 60
 
 
@@ -23,7 +23,7 @@ def default_enable_cache(*unused_args, **unused_kwargs):
     return True
 
 
-def memoized_func(timeout=default_timetout,
+def memoized_func(timeout=default_timeout,
                   key=view_cache_key,
                   enable_cache=default_enable_cache,
                   use_tables_cache=False):

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -19,8 +19,21 @@ def default_timetout(*unused_args, **unused_kwargs):
     return 5 * 60
 
 
-def memoized_func(timeout=default_timetout, key=view_cache_key, use_tables_cache=False):
+def default_enable_cache(*unused_args, **unused_kwargs):
+    return True
+
+
+def memoized_func(timeout=default_timetout,
+                  key=view_cache_key,
+                  enable_cache=default_enable_cache,
+                  use_tables_cache=False):
     """Use this decorator to cache functions that have predefined first arg.
+
+    If enable_cache() is False,
+        the function will never be cached.
+    If enable_cache() is True,
+        cache is adopted and will timeout in timeout() seconds.
+        If force is True, cache will be refreshed.
 
     memoized_func uses simple_cache and stored the data in memory.
     Key is a callable function that takes function arguments and
@@ -35,6 +48,9 @@ def memoized_func(timeout=default_timetout, key=view_cache_key, use_tables_cache
 
         if selected_cache:
             def wrapped_f(cls, *args, **kwargs):
+                if not enable_cache(*args, **kwargs):
+                    return f(cls, *args, **kwargs)
+
                 cache_key = key(*args, **kwargs)
                 o = selected_cache.get(cache_key)
                 if not kwargs['force'] and o is not None:

--- a/superset/config.py
+++ b/superset/config.py
@@ -185,7 +185,7 @@ IMG_UPLOAD_URL = '/static/uploads/'
 # IMG_SIZE = (300, 200, True)
 
 CACHE_DEFAULT_TIMEOUT = 60 * 60 * 24
-CACHE_CONFIG = {'CACHE_TYPE': 'simple'}
+CACHE_CONFIG = {'CACHE_TYPE': 'null'}
 TABLE_NAMES_CACHE_CONFIG = {'CACHE_TYPE': 'null'}
 
 # CORS Options

--- a/superset/config.py
+++ b/superset/config.py
@@ -185,7 +185,7 @@ IMG_UPLOAD_URL = '/static/uploads/'
 # IMG_SIZE = (300, 200, True)
 
 CACHE_DEFAULT_TIMEOUT = 60 * 60 * 24
-CACHE_CONFIG = {'CACHE_TYPE': 'null'}
+CACHE_CONFIG = {'CACHE_TYPE': 'simple'}
 TABLE_NAMES_CACHE_CONFIG = {'CACHE_TYPE': 'null'}
 
 # CORS Options

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -301,17 +301,17 @@ class BaseEngineSpec(object):
 
     @classmethod
     @cache_util.memoized_func(
-        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout') or 1,
+        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
+        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{}:schema_list'.format(kwargs.get('db_id')))
-    def get_schema_names(cls, inspector, cache_timeout, db_id, force=False):
-        """A function to get all schema names in this db
-
-        If cache_timeout is not passed to the function,
-        the cache will timeout in just 1 second
+    def get_schema_names(cls, inspector, db_id,
+                         enable_cache, cache_timeout, force=False):
+        """A function to get all schema names in this db.
 
         :param inspector: URI string
-        :param cache_timeout: timeout settings for cache in second
         :param db_id: database id
+        :param enable_cache: whether to enable cache for the function
+        :param cache_timeout: timeout settings for cache in second.
         :param force: force to refresh
         :return: a list of schema names
         """
@@ -1453,9 +1453,11 @@ class ImpalaEngineSpec(BaseEngineSpec):
 
     @classmethod
     @cache_util.memoized_func(
-        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout') or 1,
+        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
+        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{}:schema_list'.format(kwargs.get('db_id')))
-    def get_schema_names(cls, inspector, cache_timeout, db_id, force=False):
+    def get_schema_names(cls, inspector, db_id,
+                         enable_cache, cache_timeout, force=False):
         schemas = [row[0] for row in inspector.engine.execute('SHOW SCHEMAS')
                    if not row[0].startswith('_')]
         return schemas

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -872,14 +872,14 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         return views
 
     def all_schema_names(self, force_refresh=False):
-        medatada_cache_timeout = self.get_extra().get("metadata_cache_timeout", {})
-        enable_cache = "schema_cache_timeout" in medatada_cache_timeout
+        medatada_cache_timeout = self.get_extra().get('metadata_cache_timeout', {})
+        enable_cache = 'schema_cache_timeout' in medatada_cache_timeout
         return sorted(self.db_engine_spec.get_schema_names(
             inspector=self.inspector,
             enable_cache=enable_cache,
             cache_timeout=(self.get_extra().
-                           get("metadata_cache_timeout", {}).
-                           get("schema_cache_timeout")),
+                           get('metadata_cache_timeout', {}).
+                           get('schema_cache_timeout')),
             db_id=self.id,
             force=force_refresh))
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -647,9 +647,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     {
         "metadata_params": {},
         "engine_params": {},
-        "metadata_cache_timeout": {
-            "schema_timeout": 1
-        },
+        "metadata_cache_timeout": {},
         "schemas_allowed_for_csv_upload": []
     }
     """))
@@ -874,11 +872,14 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         return views
 
     def all_schema_names(self, force_refresh=False):
+        medatada_cache_timeout = self.get_extra().get("metadata_cache_timeout", {})
+        enable_cache = "schema_cache_timeout" in medatada_cache_timeout
         return sorted(self.db_engine_spec.get_schema_names(
             inspector=self.inspector,
+            enable_cache=enable_cache,
             cache_timeout=(self.get_extra().
                            get("metadata_cache_timeout", {}).
-                           get("schema_timeout")),
+                           get("schema_cache_timeout")),
             db_id=self.id,
             force=force_refresh))
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -647,6 +647,9 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     {
         "metadata_params": {},
         "engine_params": {},
+        "metadata_cache_timeout": {
+            "schema_timeout": 1
+        },
         "schemas_allowed_for_csv_upload": []
     }
     """))
@@ -872,7 +875,12 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
     def all_schema_names(self, force_refresh=False):
         return sorted(self.db_engine_spec.get_schema_names(
-            inspector=self.inspector, db_id=self.id, force=force_refresh))
+            inspector=self.inspector,
+            cache_timeout=(self.get_extra().
+                           get("metadata_cache_timeout", {}).
+                           get("schema_timeout")),
+            db_id=self.id,
+            force=force_refresh))
 
     @property
     def db_engine_spec(self):

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -872,14 +872,14 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         return views
 
     def all_schema_names(self, force_refresh=False):
-        medatada_cache_timeout = self.get_extra().get('metadata_cache_timeout', {})
+        extra = self.get_extra()
+        medatada_cache_timeout = extra.get('metadata_cache_timeout', {})
+        schema_cache_timeout = medatada_cache_timeout.get('schema_cache_timeout')
         enable_cache = 'schema_cache_timeout' in medatada_cache_timeout
         return sorted(self.db_engine_spec.get_schema_names(
             inspector=self.inspector,
             enable_cache=enable_cache,
-            cache_timeout=(self.get_extra().
-                           get('metadata_cache_timeout', {}).
-                           get('schema_cache_timeout')),
+            cache_timeout=schema_cache_timeout,
             db_id=self.id,
             force=force_refresh))
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -870,8 +870,9 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             pass
         return views
 
-    def all_schema_names(self):
-        return sorted(self.db_engine_spec.get_schema_names(self.inspector))
+    def all_schema_names(self, force_refresh=False):
+        return sorted(self.db_engine_spec.get_schema_names(
+            inspector=self.inspector, db_id=self.id, force=force_refresh))
 
     @property
     def db_engine_spec(self):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -262,7 +262,6 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
         db.set_sqlalchemy_uri(db.sqlalchemy_uri)
         security_manager.merge_perm('database_access', db.perm)
         # adding a new database we always want to force refresh schema list
-        # instead of getting cache from another database
         for schema in db.all_schema_names(force_refresh=True):
             security_manager.merge_perm(
                 'schema_access', security_manager.get_schema_perm(db, schema))

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -212,7 +212,7 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
             '(http://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html'
             '#sqlalchemy.schema.MetaData) call.<br/>'
             '2. The ``metadata_cache_timeout`` is a cache timeout setting '
-            'in second for metadata fetch of this database. Specify it as '
+            'in seconds for metadata fetch of this database. Specify it as '
             '**"metadata_cache_timeout": {"schema_cache_timeout": 600}**. '
             'If unset, cache will not be enabled for the functionality. '
             'A timeout of 0 indicates that the cache never expires.<br/>'
@@ -1536,11 +1536,11 @@ class Superset(BaseSupersetView):
 
     @api
     @has_access_api
+    @expose('/schemas/<db_id>/')
     @expose('/schemas/<db_id>/<force_refresh>/')
-    def schemas(self, db_id, force_refresh):
+    def schemas(self, db_id, force_refresh='true'):
         db_id = int(db_id)
         force_refresh = force_refresh.lower() == 'true'
-        print(force_refresh)
         database = (
             db.session
             .query(models.Database)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -211,7 +211,12 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
             'gets unpacked into the [sqlalchemy.MetaData]'
             '(http://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html'
             '#sqlalchemy.schema.MetaData) call.<br/>'
-            '2. The ``schemas_allowed_for_csv_upload`` is a comma separated list '
+            '2. The ``metadata_cache_timeout`` is a cache timeout setting '
+            'in second for metadata fetch of this database. Specify it as '
+            '**"metadata_cache_timeout": {"schema_cache_timeout": 600}**. '
+            'If unset, cache will not be enabled for the functionality. '
+            'A timeout of 0 indicates that the cache never expires.<br/>'
+            '3. The ``schemas_allowed_for_csv_upload`` is a comma separated list '
             'of schemas that CSVs are allowed to upload to. '
             'Specify it as **"schemas_allowed": ["public", "csv_upload"]**. '
             'If database flavor does not support schema or any schema is allowed '
@@ -227,7 +232,7 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
             'all database schemas. For large data warehouse with thousands of '
             'tables, this can be expensive and put strain on the system.'),
         'cache_timeout': _(
-            'Duration (in seconds) of the caching timeout for this database. '
+            'Duration (in seconds) of the caching timeout for charts of this database. '
             'A timeout of 0 indicates that the cache never expires. '
             'Note this defaults to the global timeout if undefined.'),
         'allow_csv_upload': _(
@@ -242,7 +247,7 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
         'creator': _('Creator'),
         'changed_on_': _('Last Changed'),
         'sqlalchemy_uri': _('SQLAlchemy URI'),
-        'cache_timeout': _('Cache Timeout'),
+        'cache_timeout': _('Chart Cache Timeout'),
         'extra': _('Extra'),
         'allow_run_sync': _('Allow Run Sync'),
         'allow_run_async': _('Allow Run Async'),


### PR DESCRIPTION
### Several changes in this PR:
1. Introduced `"metadata_cache_timeout": {}` setting in `extra` of a database configuration. If `schema_cache_timeout` is unset in the field, cache will not be enabled for the metadata fetch of this database. If it is set to 0, cache will never time out. 
2. Added a button to sqllab UI which allows user to refetch schemas metadata and force refresh cache if cache is enabled.
3. Added a new component which is called `RefreshLabel`. It is similar to `CacheLabel` but simpler. Not sure if we need to integrate the two labels into one component and not sure how to implement if so. Any suggestion is welcome.

### Next step:
Implement similar things on fetching table list.

<img width="853" alt="screen shot 2018-09-19 at 12 50 26 pm" src="https://user-images.githubusercontent.com/26216756/45777440-9fb60080-bc0a-11e8-83fc-954500abea75.png">
