### PR TITLE
Add See Tableview Form button to the Datasource Editor modal

### DIFF
--- a/superset/assets/src/datasource/DatasourceModal.jsx
+++ b/superset/assets/src/datasource/DatasourceModal.jsx
@@ -147,7 +147,7 @@ class DatasourceModal extends React.PureComponent {
               target="_blank"
               href={this.props.datasource.edit_url}
             >
-              {t('See Tableview Form')}
+              {t('Use Legacy Datasource Editor')}
             </Button>
           </span>
 

--- a/superset/assets/src/datasource/DatasourceModal.jsx
+++ b/superset/assets/src/datasource/DatasourceModal.jsx
@@ -140,6 +140,17 @@ class DatasourceModal extends React.PureComponent {
             />}
         </Modal.Body>
         <Modal.Footer>
+          <span className="float-left">
+            <Button
+              bsSize="sm"
+              bsStyle="default"
+              target="_blank"
+              href={this.props.datasource.edit_url}
+            >
+              {t('See Tableview Form')}
+            </Button>
+          </span>
+
           <span className="float-right">
             <Button
               bsSize="sm"


### PR DESCRIPTION
This is a PR for https://github.com/apache/incubator-superset/issues/6101.
Turned out to be easier than I thought because edit_url was already in the props.

Things to be especially considered in the review phase:
* Modal doesn't have all of the fields that are available in the /edit link, and if I understand correctly, this was a motivation for creating this issue. I can still add those, even though the edit button is now here, if desired (perhaps in a new PR?)
* Whether the new button should stay on the left or right side of modal, as pointed out by hughhhh during our conversation

Preview:
![image](https://user-images.githubusercontent.com/45320817/48973926-8e92d100-f04b-11e8-8a41-6a8d7df41558.png)
