### PR TITLE
fix cache key name bug

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -912,7 +912,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         return tables
 
     @cache_util.memoized_func(
-        key=lambda *args, **kwargs: 'db:{{}}:schema:{}:table_list'.format(
+        key=lambda *args, **kwargs: 'db:{{}}:schema:{}:view_list'.format(
             kwargs.get('schema')),
         attribute_in_key='id')
     def all_view_names_in_schema(self, schema, cache=False,


### PR DESCRIPTION
There is a bug in the key name of metadata cache which makes cache messed up between table list and view list. This small PR should be able to fix it.