### PR TITLE
[bugfix] show results in query history & revert #5848

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -26,7 +26,7 @@ class QueryAutoRefresh extends React.PureComponent {
     return (
       queriesLastUpdate > 0 &&
       Object.values(queries).some(
-        q => ['running', 'started', 'pending', 'fetching', 'rendering'].indexOf(q.state) >= 0 &&
+        q => ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 &&
         now - q.startDttm < MAX_QUERY_AGE_TO_POLL,
       )
     );

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -213,7 +213,7 @@ export default class ResultSet extends React.PureComponent {
     }
     let progressBar;
     let trackingUrl;
-    if (query.progress > 0 && query.state === 'running') {
+    if (query.progress > 0) {
       progressBar = (
         <ProgressBar
           striped

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -213,7 +213,7 @@ export default class ResultSet extends React.PureComponent {
     }
     let progressBar;
     let trackingUrl;
-    if (query.progress > 0) {
+    if (query.progress > 0 && query.state === 'running') {
       progressBar = (
         <ProgressBar
           striped

--- a/superset/assets/src/SqlLab/constants.js
+++ b/superset/assets/src/SqlLab/constants.js
@@ -5,7 +5,6 @@ export const STATE_BSSTYLE_MAP = {
   fetching: 'info',
   running: 'warning',
   stopped: 'danger',
-  rendering: 'info',
   success: 'success',
 };
 

--- a/superset/assets/src/SqlLab/reducers/sqlLab.js
+++ b/superset/assets/src/SqlLab/reducers/sqlLab.js
@@ -164,7 +164,7 @@ export default function sqlLabReducer(state = {}, action) {
         progress: 100,
         results: action.results,
         rows,
-        state: action.query.state,
+        state: 'success',
         errorMessage: null,
         cached: false,
       };

--- a/superset/assets/src/SqlLab/reducers/sqlLab.js
+++ b/superset/assets/src/SqlLab/reducers/sqlLab.js
@@ -164,7 +164,7 @@ export default function sqlLabReducer(state = {}, action) {
         progress: 100,
         results: action.results,
         rows,
-        state: 'rendering',
+        state: action.query.state,
         errorMessage: null,
         cached: false,
       };


### PR DESCRIPTION
Update:

`Rendering` is not necessary for query state. @graceguo-supercat made a really good point that it does not solve the inconsistency in 100% progress bar and running query state. 

The query lifecycle like `pending -> running -> success (or failed, stopped) ->fetching` would be a simpler and better solution to solve it. 

I have tested `show query results` in query history and verified it is not broken.