### PR TITLE
Ensure npm run build is in production mode

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -15,7 +15,7 @@
     "dev": "webpack --mode=development --colors --progress --debug --watch",
     "dev-server": "webpack-dev-server --mode=development --progress",
     "prod": "node --max_old_space_size=4096 webpack --mode=production --colors --progress",
-    "build": "webpack --mode=production --colors --progress",
+    "build": "NODE_ENV=production webpack --mode=production --colors --progress",
     "lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx .",
     "lint-fix": "eslint --fix --ignore-path=.eslintignore --ext .js,.jsx .",
     "sync-backend": "babel-node --presets env src/syncBackend.js",


### PR DESCRIPTION
Using `--mode=production` does not work with some modules. In particular, `react-hot-loader` uses `NODE_ENV` to decide whether to use empty shell or HMR code. 

See bundle size before / after this change. 

![pasted_image_9_19_18__3_39_pm](https://user-images.githubusercontent.com/1659771/45785976-37274d80-bc23-11e8-8db9-7ac6c9169f25.png)

p.s. I tried using `webpack.DefinePlugin({ 'process.env.NODE_ENV': mode })` to avoid hardcoding env variable in npm script but was not successful, so I settle with this.

@williaster @xtinec 