### PR TITLE
make loading icon bigger

### DIFF
--- a/superset/assets/src/SqlLab/components/TableElement.jsx
+++ b/superset/assets/src/SqlLab/components/TableElement.jsx
@@ -172,7 +172,7 @@ class TableElement extends React.PureComponent {
         </div>
         <div className="pull-right">
           {table.isMetadataLoading || table.isExtraMetadataLoading ?
-            <Loading size={20} />
+            <Loading size={50} />
             :
             this.renderControls()
           }


### PR DESCRIPTION
The loading icon's size was set to 20 which is too small.
<img width="366" alt="screen shot 2018-12-04 at 4 33 19 pm" src="https://user-images.githubusercontent.com/26216756/49482102-9a685b00-f7e2-11e8-98cb-1c83e91e774a.png">

Bumping the size up to the max size, 50, according to https://github.com/williaster/superset/blob/32a45ec0bff1ff12a7b641bdff8530e09644c246/superset/assets/src/components/Loading.jsx#L18
<img width="384" alt="screen shot 2018-12-04 at 4 33 56 pm" src="https://user-images.githubusercontent.com/26216756/49482118-ac49fe00-f7e2-11e8-8c4c-cd081a31e244.png">
