### PR TITLE
[tablemodelview] Fixing JSON api/read serializable issue

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -318,6 +318,10 @@ class SqlaTable(Model, BaseDatasource):
         return self.table_name
 
     @property
+    def database_name(self):
+        return self.database.name
+
+    @property
     def link(self):
         name = escape(self.name)
         anchor = '<a target="_blank" href="{self.explore_url}">{name}</a>'

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -160,7 +160,7 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
     edit_title = _('Edit Table')
 
     list_columns = [
-        'link', 'database',
+        'link', 'database_name',
         'changed_by_', 'modified']
     order_columns = ['modified']
     add_columns = ['database', 'schema', 'table_name']
@@ -229,6 +229,7 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
         'link': _('Table'),
         'changed_by_': _('Changed By'),
         'database': _('Database'),
+        'database_name': _('Database'),
         'changed_on_': _('Last Changed'),
         'filter_select_enabled': _('Enable Filter Select'),
         'schema': _('Schema'),


### PR DESCRIPTION
This PR resolves an issue with `tablemodelview/api/read` which throws the following exception,
```
TypeError: Object of type Database is not JSON serializable
```
i.e., it's trying to to serialize the `Database` object to JSON which is defined as one of the FAB `list_columns`. The remedy is to simply reference the `Database.name` attribute as opposed to the `Database` object. 

Attached is a screenshot, note I've kept the label unchanged so the UI remains unchanged:

![screenshot](https://user-images.githubusercontent.com/4567245/46379066-8d988100-c652-11e8-97e8-4a80bc644440.png)

and here's the corresponding API response (truncated):
```
{
  "count": 11, 
  "label_columns": {
    "cache_timeout": "Cache Timeout", 
    "changed_by": "Changed By", 
    "changed_by_": "Changed By", 
    "changed_by_fk": "Changed By Fk", 
    "changed_on": "Changed On", 
    "changed_on_": "Last Changed", 
    "columns": "Columns", 
    "created_by": "Created By", 
    "created_by_fk": "Created By Fk", 
    "created_on": "Created On", 
    "database": "Database", 
    "database_id": "Database Id", 
    "database_name": "Database", 
    "default_endpoint": "Default Endpoint", 
    "description": "Description", 
    "fetch_values_predicate": "Fetch Values Predicate", 
    "filter_select_enabled": "Enable Filter Select", 
    "id": "Id", 
    "is_featured": "Is Featured", 
    "is_sqllab_view": "SQL Lab View", 
    "link": "Table", 
    "main_dttm_col": "Main Datetime Column", 
    "metrics": "Metrics", 
    "modified": "Modified", 
    "offset": "Offset", 
    "owner": "Owner", 
    "params": "Params", 
    "perm": "Perm", 
    "schema": "Schema", 
    "slices": "Associated Charts", 
    "sql": "Sql", 
    "table_name": "Table Name", 
    "template_params": "Template parameters", 
    "user_id": "User Id"
  }, 
  "list_columns": [
    "link", 
    "database_name", 
    "changed_by_", 
    "modified"
  ], 
  "modelview_name": "TableModelView", 
  "order_columns": [
    "modified"
  ], 
  "page": null, 
  "page_size": null, 
  "pks": [
    1, 
    2, 
    3, 
    4, 
    5, 
    6, 
    7, 
    8, 
    9, 
    10, 
    11
  ], 
  "result": [
    {
      "changed_by_": "", 
      "database_name": "main", 
      "link": "<a target=\"_blank\" href=\"/superset/explore/table/1/\">energy_usage</a>", 
      "modified": "an hour ago"
    }, 
   ...
```

to: @michellethomas @mistercrunch 
cc: @graceguo-supercat @timifasubaa 