### PR TITLE
Dockerfile change because error: E: The method driver /usr/lib/apt/methods/https…

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG=C.UTF-8 \
     HOME=/home/work
 
 RUN apt-get update -y
-
+RUN apt-get install -y apt-transport-https apt-utils
 # Install some dependencies
 # http://airbnb.io/superset/installation.html#os-dependencies
 RUN apt-get update -y && apt-get install -y build-essential libssl-dev \

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -11,6 +11,7 @@ ENV LANG=C.UTF-8 \
     HOME=/home/work
 
 RUN apt-get update -y
+#Install dependencies to fix `curl https support error` and `elaying package configuration warning`
 RUN apt-get install -y apt-transport-https apt-utils
 # Install some dependencies
 # http://airbnb.io/superset/installation.html#os-dependencies


### PR DESCRIPTION
issues: https://github.com/apache/incubator-superset/issues/6256

Got error 
```
E: The method driver /usr/lib/apt/methods/https could not be found.
E: Failed to fetch https://dl.yarnpkg.com/debian/dists/stable/InRelease                 
E: Some index files failed to download. They have been ignored, or old ones used instead. 
```
when without apt-transport-https
and got warning
```
debconf: delaying package configuration, since apt-utils is not installed
```
without apt-utils