### PR TITLE
fix errors in Database.get_table() function

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -806,7 +806,7 @@ class SqlaTable(Model, BaseDatasource):
         try:
             table = self.get_sqla_table_object()
         except Exception as e:
-            logging.error(e)
+            logging.exception(e)
             raise Exception(_(
                 "Table [{}] doesn't seem to exist in the specified database, "
                 "couldn't fetch column information").format(self.table_name))

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -805,7 +805,8 @@ class SqlaTable(Model, BaseDatasource):
         """Fetches the metadata for the table and merges it in"""
         try:
             table = self.get_sqla_table_object()
-        except Exception:
+        except Exception as e:
+            logging.error(e)
             raise Exception(_(
                 "Table [{}] doesn't seem to exist in the specified database, "
                 "couldn't fetch column information").format(self.table_name))

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -913,7 +913,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
     def get_table(self, table_name, schema=None):
         extra = self.get_extra()
-        meta = MetaData(**extra.get('metadata_params', {}))
+        meta = MetaData(extra.get('metadata_params', {}))
         return Table(
             table_name, meta,
             schema=schema or None,


### PR DESCRIPTION
The csv upload works well if there is no parameter set for `metadata_params` in `extra` field of the database. However, if we have `metadata_params` set up for the db, like
```
{
    "metadata_params": {
          "connect_args":{
              "sslmode":"require"
        }
},
    "engine_params": {
          "connect_args":{
              "sslmode":"require"
        }
     }
}
```
The csv upload will throw errors. See attached screenshot. The exception is 
```
Traceback (most recent call last):
  File "/Users/jundayang/fun/youngyjd-superset/superset/connectors/sqla/models.py", line 807, in fetch_metadata
    table = self.get_sqla_table_object()
  File "/Users/jundayang/fun/youngyjd-superset/superset/connectors/sqla/models.py", line 802, in get_sqla_table_object
    return self.database.get_table(self.table_name, schema=self.schema)
  File "/Users/jundayang/fun/youngyjd-superset/superset/models/core.py", line 916, in get_table
    meta = MetaData(**extra.get('metadata_params', {}))
TypeError: __init__() got an unexpected keyword argument 'connect_args'
```
Have to remove `**` to make it work.

<img width="1316" alt="screen shot 2018-09-27 at 3 56 50 pm" src="https://user-images.githubusercontent.com/26216756/46178994-03c17000-c26e-11e8-88a7-456ad65fec5e.png">

