### PR TITLE
[design] use angle icons instead of carets for expandable panels

### DIFF
--- a/superset/assets/cypress/integration/explore/control.test.js
+++ b/superset/assets/cypress/integration/explore/control.test.js
@@ -208,6 +208,7 @@ describe('Advanced analytics', () => {
 
     cy.get('span')
       .contains('Advanced Analytics')
+      .parent()
       .siblings()
       .first()
       .click();

--- a/superset/assets/src/explore/components/ControlPanelSection.jsx
+++ b/superset/assets/src/explore/components/ControlPanelSection.jsx
@@ -31,21 +31,21 @@ export default class ControlPanelSection extends React.Component {
     return (
       label &&
         <div>
+          <span>
+            <span onClick={this.toggleExpand.bind(this)}>{label}</span>
+            {' '}
+            {description && <InfoTooltipWithTrigger label={label} tooltip={description} />}
+            {hasErrors &&
+              <InfoTooltipWithTrigger
+                label="validation-errors"
+                bsStyle="danger"
+                tooltip="This section contains validation errors"
+              />}
+          </span>
           <i
-            className={`text-primary expander fa fa-caret-${this.state.expanded ? 'down' : 'right'}`}
+            className={`float-right fa-lg text-primary expander fa fa-angle-${this.state.expanded ? 'up' : 'down'}`}
             onClick={this.toggleExpand.bind(this)}
           />
-          {' '}
-          <span onClick={this.toggleExpand.bind(this)}>{label}</span>
-          {' '}
-          {description && <InfoTooltipWithTrigger label={label} tooltip={description} />}
-          {hasErrors &&
-            <InfoTooltipWithTrigger
-              label="validation-errors"
-              bsStyle="danger"
-              tooltip="This section contains validation errors"
-            />
-          }
         </div>);
   }
 


### PR DESCRIPTION
Also moving to the right to conform to the material design specs

# before
<img width="479" alt="screen shot 2018-12-21 at 12 41 38 pm" src="https://user-images.githubusercontent.com/487433/50362764-d22f0c80-051d-11e9-8a54-eca4f07e5a6a.png">

# after
<img width="488" alt="screen shot 2018-12-21 at 12 35 12 pm" src="https://user-images.githubusercontent.com/487433/50362765-d22f0c80-051d-11e9-99d4-e032b29385de.png">
@elibrumbaugh 