### PR TITLE
authentication via JWT providers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,7 @@ polyline==1.3.2
 pycparser==2.19           # via cffi
 pydruid==0.4.4
 pyhive==0.5.1
+PyJWT==1.6.4
 python-dateutil==2.6.1
 python-editor==1.0.3      # via alembic
 python-geohash==0.8.5

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'polyline',
         'pydruid>=0.4.3',
         'pyhive>=0.4.0',
+        'PyJWT>=1.6.4',
         'python-dateutil',
         'python-geohash',
         'pyyaml>=3.11',

--- a/superset/config.py
+++ b/superset/config.py
@@ -137,6 +137,15 @@ AUTH_TYPE = AUTH_DB
 #    { 'name': 'Flickr', 'url': 'http://www.flickr.com/<username>' },
 #    { 'name': 'MyOpenID', 'url': 'https://www.myopenid.com' }]
 
+# Setup use JWT token from JWT provider for authentication
+# JWT_LOGIN_ENABLED = False
+# JWT_AUTH_ALGORITHMS = ['HS256', 'RS256', 'ES256']
+# JWT_AUTH_ISSUER = 'https://issuer'
+# JWT_AUTH_PUBLIC_CERTS_URL = 'https://certs'
+# JWT_AUTH_AUDIENCE = 'aud'
+# JWT_AUTH_COOKIE_NAME = 'CF_Authorization'
+# AUTH_USER_REGISTRATION = True
+
 # ---------------------------------------------------
 # Roles config
 # ---------------------------------------------------

--- a/superset/jwt_auth.py
+++ b/superset/jwt_auth.py
@@ -1,0 +1,62 @@
+import jwt
+import requests
+import json
+import logging
+
+
+def get_public_keys(url):
+
+    """
+    Returns:
+        List of RSA public keys usable by PyJWT.
+    """
+    key_cache = get_public_keys.key_cache
+    if url in key_cache:
+        return key_cache[url]
+    else:
+        r = requests.get(url)
+        r.raise_for_status()
+        data = r.json()
+        if 'keys' in data:
+            public_keys = []
+            for key_dict in data['keys']:
+                public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key_dict))
+                public_keys.append(public_key)
+
+            get_public_keys.key_cache[url] = public_keys
+            return public_keys
+        else:
+            get_public_keys.key_cache[url] = data
+            return data
+get_public_keys.key_cache = {}
+
+
+def verify_jwt_token(jwt_token, expected_issuer, expected_audience, algorithms, public_certs_url):
+    # https://developers.cloudflare.com/access/setting-up-access/validate-jwt-tokens/
+    # https://cloud.google.com/iap/docs/signed-headers-howto
+    # Loop through the keys since we can't pass the key set to the decoder
+    keys = get_public_keys(public_certs_url)
+
+    key_id = jwt.get_unverified_header(jwt_token).get('kid', '')
+    if key_id and isinstance(keys, dict):
+        keys = [keys.get(key_id)]
+
+    valid_token = False
+    payload = None
+    for key in keys:
+        try:
+            # decode returns the claims which has the email if you need it
+            payload = jwt.decode(
+                jwt_token,
+                key=key,
+                audience=expected_audience,
+                algorithms=algorithms
+            )
+            issuer = payload['iss']
+            if issuer != expected_issuer:
+                raise Exception('Wrong issuer: {}'.format(issuer))
+            valid_token = True
+            break
+        except Exception as e:
+            logging.exception(e)
+    return payload, valid_token

--- a/superset/jwt_auth.py
+++ b/superset/jwt_auth.py
@@ -1,7 +1,7 @@
-import jwt
-import requests
 import json
 import logging
+import jwt
+import requests
 
 
 def get_public_keys(url):
@@ -28,10 +28,13 @@ def get_public_keys(url):
         else:
             get_public_keys.key_cache[url] = data
             return data
+
+
 get_public_keys.key_cache = {}
 
 
-def verify_jwt_token(jwt_token, expected_issuer, expected_audience, algorithms, public_certs_url):
+def verify_jwt_token(jwt_token, expected_issuer, expected_audience, algorithms,
+                     public_certs_url):
     # https://developers.cloudflare.com/access/setting-up-access/validate-jwt-tokens/
     # https://cloud.google.com/iap/docs/signed-headers-howto
     # Loop through the keys since we can't pass the key set to the decoder

--- a/superset/jwt_auth.py
+++ b/superset/jwt_auth.py
@@ -1,5 +1,6 @@
 import json
 import logging
+
 import jwt
 import requests
 
@@ -53,7 +54,7 @@ def verify_jwt_token(jwt_token, expected_issuer, expected_audience, algorithms,
                 jwt_token,
                 key=key,
                 audience=expected_audience,
-                algorithms=algorithms
+                algorithms=algorithms,
             )
             issuer = payload['iss']
             if issuer != expected_issuer:

--- a/superset/jwt_auth.py
+++ b/superset/jwt_auth.py
@@ -1,3 +1,4 @@
+# pylint: disable=C,R,W
 import json
 import logging
 

--- a/superset/security.py
+++ b/superset/security.py
@@ -84,10 +84,6 @@ class SupersetSecurityManager(SecurityManager):
         app.config.setdefault('JWT_LOGIN_ENABLED', False)
 
         if app.config['JWT_LOGIN_ENABLED']:
-            try:
-                import jwt
-            except ImportError:
-                raise Exception('No PyJWT library for python.')
 
             if not any([app.config.get('JWT_AUTH_COOKIE_NAME'),
                         app.config.get('JWT_AUTH_HEADER_NAME')]):
@@ -474,11 +470,11 @@ class SupersetSecurityManager(SecurityManager):
                 first_name=payload.get('first_name', ''),
                 last_name=payload.get('last_name', ''),
                 email=payload['email'],
-                role=self.find_role(self.auth_user_registration_role)
+                role=self.find_role(self.auth_user_registration_role),
             )
 
             if not user:
-                log.error("Error creating a new JWT user {0}".format(payload))
+                log.error('Error creating a new JWT user {0}'.format(payload))
                 return None
         return user
 

--- a/superset/security.py
+++ b/superset/security.py
@@ -89,10 +89,12 @@ class SupersetSecurityManager(SecurityManager):
             except ImportError:
                 raise Exception('No PyJWT library for python.')
 
-            if not any([app.config.get('JWT_AUTH_COOKIE_NAME'), app.config.get('JWT_AUTH_HEADER_NAME')]):
+            if not any([app.config.get('JWT_AUTH_COOKIE_NAME'),
+                        app.config.get('JWT_AUTH_HEADER_NAME')]):
                 raise Exception('Missing JWT_AUTH_COOKIE_NAME or JWT_AUTH_HEADER_NAME')
             empty_jwt_values = [
-                k for k in ['JWT_AUTH_PUBLIC_CERTS_URL', 'JWT_AUTH_AUDIENCE', 'JWT_AUTH_ISSUER', 'JWT_AUTH_ALGORITHMS']
+                k for k in ['JWT_AUTH_PUBLIC_CERTS_URL', 'JWT_AUTH_AUDIENCE',
+                            'JWT_AUTH_ISSUER', 'JWT_AUTH_ALGORITHMS']
                 if not app.config.get(k)
             ]
             if empty_jwt_values:
@@ -509,7 +511,8 @@ class SupersetSecurityManager(SecurityManager):
             return self.auth_user_jwt(payload)
 
     def load_user_from_jwt_token(self, request):
-        if self.appbuilder.app.config['JWT_LOGIN_ENABLED'] and not getattr(request, '_load_user_from_jwt_token_lock', False):
+        if self.appbuilder.app.config['JWT_LOGIN_ENABLED'] and \
+                not getattr(request, '_load_user_from_jwt_token_lock', False):
             request._load_user_from_jwt_token_lock = True
             user = self.jwt_token_load_user_from_request(request)
             request._load_user_from_jwt_token_lock = False


### PR DESCRIPTION
This add one more authentication method via JWT providers like Cloudflare Access or Google IAP.
Example config:
```python
JWT_LOGIN_ENABLED = True
JWT_AUTH_ALGORITHMS = ['HS256', 'RS256', 'ES256']
AUTH_USER_REGISTRATION = True
AUTH_USER_REGISTRATION_ROLE = 'Admin'

# For CF Access
JWT_AUTH_ISSUER = '<your auth domain>'
JWT_AUTH_PUBLIC_CERTS_URL = 'https://<your auth domain>/cdn-cgi/access/certs'
JWT_AUTH_AUDIENCE = 'e71a4e5efa1dc461bcc44050ef65cf25ba124b8364ccd5db472f3845a72c34f9'
JWT_AUTH_COOKIE_NAME = 'CF_Authorization'

# For Google IAP
JWT_AUTH_PUBLIC_CERTS_URL = 'https://www.gstatic.com/iap/verify/public_key'
JWT_AUTH_AUDIENCE = '/projects/PROJECT_NUMBER/apps/PROJECT_ID'
JWT_AUTH_ISSUER = 'https://cloud.google.com/iap'
JWT_AUTH_HEADER_NAME = 'X-Goog-IAP-JWT-Assertion'
```