### PR TITLE
[bugfix] fix bar chart value overlap with legend

### DIFF
--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -322,6 +322,9 @@ function nvd3Vis(element, props) {
           });
         }
         if (showBarValue) {
+          // Add more margin to avoid label colliding with legend.
+          const top = chart.margin().top;
+          chart.margin({ top: top + 24 });
           setTimeout(function () {
             drawBarValues(svg, data, isBarStacked, yAxisFormat);
           }, ANIMATION_TIME);


### PR DESCRIPTION
Bar chart values overlap with legend when "Show bar values" is selected (PRODUCT-59209)

@graceguo-supercat @michellethomas @williaster @conglei 