### PR TITLE
Removing the key from cypress build and removing parallel flag

### DIFF
--- a/superset/assets/cypress_build.sh
+++ b/superset/assets/cypress_build.sh
@@ -12,5 +12,5 @@ cd "$(dirname "$0")"
 npm install -g yarn
 yarn
 npm run build
-npm run cypress run --record --parallel --key 1f958c86-be14-44d9-8d08-fad68da06811
+npm run cypress run --record
 kill %1


### PR DESCRIPTION
I was not actually supposed to commit the key, so removing it and I'll recycle the key. Also we'd need to pay to parallelize so removing that flag for now.

@graceguo-supercat @john-bodley 