### PR TITLE
[fix] should allow force refresh when having charts under tab

### DIFF
--- a/superset/assets/cypress/integration/dashboard/controls.js
+++ b/superset/assets/cypress/integration/dashboard/controls.js
@@ -57,9 +57,10 @@ export default () => describe('top-level controls', () => {
   });
 
   it('should allow dashboard level force refresh', () => {
-    // should not show dashobard level force refresh
+    // when charts are not start loading, for example, under a secondary tab,
+    // should allow force refresh
     cy.get('#save-dash-split-button').trigger('click');
-    cy.contains('Force refresh dashboard').parent().should('have.class', 'disabled');
+    cy.contains('Force refresh dashboard').parent().not('have.class', 'disabled');
 
     // wait the all dash finish loading.
     cy.wait(sliceRequests);

--- a/superset/assets/src/dashboard/util/isDashboardLoading.js
+++ b/superset/assets/src/dashboard/util/isDashboardLoading.js
@@ -1,5 +1,5 @@
 export default function isDashboardLoading(charts) {
   return Object.values(charts).some(
-    chart => chart.chartUpdateStartTime >= (chart.chartUpdateEndTime || 0),
+    chart => chart.chartUpdateStartTime > (chart.chartUpdateEndTime || 0),
   );
 }


### PR DESCRIPTION
this issue was introduced from #6034. 
When charts are under secondary tabs, they are not start loading unless tab is selected. in this case we will have chart's chartUpdateStartTime = 0, and we should treat this state as not loading.