### PR TITLE
Move metadata cache one layer up

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -353,8 +353,12 @@ def update_datasources_cache():
     for database in db.session.query(Database).all():
         print('Fetching {} datasources ...'.format(database.name))
         try:
-            database.all_table_names(enable_cache=True, force=True)
-            database.all_view_names(enable_cache=True, force=True)
+            database.all_table_names_in_database(
+                db_id=database.id, force=True,
+                cache=True, cache_timeout=24 * 60 * 60)
+            database.all_view_names_in_database(
+                db_id=database.id, force=True,
+                cache=True, cache_timeout=24 * 60 * 60)
         except Exception as e:
             print('{}'.format(str(e)))
 

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -353,8 +353,8 @@ def update_datasources_cache():
     for database in db.session.query(Database).all():
         print('Fetching {} datasources ...'.format(database.name))
         try:
-            database.all_table_names(force=True)
-            database.all_view_names(force=True)
+            database.all_table_names(enable_cache=True, force=True)
+            database.all_view_names(enable_cache=True, force=True)
         except Exception as e:
             print('{}'.format(str(e)))
 

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -351,16 +351,17 @@ def update_datasources_cache():
     """Refresh sqllab datasources cache"""
     from superset.models.core import Database
     for database in db.session.query(Database).all():
-        print('Fetching {} datasources ...'.format(database.name))
-        try:
-            database.all_table_names_in_database(
-                db_id=database.id, force=True,
-                cache=True, cache_timeout=24 * 60 * 60)
-            database.all_view_names_in_database(
-                db_id=database.id, force=True,
-                cache=True, cache_timeout=24 * 60 * 60)
-        except Exception as e:
-            print('{}'.format(str(e)))
+        if database.allow_multi_schema_metadata_fetch:
+            print('Fetching {} datasources ...'.format(database.name))
+            try:
+                database.all_table_names_in_database(
+                    db_id=database.id, force=True,
+                    cache=True, cache_timeout=24 * 60 * 60)
+                database.all_view_names_in_database(
+                    db_id=database.id, force=True,
+                    cache=True, cache_timeout=24 * 60 * 60)
+            except Exception as e:
+                print('{}'.format(str(e)))
 
 
 @app.cli.command()

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -355,11 +355,9 @@ def update_datasources_cache():
             print('Fetching {} datasources ...'.format(database.name))
             try:
                 database.all_table_names_in_database(
-                    db_id=database.id, force=True,
-                    cache=True, cache_timeout=24 * 60 * 60)
+                    force=True, cache=True, cache_timeout=24 * 60 * 60)
                 database.all_view_names_in_database(
-                    db_id=database.id, force=True,
-                    cache=True, cache_timeout=24 * 60 * 60)
+                    force=True, cache=True, cache_timeout=24 * 60 * 60)
             except Exception as e:
                 print('{}'.format(str(e)))
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -187,8 +187,8 @@ IMG_UPLOAD_URL = '/static/uploads/'
 # IMG_SIZE = (300, 200, True)
 
 CACHE_DEFAULT_TIMEOUT = 60 * 60 * 24
-CACHE_CONFIG = {'CACHE_TYPE': 'null'}
-TABLE_NAMES_CACHE_CONFIG = {'CACHE_TYPE': 'null'}
+CACHE_CONFIG = {'CACHE_TYPE': 'simple'}
+TABLE_NAMES_CACHE_CONFIG = {'CACHE_TYPE': 'simple'}
 
 # CORS Options
 ENABLE_CORS = False

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -12,7 +12,7 @@ at all. The classes here will use a common interface to specify all this.
 
 The general idea is to use static classes and an inheritance scheme.
 """
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 import inspect
 import logging
 import os

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -235,16 +235,23 @@ class BaseEngineSpec(object):
         Empty schema corresponds to the list of full names of the all
         tables or views: <schema>.<result_set_name>.
         """
-        schemas = db.inspector.get_schema_names()
+        schemas = db.all_schema_names(db_id=db.id,
+                                      cache=db.schema_cache_enabled,
+                                      cache_timeout=db.schema_cache_timeout,
+                                      force=True)
         result_sets = {}
         all_result_sets = []
         for schema in schemas:
             if datasource_type == 'table':
-                result_sets[schema] = sorted(
-                    db.inspector.get_table_names(schema))
+                result_sets[schema] = db.all_table_names_in_schema(
+                    db_id=db.id, schema=schema, force=True,
+                    cache=db.table_cache_enabled,
+                    cache_timeout=db.table_cache_timeout)
             elif datasource_type == 'view':
-                result_sets[schema] = sorted(
-                    db.inspector.get_view_names(schema))
+                result_sets[schema] = db.all_view_names_in_schema(
+                    db_id=db.id, schema=schema, force=True,
+                    cache=db.table_cache_enabled,
+                    cache_timeout=db.table_cache_timeout)
             all_result_sets += [
                 '{}.{}'.format(schema, t) for t in result_sets[schema]]
         if all_result_sets:
@@ -557,14 +564,23 @@ class SqliteEngineSpec(BaseEngineSpec):
 
     @classmethod
     def fetch_result_sets(cls, db, datasource_type):
-        schemas = db.inspector.get_schema_names()
+        schemas = db.all_schema_names(db_id=db.id,
+                                      cache=db.schema_cache_enabled,
+                                      cache_timeout=db.schema_cache_timeout,
+                                      force=True)
         result_sets = {}
         all_result_sets = []
         schema = schemas[0]
         if datasource_type == 'table':
-            result_sets[schema] = sorted(db.inspector.get_table_names())
+            result_sets[schema] = db.all_table_names_in_schema(
+                db_id=db.id, schema=schema, force=True,
+                cache=db.table_cache_enabled,
+                cache_timeout=db.table_cache_timeout)
         elif datasource_type == 'view':
-            result_sets[schema] = sorted(db.inspector.get_view_names())
+            result_sets[schema] = db.all_view_names_in_schema(
+                db_id=db.id, schema=schema, force=True,
+                cache=db.table_cache_enabled,
+                cache_timeout=db.table_cache_timeout)
         all_result_sets += [
             '{}.{}'.format(schema, t) for t in result_sets[schema]]
         if all_result_sets:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -864,58 +864,40 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         return sqla.inspect(engine)
 
     @cache_util.memoized_func(
-        key=lambda *args, **kwargs: 'db:{db_id}:schema:None:table_list'.format(
-            db_id=kwargs.get('db_id')),
-        use_tables_cache=True)
-    def all_table_names_in_database(self, db_id=None, cache=False,
-                                    cache_timeout=None, force=False):
-        """
-        Parameters need to be passed as keyword arguments.
-        If cache=True, db_id must be passed in for setting cache key
-        """
+        key=lambda *args, **kwargs: 'db:{}:schema:None:table_list',
+        attribute_in_key='id')
+    def all_table_names_in_database(self, cache=False, cache_timeout=None, force=False):
+        """Parameters need to be passed as keyword arguments."""
         if not self.allow_multi_schema_metadata_fetch:
             return []
-        tables_dict = self.db_engine_spec.fetch_result_sets(self, 'table')
-        return tables_dict.get('', [])
+        return self.db_engine_spec.fetch_result_sets(self, 'table')
 
     @cache_util.memoized_func(
-        key=lambda *args, **kwargs: 'db:{db_id}:schema:None:view_list'.format(
-            db_id=kwargs.get('db_id')),
-        use_tables_cache=True)
-    def all_view_names_in_database(self, db_id=None, cache=False,
-                                   cache_timeout=None, force=False):
-        """
-        Parameters need to be passed as keyword arguments.
-        If cache=True, db_id must be passed in for setting cache key
-        """
+        key=lambda *args, **kwargs: 'db:{}:schema:None:view_list',
+        attribute_in_key='id')
+    def all_view_names_in_database(self, cache=False, cache_timeout=None, force=False):
+        """Parameters need to be passed as keyword arguments."""
         if not self.allow_multi_schema_metadata_fetch:
             return []
-        views_dict = self.db_engine_spec.fetch_result_sets(self, 'view')
-        return views_dict.get('', [])
+        return self.db_engine_spec.fetch_result_sets(self, 'view')
 
     @cache_util.memoized_func(
-        key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
-            db_id=kwargs.get('db_id'), schema=kwargs.get('schema')),
-        use_tables_cache=True)
-    def all_table_names_in_schema(self, schema, db_id=None, cache=False,
-                                  cache_timeout=None, force=False):
-        """
-        Parameters need to be passed as keyword arguments.
-        If cache=True, db_id must be passed in for setting cache key
+        key=lambda *args, **kwargs: 'db:{{}}:schema:{}:table_list'.format(kwargs.get('schema')),
+        attribute_in_key='id')
+    def all_table_names_in_schema(self, schema, cache=False, cache_timeout=None, force=False):
+        """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
         cache_util.memoized_func decorator.
 
-        :param enable_cache: whether cache is enabled for the function
-        :type enable_cache: bool
+        :param schema: schema name
+        :type schema: str
+        :param cache: whether cache is enabled for the function
+        :type cache: bool
         :param cache_timeout: timeout in seconds for the cache
         :type cache_timeout: int
         :param force: whether to force refresh the cache
         :type force: bool
-        :param db_id: database id
-        :type db_id: int
-        :param schema: schema name
-        :type schema: str
         :return: table list
         :rtype: list
         """
@@ -925,32 +907,25 @@ class Database(Model, AuditMixinNullable, ImportMixin):
                 inspector=self.inspector, schema=schema)
         except Exception as e:
             logging.exception(e)
-            pass
         return tables
 
     @cache_util.memoized_func(
-        key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:view_list'.format(
-            db_id=kwargs.get('db_id'), schema=kwargs.get('schema')),
-        use_tables_cache=True)
-    def all_view_names_in_schema(self, schema, db_id=None, cache=False,
-                                 cache_timeout=None, force=False):
-        """
-        Parameters need to be passed as keyword arguments.
-        If cache=True, db_id must be passed in for setting cache key
+        key=lambda *args, **kwargs: 'db:{{}}:schema:{}:table_list'.format(kwargs.get('schema')),
+        attribute_in_key='id')
+    def all_view_names_in_schema(self, schema, cache=False, cache_timeout=None, force=False):
+        """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
         cache_util.memoized_func decorator.
 
-        :param enable_cache: whether cache is enabled for the function
-        :type enable_cache: bool
+        :param schema: schema name
+        :type schema: str
+        :param cache: whether cache is enabled for the function
+        :type cache: bool
         :param cache_timeout: timeout in seconds for the cache
         :type cache_timeout: int
         :param force: whether to force refresh the cache
         :type force: bool
-        :param db_id: database id
-        :type db_id: int
-        :param schema: schema name
-        :type schema: str
         :return: view list
         :rtype: list
         """
@@ -960,29 +935,23 @@ class Database(Model, AuditMixinNullable, ImportMixin):
                 inspector=self.inspector, schema=schema)
         except Exception as e:
             logging.exception(e)
-            pass
         return views
 
     @cache_util.memoized_func(
-        key=lambda *args, **kwargs: 'db:{}:schema_list'.format(kwargs.get('db_id')),
-        use_tables_cache=True)
-    def all_schema_names(self, db_id=None, cache=False,
-                         cache_timeout=None, force=False):
-        """
-        Parameters need to be passed as keyword arguments.
-        If cache=True, db_id must be passed in for setting cache key
+        key=lambda *args, **kwargs: 'db:{}:schema_list',
+        attribute_in_key='id')
+    def all_schema_names(self, cache=False, cache_timeout=None, force=False):
+        """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
         cache_util.memoized_func decorator.
 
-        :param enable_cache: whether cache is enabled for the function
-        :type enable_cache: bool
+        :param cache: whether cache is enabled for the function
+        :type cache: bool
         :param cache_timeout: timeout in seconds for the cache
         :type cache_timeout: int
         :param force: whether to force refresh the cache
         :type force: bool
-        :param db_id: database id
-        :type db_id: int
         :return: schema list
         :rtype: list
         """

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -34,7 +34,10 @@ from superset.connectors.connector_registry import ConnectorRegistry
 from superset.legacy import update_time_range
 from superset.models.helpers import AuditMixinNullable, ImportMixin
 from superset.models.user_attributes import UserAttribute
-from superset.utils import core as utils
+from superset.utils import (
+    cache as cache_util,
+    core as utils,
+)
 from superset.viz import viz_types
 install_aliases()
 from urllib import parse  # noqa
@@ -840,61 +843,95 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         engine = self.get_sqla_engine()
         return sqla.inspect(engine)
 
-    def all_table_names(self, schema=None, force=False):
+    @cache_util.memoized_func(
+        key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:table_list'.format(
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema')),
+        use_tables_cache=True)
+    def all_table_names(self, enable_cache=False, cache_timeout=None,
+                        force=False, db_id=None, schema=None):
+        """
+        For unused parameters, they are referenced in
+        cache_util.memoized_func decorator
+
+        :param enable_cache: whether cache is enabled for the function
+        :type enable_cache: bool
+        :param cache_timeout: timeout in seconds for the cache
+        :type cache_timeout: int
+        :param force: whether to force refresh the cache
+        :type force: bool
+        :param db_id: database id
+        :type db_id: int
+        :param schema: schema name
+        :type schema: str
+        :return: table list
+        :rtype: list
+        """
         if not schema:
             if not self.allow_multi_schema_metadata_fetch:
                 return []
-            tables_dict = self.db_engine_spec.fetch_result_sets(
-                self, 'table', force=force)
+            tables_dict = self.db_engine_spec.fetch_result_sets(self, 'table')
             return tables_dict.get('', [])
 
-        extra = self.get_extra()
-        medatada_cache_timeout = extra.get('metadata_cache_timeout', {})
-        table_cache_timeout = medatada_cache_timeout.get('table_cache_timeout')
-        enable_cache = 'table_cache_timeout' in medatada_cache_timeout
         return sorted(self.db_engine_spec.get_table_names(
-            inspector=self.inspector,
-            db_id=self.id,
-            schema=schema,
-            enable_cache=enable_cache,
-            cache_timeout=table_cache_timeout,
-            force=force))
+            inspector=self.inspector, schema=schema))
 
-    def all_view_names(self, schema=None, force=False):
+    @cache_util.memoized_func(
+        key=lambda *args, **kwargs: 'db:{db_id}:schema:{schema}:view_list'.format(
+            db_id=kwargs.get('db_id'), schema=kwargs.get('schema')),
+        use_tables_cache=True)
+    def all_view_names(self, enable_cache=False, cache_timeout=None,
+                       force=False, db_id=None, schema=None):
+        """
+        For unused parameters, they are referenced in
+        cache_util.memoized_func decorator
+
+        :param enable_cache: whether cache is enabled for the function
+        :type enable_cache: bool
+        :param cache_timeout: timeout in seconds for the cache
+        :type cache_timeout: int
+        :param force: whether to force refresh the cache
+        :type force: bool
+        :param db_id: database id
+        :type db_id: int
+        :param schema: schema name
+        :type schema: str
+        :return: view list
+        :rtype: list
+        """
         if not schema:
             if not self.allow_multi_schema_metadata_fetch:
                 return []
-            views_dict = self.db_engine_spec.fetch_result_sets(
-                self, 'view', force=force)
+            views_dict = self.db_engine_spec.fetch_result_sets(self, 'view')
             return views_dict.get('', [])
         views = []
         try:
-            extra = self.get_extra()
-            medatada_cache_timeout = extra.get('metadata_cache_timeout', {})
-            table_cache_timeout = medatada_cache_timeout.get('table_cache_timeout')
-            enable_cache = 'table_cache_timeout' in medatada_cache_timeout
             views = self.db_engine_spec.get_view_names(
-                inspector=self.inspector,
-                db_id=self.id,
-                schema=schema,
-                enable_cache=enable_cache,
-                cache_timeout=table_cache_timeout,
-                force=force)
+                inspector=self.inspector, schema=schema)
         except Exception:
             pass
         return views
 
-    def all_schema_names(self, force_refresh=False):
-        extra = self.get_extra()
-        medatada_cache_timeout = extra.get('metadata_cache_timeout', {})
-        schema_cache_timeout = medatada_cache_timeout.get('schema_cache_timeout')
-        enable_cache = 'schema_cache_timeout' in medatada_cache_timeout
-        return sorted(self.db_engine_spec.get_schema_names(
-            inspector=self.inspector,
-            enable_cache=enable_cache,
-            cache_timeout=schema_cache_timeout,
-            db_id=self.id,
-            force=force_refresh))
+    @cache_util.memoized_func(
+        key=lambda *args, **kwargs: 'db:{}:schema_list'.format(kwargs.get('db_id')),
+        use_tables_cache=True)
+    def all_schema_names(self, enable_cache=False, cache_timeout=None,
+                         force=False, db_id=None):
+        """
+        For unused parameters, they are referenced in
+        cache_util.memoized_func decorator
+
+        :param enable_cache: whether cache is enabled for the function
+        :type enable_cache: bool
+        :param cache_timeout: timeout in seconds for the cache
+        :type cache_timeout: int
+        :param force: whether to force refresh the cache
+        :type force: bool
+        :param db_id: database id
+        :type db_id: int
+        :return: schema list
+        :rtype: list
+        """
+        return self.db_engine_spec.get_schema_names(self.inspector)
 
     @property
     def db_engine_spec(self):

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -933,7 +933,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             db_id=kwargs.get('db_id'), schema=kwargs.get('schema')),
         use_tables_cache=True)
     def all_view_names_in_schema(self, schema, db_id=None, cache=False,
-                                  cache_timeout=None, force=False):
+                                 cache_timeout=None, force=False):
         """
         Parameters need to be passed as keyword arguments.
         If cache=True, db_id must be passed in for setting cache key

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -866,7 +866,8 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     @cache_util.memoized_func(
         key=lambda *args, **kwargs: 'db:{}:schema:None:table_list',
         attribute_in_key='id')
-    def all_table_names_in_database(self, cache=False, cache_timeout=None, force=False):
+    def all_table_names_in_database(self, cache=False,
+                                    cache_timeout=None, force=False):
         """Parameters need to be passed as keyword arguments."""
         if not self.allow_multi_schema_metadata_fetch:
             return []
@@ -875,16 +876,19 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     @cache_util.memoized_func(
         key=lambda *args, **kwargs: 'db:{}:schema:None:view_list',
         attribute_in_key='id')
-    def all_view_names_in_database(self, cache=False, cache_timeout=None, force=False):
+    def all_view_names_in_database(self, cache=False,
+                                   cache_timeout=None, force=False):
         """Parameters need to be passed as keyword arguments."""
         if not self.allow_multi_schema_metadata_fetch:
             return []
         return self.db_engine_spec.fetch_result_sets(self, 'view')
 
     @cache_util.memoized_func(
-        key=lambda *args, **kwargs: 'db:{{}}:schema:{}:table_list'.format(kwargs.get('schema')),
+        key=lambda *args, **kwargs: 'db:{{}}:schema:{}:table_list'.format(
+            kwargs.get('schema')),
         attribute_in_key='id')
-    def all_table_names_in_schema(self, schema, cache=False, cache_timeout=None, force=False):
+    def all_table_names_in_schema(self, schema, cache=False,
+                                  cache_timeout=None, force=False):
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
@@ -910,9 +914,11 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         return tables
 
     @cache_util.memoized_func(
-        key=lambda *args, **kwargs: 'db:{{}}:schema:{}:table_list'.format(kwargs.get('schema')),
+        key=lambda *args, **kwargs: 'db:{{}}:schema:{}:table_list'.format(
+            kwargs.get('schema')),
         attribute_in_key='id')
-    def all_view_names_in_schema(self, schema, cache=False, cache_timeout=None, force=False):
+    def all_view_names_in_schema(self, schema, cache=False,
+                                 cache_timeout=None, force=False):
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -638,7 +638,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     allow_ctas = Column(Boolean, default=False)
     allow_dml = Column(Boolean, default=False)
     force_ctas_schema = Column(String(250))
-    allow_multi_schema_metadata_fetch = Column(Boolean, default=True)
+    allow_multi_schema_metadata_fetch = Column(Boolean, default=False)
     extra = Column(Text, default=textwrap.dedent("""\
     {
         "metadata_params": {},

--- a/superset/templates/superset/form_view/csv_to_database_view/edit.html
+++ b/superset/templates/superset/form_view/csv_to_database_view/edit.html
@@ -18,7 +18,7 @@
     function update_schemas_allowed_for_csv_upload(db_id) {
         $.ajax({
           method: "GET",
-          url: "/superset/schema_access_for_csv_upload",
+          url: "/superset/schemas_access_for_csv_upload",
           data: {db_id: db_id},
           dataType: 'json',
           contentType: "application/json; charset=utf-8"

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -53,7 +53,7 @@ def memoized_func(key=view_cache_key, use_tables_cache=False):
         else:
             # noop
             def wrapped_f(cls, *args, **kwargs):
-                logging.info('no cache is selected')
+                logging.info('no cache is configured or selected')
                 return f(cls, *args, **kwargs)
         return wrapped_f
     return wrap

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -1,6 +1,4 @@
 # pylint: disable=C,R,W
-import logging
-
 from flask import request
 
 from superset import cache, tables_cache
@@ -37,15 +35,12 @@ def memoized_func(key=view_cache_key, use_tables_cache=False):
         if selected_cache:
             def wrapped_f(cls, *args, **kwargs):
                 if not kwargs.get('cache', True):
-                    logging.info('dont use cache per function call')
                     return f(cls, *args, **kwargs)
 
                 cache_key = key(*args, **kwargs)
                 o = selected_cache.get(cache_key)
                 if not kwargs.get('force') and o is not None:
-                    logging.info('use cache')
                     return o
-                logging.info('cache is expired and/or force refresh')
                 o = f(cls, *args, **kwargs)
                 selected_cache.set(cache_key, o,
                                    timeout=kwargs.get('cache_timeout'))
@@ -53,7 +48,6 @@ def memoized_func(key=view_cache_key, use_tables_cache=False):
         else:
             # noop
             def wrapped_f(cls, *args, **kwargs):
-                logging.info('no cache is configured or selected')
                 return f(cls, *args, **kwargs)
         return wrapped_f
     return wrap

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -32,7 +32,8 @@ def memoized_func(key=view_cache_key, attribute_in_key=None):
                     return f(self, *args, **kwargs)
 
                 if attribute_in_key:
-                    cache_key = key(*args, **kwargs).format(getattr(self, attribute_in_key))
+                    cache_key = key(*args, **kwargs).format(
+                        getattr(self, attribute_in_key))
                 else:
                     cache_key = key(*args, **kwargs)
                 o = tables_cache.get(cache_key)

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -1,7 +1,7 @@
 # pylint: disable=C,R,W
 from flask import request
 
-from superset import cache, tables_cache
+from superset import tables_cache
 
 
 def view_cache_key(*unused_args, **unused_kwargs):
@@ -9,7 +9,7 @@ def view_cache_key(*unused_args, **unused_kwargs):
     return 'view/{}/{}'.format(request.path, args_hash)
 
 
-def memoized_func(key=view_cache_key, use_tables_cache=False):
+def memoized_func(key=view_cache_key, attribute_in_key=None):
     """Use this decorator to cache functions that have predefined first arg.
 
     enable_cache is treated as True by default,
@@ -26,28 +26,25 @@ def memoized_func(key=view_cache_key, use_tables_cache=False):
     returns the caching key.
     """
     def wrap(f):
-        selected_cache = None
-        if use_tables_cache and tables_cache:
-            selected_cache = tables_cache
-        elif not use_tables_cache and cache:
-            selected_cache = cache
-
-        if selected_cache:
-            def wrapped_f(cls, *args, **kwargs):
+        if tables_cache:
+            def wrapped_f(self, *args, **kwargs):
                 if not kwargs.get('cache', True):
-                    return f(cls, *args, **kwargs)
+                    return f(self, *args, **kwargs)
 
-                cache_key = key(*args, **kwargs)
-                o = selected_cache.get(cache_key)
+                if attribute_in_key:
+                    cache_key = key(*args, **kwargs).format(getattr(self, attribute_in_key))
+                else:
+                    cache_key = key(*args, **kwargs)
+                o = tables_cache.get(cache_key)
                 if not kwargs.get('force') and o is not None:
                     return o
-                o = f(cls, *args, **kwargs)
-                selected_cache.set(cache_key, o,
-                                   timeout=kwargs.get('cache_timeout'))
+                o = f(self, *args, **kwargs)
+                tables_cache.set(cache_key, o,
+                                 timeout=kwargs.get('cache_timeout'))
                 return o
         else:
             # noop
-            def wrapped_f(cls, *args, **kwargs):
-                return f(cls, *args, **kwargs)
+            def wrapped_f(self, *args, **kwargs):
+                return f(self, *args, **kwargs)
         return wrapped_f
     return wrap

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -36,8 +36,8 @@ def memoized_func(key=view_cache_key, use_tables_cache=False):
 
         if selected_cache:
             def wrapped_f(cls, *args, **kwargs):
-                if not kwargs.get('enable_cache', True):
-                    logging.info('cache is not enabled')
+                if not kwargs.get('cache', True):
+                    logging.info('dont use cache per function call')
                     return f(cls, *args, **kwargs)
 
                 cache_key = key(*args, **kwargs)
@@ -48,7 +48,7 @@ def memoized_func(key=view_cache_key, use_tables_cache=False):
                 logging.info('cache is expired and/or force refresh')
                 o = f(cls, *args, **kwargs)
                 selected_cache.set(cache_key, o,
-                                   timeout=kwargs.get('cache_timeout', 600))
+                                   timeout=kwargs.get('cache_timeout'))
                 return o
         else:
             # noop

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2840,7 +2840,7 @@ class Superset(BaseSupersetView):
 
     @api
     @has_access_api
-    @expose('/schema_access_for_csv_upload')
+    @expose('/schemas_access_for_csv_upload')
     def schemas_access_for_csv_upload(self):
         """
         This method exposes an API endpoint to

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1552,8 +1552,7 @@ class Superset(BaseSupersetView):
             .filter_by(id=db_id)
             .one()
         )
-        schemas = database.all_schema_names(db_id=db_id,
-                                            cache=database.schema_cache_enabled,
+        schemas = database.all_schema_names(cache=database.schema_cache_enabled,
                                             cache_timeout=database.schema_cache_timeout,
                                             force=force_refresh)
         schemas = security_manager.schemas_accessible_by_user(database, schemas)
@@ -1575,18 +1574,18 @@ class Superset(BaseSupersetView):
 
         if schema:
             table_names = database.all_table_names_in_schema(
-                db_id=db_id, schema=schema, force=force_refresh,
+                schema=schema, force=force_refresh,
                 cache=database.table_cache_enabled,
                 cache_timeout=database.table_cache_timeout)
             view_names = database.all_view_names_in_schema(
-                db_id=db_id, schema=schema, force=force_refresh,
+                schema=schema, force=force_refresh,
                 cache=database.table_cache_enabled,
                 cache_timeout=database.table_cache_timeout)
         else:
             table_names = database.all_table_names_in_database(
-                db_id=db_id, cache=True, force=False, cache_timeout=24 * 60 * 60)
+                cache=True, force=False, cache_timeout=24 * 60 * 60)
             view_names = database.all_view_names_in_database(
-                db_id=db_id, cache=True, force=False, cache_timeout=24 * 60 * 60)
+                cache=True, force=False, cache_timeout=24 * 60 * 60)
         table_names = security_manager.accessible_by_user(database, table_names, schema)
         view_names = security_manager.accessible_by_user(database, view_names, schema)
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -212,7 +212,7 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
             'A timeout of 0 indicates that the cache never expires.<br/>'
             '3. The ``schemas_allowed_for_csv_upload`` is a comma separated list '
             'of schemas that CSVs are allowed to upload to. '
-            'Specify it as **"schemas_allowed": ["public", "csv_upload"]**. '
+            'Specify it as **"schemas_allowed_for_csv_upload": ["public", "csv_upload"]**. '
             'If database flavor does not support schema or any schema is allowed '
             'to be accessed, just leave the list empty', True),
         'impersonate_user': _(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -398,7 +398,7 @@ appbuilder.add_view_no_menu(CsvToDatabaseView)
 
 
 class DatabaseTablesAsync(DatabaseView):
-    list_columns = ['id', 'all_table_names', 'all_schema_names']
+    list_columns = ['id', 'all_table_names_in_database', 'all_schema_names']
 
 
 appbuilder.add_view_no_menu(DatabaseTablesAsync)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -715,7 +715,7 @@ class CoreTests(SupersetTestCase):
             id=db_id,
             extra=extra)
         data = self.get_json_resp(
-            url='/superset/schema_access_for_csv_upload?db_id={db_id}'
+            url='/superset/schemas_access_for_csv_upload?db_id={db_id}'
                 .format(db_id=dbobj.id))
         assert data == ['this_schema_is_allowed_too']
 


### PR DESCRIPTION
1. `pyhive` is calling `use default` when a connection is initiated, https://github.com/dropbox/PyHive/blob/2c2446bf905ea321aac9dcdd3fa033909ff0b0b5/pyhive/hive.py#L205. This statement took 3 seconds in my experiment, so even metadata cache is enabled for Hive, user experience is still not very good.

Moving the cache one layer up can avoid running `use default` statement.

2. Refactored the cache logic for multi schema metadata fetch. Every time when multi schema metadata fetch is updated, it refreshes table list cache for every schema as well.