### PR TITLE
Revert old precision formatters

### DIFF
--- a/superset/assets/src/visualizations/Sunburst/Sunburst.js
+++ b/superset/assets/src/visualizations/Sunburst/Sunburst.js
@@ -79,8 +79,8 @@ function Sunburst(element, props) {
     .innerRadius(d => Math.sqrt(d.y))
     .outerRadius(d => Math.sqrt(d.y + d.dy));
 
-  const formatNum = d3.format('.1s');
-  const formatPerc = d3.format('.1p');
+  const formatNum = d3.format('.3s');
+  const formatPerc = d3.format('.3p');
 
   container.select('svg').remove();
 


### PR DESCRIPTION
Revert commit https://github.com/apache/incubator-superset/commit/66fcf9b687bdd6cc8a6039f002ed87193a16b365#diff-366fb3d6e52b5fb2b9c306763adbc983
It caused sunburst to became confusing.

Eg. in following visualizations:
![image](https://user-images.githubusercontent.com/608642/46598242-23695b80-caec-11e8-900e-aec789083d17.png)

As you can see the visualization has label 100% of the parent but you can clearly see it's not 100%