### PR TITLE
Parse datasource_id as integer on the server side

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -19,7 +19,7 @@ class QueryContext:
             queries: List[Dict],
     ):
         self.datasource = ConnectorRegistry.get_datasource(datasource.get('type'),
-                                                           datasource.get('id'),
+                                                           int(datasource.get('id')),
                                                            db.session)
         self.queries = list(map(lambda query_obj: QueryObject(**query_obj), queries))
 


### PR DESCRIPTION
- Datasource ids are being serialized into strings on the client side and python's default json.load doesn't deserialize strings representing integers as integers. Adding an integer parsing step when initializing QueryContext.

@conglei @kristw @williaster @mistercrunch 