### PR TITLE
[SIP-5] Open a new /api/v1/query endpoint that takes query_obj

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -232,7 +232,7 @@ logging-modules=logging
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+notes=FIXME,XXX
 
 
 [SIMILARITIES]

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -12,10 +12,11 @@ class QueryContext():
     """
     # TODO: Type datasource and query_object dictionary with TypedDict when it becomes
     # a vanilla python type https://github.com/python/mypy/issues/5288
-    def __init__(self,
-                 datasource: Dict,
-                 query_object: Dict,
-                 ):
+    def __init__(
+            self,
+            datasource: Dict,
+            query_object: Dict,
+    ):
         self._datasource = ConnectorRegistry.get_datasource(datasource.get('type'),
                                                             datasource.get('id'),
                                                             db.session)

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -1,5 +1,5 @@
 # pylint: disable=R
-from typing import Dict
+from typing import Dict, List
 
 from superset import db
 from superset.connectors.connector_registry import ConnectorRegistry
@@ -16,9 +16,12 @@ class QueryContext:
     def __init__(
             self,
             datasource: Dict,
-            query_object: Dict,
+            queries: List[Dict],
     ):
         self.datasource = ConnectorRegistry.get_datasource(datasource.get('type'),
                                                            datasource.get('id'),
                                                            db.session)
-        self.query_object = QueryObject(**query_object)
+        self.queries = list(map(lambda query_obj: QueryObject(**query_obj), queries))
+
+    def get_data(self):
+        raise NotImplementedError()

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -1,0 +1,28 @@
+from typing import Dict
+from superset import db
+from superset.connectors.connector_registry import ConnectorRegistry
+from .query_object import QueryObject
+
+class QueryContext():
+    """
+    The query context contains the query object and additional fields necessary
+    to retrieve the data payload for a given viz.
+    """
+    # TODO: Type datasource and query_object dictionary with TypedDict when it becomes
+    # a vanilla python type https://github.com/python/mypy/issues/5288
+    def __init__(self,
+                 datasource: Dict,
+                 query_object: Dict
+                ):
+        self._datasource = ConnectorRegistry.get_datasource(datasource.get('type'),
+                                                            datasource.get('id'),
+                                                            db.session)
+        self._query_object = QueryObject(**query_object)
+
+    @property
+    def datasource(self):
+        return self._datasource
+
+    @property
+    def query_object(self):
+        return self._query_object

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -1,3 +1,4 @@
+# pylint: disable=R
 from typing import Dict
 
 from superset import db
@@ -5,7 +6,7 @@ from superset.connectors.connector_registry import ConnectorRegistry
 from .query_object import QueryObject
 
 
-class QueryContext():
+class QueryContext:
     """
     The query context contains the query object and additional fields necessary
     to retrieve the data payload for a given viz.
@@ -17,15 +18,7 @@ class QueryContext():
             datasource: Dict,
             query_object: Dict,
     ):
-        self._datasource = ConnectorRegistry.get_datasource(datasource.get('type'),
-                                                            datasource.get('id'),
-                                                            db.session)
-        self._query_object = QueryObject(**query_object)
-
-    @property
-    def datasource(self):
-        return self._datasource
-
-    @property
-    def query_object(self):
-        return self._query_object
+        self.datasource = ConnectorRegistry.get_datasource(datasource.get('type'),
+                                                           datasource.get('id'),
+                                                           db.session)
+        self.query_object = QueryObject(**query_object)

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -1,7 +1,9 @@
 from typing import Dict
+
 from superset import db
 from superset.connectors.connector_registry import ConnectorRegistry
 from .query_object import QueryObject
+
 
 class QueryContext():
     """
@@ -12,8 +14,8 @@ class QueryContext():
     # a vanilla python type https://github.com/python/mypy/issues/5288
     def __init__(self,
                  datasource: Dict,
-                 query_object: Dict
-                ):
+                 query_object: Dict,
+                 ):
         self._datasource = ConnectorRegistry.get_datasource(datasource.get('type'),
                                                             datasource.get('id'),
                                                             db.session)

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -51,6 +51,3 @@ class QueryObject:
 
     def to_dict(self):
         raise NotImplementedError()
-
-    def get_data(self):
-        raise NotImplementedError()

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -21,8 +21,6 @@ class QueryObject:
             metrics: List[Metric],
             filters: List[str],
             time_range: Optional[str] = None,
-            since: Optional[str] = None,
-            until: Optional[str] = None,
             time_shift: Optional[str] = None,
             is_timeseries: bool = False,
             row_limit: int = app.config.get('ROW_LIMIT'),
@@ -33,11 +31,11 @@ class QueryObject:
     ):
         self.granularity = granularity
 
-        since_dttm, until_dttm = utils.get_since_until(time_range, since, until)
+        since_dttm, until_dttm = utils.get_since_until(time_range)
         time_shift_dttm = utils.parse_human_timedelta(time_shift)
         self.from_dttm = None if since_dttm is None else (since_dttm - time_shift_dttm)
         self.to_dttm = None if until_dttm is None else (until_dttm - time_shift_dttm)
-        utils.check_from_to_dttm(self.from_dttm, self.to_dttm)
+        utils.assert_from_to_dttm(self.from_dttm, self.to_dttm)
 
         self.is_timeseries = is_timeseries
         self.groupby = groupby
@@ -52,8 +50,7 @@ class QueryObject:
         self.extras = extras
 
     def to_dict(self):
-        pass
+        raise NotImplementedError()
 
     def get_data(self):
-        # TODO: implement
-        return ''
+        raise NotImplementedError()

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -1,8 +1,5 @@
-"""
-The query object's schema matches the interfaces of DB connectors like sqla
-and druid. The query objects are constructed on the client.
-"""
 from typing import Dict, List, Optional, Union
+
 from superset import app
 from superset.utils import core as utils
 
@@ -10,7 +7,12 @@ from superset.utils import core as utils
 # https://github.com/python/mypy/issues/5288
 Metric = Union[str, Dict]
 
+
 class QueryObject:
+    """
+    The query object's schema matches the interfaces of DB connectors like sqla
+    and druid. The query objects are constructed on the client.
+    """
     def __init__(self,
                  granularity: str,
                  groupby: List[str],
@@ -51,4 +53,5 @@ class QueryObject:
         pass
 
     def get_data(self):
-        pass
+        # TODO: implement
+        return ''

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -1,3 +1,4 @@
+# pylint: disable=R
 from typing import Dict, List, Optional, Union
 
 from superset import app
@@ -13,22 +14,23 @@ class QueryObject:
     The query object's schema matches the interfaces of DB connectors like sqla
     and druid. The query objects are constructed on the client.
     """
-    def __init__(self,
-                 granularity: str,
-                 groupby: List[str],
-                 metrics: List[Metric],
-                 filters: List[str],
-                 time_range: Optional[str] = None,
-                 since: Optional[str] = None,
-                 until: Optional[str] = None,
-                 time_shift: Optional[str] = None,
-                 is_timeseries: bool = False,
-                 row_limit: int = app.config.get('ROW_LIMIT'),
-                 limit: int = 0,
-                 timeseries_limit_metric: Optional[Metric] = None,
-                 order_desc: bool = True,
-                 extras: Optional[Dict] = None,
-                 ):
+    def __init__(
+            self,
+            granularity: str,
+            groupby: List[str],
+            metrics: List[Metric],
+            filters: List[str],
+            time_range: Optional[str] = None,
+            since: Optional[str] = None,
+            until: Optional[str] = None,
+            time_shift: Optional[str] = None,
+            is_timeseries: bool = False,
+            row_limit: int = app.config.get('ROW_LIMIT'),
+            limit: int = 0,
+            timeseries_limit_metric: Optional[Metric] = None,
+            order_desc: bool = True,
+            extras: Optional[Dict] = None,
+    ):
         self.granularity = granularity
 
         since_dttm, until_dttm = utils.get_since_until(time_range, since, until)

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -30,13 +30,7 @@ class QueryObject:
             extras: Optional[Dict] = None,
     ):
         self.granularity = granularity
-
-        since_dttm, until_dttm = utils.get_since_until(time_range)
-        time_shift_dttm = utils.parse_human_timedelta(time_shift)
-        self.from_dttm = None if since_dttm is None else (since_dttm - time_shift_dttm)
-        self.to_dttm = None if until_dttm is None else (until_dttm - time_shift_dttm)
-        utils.assert_from_to_dttm(self.from_dttm, self.to_dttm)
-
+        self.from_dttm, self.to_dttm = utils.get_since_until(time_range, time_shift)
         self.is_timeseries = is_timeseries
         self.groupby = groupby
         self.metrics = metrics

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -1,0 +1,54 @@
+"""
+The query object's schema matches the interfaces of DB connectors like sqla
+and druid. The query objects are constructed on the client.
+"""
+from typing import Dict, List, Optional, Union
+from superset import app
+from superset.utils import core as utils
+
+# TODO: Type Metrics dictionary with TypedDict when it becomes a vanilla python type
+# https://github.com/python/mypy/issues/5288
+Metric = Union[str, Dict]
+
+class QueryObject:
+    def __init__(self,
+                 granularity: str,
+                 groupby: List[str],
+                 metrics: List[Metric],
+                 filters: List[str],
+                 time_range: Optional[str] = None,
+                 since: Optional[str] = None,
+                 until: Optional[str] = None,
+                 time_shift: Optional[str] = None,
+                 is_timeseries: bool = False,
+                 row_limit: int = app.config.get('ROW_LIMIT'),
+                 limit: int = 0,
+                 timeseries_limit_metric: Optional[Metric] = None,
+                 order_desc: bool = True,
+                 extras: Optional[Dict] = None,
+                 ):
+        self.granularity = granularity
+
+        since_dttm, until_dttm = utils.get_since_until(time_range, since, until)
+        time_shift_dttm = utils.parse_human_timedelta(time_shift)
+        self.from_dttm = None if since_dttm is None else (since_dttm - time_shift_dttm)
+        self.to_dttm = None if until_dttm is None else (until_dttm - time_shift_dttm)
+        utils.check_from_to_dttm(self.from_dttm, self.to_dttm)
+
+        self.is_timeseries = is_timeseries
+        self.groupby = groupby
+        self.metrics = metrics
+        self.row_limit = row_limit
+        self.filter = filters
+        self.timeseries_limit = int(limit)
+        self.timeseries_limit_metric = timeseries_limit_metric
+        self.order_desc = order_desc
+        self.prequeries = []
+        self.is_prequery = False
+        self.extras = extras
+
+    def to_dict(self):
+        pass
+
+    def get_data(self):
+        pass

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -18,6 +18,8 @@ class ConnectorRegistry(object):
 
     @classmethod
     def get_datasource(cls, datasource_type, datasource_id, session):
+        print('session')
+        print(session)
         return (
             session.query(cls.sources[datasource_type])
             .filter_by(id=datasource_id)

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -18,8 +18,6 @@ class ConnectorRegistry(object):
 
     @classmethod
     def get_datasource(cls, datasource_type, datasource_id, session):
-        print('session')
-        print(session)
         return (
             session.query(cls.sources[datasource_type])
             .filter_by(id=datasource_id)

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -7,6 +7,7 @@ class SupersetException(Exception):
     def __init__(self, msg):
         super(SupersetException, self).__init__(msg)
 
+
 class SupersetTimeoutException(SupersetException):
     pass
 
@@ -14,9 +15,10 @@ class SupersetTimeoutException(SupersetException):
 class SupersetSecurityException(SupersetException):
     status = 401
 
-    def __init__(self, msg, link):
+    def __init__(self, msg, link=None):
         super(SupersetSecurityException, self).__init__(msg)
         self.link = link
+
 
 class MetricPermException(SupersetException):
     pass

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -4,14 +4,19 @@
 class SupersetException(Exception):
     status = 500
 
+    def __init__(self, msg):
+        super(SupersetException, self).__init__(msg)
 
 class SupersetTimeoutException(SupersetException):
     pass
 
 
 class SupersetSecurityException(SupersetException):
-    pass
+    status = 401
 
+    def __init__(self, msg, link):
+        super(SupersetSecurityException, self).__init__(msg)
+        self.link = link
 
 class MetricPermException(SupersetException):
     pass

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -37,7 +37,7 @@ from superset.utils import (
     cache as cache_util,
     core as utils,
 )
-from superset.viz import METRIC_KEYS, viz_types
+from superset.viz import viz_types
 from urllib import parse  # noqa
 
 config = app.config

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -29,6 +29,7 @@ from sqlalchemy_utils import EncryptedType
 import sqlparse
 
 from superset import app, db, db_engine_specs, security_manager
+from superset.common.query_context import QueryContext
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.legacy import update_time_range
 from superset.models.helpers import AuditMixinNullable, ImportMixin
@@ -86,37 +87,6 @@ def copy_dashboard(mapper, connection, target):
     )
     session.add(extra_attributes)
     session.commit()
-
-
-def query_obj_backfill(form_data, datasource_id=None, datasource_type=None):
-    # Backfill query_obj. This will be generated on the client in the future.
-    # Note we unpack the metrics on the viz here so we can create the metrics
-    # dictionary during viz initialization without leveraging form_data.
-    #
-    # TODO: Note structure of the backfilled query_obj is temporary. It will be
-    # restructured as we build out the query object on the client side.
-    # The fields included are necessary to load a table viz without form_data
-    query_obj = {
-        'viz_type': form_data.get('viz_type', 'table'),
-        'time_range': form_data.get('time_range'),
-        'include_time': form_data.get('include_time'),
-        'token': form_data.get('token'),
-        'metrics': form_data.get('metrics'),
-        'percent_metrics': form_data.get('percent_metrics'),
-        'granularity_sqla': form_data.get('granularity_sqla'),
-        'time_grain_sqla': form_data.get('time_grain_sqla'),
-        'query': {
-            'groupby': form_data.get('groupby'),
-            'metrics': [form_data.get(mkey) for mkey in METRIC_KEYS if mkey in form_data],
-            'granularity': form_data.get('granularity'),
-        },
-    }
-    if datasource_type and datasource_id:
-        query_obj['datasource'] = {
-            'id': datasource_id,
-            'type': datasource_type,
-        }
-    return query_obj
 
 
 sqla.event.listen(User, 'after_insert', copy_dashboard)
@@ -229,8 +199,7 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
         d = json.loads(self.params)
         viz_class = viz_types[self.viz_type]
         # pylint: disable=no-member
-        query_obj = query_obj_backfill(d)
-        return viz_class(datasource=self.datasource, form_data=d, query_obj=query_obj)
+        return viz_class(datasource=self.datasource, form_data=d)
 
     @property
     def description_markeddown(self):
@@ -328,7 +297,6 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
         return viz_types[slice_params.get('viz_type')](
             self.datasource,
             form_data=slice_params,
-            query_obj=query_obj_backfill(slice_params),
             force=force,
         )
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -29,7 +29,6 @@ from sqlalchemy_utils import EncryptedType
 import sqlparse
 
 from superset import app, db, db_engine_specs, security_manager
-from superset.common.query_context import QueryContext
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.legacy import update_time_range
 from superset.models.helpers import AuditMixinNullable, ImportMixin

--- a/superset/security.py
+++ b/superset/security.py
@@ -9,6 +9,7 @@ from sqlalchemy import or_
 
 from superset import sql_parse
 from superset.connectors.connector_registry import ConnectorRegistry
+from superset.exceptions import SupersetSecurityException
 
 READ_ONLY_MODEL_VIEWS = {
     'DatabaseAsync',
@@ -427,4 +428,11 @@ class SupersetSecurityManager(SecurityManager):
                     permission_id=permission.id,
                     view_menu_id=view_menu.id,
                 ),
+            )
+
+    def check_datasource_permission(self, datasource, user=None):
+        if not self.datasource_access(datasource, user):
+            raise SupersetSecurityException(
+                self.get_datasource_access_error_msg(datasource),
+                self.get_datasource_access_link(datasource),
             )

--- a/superset/security.py
+++ b/superset/security.py
@@ -430,7 +430,7 @@ class SupersetSecurityManager(SecurityManager):
                 ),
             )
 
-    def check_datasource_permission(self, datasource, user=None):
+    def assert_datasource_permission(self, datasource, user=None):
         if not self.datasource_access(datasource, user):
             raise SupersetSecurityException(
                 self.get_datasource_access_error_msg(datasource),

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -213,6 +213,29 @@ def dttm_from_timtuple(d):
         d.tm_year, d.tm_mon, d.tm_mday, d.tm_hour, d.tm_min, d.tm_sec)
 
 
+def decode_iso_dttm(o):
+    """
+    Function to be passed into json.loads object_hook parameter
+    to decode ISO datetime.
+    """
+    if not isinstance(o, dict):
+        return o
+
+    for k, v in o.items():
+        if isinstance(v, list):
+            for a in v:
+                decode_iso_dttm(a)
+        elif isinstance(v, dict):
+            decode_iso_dttm(v)
+        elif isinstance(v, basestring):
+            try:
+                o[k] = parse(v, ignoretz=True)
+            except:
+                pass
+
+    return o
+
+
 def decode_dashboards(o):
     """
     Function to be passed into json.loads obj_hook parameter

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -953,7 +953,7 @@ def check_from_to_dttm(from_dttm, to_dttm):
     if from_dttm and to_dttm and from_dttm > to_dttm:
         raise Exception(_('From date cannot be larger than to date'))
 
-        
+
 def add_ago_to_since(since):
     """
     Backwards compatibility hack. Without this slices with since: 7 days will

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -24,6 +24,7 @@ from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from flask import flash, g, Markup, render_template
 from flask_babel import gettext as __
+from flask_babel import lazy_gettext as _
 from flask_caching import Cache
 import markdown as md
 import numpy

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -15,6 +15,7 @@ import os
 import signal
 import smtplib
 import sys
+from typing import Optional
 import uuid
 import zlib
 
@@ -886,8 +887,12 @@ def ensure_path_exists(path):
             raise
 
 
-def get_since_until(time_range=None, since=None, until=None):
-    """Return `since` and `until` from form_data.
+def get_since_until(time_range: Optional[str] = None,
+                    since: Optional[str] = None,
+                    until: Optional[str] = None,
+                    time_shift: Optional[str] = None) -> (datetime, datetime):
+    """Return `since` and `until` date time tuple from string representations of
+    time_range, since, until and time_shift.
 
     This functiom supports both reading the keys separately (from `since` and
     `until`), as well as the new `time_range` key. Valid formats are:
@@ -946,12 +951,15 @@ def get_since_until(time_range=None, since=None, until=None):
         since = parse_human_datetime(since)
         until = parse_human_datetime(until or 'now')
 
-    return since, until
+    if time_shift:
+        time_shift = parse_human_timedelta(time_shift)
+        since = since if since is None else (since - time_shift)
+        until = until if until is None else (until - time_shift)
 
-
-def assert_from_to_dttm(from_dttm, to_dttm):
-    if from_dttm and to_dttm and from_dttm > to_dttm:
+    if since and until and since > until:
         raise ValueError(_('From date cannot be larger than to date'))
+
+    return since, until
 
 
 def add_ago_to_since(since):

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -949,9 +949,9 @@ def get_since_until(time_range=None, since=None, until=None):
     return since, until
 
 
-def check_from_to_dttm(from_dttm, to_dttm):
+def assert_from_to_dttm(from_dttm, to_dttm):
     if from_dttm and to_dttm and from_dttm > to_dttm:
-        raise Exception(_('From date cannot be larger than to date'))
+        raise ValueError(_('From date cannot be larger than to date'))
 
 
 def add_ago_to_since(since):

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -230,7 +230,7 @@ def decode_iso_dttm(o):
         elif isinstance(v, basestring):
             try:
                 o[k] = parse(v, ignoretz=True)
-            except:
+            except Exception:
                 pass
 
     return o

--- a/superset/views/__init__.py
+++ b/superset/views/__init__.py
@@ -1,4 +1,5 @@
 from . import base  # noqa
+from . import api # noqa
 from . import core  # noqa
 from . import sql_lab  # noqa
 from . import annotations # noqa

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -1,3 +1,4 @@
+# pylint: disable=R
 import json
 
 from flask import g, request

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -1,11 +1,14 @@
 import json
+
 from flask import g, request
 from flask_appbuilder import expose
 from flask_appbuilder.security.decorators import has_access_api
+
 from superset import appbuilder, security_manager
 from superset.common.query_context import QueryContext
 from superset.models.core import Log
 from .base import api, BaseSupersetView, data_payload_response, handle_superset_exception
+
 
 class Api(BaseSupersetView):
     @Log.log_this
@@ -23,5 +26,6 @@ class Api(BaseSupersetView):
         security_manager.check_datasource_permission(query_context.datasource, g.user)
         payload_json = query_context.query_object.get_data()
         return data_payload_response(payload_json)
+
 
 appbuilder.add_view_no_menu(Api)

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -23,9 +23,8 @@ class Api(BaseSupersetView):
         for the given query_obj.
         """
         query_context = QueryContext(**json.loads(request.form.get('query_context')))
-        print(query_context)
         security_manager.assert_datasource_permission(query_context.datasource, g.user)
-        payload_json = query_context.query_object.get_data()
+        payload_json = query_context.get_data()
         return data_payload_response(payload_json)
 
 

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -1,0 +1,27 @@
+import json
+from flask import g, request
+from flask_appbuilder import expose
+from flask_appbuilder.security.decorators import has_access_api
+from superset import appbuilder, security_manager
+from superset.common.query_context import QueryContext
+from superset.models.core import Log
+from .base import api, BaseSupersetView, data_payload_response, handle_superset_exception
+
+class Api(BaseSupersetView):
+    @Log.log_this
+    @api
+    @handle_superset_exception
+    @has_access_api
+    @expose('/v1/query/', methods=['POST'])
+    def query(self):
+        """
+        Takes a query_obj constructed in the client and returns payload data response
+        for the given query_obj.
+        """
+        query_context = QueryContext(**json.loads(request.form.get('query_context')))
+        print(query_context)
+        security_manager.check_datasource_permission(query_context.datasource, g.user)
+        payload_json = query_context.query_object.get_data()
+        return data_payload_response(payload_json)
+
+appbuilder.add_view_no_menu(Api)

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -24,7 +24,7 @@ class Api(BaseSupersetView):
         """
         query_context = QueryContext(**json.loads(request.form.get('query_context')))
         print(query_context)
-        security_manager.check_datasource_permission(query_context.datasource, g.user)
+        security_manager.assert_datasource_permission(query_context.datasource, g.user)
         payload_json = query_context.query_object.get_data()
         return data_payload_response(payload_json)
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -86,7 +86,7 @@ def handle_superset_exception(f):
         except SupersetException as se:
             logging.exception(se)
             return json_error_response(utils.error_msg_from_exception(se),
-                                        status=se.status)
+                                       status=se.status)
     return functools.update_wrapper(wraps, f)
 
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1140,7 +1140,9 @@ class Superset(BaseSupersetView):
             samples=False,
     ):
         viz_obj = self.get_viz(
-            query_obj=models.query_obj_backfill(form_data, datasource_id, datasource_type),
+            query_obj=models.query_obj_backfill(form_data,
+                                                datasource_id,
+                                                datasource_type),
             form_data=form_data,
             force=force,
         )
@@ -1213,8 +1215,8 @@ class Superset(BaseSupersetView):
                                object_hook=utils.decode_iso_dttm)
         viz_obj = self.get_viz(query_obj=query_obj)
         self.check_datasource_permission(viz_obj.datasource, g.user)
-        payload_json_and_error = viz_obj.get_payload_json_and_error(query_obj.get('query'))
-        return self.payload_response(payload_json_and_error)
+        json_and_error = viz_obj.get_payload_json_and_error(query_obj.get('query'))
+        return self.payload_response(json_and_error)
 
     @log_this
     @api

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1126,7 +1126,7 @@ class Superset(BaseSupersetView):
             form_data=form_data,
             force=force,
         )
-        security_manager.check_datasource_permission(viz_obj.datasource, g.user)
+        security_manager.assert_datasource_permission(viz_obj.datasource, g.user)
 
         if csv:
             return CsvResponse(
@@ -1376,7 +1376,7 @@ class Superset(BaseSupersetView):
             datasource_type, datasource_id, db.session)
         if not datasource:
             return json_error_response(DATASOURCE_MISSING_ERR)
-        security_manager.check_datasource_permission(datasource)
+        security_manager.assert_datasource_permission(datasource)
         payload = json.dumps(
             datasource.values_for_column(
                 column,
@@ -2623,7 +2623,7 @@ class Superset(BaseSupersetView):
             return json_error_response(DATASOURCE_MISSING_ERR)
 
         # Check permission for datasource
-        security_manager.check_datasource_permission(datasource)
+        security_manager.assert_datasource_permission(datasource)
         return json_success(json.dumps(datasource.data))
 
     @expose('/queries/<last_updated_ms>')
@@ -2809,7 +2809,7 @@ class Superset(BaseSupersetView):
         get the database query string for this slice
         """
         viz_obj = self.get_viz(slice_id)
-        security_manager.check_datasource_permission(viz_obj.datasource)
+        security_manager.assert_datasource_permission(viz_obj.datasource)
         return self.get_query_string_response(viz_obj)
 
     @api

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -470,7 +470,7 @@ class BaseViz(object):
 
     def payload_json_and_has_error(self, payload):
         has_error = payload.get('status') == utils.QueryStatus.FAILED or \
-                    payload.get('error') is not None
+            payload.get('error') is not None
         return self.json_dumps(payload), has_error
 
     @property

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -31,10 +31,8 @@ from past.builtins import basestring
 import polyline
 import simplejson as json
 
-from superset import app, cache, db, get_css_manifest_files
-from superset.connectors.connector_registry import ConnectorRegistry
+from superset import app, cache, get_css_manifest_files
 from superset.exceptions import NullValueException, SpatialException
-from superset.models import core as models
 from superset.utils import core as utils
 from superset.utils.core import (
     DTTM_ALIAS,
@@ -65,42 +63,22 @@ class BaseViz(object):
     cache_type = 'df'
     enforce_numerical_metrics = True
 
-    def __init__(self, datasource, form_data, query_obj={}, force=False):
-        if datasource:
-            self.datasource = datasource
-        else:
-            datasource_dict = query_obj.get('datasource', {})
-            ds = ConnectorRegistry.get_datasource(
-                datasource_dict.get('type'), datasource_dict.get('id'), db.session)
-            if not ds:
-                raise Exception(_('Viz is missing a datasource'))
-            else:
-                self.datasource = ds
+    def __init__(self, datasource, form_data, force=False):
+        if not datasource:
+            raise Exception(_('Viz is missing a datasource'))
 
-        if not query_obj:
-            query_obj = models.query_obj_backfill(form_data)
-
+        self.datasource = datasource
         self.request = request
-
-        self.viz_type = query_obj.get('viz_type')
-        self.time_range = query_obj.get('time_range')
-        self.include_time = query_obj.get('include_time')
-        self.token = query_obj.get('token', 'token_' + uuid.uuid4().hex[:8])
-        self.metrics = query_obj.get('metrics')
-        self.percent_metrics = query_obj.get('percent_metrics')
-        self.granularity_sqla = query_obj.get('granularity_sqla')
-        self.time_grain_sqla = query_obj.get('time_grain_sqla')
-        self.q_obj = query_obj.get('query')
-        self.groupby = self.q_obj.get('groupby') or []
-
-        # TODO: sunset form_data and move all fields we're currently retrieving
-        # from form_data to query_obj generated on the client. Temporarily set
-        # form_data as it is used extensively in viz.py.
+        self.viz_type = form_data.get('viz_type')
         self.form_data = form_data
 
+        self.query = ''
+        self.token = self.form_data.get(
+            'token', 'token_' + uuid.uuid4().hex[:8])
+
+        self.groupby = self.form_data.get('groupby') or []
         self.time_shift = timedelta()
 
-        self.query = ''
         self.status = None
         self.error_message = None
         self.force = force
@@ -114,20 +92,23 @@ class BaseViz(object):
         self._any_cached_dttm = None
         self._extra_chart_data = []
 
-        self.process_metrics(self.q_obj.get('metrics'))
+        self.process_metrics()
 
-    def process_metrics(self, metrics):
+    def process_metrics(self):
         # metrics in TableViz is order sensitive, so metric_dict should be
         # OrderedDict
         self.metric_dict = OrderedDict()
-        for val in metrics:
-            if not isinstance(val, list):
-                val = [val]
-            for o in val:
-                label = self.get_metric_label(o)
-                if isinstance(o, dict):
-                    o['label'] = label
-                self.metric_dict[label] = o
+        fd = self.form_data
+        for mkey in METRIC_KEYS:
+            val = fd.get(mkey)
+            if val:
+                if not isinstance(val, list):
+                    val = [val]
+                for o in val:
+                    label = self.get_metric_label(o)
+                    if isinstance(o, dict):
+                        o['label'] = label
+                    self.metric_dict[label] = o
 
         # Cast to list needed to return serializable object in py3
         self.all_metrics = list(self.metric_dict.values())
@@ -298,7 +279,9 @@ class BaseViz(object):
         # default order direction
         order_desc = form_data.get('order_desc', True)
 
-        since, until = utils.get_since_until(form_data)
+        since, until = utils.get_since_until(form_data.get('time_range'),
+                                             form_data.get('since'),
+                                             form_data.get('until'))
         time_shift = form_data.get('time_shift', '')
         self.time_shift = utils.parse_human_timedelta(time_shift)
         from_dttm = None if since is None else (since - self.time_shift)
@@ -339,9 +322,7 @@ class BaseViz(object):
 
     @property
     def cache_timeout(self):
-        if self.q_obj and self.q_obj.get('cache_timeout') is not None:
-            return int(self.q_obj.get('cache_timeout'))
-        if self.form_data and self.form_data.get('cache_timeout') is not None:
+        if self.form_data.get('cache_timeout') is not None:
             return int(self.form_data.get('cache_timeout'))
         if self.datasource.cache_timeout is not None:
             return self.datasource.cache_timeout
@@ -375,7 +356,7 @@ class BaseViz(object):
         for k in ['from_dttm', 'to_dttm']:
             del cache_dict[k]
 
-        cache_dict['time_range'] = self.time_range
+        cache_dict['time_range'] = self.form_data.get('time_range')
         cache_dict['datasource'] = self.datasource.uid
         json_data = self.json_dumps(cache_dict, sort_keys=True)
         return hashlib.md5(json_data.encode('utf-8')).hexdigest()
@@ -394,19 +375,6 @@ class BaseViz(object):
         if 'df' in payload:
             del payload['df']
         return payload
-
-    def get_payload_json_and_error(self, query_obj=None):
-        """
-        Returns the json dump of the payload data and metadata
-        and whether the query resulted in errors
-        """
-        payload = self.get_payload(query_obj)
-        has_error = payload.get('status') == utils.QueryStatus.FAILED or \
-            payload.get('error') is not None
-        return {
-            'json': self.json_dumps(payload),
-            'has_error': has_error,
-        }
 
     def get_df_payload(self, query_obj=None, **kwargs):
         """Handles caching around the df payload retrieval"""
@@ -500,6 +468,11 @@ class BaseViz(object):
             sort_keys=sort_keys,
         )
 
+    def payload_json_and_has_error(self, payload):
+        has_error = payload.get('status') == utils.QueryStatus.FAILED or \
+                    payload.get('error') is not None
+        return self.json_dumps(payload), has_error
+
     @property
     def data(self):
         """This is the data object serialized to the js layer"""
@@ -535,17 +508,17 @@ class TableViz(BaseViz):
     enforce_numerical_metrics = False
 
     def should_be_timeseries(self):
-        granularity = self.q_obj.get('granularity')
+        fd = self.form_data
         # TODO handle datasource-type-specific code in datasource
         conditions_met = (
-            (granularity and granularity != 'all') or
-            (self.granularity_sqla and self.time_grain_sqla)
+            (fd.get('granularity') and fd.get('granularity') != 'all') or
+            (fd.get('granularity_sqla') and fd.get('time_grain_sqla'))
         )
-        if self.include_time and not conditions_met:
+        if fd.get('include_time') and not conditions_met:
             raise Exception(_(
                 'Pick a granularity in the Time section or '
                 "uncheck 'Include Time'"))
-        return self.include_time
+        return fd.get('include_time')
 
     def query_obj(self):
         d = super(TableViz, self).query_obj()
@@ -579,6 +552,7 @@ class TableViz(BaseViz):
         return d
 
     def get_data(self, df):
+        fd = self.form_data
         if (
                 not self.should_be_timeseries() and
                 df is not None and
@@ -587,7 +561,7 @@ class TableViz(BaseViz):
             del df[DTTM_ALIAS]
 
         # Sum up and compute percentages for all percent metrics
-        percent_metrics = self.percent_metrics or []
+        percent_metrics = fd.get('percent_metrics') or []
         percent_metrics = [self.get_metric_label(m) for m in percent_metrics]
 
         if len(percent_metrics):
@@ -605,7 +579,7 @@ class TableViz(BaseViz):
                 m_name = '%' + m
                 df[m_name] = pd.Series(metric_percents[m], name=m_name)
             # Remove metrics that are not in the main metrics list
-            metrics = self.metrics or []
+            metrics = fd.get('metrics') or []
             metrics = [self.get_metric_label(m) for m in metrics]
             for m in filter(
                 lambda m: m not in metrics and m in df.columns,
@@ -622,8 +596,7 @@ class TableViz(BaseViz):
         return data
 
     def json_dumps(self, obj, sort_keys=False):
-        if (self.q_obj and self.q_obj.get('all_columns')) or \
-           (self.form_data and self.form_data.get('all_columns')):
+        if self.form_data.get('all_columns'):
             return json.dumps(
                 obj,
                 default=utils.json_iso_dttm_ser,
@@ -822,7 +795,9 @@ class CalHeatmapViz(BaseViz):
                 for obj in records
             }
 
-        start, end = utils.get_since_until(form_data)
+        start, end = utils.get_since_until(form_data.get('time_range'),
+                                           form_data.get('since'),
+                                           form_data.get('until'))
         if not start or not end:
             raise Exception('Please provide both time bounds (Since and Until)')
         domain = form_data.get('domain_granularity')
@@ -1297,6 +1272,7 @@ class MultiLineViz(NVD3Viz):
         fd = self.form_data
         # Late imports to avoid circular import issues
         from superset.models.core import Slice
+        from superset import db
         slice_ids1 = fd.get('line_charts')
         slices1 = db.session.query(Slice).filter(Slice.id.in_(slice_ids1)).all()
         slice_ids2 = fd.get('line_charts_2')
@@ -2078,6 +2054,7 @@ class DeckGLMultiLayer(BaseViz):
         fd = self.form_data
         # Late imports to avoid circular import issues
         from superset.models.core import Slice
+        from superset import db
         slice_ids = fd.get('deck_slices')
         slices = db.session.query(Slice).filter(Slice.id.in_(slice_ids)).all()
         return {

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -100,14 +100,14 @@ class CoreTests(SupersetTestCase):
                 'groupby': ['name'],
                 'metrics': ['sum__num'],
                 'filters': [],
-                'since': form_data.get('since'),
-                'until': form_data.get('until'),
+                'time_range': '{} : {}'.format(form_data.get('since'),
+                                               form_data.get('until')),
                 'limit': 100,
             },
         })
-        # Just verifying the endpoint doesn't crash here.
         # TODO: update once get_data is implemented for QueryObject
-        self.get_resp('/api/v1/query/', {'query_context': data})
+        with self.assertRaises(Exception):
+            self.get_resp('/api/v1/query/', {'query_context': data})
 
     def test_old_slice_json_endpoint(self):
         self.login(username='admin')

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -95,7 +95,7 @@ class CoreTests(SupersetTestCase):
                 'id': slc.datasource_id,
                 'type': slc.datasource_type,
             },
-            'query_object': {
+            'queries': [{
                 'granularity': 'ds',
                 'groupby': ['name'],
                 'metrics': ['sum__num'],
@@ -103,7 +103,7 @@ class CoreTests(SupersetTestCase):
                 'time_range': '{} : {}'.format(form_data.get('since'),
                                                form_data.get('until')),
                 'limit': 100,
-            },
+            }]
         })
         # TODO: update once get_data is implemented for QueryObject
         with self.assertRaises(Exception):

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -103,7 +103,7 @@ class CoreTests(SupersetTestCase):
                 'time_range': '{} : {}'.format(form_data.get('since'),
                                                form_data.get('until')),
                 'limit': 100,
-            }]
+            }],
         })
         # TODO: update once get_data is implemented for QueryObject
         with self.assertRaises(Exception):

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -86,6 +86,17 @@ class CoreTests(SupersetTestCase):
         qobj['groupby'] = []
         self.assertNotEqual(cache_key, viz.cache_key(qobj))
 
+    def test_api_v1_query_endpoint(self):
+        self.login(username='admin')
+        slc = self.get_slice('Girls', db.session)
+        query_obj = models.query_obj_backfill(slc.form_data,
+                                              slc.datasource_id, slc.datasource_type)
+        query_obj.get('query').update(slc.viz.query_obj())
+        data = json.dumps(query_obj, default=utils.json_iso_dttm_ser)
+
+        resp = self.get_resp('/superset/api/v1/query/', {'query_obj': data})
+        assert '"Jennifer"' in resp
+
     def test_old_slice_json_endpoint(self):
         self.login(username='admin')
         slc = self.get_slice('Girls', db.session)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -88,14 +88,26 @@ class CoreTests(SupersetTestCase):
 
     def test_api_v1_query_endpoint(self):
         self.login(username='admin')
-        slc = self.get_slice('Girls', db.session)
-        query_obj = models.query_obj_backfill(slc.form_data,
-                                              slc.datasource_id, slc.datasource_type)
-        query_obj.get('query').update(slc.viz.query_obj())
-        data = json.dumps(query_obj, default=utils.json_iso_dttm_ser)
-
-        resp = self.get_resp('/superset/api/v1/query/', {'query_obj': data})
-        assert '"Jennifer"' in resp
+        slc = self.get_slice('Name Cloud', db.session)
+        form_data = slc.form_data
+        data = json.dumps({
+            'datasource': {
+                'id': slc.datasource_id,
+                'type': slc.datasource_type,
+            },
+            'query_object': {
+                'granularity': 'ds',
+                'groupby': ['name'],
+                'metrics': ['sum__num'],
+                'filters': [],
+                'since': form_data.get('since'),
+                'until': form_data.get('until'),
+                'limit': 100,
+            },
+        })
+        # Just verifying the endpoint doesn't crash here.
+        # TODO: update once get_data is implemented for QueryObject
+        self.get_resp('/api/v1/query/', {'query_context': data})
 
     def test_old_slice_json_endpoint(self):
         self.login(username='admin')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 import json
-import datetime
 from os import path
 
 FIXTURES_DIR = 'tests/fixtures'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 from os import path
 
 FIXTURES_DIR = 'tests/fixtures'

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -578,48 +578,39 @@ class UtilsTestCase(unittest.TestCase):
 
     @patch('superset.utils.core.parse_human_datetime', mock_parse_human_datetime)
     def test_get_since_until(self):
-        form_data = {}
-        result = get_since_until(form_data)
+        result = get_since_until()
         expected = None, datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
-        form_data = {'time_range': ' : now'}
-        result = get_since_until(form_data)
+        result = get_since_until(' : now')
         expected = None, datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
-        form_data = {'time_range': 'yesterday : tomorrow'}
-        result = get_since_until(form_data)
+        result = get_since_until('yesterday : tomorrow')
         expected = datetime(2016, 11, 6), datetime(2016, 11, 8)
         self.assertEqual(result, expected)
 
-        form_data = {'time_range': '2018-01-01T00:00:00 : 2018-12-31T23:59:59'}
-        result = get_since_until(form_data)
+        result = get_since_until('2018-01-01T00:00:00 : 2018-12-31T23:59:59')
         expected = datetime(2018, 1, 1), datetime(2018, 12, 31, 23, 59, 59)
         self.assertEqual(result, expected)
 
-        form_data = {'time_range': 'Last year'}
-        result = get_since_until(form_data)
+        result = get_since_until('Last year')
         expected = datetime(2015, 11, 7), datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
-        form_data = {'time_range': 'Last 5 months'}
-        result = get_since_until(form_data)
+        result = get_since_until('Last 5 months')
         expected = datetime(2016, 6, 7), datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
-        form_data = {'time_range': 'Next 5 months'}
-        result = get_since_until(form_data)
+        result = get_since_until('Next 5 months')
         expected = datetime(2016, 11, 7), datetime(2017, 4, 7)
         self.assertEqual(result, expected)
 
-        form_data = {'since': '5 days'}
-        result = get_since_until(form_data)
+        result = get_since_until(since='5 days')
         expected = datetime(2016, 11, 2), datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
-        form_data = {'since': '5 days ago', 'until': 'tomorrow'}
-        result = get_since_until(form_data)
+        result = get_since_until(since='5 days ago', until='tomorrow')
         expected = datetime(2016, 11, 2), datetime(2016, 11, 8)
         self.assertEqual(result, expected)
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -614,6 +614,13 @@ class UtilsTestCase(unittest.TestCase):
         expected = datetime(2016, 11, 2), datetime(2016, 11, 8)
         self.assertEqual(result, expected)
 
+        result = get_since_until(time_range='yesterday : tomorrow', time_shift='1 day')
+        expected = datetime(2016, 11, 5), datetime(2016, 11, 7)
+        self.assertEqual(result, expected)
+
+        with self.assertRaises(ValueError):
+            get_since_until(time_range='tomorrow : yesterday')
+
     @patch('superset.utils.core.to_adhoc', mock_to_adhoc)
     def test_convert_legacy_filters_into_adhoc_where(self):
         form_data = {


### PR DESCRIPTION
- Introduce a new handle_superset_exception decorator to avoid repeating the logic for catching SupersetExceptions
- Create a new /api/v1/query endpoint that takes a query_context which contains datasource info and the query_object. Note the query_context will be constructed in the client. The endpoint currently only initializes corresponding query_context and query_object based on data it receives. It doesn't have an implementation for `get_data`.
- Unit test to verify the new endpoint throws an exception.

@mistercrunch @kristw @williaster @john-bodley @conglei 