### PR TITLE
 Adding cypress tests for showing errors, time range filter, and verbose name

### DIFF
--- a/superset/assets/cypress/integration/explore/chart.test.js
+++ b/superset/assets/cypress/integration/explore/chart.test.js
@@ -1,0 +1,39 @@
+import { FORM_DATA_DEFAULTS, NUM_METRIC } from './visualizations/shared.helper';
+import readResponseBlob from '../../utils/readResponseBlob';
+
+describe('Error', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.server();
+    cy.route('POST', '/superset/explore_json/**').as('getJson');
+  });
+
+  it('No data error message shows up', () => {
+    const formData = {
+      ...FORM_DATA_DEFAULTS,
+      metrics: [NUM_METRIC],
+      viz_type: 'line',
+      adhoc_filters: [{
+        expressionType: 'SIMPLE',
+        subject: 'state',
+        operator: 'in',
+        comparator: ['Fake State'],
+        clause: 'WHERE',
+        sqlExpression: null,
+        fromFormData: true,
+      }],
+    };
+
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.wait('@getJson').then(async (xhr) => {
+      expect(xhr.status).to.eq(400);
+
+      const responseBody = await readResponseBlob(xhr.response.body);
+
+      if (responseBody.error) {
+        expect(responseBody.error).to.eq('No data');
+      }
+    });
+    cy.get('div.alert').contains('No data');
+  });
+});

--- a/superset/assets/cypress/integration/explore/visualizations/line.js
+++ b/superset/assets/cypress/integration/explore/visualizations/line.js
@@ -113,4 +113,15 @@ export default () => describe('Line', () => {
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
+
+  it('Test verbose name shows up in legend', () => {
+    const formData = {
+      ...LINE_CHART_DEFAULTS,
+      metrics: ['count'],
+    };
+
+    cy.visitChartByParams(JSON.stringify(formData));
+    cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
+    cy.get('text.nv-legend-text').contains('COUNT(*)');
+  });
 });

--- a/superset/assets/cypress/integration/explore/visualizations/table.js
+++ b/superset/assets/cypress/integration/explore/visualizations/table.js
@@ -66,6 +66,7 @@ export default () => describe('Table chart', () => {
       const responseBody = await readResponseBlob(xhr.response.body);
       expect(responseBody.data.records.length).to.eq(limit);
     });
+    cy.get('span.label-danger').contains('10 rows');
   });
 
   it('Test table with columns and row limit', () => {

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -618,6 +618,10 @@ class UtilsTestCase(unittest.TestCase):
         expected = datetime(2016, 11, 5), datetime(2016, 11, 7)
         self.assertEqual(result, expected)
 
+        result = get_since_until(time_range='5 days : now')
+        expected = datetime(2016, 11, 2), datetime(2016, 11, 7)
+        self.assertEqual(result, expected)
+
         with self.assertRaises(ValueError):
             get_since_until(time_range='tomorrow : yesterday')
 


### PR DESCRIPTION
This PR adds some tests for bugs we've recently fixed.

- Turns back on the flaky test "Clear metric and set custom sql adhoc metric" so that it no longer uses the functionality that's flaky
- A test for time range filter
- A line chart test to make sure verbose name is showing in the legend
- A unit test to make sure the time_range `5 days : now` works as expected (the same as "5 days ago")

@graceguo-supercat @kristw 