### PR TITLE
[explore] Include "Autocomplete Query Predicate" field to Table Editor

### DIFF
--- a/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -6,6 +6,7 @@ import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
 
 import DatasourceEditor from '../../../src/datasource/DatasourceEditor';
+import Field from '../../../src/CRUD/Field';
 import mockDatasource from '../../fixtures/mockDatasource';
 
 const props = {
@@ -69,5 +70,10 @@ describe('DatasourceEditor', () => {
     expect(inst.state.databaseColumns).toHaveLength(numCols);
     inst.mergeColumns([extraColumn]);
     expect(inst.state.databaseColumns).toHaveLength(numCols + 1);
+  });
+
+  it('renders isSqla fields', () => {
+    expect(wrapper.state('isSqla')).toBe(true);
+    expect(wrapper.find(Field).find({ fieldKey: 'fetch_values_predicate' }).exists()).toBe(true);
   });
 });

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -336,6 +336,18 @@ export class DatasourceEditor extends React.PureComponent {
           descr={t('Whether to populate autocomplete filters options')}
           control={<CheckboxControl />}
         />
+        {this.state.isSqla &&
+          <Field
+            fieldKey="fetch_values_predicate"
+            label={t('Autocomplete Query Predicate')}
+            descr={t(
+              'When using "Autocomplete filters", this can be used to improve performance ' +
+              'of the query fetching the values. Use this option to apply a ' +
+              'predicate (WHERE clause) to the query selecting the distinct ' +
+              'values from the table. Typically the intent would be to limit the scan ' +
+              'by applying a relative time filter on a partitioned or indexed time-related field.')}
+            control={<TextControl />}
+          />}
         <Field
           fieldKey="owner"
           label={t('Owner')}

--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -177,13 +177,13 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
 
       const controller = new AbortController();
       const { signal } = controller;
-      this.setState({ abortActiveRequest: controller.abort });
+      this.setState({ abortActiveRequest: controller.abort, loading: true });
 
       SupersetClient.get({
         signal,
         endpoint: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
       }).then(({ json }) => {
-        this.setState(() => ({ suggestions: json, abortActiveRequest: null }));
+        this.setState(() => ({ suggestions: json, abortActiveRequest: null, loading: false }));
       });
     }
   }
@@ -272,7 +272,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
                 freeForm
                 name="filter-comparator-value"
                 value={adhocFilter.comparator}
-                isLoading={false}
+                isLoading={this.state.loading}
                 choices={this.state.suggestions}
                 onChange={this.onComparatorChange}
                 showHeader={false}

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -282,7 +282,9 @@ class SqlaTable(Model, BaseDatasource):
     export_fields = (
         'table_name', 'main_dttm_col', 'description', 'default_endpoint',
         'database_id', 'offset', 'cache_timeout', 'schema',
-        'sql', 'params', 'template_params', 'filter_select_enabled')
+        'sql', 'params', 'template_params', 'filter_select_enabled',
+        'fetch_values_predicate',
+    )
     update_from_object_fields = [
         f for f in export_fields if f not in ('table_name', 'database_id')]
     export_parent = 'database'
@@ -414,6 +416,7 @@ class SqlaTable(Model, BaseDatasource):
             d['granularity_sqla'] = utils.choicify(self.dttm_cols)
             d['time_grain_sqla'] = grains
             d['main_dttm_col'] = self.main_dttm_col
+            d['fetch_values_predicate'] = self.fetch_values_predicate
         return d
 
     def values_for_column(self, column_name, limit=10000):


### PR DESCRIPTION
1. Bringing "Autocomplete Query Predicate" to table editor
1. Show loading spinner while values are getting fetched
<img width="420" alt="screen shot 2018-10-24 at 12 36 26 am" src="https://user-images.githubusercontent.com/487433/47414067-ec6a8b00-d724-11e8-9627-dc2c37e6e096.png">

@betodealmeida 
