### PR TITLE
[cleanup] Remove future imports from tests and utils

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 console_log==0.2.10
 flake8-coding==1.3.0
 flake8-commas==2.0.0
-flake8-future-import==0.4.5
 flake8-import-order==0.18
 flake8-quotes==1.0.0
 flake8==3.5.0

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import logging
 from subprocess import Popen

--- a/superset/data/__init__.py
+++ b/superset/data/__init__.py
@@ -1,10 +1,5 @@
 """Loads datasets, dashboards and slices in a new superset instance"""
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import datetime
 import gzip
 import json

--- a/superset/utils.py
+++ b/superset/utils.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """Utility functions used across Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from builtins import object
 from datetime import date, datetime, time, timedelta
 import decimal

--- a/tests/access_tests.py
+++ b/tests/access_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import unittest
 

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import logging
 import os

--- a/tests/cache_tests.py
+++ b/tests/cache_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset with caching"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 
 from superset import cache, db, utils

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset Celery worker"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import subprocess
 import time

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import csv
 import datetime
 import doctest

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import unittest
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import numpy as np
 
 from superset.dataframe import dedup, SupersetDataFrame

--- a/tests/datasource_tests.py
+++ b/tests/datasource_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 
 from .base_tests import SupersetTestCase

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import inspect
 
 from six import text_type

--- a/tests/dict_import_export_tests.py
+++ b/tests/dict_import_export_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import unittest
 
@@ -25,7 +20,6 @@ ID_PREFIX = 20000
 
 class DictImportExportTests(SupersetTestCase):
     """Testing export import functionality for dashboards"""
-
     def __init__(self, *args, **kwargs):
         super(DictImportExportTests, self).__init__(*args, **kwargs)
 

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import unittest
 

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import json
 import unittest

--- a/tests/email_tests.py
+++ b/tests/email_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for email service in Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 import logging

--- a/tests/fixtures/datasource.py
+++ b/tests/fixtures/datasource.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Fixtures for test_datasource.py"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 datasource_post = {
     'id': None,
     'column_formats': {'ratio': '.2%'},

--- a/tests/form_tests.py
+++ b/tests/form_tests.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from wtforms.form import Form
 
 from superset.forms import (

--- a/tests/import_export_tests.py
+++ b/tests/import_export_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import unittest
 

--- a/tests/macro_tests.py
+++ b/tests/macro_tests.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask import json
 
 from superset import app

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import textwrap
 
 from sqlalchemy.engine.url import make_url

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from superset import app, security_manager
 from .base_tests import SupersetTestCase
 

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import unittest
 
 from superset import sql_parse

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """Unit tests for Sql Lab"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta
 import json
 import unittest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 from os import path
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 import unittest

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import uuid
 


### PR DESCRIPTION
Since we now no longer support python2, This PR starts taking out the __future__ imports from tests and utils. 
I will follow up with the same thing for other parts of the code base and also do the same for six and utf8. 

@john-bodley @mistercrunch 