### PR TITLE
TableViz uses epoch dates

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -595,14 +595,11 @@ class TableViz(BaseViz):
         return data
 
     def json_dumps(self, obj, sort_keys=False):
-        if self.form_data.get('all_columns'):
-            return json.dumps(
-                obj,
-                default=utils.json_iso_dttm_ser,
-                sort_keys=sort_keys,
-                ignore_nan=True)
-        else:
-            return super(TableViz, self).json_dumps(obj)
+        return json.dumps(
+            obj,
+            default=utils.json_iso_dttm_ser,
+            sort_keys=sort_keys,
+            ignore_nan=True)
 
 
 class TimeTableViz(BaseViz):


### PR DESCRIPTION
As reported in
https://github.com/apache/incubator-superset/issues/4931, https://github.com/apache/incubator-superset/issues/5182 and https://github.com/apache/incubator-superset/issues/5312

Theres also this another PR which takes different angle. https://github.com/apache/incubator-superset/pull/5365

TableViz uses json_int_dttm_ser for grouped columns and json_iso_dttm_ser for non-grouped. This was originally introduced in https://github.com/apache/incubator-superset/commit/0ec9cd4ad279c24b6d65fb825a319357958297fd commit.

This PR uses just json_iso_dttm_ser serializer for everything.

