### PR TITLE
add back `lower` on redshift/oracle

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -501,6 +501,10 @@ class RedshiftEngineSpec(PostgresBaseEngineSpec):
     engine = 'redshift'
     force_column_alias_quotes = True
 
+    @staticmethod
+    def normalize_column_name(column_name):
+        return column_name.lower()
+
 
 class OracleEngineSpec(PostgresBaseEngineSpec):
     engine = 'oracle'
@@ -524,6 +528,10 @@ class OracleEngineSpec(PostgresBaseEngineSpec):
         return (
             """TO_TIMESTAMP('{}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""
         ).format(dttm.isoformat())
+
+    @staticmethod
+    def normalize_column_name(column_name):
+        return column_name.lower()
 
 
 class Db2EngineSpec(BaseEngineSpec):


### PR DESCRIPTION
Seems the fix here https://github.com/apache/incubator-superset/pull/5337 got recently removed by https://github.com/apache/incubator-superset/commit/a165aec822e5014a99b6467ed6d3d87184e13bc4#diff-6519edc75f2440a575cb22492f401100 (https://github.com/apache/incubator-superset/pull/5467)