### PR TITLE
Add copy to clipboard buttons in explore and sqllab

### DIFF
--- a/superset/assets/spec/javascripts/utils/common_spec.jsx
+++ b/superset/assets/spec/javascripts/utils/common_spec.jsx
@@ -1,4 +1,4 @@
-import { isTruthy, optionFromValue } from '../../../src/utils/common';
+import { isTruthy, optionFromValue, prepareCopyToClipboardTabularData } from '../../../src/utils/common';
 
 describe('utils/common', () => {
   describe('isTruthy', () => {
@@ -46,6 +46,19 @@ describe('utils/common', () => {
       expect(optionFromValue('')).toEqual({ value: '', label: '<empty string>' });
       expect(optionFromValue('foo')).toEqual({ value: 'foo', label: 'foo' });
       expect(optionFromValue(5)).toEqual({ value: 5, label: '5' });
+    });
+  });
+  describe('prepareCopyToClipboardTabularData', () => {
+    it('converts empty array', () => {
+      const array = [];
+      expect(prepareCopyToClipboardTabularData(array)).toEqual('');
+    });
+    it('converts non empty array', () => {
+      const array = [
+          { column1: 'lorem', column2: 'ipsum' },
+          { column1: 'dolor', column2: 'sit', column3: 'amet' },
+      ];
+      expect(prepareCopyToClipboardTabularData(array)).toEqual('lorem\tipsum\ndolor\tsit\tamet\n');
     });
   });
 });

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -9,6 +9,7 @@ import ExploreResultsButton from './ExploreResultsButton';
 import HighlightedSql from './HighlightedSql';
 import FilterableTable from '../../components/FilterableTable/FilterableTable';
 import QueryStateLabel from './QueryStateLabel';
+import CopyToClipboard from "../../components/CopyToClipboard";
 
 const propTypes = {
   actions: PropTypes.object,
@@ -112,6 +113,16 @@ export default class ResultSet extends React.PureComponent {
                   <Button bsSize="small" href={'/superset/csv/' + this.props.query.id}>
                     <i className="fa fa-file-text-o" /> {t('.CSV')}
                   </Button>}
+
+                <CopyToClipboard
+                  text={this.prepareCopyToClipboardData(this.props.query.results.data)}
+                  wrapped={false}
+                  copyNode={
+                    <Button bsSize="small">
+                      <i className="fa fa-clipboard" /> {t('Clipboard')}
+                    </Button>
+                  }
+                />
               </ButtonGroup>
             </div>
             <div className="pull-right">
@@ -129,6 +140,13 @@ export default class ResultSet extends React.PureComponent {
       );
     }
     return <div className="noControls" />;
+  }
+  prepareCopyToClipboardData(data) {
+    let result = '';
+    for(let i = 0; i < data.length; ++i) {
+      result += Object.values(data[i]).join('\t') + '\n';
+    }
+    return result;
   }
   render() {
     const query = this.props.query;

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -10,6 +10,7 @@ import HighlightedSql from './HighlightedSql';
 import FilterableTable from '../../components/FilterableTable/FilterableTable';
 import QueryStateLabel from './QueryStateLabel';
 import CopyToClipboard from '../../components/CopyToClipboard';
+import { prepareCopyToClipboardTabularData } from '../../utils/common';
 
 const propTypes = {
   actions: PropTypes.object,
@@ -96,13 +97,6 @@ export default class ResultSet extends React.PureComponent {
       this.props.actions.runQuery(query, true);
     }
   }
-  prepareCopyToClipboardData(data) {
-    let result = '';
-    for (let i = 0; i < data.length; ++i) {
-      result += Object.values(data[i]).join('\t') + '\n';
-    }
-    return result;
-  }
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
       return (
@@ -122,7 +116,7 @@ export default class ResultSet extends React.PureComponent {
                   </Button>}
 
                 <CopyToClipboard
-                  text={this.prepareCopyToClipboardData(this.props.query.results.data)}
+                  text={prepareCopyToClipboardTabularData(this.props.query.results.data)}
                   wrapped={false}
                   copyNode={
                     <Button bsSize="small">

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -9,7 +9,7 @@ import ExploreResultsButton from './ExploreResultsButton';
 import HighlightedSql from './HighlightedSql';
 import FilterableTable from '../../components/FilterableTable/FilterableTable';
 import QueryStateLabel from './QueryStateLabel';
-import CopyToClipboard from "../../components/CopyToClipboard";
+import CopyToClipboard from '../../components/CopyToClipboard';
 
 const propTypes = {
   actions: PropTypes.object,
@@ -96,6 +96,13 @@ export default class ResultSet extends React.PureComponent {
       this.props.actions.runQuery(query, true);
     }
   }
+  prepareCopyToClipboardData(data) {
+    let result = '';
+    for (let i = 0; i < data.length; ++i) {
+      result += Object.values(data[i]).join('\t') + '\n';
+    }
+    return result;
+  }
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
       return (
@@ -140,13 +147,6 @@ export default class ResultSet extends React.PureComponent {
       );
     }
     return <div className="noControls" />;
-  }
-  prepareCopyToClipboardData(data) {
-    let result = '';
-    for(let i = 0; i < data.length; ++i) {
-      result += Object.values(data[i]).join('\t') + '\n';
-    }
-    return result;
   }
   render() {
     const query = this.props.query;

--- a/superset/assets/src/components/CopyToClipboard.jsx
+++ b/superset/assets/src/components/CopyToClipboard.jsx
@@ -157,8 +157,9 @@ export default class CopyToClipboard extends React.Component {
   }
 
   render() {
-    if(!this.props.wrapped)
-      return this.renderNotWrapped();
+    if (!this.props.wrapped) {
+        return this.renderNotWrapped();
+    }
     return this.props.inMenu ? this.renderInMenu() : this.renderLink();
   }
 }

--- a/superset/assets/src/components/CopyToClipboard.jsx
+++ b/superset/assets/src/components/CopyToClipboard.jsx
@@ -97,6 +97,7 @@ export default class CopyToClipboard extends React.Component {
   }
 
   renderNotWrapped() {
+    const { copyNode } = this.props;
     return (
       <OverlayTrigger
         placement="top"
@@ -107,7 +108,7 @@ export default class CopyToClipboard extends React.Component {
         onClick={this.onClick}
         onMouseOut={this.onMouseOut}
       >
-        {this.props.copyNode}
+        {copyNode}
       </OverlayTrigger>
     );
   }
@@ -157,10 +158,11 @@ export default class CopyToClipboard extends React.Component {
   }
 
   render() {
-    if (!this.props.wrapped) {
-        return this.renderNotWrapped();
+    const { wrapped, inMenu } = this.props;
+    if (!wrapped) {
+      return this.renderNotWrapped();
     }
-    return this.props.inMenu ? this.renderInMenu() : this.renderLink();
+    return inMenu ? this.renderInMenu() : this.renderLink();
   }
 }
 

--- a/superset/assets/src/components/CopyToClipboard.jsx
+++ b/superset/assets/src/components/CopyToClipboard.jsx
@@ -10,6 +10,7 @@ const propTypes = {
   shouldShowText: PropTypes.bool,
   text: PropTypes.string,
   inMenu: PropTypes.bool,
+  wrapped: PropTypes.bool,
   tooltipText: PropTypes.string,
 };
 
@@ -18,6 +19,7 @@ const defaultProps = {
   onCopyEnd: () => {},
   shouldShowText: true,
   inMenu: false,
+  wrapped: true,
   tooltipText: t('Copy to clipboard'),
 };
 
@@ -94,6 +96,22 @@ export default class CopyToClipboard extends React.Component {
     return this.props.tooltipText;
   }
 
+  renderNotWrapped() {
+    return (
+      <OverlayTrigger
+        placement="top"
+        style={{ cursor: 'pointer' }}
+        overlay={this.renderTooltip()}
+        trigger={['hover']}
+        bsStyle="link"
+        onClick={this.onClick}
+        onMouseOut={this.onMouseOut}
+      >
+        {this.props.copyNode}
+      </OverlayTrigger>
+    );
+  }
+
   renderLink() {
     return (
       <span>
@@ -139,6 +157,8 @@ export default class CopyToClipboard extends React.Component {
   }
 
   render() {
+    if(!this.props.wrapped)
+      return this.renderNotWrapped();
     return this.props.inMenu ? this.renderInMenu() : this.renderLink();
   }
 }

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -86,6 +86,13 @@ export default class DisplayQueryButton extends React.PureComponent {
   redirectSQLLab() {
     this.props.onOpenInEditor(this.props.latestQueryFormData);
   }
+  prepareCopyToClipboardData(data) {
+    let result = '';
+    for (let i = 0; i < data.length; ++i) {
+      result += Object.values(data[i]).join('\t') + '\n';
+    }
+    return result;
+  }
   renderQueryModalBody() {
     if (this.state.isLoading) {
       return <Loading />;
@@ -124,13 +131,6 @@ export default class DisplayQueryButton extends React.PureComponent {
     }
     return null;
   }
-  prepareCopyToClipboardData(data) {
-    let result = '';
-    for(let i = 0; i < data.length; ++i) {
-      result += Object.values(data[i]).join('\t') + '\n';
-    }
-    return result;
-  }
   renderDataTable(data) {
     return (
       <div style={{ overflow: 'auto' }}>
@@ -141,7 +141,7 @@ export default class DisplayQueryButton extends React.PureComponent {
               text={this.prepareCopyToClipboardData(data)}
               wrapped={false}
               copyNode={
-                <Button style={{padding: "2px 10px", fontSize: "11px"}}>
+                <Button style={{ padding: '2px 10px', fontSize: '11px' }}>
                   <i className="fa fa-clipboard" />
                 </Button>
               }

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -19,6 +19,7 @@ import Loading from '../../components/Loading';
 import ModalTrigger from './../../components/ModalTrigger';
 import Button from '../../components/Button';
 import RowCountLabel from './RowCountLabel';
+import { prepareCopyToClipboardTabularData } from '../../utils/common';
 
 registerLanguage('markdown', markdownSyntax);
 registerLanguage('html', htmlSyntax);
@@ -86,13 +87,6 @@ export default class DisplayQueryButton extends React.PureComponent {
   redirectSQLLab() {
     this.props.onOpenInEditor(this.props.latestQueryFormData);
   }
-  prepareCopyToClipboardData(data) {
-    let result = '';
-    for (let i = 0; i < data.length; ++i) {
-      result += Object.values(data[i]).join('\t') + '\n';
-    }
-    return result;
-  }
   renderQueryModalBody() {
     if (this.state.isLoading) {
       return <Loading />;
@@ -138,7 +132,7 @@ export default class DisplayQueryButton extends React.PureComponent {
           <Col md={9}>
             <RowCountLabel rowcount={data.length} suffix={t('rows retrieved')} />
             <CopyToClipboard
-              text={this.prepareCopyToClipboardData(data)}
+              text={prepareCopyToClipboardTabularData(data)}
               wrapped={false}
               copyNode={
                 <Button style={{ padding: '2px 10px', fontSize: '11px' }}>

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -124,12 +124,28 @@ export default class DisplayQueryButton extends React.PureComponent {
     }
     return null;
   }
+  prepareCopyToClipboardData(data) {
+    let result = '';
+    for(let i = 0; i < data.length; ++i) {
+      result += Object.values(data[i]).join('\t') + '\n';
+    }
+    return result;
+  }
   renderDataTable(data) {
     return (
       <div style={{ overflow: 'auto' }}>
         <Row>
           <Col md={9}>
             <RowCountLabel rowcount={data.length} suffix={t('rows retrieved')} />
+            <CopyToClipboard
+              text={this.prepareCopyToClipboardData(data)}
+              wrapped={false}
+              copyNode={
+                <Button style={{padding: "2px 10px", fontSize: "11px"}}>
+                  <i className="fa fa-clipboard" />
+                </Button>
+              }
+            />
           </Col>
           <Col md={3}>
             <FormControl

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -100,3 +100,11 @@ export function optionFromValue(opt) {
   // From a list of options, handles special values & labels
   return { value: optionValue(opt), label: optionLabel(opt) };
 }
+
+export function prepareCopyToClipboardTabularData(data) {
+  let result = '';
+  for (let i = 0; i < data.length; ++i) {
+    result += Object.values(data[i]).join('\t') + '\n';
+  }
+  return result;
+}


### PR DESCRIPTION
This is a second attempt at https://github.com/apache/incubator-superset/issues/6064.

I've decided that if we want to display the copy to clipboard button in the View results modal, then my component is not needed because the data is already available there. Therefore I think https://github.com/apache/incubator-superset/pull/6452 should be closed, but I'll refrain from doing so till I get a review on this one.

Not sure if we'd like to create another component, e.g. `CopyToClipboardTabularData` to avoid duplication of `prepareCopyToClipboardData`.

Preview:
![image](https://user-images.githubusercontent.com/19548267/49184277-39aecd80-f35f-11e8-88eb-d5b85c757a89.png)
![image](https://user-images.githubusercontent.com/19548267/49184298-46cbbc80-f35f-11e8-80cb-f98af5852108.png)
