### PR TITLE
[vis] Import only world map from datamaps

### DIFF
--- a/superset/assets/src/visualizations/WorldMap/WorldMap.js
+++ b/superset/assets/src/visualizations/WorldMap/WorldMap.js
@@ -1,6 +1,6 @@
 import d3 from 'd3';
 import PropTypes from 'prop-types';
-import Datamap from 'datamaps';
+import Datamap from 'datamaps/dist/datamaps.world.min';
 import './WorldMap.css';
 
 const propTypes = {


### PR DESCRIPTION
Import only world map from `datamaps` instead of importing all maps by default. 
Reduce the bundle size a bit. (142KB vs 114KB)

@williaster @conglei @graceguo-supercat  