### PR TITLE
[select-star] Adding optional schema to view

### DIFF
--- a/superset/templates/superset/ajah.html
+++ b/superset/templates/superset/ajah.html
@@ -1,1 +1,0 @@
-{{ content |safe }}

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2332,7 +2332,7 @@ class Superset(BaseSupersetView):
             'columns': payload_columns,
             'selectStar': mydb.select_star(
                 table_name, schema=schema, show_cols=True, indent=True,
-                cols=columns, latest_partition=False),
+                cols=columns, latest_partition=True),
             'primaryKey': primary_key,
             'foreignKeys': foreign_keys,
             'indexes': keys,
@@ -2350,14 +2350,19 @@ class Superset(BaseSupersetView):
         return json_success(json.dumps(payload))
 
     @has_access
-    @expose('/select_star/<database_id>/<table_name>/')
+    @expose('/select_star/<database_id>/<table_name>')
+    @expose('/select_star/<database_id>/<table_name>/<schema>')
     @log_this
-    def select_star(self, database_id, table_name):
+    def select_star(self, database_id, table_name, schema=None):
         mydb = db.session.query(
             models.Database).filter_by(id=database_id).first()
-        return self.render_template(
-            'superset/ajah.html',
-            content=mydb.select_star(table_name, show_cols=True),
+        return json_success(
+            mydb.select_star(
+                table_name,
+                schema,
+                latest_partition=True,
+                show_cols=True,
+            ),
         )
 
     @expose('/theme/')

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -727,6 +727,11 @@ class CoreTests(SupersetTestCase):
                 .format(db_id=dbobj.id))
         assert data == ['this_schema_is_allowed_too']
 
+    def test_select_star(self):
+        self.login(username='admin')
+        resp = self.get_resp('/superset/select_star/1/birth_names')
+        self.assertIn('gender', resp)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR updates a couple of aspects of the select-star logic including:

- Adding an optional schema to the `/select_star` route.
- Making the `/select_star` route return a JSON response as opposed to HTML. 
- Ensured that the `/select_star` route includes a partition (if appropriate). 
- Ensured that the `/table` route includes a partition (if appropriate)†.
- Added a `where_latest_partition` for Presto. 
- Changed the default Hive `where_latest_partition` behavior to return the first partition if the table is multi-partitioned. Previous it would return `False` is the table was partitioned but contained more than one partition key. 

† Note this improves the performance of the SQL Lab preview by including a partition predicate even though there is additional overhead of finding the latest partition. At Airbnb for a large daily partitioned table with several years of data this reduced the query time from ~ 75 seconds to ~ 3 seconds. This also helps to ensure that the data preview is associated with the partition (guaranteed for the single partitioned case) shown in the UI. 

<img width="404" alt="screen shot 2018-10-05 at 10 25 13 pm" src="https://user-images.githubusercontent.com/4567245/46567771-06ffd000-c8ee-11e8-9b91-2abbe0be80d3.png">

to: @graceguo-supercat @kristw @michellethomas @mistercrunch @timifasubaa @williaster 