### PR TITLE
add get_data method to IFrameViz

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1823,6 +1823,9 @@ class IFrameViz(BaseViz):
     def get_df(self, query_obj=None):
         return None
 
+    def get_data(self, df):
+        return {}
+
 
 class ParallelCoordinatesViz(BaseViz):
 


### PR DESCRIPTION
Fixes #6177 

I'm new to the superset code. Looking at viz.py it seems valid to overwrite the `get_data` method in a specific visualization. Not sure about tests. There does not seem to be a test for the IFrameViz to begin with, so I hope this is ok like this?