### PR TITLE
[build] fix pip install issues on OSX High Sierra

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -36,7 +36,9 @@ WORKDIR $HOME/incubator-superset
 COPY ./ ./
 
 RUN pip install --upgrade setuptools pip
-RUN pip install -e . && pip install -r requirements-dev.txt
+RUN pip install -r requirements.txt
+RUN pip install -r requirements-dev.txt
+RUN pip install -e .
 
 ENV PATH=/home/work/incubator-superset/superset/bin:$PATH \
     PYTHONPATH=./superset/:$PYTHONPATH

--- a/contrib/docker/docker-init.sh
+++ b/contrib/docker/docker-init.sh
@@ -9,7 +9,7 @@ fabmanager create-admin --app superset
 superset db upgrade
 
 # Load some data to play with
-superset load-examples
+superset load_examples
 
 # Create default roles and permissions
 superset init

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -145,7 +145,7 @@ Follow these few simple steps to install Superset.::
     superset db upgrade
 
     # Load some data to play with
-    superset load-examples
+    superset load_examples
 
     # Create default roles and permissions
     superset init

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ celery==4.2.0
 certifi==2018.8.24        # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
-click==6.7                # via flask, flask-appbuilder, tableschema, tabulator
+click==6.7
 colorama==0.3.9
 contextlib2==0.5.5
 cryptography==1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ billiard==3.5.0.4         # via celery
 bleach==2.1.2
 boto3==1.4.7
 botocore==1.7.48
-cchardet==1.1.3           # via tabulator
+cchardet==1.0.0           # via tabulator
 celery==4.2.0
 certifi==2018.8.24        # via requests
 cffi==1.11.5              # via cryptography
@@ -24,19 +24,18 @@ cryptography==1.9
 defusedxml==0.5.0         # via python3-openid
 docutils==0.14            # via botocore
 et-xmlfile==1.0.1         # via openpyxl
-flask-appbuilder==1.12.0
+flask-appbuilder==1.12.1
 flask-babel==0.11.1       # via flask-appbuilder
 flask-caching==1.4.0
 flask-compress==1.4.0
 flask-login==0.4.1        # via flask-appbuilder
 flask-migrate==2.1.1
 flask-openid==1.2.5       # via flask-appbuilder
-flask-sqlalchemy==2.1     # via flask-appbuilder, flask-migrate
+flask-sqlalchemy==2.3.2   # via flask-appbuilder, flask-migrate
 flask-wtf==0.14.2
 flask==0.12.2
 flower==0.9.2
 future==0.16.0
-futures==3.1.1            # via flower
 geopy==1.11.0
 gunicorn==19.8.0
 html5lib==1.0.1           # via bleach
@@ -69,12 +68,13 @@ python-editor==1.0.3      # via alembic
 python-geohash==0.8.5
 python3-openid==3.1.0     # via flask-openid
 pytz==2018.5              # via babel, celery, flower, pandas
-pyyaml==3.12
+pyyaml==3.13
 requests==2.18.4
 rfc3986==1.1.0            # via tableschema
 s3transfer==0.1.13        # via boto3
 sasl==0.2.1               # via thrift-sasl
 simplejson==3.15.0
+six==1.11.0               # via bleach, cryptography, html5lib, isodate, jsonlines, linear-tsv, pathlib2, polyline, pydruid, python-dateutil, sasl, sqlalchemy-utils, tableschema, tabulator, thrift
 sqlalchemy-utils==0.32.21
 sqlalchemy==1.2.2
 sqlparse==0.2.4

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'boto3==1.4.7',
         'botocore>=1.7.0, <1.8.0',
         'celery>=4.2.0',
+        'click>=6.0, <7.0.0',  # click >=7 forces "-" instead of "_"
         'colorama',
         'contextlib2',
         'cryptography',

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'pyhive>=0.4.0',
         'python-dateutil',
         'python-geohash',
-        'pyyaml>=3.11',
+        'pyyaml>=3.13',
         'requests',
         'simplejson>=3.15.0',
         'sqlalchemy',


### PR DESCRIPTION
* compiled out-of-sync as `requirements.txt`
* constraining `click` to `<7` as 7 changes commands from `load_examples` to `load-examples` which is backward incompatible. People in the wild that don't used the pinned  `requirements.txt` have been hit bit this, some changes had been merged to allow click>=7, but rolling those back now as one of our libs requires <7. Can't have both (CAN SOMEONE FIX SETUPTOOLS TO SUPPORT DIAMOND DEPS ALREADY!?!?!!?!?!). We can upgrade cautiously once that lib (`tableschema`) upgrades to support >7
* modified the docker build process to use the compiled `requirements.txt`, trying to test this now


Also had to, not sure if necessary though:
```
export LDFLAGS="-L/usr/local/opt/openssl/lib"
export CPPFLAGS="-I/usr/local/opt/openssl/include"
export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
```