### PR TITLE
fix error for flask version >1

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR $HOME/incubator-superset
 
 COPY ./ ./
 
-RUN RUN mkdir -p /home/work/.cache
+RUN mkdir -p /home/work/.cache
 RUN pip install --upgrade setuptools pip
 RUN pip install -r requirements.txt
 RUN pip install -r requirements-dev.txt

--- a/superset/bin/superset
+++ b/superset/bin/superset
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import warnings
+#import warnings
 import click
 from flask.cli import FlaskGroup
 #from flask.exthook import ExtDeprecationWarning

--- a/superset/bin/superset
+++ b/superset/bin/superset
@@ -2,10 +2,10 @@
 import warnings
 import click
 from flask.cli import FlaskGroup
-from flask.exthook import ExtDeprecationWarning
+#from flask.exthook import ExtDeprecationWarning
 from superset.cli import create_app
 
-warnings.simplefilter('ignore', ExtDeprecationWarning)
+#warnings.simplefilter('ignore', ExtDeprecationWarning)
 
 @click.group(cls=FlaskGroup, create_app=create_app)
 def cli():


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/work/incubator-superset/superset/bin/superset", line 5, in <module>
    from flask.exthook import ExtDeprecationWarning
ModuleNotFoundError: No module named 'flask.exthook'
work@1e7cbde60a06:~/incubator-superset$ superset db upgrade

