### PR TITLE
override get_view_names in PrestoEngineSpec

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -687,6 +687,16 @@ class PrestoEngineSpec(BaseEngineSpec):
     }
 
     @classmethod
+    def get_view_names(cls, inspector, schema):
+        """Returns an empty list
+
+        get_table_names() function returns all table names and view names,
+        and get_view_names() is not implemented in sqlalchemy_presto.py
+        https://github.com/dropbox/PyHive/blob/e25fc8440a0686bbb7a5db5de7cb1a77bdb4167a/pyhive/sqlalchemy_presto.py
+        """
+        return []
+
+    @classmethod
     def adjust_database_uri(cls, uri, selected_schema=None):
         database = uri.database
         if selected_schema and database:

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -1,4 +1,5 @@
 import inspect
+import mock
 
 from superset import db_engine_specs
 from superset.db_engine_specs import (
@@ -284,3 +285,9 @@ class DbEngineSpecsTestCase(SupersetTestCase):
                 defined_time_grains = {grain.duration for grain in cls.get_time_grains()}
                 intersection = time_grains.intersection(defined_time_grains)
                 self.assertSetEqual(defined_time_grains, intersection, cls_name)
+
+    def test_presto_get_view_names_return_empty_list(self):
+        self.assertEquals([], PrestoEngineSpec.get_view_names(mock.ANY, mock.ANY))
+
+    def test_hive_get_view_names_return_empty_list(self):
+        self.assertEquals([], HiveEngineSpec.get_view_names(mock.ANY, mock.ANY))

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -1,5 +1,6 @@
-import inspect
 import mock
+
+import inspect
 
 from superset import db_engine_specs
 from superset.db_engine_specs import (

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -1,6 +1,6 @@
-import mock
-
 import inspect
+
+import mock
 
 from superset import db_engine_specs
 from superset.db_engine_specs import (


### PR DESCRIPTION
When fetching metadata for presto engine spec we got an error which says: 
```
ts=2018-11-28T20:42:52.414Z uuid=98709625-59fd-4d9d-88e2-22471db6fec0 app=superset name=root lvlname=ERROR lvlno=40 pid=103884 request_id=3b7d72c3-4949-97a7-9749-92da9cd4e2a9 exc="Traceback (most recent call last):
File \"/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/superset/models/core.py\", line 947, in all_view_names_in_schema
inspector=self.inspector, schema=schema)
File \"/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/superset/db_engine_specs.py\", line 306, in get_view_names
return sorted(inspector.get_view_names(schema))
File \"/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/reflection.py\", line 324, in get_view_names 
info_cache=self.info_cache)
File \"/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/interfaces.py\", line 330, in get_view_names
raise NotImplementedError()
NotImplementedError" msg=
```

Then I found `get_view_names()` is not implemented in https://github.com/dropbox/PyHive/blob/e25fc8440a0686bbb7a5db5de7cb1a77bdb4167a/pyhive/sqlalchemy_presto.py because `get_table_names()` function returns all table names and view names.

For Hive, I observed that every time when superset tries to fetch table list and view list in `default` schema, it issues `SHOW TABLES IN default` twice. I found out that's because [get_view_names()](https://github.com/dropbox/PyHive/blob/e25fc8440a0686bbb7a5db5de7cb1a77bdb4167a/pyhive/sqlalchemy_hive.py#L267) is indeed a call of `get_table_names`. Since `HiveEngineSpec()` inherits from `PrestoEngineSpec()`, we can just leverage the `get_view_names()` in `PrestoEngineSpec()`.