### PR TITLE
[superset-client][bugfix] fix stop query

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -174,7 +174,7 @@ export function runQuery(formData, force = false, timeout = 60, key) {
 
         if (response.statusText === 'timeout') {
           return dispatch(chartUpdateTimeout(response.statusText, timeout, key));
-        } else if (response.statusText === 'AbortError') {
+        } else if (response.name === 'AbortError') {
           return dispatch(chartUpdateStopped(key));
         }
         return getClientErrorObject(response).then(parsedResponse =>

--- a/superset/assets/src/chart/chartReducer.js
+++ b/superset/assets/src/chart/chartReducer.js
@@ -10,7 +10,7 @@ export const chart = {
   chartUpdateEndTime: null,
   chartUpdateStartTime: 0,
   latestQueryFormData: {},
-  queryRequest: null,
+  queryController: null,
   queryResponse: null,
   triggerQuery: true,
   lastRendered: 0,
@@ -32,12 +32,13 @@ export default function chartReducer(charts = {}, action) {
       };
     },
     [actions.CHART_UPDATE_STARTED](state) {
-      return { ...state,
+      return {
+        ...state,
         chartStatus: 'loading',
         chartAlert: null,
         chartUpdateEndTime: null,
         chartUpdateStartTime: now(),
-        queryRequest: action.queryRequest,
+        queryController: action.queryController,
       };
     },
     [actions.CHART_UPDATE_STOPPED](state) {

--- a/superset/assets/src/common.js
+++ b/superset/assets/src/common.js
@@ -6,9 +6,6 @@ import { toggleCheckbox } from './modules/utils';
 import setupClient from './setup/setupClient';
 import setupColors from './setup/setupColors';
 
-setupClient();
-setupColors();
-
 $(document).ready(function () {
   $(':checkbox[data-checkbox-api-prefix]').change(function () {
     const $this = $(this);
@@ -31,6 +28,9 @@ $(document).ready(function () {
 });
 
 export function appSetup() {
+  setupClient();
+  setupColors();
+
   // A set of hacks to allow apps to run within a FAB template
   // this allows for the server side generated menus to function
   window.$ = $;


### PR DESCRIPTION
🐛Bug fixes
This PR fixes two issues

- When breaking the larger ajax refactor into multiple PRs this functionality was partially lost and the fetch `queryController` was not passed along properly to the control panel meaning that clicking `Stop` in the explore view for a query had no effect. This PR fixes that:  

<img src="https://user-images.githubusercontent.com/4496521/47452442-25cfe480-d77f-11e8-894c-370ddab7a154.png" width="500" />

- #6166 moved `setupClient` to the top of the `common.js` file, but at call time the DOM is not available and so we can never pull the `csrf` token value at that time. that means that we always request the token which is unnecesssary and also may contribute to cypress flakiness. This PR moves `setupClient` calls back into `appSetup`

@kristw @mistercrunch @michellethomas @graceguo-supercat 