### PR TITLE
[cosmetic] remove margin-bottom on dropdowns

### DIFF
--- a/superset/assets/src/explore/components/Control.css
+++ b/superset/assets/src/explore/components/Control.css
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+.Control {
+  padding-bottom: 4px;
+}

--- a/superset/assets/src/explore/components/Control.jsx
+++ b/superset/assets/src/explore/components/Control.jsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import './Control.css';
 import controlMap from './controls';
 
 const controlTypes = Object.keys(controlMap);
@@ -106,6 +107,7 @@ export default class Control extends React.PureComponent {
     const divStyle = this.props.hidden ? { display: 'none' } : null;
     return (
       <div
+        className="Control"
         data-test={this.props.name}
         style={divStyle}
         onMouseEnter={this.setHover.bind(this, true)}

--- a/superset/assets/src/explore/main.css
+++ b/superset/assets/src/explore/main.css
@@ -235,6 +235,3 @@ h2.section-header {
   padding-bottom: 5px;
 }
 
-.Select {
-  margin-bottom: 15px;
-}

--- a/superset/migrations/versions/8b70aa3d0f87_.py
+++ b/superset/migrations/versions/8b70aa3d0f87_.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """empty message
 
 Revision ID: 8b70aa3d0f87


### PR DESCRIPTION
`react-select` components have been added 15px bottom-margin without a
good reason. Other controls like text or checkboxes don't have that,
making Selects look non-standard, add making the control list too
sparse.

My perspective is that all controls should have the same
padding/margins.

## before 
<img width="462" alt="screen shot 2019-01-09 at 5 34 39 pm" src="https://user-images.githubusercontent.com/487433/50940217-e8e9c480-1434-11e9-9644-fa16d22234cd.png">

## after
<img width="478" alt="screen shot 2019-01-09 at 5 26 51 pm" src="https://user-images.githubusercontent.com/487433/50940218-e8e9c480-1434-11e9-9cdb-b5d2ffb682b4.png">
