### PR TITLE
Add support for Apache Drill

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -392,6 +392,12 @@ Here's a list of some of the recommended packages.
 |  Pinot        | ``pip install pinotdb``             | ``pinot+http://controller:5436/``               |
 |               |                                     | ``query?server=http://controller:5983/``        |
 +---------------+-------------------------------------+-------------------------------------------------+
+|  Apache Drill |                                     | For the REST API:``                             |
+|               |                                     | ``drill+sadrill://``                            |
+|               |                                     | For JDBC                                        |
+|               |                                     | ``drill+jdbc://``                               |
++---------------+-------------------------------------+-------------------------------------------------+
+
 
 Note that many other databases are supported, the main criteria being the
 existence of a functional SqlAlchemy dialect and Python driver. Googling
@@ -448,6 +454,31 @@ Required environment variables: ::
     export ODBCINST=/.../teradata/client/ODBC_64/odbcinst.ini
 
 See `Teradata SQLAlchemy <https://github.com/Teradata/sqlalchemy-teradata>`_.
+
+Apache Drill
+---------
+At the time of writing, the SQLAlchemy Dialect is not available on pypi and must be downloaded here:
+`SQLAlchemy Drill <https://github.com/JohnOmernik/sqlalchemy-drill>`_
+
+Alternatively, you can install it completely from the command line as follows: ::
+
+    git clone https://github.com/JohnOmernik/sqlalchemy-drill
+    cd sqlalchemy-drill
+    python3 setup.py install
+
+Once that is done, you can connect to Drill in two ways, either via the REST interface or by JDBC.  If you are connecting via JDBC, you must have the
+Drill JDBC Driver installed.
+
+The basic connection string for Drill looks like this ::
+
+    drill+sadrill://{username}:{password}@{host}:{port}/{storage_plugin}?use_ssl=True
+
+If you are using JDBC to connect to Drill, the connection string looks like this: ::
+
+    drill+jdbc://{username}:{password}@{host}:{port}/{storage_plugin}
+
+For a complete tutorial about how to use Apache Drill with Superset, see this tutorial:
+`Visualize Anything with Superset and Drill <http://thedataist.com/visualize-anything-with-superset-and-drill/>`_
 
 Caching
 -------

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -745,6 +745,10 @@ class DrillEngineSpec(BaseEngineSpec):
     # Returns a function to convert a Unix timestamp in milliseconds to a date
     @classmethod
     def epoch_to_dttm(cls):
+        return cls.epoch_ms_to_dttm().replace('{col}', '({col}*1000)')
+
+    @classmethod
+    def epoch_ms_to_dttm(cls):
         return 'TO_DATE({col})'
 
     @classmethod

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -759,21 +759,11 @@ class DrillEngineSpec(BaseEngineSpec):
 
     @classmethod
     def adjust_database_uri(cls, uri, selected_schema):
-        database = uri.database
         if '/' in uri.database:
             database = uri.database.split('/')[0]
         if selected_schema:
-            uri.database = database + '/' + selected_schema
+            uri.database = parse.quote(selected_schema, safe='')
         return uri
-
-    @classmethod
-    def select_star(cls, my_db, table_name, engine, schema=None, limit=100,
-                    show_cols=False, indent=True, latest_partition=True,
-                    cols=None):
-
-        return super().select_star(my_db, table_name, engine,
-                                   schema, limit,
-                                   show_cols, indent, latest_partition, cols)
 
 
 class MySQLEngineSpec(BaseEngineSpec):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -767,10 +767,6 @@ class DrillEngineSpec(BaseEngineSpec):
         return uri
 
     @classmethod
-    def extra_table_metadata(cls, database, table_name, schema_name):
-        return super().extra_table_metadata(database, table_name, schema_name)
-
-    @classmethod
     def select_star(cls, my_db, table_name, engine, schema=None, limit=100,
                     show_cols=False, indent=True, latest_partition=True,
                     cols=None):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -759,8 +759,6 @@ class DrillEngineSpec(BaseEngineSpec):
 
     @classmethod
     def adjust_database_uri(cls, uri, selected_schema):
-        if '/' in uri.database:
-            database = uri.database.split('/')[0]
         if selected_schema:
             uri.database = parse.quote(selected_schema, safe='')
         return uri

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -775,14 +775,6 @@ class DrillEngineSpec(BaseEngineSpec):
                                    schema, limit,
                                    show_cols, indent, latest_partition, cols)
 
-    @classmethod
-    def get_table_names(cls, inspector, schema):
-        return sorted(inspector.get_table_names(schema))
-
-    @classmethod
-    def get_view_names(cls, inspector, schema):
-        return sorted(inspector.get_view_names(schema))
-
 
 class MySQLEngineSpec(BaseEngineSpec):
     engine = 'mysql'


### PR DESCRIPTION
This is the first attempt at support for Apache Drill in Superset.  This uses John Omernik's SQLAlchemy dialect (https://github.com/JohnOmernik/sqlalchemy-drill).

Drill has a unique aspect in its namespace which proved problematic.  Drill uses the concepts of:

- Storage Plugin
- Workspace
- Table (or file)

When connecting to Drill to a non-file based system, the behavior is pretty much as a traditional database.  However, when Drill is querying a file based system, you can have additional `.` in the namespace that are not namespace related.   For example:  
```
dfs.test.`data.json`
```
In this case, the storage plugin is `dfs`, the workspace which is optional is `test`, and the table, which in this case is a file, is `data.json`.  In this case however, the last period is not part of the namespace and was consistently misinterpreted by Superset.  

The solution I found, which seemed like complete hackery, was to replace the last period with `@@@` in the dropdown in SQLlab.  Then I modified `view/core.py` to replace the `@@@` with a period in the various functions that generate tables.   

**UPDATE:  All Hackery Removed** 

