### PR TITLE
[bugfix] nvd3 legend not using verbose name

### DIFF
--- a/superset/assets/src/visualizations/nvd3/transformProps.js
+++ b/superset/assets/src/visualizations/nvd3/transformProps.js
@@ -60,7 +60,7 @@ export default function transformProps(chartProps) {
   const data = Array.isArray(rawData)
     ? rawData.map(row => ({
       ...row,
-      key: formatLabel(row.key, datasource.verbose_map),
+      key: formatLabel(row.key, datasource.verboseMap),
     }))
     : rawData;
 


### PR DESCRIPTION
### Bug

NVD3 chart legend not using verbose name that users set.

![image](https://user-images.githubusercontent.com/1659771/48281818-a4c64d80-e40c-11e8-86c8-02007352d067.png)

![image](https://user-images.githubusercontent.com/1659771/48281821-ab54c500-e40c-11e8-9ff4-ad01ee525122.png)


### Solution

Fix field name typo.

@john-bodley @williaster @graceguo-supercat @michellethomas @conglei 