### PR TITLE
[bugfix] Display raw value in addition to ERROR

### DIFF
--- a/superset/assets/spec/javascripts/modules/utils_spec.jsx
+++ b/superset/assets/spec/javascripts/modules/utils_spec.jsx
@@ -29,7 +29,7 @@ describe('utils', () => {
       expect(d3format('.3s', 1234)).toBe('1.23k');
       expect(d3format('.3s', 1237)).toBe('1.24k');
       expect(d3format('', 1237)).toBe('1.24k');
-      expect(d3format('.2efd2.ef.2.e', 1237)).toBe('ERROR');
+      expect(d3format('.2efd2.ef.2.e', 1237)).toBe('1237 (Invalid format: .2efd2.ef.2.e)');
     });
   });
 
@@ -48,7 +48,7 @@ describe('utils', () => {
     });
     it('returns a working formatter', () => {
       expect(d3FormatPreset('smart_date')(0)).toBe('1970');
-      expect(d3FormatPreset('%%GIBBERISH')(0)).toBe('ERROR');
+      expect(d3FormatPreset('%%GIBBERISH')(0)).toBe('0 (Invalid format: %%GIBBERISH)');
     });
   });
 

--- a/superset/assets/src/modules/utils.js
+++ b/superset/assets/src/modules/utils.js
@@ -6,7 +6,6 @@ import { timeFormat as d3TimeFormat } from 'd3-time-format';
 import { formatDate, UTC } from './dates';
 
 const siFormatter = d3Format('.3s');
-const ERROR_STRING = 'ERROR';
 
 export function defaultNumberFormatter(n) {
   let si = siFormatter(n);
@@ -28,7 +27,7 @@ export function d3FormatPreset(format) {
     } catch (e) {
       // eslint-disable-next-line no-console
       console.warn(e);
-      return () => ERROR_STRING;
+      return value => `${value} (Invalid format: ${format})`;
     }
   }
   return defaultNumberFormatter;
@@ -57,13 +56,13 @@ export function d3format(format, number) {
     } catch (e) {
       // eslint-disable-next-line no-console
       console.warn(e);
-      return ERROR_STRING;
+      return `${number} (Invalid format: ${format})`;
     }
   }
   try {
     return formatters[format](number);
   } catch (e) {
-    return ERROR_STRING;
+    return `${number} (Invalid format: ${format})`;
   }
 }
 


### PR DESCRIPTION
Follow-up for #6386 until the `@superset-ui/number-format` is integrated.

After trying `0.29` in internal environment. Many big numbers show up as `ERROR`. 
This PR will provide error message about invalid formatting while showing the raw value.

@michellethomas @graceguo-supercat @mistercrunch 