### PR TITLE
Allow customizable cursor init params

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -291,6 +291,12 @@ MAX_TABLE_NAMES = 3000
 # not the production version of the site.
 WARNING_MSG = None
 
+# The source label for sqllab pyhive connection initialization.
+SQLLAB_PYHIVE_SOURCE = None
+
+# The source label for chart pyhive connection initialization.
+CHART_PYHIVE_SOURCE = None
+
 # Default celery config is to use SQLA as a broker, in a production setting
 # you'll want to use a proper broker as specified here:
 # http://docs.celeryproject.org/en/latest/getting-started/brokers/index.html

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -376,6 +376,14 @@ class BaseEngineSpec(object):
         cursor.execute(query)
 
     @classmethod
+    def custom_sqllab_cursor_params(cls):
+        pass
+
+    @classmethod
+    def custom_chart_cursor_params(cls):
+        pass
+
+    @classmethod
     def make_label_compatible(cls, label):
         """
         Return a sqlalchemy.sql.elements.quoted_name if the engine requires
@@ -888,6 +896,14 @@ class PrestoEngineSpec(BaseEngineSpec):
         sql = cls._partition_query(table_name, 1, [(part_field, True)])
         df = database.get_df(sql, schema)
         return part_field, cls._latest_partition_from_df(df)
+
+    @classmethod
+    def custom_sqllab_cursor_params(cls):
+        return config['SQLLAB_PYHIVE_SOURCE']
+
+    @classmethod
+    def custom_chart_cursor_params(cls):
+        return config['CHART_PYHIVE_SOURCE']
 
     @classmethod
     def latest_sub_partition(cls, table_name, schema, database, **kwargs):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -899,11 +899,11 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     def custom_sqllab_cursor_params(cls):
-        return config['SQLLAB_PYHIVE_SOURCE']
+        return {'source': config['SQLLAB_PYHIVE_SOURCE']}
 
     @classmethod
     def custom_chart_cursor_params(cls):
-        return config['CHART_PYHIVE_SOURCE']
+        return {'source': config['CHART_PYHIVE_SOURCE']}
 
     @classmethod
     def latest_sub_partition(cls, table_name, schema, database, **kwargs):

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -768,13 +768,18 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             url, params = DB_CONNECTION_MUTATOR(
                 url, params, effective_username, security_manager)
 
+        custom_url_params = None
+
         if (sqllab and self.db_engine_spec.custom_sqllab_cursor_params()):
-            url = '{}?source={}'.format(
-                url, self.db_engine_spec.custom_sqllab_cursor_params())
+            custom_url_params = parse.urlencode(
+                self.db_engine_spec.custom_sqllab_cursor_params())
 
         if ((not sqllab) and self.db_engine_spec.custom_chart_cursor_params()):
-            url = '{}?source={}'.format(
-                url, self.db_engine_spec.custom_chart_cursor_params())
+            custom_url_params = parse.urlencode(
+                self.db_engine_spec.custom_chart_cursor_params())
+
+        if custom_url_params:
+            url = '{}?{}'.format(url, custom_url_params)
 
         return create_engine(url, **params)
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -733,7 +733,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
     @utils.memoized(
         watch=('impersonate_user', 'sqlalchemy_uri_decrypted', 'extra'))
-    def get_sqla_engine(self, schema=None, nullpool=True, user_name=None):
+    def get_sqla_engine(self, schema=None, nullpool=True, user_name=None, sqllab=False):
         extra = self.get_extra()
         url = make_url(self.sqlalchemy_uri_decrypted)
         url = self.db_engine_spec.adjust_database_uri(url, schema)
@@ -767,6 +767,15 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         if DB_CONNECTION_MUTATOR:
             url, params = DB_CONNECTION_MUTATOR(
                 url, params, effective_username, security_manager)
+
+        if (sqllab and self.db_engine_spec.custom_sqllab_cursor_params()):
+            url = '{}?source={}'.format(
+                url, self.db_engine_spec.custom_sqllab_cursor_params())
+
+        if ((not sqllab) and self.db_engine_spec.custom_chart_cursor_params()):
+            url = '{}?source={}'.format(
+                url, self.db_engine_spec.custom_chart_cursor_params())
+
         return create_engine(url, **params)
 
     def get_reserved_words(self):

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -176,6 +176,7 @@ def execute_sql(
             schema=query.schema,
             nullpool=True,
             user_name=user_name,
+            sqllab=True,
         )
         conn = engine.raw_connection()
         cursor = conn.cursor()


### PR DESCRIPTION
This PR allows each deployment specify parameters in its cursor instantiation. 
The intended use case is to label sqllab queries differently from chart queries, using the source parameter.
@john-bodley @mistercrunch 