### PR TITLE
Remove note about snowflake-sqlalchemy stable version regression

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -397,10 +397,6 @@ Make sure the user has privileges to access and use all required
 databases/schemas/tables/views/warehouses, as the Snowflake SQLAlchemy engine does
 not test for user rights during engine creation.
 
-*Note*: At the time of writing, there is a regression in the current stable version (1.1.2) of
-snowflake-sqlalchemy package that causes problems when used with Superset. It is recommended to
-use version 1.1.0 or try a newer version.
-
 See `Snowflake SQLAlchemy <https://github.com/snowflakedb/snowflake-sqlalchemy>`_.
 
 Teradata


### PR DESCRIPTION
The regression referenced in the installation guide has been fixed as of `snowflake-sqlalchemy-1.1.4` released on 2018-11-13:

Fix PR: https://github.com/snowflakedb/snowflake-sqlalchemy/pull/67