### PR TITLE
send username in sync request

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2533,7 +2533,7 @@ class Superset(BaseSupersetView):
                     rendered_query,
                     return_results=False,
                     store_results=not query.select_as_cta,
-                    user_name=g.user.username,
+                    user_name=g.user.username if g.user else None,
                     start_time=utils.now_as_float())
             except Exception as e:
                 logging.exception(e)
@@ -2566,7 +2566,7 @@ class Superset(BaseSupersetView):
                     query_id,
                     rendered_query,
                     return_results=True,
-                    user_name=g.user.username)
+                    user_name=g.user.username if g.user else None)
             payload = json.dumps(
                 data,
                 default=utils.pessimistic_json_iso_dttm_ser,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2565,7 +2565,8 @@ class Superset(BaseSupersetView):
                 data = sql_lab.get_sql_results(
                     query_id,
                     rendered_query,
-                    return_results=True)
+                    return_results=True,
+                    user_name=g.user.username)
             payload = json.dumps(
                 data,
                 default=utils.pessimistic_json_iso_dttm_ser,


### PR DESCRIPTION
`user_name` is sent to `sql_lab.get_sql_results` in running async query (https://github.com/apache/incubator-superset/blob/b15ed5135629eddd21409ac0ca749130dac78055/superset/views/core.py#L2543)
but did not get sent in running sync query.