### PR TITLE
[Bugfix] Fix typo in Druid granularity

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -541,7 +541,7 @@ class DruidDatasource(Model, BaseDatasource):
     def time_column_grains(self):
         return {
             'time_columns': [
-                'all', '5 seconds', '30 seconds', '1 minute', '5 minutes'
+                'all', '5 seconds', '30 seconds', '1 minute', '5 minutes',
                 '30 minutes', '1 hour', '6 hour', '1 day', '7 days',
                 'week', 'week_starting_sunday', 'week_ending_saturday',
                 'month', 'quarter', 'year',


### PR DESCRIPTION
Currently I don't think anything else references this code, but one of our internal features does, and this may be the case for others too. It might also make sense to have granularities defined in fewer places.

@mistercrunch @timifasubaa 