### PR TITLE
[SIP-5] Remove references to slice from all deck.gl components. 

### DIFF
--- a/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
@@ -37,6 +37,8 @@ const propTypes = {
   viewport: PropTypes.object.isRequired,
   getLayer: PropTypes.func.isRequired,
   payload: PropTypes.object.isRequired,
+  onAddFilter: PropTypes.func,
+  onTooltip: PropTypes.func,
 };
 
 export default class CategoricalDeckGLContainer extends React.PureComponent {

--- a/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
@@ -31,7 +31,7 @@ function getCategories(fd, data) {
 }
 
 const propTypes = {
-  slice: PropTypes.object.isRequired,
+  formData: PropTypes.object.isRequired,
   mapboxApiKey: PropTypes.string.isRequired,
   setControlValue: PropTypes.func.isRequired,
   viewport: PropTypes.object.isRequired,
@@ -49,7 +49,7 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
 
   /* eslint-disable-next-line react/sort-comp */
   static getDerivedStateFromProps(nextProps) {
-    const fd = nextProps.slice.formData;
+    const fd = nextProps.formData;
 
     const timeGrain = fd.time_grain_sqla || fd.granularity || 'PT1M';
     const timestamps = nextProps.payload.data.features.map(f => f.__timestamp);
@@ -70,8 +70,7 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
     this.setState(CategoricalDeckGLContainer.getDerivedStateFromProps(nextProps, this.state));
   }
   getLayers(values) {
-    const { getLayer, payload, slice } = this.props;
-    const fd = slice.formData;
+    const { getLayer, payload, formData: fd } = this.props;
     let data = [...payload.data.features];
 
     // Add colors from categories or fixed color
@@ -142,14 +141,14 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
           disabled={this.state.disabled}
           viewport={this.props.viewport}
           mapboxApiAccessToken={this.props.mapboxApiKey}
-          mapStyle={this.props.slice.formData.mapbox_style}
+          mapStyle={this.props.formData.mapbox_style}
           setControlValue={this.props.setControlValue}
         >
           <Legend
             categories={this.state.categories}
             toggleCategory={this.toggleCategory}
             showSingleCategory={this.showSingleCategory}
-            position={this.props.slice.formData.legend_position}
+            position={this.props.formData.legend_position}
           />
         </AnimatableDeckGLContainer>
       </div>

--- a/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
@@ -70,7 +70,13 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
     this.setState(CategoricalDeckGLContainer.getDerivedStateFromProps(nextProps, this.state));
   }
   getLayers(values) {
-    const { getLayer, payload, formData: fd } = this.props;
+    const {
+      getLayer,
+      payload,
+      formData: fd,
+      onAddFilter,
+      onTooltip,
+    } = this.props;
     let data = [...payload.data.features];
 
     // Add colors from categories or fixed color
@@ -95,7 +101,7 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
     }
 
     payload.data.features = data;
-    return [getLayer(fd, payload, slice)];
+    return [getLayer(fd, payload, onAddFilter, onTooltip)];
   }
   addColor(data, fd) {
     const c = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };

--- a/superset/assets/src/visualizations/deckgl/createAdaptor.jsx
+++ b/superset/assets/src/visualizations/deckgl/createAdaptor.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const IDENTITY = x => x;
+
+class DeckGlChartInput {
+  constructor(slice, payload, setControlValue) {
+    this.width = slice.width();
+    this.height = slice.height();
+    this.formData = slice.formData;
+    this.payload = payload;
+    this.setControlValue = setControlValue;
+    this.onAddFilter = (...args) => { slice.addFilter(...args); };
+    this.onTooltip = (...args) => { slice.tooltip(...args); }
+  }
+}
+
+export default function createAdaptor(Component, transformProps = IDENTITY) {
+  return function adaptor(slice, payload, setControlValue) {
+    const chartInput = new DeckGlChartInput(slice, payload, setControlValue);
+    ReactDOM.render(
+      <Component {...transformProps(chartInput)} />,
+      document.querySelector(slice.selector),
+    );
+  };
+}

--- a/superset/assets/src/visualizations/deckgl/createAdaptor.jsx
+++ b/superset/assets/src/visualizations/deckgl/createAdaptor.jsx
@@ -5,13 +5,17 @@ const IDENTITY = x => x;
 
 class DeckGlChartInput {
   constructor(slice, payload, setControlValue) {
-    this.width = slice.width();
-    this.height = slice.height();
     this.formData = slice.formData;
     this.payload = payload;
     this.setControlValue = setControlValue;
-    this.onAddFilter = (...args) => { slice.addFilter(...args); };
-    this.onTooltip = (...args) => { slice.tooltip(...args); }
+    this.viewport = {
+      ...this.formData.viewport,
+      width: slice.width(),
+      height: slice.height(),
+    };
+
+    this.onAddFilter = ((...args) => { slice.addFilter(...args); });
+    this.onTooltip = ((...args) => { slice.tooltip(...args); });
   }
 }
 

--- a/superset/assets/src/visualizations/deckgl/factory.jsx
+++ b/superset/assets/src/visualizations/deckgl/factory.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import DeckGLContainer from './DeckGLContainer';
+import CategoricalDeckGLContainer from './CategoricalDeckGLContainer';
+import { fitViewport } from './layers/common';
+
+export function createDeckGLComponent(getLayer, getPoints) {
+  function Component(props) {
+    const {
+      formData,
+      payload,
+      setControlValue,
+      onAddFilter,
+      onTooltip,
+      viewport: originalViewport,
+    } = props;
+
+    const viewport = formData.autozoom
+      ? fitViewport(originalViewport, getPoints(payload.data.features))
+      : originalViewport;
+
+    const layer = getLayer(formData, payload, onAddFilter, onTooltip);
+
+    return (
+      <DeckGLContainer
+        mapboxApiAccessToken={payload.data.mapboxApiKey}
+        viewport={viewport}
+        layers={[layer]}
+        mapStyle={formData.mapbox_style}
+        setControlValue={setControlValue}
+      />
+    );
+  }
+
+  return Component;
+}
+
+export function createCategoricalDeckGLComponent(getLayer, getPoints) {
+  function Component(props) {
+    const {
+      formData,
+      payload,
+      setControlValue,
+      onAddFilter,
+      onTooltip,
+      viewport: originalViewport,
+    } = props;
+
+    const viewport = formData.autozoom
+      ? fitViewport(originalViewport, getPoints(payload.data.features))
+      : originalViewport;
+
+    return (
+      <CategoricalDeckGLContainer
+        formData={formData}
+        mapboxApiKey={payload.data.mapboxApiKey}
+        setControlValue={setControlValue}
+        viewport={viewport}
+        getLayer={getLayer}
+        payload={payload}
+        onAddFilter={onAddFilter}
+        onTooltip={onTooltip}
+      />
+    );
+  }
+
+  return Component;
+}

--- a/superset/assets/src/visualizations/deckgl/factory.jsx
+++ b/superset/assets/src/visualizations/deckgl/factory.jsx
@@ -1,7 +1,21 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import DeckGLContainer from './DeckGLContainer';
 import CategoricalDeckGLContainer from './CategoricalDeckGLContainer';
 import { fitViewport } from './layers/common';
+
+const propTypes = {
+  formData: PropTypes.object.isRequired,
+  payload: PropTypes.object.isRequired,
+  setControlValue: PropTypes.func.isRequired,
+  viewport: PropTypes.object.isRequired,
+  onAddFilter: PropTypes.func,
+  onTooltip: PropTypes.func,
+};
+const defaultProps = {
+  onAddFilter() {},
+  onTooltip() {},
+};
 
 export function createDeckGLComponent(getLayer, getPoints) {
   function Component(props) {
@@ -30,6 +44,9 @@ export function createDeckGLComponent(getLayer, getPoints) {
       />
     );
   }
+
+  Component.propTypes = propTypes;
+  Component.defaultProps = defaultProps;
 
   return Component;
 }
@@ -62,6 +79,9 @@ export function createCategoricalDeckGLComponent(getLayer, getPoints) {
       />
     );
   }
+
+  Component.propTypes = propTypes;
+  Component.defaultProps = defaultProps;
 
   return Component;
 }

--- a/superset/assets/src/visualizations/deckgl/layers/arc.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/arc.jsx
@@ -37,8 +37,6 @@ function deckArc(props) {
     viewport: originalViewport,
   } = props;
 
-  const { autozoom } = formData;
-
   const viewport = formData.autozoom
     ? fitViewport(originalViewport, getPoints(payload.data.features))
     : originalViewport;

--- a/superset/assets/src/visualizations/deckgl/layers/arc.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/arc.jsx
@@ -29,24 +29,19 @@ function getLayer(fd, payload, onAddFilter, onTooltip) {
 
 function deckArc(props) {
   const {
-    width,
-    height,
     formData,
     payload,
     setControlValue,
     onAddFilter,
     onTooltip,
+    viewport: originalViewport,
   } = props;
 
-  let viewport = {
-    ...formData.viewport,
-    width,
-    height,
-  };
+  const { autozoom } = formData;
 
-  if (formData.autozoom) {
-    viewport = fitViewport(viewport, getPoints(payload.data.features));
-  }
+  const viewport = formData.autozoom
+    ? fitViewport(originalViewport, getPoints(payload.data.features))
+    : originalViewport;
 
   return (
     <CategoricalDeckGLContainer

--- a/superset/assets/src/visualizations/deckgl/layers/arc.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/arc.jsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import { ArcLayer } from 'deck.gl';
-import CategoricalDeckGLContainer from '../CategoricalDeckGLContainer';
-import { commonLayerProps, fitViewport } from './common';
+import { commonLayerProps } from './common';
 import createAdaptor from '../createAdaptor';
+import { createCategoricalDeckGLComponent } from '../factory';
 
 function getPoints(data) {
   const points = [];
@@ -27,35 +26,7 @@ function getLayer(fd, payload, onAddFilter, onTooltip) {
   });
 }
 
-function deckArc(props) {
-  const {
-    formData,
-    payload,
-    setControlValue,
-    onAddFilter,
-    onTooltip,
-    viewport: originalViewport,
-  } = props;
-
-  const viewport = formData.autozoom
-    ? fitViewport(originalViewport, getPoints(payload.data.features))
-    : originalViewport;
-
-  return (
-    <CategoricalDeckGLContainer
-      formData={formData}
-      mapboxApiKey={payload.data.mapboxApiKey}
-      setControlValue={setControlValue}
-      viewport={viewport}
-      getLayer={getLayer}
-      payload={payload}
-      onAddFilter={onAddFilter}
-      onTooltip={onTooltip}
-    />
-  );
-}
-
 module.exports = {
-  default: createAdaptor(deckArc),
+  default: createAdaptor(createCategoricalDeckGLComponent(getLayer, getPoints)),
   getLayer,
 };

--- a/superset/assets/src/visualizations/deckgl/layers/arc.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/arc.jsx
@@ -12,7 +12,7 @@ function getPoints(data) {
   return points;
 }
 
-function getLayer(fd, payload, onAddFilter, onTooltip) {
+export function getLayer(fd, payload, onAddFilter, onTooltip) {
   const data = payload.data.features;
   const sc = fd.color_picker;
   const tc = fd.target_color_picker;
@@ -26,7 +26,4 @@ function getLayer(fd, payload, onAddFilter, onTooltip) {
   });
 }
 
-module.exports = {
-  default: createAdaptor(createCategoricalDeckGLComponent(getLayer, getPoints)),
-  getLayer,
-};
+export default createAdaptor(createCategoricalDeckGLComponent(getLayer, getPoints));

--- a/superset/assets/src/visualizations/deckgl/layers/common.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/common.jsx
@@ -32,7 +32,7 @@ export function fitViewport(viewport, points, padding = 10) {
   }
 }
 
-export function commonLayerProps(formData, slice) {
+export function commonLayerProps(formData, onAddFilter, onTooltip) {
   const fd = formData;
   let onHover;
   let tooltipContentGenerator;
@@ -49,13 +49,13 @@ export function commonLayerProps(formData, slice) {
   if (tooltipContentGenerator) {
     onHover = (o) => {
       if (o.picked) {
-        slice.setTooltip({
+        onTooltip({
           content: tooltipContentGenerator(o),
           x: o.x,
           y: o.y,
         });
       } else {
-        slice.setTooltip(null);
+        onTooltip(null);
       }
     };
   }
@@ -66,7 +66,7 @@ export function commonLayerProps(formData, slice) {
       window.open(href);
     };
   } else if (fd.table_filter && fd.line_type === 'geohash') {
-    onClick = o => slice.addFilter(fd.line_column, [o.object[fd.line_column]], false);
+    onClick = o => onAddFilter(fd.line_column, [o.object[fd.line_column]], false);
   }
   return {
     onClick,

--- a/superset/assets/src/visualizations/deckgl/layers/common.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/common.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fitBounds } from 'viewport-mercator-project';
 import d3 from 'd3';
-
 import sandboxedEval from '../../../modules/sandbox';
 
 export function getBounds(points) {

--- a/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { GeoJsonLayer } from 'deck.gl';
 // TODO import geojsonExtent from 'geojson-extent';
 
@@ -92,6 +93,19 @@ function getLayer(formData, payload, onAddFilter, onTooltip) {
   });
 }
 
+const propTypes = {
+  formData: PropTypes.object.isRequired,
+  payload: PropTypes.object.isRequired,
+  setControlValue: PropTypes.func.isRequired,
+  viewport: PropTypes.object.isRequired,
+  onAddFilter: PropTypes.func,
+  onTooltip: PropTypes.func,
+};
+const defaultProps = {
+  onAddFilter() {},
+  onTooltip() {},
+};
+
 function deckGeoJson(props) {
   const {
     formData,
@@ -119,6 +133,9 @@ function deckGeoJson(props) {
     />
   );
 }
+
+deckGeoJson.propTypes = propTypes;
+deckGeoJson.defaultProps = defaultProps;
 
 module.exports = {
   default: createAdaptor(deckGeoJson),

--- a/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
@@ -104,7 +104,7 @@ function deckGeoJson(props) {
 
   // TODO get this to work
   // if (formData.autozoom) {
-    // viewport = common.fitViewport(viewport, geojsonExtent(payload.data.features));
+  //   viewport = common.fitViewport(viewport, geojsonExtent(payload.data.features));
   // }
 
   const layer = getLayer(formData, payload, onAddFilter, onTooltip);

--- a/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
@@ -58,7 +58,7 @@ const recurseGeoJson = (node, propOverrides, extraProps) => {
   }
 };
 
-function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, onTooltip) {
   const fd = formData;
   const fc = fd.fill_color_picker;
   const sc = fd.stroke_color_picker;
@@ -137,7 +137,4 @@ function deckGeoJson(props) {
 deckGeoJson.propTypes = propTypes;
 deckGeoJson.defaultProps = defaultProps;
 
-module.exports = {
-  default: createAdaptor(deckGeoJson),
-  getLayer,
-};
+export default createAdaptor(deckGeoJson);

--- a/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/geojson.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { GeoJsonLayer } from 'deck.gl';
 // TODO import geojsonExtent from 'geojson-extent';
 
 import DeckGLContainer from './../DeckGLContainer';
-import * as common from './common';
 import { hexToRGB } from '../../../modules/colors';
 import sandboxedEval from '../../../modules/sandbox';
+import { commonLayerProps } from './common';
+import createAdaptor from '../createAdaptor';
 
 const propertyMap = {
   fillColor: 'fillColor',
@@ -57,7 +57,7 @@ const recurseGeoJson = (node, propOverrides, extraProps) => {
   }
 };
 
-function getLayer(formData, payload, slice) {
+function getLayer(formData, payload, onAddFilter, onTooltip) {
   const fd = formData;
   const fc = fd.fill_color_picker;
   const sc = fd.stroke_color_picker;
@@ -88,35 +88,39 @@ function getLayer(formData, payload, slice) {
     stroked: fd.stroked,
     extruded: fd.extruded,
     pointRadiusScale: fd.point_radius_scale,
-    ...common.commonLayerProps(fd, slice),
+    ...commonLayerProps(fd, onAddFilter, onTooltip),
   });
 }
 
-function deckGeoJson(slice, payload, setControlValue) {
-  const layer = getLayer(slice.formData, payload, slice);
-  const viewport = {
-    ...slice.formData.viewport,
-    width: slice.width(),
-    height: slice.height(),
-  };
-  if (slice.formData.autozoom) {
-    // TODO get this to work
-    // viewport = common.fitViewport(viewport, geojsonExtent(payload.data.features));
-  }
+function deckGeoJson(props) {
+  const {
+    formData,
+    payload,
+    setControlValue,
+    onAddFilter,
+    onTooltip,
+    viewport,
+  } = props;
 
-  ReactDOM.render(
+  // TODO get this to work
+  // if (formData.autozoom) {
+    // viewport = common.fitViewport(viewport, geojsonExtent(payload.data.features));
+  // }
+
+  const layer = getLayer(formData, payload, onAddFilter, onTooltip);
+
+  return (
     <DeckGLContainer
       mapboxApiAccessToken={payload.data.mapboxApiKey}
       viewport={viewport}
       layers={[layer]}
-      mapStyle={slice.formData.mapbox_style}
+      mapStyle={formData.mapbox_style}
       setControlValue={setControlValue}
-    />,
-    document.getElementById(slice.containerId),
+    />
   );
 }
 
 module.exports = {
-  default: deckGeoJson,
+  default: createAdaptor(deckGeoJson),
   getLayer,
 };

--- a/superset/assets/src/visualizations/deckgl/layers/grid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/grid.jsx
@@ -1,14 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-
 import { GridLayer } from 'deck.gl';
-
-import DeckGLContainer from './../DeckGLContainer';
-
-import * as common from './common';
+import { commonLayerProps } from './common';
 import sandboxedEval from '../../../modules/sandbox';
+import createAdaptor from '../createAdaptor';
+import { createDeckGLComponent } from '../factory';
 
-function getLayer(formData, payload, slice) {
+function getLayer(formData, payload, onAddFilter, onTooltip) {
   const fd = formData;
   const c = fd.color_picker;
   let data = payload.data.features.map(d => ({
@@ -32,7 +28,7 @@ function getLayer(formData, payload, slice) {
     outline: false,
     getElevationValue: points => points.reduce((sum, point) => sum + point.weight, 0),
     getColorValue: points => points.reduce((sum, point) => sum + point.weight, 0),
-    ...common.commonLayerProps(fd, slice),
+    ...commonLayerProps(fd, onAddFilter, onTooltip),
   });
 }
 
@@ -40,31 +36,7 @@ function getPoints(data) {
   return data.map(d => d.position);
 }
 
-function deckGrid(slice, payload, setControlValue) {
-  const layer = getLayer(slice.formData, payload, slice);
-  let viewport = {
-    ...slice.formData.viewport,
-    width: slice.width(),
-    height: slice.height(),
-  };
-
-  if (slice.formData.autozoom) {
-    viewport = common.fitViewport(viewport, getPoints(payload.data.features));
-  }
-
-  ReactDOM.render(
-    <DeckGLContainer
-      mapboxApiAccessToken={payload.data.mapboxApiKey}
-      viewport={viewport}
-      layers={[layer]}
-      mapStyle={slice.formData.mapbox_style}
-      setControlValue={setControlValue}
-    />,
-    document.getElementById(slice.containerId),
-  );
-}
-
 module.exports = {
-  default: deckGrid,
+  default: createAdaptor(createDeckGLComponent(getLayer, getPoints)),
   getLayer,
 };

--- a/superset/assets/src/visualizations/deckgl/layers/grid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/grid.jsx
@@ -4,7 +4,7 @@ import sandboxedEval from '../../../modules/sandbox';
 import createAdaptor from '../createAdaptor';
 import { createDeckGLComponent } from '../factory';
 
-function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, onTooltip) {
   const fd = formData;
   const c = fd.color_picker;
   let data = payload.data.features.map(d => ({
@@ -37,7 +37,4 @@ function getPoints(data) {
   return data.map(d => d.position);
 }
 
-module.exports = {
-  default: createAdaptor(createDeckGLComponent(getLayer, getPoints)),
-  getLayer,
-};
+export default createAdaptor(createDeckGLComponent(getLayer, getPoints));

--- a/superset/assets/src/visualizations/deckgl/layers/grid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/grid.jsx
@@ -17,6 +17,7 @@ function getLayer(formData, payload, onAddFilter, onTooltip) {
     const jsFnMutator = sandboxedEval(fd.js_data_mutator);
     data = jsFnMutator(data);
   }
+
   return new GridLayer({
     id: `grid-layer-${fd.slice_id}`,
     data,

--- a/superset/assets/src/visualizations/deckgl/layers/hex.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/hex.jsx
@@ -1,14 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-
 import { HexagonLayer } from 'deck.gl';
-
-import DeckGLContainer from './../DeckGLContainer';
-
-import * as common from './common';
+import { commonLayerProps } from './common';
 import sandboxedEval from '../../../modules/sandbox';
+import createAdaptor from '../createAdaptor';
+import { createDeckGLComponent } from '../factory';
 
-function getLayer(formData, payload, slice) {
+function getLayer(formData, payload, onAddFilter, onTooltip) {
   const fd = formData;
   const c = fd.color_picker;
   let data = payload.data.features.map(d => ({
@@ -33,7 +29,7 @@ function getLayer(formData, payload, slice) {
     outline: false,
     getElevationValue: points => points.reduce((sum, point) => sum + point.weight, 0),
     getColorValue: points => points.reduce((sum, point) => sum + point.weight, 0),
-    ...common.commonLayerProps(fd, slice),
+    ...commonLayerProps(fd, onAddFilter, onTooltip),
   });
 }
 
@@ -41,31 +37,7 @@ function getPoints(data) {
   return data.map(d => d.position);
 }
 
-function deckHex(slice, payload, setControlValue) {
-  const layer = getLayer(slice.formData, payload, slice);
-  let viewport = {
-    ...slice.formData.viewport,
-    width: slice.width(),
-    height: slice.height(),
-  };
-
-  if (slice.formData.autozoom) {
-    viewport = common.fitViewport(viewport, getPoints(payload.data.features));
-  }
-
-  ReactDOM.render(
-    <DeckGLContainer
-      mapboxApiAccessToken={payload.data.mapboxApiKey}
-      viewport={viewport}
-      layers={[layer]}
-      mapStyle={slice.formData.mapbox_style}
-      setControlValue={setControlValue}
-    />,
-    document.getElementById(slice.containerId),
-  );
-}
-
 module.exports = {
-  default: deckHex,
+  default: createAdaptor(createDeckGLComponent(getLayer, getPoints)),
   getLayer,
 };

--- a/superset/assets/src/visualizations/deckgl/layers/hex.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/hex.jsx
@@ -4,7 +4,7 @@ import sandboxedEval from '../../../modules/sandbox';
 import createAdaptor from '../createAdaptor';
 import { createDeckGLComponent } from '../factory';
 
-function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, onTooltip) {
   const fd = formData;
   const c = fd.color_picker;
   let data = payload.data.features.map(d => ({
@@ -37,7 +37,4 @@ function getPoints(data) {
   return data.map(d => d.position);
 }
 
-module.exports = {
-  default: createAdaptor(createDeckGLComponent(getLayer, getPoints)),
-  getLayer,
-};
+export default createAdaptor(createDeckGLComponent(getLayer, getPoints));

--- a/superset/assets/src/visualizations/deckgl/layers/index.js
+++ b/superset/assets/src/visualizations/deckgl/layers/index.js
@@ -18,4 +18,5 @@ const layerGenerators = {
   deck_arc,
   deck_polygon,
 };
+
 export default layerGenerators;

--- a/superset/assets/src/visualizations/deckgl/layers/path.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/path.jsx
@@ -4,7 +4,8 @@ import sandboxedEval from '../../../modules/sandbox';
 import createAdaptor from '../createAdaptor';
 import { createDeckGLComponent } from '../factory';
 
-function getLayer(fd, payload, onAddFilter, onTooltip) {
+function getLayer(formData, payload, onAddFilter, onTooltip) {
+  const fd = formData;
   const c = fd.color_picker;
   const fixedColor = [c.r, c.g, c.b, 255 * c.a];
   let data = payload.data.features.map(feature => ({

--- a/superset/assets/src/visualizations/deckgl/layers/path.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/path.jsx
@@ -64,30 +64,6 @@ function deckPath(props) {
   );
 }
 
-// function deckPath(slice, payload, setControlValue) {
-//   const layer = getLayer(slice.formData, payload, slice);
-//   let viewport = {
-//     ...slice.formData.viewport,
-//     width: slice.width(),
-//     height: slice.height(),
-//   };
-
-//   if (slice.formData.autozoom) {
-//     viewport = fitViewport(viewport, getPoints(payload.data.features));
-//   }
-
-//   ReactDOM.render(
-//     <DeckGLContainer
-//       mapboxApiAccessToken={payload.data.mapboxApiKey}
-//       viewport={viewport}
-//       layers={[layer]}
-//       mapStyle={slice.formData.mapbox_style}
-//       setControlValue={setControlValue}
-//     />,
-//     document.getElementById(slice.containerId),
-//   );
-// }
-
 module.exports = {
   default: createAdaptor(deckPath),
   getLayer,

--- a/superset/assets/src/visualizations/deckgl/layers/path.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/path.jsx
@@ -4,7 +4,7 @@ import sandboxedEval from '../../../modules/sandbox';
 import createAdaptor from '../createAdaptor';
 import { createDeckGLComponent } from '../factory';
 
-function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, onTooltip) {
   const fd = formData;
   const c = fd.color_picker;
   const fixedColor = [c.r, c.g, c.b, 255 * c.a];
@@ -37,7 +37,4 @@ function getPoints(data) {
   return points;
 }
 
-module.exports = {
-  default: createAdaptor(createDeckGLComponent(getLayer, getPoints)),
-  getLayer,
-};
+export default createAdaptor(createDeckGLComponent(getLayer, getPoints));

--- a/superset/assets/src/visualizations/deckgl/layers/path.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/path.jsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { PathLayer } from 'deck.gl';
-import DeckGLContainer from './../DeckGLContainer';
-import { commonLayerProps, fitViewport } from './common';
+import { commonLayerProps } from './common';
 import sandboxedEval from '../../../modules/sandbox';
 import createAdaptor from '../createAdaptor';
+import { createDeckGLComponent } from '../factory';
 
 function getLayer(fd, payload, onAddFilter, onTooltip) {
   const c = fd.color_picker;
@@ -37,34 +36,7 @@ function getPoints(data) {
   return points;
 }
 
-function deckPath(props) {
-  const {
-    formData,
-    payload,
-    setControlValue,
-    onAddFilter,
-    onTooltip,
-    viewport: originalViewport,
-  } = props;
-
-  const viewport = formData.autozoom
-    ? fitViewport(originalViewport, getPoints(payload.data.features))
-    : originalViewport;
-
-  const layer = getLayer(formData, payload, onAddFilter, onTooltip);
-
-  return (
-    <DeckGLContainer
-      mapboxApiAccessToken={payload.data.mapboxApiKey}
-      viewport={viewport}
-      layers={[layer]}
-      mapStyle={formData.mapbox_style}
-      setControlValue={setControlValue}
-    />
-  );
-}
-
 module.exports = {
-  default: createAdaptor(deckPath),
+  default: createAdaptor(createDeckGLComponent(getLayer, getPoints)),
   getLayer,
 };

--- a/superset/assets/src/visualizations/deckgl/layers/polygon.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/polygon.jsx
@@ -77,31 +77,6 @@ function deckPolygon(props) {
   );
 }
 
-// function deckPolygon(slice, payload, setControlValue) {
-//   const layer = getLayer(slice.formData, payload, slice);
-//   const fd = slice.formData;
-//   let viewport = {
-//     ...slice.formData.viewport,
-//     width: slice.width(),
-//     height: slice.height(),
-//   };
-
-//   if (fd.autozoom) {
-//     viewport = fitViewport(viewport, getPoints(payload.data.features));
-//   }
-
-//   ReactDOM.render(
-//     <DeckGLContainer
-//       mapboxApiAccessToken={payload.data.mapboxApiKey}
-//       viewport={viewport}
-//       layers={[layer]}
-//       mapStyle={slice.formData.mapbox_style}
-//       setControlValue={setControlValue}
-//     />,
-//     document.getElementById(slice.containerId),
-//   );
-// }
-
 module.exports = {
   default: createAdaptor(deckPolygon),
   getLayer,

--- a/superset/assets/src/visualizations/deckgl/layers/polygon.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/polygon.jsx
@@ -11,7 +11,7 @@ function getPoints(features) {
   return flatten(features.map(d => d.polygon), true);
 }
 
-function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, onTooltip) {
   const fd = formData;
   const fc = fd.fill_color_picker;
   const sc = fd.stroke_color_picker;
@@ -49,7 +49,4 @@ function getLayer(formData, payload, onAddFilter, onTooltip) {
   });
 }
 
-module.exports = {
-  default: createAdaptor(createDeckGLComponent(getLayer, getPoints)),
-  getLayer,
-};
+export default createAdaptor(createDeckGLComponent(getLayer, getPoints));

--- a/superset/assets/src/visualizations/deckgl/layers/polygon.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/polygon.jsx
@@ -1,12 +1,11 @@
 import d3 from 'd3';
-import React from 'react';
 import { PolygonLayer } from 'deck.gl';
 import { flatten } from 'lodash';
-import DeckGLContainer from './../DeckGLContainer';
-import { commonLayerProps, fitViewport } from './common';
 import { colorScalerFactory } from '../../../modules/colors';
+import { commonLayerProps } from './common';
 import sandboxedEval from '../../../modules/sandbox';
 import createAdaptor from '../createAdaptor';
+import { createDeckGLComponent } from '../factory';
 
 function getPoints(features) {
   return flatten(features.map(d => d.polygon), true);
@@ -50,34 +49,7 @@ function getLayer(formData, payload, onAddFilter, onTooltip) {
   });
 }
 
-function deckPolygon(props) {
-  const {
-    formData,
-    payload,
-    setControlValue,
-    onAddFilter,
-    onTooltip,
-    viewport: originalViewport,
-  } = props;
-
-  const viewport = formData.autozoom
-    ? fitViewport(originalViewport, getPoints(payload.data.features))
-    : originalViewport;
-
-  const layer = getLayer(formData, payload, onAddFilter, onTooltip);
-
-  return (
-    <DeckGLContainer
-      mapboxApiAccessToken={payload.data.mapboxApiKey}
-      viewport={viewport}
-      layers={[layer]}
-      mapStyle={formData.mapbox_style}
-      setControlValue={setControlValue}
-    />
-  );
-}
-
 module.exports = {
-  default: createAdaptor(deckPolygon),
+  default: createAdaptor(createDeckGLComponent(getLayer, getPoints)),
   getLayer,
 };

--- a/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
@@ -4,12 +4,11 @@ import createAdaptor from '../createAdaptor';
 import { createCategoricalDeckGLComponent } from '../factory';
 import { unitToRadius } from '../../../modules/geo';
 
-
 function getPoints(data) {
   return data.map(d => d.position);
 }
 
-function getLayer(fd, payload, slice) {
+export function getLayer(fd, payload, slice) {
   const dataWithRadius = payload.data.features.map((d) => {
     let radius = unitToRadius(fd.point_unit, d.radius) || 10;
     if (fd.multiplier) {
@@ -34,7 +33,4 @@ function getLayer(fd, payload, slice) {
   });
 }
 
-module.exports = {
-  default: createAdaptor(createCategoricalDeckGLComponent(getLayer, getPoints)),
-  getLayer,
-};
+export default createAdaptor(createCategoricalDeckGLComponent(getLayer, getPoints));

--- a/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/scatter.jsx
@@ -1,12 +1,7 @@
-/* eslint no-underscore-dangle: ["error", { "allow": ["", "__timestamp"] }] */
-
-import React from 'react';
-import ReactDOM from 'react-dom';
-
 import { ScatterplotLayer } from 'deck.gl';
-
-import CategoricalDeckGLContainer from '../CategoricalDeckGLContainer';
-import * as common from './common';
+import { commonLayerProps } from './common';
+import createAdaptor from '../createAdaptor';
+import { createCategoricalDeckGLComponent } from '../factory';
 import { unitToRadius } from '../../../modules/geo';
 
 
@@ -35,36 +30,11 @@ function getLayer(fd, payload, slice) {
     radiusMinPixels: fd.min_radius || null,
     radiusMaxPixels: fd.max_radius || null,
     outline: false,
-    ...common.commonLayerProps(fd, slice),
+    ...commonLayerProps(fd, slice),
   });
 }
 
-function deckScatter(slice, payload, setControlValue) {
-  const fd = slice.formData;
-  let viewport = {
-    ...fd.viewport,
-    width: slice.width(),
-    height: slice.height(),
-  };
-
-  if (fd.autozoom) {
-    viewport = common.fitViewport(viewport, getPoints(payload.data.features));
-  }
-
-  ReactDOM.render(
-    <CategoricalDeckGLContainer
-      slice={slice}
-      mapboxApiKey={payload.data.mapboxApiKey}
-      setControlValue={setControlValue}
-      viewport={viewport}
-      getLayer={getLayer}
-      payload={payload}
-    />,
-    document.getElementById(slice.containerId),
-  );
-}
-
 module.exports = {
-  default: deckScatter,
+  default: createAdaptor(createCategoricalDeckGLComponent(getLayer, getPoints)),
   getLayer,
 };

--- a/superset/assets/src/visualizations/deckgl/layers/screengrid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/screengrid.jsx
@@ -13,7 +13,7 @@ function getPoints(data) {
   return data.map(d => d.position);
 }
 
-function getLayer(formData, payload, onAddFilter, onTooltip, filters) {
+export function getLayer(formData, payload, onAddFilter, onTooltip, filters) {
   const fd = formData;
   const c = fd.color_picker;
   let data = payload.data.features.map(d => ({
@@ -130,7 +130,4 @@ class DeckGLScreenGrid extends React.PureComponent {
 DeckGLScreenGrid.propTypes = propTypes;
 DeckGLScreenGrid.defaultProps = defaultProps;
 
-module.exports = {
-  default: createAdaptor(DeckGLScreenGrid),
-  getLayer,
-};
+export default createAdaptor(DeckGLScreenGrid);

--- a/superset/assets/src/visualizations/deckgl/layers/screengrid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/screengrid.jsx
@@ -96,7 +96,13 @@ class DeckGLScreenGrid extends React.PureComponent {
 
     return [layer];
   }
+
   render() {
+    const { formData, payload } = this.props;
+    const viewport = formData.autozoom
+      ? fitViewport(this.props.viewport, getPoints(payload.data.features))
+      : this.props.viewport;
+
     return (
       <div>
         <AnimatableDeckGLContainer
@@ -106,7 +112,7 @@ class DeckGLScreenGrid extends React.PureComponent {
           getStep={this.state.getStep}
           values={this.state.values}
           disabled={this.state.disabled}
-          viewport={this.props.viewport}
+          viewport={viewport}
           mapboxApiAccessToken={this.props.payload.data.mapboxApiKey}
           mapStyle={this.props.formData.mapbox_style}
           setControlValue={this.props.setControlValue}
@@ -119,33 +125,7 @@ class DeckGLScreenGrid extends React.PureComponent {
 
 DeckGLScreenGrid.propTypes = propTypes;
 
-function deckScreenGrid(props) {
-  const {
-    formData,
-    payload,
-    setControlValue,
-    onAddFilter,
-    onTooltip,
-    viewport: originalViewport,
-  } = props;
-
-  const viewport = formData.autozoom
-    ? fitViewport(originalViewport, getPoints(payload.data.features))
-    : originalViewport;
-
-  return (
-    <DeckGLScreenGrid
-      formData={formData}
-      payload={payload}
-      setControlValue={setControlValue}
-      viewport={viewport}
-      onAddFilter={onAddFilter}
-      onTooltip={onTooltip}
-    />
-  );
-}
-
 module.exports = {
-  default: createAdaptor(deckScreenGrid),
+  default: createAdaptor(DeckGLScreenGrid),
   getLayer,
 };

--- a/superset/assets/src/visualizations/deckgl/layers/screengrid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/screengrid.jsx
@@ -56,6 +56,10 @@ const propTypes = {
   onAddFilter: PropTypes.func,
   onTooltip: PropTypes.func,
 };
+const defaultProps = {
+  onAddFilter() {},
+  onTooltip() {},
+};
 
 class DeckGLScreenGrid extends React.PureComponent {
   /* eslint-disable-next-line react/sort-comp */
@@ -124,6 +128,7 @@ class DeckGLScreenGrid extends React.PureComponent {
 }
 
 DeckGLScreenGrid.propTypes = propTypes;
+DeckGLScreenGrid.defaultProps = defaultProps;
 
 module.exports = {
   default: createAdaptor(DeckGLScreenGrid),

--- a/superset/assets/src/visualizations/deckgl/multi.jsx
+++ b/superset/assets/src/visualizations/deckgl/multi.jsx
@@ -1,57 +1,84 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import $ from 'jquery';
-
 import DeckGLContainer from './DeckGLContainer';
 import { getExploreLongUrl } from '../../explore/exploreUtils';
 import layerGenerators from './layers';
+import createAdaptor from './createAdaptor';
 
+const propTypes = {
+  formData: PropTypes.object.isRequired,
+  payload: PropTypes.object.isRequired,
+  setControlValue: PropTypes.func.isRequired,
+  viewport: PropTypes.object.isRequired,
+};
 
-function deckMulti(slice, payload, setControlValue) {
-  const subSlicesLayers = {};
-  const fd = slice.formData;
-  const render = () => {
-    const viewport = {
-      ...fd.viewport,
-      width: slice.width(),
-      height: slice.height(),
-    };
+class DeckMulti extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = { subSlicesLayers: {} };
+  }
+
+  componentDidMount() {
+    const { formData, payload } = this.props;
+    this.loadLayers(formData, payload);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { formData, payload } = nextProps;
+    this.loadLayers(formData, payload);
+  }
+
+  loadLayers(formData, payload) {
+    this.setState({ subSlicesLayers: {} });
+    payload.data.slices.forEach((subslice) => {
+      // Filters applied to multi_deck are passed down to underlying charts
+      // note that dashboard contextual information (filter_immune_slices and such) aren't
+      // taken into consideration here
+      const filters = [
+        ...(subslice.form_data.filters || []),
+        ...(formData.filters || []),
+        ...(formData.extra_filters || []),
+      ];
+      const subsliceCopy = {
+        ...subslice,
+        form_data: {
+          ...subslice.form_data,
+          filters,
+        },
+      };
+
+      const url = getExploreLongUrl(subsliceCopy.form_data, 'json');
+      $.get(url, (data) => {
+        const layer = layerGenerators[subsliceCopy.form_data.viz_type](subsliceCopy.form_data, data);
+        this.setState({
+          subSlicesLayers: {
+            ...this.state.subSlicesLayers,
+            [subsliceCopy.slice_id]: layer,
+          },
+        });
+      });
+    });
+  }
+
+  render() {
+    const { payload, viewport, formData, setControlValue } = this.props;
+    const { subSlicesLayers } = this.state;
+
     const layers = Object.keys(subSlicesLayers).map(k => subSlicesLayers[k]);
-    ReactDOM.render(
+
+    return (
       <DeckGLContainer
         mapboxApiAccessToken={payload.data.mapboxApiKey}
         viewport={viewport}
         layers={layers}
-        mapStyle={fd.mapbox_style}
+        mapStyle={formData.mapbox_style}
         setControlValue={setControlValue}
-      />,
-      document.getElementById(slice.containerId),
+      />
     );
-  };
-  render();
-  payload.data.slices.forEach((subslice) => {
-    // Filters applied to multi_deck are passed down to underlying charts
-    // note that dashboard contextual information (filter_immune_slices and such) aren't
-    // taken into consideration here
-    const filters = [
-      ...(subslice.form_data.filters || []),
-      ...(fd.filters || []),
-      ...(fd.extra_filters || []),
-    ];
-    const subsliceCopy = {
-      ...subslice,
-      form_data: {
-        ...subslice.form_data,
-        filters,
-      },
-    };
-
-    const url = getExploreLongUrl(subsliceCopy.form_data, 'json');
-    $.get(url, (data) => {
-      const layer = layerGenerators[subsliceCopy.form_data.viz_type](subsliceCopy.form_data, data);
-      subSlicesLayers[subsliceCopy.slice_id] = layer;
-      render();
-    });
-  });
+  }
 }
-module.exports = deckMulti;
+
+DeckMulti.propTypes = propTypes;
+
+export default createAdaptor(DeckMulti);

--- a/superset/assets/src/visualizations/deckgl/multi.jsx
+++ b/superset/assets/src/visualizations/deckgl/multi.jsx
@@ -50,7 +50,10 @@ class DeckMulti extends React.PureComponent {
 
       const url = getExploreLongUrl(subsliceCopy.form_data, 'json');
       $.get(url, (data) => {
-        const layer = layerGenerators[subsliceCopy.form_data.viz_type](subsliceCopy.form_data, data);
+        const layer = layerGenerators[subsliceCopy.form_data.viz_type](
+          subsliceCopy.form_data,
+          data,
+        );
         this.setState({
           subSlicesLayers: {
             ...this.state.subSlicesLayers,


### PR DESCRIPTION
Decouple all visualization components from the parent container (Currently passed in as`slice`). This is the last part of SIP-5 #5680 and is important to **unblock the work on chart plugin system**.

This PR is slightly different from other SIP-5 PRs because those also decouple visualization code from `formData`, but for this PR, I am leaving `formData` as-is.

Also, create utility function `createAdaptor` particularly for deck.gl components. This function handles extracting the necessary fields from `slice`, then calls ReactDOM and render the given React Component onto the target DOM element, passing it the transformed `props`. 

Most of deck.gl components have lots of similarity and most can be defined by 3 factors: 
- `getLayer` function
- `getPoints` function
- whether it uses `DeckGLContainer` or `CategoricalDeckGLContainer`
so I create two factory functions in `factory.jsx` that create a React component given `getLayer` and `getPoints`. See `arc.jsx` for example of how the code was simplified.

The two exceptions are `ScreenGrid` and `GeoJson` that are different.

I have verified with example data and they are working.

@betodealmeida @mistercrunch @xtinec @williaster @conglei 
