### PR TITLE
[bugfix] don't parse save dashboard response

### DIFF
--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -132,6 +132,7 @@ export function saveDashboardRequest(data, id, saveType) {
     SupersetClient.post({
       endpoint: `/superset/${path}/${id}/`,
       postPayload: { data },
+      parseMethod: null,
     })
       .then(response =>
         Promise.all([

--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -148,7 +148,7 @@ export function saveDashboardRequest(data, id, saveType) {
             addDangerToast(
               `${t(
                 'Sorry, there was an error saving this dashboard: ',
-              )} ${error}}`,
+              )} ${error}`,
             ),
           ),
         ),


### PR DESCRIPTION
Right now a straight `save` on a dashboard displays an error message in the UI (tho the save is successful) because the success response is not JSON, which is the default `parseMethod` for `SupersetClient`

This also removes an extra bracket shown in the error message when there _is_ an error saving. 

Verified locally.

@michellethomas @graceguo-supercat @kristw @mistercrunch 