### PR TITLE
[bugfix] visualization flickers when rerunning query

### DIFF
--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -79,7 +79,7 @@ class Chart extends React.PureComponent {
 
   handleRenderSuccess() {
     const { actions, chartStatus, chartId, vizType } = this.props;
-    if (chartStatus !== 'rendered') {
+    if (['loading', 'rendered'].indexOf(chartStatus) < 0) {
       actions.chartRenderingSucceeded(chartId);
     }
 


### PR DESCRIPTION
When hitting the Query button in the explore view, the previous chart
gets shown (flaskhed quickly) between the moment where the loading
spinner goes away and the new chart show up. This fix seems to prevent
this.