### PR TITLE
Documentation Correction to use http.server for Python3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,8 @@ and start a simple web server so we can check out the docs in a browser:
 
 ```bash
 cd docs/_build/html
-python -m SimpleHTTPServer
+python -m http.server # Python2 users should use SimpleHTTPServer
+
 ```
 
 This will start a small Python web server listening on port 8000. Point your


### PR DESCRIPTION
As per https://docs.python.org/2/library/simplehttpserver.html, SimpleHTTPServer module has been merged into http.server in Python 3.