### PR TITLE
[test] change cypress viewport dimension

### DIFF
--- a/superset/assets/cypress.json
+++ b/superset/assets/cypress.json
@@ -2,5 +2,7 @@
   "baseUrl": "http://localhost:8081",
   "videoUploadOnPasses": false,
   "ignoreTestFiles": ["**/!(*.test.js)"],
-  "projectId": "fbf96q"
+  "projectId": "fbf96q",
+  "viewportWidth": 1280,
+  "viewportHeight": 800
 }


### PR DESCRIPTION
default is `1000x600` which is kinda small and sometimes cause overflow on the right side. 
changing to `1280x800`

@michellethomas @graceguo-supercat @williaster @conglei 