### PR TITLE
[bugfix] no error message is displayed

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -176,22 +176,22 @@ export function runQuery(formData, force = false, timeout = 60, key) {
         } else if (err.statusText === 'AbortError') {
           dispatch(chartUpdateStopped(key));
         } else {
-          let errObject = err;
-          if (err.responseJSON) {
-            errObject = err.responseJSON;
-          } else if (err.stack) {
-            errObject = {
-              error:
-                t('Unexpected error: ') +
-                (err.description || t('(no description, click to see stack trace)')),
-              stacktrace: err.stack,
-            };
-          } else if (err.responseText && err.responseText.indexOf('CSRF') >= 0) {
-            errObject = {
-              error: COMMON_ERR_MESSAGES.SESSION_TIMED_OUT,
-            };
-          }
-          dispatch(chartUpdateFailed(errObject, key));
+          err.json().then((errPayload) => {
+            let errObject = { ...errPayload };
+            if (errObject.stack) {
+              errObject = {
+                error:
+                  t('Unexpected error: ') +
+                  (err.description || t('(no description, click to see stack trace)')),
+                stacktrace: err.stack,
+              };
+            } else if (err.responseText && err.responseText.indexOf('CSRF') >= 0) {
+              errObject = {
+                error: COMMON_ERR_MESSAGES.SESSION_TIMED_OUT,
+              };
+            }
+            dispatch(chartUpdateFailed(errObject, key));
+          });
         }
       });
 


### PR DESCRIPTION
This bug is pretty bad as no error messages are displayed in both the
dashboard and explore view. I'm guessing it's related to moving from
using jQuery to fetch.

@williaster @kristw 