### PR TITLE
[refactor] Remove label and showOnExplore from visTypes. Import specific validators

### DIFF
--- a/superset/assets/src/explore/visTypes.jsx
+++ b/superset/assets/src/explore/visTypes.jsx
@@ -7,7 +7,7 @@ import { t } from '@superset-ui/translation';
 
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { D3_TIME_FORMAT_OPTIONS } from './controls';
-import * as v from './validators';
+import { nonEmpty } from './validators';
 
 export const sections = {
   druidTimeSeries: {
@@ -99,8 +99,6 @@ const timeGrainSqlaAnimationOverrides = {
 
 export const visTypes = {
   dist_bar: {
-    label: t('Distribution - Bar Chart'),
-    showOnExplore: true,
     controlPanelSections: [
       {
         label: t('Query'),
@@ -146,8 +144,6 @@ export const visTypes = {
   },
 
   pie: {
-    label: t('Pie Chart'),
-    showOnExplore: true,
     controlPanelSections: [
       {
         label: t('Query'),
@@ -178,8 +174,6 @@ export const visTypes = {
   },
 
   line: {
-    label: t('Time Series - Line Chart'),
-    showOnExplore: true,
     requiresTime: true,
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
@@ -226,8 +220,6 @@ export const visTypes = {
   },
 
   line_multi: {
-    label: t('Time Series - Multiple Line Charts'),
-    showOnExplore: true,
     requiresTime: true,
     controlPanelSections: [
       {
@@ -300,8 +292,6 @@ export const visTypes = {
   },
 
   time_pivot: {
-    label: t('Time Series - Periodicity Pivot'),
-    showOnExplore: true,
     requiresTime: true,
     controlPanelSections: [
       {
@@ -351,7 +341,6 @@ export const visTypes = {
   },
 
   dual_line: {
-    label: t('Dual Axis Line Chart'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -401,8 +390,6 @@ export const visTypes = {
   },
 
   bar: {
-    label: t('Time Series - Bar Chart'),
-    showOnExplore: true,
     requiresTime: true,
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
@@ -447,7 +434,6 @@ export const visTypes = {
   },
 
   compare: {
-    label: t('Time Series - Percent Change'),
     requiresTime: true,
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
@@ -488,7 +474,6 @@ export const visTypes = {
   },
 
   deck_multi: {
-    label: t('Deck.gl - Multiple Layers'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -510,7 +495,6 @@ export const visTypes = {
   },
 
   deck_hex: {
-    label: t('Deck.gl - Hexagons'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -550,7 +534,6 @@ export const visTypes = {
   },
 
   deck_grid: {
-    label: t('Deck.gl - Grid'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -584,13 +567,12 @@ export const visTypes = {
       size: {
         label: t('Height'),
         description: t('Metric used to control height'),
-        validators: [v.nonEmpty],
+        validators: [nonEmpty],
       },
     },
   },
 
   deck_path: {
-    label: t('Deck.gl - Paths'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -632,7 +614,6 @@ export const visTypes = {
   },
 
   deck_screengrid: {
-    label: t('Deck.gl - Screen grid'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -672,14 +653,13 @@ export const visTypes = {
       size: {
         label: t('Weight'),
         description: t("Metric used as a weight for the grid's coloring"),
-        validators: [v.nonEmpty],
+        validators: [nonEmpty],
       },
       time_grain_sqla: timeGrainSqlaAnimationOverrides,
     },
   },
 
   deck_geojson: {
-    label: t('Deck.gl - GeoJson'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -720,7 +700,6 @@ export const visTypes = {
   },
 
   deck_polygon: {
-    label: t('Deck.gl - Polygon'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -784,7 +763,6 @@ export const visTypes = {
   },
 
   deck_arc: {
-    label: t('Deck.gl - Arc'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -834,7 +812,6 @@ export const visTypes = {
   },
 
   deck_scatter: {
-    label: t('Deck.gl - Scatter plot'),
     requiresTime: true,
     onInit: controlState => ({
       ...controlState,
@@ -903,7 +880,6 @@ export const visTypes = {
   },
 
   area: {
-    label: t('Time Series - Stacked'),
     requiresTime: true,
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
@@ -949,7 +925,6 @@ export const visTypes = {
   },
 
   table: {
-    label: t('Table View'),
     controlPanelSections: [
       {
         label: t('GROUP BY'),
@@ -999,7 +974,6 @@ export const visTypes = {
   },
 
   time_table: {
-    label: t('Time Series Table'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1027,7 +1001,6 @@ export const visTypes = {
   },
 
   markup: {
-    label: t('Markup'),
     controlPanelSections: [
       {
         label: t('Code'),
@@ -1041,7 +1014,6 @@ export const visTypes = {
   },
 
   pivot_table: {
-    label: t('Pivot Table'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1069,7 +1041,6 @@ export const visTypes = {
   },
 
   separator: {
-    label: t('Separator'),
     controlPanelSections: [
       {
         label: t('Code'),
@@ -1091,7 +1062,6 @@ export const visTypes = {
   },
 
   word_cloud: {
-    label: t('Word Cloud'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1115,7 +1085,6 @@ export const visTypes = {
   },
 
   treemap: {
-    label: t('Treemap'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1145,7 +1114,6 @@ export const visTypes = {
   },
 
   cal_heatmap: {
-    label: t('Calendar Heatmap'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -1184,7 +1152,6 @@ export const visTypes = {
   },
 
   box_plot: {
-    label: t('Box Plot'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1261,7 +1228,6 @@ export const visTypes = {
   },
 
   bullet: {
-    label: t('Bullet Chart'),
     requiresTime: false,
     controlPanelSections: [
       {
@@ -1286,7 +1252,6 @@ export const visTypes = {
   },
 
   big_number: {
-    label: t('Big Number with Trendline'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1315,7 +1280,6 @@ export const visTypes = {
   },
 
   big_number_total: {
-    label: t('Big Number'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1342,7 +1306,6 @@ export const visTypes = {
   },
 
   histogram: {
-    label: t('Histogram'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1385,7 +1348,6 @@ export const visTypes = {
   },
 
   sunburst: {
-    label: t('Sunburst'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1426,7 +1388,6 @@ export const visTypes = {
   },
 
   sankey: {
-    label: t('Sankey'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1455,7 +1416,6 @@ export const visTypes = {
   },
 
   directed_force: {
-    label: t('Force-directed Graph'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1483,7 +1443,6 @@ export const visTypes = {
     },
   },
   chord: {
-    label: t('Chord Diagram'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1513,19 +1472,18 @@ export const visTypes = {
       groupby: {
         label: t('Source'),
         multi: false,
-        validators: [v.nonEmpty],
+        validators: [nonEmpty],
         description: t('Choose a source'),
       },
       columns: {
         label: t('Target'),
         multi: false,
-        validators: [v.nonEmpty],
+        validators: [nonEmpty],
         description: t('Choose a target'),
       },
     },
   },
   country_map: {
-    label: t('Country Map'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1560,7 +1518,6 @@ export const visTypes = {
     },
   },
   world_map: {
-    label: t('World Map'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1599,7 +1556,6 @@ export const visTypes = {
   },
 
   filter_box: {
-    label: t('Filter Box'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1628,7 +1584,6 @@ export const visTypes = {
   },
 
   iframe: {
-    label: t('iFrame'),
     controlPanelSections: [
       {
         label: t('Options'),
@@ -1640,7 +1595,6 @@ export const visTypes = {
   },
 
   para: {
-    label: t('Parallel Coordinates'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1665,7 +1619,6 @@ export const visTypes = {
   },
 
   heatmap: {
-    label: t('Heatmap'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1694,10 +1647,10 @@ export const visTypes = {
     ],
     controlOverrides: {
       all_columns_x: {
-        validators: [v.nonEmpty],
+        validators: [nonEmpty],
       },
       all_columns_y: {
-        validators: [v.nonEmpty],
+        validators: [nonEmpty],
       },
       normalized: t('Whether to apply a normal distribution based on rank on the color scale'),
       y_axis_bounds: {
@@ -1714,7 +1667,6 @@ export const visTypes = {
   },
 
   horizon: {
-    label: t('Horizon'),
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
       {
@@ -1728,7 +1680,6 @@ export const visTypes = {
   },
 
   mapbox: {
-    label: t('Mapbox'),
     controlPanelSections: [
       {
         label: t('Query'),
@@ -1800,7 +1751,6 @@ export const visTypes = {
   },
 
   event_flow: {
-    label: t('Event flow'),
     requiresTime: true,
     controlPanelSections: [
       {
@@ -1834,7 +1784,7 @@ export const visTypes = {
       },
       all_columns_x: {
         label: t('Column containing event names'),
-        validators: [v.nonEmpty],
+        validators: [nonEmpty],
         default: control => (
           control.choices && control.choices.length > 0 ?
             control.choices[0][0] : null
@@ -1852,8 +1802,6 @@ export const visTypes = {
   },
 
   paired_ttest: {
-    label: t('Time Series - Paired t-test'),
-    showOnExplore: true,
     requiresTime: true,
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
@@ -1870,8 +1818,6 @@ export const visTypes = {
   },
 
   rose: {
-    label: t('Time Series - Nightingale Rose Chart'),
-    showOnExplore: true,
     requiresTime: true,
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
@@ -1889,8 +1835,6 @@ export const visTypes = {
   },
 
   partition: {
-    label: t('Partition Diagram'),
-    showOnExplore: true,
     controlPanelSections: [
       sections.NVD3TimeSeries[0],
       {


### PR DESCRIPTION
- The `label` field is not used any more. Now all chart labels are from the `ChartMetadata` defined in each plugin. 
- `showOnExplore` is a field defined in #3241 which is no longer used. 
- `import { nonEmpty }` instead of `import *`

@williaster @conglei @graceguo-supercat @michellethomas @mistercrunch 