### PR TITLE
[datasource] Update SQL Lab exploration

### DIFF
--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -127,11 +127,15 @@ class DatasourceControl extends React.PureComponent {
             placement="right"
             overlay={
               <Tooltip id={'datasource-sqllab'}>
-                {t('Run SQL queries against this datasource')}
+                {t('Explore this datasource in SQL Lab')}
               </Tooltip>
             }
           >
-            <a href={'/superset/sqllab?datasourceKey=' + this.props.value}>
+            <a
+              href={`/superset/sqllab?datasourceKey=${this.props.value}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <i className="fa fa-flask m-r-5" />
             </a>
           </OverlayTrigger>}


### PR DESCRIPTION
This PR updates the exploration of a datasource in SQL Lab to ensure that the link opens in a new tab as it seems more intuitive that users would want to continue exploring. I also updated the tooltip to better reflect the action. 

Note that for Superset views the SQL Lab query in incorrect, i.e., it should contain the SQL associated with the view as opposed to `SELECT * FROM <view> LIMIT 100`. 

<img width="262" alt="screen shot 2018-10-25 at 5 28 46 pm" src="https://user-images.githubusercontent.com/4567245/47537698-3023d880-d87c-11e8-9d55-35557e8762d5.png">

to: @graceguo-supercat @kristw @michellethomas @mistercrunch   