### PR TITLE
[cleanup] remove future imports from db migrations

### DIFF
--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import with_statement
-
 import logging
 from logging.config import fileConfig
 

--- a/superset/migrations/versions/1226819ee0e3_fix_wrong_constraint_on_table_columns.py
+++ b/superset/migrations/versions/1226819ee0e3_fix_wrong_constraint_on_table_columns.py
@@ -6,11 +6,6 @@ Revises: 956a063c52b3
 Create Date: 2016-05-27 15:03:32.980343
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '1226819ee0e3'
 down_revision = '956a063c52b3'

--- a/superset/migrations/versions/130915240929_is_sqllab_viz_flow.py
+++ b/superset/migrations/versions/130915240929_is_sqllab_viz_flow.py
@@ -5,10 +5,6 @@ Revises: f231d82b9b26
 Create Date: 2018-04-03 08:19:34.098789
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base

--- a/superset/migrations/versions/18e88e1cc004_making_audit_nullable.py
+++ b/superset/migrations/versions/18e88e1cc004_making_audit_nullable.py
@@ -6,11 +6,6 @@ Revises: 430039611635
 Create Date: 2016-03-13 21:30:24.833107
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/superset/migrations/versions/1d2ddd543133_log_dt.py
+++ b/superset/migrations/versions/1d2ddd543133_log_dt.py
@@ -6,11 +6,6 @@ Revises: d2424a248d63
 Create Date: 2016-03-25 14:35:44.642576
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '1d2ddd543133'
 down_revision = 'd2424a248d63'

--- a/superset/migrations/versions/1d9e835a84f9_.py
+++ b/superset/migrations/versions/1d9e835a84f9_.py
@@ -5,11 +5,6 @@ Revises: 3dda56f1c4c6
 Create Date: 2018-07-16 18:04:07.764659
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.sql import expression

--- a/superset/migrations/versions/21e88bc06c02_annotation_migration.py
+++ b/superset/migrations/versions/21e88bc06c02_annotation_migration.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 import json
 
 from alembic import op

--- a/superset/migrations/versions/289ce07647b_add_encrypted_password_field.py
+++ b/superset/migrations/versions/289ce07647b_add_encrypted_password_field.py
@@ -6,10 +6,6 @@ Revises: 2929af7925ed
 Create Date: 2015-11-21 11:18:00.650587
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from alembic import op
 import sqlalchemy as sa

--- a/superset/migrations/versions/2fcdcb35e487_saved_queries.py
+++ b/superset/migrations/versions/2fcdcb35e487_saved_queries.py
@@ -6,11 +6,6 @@ Revises: a6c18f869a4e
 Create Date: 2017-03-29 15:04:35.734190
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/superset/migrations/versions/33d996bcc382_update_slice_model.py
+++ b/superset/migrations/versions/33d996bcc382_update_slice_model.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 from alembic import op
 import sqlalchemy as sa
 from superset import db

--- a/superset/migrations/versions/3dda56f1c4c6_migrate_num_period_compare_and_period_.py
+++ b/superset/migrations/versions/3dda56f1c4c6_migrate_num_period_compare_and_period_.py
@@ -6,8 +6,6 @@ Create Date: 2018-07-05 15:19:14.609299
 
 """
 
-from __future__ import division
-
 # revision identifiers, used by Alembic.
 
 import datetime

--- a/superset/migrations/versions/41f6a59a61f2_database_options_for_sql_lab.py
+++ b/superset/migrations/versions/41f6a59a61f2_database_options_for_sql_lab.py
@@ -6,10 +6,6 @@ Revises: 3c3ffe173e4f
 Create Date: 2016-08-31 10:26:37.969107
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 from alembic import op
 import sqlalchemy as sa
 

--- a/superset/migrations/versions/430039611635_log_more.py
+++ b/superset/migrations/versions/430039611635_log_more.py
@@ -6,11 +6,6 @@ Revises: d827694c7555
 Create Date: 2016-02-10 08:47:28.950891
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/superset/migrations/versions/4fa88fe24e94_owners_many_to_many.py
+++ b/superset/migrations/versions/4fa88fe24e94_owners_many_to_many.py
@@ -6,11 +6,6 @@ Revises: b4456560d4f3
 Create Date: 2016-04-15 17:58:33.842012
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '4fa88fe24e94'
 down_revision = 'b4456560d4f3'

--- a/superset/migrations/versions/5ccf602336a0_.py
+++ b/superset/migrations/versions/5ccf602336a0_.py
@@ -5,11 +5,6 @@ Revises: ('130915240929', 'c9495751e314')
 Create Date: 2018-04-12 16:00:47.639218
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '5ccf602336a0'
 down_revision = ('130915240929', 'c9495751e314')

--- a/superset/migrations/versions/6414e83d82b7_.py
+++ b/superset/migrations/versions/6414e83d82b7_.py
@@ -6,11 +6,6 @@ Revises: ('525c854f0005', 'f1f2d4af5b90')
 Create Date: 2016-12-19 09:57:05.814013
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '6414e83d82b7'
 down_revision = ('525c854f0005', 'f1f2d4af5b90')

--- a/superset/migrations/versions/705732c70154_.py
+++ b/superset/migrations/versions/705732c70154_.py
@@ -5,11 +5,6 @@ Revises: ('4451805bbaa1', '1d9e835a84f9')
 Create Date: 2018-07-22 21:51:19.235558
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '705732c70154'
 down_revision = ('4451805bbaa1', '1d9e835a84f9')

--- a/superset/migrations/versions/836c0bf75904_cache_timeouts.py
+++ b/superset/migrations/versions/836c0bf75904_cache_timeouts.py
@@ -6,11 +6,6 @@ Revises: 18e88e1cc004
 Create Date: 2016-03-17 08:40:03.186534
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '836c0bf75904'
 down_revision = '18e88e1cc004'

--- a/superset/migrations/versions/867bf4f117f9_adding_extra_field_to_database_model.py
+++ b/superset/migrations/versions/867bf4f117f9_adding_extra_field_to_database_model.py
@@ -6,11 +6,6 @@ Revises: fee7b758c130
 Create Date: 2016-04-03 15:23:20.280841
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '867bf4f117f9'
 down_revision = 'fee7b758c130'

--- a/superset/migrations/versions/8e80a26a31db_.py
+++ b/superset/migrations/versions/8e80a26a31db_.py
@@ -6,11 +6,6 @@ Revises: 2591d77e9831
 Create Date: 2016-01-13 20:24:45.256437
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = '8e80a26a31db'
 down_revision = '2591d77e9831'

--- a/superset/migrations/versions/956a063c52b3_adjusting_key_length.py
+++ b/superset/migrations/versions/956a063c52b3_adjusting_key_length.py
@@ -6,11 +6,6 @@ Revises: f0fbf6129e13
 Create Date: 2016-05-11 17:28:32.407340
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/superset/migrations/versions/a6c18f869a4e_query_start_running_time.py
+++ b/superset/migrations/versions/a6c18f869a4e_query_start_running_time.py
@@ -6,11 +6,6 @@ Revises: 979c03af3341
 Create Date: 2017-03-28 11:28:41.387182
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/superset/migrations/versions/a9c47e2c1547_add_impersonate_user_to_dbs.py
+++ b/superset/migrations/versions/a9c47e2c1547_add_impersonate_user_to_dbs.py
@@ -6,11 +6,6 @@ Revises: ca69c70ec99b
 Create Date: 2017-08-31 17:35:58.230723
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = 'a9c47e2c1547'
 down_revision = 'ca69c70ec99b'

--- a/superset/migrations/versions/b347b202819b_.py
+++ b/superset/migrations/versions/b347b202819b_.py
@@ -6,11 +6,6 @@ Revises: ('33d996bcc382', '65903709c321')
 Create Date: 2016-09-19 17:22:40.138601
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = 'b347b202819b'
 down_revision = ('33d996bcc382', '65903709c321')

--- a/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
+++ b/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
@@ -6,10 +6,6 @@ Revises: bb51420eaf83
 Create Date: 2016-04-15 08:31:26.249591
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/superset/migrations/versions/bf706ae5eb46_cal_heatmap_metric_to_metrics.py
+++ b/superset/migrations/versions/bf706ae5eb46_cal_heatmap_metric_to_metrics.py
@@ -5,11 +5,6 @@ Revises: f231d82b9b26
 Create Date: 2018-04-10 11:19:47.621878
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 
 from alembic import op

--- a/superset/migrations/versions/c3a8f8611885_materializing_permission.py
+++ b/superset/migrations/versions/c3a8f8611885_materializing_permission.py
@@ -6,11 +6,6 @@ Revises: 4fa88fe24e94
 Create Date: 2016-04-25 08:54:04.303859
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import Column, ForeignKey, Integer, String

--- a/superset/migrations/versions/c9495751e314_.py
+++ b/superset/migrations/versions/c9495751e314_.py
@@ -5,11 +5,6 @@ Revises: ('30bb17c0dc76', 'bf706ae5eb46')
 Create Date: 2018-04-10 20:46:57.890773
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = 'c9495751e314'
 down_revision = ('30bb17c0dc76', 'bf706ae5eb46')

--- a/superset/migrations/versions/d6db5a5cdb5d_.py
+++ b/superset/migrations/versions/d6db5a5cdb5d_.py
@@ -6,11 +6,6 @@ Revises: ('a99f2f7c195a', 'bcf3126872fc')
 Create Date: 2017-02-10 17:58:20.149960
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = 'd6db5a5cdb5d'
 down_revision = ('a99f2f7c195a', 'bcf3126872fc')

--- a/superset/migrations/versions/e46f2d27a08e_materialize_perms.py
+++ b/superset/migrations/versions/e46f2d27a08e_materialize_perms.py
@@ -6,11 +6,6 @@ Revises: c611f2b591b8
 Create Date: 2016-11-14 15:23:32.594898
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = 'e46f2d27a08e'
 down_revision = 'c611f2b591b8'

--- a/superset/migrations/versions/ef8843b41dac_.py
+++ b/superset/migrations/versions/ef8843b41dac_.py
@@ -6,11 +6,6 @@ Revises: ('3b626e2a6783', 'ab3d66c4246e')
 Create Date: 2016-10-02 10:35:38.825231
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # revision identifiers, used by Alembic.
 revision = 'ef8843b41dac'
 down_revision = ('3b626e2a6783', 'ab3d66c4246e')


### PR DESCRIPTION
This is the second part of the cleanup. This PR removes futures imports from the db migrations. 

@john-bodley @mistercrunch 