### PR TITLE
Explicit set markdown version to >= 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
 isodate==0.6.0
-markdown==2.6.11
+markdown>=3.0
 pandas==0.23.1
 parsedatetime==2.0.0
 pathlib2==2.3.0
@@ -39,4 +39,3 @@ thrift-sasl==0.3.0
 unicodecsv==0.14.1
 unidecode==1.0.22
 contextlib2==0.5.5
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
 isodate==0.6.0
-markdown>=3.0
+markdown==3.0
 pandas==0.23.1
 parsedatetime==2.0.0
 pathlib2==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'humanize',
         'idna',
         'isodate',
-        'markdown',
+        'markdown>=3.0',
         'pandas>=0.18.0',
         'parsedatetime',
         'pathlib2',

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -420,7 +420,7 @@ def markdown(s, markup_wrap=False):
                           'li', 'dd', 'dt', 'img', 'a']
     safe_markdown_attrs = {'img': ['src', 'alt', 'title'],
                            'a': ['href', 'alt', 'title']}
-    s = md.markdown(s or '', [
+    s = md.markdown(s or '', extensions=[
         'markdown.extensions.tables',
         'markdown.extensions.fenced_code',
         'markdown.extensions.codehilite',


### PR DESCRIPTION
Positional arguments deprecated in markdown.markdown() function of markdown 3.0.

https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/release-3.0.md