### PR TITLE
Setting default row_limit to 50K for line chart

### DIFF
--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -218,6 +218,9 @@ export const visTypes = {
         choices: D3_TIME_FORMAT_OPTIONS,
         default: 'smart_date',
       },
+      row_limit: {
+        default: 50000,
+      },
     },
   },
 


### PR DESCRIPTION
This PR sets default row_limit to null for line chart, bar chart, compare chart, and area chart. Because row_limit is a new field on timeseries charts, existing charts may be affected if they have over 10,000 rows.

@mistercrunch what do you think about setting the row_limit default to null? We could also set the default to 50,000 instead, it seems less likely that a chart with 50,000 rows would render very well anyways.