### PR TITLE
[superset-client] `getClientErrorObject` for everyone

### DIFF
--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -9,6 +9,7 @@ import {
   addDangerToast as addDangerToastAction,
   addInfoToast as addInfoToastAction,
 } from '../messageToasts/actions';
+import getClientErrorObject from '../utils/getClientErrorObject';
 import COMMON_ERR_MESSAGES from '../utils/errorMessages';
 
 export const RESET_STATE = 'RESET_STATE';
@@ -115,12 +116,14 @@ export function fetchQueryResults(query) {
         const bigIntJson = JSONbig.parse(text);
         dispatch(querySuccess(query, bigIntJson));
       })
-      .catch((error) => {
-        const message = error.error || error.statusText || t('Failed at retrieving results');
+      .catch(response =>
+        getClientErrorObject(response).then((error) => {
+          const message = error.error || error.statusText || t('Failed at retrieving results');
 
-        return dispatch(queryFailed(query, message, error.link));
-      });
-  };
+          return dispatch(queryFailed(query, message, error.link));
+        }),
+      );
+    };
 }
 
 export function runQuery(query) {
@@ -150,14 +153,15 @@ export function runQuery(query) {
           dispatch(querySuccess(query, json));
         }
       })
-      .catch((error) => {
-        let message = error.error || error.statusText || t('Unknown error');
-        if (message.includes('CSRF token')) {
-          message = t(COMMON_ERR_MESSAGES.SESSION_TIMED_OUT);
-        }
-        // @TODO how to verify link?
-        dispatch(queryFailed(query, message, error.link));
-      });
+      .catch(response =>
+        getClientErrorObject(response).then((error) => {
+          let message = error.error || error.statusText || t('Unknown error');
+          if (message.includes('CSRF token')) {
+            message = t(COMMON_ERR_MESSAGES.SESSION_TIMED_OUT);
+          }
+          dispatch(queryFailed(query, message, error.link));
+        }),
+      );
   };
 }
 

--- a/superset/assets/src/SqlLab/components/ShareSqlLabQuery.jsx
+++ b/superset/assets/src/SqlLab/components/ShareSqlLabQuery.jsx
@@ -39,10 +39,11 @@ class ShareSqlLabQuery extends React.Component {
         this.setState({ shortUrl });
       })
       .catch((response) => {
-        getClientErrorObject(response).then(({ error }) => {
-          this.props.addDangerToast(error);
-          this.setState({ shortUrl: t('Error') });
-        });
+        getClientErrorObject(response)
+          .then(({ error }) => {
+            this.props.addDangerToast(error);
+            this.setState({ shortUrl: t('Error') });
+          });
       });
   }
 

--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -101,15 +101,16 @@ export function runAnnotationQuery(annotation, timeout = 60, formData = null, ke
       timeout: timeout * 1000,
     })
       .then(({ json }) => dispatch(annotationQuerySuccess(annotation, json, sliceKey)))
-      .catch((err) => {
+      .catch(response => getClientErrorObject(response).then((err) => {
         if (err.statusText === 'timeout') {
           dispatch(annotationQueryFailed(annotation, { error: 'Query Timeout' }, sliceKey));
-        } else if ((err.responseJSON.error || '').toLowerCase().includes('no data')) {
+        } else if ((err.error || '').toLowerCase().includes('no data')) {
           dispatch(annotationQuerySuccess(annotation, err, sliceKey));
         } else if (err.statusText !== 'abort') {
-          dispatch(annotationQueryFailed(annotation, err.responseJSON, sliceKey));
+          dispatch(annotationQueryFailed(annotation, err, sliceKey));
         }
-      });
+      }),
+    );
   };
 }
 

--- a/superset/assets/src/components/AsyncSelect.jsx
+++ b/superset/assets/src/components/AsyncSelect.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Select from 'react-select';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/core';
+import getClientErrorObject from '../utils/getClientErrorObject';
 
 const propTypes = {
   dataEndpoint: PropTypes.string.isRequired,
@@ -57,10 +58,11 @@ class AsyncSelect extends React.PureComponent {
           this.onChange(options[0]);
         }
       })
-      .catch((error) => {
+      .catch(response => getClientErrorObject(response).then((error) => {
         this.props.onAsyncError(error.error || error.statusText || error);
         this.setState({ isLoading: false });
-      });
+      }),
+    );
   }
 
   render() {

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -4,6 +4,7 @@ import { Alert, Badge, Col, Label, Tabs, Tab, Well } from 'react-bootstrap';
 import shortid from 'shortid';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/core';
+import getClientErrorObject from '../utils/getClientErrorObject';
 
 import Button from '../components/Button';
 import Loading from '../components/Loading';
@@ -267,11 +268,11 @@ export class DatasourceEditor extends React.PureComponent {
       this.mergeColumns(json);
       this.props.addSuccessToast(t('Metadata has been synced'));
       this.setState({ metadataLoading: false });
-    }).catch((error) => {
-      const msg = error.error || error.statusText || t('An error has occurred');
-      this.props.addDangerToast(msg);
-      this.setState({ metadataLoading: false });
-    });
+    }).catch(response => getClientErrorObject(response).then(({ error, statusText }) => {
+        this.props.addDangerToast(error || statusText || t('An error has occurred'));
+        this.setState({ metadataLoading: false });
+      }),
+    );
   }
 
   findDuplicates(arr, accessor) {

--- a/superset/assets/src/datasource/DatasourceModal.jsx
+++ b/superset/assets/src/datasource/DatasourceModal.jsx
@@ -5,6 +5,7 @@ import Dialog from 'react-bootstrap-dialog';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/core';
 
+import getClientErrorObject from '../utils/getClientErrorObject';
 import DatasourceEditor from '../datasource/DatasourceEditor';
 import withToasts from '../messageToasts/enhancers/withToasts';
 
@@ -65,17 +66,19 @@ class DatasourceModal extends React.PureComponent {
         this.props.onDatasourceSave(json);
         this.props.onHide();
       })
-      .catch((error) => {
-        this.dialog.show({
-          title: 'Error',
-          bsSize: 'medium',
-          bsStyle: 'danger',
-          actions: [
-            Dialog.DefaultAction('Ok', () => {}, 'btn-danger'),
-          ],
-          body: error.error || error.statusText || t('An error has occurred'),
-        });
-      });
+      .catch(response =>
+        getClientErrorObject(response).then(({ error, statusText }) => {
+          this.dialog.show({
+            title: 'Error',
+            bsSize: 'medium',
+            bsStyle: 'danger',
+            actions: [
+              Dialog.DefaultAction('Ok', () => {}, 'btn-danger'),
+            ],
+            body: error || statusText || t('An error has occurred'),
+          });
+        }),
+      );
   }
 
   onDatasourceChange(datasource, errors) {

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -11,6 +11,7 @@ import { Table } from 'reactable';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/core';
 
+import getClientErrorObject from '../../utils/getClientErrorObject';
 import CopyToClipboard from './../../components/CopyToClipboard';
 import { getExploreUrlAndPayload } from '../exploreUtils';
 
@@ -70,12 +71,14 @@ export default class DisplayQueryButton extends React.PureComponent {
           error: null,
         });
       })
-      .catch((error) => {
-        this.setState({
-          error: error.error || error.statusText || t('Sorry, An error occurred'),
-          isLoading: false,
-        });
-      });
+      .catch(response =>
+        getClientErrorObject(response).then(({ error, statusText }) => {
+          this.setState({
+            error: error || statusText || t('Sorry, An error occurred'),
+            isLoading: false,
+          });
+        }),
+      );
   }
   changeFilterText(event) {
     this.setState({ filterText: event.target.value });

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -1,5 +1,6 @@
 import d3 from 'd3';
 import { SupersetClient } from '@superset-ui/core';
+import getClientErrorObject from './getClientErrorObject';
 
 export const EARTH_CIRCUMFERENCE_KM = 40075.16;
 export const LUMINANCE_RED_WEIGHT = 0.2126;
@@ -63,7 +64,11 @@ export function getShortUrl(longUrl) {
     postPayload: { data: `/${longUrl}` }, // note: url should contain 2x '/' to redirect properly
     parseMethod: 'text',
     stringify: false, // the url saves with an extra set of string quotes without this
-  }).then(({ text }) => text);
+  })
+    .then(({ text }) => text)
+    .catch(response =>
+      getClientErrorObject(response)
+        .then(({ error, statusText }) => Promise.reject(error || statusText)));
 }
 
 export function supersetURL(rootUrl, getParams = {}) {


### PR DESCRIPTION
This fixes #6272 and probably some other error 🐛 s that haven't been reported.

I searched for all instances of `SupersetClient.xxx().catch()` and if any call attempted to pull an error message from the `response` I wrapped it in the `getClientErrorObject` which properly parses the response.

Tested most of them manually by hand by inducing an error, here's the updated error for the reported bug:

![image](https://user-images.githubusercontent.com/4496521/48025316-e945a680-e0f7-11e8-9b2b-f38127dee1fd.png)

@mistercrunch @kristw @michellethomas @graceguo-supercat

