### PR TITLE
Disable flaky cypress SQL Lab test

### DIFF
--- a/superset/assets/cypress/integration/sqllab/sourcePanel.js
+++ b/superset/assets/cypress/integration/sqllab/sourcePanel.js
@@ -8,7 +8,8 @@ export default () => {
       cy.visit('/superset/sqllab');
     });
 
-    it('creates a table schema and preview when a database, schema, and table are selected', () => {
+    // TODO the test bellow is flaky, and has been disabled for the time being (notice the `it.skip`)
+    it.skip('creates a table schema and preview when a database, schema, and table are selected', () => {
       cy.route('/superset/table/**').as('tableMetadata');
 
       // it should have dropdowns to select database, schema, and table

--- a/superset/assets/cypress/integration/sqllab/sourcePanel.js
+++ b/superset/assets/cypress/integration/sqllab/sourcePanel.js
@@ -8,8 +8,9 @@ export default () => {
       cy.visit('/superset/sqllab');
     });
 
-    // TODO the test bellow is flaky, and has been disabled for the time being (notice the `it.skip`)
-    it.skip('creates a table schema and preview when a database, schema, and table are selected', () => {
+    // TODO the test bellow is flaky, and has been disabled for the time being
+    // (notice the `it.skip`)
+    it.skip('creates a table preview when a database, schema, and table are selected', () => {
       cy.route('/superset/table/**').as('tableMetadata');
 
       // it should have dropdowns to select database, schema, and table


### PR DESCRIPTION
Cypress is by far the longest item in our build matrix and having a flaky test there hurts much more than it hurts to not have this test. Let's disable it for now.