### PR TITLE
Fix deck.gl Polygon not show

### DIFF
--- a/superset/assets/src/visualizations/deckgl/utils.js
+++ b/superset/assets/src/visualizations/deckgl/utils.js
@@ -89,7 +89,7 @@ export function getBuckets(fd, features, accessor) {
   breakPoints.slice(1).forEach((value, i) => {
     const range = breakPoints[i] + ' - ' + breakPoints[i + 1];
     const mid = 0.5 * (parseInt(breakPoints[i], 10) + parseInt(breakPoints[i + 1], 10));
-   //fix polygon cannot show
+   // fix polygon doesn't show
    const metricLabel = fd.metric ? fd.metric.label || fd.metric : null;
     buckets[range] = {
       color: colorScaler({ [metricLabel || fd.metric]: mid }),

--- a/superset/assets/src/visualizations/deckgl/utils.js
+++ b/superset/assets/src/visualizations/deckgl/utils.js
@@ -89,8 +89,10 @@ export function getBuckets(fd, features, accessor) {
   breakPoints.slice(1).forEach((value, i) => {
     const range = breakPoints[i] + ' - ' + breakPoints[i + 1];
     const mid = 0.5 * (parseInt(breakPoints[i], 10) + parseInt(breakPoints[i + 1], 10));
+   //fix polygon cannot show
+   const metricLabel = fd.metric ? fd.metric.label || fd.metric : null;
     buckets[range] = {
-      color: colorScaler({ [fd.metric.label || fd.metric]: mid }),
+      color: colorScaler({ [metricLabel || fd.metric]: mid }),
       enabled: true,
     };
   });


### PR DESCRIPTION
Fix bug Polygon doesn't show

Before fixed
![polygon-error](https://user-images.githubusercontent.com/45657828/50071622-fc728880-0204-11e9-8663-e3b36bfaaa82.png)

After fixed
![polygon-fixed](https://user-images.githubusercontent.com/45657828/50071649-1ca24780-0205-11e9-88ca-a3c3ab6a4a97.png)


I fixed it on this file below.
superset/assets/src/visualizations/deckgl/utils.jsx

function getBuckets
>> before
  buckets[range] = {
     color: colorScaler({ [fd.metric.label || fd.metric]: mid }),
     enabled: true,
   };

>> after
  const metricLabel = fd.metric ? fd.metric.label || fd.metric : null;
   buckets[range] = {
     color: colorScaler({ [metricLabel || fd.metric]: mid }),
     enabled: true,
   };
