### PR TITLE
make scheme level access control on csv optional

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -450,6 +450,10 @@ SQL_QUERY_MUTATOR = None
 # using flask-compress
 ENABLE_FLASK_COMPRESS = True
 
+# This determines if schema level access control will be enabled for
+# CSV upload.
+ENABLE_CSV_UPLOAD_SCHEMA_LEVEL_CONTROLS = False
+
 try:
     if CONFIG_PATH_ENV_VAR in os.environ:
         # Explicitly import config module that is not in pythonpath; useful

--- a/superset/config.py
+++ b/superset/config.py
@@ -452,7 +452,7 @@ ENABLE_FLASK_COMPRESS = True
 
 # This determines if schema level access control will be enabled for
 # CSV upload.
-ENABLE_CSV_UPLOAD_SCHEMA_LEVEL_CONTROLS = False
+ENABLE_CSV_UPLOAD_SCHEMA_LEVEL_CONTROLS = True
 
 try:
     if CONFIG_PATH_ENV_VAR in os.environ:

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -48,6 +48,9 @@ class CsvToDatabaseForm(DynamicForm):
         csv_enabled_dbs = db.session.query(
             models.Database).filter_by(
             allow_csv_upload=True).all()
+        if not config.get('ENABLE_CSV_UPLOAD_SCHEMA_LEVEL_CONTROLS'):
+            return csv_enabled_dbs
+
         for csv_enabled_db in csv_enabled_dbs:
             if CsvToDatabaseForm.at_least_one_schema_is_allowed(csv_enabled_db):
                 csv_allowed_dbs.append(csv_enabled_db)


### PR DESCRIPTION
This PR makes the schema level access control implemented here (https://github.com/apache/incubator-superset/pull/5787) configurable. 

@mistercrunch @youngyjd @john-bodley 