### PR TITLE
Avoid resetting margin to 0

### DIFF
--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -407,8 +407,8 @@ function nvd3Vis(element, props) {
       default:
         throw new Error('Unrecognized visualization for nvd3' + vizType);
     }
-    // Assuming the container has padding already
-    chart.margin({ top: 0, left: 0, right: 0, bottom: 0 });
+    // Assuming the container has padding already other than for top margin
+    chart.margin({ left: 0, right: 0, bottom: 0 });
 
     if (showBarValue) {
       setTimeout(function () {

--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -353,6 +353,8 @@ function nvd3Vis(element, props) {
             chart.labelType(d => `${d.data.x}: ${((d.data.y / total) * 100).toFixed()}%`);
           }
         }
+        // Pie chart does not need top margin
+        chart.margin({ top: 0 });
         break;
 
       case 'column':


### PR DESCRIPTION
Y axis labels were getting cut off at the top because margin.top was previously set to 30 and now gets reset to 0 without getting set again later. That top margin is necessary when a chart doesn't have a legend, the top gets cut off. 

Fixes #6517 

@mistercrunch @kristw 