### PR TITLE
[fix] should set chartUpdateEndTime when chart fetch failed or stopped

### DIFF
--- a/superset/assets/spec/javascripts/chart/chartReducers_spec.js
+++ b/superset/assets/spec/javascripts/chart/chartReducers_spec.js
@@ -1,0 +1,28 @@
+import chartReducer, { chart } from '../../../src/chart/chartReducer';
+import * as actions from '../../../src/chart/chartAction';
+
+
+describe('chart reducers', () => {
+  const chartKey = 1;
+  let testChart;
+  let charts;
+  beforeEach(() => {
+    testChart = {
+      ...chart,
+      id: chartKey,
+    };
+    charts = { [chartKey]: testChart };
+  });
+
+  it('should update endtime on fail', () => {
+    const newState = chartReducer(charts, actions.chartUpdateStopped(chartKey));
+    expect(newState[chartKey].chartUpdateEndTime).toBeGreaterThan(0);
+    expect(newState[chartKey].chartStatus).toEqual('stopped');
+  });
+
+  it('should update endtime on timeout', () => {
+    const newState = chartReducer(charts, actions.chartUpdateTimeout('timeout', 60, chartKey));
+    expect(newState[chartKey].chartUpdateEndTime).toBeGreaterThan(0);
+    expect(newState[chartKey].chartStatus).toEqual('failed');
+  });
+});

--- a/superset/assets/src/chart/chartReducer.js
+++ b/superset/assets/src/chart/chartReducer.js
@@ -45,6 +45,7 @@ export default function chartReducer(charts = {}, action) {
       return { ...state,
         chartStatus: 'stopped',
         chartAlert: t('Updating chart was stopped'),
+        chartUpdateEndTime: now(),
       };
     },
     [actions.CHART_RENDERING_SUCCEEDED](state) {
@@ -68,6 +69,7 @@ export default function chartReducer(charts = {}, action) {
             'or you are simply querying a data source that is too large ' +
             'to be processed within the timeout range. ' +
             'If that is the case, we recommend that you summarize your data further.')),
+        chartUpdateEndTime: now(),
       };
     },
     [actions.CHART_UPDATE_FAILED](state) {


### PR DESCRIPTION
we should update chart state chartUpdateEndTime when chart fetching is timeout or stopped.

@michellethomas @kristw @williaster