### PR TITLE
[annotation] Only allow override whole time_range

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -1,12 +1,12 @@
 /* global window, AbortController */
 /* eslint no-undef: 'error' */
+/* eslint no-param-reassign: ["error", { "props": false }] */
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
 import { getExploreUrlAndPayload, getAnnotationJsonUrl } from '../explore/exploreUtils';
 import { requiresQuery, ANNOTATION_SOURCE_TYPES } from '../modules/AnnotationTypes';
 import { addDangerToast } from '../messageToasts/actions';
 import { Logger, LOG_ACTIONS_LOAD_CHART } from '../logger';
-import { TIME_RANGE_SEPARATOR } from '../utils/common';
 import getClientErrorObject from '../utils/getClientErrorObject';
 
 export const CHART_UPDATE_STARTED = 'CHART_UPDATE_STARTED';
@@ -77,10 +77,13 @@ export function runAnnotationQuery(annotation, timeout = 60, formData = null, ke
     const granularity = fd.time_grain_sqla || fd.granularity;
     fd.time_grain_sqla = granularity;
     fd.granularity = granularity;
-    if (fd.time_range) {
-      [fd.since, fd.until] = fd.time_range.split(TIME_RANGE_SEPARATOR);
+    const overridesKeys = Object.keys(annotation.overrides);
+    if (overridesKeys.includes('since') || overridesKeys.includes('until')) {
+      annotation.overrides = {
+        ...annotation.overrides,
+        time_range: null,
+      };
     }
-
     const sliceFormData = Object.keys(annotation.overrides).reduce(
       (d, k) => ({
         ...d,

--- a/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
@@ -97,6 +97,14 @@ export default class AnnotationLayer extends React.PureComponent {
       timeColumn,
       intervalEndColumn,
     } = props;
+
+    const overridesKeys = Object.keys(overrides);
+    if (overridesKeys.includes('since') || overridesKeys.includes('until')) {
+      overrides.time_range = null;
+      delete overrides.since;
+      delete overrides.until;
+    }
+
     this.state = {
       // base
       name,
@@ -215,7 +223,7 @@ export default class AnnotationLayer extends React.PureComponent {
       intervalEndColumn: null,
       timeColumn: null,
       titleColumn: null,
-      overrides: { since: null, until: null },
+      overrides: { time_range: null },
     });
   }
 
@@ -427,31 +435,15 @@ export default class AnnotationLayer extends React.PureComponent {
             <div style={{ marginTop: '1rem' }}>
               <CheckboxControl
                 hovered
-                name="annotation-override-since"
-                label="Override 'Since'"
-                description={`This controls whether the "Since" field from the current
+                name="annotation-override-time_range"
+                label="Override time range"
+                description={`This controls whether the "time_range" field from the current
                   view should be passed down to the chart containing the annotation data.`}
-                value={!!Object.keys(overrides).find(x => x === 'since')}
+                value={!!Object.keys(overrides).find(x => x === 'time_range')}
                 onChange={(v) => {
-                  delete overrides.since;
+                  delete overrides.time_range;
                   if (v) {
-                    this.setState({ overrides: { ...overrides, since: null } });
-                  } else {
-                    this.setState({ overrides: { ...overrides } });
-                  }
-                }}
-              />
-              <CheckboxControl
-                hovered
-                name="annotation-override-until"
-                label="Override 'Until'"
-                description={`This controls whether the "Until" field from the current
-                  view should be passed down to the chart containing the annotation data.`}
-                value={!!Object.keys(overrides).find(x => x === 'until')}
-                onChange={(v) => {
-                  delete overrides.until;
-                  if (v) {
-                    this.setState({ overrides: { ...overrides, until: null } });
+                    this.setState({ overrides: { ...overrides, time_range: null } });
                   } else {
                     this.setState({ overrides: { ...overrides } });
                   }

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -114,6 +114,3 @@ export function optionFromValue(opt) {
   // From a list of options, handles special values & labels
   return { value: optionValue(opt), label: optionLabel(opt) };
 }
-
-// time_range separator
-export const TIME_RANGE_SEPARATOR = ' : ';

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1032,15 +1032,7 @@ class Superset(BaseSupersetView):
         if slice_id and (use_slice_data or contains_only_slc_id):
             slc = db.session.query(models.Slice).filter_by(id=slice_id).first()
             slice_form_data = slc.form_data.copy()
-            # allow form_data in request override slice from_data
-            # special treat for since/until and time_range parameter:
-            # we need to breakdown time_range into since/until so request parameters
-            # has precedence over slice parameters for time fields.
-            if 'since' in form_data or 'until' in form_data:
-                form_data['since'], form_data['until'] = \
-                    utils.get_since_until(form_data)
-                slice_form_data['since'], slice_form_data['until'] = \
-                    utils.get_since_until(slice_form_data)
+
             slice_form_data.update(form_data)
             form_data = slice_form_data
 


### PR DESCRIPTION

<img width="1336" alt="screen shot 2018-11-06 at 5 20 57 pm" src="https://user-images.githubusercontent.com/27990562/48104449-64868580-e1e8-11e8-9493-de75a534cc73.png">


This PR is related with #6251. 

Before `time_range` we used `since`, `until` parameters. And in annotation layer UI we allow user to override since, or until, or both. But after we introduced `time_range`, it offers many framed time range string like `Last day`, `Last 3 month` etc. in #6251, i tried to merge old since until into time_range, but today we found there are so many cases that no simple solution to cover all. So @michellethomas and me are thinking about simplify the override feature in annotation layer: instead of allow since or until or both, now we only allow override time_range as a whole.

in airbnb we don't have many cases where user want to override only since or until. if @fabianmenges feel this solution is not good enough, we can think about more possible solutions.

@fabianmenges @betodealmeida @mistercrunch @michellethomas  