### PR TITLE
[dashboard] fix save/save-as flow

### DIFF
--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -132,7 +132,6 @@ export function saveDashboardRequest(data, id, saveType) {
     SupersetClient.post({
       endpoint: `/superset/${path}/${id}/`,
       postPayload: { data },
-      parseMethod: null,
     })
       .then(response =>
         Promise.all([

--- a/superset/assets/src/dashboard/components/SaveModal.jsx
+++ b/superset/assets/src/dashboard/components/SaveModal.jsx
@@ -93,16 +93,16 @@ class SaveModal extends React.PureComponent {
         t('You must pick a name for the new dashboard'),
       );
     } else {
-      this.onSave(data, dashboardId, saveType).then(resp => {
-        if (
-          saveType === SAVE_TYPE_NEWDASHBOARD &&
-          resp &&
-          resp.json &&
-          resp.json.id
-        ) {
-          window.location = `/superset/dashboard/${resp.json.id}/`;
-        }
-      });
+      this.onSave(data, dashboardId, saveType)
+        .then(resp => resp.json())
+        .then(json => {
+          if (saveType === SAVE_TYPE_NEWDASHBOARD && json && json.id) {
+            window.location = `/superset/dashboard/${json.id}/`;
+          }
+        })
+        .catch(() =>
+          this.props.addDangerToast(t('Could not re-direct to new dashboard')),
+        );
       this.modal.close();
     }
   }

--- a/superset/assets/src/dashboard/components/SaveModal.jsx
+++ b/superset/assets/src/dashboard/components/SaveModal.jsx
@@ -93,16 +93,16 @@ class SaveModal extends React.PureComponent {
         t('You must pick a name for the new dashboard'),
       );
     } else {
-      this.onSave(data, dashboardId, saveType)
-        .then(resp => resp.json())
-        .then(json => {
-          if (saveType === SAVE_TYPE_NEWDASHBOARD && json && json.id) {
-            window.location = `/superset/dashboard/${json.id}/`;
-          }
-        })
-        .catch(() =>
-          this.props.addDangerToast(t('Could not re-direct to new dashboard')),
-        );
+      this.onSave(data, dashboardId, saveType).then(resp => {
+        if (
+          saveType === SAVE_TYPE_NEWDASHBOARD &&
+          resp &&
+          resp.json &&
+          resp.json.id
+        ) {
+          window.location = `/superset/dashboard/${resp.json.id}/`;
+        }
+      });
       this.modal.close();
     }
   }

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1632,7 +1632,7 @@ class Superset(BaseSupersetView):
         session.merge(dash)
         session.commit()
         session.close()
-        return 'SUCCESS'
+        return json_success(json.dumps({'status': 'SUCCESS'}))
 
     @staticmethod
     def _set_dash_metadata(dashboard, data):


### PR DESCRIPTION
Previously #6189 fixed a dashboard `save as` redirect bug, but introduced a dashboard `save` bug which was fixed today by #6349. However fixing the `save` bug re-introduced the `save as` bug 🙉 

Basically `save-as` returns the new `id` for the redirect as `json`, but `save` returns `HTML` which throws if you parse it as `json` 🙄Putting the two together, ~this PR keeps `parseMethod: null`, and handles the json parsing within the `save-as` handler.~ 

EDIT: updated to just make the return type consistent (`json`) and always parse as `json`.

Tested BOTH locally.

@michellethomas @graceguo-supercat @kristw @mistercrunch 