### PR TITLE
[dashboard] fix <Loading /> spinners disappear too early

### DIFF
--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -176,7 +176,7 @@ class Chart extends React.PureComponent {
       >
         {this.renderTooltip()}
 
-        {isLoading && <Loading size={50} />}
+        {chartStatus !== 'rendered' && <Loading size={50} />}
 
         {chartAlert && (
           <StackTraceMessage


### PR DESCRIPTION
Recently I noticed that loading spinners on dashboards would disappear
too early. @kristw @williaster 
![gnnryhxtfj](https://user-images.githubusercontent.com/487433/48050126-deb9fa00-e155-11e8-98f0-556ff70b953b.gif)
