### PR TITLE
Deprecate support for Python < 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,8 @@ jobs:
       before_install:
         - nvm install 8.9
     - language: python
-      python: 2.7
-      env: TOXENV=flake8
-    - language: python
-      python: 2.7
-      env: TOXENV=py27-sqlite
-      services:
-        - redis-server
-    - language: python
-      python: 2.7
-      env: TOXENV=py27-mysql
+      python: 3.6
+      env: TOXENV=py36-mysql
       services:
         - mysql
         - redis-server
@@ -33,9 +25,6 @@ jobs:
         - mysql -u root -e "DROP DATABASE IF EXISTS superset; CREATE DATABASE superset DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci"
         - mysql -u root -e "CREATE USER 'mysqluser'@'localhost' IDENTIFIED BY 'mysqluserpassword';"
         - mysql -u root -e "GRANT ALL ON superset.* TO 'mysqluser'@'localhost';"
-    - language: python
-      python: 2.7
-      env: TOXENV=pylint
     - language: node_js
       node_js: 8.9
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,6 @@ jobs:
     - language: python
       python: 3.6
       env: TOXENV=pylint
-    - python: 3.6
-      env: TOXENV=pylint
 install:
   - pip install --upgrade pip
   - pip install codecov tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,13 +57,7 @@ jobs:
       python: 3.6
       env: TOXENV=pylint
     - python: 3.6
-      env: TOXENV=py36-mysql
-    - python: 3.6
       env: TOXENV=pylint
-    - python: 3.6
-      env: TOXENV=cypress
-  exclude:
-    - python: 3.6
 install:
   - pip install --upgrade pip
   - pip install codecov tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,14 @@ jobs:
     - language: python
       python: 3.6
       env: TOXENV=pylint
+    - python: 3.6
+      env: TOXENV=py36-mysql
+    - python: 3.6
+      env: TOXENV=pylint
+    - python: 3.6
+      env: TOXENV=cypress
+  exclude:
+    - python: 3.6
 install:
   - pip install --upgrade pip
   - pip install codecov tox

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -4,6 +4,9 @@ This file documents any backwards-incompatible changes in Superset and
 assists people when migrating to a new version.
 
 ## Superset 0.28.0
+* Support for Python 2 is deprecated, we only support >=3.6 from
+  `0.28.0` onwards
+
 * Superset 0.28 deprecates the previous dashboard layout. While 0.27
   offered a migration workflow to users and allowed them to validate and
   publish their migrated dashboards individually, 0.28 forces

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,9 +4,10 @@ Installation & Configuration
 Getting Started
 ---------------
 
-Superset is currently tested against Python ``2.7`` and Python ``3.6``.
-Python 3.6 is preferred. Support for Python ``<=3.6`` is planned to get
-phased out.
+Superset has deprecated support for Python ``2.*`` and supports
+only ``~=3.6`` to take advantage of the newer Python features and reduce
+the burden of supporting previous versions. We run our test suite
+against ``3.6``, but running on ``3.7`` **should** work as well.
 
 Cloud-native!
 -------------

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,12 @@ import io
 import json
 import os
 import subprocess
+import sys
 
 from setuptools import find_packages, setup
+
+if sys.version_info < (3, 6):
+    sys.exit('Sorry, Python < 3.6 is not supported')
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 PACKAGE_DIR = os.path.join(BASE_DIR, 'superset', 'static', 'assets')
@@ -109,8 +113,6 @@ setup(
         '/apache/incubator-superset/tarball/' + version_string
     ),
     classifiers=[
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -38,10 +38,10 @@ setenv =
     PYTHONPATH = {toxinidir}
     SUPERSET_CONFIG = tests.superset_test_config
     SUPERSET_HOME = {envtmpdir}
-    py27-mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
+    py36-mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
     py36-mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset
-    py{27,36}-postgres: SUPERSET__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://postgresuser:pguserpassword@localhost/superset
-    py{27,36}-sqlite: SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
+    py36-postgres: SUPERSET__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://postgresuser:pguserpassword@localhost/superset
+    py36-sqlite: SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
 whitelist_externals =
     npm
 


### PR DESCRIPTION
This is a first step, beyond this we can:
* remove all from future imports
* remove 'six' lib as a dependency
* start using f-strings
* enjoy ourselves