### PR TITLE
[Fix] merge since, until request parameter with time_range

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1032,6 +1032,15 @@ class Superset(BaseSupersetView):
             slc = db.session.query(models.Slice).filter_by(id=slice_id).first()
             slice_form_data = slc.form_data.copy()
             # allow form_data in request override slice from_data
+            # special treat for since/until and time_range parameter:
+            # we need to breakdown time_range into since/until so request parameters
+            # has precedence over slice parameters for time fields.
+            if 'time_range' in form_data:
+                form_data['since'], separator, form_data['until'] = \
+                    form_data['time_range'].partition(' : ')
+            if 'time_range' in slice_form_data:
+                slice_form_data['since'], separator, slice_form_data['until'] = \
+                    slice_form_data['time_range'].partition(' : ')
             slice_form_data.update(form_data)
             form_data = slice_form_data
 


### PR DESCRIPTION
When exploring, Superset allow request parameter override slice parameter. 
There is an issue that slice has time_range parameter, while request has since/until (or vise verse), they didn't merge correct. Example: annotation request like:
http://localhost:8080/superset/slice_json/240?form_data=%7B%22until%22%3A%222008-10-30T00%3A00%3A00%22%7D

@betodealmeida @fabianmenges @michellethomas @kristw 