### PR TITLE
[external-metadata] Fix unknown column types

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     and_, asc, Boolean, Column, DateTime, desc, ForeignKey, Integer, or_,
     select, String, Text,
 )
+from sqlalchemy.exc import CompileError
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql import column, literal_column, table, text
@@ -377,7 +378,10 @@ class SqlaTable(Model, BaseDatasource):
     def external_metadata(self):
         cols = self.database.get_columns(self.table_name, schema=self.schema)
         for col in cols:
-            col['type'] = '{}'.format(col['type'])
+            try:
+                col['type'] = str(col['type'])
+            except CompileError:
+                col['type'] = 'UNKNOWN'
         return cols
 
     @property


### PR DESCRIPTION
This PR fixes an issue where the SQLAlchemy `NullType()` cannot be cast to a string. Similar to [here](https://github.com/apache/incubator-superset/blob/bbfd69a138e97c062774c8f5997c9ecfce395fe4/superset/connectors/sqla/models.py#L832) the fix is merely to set the type as `UNKNOWN`.

to: @michellethomas @mistercrunch 