### PR TITLE
[superset-client] pass `csrfToken` as configuration

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -51,7 +51,7 @@
     "@data-ui/sparkline": "^0.0.54",
     "@data-ui/theme": "^0.0.62",
     "@data-ui/xy-chart": "^0.0.61",
-    "@superset-ui/core": "^0.0.5",
+    "@superset-ui/core": "^0.0.7",
     "@vx/legend": "^0.0.170",
     "@vx/responsive": "0.0.172",
     "@vx/scale": "^0.0.165",

--- a/superset/assets/src/common.js
+++ b/superset/assets/src/common.js
@@ -42,9 +42,13 @@ export function appSetup() {
   window.jQuery = $;
   require('bootstrap');
 
+  const csrfNode = document.querySelector('#csrf_token');
+  const csrfToken = csrfNode ? csrfNode.value : null;
+
   SupersetClient.configure({
     protocol: (window.location && window.location.protocol) || '',
     host: (window.location && window.location.host) || '',
+    csrfToken,
   })
     .init()
     .catch((error) => {

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -66,6 +66,12 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -377,11 +383,11 @@
   dependencies:
     samsam "1.3.0"
 
-"@superset-ui/core@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/core/-/core-0.0.5.tgz#2dbb39d7ec55c01a017c923468b276240a9fbc8b"
+"@superset-ui/core@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@superset-ui/core/-/core-0.0.7.tgz#e91374d10c96de504225a24d7d1d76e73cdb06cd"
   dependencies:
-    babel-runtime "^6.26.0"
+    "@babel/runtime" "^7.1.2"
     whatwg-fetch "^2.0.4"
 
 "@types/blob-util@1.3.3":
@@ -9983,6 +9989,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
This PR bumps the version of `@superset-ui/core` to [support passing a `CSRF` token at configuration time](https://github.com/apache-superset/superset-ui/pull/9) in order to remove the request to `superest/csrf_token` upon initialization.

Because the Superset app should always have access to the token in the HTML this makes sense (vs external apps which will have to request it), and it may be contributing to increased flakiness of the cypress tests 🤞 

Unit tests live in `@superset-ui`, tested this functionally to ensure that the `csrf` request is no longer issued.

**before**
![image](https://user-images.githubusercontent.com/4496521/47192596-065e3500-d303-11e8-9e33-c2d35f83e095.png)

**after**
![image](https://user-images.githubusercontent.com/4496521/47192605-0d854300-d303-11e8-9b31-4986f6343dc3.png)

@kristw @michellethomas @graceguo-supercat 