### PR TITLE
Reduce log level for generated queries and attach message

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -465,7 +465,7 @@ class SqlaTable(Model, BaseDatasource):
     def get_query_str(self, query_obj):
         qry = self.get_sqla_query(**query_obj)
         sql = self.database.compile_sqla_query(qry)
-        logging.info(sql)
+        logging.debug('Calculated query : %s', sql)
         sql = sqlparse.format(sql, reindent=True)
         if query_obj['is_prequery']:
             query_obj['prequeries'].append(sql)


### PR DESCRIPTION
Generating INFO logs that will span on multiple lines make the logs far harder to read and parse.
Since this is obviously for debug purpose, I reduce the log level to debug, and add a small message to the query string.