### PR TITLE
Pinning a version of click to fix travis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bleach==2.1.2
 boto3==1.4.7
 botocore==1.7.48
 celery==4.2.0
+click==6.7
 colorama==0.3.9
 cryptography==1.9
 flask==0.12.2


### PR DESCRIPTION
Click recently came out with a new version where "Subcommands that are named by the function now automatically have the underscore replaced with a dash. If you register a function named my_command it becomes my-command in the command line interface." This breaks tests as it affects some cli commands `superset load_examples` is now `superset load-examples`.

Pinning to the previous version of click before this change to fix travis. 
@williaster @john-bodley @kristw 