### PR TITLE
Ensure that dttm is of same timezone as epoch_with_tz

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -358,6 +358,7 @@ def pessimistic_json_iso_dttm_ser(obj):
 
 def datetime_to_epoch(dttm):
     if dttm.tzinfo:
+        dttm = dttm.replace(tzinfo=pytz.utc)
         epoch_with_tz = pytz.utc.localize(EPOCH)
         return (dttm - epoch_with_tz).total_seconds() * 1000
     return (dttm - EPOCH).total_seconds() * 1000


### PR DESCRIPTION
When querying columns with timezone on `postgres` and `redshift`, `psycopg2` returns `datetime` objects with`tzinfo` of type `psycopg2.tz.FixedOffsetTimezone` which is incompatible with `pytz.utc`. This PR ensures that `dttm` is always of type `pytz.utc`. Should have no adverse effects on other engines, as subtraction is only possible if both datetimes are of same timezone. Closes #5910, closes #6284

![image](https://user-images.githubusercontent.com/33317356/49130855-87372600-f2de-11e8-82d1-cc98182889f6.png)
