### PR TITLE
[bugfix] moving from reactable to reactable-arc fork

### DIFF
--- a/superset/assets/package-lock.json
+++ b/superset/assets/package-lock.json
@@ -3827,11 +3827,6 @@
         }
       }
     },
-    "base64-js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
-      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
-    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -3957,15 +3952,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-10.4.0.tgz",
       "integrity": "sha512-ONP9SGV17pr2l3RJHhoX+3qAUDF3ltByQD5rP7Dw2QytOYAL6JjRVOvyFKv/CR+Xq2T7hJtq3NZyDzfX9CZPFw=="
-    },
-    "bops": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
-      "integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo=",
-      "requires": {
-        "base64-js": "0.0.2",
-        "to-utf8": "0.0.1"
-      }
     },
     "bowser": {
       "version": "1.9.4",
@@ -7314,11 +7300,6 @@
         "is-extendable": "^0.1.0"
       }
     },
-    "extent": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/extent/-/extent-0.2.0.tgz",
-      "integrity": "sha1-760IaWgtNii9vusUDB9NACPmvsQ="
-    },
     "external-editor": {
       "version": "2.2.0",
       "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
@@ -8805,63 +8786,6 @@
           }
         }
       }
-    },
-    "geojson-coords": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/geojson-coords/-/geojson-coords-0.0.0.tgz",
-      "integrity": "sha1-3NuoZhLaa+a5UR8W846Q/My23XU=",
-      "requires": {
-        "geojson-flatten": "~0.1.0",
-        "geojson-normalize": "0.0.0"
-      }
-    },
-    "geojson-extent": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/geojson-extent/-/geojson-extent-0.3.2.tgz",
-      "integrity": "sha1-LuXz+r8MdlnAUJ4FeCkQ3+HfJ+g=",
-      "requires": {
-        "extent": "0.2.0",
-        "geojson-coords": "0.0.0",
-        "rw": "~0.1.4",
-        "traverse": "~0.6.6"
-      },
-      "dependencies": {
-        "rw": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/rw/-/rw-0.1.4.tgz",
-          "integrity": "sha1-SQPL2AJIrg7eaFv1j9I2p6mymj4="
-        }
-      }
-    },
-    "geojson-flatten": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-0.1.0.tgz",
-      "integrity": "sha1-wcb5a7tXExFMmxSgtLqA9H5GIss=",
-      "requires": {
-        "concat-stream": "~1.2.1",
-        "minimist": "0.0.5",
-        "sharkdown": "~0.1.0"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.2.1.tgz",
-          "integrity": "sha1-81EAtsRjeL+6i2uA+fDQzN8T3GA=",
-          "requires": {
-            "bops": "0.0.6"
-          }
-        },
-        "minimist": {
-          "version": "0.0.5",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
-        }
-      }
-    },
-    "geojson-normalize": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/geojson-normalize/-/geojson-normalize-0.0.0.tgz",
-      "integrity": "sha1-Lbw2eM0bMbgXnodr2nDNEg3eNcA="
     },
     "geojson-rewind": {
       "version": "0.3.1",
@@ -16130,15 +16054,6 @@
         "scheduler": "^0.11.2"
       }
     },
-    "react-draggable": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.0.5.tgz",
-      "integrity": "sha512-qo76q6+pafyGllbmfc+CgWfOkwY9v3UoJa3jp6xG2vdsRY8uJTN1kqNievLj0uVNjEqCvZ0OFiEBxlAJNj3OTg==",
-      "requires": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.0"
-      }
-    },
     "react-gravatar": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/react-gravatar/-/react-gravatar-2.6.3.tgz",
@@ -16348,15 +16263,6 @@
         }
       }
     },
-    "react-resizable": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.7.5.tgz",
-      "integrity": "sha512-lauPcBsLqmxMHXHpTeOBpYenGalbSikYr8hK+lwtNYMQX1pGd2iYE+pDvZEV97nCnzuCtWM9htp7OpsBIY2Sjw==",
-      "requires": {
-        "prop-types": "15.x",
-        "react-draggable": "^2.2.6 || ^3.0.3"
-      }
-    },
     "react-search-input": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/react-search-input/-/react-search-input-0.11.3.tgz",
@@ -16479,10 +16385,10 @@
         "has": "^1.0.1"
       }
     },
-    "reactable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/reactable/-/reactable-1.0.2.tgz",
-      "integrity": "sha1-Z6V5/uOvaLmRtfBN+SGkpA7OC3I="
+    "reactable-arc": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/reactable-arc/-/reactable-arc-0.14.42.tgz",
+      "integrity": "sha512-dYWTX+JdknG/DgQlqbjf4ZIJj2z6blEfl7gqTNsLD66gcM+YrgRsTbl4S0E71/iPzfgGujxyk3TLilbozx9c9Q=="
     },
     "reactcss": {
       "version": "1.2.3",
@@ -19364,11 +19270,6 @@
         }
       }
     },
-    "to-utf8": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
-      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
-    },
     "topojson": {
       "version": "1.6.27",
       "resolved": "https://registry.npmjs.org/topojson/-/topojson-1.6.27.tgz",
@@ -19415,11 +19316,6 @@
       "requires": {
         "loader-utils": "^1.0.2"
       }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim": {
       "version": "0.0.1",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -120,7 +120,7 @@
     "react-syntax-highlighter": "^7.0.4",
     "react-virtualized": "9.19.1",
     "react-virtualized-select": "^3.1.3",
-    "reactable": "1.0.2",
+    "reactable-arc": "0.14.42",
     "redux": "^3.5.2",
     "redux-localstorage": "^0.4.1",
     "redux-thunk": "^2.1.0",

--- a/superset/assets/spec/javascripts/components/AlteredSliceTag_spec.jsx
+++ b/superset/assets/spec/javascripts/components/AlteredSliceTag_spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Table, Thead, Td, Th, Tr } from 'reactable';
+import { Table, Thead, Td, Th, Tr } from 'reactable-arc';
 
 import AlteredSliceTag from '../../../src/components/AlteredSliceTag';
 import ModalTrigger from '../../../src/components/ModalTrigger';

--- a/superset/assets/spec/javascripts/sqllab/QueryTable_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/QueryTable_spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Table } from 'reactable';
+import { Table } from 'reactable-arc';
 
 import { queries } from './fixtures';
 import QueryTable from '../../../src/SqlLab/components/QueryTable';

--- a/superset/assets/spec/javascripts/welcome/DashboardTable_spec.jsx
+++ b/superset/assets/spec/javascripts/welcome/DashboardTable_spec.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
-import { Table } from 'reactable';
+import { Table } from 'reactable-arc';
 
 import DashboardTable from '../../../src/welcome/DashboardTable';
 import Loading from '../../../src/components/Loading';

--- a/superset/assets/src/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/src/SqlLab/components/QueryTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { Table } from 'reactable';
+import { Table } from 'reactable-arc';
 import { Label, ProgressBar, Well } from 'react-bootstrap';
 import { t } from '@superset-ui/translation';
 

--- a/superset/assets/src/components/AlteredSliceTag.jsx
+++ b/superset/assets/src/components/AlteredSliceTag.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table, Tr, Td, Thead, Th } from 'reactable';
+import { Table, Tr, Td, Thead, Th } from 'reactable-arc';
 import { isEqual, isEmpty } from 'lodash';
 import { t } from '@superset-ui/translation';
 import TooltipWrapper from './TooltipWrapper';

--- a/superset/assets/src/components/TableLoader.jsx
+++ b/superset/assets/src/components/TableLoader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table, Tr, Td } from 'reactable';
+import { Table, Tr, Td } from 'reactable-arc';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
 

--- a/superset/assets/src/explore/components/DisplayQueryButton.jsx
+++ b/superset/assets/src/explore/components/DisplayQueryButton.jsx
@@ -7,7 +7,7 @@ import sqlSyntax from 'react-syntax-highlighter/languages/hljs/sql';
 import jsonSyntax from 'react-syntax-highlighter/languages/hljs/json';
 import github from 'react-syntax-highlighter/styles/hljs/github';
 import { DropdownButton, MenuItem, Row, Col, FormControl } from 'react-bootstrap';
-import { Table } from 'reactable';
+import { Table } from 'reactable-arc';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
 

--- a/superset/assets/src/visualizations/PairedTTest/TTestTable.jsx
+++ b/superset/assets/src/visualizations/PairedTTest/TTestTable.jsx
@@ -1,6 +1,6 @@
 import dist from 'distributions';
 import React from 'react';
-import { Table, Tr, Td, Thead, Th } from 'reactable';
+import { Table, Tr, Td, Thead, Th } from 'reactable-arc';
 import PropTypes from 'prop-types';
 
 export const dataPropType = PropTypes.arrayOf(PropTypes.shape({

--- a/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Mustache from 'mustache';
 import { scaleLinear } from 'd3-scale';
-import { Table, Thead, Th, Tr, Td } from 'reactable';
+import { Table, Thead, Th, Tr, Td } from 'reactable-arc';
 import { formatNumber } from '@superset-ui/number-format';
 import { formatTime } from '@superset-ui/time-format';
 

--- a/superset/assets/src/welcome/DashboardTable.jsx
+++ b/superset/assets/src/welcome/DashboardTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table, Tr, Td, unsafe } from 'reactable';
+import { Table, Tr, Td, unsafe } from 'reactable-arc';
 import { SupersetClient } from '@superset-ui/connection';
 import { t } from '@superset-ui/translation';
 


### PR DESCRIPTION
The npm `reactable` library is not well maintained and has issues with React 16 and `react-hot-loader`. `reactable-arc` https://www.npmjs.com/package/reactable-arc is a fork that addresses these issues.

Long term we should probably  move away from both of these options as discussed here https://github.com/apache/incubator-superset/issues/4649

In the meantime, this closes https://github.com/apache/incubator-superset/issues/5935, https://github.com/apache/incubator-superset/issues/6343