### PR TITLE
[logging] Add render failure error into log

### DIFF
--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -95,6 +95,14 @@ class Chart extends React.PureComponent {
     const { actions, chartId } = this.props;
     console.warn(error); // eslint-disable-line
     actions.chartRenderingFailed(error.toString(), chartId, info ? info.componentStack : null);
+
+    Logger.append(LOG_ACTIONS_RENDER_CHART, {
+      slice_id: chartId,
+      has_err: true,
+      error_details: error.toString(),
+      start_offset: this.renderStartTime,
+      duration: Logger.getTimestamp() - this.renderStartTime,
+    });
   }
 
   prepareChartProps() {


### PR DESCRIPTION
Add JS render failure error message into log.

Currently if js package is missing we will display error but not logged:
<img width="912" alt="screen shot 2018-11-21 at 4 42 00 pm" src="https://user-images.githubusercontent.com/27990562/48875220-633e8680-edac-11e8-9e7a-0253e668bd2d.png">

@kristw @michellethomas 
