### PR TITLE
fix bug : docker build error with no permission with this floder

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -35,6 +35,7 @@ WORKDIR $HOME/incubator-superset
 
 COPY ./ ./
 
+RUN RUN mkdir -p /home/work/.cache
 RUN pip install --upgrade setuptools pip
 RUN pip install -r requirements.txt
 RUN pip install -r requirements-dev.txt


### PR DESCRIPTION
changed：     contrib/docker/Dockerfile
because I found build error with no permission with this folder '/home/work/.cache' and created before use it can fix this error