### PR TITLE
[RfC] Fix URL too long

### DIFF
--- a/superset/assets/src/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/src/explore/components/ExploreViewContainer.jsx
@@ -171,7 +171,7 @@ class ExploreViewContainer extends React.Component {
 
   addHistory({ isReplace = false, title }) {
     const { payload } = getExploreUrlAndPayload({ formData: this.props.form_data });
-    const longUrl = getExploreLongUrl(this.props.form_data);
+    const longUrl = getExploreLongUrl(this.props.form_data, null, false);
     try {
       if (isReplace) {
         history.replaceState(payload, title, longUrl);


### PR DESCRIPTION
When a URL gets too long (usually happens with controls that allow
free form text), it creates an array of bugs.
* bug when creating a short URL, because the POST request's referrer
field is too long
* a bug when saving a chart (when the modal shows up) also because of
the referrer being too long

Some work has been done in the past to mitigate this, and I'm unclear if
there's been some sort of recent regression because of the Flask upgrade or some
browser change, or whether these bugs have always been around.

This is a request for comment on an approach that works but isn't perfect. Let me know if
you can think of better ideas as to how to manage this.

My current solution looks for 8000+ characters URLs and shrinks them to
only `/superset/explore/?URL_IS_TOO_LONG_TO_SHARE&form_data=...` and we
only keep the formData keys for `datasource` and `viz_type`. Not super
elegant but does the trick, and 8k+ long url aren't common.

@graceguo-supercat, @betodealmeida any thoughts on this?