### PR TITLE
Fix top groups with user defined metrics

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -19,7 +19,7 @@ assists people when migrating to a new version.
 * Superset 0.28 upgrades `flask-login` to `>=0.3`, which includes a
     backwards-incompatible change: `g.user.is_authenticated`,
     `g.user.is_anonymous`, and `g.user.is_active` are now properties
-    instead of properties.
+    instead of methods.
 
 ## Superset 0.27.0
 * Superset 0.27 start to use nested layout for dashboard builder, which is not

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -757,7 +757,11 @@ class SqlaTable(Model, BaseDatasource):
                     'order_desc': True,
                 }
                 result = self.query(subquery_obj)
-                dimensions = [c for c in result.df.columns if c not in metrics]
+                cols = {col.column_name: col for col in self.columns}
+                dimensions = [
+                    c for c in result.df.columns
+                    if c not in metrics and c in cols
+                ]
                 top_groups = self._get_top_groups(result.df, dimensions)
                 qry = qry.where(top_groups)
 


### PR DESCRIPTION
Top groups is not working when freeform metrics (ie, metrics not configured in the semantic layer) are used. This happens because the code currently does a naive test to determine dimensions: everything that is a not a pre-defined metric is considered a dimension.

In the chart that raised this bug, `SUM(response_content_length)` was added:

<img width="277" alt="screen shot 2018-10-10 at 6 26 40 pm" src="https://user-images.githubusercontent.com/1534870/46775002-0edabe00-ccba-11e8-8862-5fe22b887f84.png">

Resulting in the backend considering it as a dimension. I added an extra check verifying that the dimension is actually a column in the datasource (since we can only group by columns).