### PR TITLE
Use @vx/responsive to provide Chart width on Explore page

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
-import ParentSize from '@vx/responsive/build/components/ParentSize';
+import { ParentSize } from '@vx/responsive';
 import { Sticky, StickyContainer } from 'react-sticky';
 import { TabContainer, TabContent, TabPane } from 'react-bootstrap';
 

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -150,9 +150,7 @@ class Chart extends React.PureComponent {
   }
 
   width() {
-    return (
-      this.props.width || (this.container && this.container.el && this.container.el.offsetWidth)
-    );
+    return this.props.width;
   }
 
   headerHeight() {
@@ -160,9 +158,7 @@ class Chart extends React.PureComponent {
   }
 
   height() {
-    return (
-      this.props.height || (this.container && this.container.el && this.container.el.offsetHeight)
-    );
+    return this.props.height;
   }
 
   error(e) {

--- a/superset/assets/src/dashboard/components/BuilderComponentPane.jsx
+++ b/superset/assets/src/dashboard/components/BuilderComponentPane.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import { StickyContainer, Sticky } from 'react-sticky';
-import ParentSize from '@vx/responsive/build/components/ParentSize';
+import { ParentSize } from '@vx/responsive';
 
 import NewColumn from './gridComponents/new/NewColumn';
 import NewDivider from './gridComponents/new/NewDivider';

--- a/superset/assets/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset/assets/src/dashboard/components/DashboardBuilder.jsx
@@ -2,7 +2,7 @@
 import cx from 'classnames';
 // ParentSize uses resize observer so the dashboard will update size
 // when its container size changes, due to e.g., builder side panel opening
-import ParentSize from '@vx/responsive/build/components/ParentSize';
+import { ParentSize } from '@vx/responsive';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Sticky, StickyContainer } from 'react-sticky';

--- a/superset/assets/src/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/src/explore/components/ExploreChartPanel.jsx
@@ -31,13 +31,10 @@ const propTypes = {
 };
 
 class ExploreChartPanel extends React.PureComponent {
-  getHeight() {
-    const headerHeight = this.props.standalone ? 0 : 100;
-    return parseInt(this.props.height, 10) - headerHeight;
-  }
-
   renderChart() {
     const { chart } = this.props;
+    const headerHeight = this.props.standalone ? 0 : 80;
+
     return (
       <ParentSize>
         {({ width, height }) => (width > 0 && height > 0) && (
@@ -47,7 +44,7 @@ class ExploreChartPanel extends React.PureComponent {
             datasource={this.props.datasource}
             formData={this.props.form_data}
             width={Math.floor(width)}
-            height={this.getHeight()}
+            height={parseInt(this.props.height, 10) - headerHeight}
             slice={this.props.slice}
             setControlValue={this.props.actions.setControlValue}
             timeout={this.props.timeout}

--- a/superset/assets/src/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/src/explore/components/ExploreChartPanel.jsx
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Panel } from 'react-bootstrap';
@@ -76,7 +75,11 @@ class ExploreChartPanel extends React.PureComponent {
   render() {
     if (this.props.standalone) {
       // dom manipulation hack to get rid of the boostrap theme's body background
-      $('body').addClass('background-transparent');
+      const standaloneClass = 'background-transparent';
+      const bodyClasses = document.body.className.split(' ');
+      if (bodyClasses.indexOf(standaloneClass) === -1) {
+        document.body.className += ` ${standaloneClass}`;
+      }
       return this.renderChart();
     }
 

--- a/superset/assets/src/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/src/explore/components/ExploreChartPanel.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Panel } from 'react-bootstrap';
-import ParentSize from '@vx/responsive/build/components/ParentSize';
+import { ParentSize } from '@vx/responsive';
 import { chartPropShape } from '../../dashboard/util/propShapes';
 import ChartContainer from '../../chart/ChartContainer';
 import ExploreChartHeader from './ExploreChartHeader';
@@ -42,31 +42,31 @@ class ExploreChartPanel extends React.PureComponent {
       <ParentSize>
         {({ width, height }) => (width > 0 && height > 0) && (
           <ChartContainer
-          chartId={chart.id}
-          containerId={this.props.containerId}
-          datasource={this.props.datasource}
-          formData={this.props.form_data}
-          width={Math.floor(width)}
-          height={this.getHeight()}
-          slice={this.props.slice}
-          setControlValue={this.props.actions.setControlValue}
-          timeout={this.props.timeout}
-          vizType={this.props.vizType}
-          refreshOverlayVisible={this.props.refreshOverlayVisible}
-          errorMessage={this.props.errorMessage}
-          onQuery={this.props.onQuery}
-          onDismissRefreshOverlay={this.props.onDismissRefreshOverlay}
-          annotationData={chart.annotationData}
-          chartAlert={chart.chartAlert}
-          chartStatus={chart.chartStatus}
-          chartUpdateEndTime={chart.chartUpdateEndTime}
-          chartUpdateStartTime={chart.chartUpdateStartTime}
-          latestQueryFormData={chart.latestQueryFormData}
-          lastRendered={chart.lastRendered}
-          queryResponse={chart.queryResponse}
-          queryController={chart.queryController}
-          triggerQuery={chart.triggerQuery}
-        />
+            chartId={chart.id}
+            containerId={this.props.containerId}
+            datasource={this.props.datasource}
+            formData={this.props.form_data}
+            width={Math.floor(width)}
+            height={this.getHeight()}
+            slice={this.props.slice}
+            setControlValue={this.props.actions.setControlValue}
+            timeout={this.props.timeout}
+            vizType={this.props.vizType}
+            refreshOverlayVisible={this.props.refreshOverlayVisible}
+            errorMessage={this.props.errorMessage}
+            onQuery={this.props.onQuery}
+            onDismissRefreshOverlay={this.props.onDismissRefreshOverlay}
+            annotationData={chart.annotationData}
+            chartAlert={chart.chartAlert}
+            chartStatus={chart.chartStatus}
+            chartUpdateEndTime={chart.chartUpdateEndTime}
+            chartUpdateStartTime={chart.chartUpdateStartTime}
+            latestQueryFormData={chart.latestQueryFormData}
+            lastRendered={chart.lastRendered}
+            queryResponse={chart.queryResponse}
+            queryController={chart.queryController}
+            triggerQuery={chart.triggerQuery}
+          />
         )}
       </ParentSize>
     );

--- a/superset/assets/src/explore/components/ExploreChartPanel.jsx
+++ b/superset/assets/src/explore/components/ExploreChartPanel.jsx
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Panel } from 'react-bootstrap';
-
+import ParentSize from '@vx/responsive/build/components/ParentSize';
 import { chartPropShape } from '../../dashboard/util/propShapes';
 import ChartContainer from '../../chart/ChartContainer';
 import ExploreChartHeader from './ExploreChartHeader';
@@ -40,31 +40,36 @@ class ExploreChartPanel extends React.PureComponent {
   renderChart() {
     const { chart } = this.props;
     return (
-      <ChartContainer
-        chartId={chart.id}
-        containerId={this.props.containerId}
-        datasource={this.props.datasource}
-        formData={this.props.form_data}
-        height={this.getHeight()}
-        slice={this.props.slice}
-        setControlValue={this.props.actions.setControlValue}
-        timeout={this.props.timeout}
-        vizType={this.props.vizType}
-        refreshOverlayVisible={this.props.refreshOverlayVisible}
-        errorMessage={this.props.errorMessage}
-        onQuery={this.props.onQuery}
-        onDismissRefreshOverlay={this.props.onDismissRefreshOverlay}
-        annotationData={chart.annotationData}
-        chartAlert={chart.chartAlert}
-        chartStatus={chart.chartStatus}
-        chartUpdateEndTime={chart.chartUpdateEndTime}
-        chartUpdateStartTime={chart.chartUpdateStartTime}
-        latestQueryFormData={chart.latestQueryFormData}
-        lastRendered={chart.lastRendered}
-        queryResponse={chart.queryResponse}
-        queryController={chart.queryController}
-        triggerQuery={chart.triggerQuery}
-      />
+      <ParentSize>
+        {({ width, height }) => (width > 0 && height > 0) && (
+          <ChartContainer
+          chartId={chart.id}
+          containerId={this.props.containerId}
+          datasource={this.props.datasource}
+          formData={this.props.form_data}
+          width={Math.floor(width)}
+          height={this.getHeight()}
+          slice={this.props.slice}
+          setControlValue={this.props.actions.setControlValue}
+          timeout={this.props.timeout}
+          vizType={this.props.vizType}
+          refreshOverlayVisible={this.props.refreshOverlayVisible}
+          errorMessage={this.props.errorMessage}
+          onQuery={this.props.onQuery}
+          onDismissRefreshOverlay={this.props.onDismissRefreshOverlay}
+          annotationData={chart.annotationData}
+          chartAlert={chart.chartAlert}
+          chartStatus={chart.chartStatus}
+          chartUpdateEndTime={chart.chartUpdateEndTime}
+          chartUpdateStartTime={chart.chartUpdateStartTime}
+          latestQueryFormData={chart.latestQueryFormData}
+          lastRendered={chart.lastRendered}
+          queryResponse={chart.queryResponse}
+          queryController={chart.queryController}
+          triggerQuery={chart.triggerQuery}
+        />
+        )}
+      </ParentSize>
     );
   }
 
@@ -87,7 +92,8 @@ class ExploreChartPanel extends React.PureComponent {
         form_data={this.props.form_data}
         timeout={this.props.timeout}
         chart={this.props.chart}
-      />);
+      />
+    );
     return (
       <div className="chart-container">
         <Panel


### PR DESCRIPTION
- Use `ParentSize` to provide chart width in `ExploreChartPanel`.
- Remove complicated logic in `Chart.jsx` for getting element width. 
- Remove unnecessary `jQuery` usage.

@graceguo-supercat @williaster @conglei @michellethomas 