### PR TITLE
Avoid clearing metric when saving from datasource editor

### DIFF
--- a/superset/assets/src/explore/components/controls/MetricsControl.jsx
+++ b/superset/assets/src/explore/components/controls/MetricsControl.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import VirtualizedSelect from 'react-virtualized-select';
 import { t } from '@superset-ui/translation';
+import { isEqual } from 'lodash';
 
 import ControlHeader from '../ControlHeader';
 import VirtualizedRendererWrap from '../../../components/VirtualizedRendererWrap';
@@ -117,8 +118,8 @@ export default class MetricsControl extends React.PureComponent {
 
   componentWillReceiveProps(nextProps) {
     if (
-      this.props.columns !== nextProps.columns ||
-      this.props.savedMetrics !== nextProps.savedMetrics
+      isEqual(this.props.columns) !== isEqual(nextProps.columns) ||
+      isEqual(this.props.savedMetrics) !== isEqual(nextProps.savedMetrics)
     ) {
       this.setState({ options: this.optionsForSelect(nextProps) });
       this.props.onChange([]);


### PR DESCRIPTION
Clicking save from the datasource editor would clear your metrics field because we were comparing objects in MetricsControl to see if columns or saved metrics changed. We should be doing a deep compare.

Thanks @graceguo-supercat for helping track this down!

@mistercrunch @john-bodley @graceguo-supercat 

Fixes #6275