### PR TITLE
[cleanup] remove future imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,15 +89,13 @@ meets these guidelines:
 3.  If the pull request adds functionality, the docs should be updated
     as part of the same PR. Doc string are often sufficient, make
     sure to follow the sphinx compatible standards.
-4.  The pull request should work for Python 2.7 and Python 3.6.
-    ``from __future__ import`` will be required in every `.py` file soon.
-5.  If the pull request adds a Python dependency include it in `setup.py`
-    denoting any specific restrictions and run `pip-compile` to update the
-    `requirements.txt` file which ensures that the application build is deterministic.
-6.  Please rebase and resolve all conflicts before submitting.
-7.  Please ensure the necessary checks pass and that code coverage does not
+4.  If the pull request adds a Python dependency include it in `setup.py`
+    denoting any specific restrictions and in `requirements.txt` pinned to a
+    specific version which ensures that the application build is deterministic.
+5.  Please rebase and resolve all conflicts before submitting.
+6.  Please ensure the necessary checks pass and that code coverage does not
     decrease.
-8.  If you are asked to update your pull request with some changes there's
+7.  If you are asked to update your pull request with some changes there's
     no need to create a new one. Push your changes to the same branch.
 
 ## Local development

--- a/scripts/permissions_cleanup.py
+++ b/scripts/permissions_cleanup.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import defaultdict
 
 from superset import sm

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import io
 import json
 import os

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """Package's main module!"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import logging
 from logging.handlers import TimedRotatingFileHandler

--- a/superset/bin/superset
+++ b/superset/bin/superset
@@ -1,10 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import warnings
 import click
 from flask.cli import FlaskGroup

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask import request
 
 from superset import cache, tables_cache

--- a/superset/config.py
+++ b/superset/config.py
@@ -6,11 +6,6 @@ All configuration in this file can be overridden by providing a superset_config
 in your PYTHONPATH as there is a ``from superset_config import *``
 at the end of this file.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import OrderedDict
 import imp
 import json

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 
 from past.builtins import basestring

--- a/superset/connectors/base/views.py
+++ b/superset/connectors/base/views.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask import Markup
 
 from superset.exceptions import SupersetException

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from sqlalchemy.orm import subqueryload
 
 

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 # pylint: disable=invalid-unary-operand-type
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime, timedelta

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import json
 import logging

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import logging
 

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """Views used by the SqlAlchemy connector"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask import flash, Markup, redirect
 from flask_appbuilder import CompactCRUDMixin, expose
 from flask_appbuilder.actions import action

--- a/superset/data/countries.py
+++ b/superset/data/countries.py
@@ -1,9 +1,4 @@
 """This module contains data related to countries and is used for geo mapping"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 countries = [
     {
         "name": "Angola",

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -7,11 +7,6 @@ TODO(bkyryliuk): add support for the conventions like: *_dim or dim_*
 TODO(bkyryliuk): recognize integer encoded enums.
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import date, datetime
 import logging
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -13,11 +13,6 @@ at all. The classes here will use a common interface to specify all this.
 
 The general idea is to use static classes and an inheritance scheme.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import defaultdict, namedtuple
 import inspect
 import logging

--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from pyhive import hive
 from TCLIService import ttypes
 from thrift import Thrift

--- a/superset/dict_import_export_util.py
+++ b/superset/dict_import_export_util.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
 
 from superset.connectors.druid.models import DruidCluster

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 
 class SupersetException(Exception):

--- a/superset/extract_table_names.py
+++ b/superset/extract_table_names.py
@@ -12,11 +12,6 @@
 #
 # See:
 # http://groups.google.com/group/sqlparse/browse_thread/thread/b0bd9a022e9d4895
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import sqlparse
 from sqlparse.sql import Identifier, IdentifierList
 from sqlparse.tokens import DML, Keyword

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """Contains the logic to create cohesive forms on the explore view"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
 from flask_appbuilder.forms import DynamicForm
 from flask_babel import lazy_gettext as _

--- a/superset/import_util.py
+++ b/superset/import_util.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
 
 from sqlalchemy.orm.session import make_transient

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """Defines the templating context for SQL Lab"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta
 import inspect
 import json

--- a/superset/legacy.py
+++ b/superset/legacy.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """Code related with dealing with legacy / change management"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import re
 
 from superset import frontend_config

--- a/superset/models/annotations.py
+++ b/superset/models/annotations.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """a collection of Annotation-related models"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask_appbuilder import Model
 from sqlalchemy import (
     Column, DateTime, ForeignKey, Index, Integer, String, Text,

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """A collection of ORM sqlalchemy models for Superset"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from contextlib import closing
 from copy import copy, deepcopy
 from datetime import datetime

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """a collection of model-related helper classes and functions"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import json
 import logging

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """A collection of ORM sqlalchemy models for SQL Lab"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import re
 

--- a/superset/models/user_attributes.py
+++ b/superset/models/user_attributes.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask_appbuilder import Model
 from sqlalchemy import Column, ForeignKey, Integer
 from sqlalchemy.orm import relationship

--- a/superset/security.py
+++ b/superset/security.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
 """A set of constants and methods to manage permissions and security"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
 
 from flask import g

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from datetime import datetime
 import logging
 from time import sleep

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
 
 import sqlparse

--- a/superset/stats_logger.py
+++ b/superset/stats_logger.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
 
 from colorama import Fore, Style

--- a/superset/translations/utils.py
+++ b/superset/translations/utils.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 import os
 

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime
 import functools
 import logging

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta
 import inspect
 import logging

--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 
 from flask import request

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from flask import g, redirect
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import defaultdict
 
 from flask import g

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -5,11 +5,6 @@
 These objects represent the backend of all the visualizations that
 Superset can render.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import defaultdict, OrderedDict
 import copy
 from datetime import datetime, timedelta


### PR DESCRIPTION
This PR removes future imports from the rest of the files that are not migrations or tests. 
This PR also updates the contributing.md instructions. 

@john-bodley @mistercrunch 