### PR TITLE
[bugfix] NoneType df has no attribute to_dict in IFrame

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1826,6 +1826,8 @@ class IFrameViz(BaseViz):
     def get_df(self, query_obj=None):
         return None
 
+    def get_data(self, df):
+        return None
 
 class ParallelCoordinatesViz(BaseViz):
 


### PR DESCRIPTION
iFrame doesn't work, and it seems to be introduced in #5753 

Bug replication steps:

1. Change visualization type to iFrame in any Explore view
2. A exception is thrown
```
Traceback (most recent call last):
  File "/home/eric/Documents/github/incubator-superset/superset/views/core.py", line 1134, in generate_json
    payload = viz_obj.get_payload()
  File "/home/eric/Documents/github/incubator-superset/superset/viz.py", line 375, in get_payload
    payload['data'] = self.get_data(df)
  File "/home/eric/Documents/github/incubator-superset/superset/viz.py", line 489, in get_data
    return self.get_df().to_dict(orient='records')
AttributeError: 'NoneType' object has no attribute 'to_dict'
```