### PR TITLE
Sorting tables by "modified" is broken

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -279,8 +279,8 @@ class AuditMixinNullable(AuditMixin):
         return Markup(
             '<span class="no-wrap">{}</span>'.format(self.changed_on))
 
-    @renders('modified')
-    def _modified(self):
+    @renders('changed_on')
+    def modified(self):
         return humanize.naturaltime(datetime.now() - self.changed_on)
 
     @property

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -280,7 +280,7 @@ class AuditMixinNullable(AuditMixin):
             '<span class="no-wrap">{}</span>'.format(self.changed_on))
 
     @renders('modified')
-    def modified(self):
+    def _modified(self):
         return humanize.naturaltime(datetime.now() - self.changed_on)
 
     @property


### PR DESCRIPTION
The decorator should point to the column name (`changed_on`).

Currently:

<img width="1698" alt="screen shot 2018-10-03 at 10 03 30 am" src="https://user-images.githubusercontent.com/1534870/46426498-9db46d00-c6f3-11e8-98a2-4c0338bad263.png">

With this fix:

<img width="1698" alt="screen shot 2018-10-03 at 10 03 08 am" src="https://user-images.githubusercontent.com/1534870/46426507-a311b780-c6f3-11e8-89f4-9d7a1bb2c6d5.png">

Works both for ascending and descending sorting.