### PR TITLE
[datasource-editor] Correcting tooltip

### DIFF
--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -100,7 +100,7 @@ class DatasourceControl extends React.PureComponent {
         <OverlayTrigger
           placement="right"
           overlay={
-            <Tooltip id={'error-tooltip'}>{t('Click to point to another datasource')}</Tooltip>
+            <Tooltip id={'error-tooltip'}>{t('Click to edit the datasource')}</Tooltip>
           }
         >
           <Label onClick={this.toggleEditDatasourceModal} style={{ cursor: 'pointer' }} className="m-r-5">


### PR DESCRIPTION
Given that one cannot change (point to another) datasources through the datasource editor, I felt that the tooltip should be updated to reflect that one can merely only edit the existing the datasource.

![screen shot 2018-10-25 at 12 57 19 pm](https://user-images.githubusercontent.com/4567245/47526853-e2947500-d855-11e8-9a9e-b0bbe910dd63.png)

to: @graceguo-supercat @michellethomas @mistercrunch 