### PR TITLE
[bugfix] Fix case sensitivity of date column for postgres

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -397,15 +397,15 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
     engine = ''
 
     time_grain_functions = {
-        None: '{col}',
-        'PT1S': "DATE_TRUNC('second', {col}) AT TIME ZONE 'UTC'",
-        'PT1M': "DATE_TRUNC('minute', {col}) AT TIME ZONE 'UTC'",
-        'PT1H': "DATE_TRUNC('hour', {col}) AT TIME ZONE 'UTC'",
-        'P1D': "DATE_TRUNC('day', {col}) AT TIME ZONE 'UTC'",
-        'P1W': "DATE_TRUNC('week', {col}) AT TIME ZONE 'UTC'",
-        'P1M': "DATE_TRUNC('month', {col}) AT TIME ZONE 'UTC'",
-        'P0.25Y': "DATE_TRUNC('quarter', {col}) AT TIME ZONE 'UTC'",
-        'P1Y': "DATE_TRUNC('year', {col}) AT TIME ZONE 'UTC'",
+        None: '"{col}"',
+        'PT1S': "DATE_TRUNC('second', \"{col}\") AT TIME ZONE 'UTC'",
+        'PT1M': "DATE_TRUNC('minute', \"{col}\") AT TIME ZONE 'UTC'",
+        'PT1H': "DATE_TRUNC('hour', \"{col}\") AT TIME ZONE 'UTC'",
+        'P1D': "DATE_TRUNC('day', \"{col}\") AT TIME ZONE 'UTC'",
+        'P1W': "DATE_TRUNC('week', \"{col}\") AT TIME ZONE 'UTC'",
+        'P1M': "DATE_TRUNC('month', \"{col}\") AT TIME ZONE 'UTC'",
+        'P0.25Y': "DATE_TRUNC('quarter', \"{col}\") AT TIME ZONE 'UTC'",
+        'P1Y': "DATE_TRUNC('year', \"{col}\") AT TIME ZONE 'UTC'",
     }
 
     @classmethod


### PR DESCRIPTION
Closes #5886

After discussing with @villebro in #5886, we arrived to the conclusion that we shouldn't fix this bug globally by using sqlalchemy to generate the query but only at the level of postgresql.

The rationale is to avoid impacting other db since it seems this may only be touching postgres.