### PR TITLE
[eslint] add no-only-tests

### DIFF
--- a/superset/assets/.eslintrc
+++ b/superset/assets/.eslintrc
@@ -41,5 +41,9 @@
     "indent": 0,
     "no-multi-spaces": 0,
     "padded-blocks": 0,
-  }
+    "no-only-tests/no-only-tests": 2
+  },
+  "plugins": [
+    "no-only-tests"
+  ]
 }

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -154,6 +154,7 @@
     "eslint-plugin-cypress": "^2.0.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-no-only-tests": "^2.0.1",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.0.1",
     "exports-loader": "^0.7.0",

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -4562,6 +4562,10 @@ eslint-plugin-jsx-a11y@^5.1.1:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
 
+eslint-plugin-no-only-tests@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.0.1.tgz#c7bfa82a46be791f9625d720e990632b5dec3c7d"
+
 eslint-plugin-prettier@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"


### PR DESCRIPTION
This adds the `no-only-tests` `eslint` plugin + rule to ensure we don't run into disabling most tests and that a `.only()` will fail the build.

I tested it locally to make sure it failed if `.only` was present in `cypress/` or in `spec/`

@kristw @xtinec @mistercrunch @graceguo-supercat @michellethomas 