### PR TITLE
Remove lodash.throttle and replace underscore calls with lodash

### DIFF
--- a/superset/assets/.babelrc
+++ b/superset/assets/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets" : ["airbnb", "react", "env"],
-  "plugins": ["syntax-dynamic-import", "react-hot-loader/babel"]
+  "plugins": ["lodash", "syntax-dynamic-import", "react-hot-loader/babel"]
 }

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -80,7 +80,6 @@
     "jquery": "3.1.1",
     "json-bigint": "^0.3.0",
     "lodash": "^4.17.11",
-    "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^0.45.0",
     "mathjs": "^3.20.2",
     "moment": "^2.20.1",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -137,6 +137,7 @@
     "babel-loader": "^7.1.4",
     "babel-plugin-css-modules-transform": "^1.1.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
+    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-airbnb": "^2.1.1",

--- a/superset/assets/spec/javascripts/modules/utils_spec.jsx
+++ b/superset/assets/spec/javascripts/modules/utils_spec.jsx
@@ -1,6 +1,5 @@
 import { expect, assert } from 'chai';
 import {
-  slugify,
   formatSelectOptionsForRange,
   d3format,
   d3FormatPreset,
@@ -10,12 +9,6 @@ import {
 } from '../../../src/modules/utils';
 
 describe('utils', () => {
-  it('slugify slugifies', () => {
-    expect(slugify('My Neat Label! ')).to.equal('my-neat-label');
-    expect(slugify('Some Letters AnD a 5')).to.equal('some-letters-and-a-5');
-    expect(slugify(' 439278 ')).to.equal('439278');
-    expect(slugify('5')).to.equal('5');
-  });
   it('formatSelectOptionsForRange', () => {
     expect(formatSelectOptionsForRange(0, 4)).to.deep.equal([
       [0, '0'],

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import throttle from 'lodash.throttle';
+import throttle from 'lodash/fp/throttle';
 import {
   Col,
   FormGroup,
@@ -57,7 +57,7 @@ class SqlEditor extends React.PureComponent {
     };
 
     this.onResize = this.onResize.bind(this);
-    this.throttledResize = throttle(this.onResize, 250);
+    this.throttledResize = throttle(250, this.onResize);
     this.runQuery = this.runQuery.bind(this);
     this.stopQuery = this.stopQuery.bind(this);
     this.onSqlChanged = this.onSqlChanged.bind(this);

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import throttle from 'lodash/fp/throttle';
+import { throttle } from 'lodash';
 import {
   Col,
   FormGroup,
@@ -57,7 +57,7 @@ class SqlEditor extends React.PureComponent {
     };
 
     this.onResize = this.onResize.bind(this);
-    this.throttledResize = throttle(250, this.onResize);
+    this.throttledResize = throttle(this.onResize, 250);
     this.runQuery = this.runQuery.bind(this);
     this.stopQuery = this.stopQuery.bind(this);
     this.onSqlChanged = this.onSqlChanged.bind(this);

--- a/superset/assets/src/components/AlteredSliceTag.jsx
+++ b/superset/assets/src/components/AlteredSliceTag.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Table, Tr, Td, Thead, Th } from 'reactable';
-import { isEqual, isEmpty } from 'underscore';
+import { isEqual, isEmpty } from 'lodash';
 
 import TooltipWrapper from './TooltipWrapper';
 import { controls } from '../explore/controls';

--- a/superset/assets/src/components/Button.jsx
+++ b/superset/assets/src/components/Button.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { kebabCase } from 'lodash';
 import { Button as BootstrapButton, Tooltip, OverlayTrigger } from 'react-bootstrap';
-import { slugify } from '../modules/utils';
 
 const propTypes = {
   tooltip: PropTypes.node,
@@ -41,7 +41,7 @@ export default function Button(props) {
     return (
       <OverlayTrigger
         placement={placement}
-        overlay={<Tooltip id={`${slugify(tooltip)}-tooltip`}>{tooltip}</Tooltip>}
+        overlay={<Tooltip id={`${kebabCase(tooltip)}-tooltip`}>{tooltip}</Tooltip>}
       >
         {button}
       </OverlayTrigger>

--- a/superset/assets/src/components/InfoTooltipWithTrigger.jsx
+++ b/superset/assets/src/components/InfoTooltipWithTrigger.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { kebabCase } from 'lodash';
 import { Tooltip, OverlayTrigger } from 'react-bootstrap';
-import { slugify } from '../modules/utils';
 
 const propTypes = {
   label: PropTypes.string.isRequired,
@@ -36,7 +36,7 @@ export default function InfoTooltipWithTrigger({
     <OverlayTrigger
       placement={placement}
       overlay={
-        <Tooltip id={`${slugify(label)}-tooltip`} style={tooltipStyle}>
+        <Tooltip id={`${kebabCase(label)}-tooltip`} style={tooltipStyle}>
           {tooltip}
         </Tooltip>
       }

--- a/superset/assets/src/components/TooltipWrapper.jsx
+++ b/superset/assets/src/components/TooltipWrapper.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { kebabCase } from 'lodash';
 import { Tooltip, OverlayTrigger } from 'react-bootstrap';
-import { slugify } from '../modules/utils';
 
 const propTypes = {
   label: PropTypes.string.isRequired,
@@ -18,7 +18,7 @@ export default function TooltipWrapper({ label, tooltip, children, placement }) 
   return (
     <OverlayTrigger
       placement={placement}
-      overlay={<Tooltip id={`${slugify(label)}-tooltip`}>{tooltip}</Tooltip>}
+      overlay={<Tooltip id={`${kebabCase(label)}-tooltip`}>{tooltip}</Tooltip>}
     >
       {children}
     </OverlayTrigger>

--- a/superset/assets/src/dashboard/components/dnd/handleHover.js
+++ b/superset/assets/src/dashboard/components/dnd/handleHover.js
@@ -1,4 +1,4 @@
-import throttle from 'lodash.throttle';
+import throttle from 'lodash/fp/throttle';
 import getDropPosition from '../../util/getDropPosition';
 
 const HOVER_THROTTLE_MS = 100;
@@ -20,4 +20,4 @@ function handleHover(props, monitor, Component) {
 }
 
 // this is called very frequently by react-dnd
-export default throttle(handleHover, HOVER_THROTTLE_MS);
+export default throttle(HOVER_THROTTLE_MS, handleHover);

--- a/superset/assets/src/dashboard/components/dnd/handleHover.js
+++ b/superset/assets/src/dashboard/components/dnd/handleHover.js
@@ -1,4 +1,4 @@
-import throttle from 'lodash/fp/throttle';
+import { throttle } from 'lodash';
 import getDropPosition from '../../util/getDropPosition';
 
 const HOVER_THROTTLE_MS = 100;
@@ -20,4 +20,4 @@ function handleHover(props, monitor, Component) {
 }
 
 // this is called very frequently by react-dnd
-export default throttle(HOVER_THROTTLE_MS, handleHover);
+export default throttle(handleHover, HOVER_THROTTLE_MS);

--- a/superset/assets/src/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset/assets/src/explore/components/controls/ColorSchemeControl.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'underscore';
+import { isFunction } from 'lodash';
 import { Creatable } from 'react-select';
 import ControlHeader from '../ControlHeader';
 import { colorScalerFactory } from '../../../modules/colors';
@@ -48,7 +48,7 @@ export default class ColorSchemeControl extends React.PureComponent {
 
   renderOption(key) {
     const { schemes } = this.props;
-    const schemeLookup = _.isFunction(schemes) ? schemes() : schemes;
+    const schemeLookup = isFunction(schemes) ? schemes() : schemes;
     const currentScheme = schemeLookup[key.value || defaultProps.value];
 
     let colors = currentScheme;
@@ -68,7 +68,7 @@ export default class ColorSchemeControl extends React.PureComponent {
 
   render() {
     const { choices } = this.props;
-    const options = (_.isFunction(choices) ? choices() : choices)
+    const options = (isFunction(choices) ? choices() : choices)
       .map(choice => ({ value: choice[0], label: choice[1] }));
 
     const selectProps = {

--- a/superset/assets/src/modules/utils.js
+++ b/superset/assets/src/modules/utils.js
@@ -1,7 +1,6 @@
 /* eslint camelcase: 0 */
 import d3 from 'd3';
 import $ from 'jquery';
-
 import { formatDate, UTC } from './dates';
 
 const siFormatter = d3.format('.3s');
@@ -184,16 +183,6 @@ export function formatSelectOptions(options) {
   return options.map(opt =>
      [opt, opt.toString()],
   );
-}
-
-export function slugify(string) {
-  // slugify('My Neat Label! '); returns 'my-neat-label'
-  return string
-          .toString()
-          .toLowerCase()
-          .trim()
-          .replace(/[\s\W-]+/g, '-') // replace spaces, non-word chars, w/ a single dash (-)
-          .replace(/-$/, ''); // remove last floating dash
 }
 
 export function getAjaxErrorMsg(error) {

--- a/superset/assets/src/reduxUtils.js
+++ b/superset/assets/src/reduxUtils.js
@@ -1,7 +1,7 @@
 import shortid from 'shortid';
 import { compose } from 'redux';
 import persistState from 'redux-localstorage';
-import { isEqual } from 'underscore';
+import { isEqual } from 'lodash';
 
 export function addToObject(state, arrKey, obj) {
   const newObject = Object.assign({}, state[arrKey]);

--- a/superset/assets/src/visualizations/deckgl/layers/polygon.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/polygon.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { PolygonLayer } from 'deck.gl';
-import _ from 'underscore';
+import { flatten } from 'lodash';
 import d3 from 'd3';
 
 import DeckGLContainer from './../DeckGLContainer';
@@ -12,7 +12,7 @@ import { colorScalerFactory } from '../../../modules/colors';
 import sandboxedEval from '../../../modules/sandbox';
 
 function getPoints(features) {
-  return _.flatten(features.map(d => d.polygon), true);
+  return flatten(features.map(d => d.polygon), true);
 }
 
 function getLayer(formData, payload, slice) {

--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -1,4 +1,4 @@
-import throttle from 'lodash.throttle';
+import throttle from 'lodash/fp/throttle';
 import d3 from 'd3';
 import nv from 'nvd3';
 import mathjs from 'mathjs';
@@ -674,7 +674,7 @@ function nvd3Vis(element, props) {
         .call(chart);
 
       // on scroll, hide tooltips. throttle to only 4x/second.
-      window.addEventListener('scroll', throttle(hideTooltips, 250));
+      window.addEventListener('scroll', throttle(250, hideTooltips));
 
       // The below code should be run AFTER rendering because chart is updated in call()
       if (isTimeSeries && annotationLayers.length > 0) {

--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -1,4 +1,4 @@
-import throttle from 'lodash/fp/throttle';
+import { throttle } from 'lodash';
 import d3 from 'd3';
 import nv from 'nvd3';
 import mathjs from 'mathjs';
@@ -674,7 +674,7 @@ function nvd3Vis(element, props) {
         .call(chart);
 
       // on scroll, hide tooltips. throttle to only 4x/second.
-      window.addEventListener('scroll', throttle(250, hideTooltips));
+      window.addEventListener('scroll', throttle(hideTooltips, 250));
 
       // The below code should be run AFTER rendering because chart is updated in call()
       if (isTimeSeries && annotationLayers.length > 0) {

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -7467,10 +7467,6 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-
 lodash.union@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -1671,7 +1671,7 @@ babel-plugin-dynamic-import-node@^1.2.0:
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
 
-babel-plugin-lodash@^3.3.2:
+babel-plugin-lodash@^3.3.2, babel-plugin-lodash@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
   dependencies:


### PR DESCRIPTION
- Remove `lodash.throttle` from dependency since there is now `lodash`.
- Add `babel-plugin-lodash` that helps optimize bundle output by taking only necessary part from lodash instead of the entire bundle.
https://github.com/lodash/babel-plugin-lodash
- Replace `underscore` calls with `lodash` where applicable. 

@williaster @xtinec @conglei 