### PR TITLE
Fix adhoc metrics in Polygon

### DIFF
--- a/superset/assets/spec/javascripts/visualizations/deckgl/utils_spec.js
+++ b/superset/assets/spec/javascripts/visualizations/deckgl/utils_spec.js
@@ -4,6 +4,8 @@ import {
   getBuckets,
 } from '../../../../src/visualizations/deckgl/utils';
 
+const metricAccessor = d => d.count;
+
 describe('getBreakPoints', () => {
   it('is a function', () => {
     expect(typeof getBreakPoints).toBe('function');
@@ -11,7 +13,7 @@ describe('getBreakPoints', () => {
 
   it('returns sorted break points', () => {
     const fd = { break_points: ['0', '10', '100', '50', '1000'] };
-    const result = getBreakPoints(fd, []);
+    const result = getBreakPoints(fd, [], metricAccessor);
     const expected = ['0', '10', '50', '100', '1000'];
     expect(result).toEqual(expected);
   });
@@ -19,7 +21,7 @@ describe('getBreakPoints', () => {
   it('returns evenly distributed break points when no break points are specified', () => {
     const fd = { metric: 'count' };
     const features = [0, 1, 2, 10].map(count => ({ count }));
-    const result = getBreakPoints(fd, features);
+    const result = getBreakPoints(fd, features, metricAccessor);
     const expected = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
     expect(result).toEqual(expected);
   });
@@ -27,7 +29,7 @@ describe('getBreakPoints', () => {
   it('formats number with proper precision', () => {
     const fd = { metric: 'count', num_buckets: 2 };
     const features = [0, 1 / 3, 2 / 3, 1].map(count => ({ count }));
-    const result = getBreakPoints(fd, features);
+    const result = getBreakPoints(fd, features, metricAccessor);
     const expected = ['0.0', '0.5', '1.0'];
     expect(result).toEqual(expected);
   });
@@ -35,7 +37,7 @@ describe('getBreakPoints', () => {
   it('works with a zero range', () => {
     const fd = { metric: 'count', num_buckets: 1 };
     const features = [1, 1, 1].map(count => ({ count }));
-    const result = getBreakPoints(fd, features);
+    const result = getBreakPoints(fd, features, metricAccessor);
     const expected = ['1', '1'];
     expect(result).toEqual(expected);
   });
@@ -53,7 +55,7 @@ describe('getBreakPointColorScaler', () => {
       opacity: 100,
     };
     const features = [10, 20, 30].map(count => ({ count }));
-    const scaler = getBreakPointColorScaler(fd, features);
+    const scaler = getBreakPointColorScaler(fd, features, metricAccessor);
     expect(scaler({ count: 10 })).toEqual([0, 0, 0, 255]);
     expect(scaler({ count: 15 })).toEqual([64, 64, 64, 255]);
     expect(scaler({ count: 30 })).toEqual([255, 255, 255, 255]);
@@ -67,7 +69,7 @@ describe('getBreakPointColorScaler', () => {
       opacity: 100,
     };
     const features = [];
-    const scaler = getBreakPointColorScaler(fd, features);
+    const scaler = getBreakPointColorScaler(fd, features, metricAccessor);
     expect(scaler({ count: 0 })).toEqual([0, 0, 0, 255]);
     expect(scaler({ count: 0.5 })).toEqual([0, 0, 0, 255]);
     expect(scaler({ count: 1 })).toEqual([255, 255, 255, 255]);
@@ -82,7 +84,7 @@ describe('getBreakPointColorScaler', () => {
       opacity: 100,
     };
     const features = [];
-    const scaler = getBreakPointColorScaler(fd, features);
+    const scaler = getBreakPointColorScaler(fd, features, metricAccessor);
     expect(scaler({ count: -1 })).toEqual([0, 0, 0, 0]);
     expect(scaler({ count: 11 })).toEqual([255, 255, 255, 0]);
   });
@@ -101,7 +103,7 @@ describe('getBuckets', () => {
       opacity: 100,
     };
     const features = [];
-    const result = getBuckets(fd, features);
+    const result = getBuckets(fd, features, metricAccessor);
     const expected = {
       '0 - 1': { color: [0, 0, 0, 255], enabled: true },
       '1 - 10': { color: [255, 255, 255, 255], enabled: true },

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -126,8 +126,7 @@ class Chart extends React.PureComponent {
 
   renderTooltip() {
     const { tooltip } = this.state;
-
-    if (tooltip) {
+    if (tooltip && tooltip.content) {
       return (
         <Tooltip
           className="chart-tooltip"
@@ -173,32 +172,31 @@ class Chart extends React.PureComponent {
     this.renderStartTime = Logger.getTimestamp();
 
     return (
-      <div
-        className={`chart-container ${isLoading ? 'is-loading' : ''}`}
-        style={containerStyles}
-      >
-        {this.renderTooltip()}
+      <ErrorBoundary onError={this.handleRenderFailure} showMessage={false}>
+        <div
+          className={`chart-container ${isLoading ? 'is-loading' : ''}`}
+          style={containerStyles}
+        >
+          {this.renderTooltip()}
 
-        {['loading', 'success'].indexOf(chartStatus) >= 0 && <Loading size={50} />}
+          {['loading', 'success'].indexOf(chartStatus) >= 0 && <Loading size={50} />}
 
-        {chartAlert && (
-          <StackTraceMessage
-            message={chartAlert}
-            link={queryResponse ? queryResponse.link : null}
-            stackTrace={chartStackTrace}
-          />
-        )}
+          {chartAlert && (
+            <StackTraceMessage
+              message={chartAlert}
+              link={queryResponse ? queryResponse.link : null}
+              stackTrace={chartStackTrace}
+            />
+          )}
 
-        {!isLoading && !chartAlert && isFaded && (
-          <RefreshChartOverlay
-            width={width}
-            height={height}
-            onQuery={onQuery}
-            onDismiss={onDismissRefreshOverlay}
-          />
-        )}
-
-        <ErrorBoundary onError={this.handleRenderFailure} showMessage={false}>
+          {!isLoading && !chartAlert && isFaded && (
+            <RefreshChartOverlay
+              width={width}
+              height={height}
+              onQuery={onQuery}
+              onDismiss={onDismissRefreshOverlay}
+            />
+          )}
           <SuperChart
             className={`slice_container ${snakeCase(vizType)} ${isFaded ? ' faded' : ''}`}
             chartType={vizType}
@@ -207,8 +205,8 @@ class Chart extends React.PureComponent {
             onRenderFailure={this.handleRenderFailure}
             skipRendering={skipChartRendering}
           />
-        </ErrorBoundary>
-      </div>
+        </div>
+      </ErrorBoundary>
     );
   }
 }

--- a/superset/assets/src/visualizations/deckgl/layers/Polygon/Polygon.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Polygon/Polygon.jsx
@@ -48,10 +48,12 @@ export function getLayer(formData, payload, setTooltip, selected, onSelect, filt
     data = jsFnMutator(data);
   }
 
+  const metricLabel = fd.metric ? fd.metric.label || fd.metric : null;
+  const accessor = d => d[metricLabel];
   // base color for the polygons
   const baseColorScaler = fd.metric === null
     ? () => [fc.r, fc.g, fc.b, 255 * fc.a]
-    : getBreakPointColorScaler(fd, data);
+    : getBreakPointColorScaler(fd, data, accessor);
 
   // when polygons are selected, reduce the opacity of non-selected polygons
   const colorScaler = (d) => {
@@ -61,7 +63,6 @@ export function getLayer(formData, payload, setTooltip, selected, onSelect, filt
     }
     return baseColor;
   };
-
   return new PolygonLayer({
     id: `path-layer-${fd.slice_id}`,
     data,
@@ -211,7 +212,12 @@ class DeckGLPolygon extends React.Component {
   render() {
     const { payload, formData, setControlValue } = this.props;
     const { start, end, getStep, values, disabled, viewport } = this.state;
-    const buckets = getBuckets(formData, payload.data.features);
+
+    const fd = formData;
+    const metricLabel = fd.metric ? fd.metric.label || fd.metric : null;
+    const accessor = d => d[metricLabel];
+
+    const buckets = getBuckets(formData, payload.data.features, accessor);
     return (
       <div style={{ position: 'relative' }}>
         <AnimatableDeckGLContainer

--- a/superset/assets/src/visualizations/deckgl/layers/common.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/common.jsx
@@ -38,12 +38,13 @@ export function commonLayerProps(formData, setTooltip, onSelect) {
   let tooltipContentGenerator;
   if (fd.js_tooltip) {
     tooltipContentGenerator = sandboxedEval(fd.js_tooltip);
-  } else if (fd.line_column && fd.line_type === 'geohash') {
+  } else if (fd.line_column && fd.metric && ['geohash', 'zipcode'].indexOf(fd.line_type) >= 0) {
+    const metricLabel = fd.metric.label || fd.metric;
     tooltipContentGenerator = o => (
       <div>
         <div>{fd.line_column}: <strong>{o.object[fd.line_column]}</strong></div>
         {fd.metric &&
-          <div>{fd.metric}: <strong>{o.object[fd.metric]}</strong></div>}
+          <div>{metricLabel}: <strong>{o.object[metricLabel]}</strong></div>}
       </div>);
   }
   if (tooltipContentGenerator) {


### PR DESCRIPTION
* moving `<ErrorBoundary>` at higher level to catch tooltip-related errors
* retrofit color scaler breakpoints to work with "adhoc metrics", currently it works only with old-school "predefined metrics"