### PR TITLE
Search queries when enter is pressed

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
@@ -8,6 +8,7 @@ import sinon from 'sinon';
 import QuerySearch from '../../../src/SqlLab/components/QuerySearch';
 
 describe('QuerySearch', () => {
+  const search = sinon.spy(QuerySearch.prototype, 'refreshQueries');
   const mockedProps = {
     actions: {},
     height: 0,
@@ -53,15 +54,20 @@ describe('QuerySearch', () => {
     expect(wrapper.state().searchText).to.equal('text');
   });
 
+  it('refreshes queries when enter is pressed on the input', () => {
+    wrapper = shallow(<QuerySearch {...mockedProps} />);
+    const callCount = search.callCount;
+    wrapper.find('input').simulate('keyDown', { keyCode: 13 });
+    expect(search.callCount).to.equal(callCount + 1);
+  });
+
   it('should have one Button', () => {
     expect(wrapper.find(Button)).to.have.length(1);
   });
 
   it('refreshes queries when clicked', () => {
-    const search = sinon.spy(QuerySearch.prototype, 'refreshQueries');
-    wrapper = shallow(<QuerySearch {...mockedProps} />);
+    const callCount = search.callCount;
     wrapper.find(Button).simulate('click');
-    /* eslint-disable no-unused-expressions */
-    expect(search.called).to.equal(true);
+    expect(search.callCount).to.equal(callCount + 1);
   });
 });

--- a/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
@@ -55,7 +55,6 @@ describe('QuerySearch', () => {
   });
 
   it('refreshes queries when enter is pressed on the input', () => {
-    wrapper = shallow(<QuerySearch {...mockedProps} />);
     const callCount = search.callCount;
     wrapper.find('input').simulate('keyDown', { keyCode: 13 });
     expect(search.callCount).to.equal(callCount + 1);

--- a/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QuerySearch_spec.jsx
@@ -54,9 +54,11 @@ describe('QuerySearch', () => {
     expect(wrapper.state().searchText).to.equal('text');
   });
 
-  it('refreshes queries when enter is pressed on the input', () => {
+  it('refreshes queries when enter (only) is pressed on the input', () => {
     const callCount = search.callCount;
-    wrapper.find('input').simulate('keyDown', { keyCode: 13 });
+    wrapper.find('input').simulate('keyDown', { keyCode: 'a'.charCodeAt(0) });
+    expect(search.callCount).to.equal(callCount);
+    wrapper.find('input').simulate('keyDown', { keyCode: '\r'.charCodeAt(0) });
     expect(search.callCount).to.equal(callCount + 1);
   });
 

--- a/superset/assets/src/SqlLab/components/QuerySearch.jsx
+++ b/superset/assets/src/SqlLab/components/QuerySearch.jsx
@@ -41,6 +41,7 @@ class QuerySearch extends React.PureComponent {
     this.dbMutator = this.dbMutator.bind(this);
     this.onChange = this.onChange.bind(this);
     this.changeSearch = this.changeSearch.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
     this.changeFrom = this.changeFrom.bind(this);
     this.changeTo = this.changeTo.bind(this);
     this.changeStatus = this.changeStatus.bind(this);
@@ -64,6 +65,11 @@ class QuerySearch extends React.PureComponent {
   onChange(db) {
     const val = db ? db.value : null;
     this.setState({ databaseId: val });
+  }
+  onKeyDown(event) {
+    if (event.keyCode === 13) {
+      this.refreshQueries();
+    }
   }
   getTimeFromSelection(selection) {
     switch (selection) {
@@ -173,6 +179,7 @@ class QuerySearch extends React.PureComponent {
             <input
               type="text"
               onChange={this.changeSearch}
+              onKeyDown={this.onKeyDown}
               className="form-control input-sm"
               placeholder={t('Search Results')}
             />


### PR DESCRIPTION
The query search form has an input field for text search:

<img width="1675" alt="screen shot 2018-10-05 at 10 20 34 am" src="https://user-images.githubusercontent.com/1534870/46549908-57dcdd80-c888-11e8-99a0-ef1375eda5fe.png">

I added an event handler so that when pressing enter a search is executed, since I saw many users trying to do this while teaching Superset at work.