### PR TITLE
Remove isNumeric util function and use Number.isFinite instead

### DIFF
--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -21,10 +21,6 @@ export function kmToPixels(kilometers, latitude, zoomLevel) {
   return d3.round(kilometers / kmPerPixel, 2);
 }
 
-export function isNumeric(num) {
-  return !isNaN(parseFloat(num)) && isFinite(num);
-}
-
 export function rgbLuminance(r, g, b) {
   // Formula: https://en.wikipedia.org/wiki/Relative_luminance
   return (LUMINANCE_RED_WEIGHT * r) + (LUMINANCE_GREEN_WEIGHT * g) + (LUMINANCE_BLUE_WEIGHT * b);

--- a/superset/assets/src/visualizations/MapBox/ScatterPlotGlowOverlay.jsx
+++ b/superset/assets/src/visualizations/MapBox/ScatterPlotGlowOverlay.jsx
@@ -3,7 +3,6 @@ import Immutable from 'immutable';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ViewportMercator from 'viewport-mercator-project';
-import { isFinite } from 'lodash';
 import {
   kmToPixels,
   rgbLuminance,
@@ -154,7 +153,7 @@ class ScatterPlotGlowOverlay extends React.Component {
             ctx.fillStyle = gradient;
             ctx.fill();
 
-            if (isFinite(parseFloat(clusterLabel))) {
+            if (Number.isFinite(parseFloat(clusterLabel))) {
               if (clusterLabel >= 10000) {
                 clusterLabel = Math.round(clusterLabel / 1000) + 'k';
               } else if (clusterLabel >= 1000) {
@@ -187,7 +186,7 @@ class ScatterPlotGlowOverlay extends React.Component {
             }
 
             if (pointMetric !== null) {
-              pointLabel = isFinite(parseFloat(pointMetric))
+              pointLabel = Number.isFinite(parseFloat(pointMetric))
                 ? d3.round(pointMetric, 2)
                 : pointMetric;
             }

--- a/superset/assets/src/visualizations/MapBox/ScatterPlotGlowOverlay.jsx
+++ b/superset/assets/src/visualizations/MapBox/ScatterPlotGlowOverlay.jsx
@@ -3,10 +3,10 @@ import Immutable from 'immutable';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ViewportMercator from 'viewport-mercator-project';
+import { isFinite } from 'lodash';
 import {
   kmToPixels,
   rgbLuminance,
-  isNumeric,
   MILES_PER_KM,
 } from '../../utils/common';
 
@@ -154,7 +154,7 @@ class ScatterPlotGlowOverlay extends React.Component {
             ctx.fillStyle = gradient;
             ctx.fill();
 
-            if (isNumeric(clusterLabel)) {
+            if (isFinite(parseFloat(clusterLabel))) {
               if (clusterLabel >= 10000) {
                 clusterLabel = Math.round(clusterLabel / 1000) + 'k';
               } else if (clusterLabel >= 1000) {
@@ -187,7 +187,9 @@ class ScatterPlotGlowOverlay extends React.Component {
             }
 
             if (pointMetric !== null) {
-              pointLabel = isNumeric(pointMetric) ? d3.round(pointMetric, 2) : pointMetric;
+              pointLabel = isFinite(parseFloat(pointMetric))
+                ? d3.round(pointMetric, 2)
+                : pointMetric;
             }
 
             // Fall back to default points if pointRadius wasn't a numerical column


### PR DESCRIPTION
The current `isNumeric()` function checks if the value is not `NaN`, `Infinity` nor `-Infinity`. 

- This function is only used in one file
- It has unclear name (`Infinity` and `-Infinity` are usually considered `Number`) 
- It can be easily replaced with native function `Number.isFinite()`

```js
Number.isFinite(Infinity);  // false
Number.isFinite(NaN);       // false
Number.isFinite(-Infinity); // false

Number.isFinite(0);         // true
Number.isFinite(2e64);      // true

Number.isFinite('0');       // false, would've been true with
                            // global isFinite('0')
Number.isFinite(null);      // false, would've been true with
                            // global isFinite(null)
```

@graceguo-supercat @williaster @conglei @michellethomas 