### PR TITLE
Make colorpickercontrol refer to default color scheme

### DIFF
--- a/superset/assets/spec/javascripts/explore/components/ColorPickerControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ColorPickerControl_spec.jsx
@@ -8,6 +8,7 @@ import { SketchPicker } from 'react-color';
 import ColorPickerControl from
   '../../../../src/explore/components/controls/ColorPickerControl';
 import ControlHeader from '../../../../src/explore/components/ControlHeader';
+import { registerScheme } from '../../../../src/modules/ColorSchemeManager';
 
 const defaultProps = {
   value: { },
@@ -17,6 +18,8 @@ describe('ColorPickerControl', () => {
   let wrapper;
   let inst;
   beforeEach(() => {
+    registerScheme('test', ['red', 'green', 'blue'])
+      .setDefaultSchemeName('test');
     wrapper = shallow(<ColorPickerControl {...defaultProps} />);
     inst = wrapper.instance();
   });

--- a/superset/assets/src/explore/components/controls/ColorPickerControl.jsx
+++ b/superset/assets/src/explore/components/controls/ColorPickerControl.jsx
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { SketchPicker } from 'react-color';
-
 import ControlHeader from '../ControlHeader';
-import { bnbColors } from '../../../modules/colors';
+import { getScheme } from '../../../modules/ColorSchemeManager';
 
 const propTypes = {
   onChange: PropTypes.func,
@@ -59,7 +58,7 @@ export default class ColorPickerControl extends React.Component {
         <SketchPicker
           color={this.props.value}
           onChange={this.onChange}
-          presetColors={bnbColors.filter((s, i) => i < 7)}
+          presetColors={getScheme().filter((s, i) => i < 7)}
         />
       </Popover>);
   }

--- a/superset/assets/src/modules/colors.js
+++ b/superset/assets/src/modules/colors.js
@@ -1,12 +1,8 @@
 import d3 from 'd3';
 import sequentialSchemes from './colorSchemes/sequential';
-import airbnb from './colorSchemes/airbnb';
-import lyft from './colorSchemes/lyft';
 
 export const brandColor = '#00A699';
 export const colorPrimary = { r: 0, g: 122, b: 135, a: 1 };
-export const bnbColors = airbnb.bnbColors;
-export const lyftColors = lyft.lyftColors;
 
 export function hexToRGB(hex, alpha = 255) {
   if (!hex) {


### PR DESCRIPTION
This will reduce the code that point to specific color scheme and let `ColorSchemeManager` be the single point of contact for obtaining color scheme.
Developers can set company-specific default color scheme in `common.js`. 

@williaster @conglei @graceguo-supercat 