### PR TITLE
use es6 import in common.js

### DIFF
--- a/superset/assets/src/common.js
+++ b/superset/assets/src/common.js
@@ -4,18 +4,17 @@ import airbnb from './modules/colorSchemes/airbnb';
 import categoricalSchemes from './modules/colorSchemes/categorical';
 import lyft from './modules/colorSchemes/lyft';
 import { getInstance } from './modules/ColorSchemeManager';
+import { toggleCheckbox } from './modules/utils';
 
 // Everything imported in this file ends up in the common entry file
 // be mindful of double-imports
-
-const utils = require('./modules/utils');
 
 $(document).ready(function () {
   $(':checkbox[data-checkbox-api-prefix]').change(function () {
     const $this = $(this);
     const prefix = $this.data('checkbox-api-prefix');
     const id = $this.attr('id');
-    utils.toggleCheckbox(prefix, '#' + id);
+    toggleCheckbox(prefix, '#' + id);
   });
 
   // for language picker dropdown


### PR DESCRIPTION
This should help with tree-shaking for the `common` entry point as it only needs one function from `utils`. 

@williaster @graceguo-supercat 