### PR TITLE
Fix dual line chart when no right y axis present

### DIFF
--- a/superset/assets/src/visualizations/nvd3/LineMulti/LineMulti.jsx
+++ b/superset/assets/src/visualizations/nvd3/LineMulti/LineMulti.jsx
@@ -9,7 +9,7 @@ const propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   annotationData: PropTypes.object,
-  datasource: PropTypes.array,
+  datasource: PropTypes.object,
   formData: PropTypes.object,
   onAddFilter: PropTypes.func,
   onError: PropTypes.func,

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -181,7 +181,7 @@ export function getMaxLabelSize(svg, axisClass) {
   const tickTexts = svg.selectAll(`.${axisClass} g.tick text`);
   if (tickTexts.length > 0) {
     const lengths = tickTexts[0].map(text => text.getComputedTextLength());
-    return Math.ceil(Math.max(...lengths));
+    return Math.ceil(Math.max(0, ...lengths));
   }
   return 0;
 }


### PR DESCRIPTION
If a user creates a multi chart with charts only on the left y axis, the chart fails to render correctly:

<img width="1698" alt="screen shot 2018-12-26 at 2 33 40 pm" src="https://user-images.githubusercontent.com/1534870/50458864-44875e80-091b-11e9-9f5c-976c8e956f7d.png">

This happens because the function that computes the maximum label size for the second (right side) y axis returns `-Infinity`. I fixed it by making sure that the function `getMaxLabelSize` returns a non-negative number.

Fixed:

<img width="1698" alt="screen shot 2018-12-26 at 2 33 17 pm" src="https://user-images.githubusercontent.com/1534870/50458886-6ed91c00-091b-11e9-9374-aaaa4659d8db.png">
