### PR TITLE
[fix] JS error after delete row level tab

### DIFF
--- a/superset/assets/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset/assets/src/dashboard/containers/DashboardComponent.jsx
@@ -39,15 +39,17 @@ function mapStateToProps(
 
   // rows and columns need more data about their child dimensions
   // doing this allows us to not pass the entire component lookup to all Components
-  const componentType = component.type;
-  if (componentType === ROW_TYPE || componentType === COLUMN_TYPE) {
-    const { occupiedWidth, minimumWidth } = getDetailedComponentWidth({
-      id,
-      components: dashboardLayout,
-    });
+  if (component) {
+    const componentType = component.type;
+    if (componentType === ROW_TYPE || componentType === COLUMN_TYPE) {
+      const { occupiedWidth, minimumWidth } = getDetailedComponentWidth({
+        id,
+        components: dashboardLayout,
+      });
 
-    if (componentType === ROW_TYPE) props.occupiedColumnCount = occupiedWidth;
-    if (componentType === COLUMN_TYPE) props.minColumnWidth = minimumWidth;
+      if (componentType === ROW_TYPE) props.occupiedColumnCount = occupiedWidth;
+      if (componentType === COLUMN_TYPE) props.minColumnWidth = minimumWidth;
+    }
   }
 
   return props;
@@ -68,7 +70,7 @@ function mapDispatchToProps(dispatch) {
 class DashboardComponent extends React.PureComponent {
   render() {
     const { component } = this.props;
-    const Component = ComponentLookup[component.type];
+    const Component = component ? ComponentLookup[component.type] : null;
     return Component ? <Component {...this.props} /> : null;
   }
 }


### PR DESCRIPTION
This JS error only shows when user deletes row-level tab from dashboard:
<img width="1173" alt="screen shot 2018-11-14 at 5 27 03 pm" src="https://user-images.githubusercontent.com/27990562/48524430-2109c800-e835-11e8-91be-02c21ec07052.png">

<img width="1093" alt="screen shot 2018-11-14 at 5 50 26 pm" src="https://user-images.githubusercontent.com/27990562/48524599-cae95480-e835-11e8-953c-9793d9d8aa1a.png">

Fix: adding null check when creating DashboardComponent.

@williaster @michellethomas @kristw 