### PR TITLE
Add clear query editors tab

### DIFF
--- a/superset/assets/cypress/integration/sqllab/tabs.js
+++ b/superset/assets/cypress/integration/sqllab/tabs.js
@@ -10,9 +10,9 @@ export default () => {
       cy.get('#a11y-query-editor-tabs > ul > li').then((tabList) => {
         const initialTabCount = tabList.length;
 
-        // add tab
+        // add tab (second to last tab)
         cy.get('#a11y-query-editor-tabs > ul > li')
-          .last()
+          .eq(initialTabCount - 2)
           .click();
 
         cy.get('#a11y-query-editor-tabs > ul > li').should('have.length', initialTabCount + 1);

--- a/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
@@ -147,10 +147,15 @@ describe('TabbedSqlEditors', () => {
   it('should handle select', () => {
     wrapper = getWrapper();
     sinon.spy(wrapper.instance(), 'newQueryEditor');
+    sinon.spy(wrapper.instance(), 'removeQueryEditor');
     sinon.stub(wrapper.instance().props.actions, 'setActiveQueryEditor');
+    sinon.stub(window, 'confirm').returns(true);
 
     wrapper.instance().handleSelect('add_tab');
     expect(wrapper.instance().newQueryEditor.callCount).toBe(1);
+
+    wrapper.instance().handleSelect('close_all_tabs');
+    expect(wrapper.instance().removeQueryEditor.callCount).toBe(1);
 
     wrapper.instance().handleSelect('123');
     expect(wrapper.instance().props.actions.setActiveQueryEditor.getCall(0).args[0].id)
@@ -166,7 +171,7 @@ describe('TabbedSqlEditors', () => {
     expect(firstTab.find(SqlEditor)).toHaveLength(1);
 
     const lastTab = wrapper.find(Tab).last();
-    expect(lastTab.props().eventKey).toContain('add_tab');
+    expect(lastTab.props().eventKey).toContain('close_all_tabs');
   });
   it('should disable new tab when offline', () => {
     wrapper = getWrapper();

--- a/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
@@ -154,7 +154,7 @@ describe('TabbedSqlEditors', () => {
     wrapper.instance().handleSelect('add_tab');
     expect(wrapper.instance().newQueryEditor.callCount).toBe(1);
 
-    wrapper.instance().handleSelect('close_all_tabs');
+    wrapper.instance().onConfirmClose();
     expect(wrapper.instance().removeQueryEditor.callCount).toBe(1);
 
     wrapper.instance().handleSelect('123');

--- a/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -145,6 +145,13 @@ class TabbedSqlEditors extends React.PureComponent {
   handleSelect(key) {
     if (key === 'add_tab') {
       this.newQueryEditor();
+    } else if (key === 'close_all_tabs') {
+      if (window.confirm('Are you sure you wish to clear all query editors?')) {
+        for (let i = 0; i < this.props.queryEditors.length; i++) {
+          const qe = this.props.queryEditors[i];
+          this.removeQueryEditor(qe);
+        }
+      }
     } else {
       this.props.actions.setActiveQueryEditor({ id: key });
     }
@@ -241,10 +248,20 @@ class TabbedSqlEditors extends React.PureComponent {
           eventKey="add_tab"
           disabled={this.props.offline}
         />
+        <Tab
+          title={
+            <div>
+              <i className="fa fa-close" />&nbsp;
+            </div>
+          }
+          eventKey="close_all_tabs"
+          disabled={this.props.offline}
+        />
       </Tabs>
     );
   }
 }
+
 TabbedSqlEditors.propTypes = propTypes;
 TabbedSqlEditors.defaultProps = defaultProps;
 


### PR DESCRIPTION
**Summary:** It ends up being very time consuming to manually close all query editors. This PR adds the ability to clear all query editor tabs in SQL Lab. Addresses https://github.com/apache/incubator-superset/issues/6588 

**Test plan:** Jasmine test has been added. 
 
![cleareditors](https://user-images.githubusercontent.com/12538052/50745452-11788100-11df-11e9-95b2-24794dbc1cd2.gif)
