### PR TITLE
Fix typo in load-examples command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -145,7 +145,7 @@ Follow these few simple steps to install Superset.::
     superset db upgrade
 
     # Load some data to play with
-    superset load_examples
+    superset load-examples
 
     # Create default roles and permissions
     superset init


### PR DESCRIPTION
Noticed an incorrect command in the installation instructions that caused me the error as described in issue #6172.

Related issue: https://github.com/apache/incubator-superset/issues/6172
Related pull request: https://github.com/apache/incubator-superset/pull/6167