### PR TITLE
Increase size of column `name` in table `ab_view_meu`

### DIFF
--- a/superset/migrations/versions/cefabc8f7d38_increase_size_of_name_column_in_ab_view_.py
+++ b/superset/migrations/versions/cefabc8f7d38_increase_size_of_name_column_in_ab_view_.py
@@ -15,20 +15,20 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.alter_column(
-        'ab_view_menu',
-        'name',
-        existing_type=sa.String(length=100),
-        existing_nullable=False,
-        type_=sa.String(length=255),
-        nullable=False)
+    with op.batch_alter_table('ab_view_menu') as batch_op:
+        batch_op.alter_column(
+            'name',
+            existing_type=sa.String(length=100),
+            existing_nullable=False,
+            type_=sa.String(length=255),
+            nullable=False)
 
 
 def downgrade():
-    op.alter_column(
-        'ab_view_menu',
-        'name',
-        existing_type=sa.String(length=255),
-        existing_nullable=False,
-        type_=sa.String(length=100),
-        nullable=False)
+    with op.batch_alter_table('ab_view_menu') as batch_op:
+        batch_op.alter_column(
+            'name',
+            existing_type=sa.String(length=255),
+            existing_nullable=False,
+            type_=sa.String(length=100),
+            nullable=False)

--- a/superset/migrations/versions/cefabc8f7d38_increase_size_of_name_column_in_ab_view_.py
+++ b/superset/migrations/versions/cefabc8f7d38_increase_size_of_name_column_in_ab_view_.py
@@ -1,0 +1,34 @@
+"""Increase size of name column in ab_view_menu
+
+Revision ID: cefabc8f7d38
+Revises: 6c7537a6004a
+Create Date: 2018-12-13 15:38:36.772750
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'cefabc8f7d38'
+down_revision = '6c7537a6004a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column(
+        'ab_view_menu',
+        'name',
+        existing_type=sa.String(length=100),
+        existing_nullable=False,
+        type_=sa.String(length=255),
+        nullable=False)
+
+
+def downgrade():
+    op.alter_column(
+        'ab_view_menu',
+        'name',
+        existing_type=sa.String(length=255),
+        existing_nullable=False,
+        type_=sa.String(length=100),
+        nullable=False)


### PR DESCRIPTION
https://github.com/apache/incubator-superset/pull/5915 introduced support for Google Spreadsheets as datasources, using the `gsheetsdb` module. The code was tested using only SQLite as Superset's database. Today I discovered it fails in MySQL (and probably other databases that enforce column sizes for strings), since the table name of a Google spreadsheet is too big to be stored in the `ab_view_menu` table.

I increased the size of the column `name` from 100 to 255 characters, and tested the Google connector using MySQL as the main database for Superset.