### PR TITLE
[cypress][sqllab] increase timeout for sqllab results

### DIFF
--- a/superset/assets/cypress/integration/sqllab/query.js
+++ b/superset/assets/cypress/integration/sqllab/query.js
@@ -26,7 +26,7 @@ export default () => {
 
       cy.wait('@sqlLabQuery');
 
-      cy.get('.SouthPane .ReactVirtualized__Table')
+      selectResultsTab()
         .eq(0) // ensures results tab in case preview tab exists
         .then((tableNodes) => {
           const [header, bodyWrapper] = tableNodes[0].childNodes;

--- a/superset/assets/cypress/integration/sqllab/sqllab.helper.js
+++ b/superset/assets/cypress/integration/sqllab/sqllab.helper.js
@@ -1,4 +1,5 @@
-export const selectResultsTab = () => cy.get('.SouthPane .ReactVirtualized__Table');
+export const selectResultsTab = () =>
+  cy.get('.SouthPane .ReactVirtualized__Table', { timeout: 10000 });
 
 // this function asserts that the result set for two SQL lab table results are equal
 export const assertSQLLabResultsAreEqual = (resultsA, resultsB) => {


### PR DESCRIPTION
This increases the timeout waiting for SQL lab results table from the `Cypress` default of `4s` to `10s` with the hopes of making it less flaky. 

Although the test is not flaky locally, you can see from the local Cypress UI that the saved query pane takes some time to load (not sure why). Note I've already added explicit route alias wait statements [as Cypress recommends](https://docs.cypress.io/guides/references/best-practices.html#Unnecessary-wait-for-cy-get) (e.g., `cy.wait('@sqlLabQuery')` ), so hopefully this timeout will reduce the overall flakiness on CI. 

<img width="500" src="https://user-images.githubusercontent.com/4496521/46885621-5aea4780-ce0d-11e8-84e2-f6c6b65c9af1.png" />

@kristw @graceguo-supercat @xtinec 