### PR TITLE
Allow superset to be run with python -m superset

### DIFF
--- a/superset/__main__.py
+++ b/superset/__main__.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import warnings
+import click
+from flask.cli import FlaskGroup
+from flask.exthook import ExtDeprecationWarning
+from superset.cli import create_app
+
+warnings.simplefilter('ignore', ExtDeprecationWarning)
+
+@click.group(cls=FlaskGroup, create_app=create_app)
+def cli():
+    """This is a management script for the superset application."""
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
This is basically a copy of `superset/bin/superset` to a `__main__.py` module.
This allows you to run superset with a specific python, or give additional flags, for instance:
```
$ python -i -m superset
```
After failure, you can enter the post-mortem debugger.
Another suggestion would be to use the `entry-point-console_scripts` in setup.py instead of the script to avoid duplicate code.