### PR TITLE
Deprecate getColorFromScheme

### DIFF
--- a/superset/assets/spec/javascripts/modules/colors_spec.jsx
+++ b/superset/assets/spec/javascripts/modules/colors_spec.jsx
@@ -1,47 +1,7 @@
 import { expect } from 'chai';
-import { getColorFromScheme, hexToRGB } from '../../../src/modules/colors';
-import { getInstance } from '../../../src/modules/ColorSchemeManager';
-import airbnb from '../../../src/modules/colorSchemes/airbnb';
-import categoricalSchemes from '../../../src/modules/colorSchemes/categorical';
+import { hexToRGB } from '../../../src/modules/colors';
 
 describe('colors', () => {
-  before(() => {
-    // Register color schemes
-    getInstance()
-      .registerScheme('bnbColors', airbnb.bnbColors)
-      .registerMultipleSchemes(categoricalSchemes)
-      .setDefaultSchemeName('bnbColors');
-  });
-  it('default to bnbColors', () => {
-    const color1 = getColorFromScheme('CA');
-    expect(airbnb.bnbColors).to.include(color1);
-  });
-  it('getColorFromScheme series with same scheme should have the same color', () => {
-    const color1 = getColorFromScheme('CA', 'bnbColors');
-    const color2 = getColorFromScheme('CA', 'googleCategory20c');
-    const color3 = getColorFromScheme('CA', 'bnbColors');
-    const color4 = getColorFromScheme('NY', 'bnbColors');
-
-    expect(color1).to.equal(color3);
-    expect(color1).to.not.equal(color2);
-    expect(color1).to.not.equal(color4);
-  });
-  it('getColorFromScheme forcing colors persists through calls', () => {
-    expect(getColorFromScheme('boys', 'bnbColors', 'blue')).to.equal('blue');
-    expect(getColorFromScheme('boys', 'bnbColors')).to.equal('blue');
-    expect(getColorFromScheme('boys', 'googleCategory20c')).to.not.equal('blue');
-
-    expect(getColorFromScheme('girls', 'bnbColors', 'pink')).to.equal('pink');
-    expect(getColorFromScheme('girls', 'bnbColors')).to.equal('pink');
-    expect(getColorFromScheme('girls', 'googleCategory20c')).to.not.equal('pink');
-  });
-  it('getColorFromScheme is not case sensitive', () => {
-    const c1 = getColorFromScheme('girls', 'bnbColors');
-    const c2 = getColorFromScheme('Girls', 'bnbColors');
-    const c3 = getColorFromScheme('GIRLS', 'bnbColors');
-    expect(c1).to.equal(c2);
-    expect(c3).to.equal(c2);
-  });
   it('hexToRGB converts properly', () => {
     expect(hexToRGB('#FFFFFF')).to.have.same.members([255, 255, 255, 255]);
     expect(hexToRGB('#000000')).to.have.same.members([0, 0, 0, 255]);

--- a/superset/assets/src/modules/colors.js
+++ b/superset/assets/src/modules/colors.js
@@ -1,5 +1,4 @@
 import d3 from 'd3';
-import { getScale } from './CategoricalColorNamespace';
 import sequentialSchemes from './colorSchemes/sequential';
 import airbnb from './colorSchemes/airbnb';
 import lyft from './colorSchemes/lyft';
@@ -17,26 +16,6 @@ export function hexToRGB(hex, alpha = 255) {
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
   return [r, g, b, alpha];
-}
-
-/**
- * Get a color from a scheme specific palette (scheme)
- * The function cycles through the palette while memoizing labels
- * association to colors. If the function is called twice with the
- * same string, it will return the same color.
- *
- * @param {string} s - The label for which we want to get a color
- * @param {string} scheme - The palette name, or "scheme"
- * @param {string} forcedColor - A color that the caller wants to
- forcibly associate to a label.
- */
-export function getColorFromScheme(value, schemeName, forcedColor) {
-  const scale = getScale(schemeName);
-  if (forcedColor) {
-    scale.setColor(value, forcedColor);
-    return forcedColor;
-  }
-  return scale.getColor(value);
 }
 
 export const colorScalerFactory = function (colors, data, accessor, extents, outputRGBA = false) {


### PR DESCRIPTION
All calls to this function `getColorFromScheme` was replaced with `getColor` or `getScale` from `CategoricalColorNamespace` in PR #5815 . 

This function was left as a shim in PR #5815, as there were still some components using it. Now all those remaining calls have been removed so there is no need for this shim anymore. 

p.s. also enable all unit tests again after `.only` was left in one of the tests.

@williaster @conglei 