### PR TITLE
[BigNumber] fix metric change

### DIFF
--- a/superset/assets/src/visualizations/BigNumber/transformProps.js
+++ b/superset/assets/src/visualizations/BigNumber/transformProps.js
@@ -11,14 +11,17 @@ export default function transformProps(chartProps) {
     colorPicker,
     compareLag: compareLagInput,
     compareSuffix = '',
-    metric,
     showTrendLine,
     startYAxisAtZero,
     subheader = '',
     vizType,
     yAxisFormat,
   } = formData;
+
   const { data } = payload;
+
+  // We need the metric as of the last query
+  const { metric } = payload.form_data;
 
   let mainColor;
   if (colorPicker) {


### PR DESCRIPTION
When changing the metric on a big number, the "formData.metric" is used
to both define the query, and on the JS side to figure out where to read
from. Currently this gets out of sync as the JS reads the new metric
before the query has been re-run.

This fixes the issue by reading the metric from the payload (previous
query run's) formData instead of the actual current formData.

Another fix would be to not reference the metric label as the key in the
data. from `[{"__timestamp": 599853600000.0, "count": 1886}, ...]` to
something like `{[599853600000.0, 1886]}`.