### PR TITLE
[sqllab][bugfix] Set default limit on creation of new QE and on run

### DIFF
--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -149,7 +149,7 @@ class SqlEditor extends React.PureComponent {
       schema: qe.schema,
       tempTableName: ctas ? this.state.ctas : '',
       templateParams: qe.templateParams,
-      queryLimit: qe.queryLimit,
+      queryLimit: qe.queryLimit || this.props.defaultQueryLimit,
       runAsync,
       ctas,
     };

--- a/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -138,6 +138,7 @@ class TabbedSqlEditors extends React.PureComponent {
       sql: `${t(
         '-- Note: Unless you save your query, these tabs will NOT persist if you clear your cookies or change browsers.',
       )}\n\nSELECT ...`,
+      queryLimit: this.props.defaultQueryLimit,
     };
     this.props.actions.addQueryEditor(qe);
   }


### PR DESCRIPTION
An extension of https://github.com/apache/incubator-superset/pull/4941.

Query editors don't have a `queryLimit` field unless the user explicitly sets a limit (via limit control field in SQL Lab), so no limit would be applied in some cases.

This PR:
* sets the `defaultLimit` on new tabs created via SQL Lab new tab functionality
* sets the `queryLimit` to `defaultQueryLimit` if the existing `queryEditor` does not have a `queryLimit` loaded into state yet.

There are [some other cases](https://github.com/apache/incubator-superset/blob/master/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx#L48) where the `queryLimit` would not exist on the `queryEditor`, but those should be covered by the 2nd bullet point mentioned above.

@graceguo-supercat @timifasubaa 