### PR TITLE
[Dashboard] Fix margin issue in dashboard modal

### DIFF
--- a/superset/assets/src/dashboard/stylesheets/dashboard.less
+++ b/superset/assets/src/dashboard/stylesheets/dashboard.less
@@ -138,17 +138,11 @@ body {
 
   .modal-body {
     padding: 24px 24px 29px 24px;
-
-    div {
-      margin-top: 24px;
-
-      &:first-child {
-        margin-top: 0;
-      }
-    }
   }
 
   .delete-modal-actions-container {
+    margin-top: 24px;
+
     .btn {
       margin-right: 16px;
       &:last-child {


### PR DESCRIPTION
This bug was introduced by #5771. The extra margin also makes cursor in CSS Editor mis-aligned.

<img width="601" alt="screen shot 2018-10-04 at 3 33 03 pm" src="https://user-images.githubusercontent.com/27990562/46507167-0e3eb500-c7ec-11e8-9ad2-e7057a20ce12.png">
<img width="593" alt="screen shot 2018-10-04 at 3 35 55 pm" src="https://user-images.githubusercontent.com/27990562/46507175-14349600-c7ec-11e8-983e-58b9be49b7cf.png">
