### PR TITLE
Fixed the cache issue for BigNumber

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -488,8 +488,10 @@ class BaseViz(object):
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, **config.get('CSV_EXPORT'))
 
-    def get_data(self, df):
-        return self.get_df().to_dict(orient='records')
+    def get_data(self, df=None):
+        if not df:
+            df = self.get_df()
+        return df.to_dict(orient='records')
 
     @property
     def json_data(self):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -488,9 +488,7 @@ class BaseViz(object):
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, **config.get('CSV_EXPORT'))
 
-    def get_data(self, df=None):
-        if not df:
-            df = self.get_df()
+    def get_data(self, df):
         return df.to_dict(orient='records')
 
     @property


### PR DESCRIPTION
This PR is to fix the issue that for BigNumber (which uses the `get_data` function in BaseVis), `get_data` will always conduct a query no matter the result is cached or not. 

@graceguo-supercat  @kristw @williaster 