### PR TITLE
Fixing error when clearing big number metric

### DIFF
--- a/superset/assets/src/visualizations/BigNumber/transformProps.js
+++ b/superset/assets/src/visualizations/BigNumber/transformProps.js
@@ -28,7 +28,7 @@ export default function transformProps(chartProps) {
 
   let bigNumber;
   let trendLineData;
-  const metricName = metric.label || metric;
+  const metricName = metric && metric.label ? metric.label : metric;
   const compareLag = +compareLagInput || 0;
   const supportTrendLine = vizType === 'big_number';
   const supportAndShowTrendLine = supportTrendLine && showTrendLine;


### PR DESCRIPTION
Fixes the error we were seeing when clearing the metric on big number. `transformProps` gets run every time the chart or chart controls changes, so when you clear a metric, instead of showing the overlay, we'll show NaN until the user selects a new metric. I'll create a separate issue so that moving forward we can handle this case better (and possibly move this logic out of transformProps).

Fixes #6447

Tested big number with:
Saved metric
Adhoc metric
Cleared metric and added new 

@kristw @graceguo-supercat 