### PR TITLE
Add annotation information to ChartMetadata

### DIFF
--- a/superset/assets/src/visualizations/Table/TableChartPlugin.js
+++ b/superset/assets/src/visualizations/Table/TableChartPlugin.js
@@ -2,10 +2,15 @@ import ChartPlugin from '../core/models/ChartPlugin';
 import ChartMetadata from '../core/models/ChartMetadata';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
+import { ANNOTATION_TYPES } from '../../modules/AnnotationTypes';
 
 const metadata = new ChartMetadata({
   name: 'Table',
   description: '',
+  canBeAnnotation: [
+    ANNOTATION_TYPES.EVENT,
+    ANNOTATION_TYPES.INTERVAL,
+  ],
   thumbnail,
 });
 

--- a/superset/assets/src/visualizations/Table/TableChartPlugin.js
+++ b/superset/assets/src/visualizations/Table/TableChartPlugin.js
@@ -7,7 +7,7 @@ import { ANNOTATION_TYPES } from '../../modules/AnnotationTypes';
 const metadata = new ChartMetadata({
   name: 'Table',
   description: '',
-  canBeAnnotation: [
+  canBeAnnotationTypes: [
     ANNOTATION_TYPES.EVENT,
     ANNOTATION_TYPES.INTERVAL,
   ],

--- a/superset/assets/src/visualizations/core/models/ChartMetadata.js
+++ b/superset/assets/src/visualizations/core/models/ChartMetadata.js
@@ -4,20 +4,24 @@ export default class ChartMetadata {
     credits = [],
     description = '',
     show = true,
-    canBeAnnotation = [],
-    supportedAnnotations = [],
+    canBeAnnotationTypes = [],
+    supportedAnnotationTypes = [],
     thumbnail,
   }) {
     this.name = name;
     this.credits = credits;
     this.description = description;
     this.show = show;
-    this.canBeAnnotation = canBeAnnotation.reduce((prev, type) => {
+    this.canBeAnnotationTypesLookup = canBeAnnotationTypes.reduce((prev, type) => {
       const lookup = prev;
       lookup[type] = true;
       return lookup;
     }, {});
-    this.supportedAnnotations = supportedAnnotations;
+    this.supportedAnnotationTypes = supportedAnnotationTypes;
     this.thumbnail = thumbnail;
+  }
+
+  canBeAnnotationType(type) {
+    return this.canBeAnnotationTypesLookup[type] || false;
   }
 }

--- a/superset/assets/src/visualizations/core/models/ChartMetadata.js
+++ b/superset/assets/src/visualizations/core/models/ChartMetadata.js
@@ -2,14 +2,22 @@ export default class ChartMetadata {
   constructor({
     name,
     credits = [],
-    description,
-    thumbnail,
+    description = '',
     show = true,
+    canBeAnnotation = [],
+    supportedAnnotations = [],
+    thumbnail,
   }) {
     this.name = name;
     this.credits = credits;
     this.description = description;
-    this.thumbnail = thumbnail;
     this.show = show;
+    this.canBeAnnotation = canBeAnnotation.reduce((prev, type) => {
+      const lookup = prev;
+      lookup[type] = true;
+      return lookup;
+    }, {});
+    this.supportedAnnotations = supportedAnnotations;
+    this.thumbnail = thumbnail;
   }
 }

--- a/superset/assets/src/visualizations/nvd3/Area/AreaChartPlugin.js
+++ b/superset/assets/src/visualizations/nvd3/Area/AreaChartPlugin.js
@@ -8,7 +8,7 @@ const metadata = new ChartMetadata({
   name: 'Area Chart',
   description: '',
   credits: ['http://nvd3.org'],
-  supportedAnnotations: [
+  supportedAnnotationTypes: [
     ANNOTATION_TYPES.INTERVAL,
     ANNOTATION_TYPES.EVENT,
   ],

--- a/superset/assets/src/visualizations/nvd3/Area/AreaChartPlugin.js
+++ b/superset/assets/src/visualizations/nvd3/Area/AreaChartPlugin.js
@@ -2,11 +2,16 @@ import ChartPlugin from '../../core/models/ChartPlugin';
 import ChartMetadata from '../../core/models/ChartMetadata';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
+import { ANNOTATION_TYPES } from '../../../modules/AnnotationTypes';
 
 const metadata = new ChartMetadata({
   name: 'Area Chart',
   description: '',
   credits: ['http://nvd3.org'],
+  supportedAnnotations: [
+    ANNOTATION_TYPES.INTERVAL,
+    ANNOTATION_TYPES.EVENT,
+  ],
   thumbnail,
 });
 

--- a/superset/assets/src/visualizations/nvd3/Bar/BarChartPlugin.js
+++ b/superset/assets/src/visualizations/nvd3/Bar/BarChartPlugin.js
@@ -2,11 +2,16 @@ import ChartPlugin from '../../core/models/ChartPlugin';
 import ChartMetadata from '../../core/models/ChartMetadata';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
+import { ANNOTATION_TYPES } from '../../../modules/AnnotationTypes';
 
 const metadata = new ChartMetadata({
   name: 'Time-series Bar Chart',
   description: 'A bar chart where the x axis is time',
   credits: ['http://nvd3.org'],
+  supportedAnnotations: [
+    ANNOTATION_TYPES.INTERVAL,
+    ANNOTATION_TYPES.EVENT,
+  ],
   thumbnail,
 });
 

--- a/superset/assets/src/visualizations/nvd3/Bar/BarChartPlugin.js
+++ b/superset/assets/src/visualizations/nvd3/Bar/BarChartPlugin.js
@@ -8,7 +8,7 @@ const metadata = new ChartMetadata({
   name: 'Time-series Bar Chart',
   description: 'A bar chart where the x axis is time',
   credits: ['http://nvd3.org'],
-  supportedAnnotations: [
+  supportedAnnotationTypes: [
     ANNOTATION_TYPES.INTERVAL,
     ANNOTATION_TYPES.EVENT,
   ],

--- a/superset/assets/src/visualizations/nvd3/Line/LineChartPlugin.js
+++ b/superset/assets/src/visualizations/nvd3/Line/LineChartPlugin.js
@@ -8,10 +8,10 @@ const metadata = new ChartMetadata({
   name: 'Line Chart',
   description: '',
   credits: ['http://nvd3.org'],
-  canBeAnnotation: [
+  canBeAnnotationTypes: [
     ANNOTATION_TYPES.TIME_SERIES,
   ],
-  supportedAnnotations: [
+  supportedAnnotationTypes: [
     ANNOTATION_TYPES.TIME_SERIES,
     ANNOTATION_TYPES.INTERVAL,
     ANNOTATION_TYPES.EVENT,

--- a/superset/assets/src/visualizations/nvd3/Line/LineChartPlugin.js
+++ b/superset/assets/src/visualizations/nvd3/Line/LineChartPlugin.js
@@ -2,11 +2,21 @@ import ChartPlugin from '../../core/models/ChartPlugin';
 import ChartMetadata from '../../core/models/ChartMetadata';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
+import { ANNOTATION_TYPES } from '../../../modules/AnnotationTypes';
 
 const metadata = new ChartMetadata({
   name: 'Line Chart',
   description: '',
   credits: ['http://nvd3.org'],
+  canBeAnnotation: [
+    ANNOTATION_TYPES.TIME_SERIES,
+  ],
+  supportedAnnotations: [
+    ANNOTATION_TYPES.TIME_SERIES,
+    ANNOTATION_TYPES.INTERVAL,
+    ANNOTATION_TYPES.EVENT,
+    ANNOTATION_TYPES.FORMULA,
+  ],
   thumbnail,
 });
 


### PR DESCRIPTION
Add annotation information to ChartMetadata

- `canBeAnnotation` : List the annotation types that the chart can be use as a source.
- `supportedAnnotations` : List the annotation types that can be added to this chart. 

@williaster @graceguo-supercat @conglei @michellethomas 