### PR TITLE
Dashboard filter box default

### DIFF
--- a/superset/assets/cypress/integration/explore/visualizations/filter_box.js
+++ b/superset/assets/cypress/integration/explore/visualizations/filter_box.js
@@ -1,0 +1,25 @@
+import { FORM_DATA_DEFAULTS } from './shared.helper';
+
+export default () => describe('FilterBox', () => {
+  const VIZ_DEFAULTS = { ...FORM_DATA_DEFAULTS, viz_type: 'filter_box' };
+
+  function verify(formData) {
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.verifySliceSuccess({ waitAlias: '@getJson' });
+  }
+
+  beforeEach(() => {
+    cy.server();
+    cy.login();
+    cy.route('POST', '/superset/explore_json/**').as('getJson');
+  });
+
+  it('should work with default date filter', () => {
+    verify(VIZ_DEFAULTS);
+    // Filter box should default to having a date filter with no filter selected
+    cy.get('div.filter_box').within(() => {
+      cy.get('span').contains('No filter');
+    });
+  });
+
+});

--- a/superset/assets/cypress/integration/explore/visualizations/index.test.js
+++ b/superset/assets/cypress/integration/explore/visualizations/index.test.js
@@ -5,6 +5,7 @@ import BubbleTest from './bubble';
 import CompareTest from './compare';
 import DistBarTest from './dist_bar';
 import DualLineTest from './dual_line';
+import FilterBox from './filter_box';
 import HistogramTest from './histogram';
 import LineTest from './line';
 import PieTest from './pie';
@@ -23,6 +24,7 @@ describe('All Visualizations', () => {
   CompareTest();
   DistBarTest();
   DualLineTest();
+  FilterBox();
   HistogramTest();
   LineTest();
   PieTest();

--- a/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
@@ -123,7 +123,7 @@ class FilterBox extends React.Component {
               label={t('Time range')}
               description={t('Select start and end date')}
               onChange={(...args) => { this.changeFilter(TIME_RANGE, ...args); }}
-              value={this.state.selectedValues[TIME_RANGE]}
+              value={this.state.selectedValues[TIME_RANGE] || 'No filter'}
             />
           </div>
         </div>


### PR DESCRIPTION
In FilterBox, if there's no selectedValue for the DateFilterControl, we should set the default to 'No filter'. Here, the date filter doesn't get applied until some value has been selected in the dropdown, so it's a little confusing to have the default filter say "Last week" (DateFilterControl defaultProp for value) on dashboard, when there is no filter that's applied.

Added a test for filter box to go along with this. 

@betodealmeida @kristw @graceguo-supercat 