### PR TITLE
Rename onTooltip to setTooltip

### DIFF
--- a/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/CategoricalDeckGLContainer.jsx
@@ -38,7 +38,7 @@ const propTypes = {
   getLayer: PropTypes.func.isRequired,
   payload: PropTypes.object.isRequired,
   onAddFilter: PropTypes.func,
-  onTooltip: PropTypes.func,
+  setTooltip: PropTypes.func,
 };
 
 export default class CategoricalDeckGLContainer extends React.PureComponent {
@@ -77,7 +77,7 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
       payload,
       formData: fd,
       onAddFilter,
-      onTooltip,
+      setTooltip,
     } = this.props;
     let data = [...payload.data.features];
 
@@ -103,7 +103,7 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
     }
 
     payload.data.features = data;
-    return [getLayer(fd, payload, onAddFilter, onTooltip)];
+    return [getLayer(fd, payload, onAddFilter, setTooltip)];
   }
   addColor(data, fd) {
     const c = fd.color_picker || { r: 0, g: 0, b: 0, a: 1 };

--- a/superset/assets/src/visualizations/deckgl/createAdaptor.jsx
+++ b/superset/assets/src/visualizations/deckgl/createAdaptor.jsx
@@ -15,7 +15,7 @@ class DeckGlChartInput {
     };
 
     this.onAddFilter = ((...args) => { slice.addFilter(...args); });
-    this.onTooltip = ((...args) => { slice.tooltip(...args); });
+    this.setTooltip = ((...args) => { slice.tooltip(...args); });
   }
 }
 

--- a/superset/assets/src/visualizations/deckgl/createAdaptor.jsx
+++ b/superset/assets/src/visualizations/deckgl/createAdaptor.jsx
@@ -15,7 +15,7 @@ class DeckGlChartInput {
     };
 
     this.onAddFilter = ((...args) => { slice.addFilter(...args); });
-    this.setTooltip = ((...args) => { slice.tooltip(...args); });
+    this.setTooltip = ((...args) => { slice.setTooltip(...args); });
   }
 }
 

--- a/superset/assets/src/visualizations/deckgl/factory.jsx
+++ b/superset/assets/src/visualizations/deckgl/factory.jsx
@@ -10,11 +10,11 @@ const propTypes = {
   setControlValue: PropTypes.func.isRequired,
   viewport: PropTypes.object.isRequired,
   onAddFilter: PropTypes.func,
-  onTooltip: PropTypes.func,
+  setTooltip: PropTypes.func,
 };
 const defaultProps = {
   onAddFilter() {},
-  onTooltip() {},
+  setTooltip() {},
 };
 
 export function createDeckGLComponent(getLayer, getPoints) {
@@ -24,7 +24,7 @@ export function createDeckGLComponent(getLayer, getPoints) {
       payload,
       setControlValue,
       onAddFilter,
-      onTooltip,
+      setTooltip,
       viewport: originalViewport,
     } = props;
 
@@ -32,7 +32,7 @@ export function createDeckGLComponent(getLayer, getPoints) {
       ? fitViewport(originalViewport, getPoints(payload.data.features))
       : originalViewport;
 
-    const layer = getLayer(formData, payload, onAddFilter, onTooltip);
+    const layer = getLayer(formData, payload, onAddFilter, setTooltip);
 
     return (
       <DeckGLContainer
@@ -58,7 +58,7 @@ export function createCategoricalDeckGLComponent(getLayer, getPoints) {
       payload,
       setControlValue,
       onAddFilter,
-      onTooltip,
+      setTooltip,
       viewport: originalViewport,
     } = props;
 
@@ -75,7 +75,7 @@ export function createCategoricalDeckGLComponent(getLayer, getPoints) {
         getLayer={getLayer}
         payload={payload}
         onAddFilter={onAddFilter}
-        onTooltip={onTooltip}
+        setTooltip={setTooltip}
       />
     );
   }

--- a/superset/assets/src/visualizations/deckgl/layers/Arc/Arc.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Arc/Arc.jsx
@@ -12,7 +12,7 @@ function getPoints(data) {
   return points;
 }
 
-export function getLayer(fd, payload, onAddFilter, onTooltip) {
+export function getLayer(fd, payload, onAddFilter, setTooltip) {
   const data = payload.data.features;
   const sc = fd.color_picker;
   const tc = fd.target_color_picker;
@@ -22,7 +22,7 @@ export function getLayer(fd, payload, onAddFilter, onTooltip) {
     getSourceColor: d => d.sourceColor || d.color || [sc.r, sc.g, sc.b, 255 * sc.a],
     getTargetColor: d => d.targetColor || d.color || [tc.r, tc.g, tc.b, 255 * tc.a],
     strokeWidth: (fd.stroke_width) ? fd.stroke_width : 3,
-    ...commonLayerProps(fd, onAddFilter, onTooltip),
+    ...commonLayerProps(fd, onAddFilter, setTooltip),
   });
 }
 

--- a/superset/assets/src/visualizations/deckgl/layers/Geojson/Geojson.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Geojson/Geojson.jsx
@@ -58,7 +58,7 @@ const recurseGeoJson = (node, propOverrides, extraProps) => {
   }
 };
 
-export function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, setTooltip) {
   const fd = formData;
   const fc = fd.fill_color_picker;
   const sc = fd.stroke_color_picker;
@@ -89,7 +89,7 @@ export function getLayer(formData, payload, onAddFilter, onTooltip) {
     stroked: fd.stroked,
     extruded: fd.extruded,
     pointRadiusScale: fd.point_radius_scale,
-    ...commonLayerProps(fd, onAddFilter, onTooltip),
+    ...commonLayerProps(fd, onAddFilter, setTooltip),
   });
 }
 
@@ -99,11 +99,11 @@ const propTypes = {
   setControlValue: PropTypes.func.isRequired,
   viewport: PropTypes.object.isRequired,
   onAddFilter: PropTypes.func,
-  onTooltip: PropTypes.func,
+  setTooltip: PropTypes.func,
 };
 const defaultProps = {
   onAddFilter() {},
-  onTooltip() {},
+  setTooltip() {},
 };
 
 function deckGeoJson(props) {
@@ -112,7 +112,7 @@ function deckGeoJson(props) {
     payload,
     setControlValue,
     onAddFilter,
-    onTooltip,
+    setTooltip,
     viewport,
   } = props;
 
@@ -121,7 +121,7 @@ function deckGeoJson(props) {
   //   viewport = common.fitViewport(viewport, geojsonExtent(payload.data.features));
   // }
 
-  const layer = getLayer(formData, payload, onAddFilter, onTooltip);
+  const layer = getLayer(formData, payload, onAddFilter, setTooltip);
 
   return (
     <DeckGLContainer

--- a/superset/assets/src/visualizations/deckgl/layers/Grid/Grid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Grid/Grid.jsx
@@ -4,7 +4,7 @@ import sandboxedEval from '../../../../modules/sandbox';
 import createAdaptor from '../../createAdaptor';
 import { createDeckGLComponent } from '../../factory';
 
-export function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, setTooltip) {
   const fd = formData;
   const c = fd.color_picker;
   let data = payload.data.features.map(d => ({
@@ -29,7 +29,7 @@ export function getLayer(formData, payload, onAddFilter, onTooltip) {
     outline: false,
     getElevationValue: points => points.reduce((sum, point) => sum + point.weight, 0),
     getColorValue: points => points.reduce((sum, point) => sum + point.weight, 0),
-    ...commonLayerProps(fd, onAddFilter, onTooltip),
+    ...commonLayerProps(fd, onAddFilter, setTooltip),
   });
 }
 

--- a/superset/assets/src/visualizations/deckgl/layers/Hex/Hex.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Hex/Hex.jsx
@@ -4,7 +4,7 @@ import sandboxedEval from '../../../../modules/sandbox';
 import createAdaptor from '../../createAdaptor';
 import { createDeckGLComponent } from '../../factory';
 
-export function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, setTooltip) {
   const fd = formData;
   const c = fd.color_picker;
   let data = payload.data.features.map(d => ({
@@ -29,7 +29,7 @@ export function getLayer(formData, payload, onAddFilter, onTooltip) {
     outline: false,
     getElevationValue: points => points.reduce((sum, point) => sum + point.weight, 0),
     getColorValue: points => points.reduce((sum, point) => sum + point.weight, 0),
-    ...commonLayerProps(fd, onAddFilter, onTooltip),
+    ...commonLayerProps(fd, onAddFilter, setTooltip),
   });
 }
 

--- a/superset/assets/src/visualizations/deckgl/layers/Path/Path.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Path/Path.jsx
@@ -4,7 +4,7 @@ import sandboxedEval from '../../../../modules/sandbox';
 import createAdaptor from '../../createAdaptor';
 import { createDeckGLComponent } from '../../factory';
 
-export function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, setTooltip) {
   const fd = formData;
   const c = fd.color_picker;
   const fixedColor = [c.r, c.g, c.b, 255 * c.a];
@@ -25,7 +25,7 @@ export function getLayer(formData, payload, onAddFilter, onTooltip) {
     data,
     rounded: true,
     widthScale: 1,
-    ...commonLayerProps(fd, onAddFilter, onTooltip),
+    ...commonLayerProps(fd, onAddFilter, setTooltip),
   });
 }
 

--- a/superset/assets/src/visualizations/deckgl/layers/Polygon/Polygon.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Polygon/Polygon.jsx
@@ -11,7 +11,7 @@ function getPoints(features) {
   return flatten(features.map(d => d.polygon), true);
 }
 
-export function getLayer(formData, payload, onAddFilter, onTooltip) {
+export function getLayer(formData, payload, onAddFilter, setTooltip) {
   const fd = formData;
   const fc = fd.fill_color_picker;
   const sc = fd.stroke_color_picker;
@@ -45,7 +45,7 @@ export function getLayer(formData, payload, onAddFilter, onTooltip) {
     getLineWidth: fd.line_width,
     extruded: fd.extruded,
     fp64: true,
-    ...commonLayerProps(fd, onAddFilter, onTooltip),
+    ...commonLayerProps(fd, onAddFilter, setTooltip),
   });
 }
 

--- a/superset/assets/src/visualizations/deckgl/layers/Screengrid/Screengrid.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Screengrid/Screengrid.jsx
@@ -13,7 +13,7 @@ function getPoints(data) {
   return data.map(d => d.position);
 }
 
-export function getLayer(formData, payload, onAddFilter, onTooltip, filters) {
+export function getLayer(formData, payload, onAddFilter, setTooltip, filters) {
   const fd = formData;
   const c = fd.color_picker;
   let data = payload.data.features.map(d => ({
@@ -44,7 +44,7 @@ export function getLayer(formData, payload, onAddFilter, onTooltip, filters) {
     maxColor: [c.r, c.g, c.b, 255 * c.a],
     outline: false,
     getWeight: d => d.weight || 0,
-    ...commonLayerProps(fd, onAddFilter, onTooltip),
+    ...commonLayerProps(fd, onAddFilter, setTooltip),
   });
 }
 
@@ -54,11 +54,11 @@ const propTypes = {
   setControlValue: PropTypes.func.isRequired,
   viewport: PropTypes.object.isRequired,
   onAddFilter: PropTypes.func,
-  onTooltip: PropTypes.func,
+  setTooltip: PropTypes.func,
 };
 const defaultProps = {
   onAddFilter() {},
-  onTooltip() {},
+  setTooltip() {},
 };
 
 class DeckGLScreenGrid extends React.PureComponent {
@@ -95,7 +95,7 @@ class DeckGLScreenGrid extends React.PureComponent {
       this.props.formData,
       this.props.payload,
       this.props.onAddFilter,
-      this.props.onTooltip,
+      this.props.setTooltip,
       filters);
 
     return [layer];

--- a/superset/assets/src/visualizations/deckgl/layers/common.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/common.jsx
@@ -31,7 +31,7 @@ export function fitViewport(viewport, points, padding = 10) {
   }
 }
 
-export function commonLayerProps(formData, onAddFilter, onTooltip) {
+export function commonLayerProps(formData, onAddFilter, setTooltip) {
   const fd = formData;
   let onHover;
   let tooltipContentGenerator;
@@ -48,13 +48,13 @@ export function commonLayerProps(formData, onAddFilter, onTooltip) {
   if (tooltipContentGenerator) {
     onHover = (o) => {
       if (o.picked) {
-        onTooltip({
+        setTooltip({
           content: tooltipContentGenerator(o),
           x: o.x,
           y: o.y,
         });
       } else {
-        onTooltip(null);
+        setTooltip(null);
       }
     };
   }


### PR DESCRIPTION
Follow-up from #6039 , rename `onTooltip` to `setTooltip` for all deck.gl vis components

@williaster @conglei @betodealmeida @mistercrunch 