### PR TITLE
[migration]clean up __from and __to in dashboard json_metadata

### DIFF
--- a/superset/migrations/versions/4ce8df208545_migrate_time_range_for_default_filters.py
+++ b/superset/migrations/versions/4ce8df208545_migrate_time_range_for_default_filters.py
@@ -1,0 +1,96 @@
+"""empty message
+
+Revision ID: 4ce8df208545
+Revises: 55e910a74826
+Create Date: 2018-11-12 13:31:07.578090
+
+"""
+
+# revision identifiers, used by Alembic.
+import json
+
+from alembic import op
+from sqlalchemy import (
+    Column,
+    Integer,
+    Text,
+)
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+revision = '4ce8df208545'
+down_revision = '55e910a74826'
+
+Base = declarative_base()
+
+
+class Dashboard(Base):
+    """Declarative class to do query in upgrade"""
+    __tablename__ = 'dashboards'
+    id = Column(Integer, primary_key=True)
+    json_metadata = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    dashboards = session.query(Dashboard).all()
+    for i, dashboard in enumerate(dashboards):
+        print('scanning dashboard ({}/{}) >>>>'.format(i + 1, len(dashboards)))
+        if dashboard.json_metadata:
+            json_metadata = json.loads(dashboard.json_metadata)
+            has_update = False
+
+            # default_filters: it may define time_range filter
+            default_filters = json_metadata.get('default_filters')
+            if default_filters and default_filters != '{}':
+                try:
+                    filters = json.loads(default_filters)
+                    keys = [key for key, val in filters.items() if
+                            val.get('__from') or val.get('__to')]
+                    if len(keys):
+                        for key in keys:
+                            val = filters[key]
+                            __from = val.pop('__from', '')
+                            __to = val.pop('__to', '')
+                            # if user already defined __time_range,
+                            # just abandon __from and __to
+                            if '__time_range' not in val:
+                                val['__time_range'] = '{} : {}'.format(__from, __to)
+                        json_metadata["default_filters"] = json.dumps(filters)
+                        has_update = True
+                except Exception:
+                    pass
+
+            # filter_immune_slice_fields:
+            # key: chart id, value: field names that escape from filters
+            filter_immune_slice_fields = json_metadata.get('filter_immune_slice_fields')
+            if filter_immune_slice_fields:
+                keys = [key for key, val in filter_immune_slice_fields.items() if
+                        '__from' in val or '__to' in val]
+                if len(keys):
+                    for key in keys:
+                        val = filter_immune_slice_fields[key]
+                        if '__from' in val:
+                            val.remove('__from')
+                        if '__to' in val:
+                            val.remove('__to')
+                        # if user already defined __time_range,
+                        # just abandon __from and __to
+                        if '__time_range' not in val:
+                            val.append('__time_range')
+                    json_metadata['filter_immune_slice_fields'] = \
+                        filter_immune_slice_fields
+                    has_update = True
+
+            if has_update:
+                dashboard.json_metadata = json.dumps(json_metadata)
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
In dashboard Superset allows user save default values for filter slice, and saved in json_metadata. So that when the dashboard is loaded, it will be pre-populated with values for the filters. Superset also allows user set charts that immune from filters. For example:

`{"filter_immune_slices": [], "timed_refresh_immune_slices": [], "filter_immune_slice_fields": {"255": ["__from", "__to"]}, "expanded_slices": {}, "default_filters": "{\"254\": {\"__from\": \"1 months ago\", \"dim_country\": [\"all\"]}}"}`

after recently introduced time_range, __from and __to in json_metadata didn't correctly merge with time_range. It introduces extra __from/__to parameter into Filter control, and cause chart show `no data`. In airbnb we have about 500 dashboards set __from and __to in json_metadata. 

<img width="356" alt="screen shot 2018-11-15 at 10 42 32 am" src="https://user-images.githubusercontent.com/27990562/48574153-46ddae00-e8c3-11e8-972c-3d6a451d54ee.png">

Fix: I wrote this migration script to update __from/__to to __time_range for json_metadata.

@betodealmeida @mistercrunch @john-bodley @timifasubaa @michellethomas 