### PR TITLE
Use operator.itemgetter as key to sorted() in export_to_dict

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 import json
 import logging
+import operator
 import re
 
 from flask import escape, Markup
@@ -196,7 +197,7 @@ class ImportMixin(object):
                             include_defaults=include_defaults,
                         ) for child in getattr(self, c)
                     ],
-                    key=lambda k: sorted(k.items()))
+                    key=lambda k: sorted(k.items(), key=operator.itemgetter(1)))
 
         return dict_rep
 


### PR DESCRIPTION
Dicts cannot be compared using the default `<` operator so use
operator.itemgetter to sort by value.

Fixes #4783
Replaces #6266 

I based this on https://stackoverflow.com/questions/20944483/python-3-sort-a-dict-by-its-values. I ran some tests against my deployed superset instance with the patched helper and was able to export again.