### PR TITLE
Fixing time range since with no "ago"

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -923,6 +923,8 @@ def get_since_until(form_data):
         time_range = form_data['time_range']
         if separator in time_range:
             since, until = time_range.split(separator, 1)
+            if since and since not in common_time_frames:
+                since = add_ago_to_since(since)
             since = parse_human_datetime(since)
             until = parse_human_datetime(until)
         elif time_range in common_time_frames:
@@ -940,14 +942,27 @@ def get_since_until(form_data):
     else:
         since = form_data.get('since', '')
         if since:
-            since_words = since.split(' ')
-            grains = ['days', 'years', 'hours', 'day', 'year', 'weeks']
-            if len(since_words) == 2 and since_words[1] in grains:
-                since += ' ago'
+            since = add_ago_to_since(since)
         since = parse_human_datetime(since)
         until = parse_human_datetime(form_data.get('until', 'now'))
 
     return since, until
+
+
+def add_ago_to_since(since):
+    """
+    Backwards compatibility hack. Without this slices with since: 7 days will
+    be treated as 7 days in the future.
+
+    :param str since:
+    :returns: Since with ago added if necessary
+    :rtype: str
+    """
+    since_words = since.split(' ')
+    grains = ['days', 'years', 'hours', 'day', 'year', 'weeks']
+    if (len(since_words) == 2 and since_words[1] in grains):
+        since += ' ago'
+    return since
 
 
 def convert_legacy_filters_into_adhoc(fd):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1036,12 +1036,11 @@ class Superset(BaseSupersetView):
             # special treat for since/until and time_range parameter:
             # we need to breakdown time_range into since/until so request parameters
             # has precedence over slice parameters for time fields.
-            if 'time_range' in form_data:
-                form_data['since'], separator, form_data['until'] = \
-                    form_data['time_range'].partition(' : ')
-            if 'time_range' in slice_form_data:
-                slice_form_data['since'], separator, slice_form_data['until'] = \
-                    slice_form_data['time_range'].partition(' : ')
+            if 'since' in form_data or 'until' in form_data:
+                form_data['since'], form_data['until'] = \
+                    utils.get_since_until(form_data)
+                slice_form_data['since'], slice_form_data['until'] = \
+                    utils.get_since_until(slice_form_data)
             slice_form_data.update(form_data)
             form_data = slice_form_data
 


### PR DESCRIPTION
'7 days ago' is parsed correctly but we have some charts with since: 7 days until: now and it's treated as 7 days from now not since 7 days.

It looks like this backwards compatibility hack was removed [here](https://github.com/apache/incubator-superset/pull/4981/files#diff-f451672348fc6071e8d627778bdc4e96L270), I'm not sure if there was a specific reason to remove it. 

While looking into this issue, I noticed that the fix for annotations introduced an issue where a time range is always split into since/until which means that the UI will always show it as a custom start/end when the page is reloaded.

The annotations override since / until will also have issues if the filter shown is the default 'No filter', the annotation will fail because it will be added as a since filter that get_since_until doesn't know what to do with.

Overall these feel like a lot of hacky fixes because we didn't do a db migration for time range. If anyone has better suggestions or wants to migrate all since/until to time_range, let me know. 

@john-bodley @graceguo-supercat @mistercrunch @betodealmeida 

Fixes #6263