### PR TITLE
Docker Demo, Port Change

### DIFF
--- a/contrib/docker/docker-init.sh
+++ b/contrib/docker/docker-init.sh
@@ -21,4 +21,4 @@ cd superset/assets && npm run build && cd ../../
 superset worker &
 
 # Start the dev web server
-flask run -p 8080 --with-threads --reload --debugger --host=0.0.0.0
+flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0


### PR DESCRIPTION
If you follow the documentation, the current docker instructions return an error when trying to connect via localhost. This seems to be due to the fact that it's running on port 8080, but forwarding port 8088. I suppose the cleaner solution is to do this, as opposed to changing both the compose file and the instructions... Hope this helps!!