### PR TITLE
Split cypress tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
   include:
     - language: python
       python: 3.6
-      env: TOXENV=cypress
+      env: TOXENV=cypress_dashboard
       cache:
         pip: true
         yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,33 @@ jobs:
   include:
     - language: python
       python: 3.6
-      env: TOXENV=cypress_dashboard
+      env: TOXENV=cypress-dashboard
+      cache:
+        pip: true
+        yarn: true
+        directories:
+          - ~/.npm
+          - ~/.cache
+      services:
+        - redis-server
+      before_install:
+        - nvm install 8.9
+    - language: python
+      python: 3.6
+      env: TOXENV=cypress-explore
+      cache:
+        pip: true
+        yarn: true
+        directories:
+          - ~/.npm
+          - ~/.cache
+      services:
+        - redis-server
+      before_install:
+        - nvm install 8.9
+    - language: python
+      python: 3.6
+      env: TOXENV=cypress-sqllab
       cache:
         pip: true
         yarn: true

--- a/superset/assets/cypress.json
+++ b/superset/assets/cypress.json
@@ -1,8 +1,10 @@
 {
   "baseUrl": "http://localhost:8081",
   "videoUploadOnPasses": false,
+  "video": false,
   "ignoreTestFiles": ["**/!(*.test.js)"],
   "projectId": "fbf96q",
+  "defaultCommandTimeout": 10000,
   "viewportWidth": 1280,
   "viewportHeight": 800
 }

--- a/superset/assets/cypress_build.sh
+++ b/superset/assets/cypress_build.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 set -e
 
+<<<<<<< HEAD
 superset/bin/superset db upgrade
 superset/bin/superset load_test_users
 superset/bin/superset load_examples
 superset/bin/superset init
 flask run -p 8081 --with-threads --reload --debugger &
 
+=======
+>>>>>>> split into three
 cd "$(dirname "$0")"
 
-yarn install --frozen-lockfile
-npm run build
-npm run cypress run
+yarn install --frozen-lockfile & superset/bin/superset db upgrade
+superset/bin/superset load_test_users & superset/bin/superset load_examples
+superset/bin/superset init
+npm run build & flask run -p 8081 --with-threads --reload --debugger &
+
+npm run cypress run -- --spec 'cypress/integration/explore/*' & npm run cypress run -- --spec 'cypress/integration/dashboard/*' & npm run cypress run -- --spec 'cypress/integration/explore/*'
 kill %1

--- a/superset/assets/cypress_build.sh
+++ b/superset/assets/cypress_build.sh
@@ -1,21 +1,15 @@
 #!/bin/bash
 set -e
 
-<<<<<<< HEAD
-superset/bin/superset db upgrade
-superset/bin/superset load_test_users
-superset/bin/superset load_examples
-superset/bin/superset init
-flask run -p 8081 --with-threads --reload --debugger &
-
-=======
->>>>>>> split into three
 cd "$(dirname "$0")"
 
-yarn install --frozen-lockfile & superset/bin/superset db upgrade
-superset/bin/superset load_test_users & superset/bin/superset load_examples
-superset/bin/superset init
-npm run build & flask run -p 8081 --with-threads --reload --debugger &
+#run all the python steps in a background process
+(time /home/travis/build/apache/incubator-superset/superset/bin/superset db upgrade; time /home/travis/build/apache/incubator-superset/superset/bin/superset load_test_users; /home/travis/build/apache/incubator-superset/superset/bin/superset load_examples; time /home/travis/build/apache/incubator-superset/superset/bin/superset init; echo "[completed python build steps]"; flask run -p 8081 --with-threads --reload --debugger) &
 
-npm run cypress run -- --spec 'cypress/integration/explore/*' & npm run cypress run -- --spec 'cypress/integration/dashboard/*' & npm run cypress run -- --spec 'cypress/integration/explore/*'
+#block on the longer running javascript process
+(time yarn install --frozen-lockfile; time npm run build; echo "[completed js build steps]")
+
+CYPRESS_PATH='cypress/integration/'${1}'/*'
+time npm run cypress run -- --spec "$CYPRESS_PATH" --record false --config video=false
+
 kill %1

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ setenv =
 whitelist_externals =
     npm
 
-[testenv:cypress_dashboard]
+[testenv:cypress-dashboard]
 commands =
     {toxinidir}/superset/assets/cypress_build.sh dashboard
 setenv =
@@ -56,7 +56,7 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 
-[testenv:cypress_explore]
+[testenv:cypress-explore]
 commands =
     {toxinidir}/superset/assets/cypress_build.sh explore
 setenv =
@@ -67,7 +67,7 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 
-[testenv:cypress_sqllab]
+[testenv:cypress-sqllab]
 commands =
     {toxinidir}/superset/assets/cypress_build.sh sqllab
 setenv =
@@ -105,9 +105,9 @@ deps =
 
 [tox]
 envlist =
-    cypress_dashboard
-    cypress_explore
-    cypress_sqllab
+    cypress-dashboard
+    cypress-explore
+    cypress-sqllab
     eslint
     flake8
     javascript

--- a/tox.ini
+++ b/tox.ini
@@ -45,9 +45,31 @@ setenv =
 whitelist_externals =
     npm
 
-[testenv:cypress]
+[testenv:cypress_dashboard]
 commands =
-    {toxinidir}/superset/assets/cypress_build.sh
+    {toxinidir}/superset/assets/cypress_build.sh dashboard
+setenv =
+    PYTHONPATH = {toxinidir}
+    SUPERSET_CONFIG = tests.superset_test_config
+    SUPERSET_HOME = {envtmpdir}
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+
+[testenv:cypress_explore]
+commands =
+    {toxinidir}/superset/assets/cypress_build.sh explore
+setenv =
+    PYTHONPATH = {toxinidir}
+    SUPERSET_CONFIG = tests.superset_test_config
+    SUPERSET_HOME = {envtmpdir}
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+
+[testenv:cypress_sqllab]
+commands =
+    {toxinidir}/superset/assets/cypress_build.sh sqllab
 setenv =
     PYTHONPATH = {toxinidir}
     SUPERSET_CONFIG = tests.superset_test_config
@@ -83,7 +105,9 @@ deps =
 
 [tox]
 envlist =
-    cypress
+    cypress_dashboard
+    cypress_explore
+    cypress_sqllab
     eslint
     flake8
     javascript


### PR DESCRIPTION
This PR reduces the cypress runtime from ~18 minutes to ~11 minutes. It uses a few techniques listed below: 

1. splitting the tests into several independent components run in parallel
2. using subprocesses to run non-dependent build up step in each test in parallel
3. removes the recording of video that we weren't using

It also times each subcomponent so we can track how the times are growing

@mistercrunch @michellethomas @john-bodley 