### PR TITLE
[warm] Enforcing consistent form-data

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2049,7 +2049,13 @@ class Superset(BaseSupersetView):
 
         for slc in slices:
             try:
-                obj = slc.get_viz(force=True)
+                form_data = self.get_form_data(slc.id, use_slice_data=True)[0]
+                obj = self.get_viz(
+                    datasource_type=slc.datasource.type,
+                    datasource_id=slc.datasource.id,
+                    form_data=form_data,
+                    force=True,
+                )
                 obj.get_json()
             except Exception as e:
                 return json_error_response(utils.error_msg_from_exception(e))


### PR DESCRIPTION
This PR updates the cache warm up logic by ensuring that the form-data is consistent with the various other endpoints:
- `/slice/`
- `/slice_json/`
- `/explore/`
- `/explore_json/`

which all call `get_form_data` which mutates the saved form-data. 

For context the cache warm-up was failing for saved slices which still use `since` and `until` as opposed to `time_range` which is part of the cache key as defined [here](https://github.com/apache/incubator-superset/blob/master/superset/viz.py#L359).

to: @graceguo-supercat @kristw @michellethomas