### PR TITLE
[Sqllab] Add offline state to sqllab

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/SouthPane_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SouthPane_spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import { shallow } from 'enzyme';
+
+import { STATUS_OPTIONS } from '../../../src/SqlLab/constants';
+import { initialState } from './fixtures';
+import SouthPane from '../../../src/SqlLab/components/SouthPane';
+
+describe('SouthPane', () => {
+  const middlewares = [thunk];
+  const mockStore = configureStore(middlewares);
+  const store = mockStore(initialState);
+
+  const mockedProps = {
+    editorQueries: [],
+    dataPreviewQueries: [],
+    actions: {},
+    activeSouthPaneTab: '',
+    height: 1,
+    databases: {},
+    offline: false,
+  };
+
+  const getWrapper = () => (
+    shallow(<SouthPane {...mockedProps} />, {
+      context: { store },
+    }).dive());
+
+  let wrapper;
+  it('should render offline when the state is offline', () => {
+    wrapper = getWrapper();
+    wrapper.setProps({ offline: true });
+    expect(wrapper.find('.m-r-3').render().text()).toBe(STATUS_OPTIONS.offline);
+  });
+});

--- a/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
@@ -3,9 +3,8 @@ import configureStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
-import thunk from 'redux-thunk'
+import thunk from 'redux-thunk';
 
-import $ from 'jquery';
 import { table, defaultQueryEditor, databases, initialState, tables } from './fixtures';
 import SqlEditorLeftBar from '../../../src/SqlLab/components/SqlEditorLeftBar';
 import TableElement from '../../../src/SqlLab/components/TableElement';
@@ -31,7 +30,6 @@ describe('SqlEditorLeftBar', () => {
   let wrapper;
 
   beforeEach(() => {
-    ajaxStub = sinon.stub($, 'get');
     wrapper = shallow(<SqlEditorLeftBar {...mockedProps} />, {
       context: { store },
     }).dive();

--- a/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import configureStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
+import thunk from 'redux-thunk'
 
-import { table, defaultQueryEditor, databases, tables } from './fixtures';
+import $ from 'jquery';
+import { table, defaultQueryEditor, databases, initialState, tables } from './fixtures';
 import SqlEditorLeftBar from '../../../src/SqlLab/components/SqlEditorLeftBar';
 import TableElement from '../../../src/SqlLab/components/TableElement';
 
@@ -21,11 +24,17 @@ describe('SqlEditorLeftBar', () => {
     database: {},
     height: 0,
   };
+  const middlewares = [thunk];
+  const mockStore = configureStore(middlewares);
+  const store = mockStore(initialState);
 
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<SqlEditorLeftBar {...mockedProps} />);
+    ajaxStub = sinon.stub($, 'get');
+    wrapper = shallow(<SqlEditorLeftBar {...mockedProps} />, {
+      context: { store },
+    }).dive();
   });
 
   it('is valid', () => {

--- a/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
@@ -53,7 +53,6 @@ describe('TabbedSqlEditors', () => {
     getHeight: () => ('100px'),
     database: {},
   };
-
   const getWrapper = () => (
     shallow(<TabbedSqlEditors {...mockedProps} />, {
       context: { store },
@@ -169,7 +168,8 @@ describe('TabbedSqlEditors', () => {
   });
   it('should disable new tab when offline', () => {
     wrapper = getWrapper();
-    wrapper.setProps( { offline: true });
+    expect(wrapper.find(Tab).last().props().disabled).toBe(false);
+    wrapper.setProps({ offline: true });
     expect(wrapper.find(Tab).last().props().disabled).toBe(true);
   });
 });

--- a/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
@@ -53,6 +53,7 @@ describe('TabbedSqlEditors', () => {
     getHeight: () => ('100px'),
     database: {},
   };
+
   const getWrapper = () => (
     shallow(<TabbedSqlEditors {...mockedProps} />, {
       context: { store },
@@ -165,5 +166,10 @@ describe('TabbedSqlEditors', () => {
 
     const lastTab = wrapper.find(Tab).last();
     expect(lastTab.props().eventKey).toContain('add_tab');
+  });
+  it('should disable new tab when offline', () => {
+    wrapper = getWrapper();
+    wrapper.setProps( { offline: true });
+    expect(wrapper.find(Tab).last().props().disabled).toBe(true);
   });
 });

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -34,7 +34,7 @@ export const SET_DATABASES = 'SET_DATABASES';
 export const SET_ACTIVE_QUERY_EDITOR = 'SET_ACTIVE_QUERY_EDITOR';
 export const SET_ACTIVE_SOUTHPANE_TAB = 'SET_ACTIVE_SOUTHPANE_TAB';
 export const REFRESH_QUERIES = 'REFRESH_QUERIES';
-export const USER_OFFLINE = 'USER_OFFLINE';
+export const SET_USER_OFFLINE = 'SET_USER_OFFLINE';
 export const RUN_QUERY = 'RUN_QUERY';
 export const START_QUERY = 'START_QUERY';
 export const STOP_QUERY = 'STOP_QUERY';
@@ -343,9 +343,8 @@ export function refreshQueries(alteredQueries) {
   return { type: REFRESH_QUERIES, alteredQueries };
 }
 
-export function userOffline() {
-  var res= {'offline': true}
-  return { type: USER_OFFLINE, res};
+export function setUserOffline(offline) {
+  return { type: SET_USER_OFFLINE, offline };
 }
 
 export function persistEditorHeight(queryEditor, currentHeight) {

--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -34,6 +34,7 @@ export const SET_DATABASES = 'SET_DATABASES';
 export const SET_ACTIVE_QUERY_EDITOR = 'SET_ACTIVE_QUERY_EDITOR';
 export const SET_ACTIVE_SOUTHPANE_TAB = 'SET_ACTIVE_SOUTHPANE_TAB';
 export const REFRESH_QUERIES = 'REFRESH_QUERIES';
+export const USER_OFFLINE = 'USER_OFFLINE';
 export const RUN_QUERY = 'RUN_QUERY';
 export const START_QUERY = 'START_QUERY';
 export const STOP_QUERY = 'STOP_QUERY';
@@ -340,6 +341,11 @@ export function removeTable(table) {
 
 export function refreshQueries(alteredQueries) {
   return { type: REFRESH_QUERIES, alteredQueries };
+}
+
+export function userOffline() {
+  var res= {'offline': true}
+  return { type: USER_OFFLINE, res};
 }
 
 export function persistEditorHeight(queryEditor, currentHeight) {

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -9,6 +9,7 @@ import * as Actions from '../actions';
 const QUERY_UPDATE_FREQ = 2000;
 const QUERY_UPDATE_BUFFER_MS = 5000;
 const MAX_QUERY_AGE_TO_POLL = 21600000;
+const QUERY_TIMEOUT_LIMIT = 7000;
 
 class QueryAutoRefresh extends React.PureComponent {
   componentWillMount() {
@@ -44,34 +45,17 @@ class QueryAutoRefresh extends React.PureComponent {
     if (this.shouldCheckForQueries()) {
       SupersetClient.get({
         endpoint: `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`,
-        timeout: '7000',
+        timeout: QUERY_TIMEOUT_LIMIT,
       }).then(({ json }) => {
         if (Object.keys(json).length > 0) {
           this.props.actions.refreshQueries(json);
         }
-        }).catch((err) => {
-          console.log(err);
+        this.props.actions.setUserOffline(false);
+        }).catch(() => {
+          this.props.actions.setUserOffline(true);
         });
     }
   }
-/*=======
-      const url = `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`;
-      $.ajax({
-        dataType: 'json',
-        timeout: 7000,
-        url,
-        success: (data) => {
-          if (Object.keys(data).length > 0) {
-            this.props.actions.refreshQueries(data);
-          }
-          this.props.actions.setUserOffline(false);
-        },
-        error: (XMLHttpRequest) => {
-          if (XMLHttpRequest.readyState === 0) {
-            this.props.actions.setUserOffline(true);
-          }
-        },
->>>>>>> add timeout and refresh for failed backend*/
   render() {
     return null;
   }

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -41,7 +41,6 @@ class QueryAutoRefresh extends React.PureComponent {
   }
   stopwatch() {
     // only poll /superset/queries/ if there are started or running queries
-    const self = this;
     if (this.shouldCheckForQueries()) {
       SupersetClient.get({
         endpoint: `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`,
@@ -59,16 +58,17 @@ class QueryAutoRefresh extends React.PureComponent {
       const url = `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`;
       $.ajax({
         dataType: 'json',
+        timeout: 7000,
         url,
         success: (data) => {
           if (Object.keys(data).length > 0) {
-            self.props.actions.refreshQueries(data);
+            this.props.actions.refreshQueries(data);
           }
+          this.props.actions.setUserOffline(false);
         },
         error: (XMLHttpRequest) => {
           if (XMLHttpRequest.readyState === 0) {
-            self.props.actions.userOffline();
-            // document.location.reload(true);
+            this.props.actions.setUserOffline(true);
           }
         },
 >>>>>>> add timeout and refresh for failed backend*/

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -41,16 +41,37 @@ class QueryAutoRefresh extends React.PureComponent {
   }
   stopwatch() {
     // only poll /superset/queries/ if there are started or running queries
+    const self = this;
     if (this.shouldCheckForQueries()) {
       SupersetClient.get({
         endpoint: `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`,
+        timeout: '7000',
       }).then(({ json }) => {
         if (Object.keys(json).length > 0) {
           this.props.actions.refreshQueries(json);
         }
-      });
+        }).catch((err) => {
+          console.log(err);
+        });
     }
   }
+/*=======
+      const url = `/superset/queries/${this.props.queriesLastUpdate - QUERY_UPDATE_BUFFER_MS}`;
+      $.ajax({
+        dataType: 'json',
+        url,
+        success: (data) => {
+          if (Object.keys(data).length > 0) {
+            self.props.actions.refreshQueries(data);
+          }
+        },
+        error: (XMLHttpRequest) => {
+          if (XMLHttpRequest.readyState === 0) {
+            self.props.actions.userOffline();
+            // document.location.reload(true);
+          }
+        },
+>>>>>>> add timeout and refresh for failed backend*/
   render() {
     return null;
   }

--- a/superset/assets/src/SqlLab/components/QuerySearch.jsx
+++ b/superset/assets/src/SqlLab/components/QuerySearch.jsx
@@ -227,7 +227,7 @@ class QuerySearch extends React.PureComponent {
             <Select
               name="select-status"
               placeholder={t('[Query Status]')}
-              options={STATUS_OPTIONS.map(s => ({ value: s, label: s }))}
+              options={Object.keys(STATUS_OPTIONS).map(s => ({ value: s, label: s }))}
               value={this.state.status}
               isLoading={false}
               autosize={false}

--- a/superset/assets/src/SqlLab/components/SouthPane.jsx
+++ b/superset/assets/src/SqlLab/components/SouthPane.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import shortid from 'shortid';
-import { Alert, Tab, Tabs } from 'react-bootstrap';
+import { Alert, Label, Tab, Tabs } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import * as Actions from '../actions';
 import QueryHistory from './QueryHistory';
 import ResultSet from './ResultSet';
+import { OFFLINE_STATE, STATE_BSSTYLE_MAP } from '../constants';
 import { t } from '../../locales';
 
 /*
@@ -21,10 +22,12 @@ const propTypes = {
   activeSouthPaneTab: PropTypes.string,
   height: PropTypes.number,
   databases: PropTypes.object.isRequired,
+  offline: PropTypes.bool,
 };
 
 const defaultProps = {
   activeSouthPaneTab: 'Results',
+  offline: false,
 };
 
 class SouthPane extends React.PureComponent {
@@ -32,6 +35,12 @@ class SouthPane extends React.PureComponent {
     this.props.actions.setActiveSouthPaneTab(id);
   }
   render() {
+    if (this.props.offline) {
+      return (
+        <Label className="m-r-3" bsStyle={STATE_BSSTYLE_MAP[OFFLINE_STATE]}>
+          { OFFLINE_STATE }
+        </Label>);
+    }
     const innerTabHeight = this.props.height - 55;
     let latestQuery;
     const props = this.props;
@@ -103,7 +112,7 @@ function mapStateToProps({ sqlLab }) {
   return {
     activeSouthPaneTab: sqlLab.activeSouthPaneTab,
     databases: sqlLab.databases,
-    offline: offline,
+    offline: sqlLab.offline,
   };
 }
 

--- a/superset/assets/src/SqlLab/components/SouthPane.jsx
+++ b/superset/assets/src/SqlLab/components/SouthPane.jsx
@@ -8,7 +8,7 @@ import { bindActionCreators } from 'redux';
 import * as Actions from '../actions';
 import QueryHistory from './QueryHistory';
 import ResultSet from './ResultSet';
-import { OFFLINE_STATE, STATE_BSSTYLE_MAP } from '../constants';
+import { STATUS_OPTIONS, STATE_BSSTYLE_MAP } from '../constants';
 import { t } from '../../locales';
 
 /*
@@ -37,8 +37,8 @@ class SouthPane extends React.PureComponent {
   render() {
     if (this.props.offline) {
       return (
-        <Label className="m-r-3" bsStyle={STATE_BSSTYLE_MAP[OFFLINE_STATE]}>
-          { OFFLINE_STATE }
+        <Label className="m-r-3" bsStyle={STATE_BSSTYLE_MAP[STATUS_OPTIONS.offline]}>
+          { STATUS_OPTIONS.offline }
         </Label>);
     }
     const innerTabHeight = this.props.height - 55;

--- a/superset/assets/src/SqlLab/components/SouthPane.jsx
+++ b/superset/assets/src/SqlLab/components/SouthPane.jsx
@@ -103,6 +103,7 @@ function mapStateToProps({ sqlLab }) {
   return {
     activeSouthPaneTab: sqlLab.activeSouthPaneTab,
     databases: sqlLab.databases,
+    offline: offline,
   };
 }
 

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -79,11 +79,8 @@ class SqlEditorLeftBar extends React.PureComponent {
 
   fetchTables(dbId, schema, force, substr) {
     // This can be large so it shouldn't be put in the Redux store
-    if (this.props.offline) {
-      return;
-    }
     const forceRefresh = force || false;
-    if (dbId && schema) {
+    if (!this.props.offline && dbId && schema) {
       this.setState(() => ({ tableLoading: true, tableOptions: [] }));
       const endpoint = `/superset/tables/${dbId}/${schema}/${substr}/${forceRefresh}/`;
 
@@ -134,12 +131,9 @@ class SqlEditorLeftBar extends React.PureComponent {
   }
 
   fetchSchemas(dbId, force) {
-    if (this.props.offline) {
-      return;
-    }
     const actualDbId = dbId || this.props.queryEditor.dbId;
     const forceRefresh = force || false;
-    if (actualDbId) {
+    if (!this.props.offline && actualDbId) {
       this.setState({ schemaLoading: true });
       const endpoint = `/superset/schemas/${actualDbId}/${forceRefresh}/`;
 

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ControlLabel, Button } from 'react-bootstrap';
+import { connect } from 'react-redux';
 import Select from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
 import { SupersetClient } from '@superset-ui/core';
@@ -16,11 +17,13 @@ const propTypes = {
   tables: PropTypes.array,
   actions: PropTypes.object,
   database: PropTypes.object,
+  offline: PropTypes.bool,
 };
 
 const defaultProps = {
   tables: [],
   actions: {},
+  offline: false,
 };
 
 class SqlEditorLeftBar extends React.PureComponent {
@@ -50,7 +53,7 @@ class SqlEditorLeftBar extends React.PureComponent {
   }
 
   getTableNamesBySubStr(input) {
-    if (!this.props.queryEditor.dbId || !input) {
+    if (this.props.offline || !this.props.queryEditor.dbId || !input) {
       return Promise.resolve({ options: [] });
     }
 
@@ -76,6 +79,9 @@ class SqlEditorLeftBar extends React.PureComponent {
 
   fetchTables(dbId, schema, force, substr) {
     // This can be large so it shouldn't be put in the Redux store
+    if (this.props.offline) {
+      return;
+    }
     const forceRefresh = force || false;
     if (dbId && schema) {
       this.setState(() => ({ tableLoading: true, tableOptions: [] }));
@@ -128,6 +134,9 @@ class SqlEditorLeftBar extends React.PureComponent {
   }
 
   fetchSchemas(dbId, force) {
+    if (this.props.offline) {
+      return;
+    }
     const actualDbId = dbId || this.props.queryEditor.dbId;
     const forceRefresh = force || false;
     if (actualDbId) {
@@ -286,7 +295,13 @@ class SqlEditorLeftBar extends React.PureComponent {
   }
 }
 
+function mapStateToProps({ sqlLab }) {
+  return {
+    offline: sqlLab.offline,
+  };
+}
+
 SqlEditorLeftBar.propTypes = propTypes;
 SqlEditorLeftBar.defaultProps = defaultProps;
 
-export default SqlEditorLeftBar;
+export default connect(mapStateToProps)(SqlEditorLeftBar);

--- a/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -21,9 +21,11 @@ const propTypes = {
   tabHistory: PropTypes.array.isRequired,
   tables: PropTypes.array.isRequired,
   getHeight: PropTypes.func.isRequired,
+  offline: PropTypes.bool,
 };
 const defaultProps = {
   queryEditors: [],
+  offline: false,
 };
 
 let queryCount = 1;
@@ -234,6 +236,7 @@ class TabbedSqlEditors extends React.PureComponent {
             </div>
           }
           eventKey="add_tab"
+          disabled={this.props.offline}
         />
       </Tabs>
     );
@@ -250,6 +253,7 @@ function mapStateToProps({ sqlLab }) {
     tabHistory: sqlLab.tabHistory,
     tables: sqlLab.tables,
     defaultDbId: sqlLab.defaultDbId,
+    offline: sqlLab.offline,
   };
 }
 function mapDispatchToProps(dispatch) {

--- a/superset/assets/src/SqlLab/constants.js
+++ b/superset/assets/src/SqlLab/constants.js
@@ -1,4 +1,5 @@
 export const STATE_BSSTYLE_MAP = {
+  offline: 'danger',
   failed: 'danger',
   pending: 'info',
   fetching: 'info',
@@ -14,6 +15,8 @@ export const STATUS_OPTIONS = [
   'running',
   'pending',
 ];
+
+export const OFFLINE_STATE = 'offline';
 
 export const TIME_OPTIONS = [
   'now',

--- a/superset/assets/src/SqlLab/constants.js
+++ b/superset/assets/src/SqlLab/constants.js
@@ -9,14 +9,13 @@ export const STATE_BSSTYLE_MAP = {
   success: 'success',
 };
 
-export const STATUS_OPTIONS = [
-  'success',
-  'failed',
-  'running',
-  'pending',
-];
-
-export const OFFLINE_STATE = 'offline';
+export const STATUS_OPTIONS = {
+  success: 'success',
+  failed: 'failed',
+  running: 'running',
+  offline: 'offline',
+  pending: 'pending',
+};
 
 export const TIME_OPTIONS = [
   'now',

--- a/superset/assets/src/SqlLab/getInitialState.js
+++ b/superset/assets/src/SqlLab/getInitialState.js
@@ -25,7 +25,6 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
       tabHistory: [defaultQueryEditor.id],
       tables: [],
       queriesLastUpdate: Date.now(),
-      activeSouthPaneTab: 'Results',
       ...restBootstrapData,
     },
     messageToasts: getToastsFromPyFlashMessages(

--- a/superset/assets/src/SqlLab/getInitialState.js
+++ b/superset/assets/src/SqlLab/getInitialState.js
@@ -16,9 +16,11 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
   return {
     featureFlags: restBootstrapData.common.feature_flags,
     sqlLab: {
+      activeSouthPaneTab: 'Results',
       alerts: [],
-      queries: {},
       databases: {},
+      offline: false,
+      queries: {},
       queryEditors: [defaultQueryEditor],
       tabHistory: [defaultQueryEditor.id],
       tables: [],

--- a/superset/assets/src/SqlLab/reducers.js
+++ b/superset/assets/src/SqlLab/reducers.js
@@ -250,6 +250,12 @@ export const sqlLabReducer = function (state = {}, action) {
       }
       return Object.assign({}, state, { queries: newQueries, queriesLastUpdate });
     },
+    [actions.USER_OFFLINE]() {
+      console.log(action)
+      console.log(state)
+      return Object.assign({}, state, {'offline':true});
+      // set the values into the ? and it will propagate down... 
+    },
     [actions.CREATE_DATASOURCE_STARTED]() {
       return Object.assign({}, state, {
         isDatasourceLoading: true,

--- a/superset/assets/src/SqlLab/reducers.js
+++ b/superset/assets/src/SqlLab/reducers.js
@@ -251,10 +251,7 @@ export const sqlLabReducer = function (state = {}, action) {
       return Object.assign({}, state, { queries: newQueries, queriesLastUpdate });
     },
     [actions.USER_OFFLINE]() {
-      console.log(action)
-      console.log(state)
-      return Object.assign({}, state, {'offline':true});
-      // set the values into the ? and it will propagate down... 
+      return Object.assign({}, state, { offline: action.offline });
     },
     [actions.CREATE_DATASOURCE_STARTED]() {
       return Object.assign({}, state, {

--- a/superset/assets/src/SqlLab/reducers.js
+++ b/superset/assets/src/SqlLab/reducers.js
@@ -250,7 +250,7 @@ export const sqlLabReducer = function (state = {}, action) {
       }
       return Object.assign({}, state, { queries: newQueries, queriesLastUpdate });
     },
-    [actions.USER_OFFLINE]() {
+    [actions.SET_USER_OFFLINE]() {
       return Object.assign({}, state, { offline: action.offline });
     },
     [actions.CREATE_DATASOURCE_STARTED]() {


### PR DESCRIPTION
This is a user experience improvement in sqllab. Historically, if the user was disconnected from the internet or the backed was down, sqllab continues to poll from the backend. All the while showing the user they are in the pending state. This is confusing to the user as they would keep thinking their query is pending for a long time when the request hasn't been sent to the backend. 
This PR makes it show `offline` when the ajax request cannot connect to the backend to avoid confusion . 

@graceguo-supercat @kristw 
<img width="1233" alt="screen shot 2018-10-09 at 12 26 52 am" src="https://user-images.githubusercontent.com/30888507/46653166-1a16d800-cb5a-11e8-8241-e5424fe8c71b.png">
