### PR TITLE
Make it easier to select dropdown options in control tests

### DIFF
--- a/superset/assets/cypress/integration/explore/control.test.js
+++ b/superset/assets/cypress/integration/explore/control.test.js
@@ -89,8 +89,8 @@ describe('AdhocMetrics', () => {
     cy.get('[data-test=metrics]').within(() => {
       cy.get('.select-clear').click();
       cy.get('.Select-control').click({ force: true });
-      cy.get('input').type('num{downarrow}', { force: true });
-      cy.get('.VirtualizedSelectFocusedOption')
+      cy.get('input').type('num', { force: true });
+      cy.get('.VirtualizedSelectOption[data-test=_col_num]')
         .trigger('mousedown')
         .click();
     });

--- a/superset/assets/src/components/VirtualizedRendererWrap.jsx
+++ b/superset/assets/src/components/VirtualizedRendererWrap.jsx
@@ -55,6 +55,7 @@ export default function VirtualizedRendererWrap(renderer) {
         key={key}
         style={{ ...(option.style || {}), ...style }}
         title={option.title}
+        data-test={option.optionName}
         {...events}
       >
         {renderer(option)}


### PR DESCRIPTION
Making it easier to set the correct VirtualizedSelectOption in the dropdown for Cypress integration tests.

@hughhhh I think this should fix your issue with the "Clear metric and set custom sql adhoc metric" test

@kristw @graceguo-supercat 