### PR TITLE
Fix the HorizonChart title only show the first key

### DIFF
--- a/superset/assets/src/visualizations/Horizon/HorizonChart.jsx
+++ b/superset/assets/src/visualizations/Horizon/HorizonChart.jsx
@@ -62,7 +62,7 @@ class HorizonChart extends React.PureComponent {
             key={row.key}
             width={width}
             height={seriesHeight}
-            title={row.key[0]}
+            title={row.key.join(', ')}
             data={row.values}
             bands={bands}
             colors={colors}


### PR DESCRIPTION
The HorizonChart title only show the first one when there are two or more fields in groupby now.
Fix it to show all fields