### PR TITLE
allow cache and force refresh on table list

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditorLeftBar_spec.jsx
@@ -41,14 +41,10 @@ describe('SqlEditorLeftBar', () => {
     expect(wrapper.find(TableElement)).toHaveLength(1);
   });
   describe('onDatabaseChange', () => {
-    it('should fetch tables', () => {
-      sinon.stub(wrapper.instance(), 'fetchTables');
+    it('should fetch schemas', () => {
       sinon.stub(wrapper.instance(), 'fetchSchemas');
       wrapper.instance().onDatabaseChange({ value: 1, label: 'main' });
-
-      expect(wrapper.instance().fetchTables.getCall(0).args[0]).toBe(1);
       expect(wrapper.instance().fetchSchemas.getCall(0).args[0]).toBe(1);
-      wrapper.instance().fetchTables.restore();
       wrapper.instance().fetchSchemas.restore();
     });
     it('should clear tableOptions', () => {
@@ -103,9 +99,9 @@ describe('SqlEditorLeftBar', () => {
         d.resolve(tables);
         return d.promise();
       });
-      wrapper.instance().fetchTables(1, 'main', 'birth_names');
+      wrapper.instance().fetchTables(1, 'main', 'true', 'birth_names');
 
-      expect(ajaxStub.getCall(0).args[0]).toBe('/superset/tables/1/main/birth_names/');
+      expect(ajaxStub.getCall(0).args[0]).toBe('/superset/tables/1/main/birth_names/true/');
       expect(wrapper.state().tableLength).toBe(3);
     });
     it('should handle error', () => {

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -198,7 +198,7 @@ class SqlEditorLeftBar extends React.PureComponent {
               <RefreshLabel
                 onClick={this.onDatabaseChange.bind(
                     this, { value: database.id }, true)}
-                tooltipContent="force refresh schema list"
+                tooltipContent="force refresh table list"
               />
             </div>
           </div>

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -40,8 +40,7 @@ class SqlEditorLeftBar extends React.PureComponent {
   }
   onDatabaseChange(db, force) {
     const val = db ? db.value : null;
-    this.setState({ schemaOptions: [] });
-    this.setState({ tableOptions: [] });
+    this.setState({ schemaOptions: [], tableOptions: [] });
     this.props.actions.queryEditorSetSchema(this.props.queryEditor, null);
     this.props.actions.queryEditorSetDb(this.props.queryEditor, val);
     if (db) {
@@ -195,7 +194,7 @@ class SqlEditorLeftBar extends React.PureComponent {
               <RefreshLabel
                 onClick={this.onDatabaseChange.bind(
                     this, { value: database.id }, true)}
-                tooltipContent="force refresh table list"
+                tooltipContent={t('force refresh schema list')}
               />
             </div>
           </div>
@@ -244,7 +243,7 @@ class SqlEditorLeftBar extends React.PureComponent {
               <RefreshLabel
                 onClick={this.changeSchema.bind(
                     this, { value: this.props.queryEditor.schema }, true)}
-                tooltipContent="force refresh schema list"
+                tooltipContent={t('force refresh table list')}
               />
             </div>
           </div>

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -67,11 +67,8 @@ class SqlEditorLeftBar extends React.PureComponent {
   resetState() {
     this.props.actions.resetState();
   }
-  fetchTables(dbId, schema, force) {
+  fetchTables(dbId, schema, force, substr) {
     // This can be large so it shouldn't be put in the Redux store
-    // This function has never been called with substr param so we just
-    // assign null to substr and have it passed to the endpoint.
-    const substr = null;
     const forceRefresh = force || false;
     if (dbId && schema) {
       this.setState({ tableLoading: true, tableOptions: [] });

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -9,25 +9,17 @@ def view_cache_key(*unused_args, **unused_kwargs):
     return 'view/{}/{}'.format(request.path, args_hash)
 
 
-def default_timeout(*unused_args, **unused_kwargs):
-    return 5 * 60
-
-
-def default_enable_cache(*unused_args, **unused_kwargs):
-    return True
-
-
-def memoized_func(timeout=default_timeout,
-                  key=view_cache_key,
-                  enable_cache=default_enable_cache,
-                  use_tables_cache=False):
+def memoized_func(key=view_cache_key, use_tables_cache=False):
     """Use this decorator to cache functions that have predefined first arg.
 
-    If enable_cache() is False,
-        the function will never be cached.
-    If enable_cache() is True,
-        cache is adopted and will timeout in timeout() seconds.
-        If force is True, cache will be refreshed.
+    enable_cache is treated as True by default,
+    except enable_cache = False is passed to the decorated function.
+
+    force is treated as False by default,
+    except force = True is passed to the decorated function.
+
+    timeout of cache is set to 600 seconds by default,
+    except cache_timeout = {timeout in seconds} is passed to the decorated function.
 
     memoized_func uses simple_cache and stored the data in memory.
     Key is a callable function that takes function arguments and
@@ -42,15 +34,16 @@ def memoized_func(timeout=default_timeout,
 
         if selected_cache:
             def wrapped_f(cls, *args, **kwargs):
-                if not enable_cache(*args, **kwargs):
+                if not kwargs.get('enable_cache', True):
                     return f(cls, *args, **kwargs)
 
                 cache_key = key(*args, **kwargs)
                 o = selected_cache.get(cache_key)
-                if not kwargs['force'] and o is not None:
+                if not kwargs.get('force') and o is not None:
                     return o
                 o = f(cls, *args, **kwargs)
-                selected_cache.set(cache_key, o, timeout=timeout(*args, **kwargs))
+                selected_cache.set(cache_key, o,
+                                   timeout=kwargs.get('cache_timeout', 600))
                 return o
         else:
             # noop

--- a/superset/cache_util.py
+++ b/superset/cache_util.py
@@ -15,7 +15,7 @@ def memoized_func(key=view_cache_key, use_tables_cache=False):
     enable_cache is treated as True by default,
     except enable_cache = False is passed to the decorated function.
 
-    force is treated as False by default,
+    force means whether to force refresh the cache and is treated as False by default,
     except force = True is passed to the decorated function.
 
     timeout of cache is set to 600 seconds by default,

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -312,8 +312,26 @@ class BaseEngineSpec(object):
         return inspector.get_schema_names()
 
     @classmethod
-    def get_table_names(cls, schema, inspector):
+    @cache_util.memoized_func(
+        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
+        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
+        key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema'))
+    )
+    def get_table_names(cls, inspector, db_id, schema,
+                        enable_cache, cache_timeout, force=False):
         return sorted(inspector.get_table_names(schema))
+
+    @classmethod
+    @cache_util.memoized_func(
+        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
+        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
+        key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:view_list'.format(
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema'))
+    )
+    def get_view_names(cls, inspector, db_id, schema,
+                       enable_cache, cache_timeout, force=False):
+        return sorted(inspector.get_view_names(schema))
 
     @classmethod
     def where_latest_partition(
@@ -438,7 +456,14 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
     engine = 'postgresql'
 
     @classmethod
-    def get_table_names(cls, schema, inspector):
+    @cache_util.memoized_func(
+        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
+        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
+        key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema'))
+    )
+    def get_table_names(cls, inspector, db_id, schema,
+                        enable_cache, cache_timeout, force=False):
         """Need to consider foreign tables for PostgreSQL"""
         tables = inspector.get_table_names(schema)
         tables.extend(inspector.get_foreign_table_names(schema))
@@ -596,7 +621,14 @@ class SqliteEngineSpec(BaseEngineSpec):
         return "'{}'".format(iso)
 
     @classmethod
-    def get_table_names(cls, schema, inspector):
+    @cache_util.memoized_func(
+        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
+        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
+        key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema'))
+    )
+    def get_table_names(cls, inspector, db_id, schema,
+                        enable_cache, cache_timeout, force=False):
         """Need to disregard the schema for Sqlite"""
         return sorted(inspector.get_table_names())
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -316,8 +316,7 @@ class BaseEngineSpec(object):
         enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
         timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
-            db_id=kwargs.get('db_id'), schema=kwargs.get('schema'))
-    )
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema')))
     def get_table_names(cls, inspector, db_id, schema,
                         enable_cache, cache_timeout, force=False):
         return sorted(inspector.get_table_names(schema))
@@ -327,8 +326,7 @@ class BaseEngineSpec(object):
         enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
         timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:view_list'.format(
-            db_id=kwargs.get('db_id'), schema=kwargs.get('schema'))
-    )
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema')))
     def get_view_names(cls, inspector, db_id, schema,
                        enable_cache, cache_timeout, force=False):
         return sorted(inspector.get_view_names(schema))
@@ -460,8 +458,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
         enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
         timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
-            db_id=kwargs.get('db_id'), schema=kwargs.get('schema'))
-    )
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema')))
     def get_table_names(cls, inspector, db_id, schema,
                         enable_cache, cache_timeout, force=False):
         """Need to consider foreign tables for PostgreSQL"""
@@ -625,8 +622,7 @@ class SqliteEngineSpec(BaseEngineSpec):
         enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
         timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
-            db_id=kwargs.get('db_id'), schema=kwargs.get('schema'))
-    )
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema')))
     def get_table_names(cls, inspector, db_id, schema,
                         enable_cache, cache_timeout, force=False):
         """Need to disregard the schema for Sqlite"""

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -228,7 +228,6 @@ class BaseEngineSpec(object):
 
     @classmethod
     @cache_util.memoized_func(
-        timeout=600,
         key=lambda *args, **kwargs: 'db:{}:{}'.format(args[0].id, args[1]),
         use_tables_cache=True)
     def fetch_result_sets(cls, db, datasource_type, force=False):
@@ -295,8 +294,6 @@ class BaseEngineSpec(object):
 
     @classmethod
     @cache_util.memoized_func(
-        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
-        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{}:schema_list'.format(kwargs.get('db_id')))
     def get_schema_names(cls, inspector, db_id,
                          enable_cache, cache_timeout, force=False):
@@ -313,8 +310,6 @@ class BaseEngineSpec(object):
 
     @classmethod
     @cache_util.memoized_func(
-        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
-        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
             db_id=kwargs.get('db_id'), schema=kwargs.get('schema')))
     def get_table_names(cls, inspector, db_id, schema,
@@ -323,8 +318,6 @@ class BaseEngineSpec(object):
 
     @classmethod
     @cache_util.memoized_func(
-        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
-        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:view_list'.format(
             db_id=kwargs.get('db_id'), schema=kwargs.get('schema')))
     def get_view_names(cls, inspector, db_id, schema,
@@ -455,8 +448,6 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
 
     @classmethod
     @cache_util.memoized_func(
-        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
-        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
             db_id=kwargs.get('db_id'), schema=kwargs.get('schema')))
     def get_table_names(cls, inspector, db_id, schema,
@@ -592,7 +583,6 @@ class SqliteEngineSpec(BaseEngineSpec):
 
     @classmethod
     @cache_util.memoized_func(
-        timeout=600,
         key=lambda *args, **kwargs: 'db:{}:{}'.format(args[0].id, args[1]),
         use_tables_cache=True)
     def fetch_result_sets(cls, db, datasource_type, force=False):
@@ -619,8 +609,6 @@ class SqliteEngineSpec(BaseEngineSpec):
 
     @classmethod
     @cache_util.memoized_func(
-        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
-        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
             db_id=kwargs.get('db_id'), schema=kwargs.get('schema')))
     def get_table_names(cls, inspector, db_id, schema,
@@ -749,7 +737,6 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     @cache_util.memoized_func(
-        timeout=600,
         key=lambda *args, **kwargs: 'db:{}:{}'.format(args[0].id, args[1]),
         use_tables_cache=True)
     def fetch_result_sets(cls, db, datasource_type, force=False):
@@ -1031,7 +1018,6 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     @classmethod
     @cache_util.memoized_func(
-        timeout=600,
         key=lambda *args, **kwargs: 'db:{}:{}'.format(args[0].id, args[1]),
         use_tables_cache=True)
     def fetch_result_sets(cls, db, datasource_type, force=False):
@@ -1489,8 +1475,6 @@ class ImpalaEngineSpec(BaseEngineSpec):
 
     @classmethod
     @cache_util.memoized_func(
-        enable_cache=lambda *args, **kwargs: kwargs.get('enable_cache', False),
-        timeout=lambda *args, **kwargs: kwargs.get('cache_timeout'),
         key=lambda *args, **kwargs: 'db:{}:schema_list'.format(kwargs.get('db_id')))
     def get_schema_names(cls, inspector, db_id,
                          enable_cache, cache_timeout, force=False):

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -847,8 +847,18 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             tables_dict = self.db_engine_spec.fetch_result_sets(
                 self, 'table', force=force)
             return tables_dict.get('', [])
-        return sorted(
-            self.db_engine_spec.get_table_names(schema, self.inspector))
+
+        extra = self.get_extra()
+        medatada_cache_timeout = extra.get('metadata_cache_timeout', {})
+        table_cache_timeout = medatada_cache_timeout.get('table_cache_timeout')
+        enable_cache = 'table_cache_timeout' in medatada_cache_timeout
+        return sorted(self.db_engine_spec.get_table_names(
+            inspector=self.inspector,
+            db_id=self.id,
+            schema=schema,
+            enable_cache=enable_cache,
+            cache_timeout=table_cache_timeout,
+            force=force))
 
     def all_view_names(self, schema=None, force=False):
         if not schema:
@@ -859,7 +869,17 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             return views_dict.get('', [])
         views = []
         try:
-            views = self.inspector.get_view_names(schema)
+            extra = self.get_extra()
+            medatada_cache_timeout = extra.get('metadata_cache_timeout', {})
+            table_cache_timeout = medatada_cache_timeout.get('table_cache_timeout')
+            enable_cache = 'table_cache_timeout' in medatada_cache_timeout
+            views = self.db_engine_spec.get_view_names(
+                inspector=self.inspector,
+                db_id=self.id,
+                schema=schema,
+                enable_cache=enable_cache,
+                cache_timeout=table_cache_timeout,
+                force=force)
         except Exception:
             pass
         return views


### PR DESCRIPTION
This is a follow-up PR for https://github.com/apache/incubator-superset/pull/5933

1. Added `table_cache_timeout` settings to `metadata_cache_timeout` in database configuration. If `table_cache_timeout` is unset in the field, cache will not be enabled for the metadata fetch of this database. If it is set to 0, cache will never time out.
2. Added a button to sqllab UI which allows user to refetch table list metadata, or force refresh cache if cache is enabled.

<img width="1468" alt="screen shot 2018-10-11 at 4 53 56 pm" src="https://user-images.githubusercontent.com/26216756/46840136-70606280-cd76-11e8-91ab-a7452121d286.png">