### PR TITLE
Improve padding in NVD3Vis

### DIFF
--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -549,6 +549,14 @@ function nvd3Vis(element, props) {
       .attr('width', width)
       .call(chart);
 
+    if (xLabelRotation > 0) {
+      const xTicks = svg.select('.nv-x.nv-axis > g').selectAll('g');
+      xTicks
+        .selectAll('text')
+        .attr('dx', -6.5)
+        .each((i, e) => console.log(this));
+    }
+
     // align yAxis1 and yAxis2 ticks
     if (isVizTypes(['dual_line', 'line_multi'])) {
       const count = chart.yAxis1.ticks();
@@ -615,11 +623,15 @@ function nvd3Vis(element, props) {
         // If x bounds are shown, we need a right margin
         margins.right = Math.max(20, maxXAxisLabelHeight / 2) + marginPad;
       }
-      if (xLabelRotation === 45) {
-        margins.bottom = maxXAxisLabelHeight + marginPad;
-        margins.right = maxXAxisLabelHeight + marginPad;
-      } else if (staggerLabels) {
+      if (staggerLabels) {
         margins.bottom = 40;
+      } else {
+        margins.bottom = (
+          maxXAxisLabelHeight * Math.sin(Math.PI * xLabelRotation / 180)
+        ) + marginPad;
+        margins.right = (
+          maxXAxisLabelHeight * Math.cos(Math.PI * xLabelRotation / 180)
+        ) + marginPad;
       }
 
       if (isVizTypes(['dual_line', 'line_multi'])) {

--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -550,11 +550,11 @@ function nvd3Vis(element, props) {
       .call(chart);
 
     if (xLabelRotation > 0) {
+      // shift labels to the left so they look better
       const xTicks = svg.select('.nv-x.nv-axis > g').selectAll('g');
       xTicks
         .selectAll('text')
-        .attr('dx', -6.5)
-        .each((i, e) => console.log(this));
+        .attr('dx', -6.5);
     }
 
     // align yAxis1 and yAxis2 ticks

--- a/superset/config.py
+++ b/superset/config.py
@@ -54,10 +54,9 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 SECRET_KEY = '\2\1thisismyscretkey\1\2\e\y\y\h'  # noqa
 
 # The SQLAlchemy connection string.
-# SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'superset.db')
+SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'superset.db')
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
-SQLALCHEMY_DATABASE_URI = 'mysql://root@localhost/superset'
 
 # In order to hook up a custom password store for all SQLACHEMY connections
 # implement a function that takes a single argument of type 'sqla.engine.url',

--- a/superset/config.py
+++ b/superset/config.py
@@ -54,9 +54,10 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 SECRET_KEY = '\2\1thisismyscretkey\1\2\e\y\y\h'  # noqa
 
 # The SQLAlchemy connection string.
-SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'superset.db')
+# SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'superset.db')
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
+SQLALCHEMY_DATABASE_URI = 'mysql://root@localhost/superset'
 
 # In order to hook up a custom password store for all SQLACHEMY connections
 # implement a function that takes a single argument of type 'sqla.engine.url',


### PR DESCRIPTION
I made some cosmetic adjustments to the padding in the `NVD3Vis.js` file for when the x labels are at 45 degrees. First, I shifted the labels to the left so they look better. Before:

<img width="1698" alt="screen shot 2019-01-09 at 10 59 32 am" src="https://user-images.githubusercontent.com/1534870/50921864-df913580-13fd-11e9-9a1c-e851e99a5484.png">

After:

<img width="1698" alt="screen shot 2019-01-09 at 10 58 11 am" src="https://user-images.githubusercontent.com/1534870/50921874-e5871680-13fd-11e9-8bf0-a3e1cc99ee35.png">

Now they are aligned with the middle of the first character of the label. This makes a difference in long labels. Before:

<img width="1698" alt="screen shot 2019-01-09 at 11 03 48 am" src="https://user-images.githubusercontent.com/1534870/50922022-49a9da80-13fe-11e9-9a48-d641b2efa5a4.png">

After:

<img width="1698" alt="screen shot 2019-01-09 at 11 03 34 am" src="https://user-images.githubusercontent.com/1534870/50922057-5af2e700-13fe-11e9-9502-d0574c7c93c6.png">

I also improved the way the extra padding is computed. Before, it the maximum label had a length of `X` we would add `X` pixels to both the right and the bottom margin, resulting in excessive padding. I updated the padding to be a function of the rotation angle (for 45 degrees we use `X*sqrt(2)/2` instead, eg).