### PR TITLE
Add tooltips with table's description to explore and table list views

### DIFF
--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -107,7 +107,7 @@ class DatasourceControl extends React.PureComponent {
             {this.props.datasource.name}
           </Label>
         </OverlayTrigger>
-        {this.props.datasource.type === 'table' &&
+        {this.props.datasource.type === 'table' && this.props.datasource.description &&
           <OverlayTrigger
             placement="right"
             overlay={

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -107,6 +107,19 @@ class DatasourceControl extends React.PureComponent {
             {this.props.datasource.name}
           </Label>
         </OverlayTrigger>
+        {this.props.datasource.type === 'table' &&
+          <OverlayTrigger
+            placement="right"
+            overlay={
+              <Tooltip id={'datasource-table-description'}>
+                {this.props.datasource.description}
+              </Tooltip>
+            }
+          >
+            <a>
+              <i className="fa fa-info-circle m-r-5" />
+            </a>
+          </OverlayTrigger>}
         <OverlayTrigger
           placement="right"
           overlay={

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -322,7 +322,8 @@ class SqlaTable(Model, BaseDatasource):
     def link(self):
         name = escape(self.name)
         description = self.description or ''
-        anchor = '<a target="_blank" title="{description}" href="{self.explore_url}">{name}</a>'
+        anchor = '<a target="_blank" title="{description}"' \
+                 ' href="{self.explore_url}">{name}</a>'
         return Markup(anchor.format(**locals()))
 
     @property

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -321,7 +321,8 @@ class SqlaTable(Model, BaseDatasource):
     @property
     def link(self):
         name = escape(self.name)
-        anchor = '<a target="_blank" href="{self.explore_url}">{name}</a>'
+        description = self.description or ''
+        anchor = '<a target="_blank" title="{description}" href="{self.explore_url}">{name}</a>'
         return Markup(anchor.format(**locals()))
 
     @property


### PR DESCRIPTION
This is a PR for https://github.com/apache/incubator-superset/issues/5922.

Preview:
![image](https://user-images.githubusercontent.com/45320817/48981999-f6ddc300-f0dc-11e8-986a-7669a778a6dc.png)
I wasn't sure if we want to include info icon there, because 
a) it doesn't currently involve react -> we'd have to include it or duplicate InfoTooltipWithTrigger in html/py
b) imo it'd clutter the view.
Of course can still add it if requested.
![image](https://user-images.githubusercontent.com/45320817/48982093-15908980-f0de-11e8-8d59-eb7cce1d1905.png)
Long descriptions are automatically truncated by the tooltip here, but not in the explore view. Should I truncate them manually, or we're assuming it's user's responsibility to keep this short? 

I also included info icon here:
![image](https://user-images.githubusercontent.com/45320817/48982112-4375ce00-f0de-11e8-9d8b-bfa4ece173f9.png)
![image](https://user-images.githubusercontent.com/45320817/48982116-47a1eb80-f0de-11e8-8db7-6fb53ab42151.png)
although I'm not sure it's a good UX. I'd rather put it instead of "Click to edit the datasource", or merge those two texts together, but this is a decision that you're more qualified to make.