### PR TITLE
fix loose datasource permission

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -319,6 +319,10 @@ class SqlaTable(Model, BaseDatasource):
 
     @property
     def database_name(self):
+        if self.database is None:
+            _db = db.session.query(Database)\
+                .filter(Database.id == self.database_id).first()
+            return _db.database_name
         return self.database.name
 
     @property
@@ -334,7 +338,7 @@ class SqlaTable(Model, BaseDatasource):
 
     def get_perm(self):
         return (
-            '[{obj.database}].[{obj.table_name}]'
+            '[{obj.database_name}].[{obj.table_name}]'
             '(id:{obj.id})').format(obj=self)
 
     @property


### PR DESCRIPTION
when create table from SQLLab, database name can not find, so filling None value in `datasource perm`. 

this issue affects user assignment permission view to role()

## Before
![image](https://user-images.githubusercontent.com/2016594/49064767-eea99300-f256-11e8-92bd-536349b8e399.png)

## after
![image](https://user-images.githubusercontent.com/2016594/49065128-0fbeb380-f258-11e8-9541-6ff3ffe40061.png)

## refs:
- #4060
- #6442