### PR TITLE
Make NULL value grouping keys show up properly in rich tooltip

### DIFF
--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -62,11 +62,11 @@ export function drawBarValues(svg, data, stacked, axisFormat) {
 
 // Formats the series key to account for a possible NULL value
 function getFormattedKey(seriesKey, shouldDompurify) {
-    var key = shouldDompurify ? dompurify.sanitize(seriesKey) : seriesKey
-    if (key === '') {
-        key = '&lt;' + seriesKey.slice(1, -1) + '&gt;';
+    if (seriesKey === '<NULL>') {
+        return '&lt;' + seriesKey.slice(1, -1) + '&gt;';
+    } else {
+        return shouldDompurify ? dompurify.sanitize(seriesKey) : seriesKey;
     }
-    return key;
 }
 
 // Custom sorted tooltip

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -60,6 +60,20 @@ export function drawBarValues(svg, data, stacked, axisFormat) {
     });
 }
 
+// Formats the series key to account for a possible NULL value
+function getFormattedKey(seriesKey, toDompurify) {
+    let key = '';
+    if (toDompurify === true) {
+        key = dompurify.sanitize(seriesKey);
+    } else {
+        key = seriesKey;
+    }
+    if (key === '') {
+        key = '&lt;' + seriesKey.slice(1, -1) + '&gt;';
+    }
+    return key;
+}
+
 // Custom sorted tooltip
 // use a verbose formatter for times
 export function generateRichLineTooltipContent(d, timeFormatter, valueFormatter) {
@@ -69,10 +83,7 @@ export function generateRichLineTooltipContent(d, timeFormatter, valueFormatter)
     + '</td></tr></thead><tbody>';
   d.series.sort((a, b) => a.value >= b.value ? -1 : 1);
   d.series.forEach((series) => {
-    let key = dompurify.sanitize(series.key);
-    if (key === '') {
-        key = '&lt;' + series.key.slice(1, -1) + '&gt;';
-    }
+    const key = getFormattedKey(series.key, true);
     tooltip += (
       `<tr class="${series.highlight ? 'emph' : ''}">` +
         `<td class='legend-color-guide' style="opacity: ${series.highlight ? '1' : '0.75'};"">` +
@@ -99,10 +110,7 @@ export function generateMultiLineTooltipContent(d, xFormatter, yFormatters) {
 
   d.series.forEach((series, i) => {
     const yFormatter = yFormatters[i];
-    let key = series.key;
-    if (key === '') {
-        key = '&lt;' + series.key.slice(1, -1) + '&gt;';
-    }
+    const key = getFormattedKey(series.key, false);
     tooltip += "<tr><td class='legend-color-guide'>"
       + `<div style="background-color: ${series.color};"></div></td>`
       + `<td class='key'>${key}</td>`

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -70,8 +70,8 @@ export function generateRichLineTooltipContent(d, timeFormatter, valueFormatter)
   d.series.sort((a, b) => a.value >= b.value ? -1 : 1);
   d.series.forEach((series) => {
     let key = dompurify.sanitize(series.key);
-    if(key === "") {
-        key = "&lt;" + series.key.slice(1, -1) + "&gt;";
+    if (key === '') {
+        key = '&lt;' + series.key.slice(1, -1) + '&gt;';
     }
     tooltip += (
       `<tr class="${series.highlight ? 'emph' : ''}">` +
@@ -100,8 +100,8 @@ export function generateMultiLineTooltipContent(d, xFormatter, yFormatters) {
   d.series.forEach((series, i) => {
     const yFormatter = yFormatters[i];
     let key = series.key;
-    if(key === "") {
-        key = "&lt;" + series.key.slice(1, -1) + "&gt;";
+    if (key === '') {
+        key = '&lt;' + series.key.slice(1, -1) + '&gt;';
     }
     tooltip += "<tr><td class='legend-color-guide'>"
       + `<div style="background-color: ${series.color};"></div></td>`

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -64,9 +64,8 @@ export function drawBarValues(svg, data, stacked, axisFormat) {
 function getFormattedKey(seriesKey, shouldDompurify) {
     if (seriesKey === '<NULL>') {
         return '&lt;' + seriesKey.slice(1, -1) + '&gt;';
-    } else {
-        return shouldDompurify ? dompurify.sanitize(seriesKey) : seriesKey;
     }
+    return shouldDompurify ? dompurify.sanitize(seriesKey) : seriesKey;
 }
 
 // Custom sorted tooltip

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -105,7 +105,7 @@ export function generateMultiLineTooltipContent(d, xFormatter, yFormatters) {
     }
     tooltip += "<tr><td class='legend-color-guide'>"
       + `<div style="background-color: ${series.color};"></div></td>`
-      + `<td class='key'>${series.key}</td>`
+      + `<td class='key'>${key}</td>`
       + `<td class='value'>${yFormatter(series.value)}</td></tr>`;
   });
 

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -61,13 +61,8 @@ export function drawBarValues(svg, data, stacked, axisFormat) {
 }
 
 // Formats the series key to account for a possible NULL value
-function getFormattedKey(seriesKey, toDompurify) {
-    let key = '';
-    if (toDompurify === true) {
-        key = dompurify.sanitize(seriesKey);
-    } else {
-        key = seriesKey;
-    }
+function getFormattedKey(seriesKey, shouldDompurify) {
+    var key = shouldDompurify ? dompurify.sanitize(seriesKey) : seriesKey
     if (key === '') {
         key = '&lt;' + seriesKey.slice(1, -1) + '&gt;';
     }

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -69,6 +69,10 @@ export function generateRichLineTooltipContent(d, timeFormatter, valueFormatter)
     + '</td></tr></thead><tbody>';
   d.series.sort((a, b) => a.value >= b.value ? -1 : 1);
   d.series.forEach((series) => {
+    let key = dompurify.sanitize(series.key);
+    if(key === "") {
+        key = "&lt;" + series.key.slice(1, -1) + "&gt;";
+    }
     tooltip += (
       `<tr class="${series.highlight ? 'emph' : ''}">` +
         `<td class='legend-color-guide' style="opacity: ${series.highlight ? '1' : '0.75'};"">` +
@@ -76,7 +80,7 @@ export function generateRichLineTooltipContent(d, timeFormatter, valueFormatter)
             `style="border: 2px solid ${series.highlight ? 'black' : 'transparent'}; background-color: ${series.color};"` +
           '></div>' +
         '</td>' +
-        `<td>${dompurify.sanitize(series.key)}</td>` +
+        `<td>${key}</td>` +
         `<td>${valueFormatter(series.value)}</td>` +
       '</tr>'
     );
@@ -95,6 +99,10 @@ export function generateMultiLineTooltipContent(d, xFormatter, yFormatters) {
 
   d.series.forEach((series, i) => {
     const yFormatter = yFormatters[i];
+    let key = series.key;
+    if(key === "") {
+        key = "&lt;" + series.key.slice(1, -1) + "&gt;";
+    }
     tooltip += "<tr><td class='legend-color-guide'>"
       + `<div style="background-color: ${series.color};"></div></td>`
       + `<td class='key'>${series.key}</td>`


### PR DESCRIPTION
When there was a NULL value grouping key, it would show up in the legend as <NULL> but would show in the rich tooltip as an empty string. I added an if statement so that the NULL value will show up as <NULL> in the rich tooltip, as it appears in the legend.

Before:
![screen shot 2018-09-28 at 11 50 14 am](https://user-images.githubusercontent.com/10524577/46219789-42126a00-c316-11e8-9a22-356a8685aff1.png)

After:
![screen shot 2018-09-28 at 11 52 57 am](https://user-images.githubusercontent.com/10524577/46219799-48084b00-c316-11e8-874a-c5adce03754c.png)

