### PR TITLE
docker-init.sh: Fix loading examples

### DIFF
--- a/contrib/docker/docker-init.sh
+++ b/contrib/docker/docker-init.sh
@@ -9,7 +9,7 @@ fabmanager create-admin --app superset
 superset db upgrade
 
 # Load some data to play with
-superset load_examples
+superset load-examples
 
 # Create default roles and permissions
 superset init


### PR DESCRIPTION
* Rename `load_examples` command to `load-examples`, which corresponds to the current usage.