### PR TITLE
[fix] view results in sql lab

### DIFF
--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -28,6 +28,7 @@ const defaultProps = {
   csv: true,
   actions: {},
   cache: false,
+  database: {},
 };
 
 const SEARCH_HEIGHT = 46;


### PR DESCRIPTION
click `view results` from sql lab will see JS excetions:
![screen_shot_2018-11-16_at_1_48_26_pm](https://user-images.githubusercontent.com/27990562/48649146-8fba6300-e9a6-11e8-839a-2c69570b1754.jpg)
<img width="1064" alt="screen shot 2018-11-16 at 1 47 15 pm" src="https://user-images.githubusercontent.com/27990562/48649185-aeb8f500-e9a6-11e8-8b83-1d408315d831.png">

exception is from this line:
https://github.com/apache/incubator-superset/blob/69e8df404d46e35bf686cc92992d6e0415172d90/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx#L171

@mistercrunch @michellethomas @kristw 