### PR TITLE
Define chart presets

### DIFF
--- a/superset/assets/src/visualizations/presets/CommonChartPreset.js
+++ b/superset/assets/src/visualizations/presets/CommonChartPreset.js
@@ -5,11 +5,8 @@ import BigNumberChartPlugin from '../BigNumber/BigNumberChartPlugin';
 import BigNumberTotalChartPlugin from '../BigNumberTotal/BigNumberTotalChartPlugin';
 import BoxPlotChartPlugin from '../nvd3/BoxPlot/BoxPlotChartPlugin';
 import BubbleChartPlugin from '../nvd3/Bubble/BubbleChartPlugin';
-import CompareChartPlugin from '../nvd3/Compare/CompareChartPlugin';
 import DistBarChartPlugin from '../nvd3/DistBar/DistBarChartPlugin';
-import DualLineChartPlugin from '../nvd3/DualLine/DualLineChartPlugin';
 import FilterBoxChartPlugin from '../FilterBox/FilterBoxChartPlugin';
-import HeatmapChartPlugin from '../Heatmap/HeatmapChartPlugin';
 import HistogramChartPlugin from '../Histogram/HistogramChartPlugin';
 import LineChartPlugin from '../nvd3/Line/LineChartPlugin';
 import PieChartPlugin from '../nvd3/Pie/PieChartPlugin';
@@ -29,11 +26,8 @@ export default class CommonChartPreset extends Preset {
         new BigNumberTotalChartPlugin().configure({ key: 'big_number_total' }),
         new BoxPlotChartPlugin().configure({ key: 'box_plot' }),
         new BubbleChartPlugin().configure({ key: 'bubble' }),
-        new CompareChartPlugin().configure({ key: 'compare' }),
         new DistBarChartPlugin().configure({ key: 'dist_bar' }),
-        new DualLineChartPlugin().configure({ key: 'dual_line' }),
         new FilterBoxChartPlugin().configure({ key: 'filter_box' }),
-        new HeatmapChartPlugin().configure({ key: 'heatmap' }),
         new HistogramChartPlugin().configure({ key: 'histogram' }),
         new LineChartPlugin().configure({ key: 'line' }),
         new PieChartPlugin().configure({ key: 'pie' }),

--- a/superset/assets/src/visualizations/presets/CommonChartPreset.js
+++ b/superset/assets/src/visualizations/presets/CommonChartPreset.js
@@ -1,0 +1,47 @@
+import Preset from '../core/models/Preset';
+import AreaChartPlugin from '../nvd3/Area/AreaChartPlugin';
+import BarChartPlugin from '../nvd3/Bar/BarChartPlugin';
+import BigNumberChartPlugin from '../BigNumber/BigNumberChartPlugin';
+import BigNumberTotalChartPlugin from '../BigNumberTotal/BigNumberTotalChartPlugin';
+import BoxPlotChartPlugin from '../nvd3/BoxPlot/BoxPlotChartPlugin';
+import BubbleChartPlugin from '../nvd3/Bubble/BubbleChartPlugin';
+import CompareChartPlugin from '../nvd3/Compare/CompareChartPlugin';
+import DistBarChartPlugin from '../nvd3/DistBar/DistBarChartPlugin';
+import DualLineChartPlugin from '../nvd3/DualLine/DualLineChartPlugin';
+import FilterBoxChartPlugin from '../FilterBox/FilterBoxChartPlugin';
+import HeatmapChartPlugin from '../Heatmap/HeatmapChartPlugin';
+import HistogramChartPlugin from '../Histogram/HistogramChartPlugin';
+import LineChartPlugin from '../nvd3/Line/LineChartPlugin';
+import PieChartPlugin from '../nvd3/Pie/PieChartPlugin';
+import PivotTableChartPlugin from '../PivotTable/PivotTableChartPlugin';
+import TableChartPlugin from '../Table/TableChartPlugin';
+import TimeTableChartPlugin from '../TimeTable/TimeTableChartPlugin';
+import WordCloudChartPlugin from '../wordcloud/WordCloudChartPlugin';
+
+export default class CommonChartPreset extends Preset {
+  constructor() {
+    super({
+      name: 'Common charts',
+      plugins: [
+        new AreaChartPlugin().configure({ key: 'area' }),
+        new BarChartPlugin().configure({ key: 'bar' }),
+        new BigNumberChartPlugin().configure({ key: 'big_number' }),
+        new BigNumberTotalChartPlugin().configure({ key: 'big_number_total' }),
+        new BoxPlotChartPlugin().configure({ key: 'box_plot' }),
+        new BubbleChartPlugin().configure({ key: 'bubble' }),
+        new CompareChartPlugin().configure({ key: 'compare' }),
+        new DistBarChartPlugin().configure({ key: 'dist_bar' }),
+        new DualLineChartPlugin().configure({ key: 'dual_line' }),
+        new FilterBoxChartPlugin().configure({ key: 'filter_box' }),
+        new HeatmapChartPlugin().configure({ key: 'heatmap' }),
+        new HistogramChartPlugin().configure({ key: 'histogram' }),
+        new LineChartPlugin().configure({ key: 'line' }),
+        new PieChartPlugin().configure({ key: 'pie' }),
+        new PivotTableChartPlugin().configure({ key: 'pivot_table' }),
+        new TableChartPlugin().configure({ key: 'table' }),
+        new TimeTableChartPlugin().configure({ key: 'time_table' }),
+        new WordCloudChartPlugin().configure({ key: 'word_cloud' }),
+      ],
+    });
+  }
+}

--- a/superset/assets/src/visualizations/presets/DeckGLChartPreset.js
+++ b/superset/assets/src/visualizations/presets/DeckGLChartPreset.js
@@ -1,0 +1,29 @@
+import Preset from '../core/models/Preset';
+import ArcChartPlugin from '../deckgl/layers/Arc/ArcChartPlugin';
+import GeoJsonChartPlugin from '../deckgl/layers/Geojson/GeojsonChartPlugin';
+import GridChartPlugin from '../deckgl/layers/Grid/GridChartPlugin';
+import HexChartPlugin from '../deckgl/layers/Hex/HexChartPlugin';
+import MultiChartPlugin from '../deckgl/Multi/MultiChartPlugin';
+import PathChartPlugin from '../deckgl/layers/Path/PathChartPlugin';
+import PolygonChartPlugin from '../deckgl/layers/Polygon/PolygonChartPlugin';
+import ScatterChartPlugin from '../deckgl/layers/Scatter/ScatterChartPlugin';
+import ScreengridChartPlugin from '../deckgl/layers/Screengrid/ScreengridChartPlugin';
+
+export default class DeckGLChartPreset extends Preset {
+  constructor() {
+    super({
+      name: 'deck.gl charts',
+      plugins: [
+        new ArcChartPlugin().configure({ key: 'deck_arc' }),
+        new GeoJsonChartPlugin().configure({ key: 'deck_geojson' }),
+        new GridChartPlugin().configure({ key: 'deck_grid' }),
+        new HexChartPlugin().configure({ key: 'deck_hex' }),
+        new MultiChartPlugin().configure({ key: 'deck_multi' }),
+        new PathChartPlugin().configure({ key: 'deck_path' }),
+        new PolygonChartPlugin().configure({ key: 'deck_polygon' }),
+        new ScatterChartPlugin().configure({ key: 'deck_scatter' }),
+        new ScreengridChartPlugin().configure({ key: 'deck_screengrid' }),
+      ],
+    });
+  }
+}

--- a/superset/assets/src/visualizations/presets/HierarchyChartPreset.js
+++ b/superset/assets/src/visualizations/presets/HierarchyChartPreset.js
@@ -1,0 +1,17 @@
+import Preset from '../core/models/Preset';
+import PartitionChartPlugin from '../Partition/PartitionChartPlugin';
+import SunburstChartPlugin from '../Sunburst/SunburstChartPlugin';
+import TreemapChartPlugin from '../Treemap/TreemapChartPlugin';
+
+export default class HierarchyChartPreset extends Preset {
+  constructor() {
+    super({
+      name: 'Hierarchy charts',
+      plugins: [
+        new PartitionChartPlugin().configure({ key: 'partition' }),
+        new SunburstChartPlugin().configure({ key: 'sunburst' }),
+        new TreemapChartPlugin().configure({ key: 'treemap' }),
+      ],
+    });
+  }
+}

--- a/superset/assets/src/visualizations/presets/LegacyChartPreset.js
+++ b/superset/assets/src/visualizations/presets/LegacyChartPreset.js
@@ -1,0 +1,51 @@
+import Preset from '../core/models/Preset';
+import CommonChartPreset from './CommonChartPreset';
+import DeckGLChartPreset from './DeckGLChartPreset';
+import HierarchyChartPreset from './HierarchyChartPreset';
+import MapChartPreset from './MapChartPreset';
+import BulletChartPlugin from '../nvd3/Bullet/BulletChartPlugin';
+import CalendarChartPlugin from '../Calendar/CalendarChartPlugin';
+import ChordChartPlugin from '../Chord/ChordChartPlugin';
+import CompareChartPlugin from '../nvd3/Compare/CompareChartPlugin';
+import DualLineChartPlugin from '../nvd3/DualLine/DualLineChartPlugin';
+import EventFlowChartPlugin from '../EventFlow/EventFlowChartPlugin';
+import ForceDirectedChartPlugin from '../ForceDirected/ForceDirectedChartPlugin';
+import HeatmapChartPlugin from '../Heatmap/HeatmapChartPlugin';
+import HorizonChartPlugin from '../Horizon/HorizonChartPlugin';
+import LineMultiChartPlugin from '../nvd3/LineMulti/LineMultiChartPlugin';
+import PairedTTestChartPlugin from '../PairedTTest/PairedTTestChartPlugin';
+import ParallelCoordinatesChartPlugin from '../ParallelCoordinates/ParallelCoordinatesChartPlugin';
+import RoseChartPlugin from '../Rose/RoseChartPlugin';
+import SankeyChartPlugin from '../Sankey/SankeyChartPlugin';
+import TimePivotChartPlugin from '../nvd3/TimePivot/TimePivotChartPlugin';
+
+export default class LegacyChartPreset extends Preset {
+  constructor() {
+    super({
+      name: 'Legacy charts',
+      presets: [
+        new CommonChartPreset(),
+        new DeckGLChartPreset(),
+        new HierarchyChartPreset(),
+        new MapChartPreset(),
+      ],
+      plugins: [
+        new BulletChartPlugin().configure({ key: 'bullet' }),
+        new CalendarChartPlugin().configure({ key: 'cal_heatmap' }),
+        new ChordChartPlugin().configure({ key: 'chord' }),
+        new CompareChartPlugin().configure({ key: 'compare' }),
+        new DualLineChartPlugin().configure({ key: 'dual_line' }),
+        new EventFlowChartPlugin().configure({ key: 'event_flow' }),
+        new ForceDirectedChartPlugin().configure({ key: 'directed_force' }),
+        new HeatmapChartPlugin().configure({ key: 'heatmap' }),
+        new HorizonChartPlugin().configure({ key: 'horizon' }),
+        new LineMultiChartPlugin().configure({ key: 'line_multi' }),
+        new PairedTTestChartPlugin().configure({ key: 'paired_ttest' }),
+        new ParallelCoordinatesChartPlugin().configure({ key: 'para' }),
+        new RoseChartPlugin().configure({ key: 'rose' }),
+        new SankeyChartPlugin().configure({ key: 'sankey' }),
+        new TimePivotChartPlugin().configure({ key: 'time_pivot' }),
+      ],
+    });
+  }
+}

--- a/superset/assets/src/visualizations/presets/MapChartPreset.js
+++ b/superset/assets/src/visualizations/presets/MapChartPreset.js
@@ -1,0 +1,17 @@
+import Preset from '../core/models/Preset';
+import CountryMapChartPlugin from '../CountryMap/CountryMapChartPlugin';
+import MapBoxChartPlugin from '../MapBox/MapBoxChartPlugin';
+import WorldMapChartPlugin from '../WorldMap/WorldMapChartPlugin';
+
+export default class MapChartPreset extends Preset {
+  constructor() {
+    super({
+      name: 'Maps',
+      plugins: [
+        new CountryMapChartPlugin().configure({ key: 'country_map' }),
+        new MapBoxChartPlugin().configure({ key: 'mapbox' }),
+        new WorldMapChartPlugin().configure({ key: 'world_map' }),
+      ],
+    });
+  }
+}


### PR DESCRIPTION
This PR defines multiple presets of `ChartPlugin`. The main one is `LegacyChartPreset` which will import all existing vis types current Superset does. 

This is part of the work to integrate chart plugin system.
- Add annotation information to `ChartMetadata` #6136 
- Define `ChartProps` data structure #6125 
- This PR 
- [Future] Add `<SuperChart />` component and integrate with `Chart.jsx`
- [Future] Remove all adaptors

@williaster @conglei @michellethomas @graceguo-supercat 