### PR TITLE
[fix][Annotation] Fix override since/until for annotation

### DIFF
--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -117,3 +117,6 @@ export function optionFromValue(opt) {
 export const COMMON_ERR_MESSAGES = {
   SESSION_TIMED_OUT: t('Your session timed out, please refresh your page and try again.'),
 };
+
+// time_range separator
+export const TIME_RANGE_SEPARATOR = ' : ';


### PR DESCRIPTION
Superset allow chart's time range override annotation's time range parameters. here is control's UI:
<img width="1162" alt="screen shot 2018-10-26 at 11 13 54 am" src="https://user-images.githubusercontent.com/27990562/47683079-b5b0cc80-db8b-11e8-9692-07e12ccbe515.png">


this feature was broken since recent introducing time_range parameter. This PR is to fix the issue, so that user can customize annotation's time range.

@betodealmeida @michellethomas @kristw @williaster @fabianmenges 
