### PR TITLE
[bugfix] Fix language switch

### DIFF
--- a/superset/assets/src/common.js
+++ b/superset/assets/src/common.js
@@ -3,8 +3,8 @@ import $ from 'jquery';
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import { SupersetClient } from '@superset-ui/core';
 import { toggleCheckbox } from './modules/utils';
-import setupColors from './setup/setupColors';
 import setupClient from './setup/setupClient';
+import setupColors from './setup/setupColors';
 
 setupClient();
 setupColors();

--- a/superset/assets/src/common.js
+++ b/superset/assets/src/common.js
@@ -1,9 +1,13 @@
-/* eslint global-require: 0, no-console: 0 */
+/* eslint global-require: 0 */
 import $ from 'jquery';
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import { SupersetClient } from '@superset-ui/core';
 import { toggleCheckbox } from './modules/utils';
 import setupColors from './setup/setupColors';
+import setupClient from './setup/setupClient';
+
+setupClient();
+setupColors();
 
 $(document).ready(function () {
   $(':checkbox[data-checkbox-api-prefix]').change(function () {
@@ -16,15 +20,15 @@ $(document).ready(function () {
   // for language picker dropdown
   $('#language-picker a').click(function (ev) {
     ev.preventDefault();
-
-    SupersetClient.get({ endpoint: ev.currentTarget.href })
+    SupersetClient.get({
+      endpoint: ev.currentTarget.getAttribute('href'),
+      parseMethod: null,
+    })
       .then(() => {
         location.reload();
       });
   });
 });
-
-setupColors();
 
 export function appSetup() {
   // A set of hacks to allow apps to run within a FAB template
@@ -32,17 +36,4 @@ export function appSetup() {
   window.$ = $;
   window.jQuery = $;
   require('bootstrap');
-
-  const csrfNode = document.querySelector('#csrf_token');
-  const csrfToken = csrfNode ? csrfNode.value : null;
-
-  SupersetClient.configure({
-    protocol: (window.location && window.location.protocol) || '',
-    host: (window.location && window.location.host) || '',
-    csrfToken,
-  })
-    .init()
-    .catch((error) => {
-      console.warn('Error initializing SupersetClient', error);
-    });
 }

--- a/superset/assets/src/setup/setupClient.js
+++ b/superset/assets/src/setup/setupClient.js
@@ -1,0 +1,17 @@
+/* eslint no-console: 0 */
+import { SupersetClient } from '@superset-ui/core';
+
+export default function setupClient() {
+  const csrfNode = document.querySelector('#csrf_token');
+  const csrfToken = csrfNode ? csrfNode.value : null;
+
+  SupersetClient.configure({
+    protocol: (window.location && window.location.protocol) || '',
+    host: (window.location && window.location.host) || '',
+    csrfToken,
+  })
+    .init()
+    .catch((error) => {
+      console.warn('Error initializing SupersetClient', error);
+    });
+}


### PR DESCRIPTION
Language switch is not working after the switch to `SupersetClient` for multiple reasons:

1. When clicked on the dropdown, `SupersetClient.get()` was called before `SupersetClient.configure()`
2. `ev.currentTarget.href` returns full url (`http://localhost:9000/lang/en`) while `ev.currentTarget.getAttribute('href')` returns the exact value (just `/lang/en` from `<a href="/lang/en">`). The former crashed `SupersetClient.get()` because it ends up using `http://localhost:9000/http://localhost:9000/lang/en` as full url.
3. Hitting `/lang/xx` API does not require parsing. Try to parse it as json resulting in error. 

This PR fixes the above by:

1. Ensure `SupersetClient.configure()` is called in `common.js` and before the link is clicked. Also extract the setup into a separate file to keep `common.js` lean.
2. Change `ev.currentTarget.href` to `ev.currentTarget.getAttribute('href')`
3. Disable `parseMethod` by setting it to `null`.

@williaster @michellethomas @graceguo-supercat 