### PR TITLE
[bugfix] Fix for annotation layer bug

### DIFF
--- a/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
@@ -279,7 +279,7 @@ export default class AnnotationLayer extends React.PureComponent {
         description = `Use a pre defined Superset Chart as a source for annotations and overlays.
         'your chart must be one of these visualization types:
         '[${getSupportedSourceTypes(annotationType)
-            .map(x => vizTypes[x].label).join(', ')}]'`;
+            .map(x => ((x in vizTypes && 'label' in vizTypes[x]) ? vizTypes[x].label : '')).join(', ')}]'`;
       }
     } else if (annotationType === AnnotationTypes.FORMULA) {
       label = t('Formula');


### PR DESCRIPTION
This is a fix for adding an event annotation based upon a TableView chart. It fixes this JavaScript error when adding an event annotation:

`Uncaught TypeError: Cannot read property 'label' of undefined`

