### PR TITLE
[hive] Fixing where latest partition logic

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1193,8 +1193,8 @@ class HiveEngineSpec(PrestoEngineSpec):
             # table is not partitioned
             return False
         for c in columns:
-            if str(c.name) == str(col_name):
-                return qry.where(c == str(value))
+            if c.get('name') == col_name:
+                return qry.where(Column(col_name) == value)
         return False
 
     @classmethod


### PR DESCRIPTION
This PR fixes an issue with filtering the latest partition for Hive. PyHive returns a list of dictionaries for [get_columns](https://github.com/dropbox/PyHive/blob/65076bbc8697a423b438dc03e928a6dff86fd2cb/pyhive/sqlalchemy_hive.py#L323) rather than SQLAlchemy objects. Note this is the same logic as Presto per https://github.com/apache/incubator-superset/pull/6051. 

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 

 