### PR TITLE
Truncate long labels in x axis

### DIFF
--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -26,6 +26,7 @@ import {
   tryNumify,
   setAxisShowMaxMin,
   stringifyTimeRange,
+  truncateLabel,
   wrapTooltip,
 } from './utils';
 import {
@@ -609,6 +610,8 @@ function nvd3Vis(element, props) {
       if (chart.xAxis) {
         margins.bottom = 28;
       }
+      // truncate labels that are too long
+      d3.selectAll('.nv-x.nv-axis .tick text').text(truncateLabel);
       const maxYAxisLabelWidth = getMaxLabelSize(svg, chart.yAxis2 ? 'nv-y1' : 'nv-y');
       const maxXAxisLabelHeight = getMaxLabelSize(svg, 'nv-x');
       margins.left = maxYAxisLabelWidth + marginPad;
@@ -693,6 +696,9 @@ function nvd3Vis(element, props) {
         .attr('width', width)
         .attr('height', height)
         .call(chart);
+
+      // truncate labels that are too long
+      d3.selectAll('.nv-x.nv-axis .tick text').text(truncateLabel);
 
       // on scroll, hide tooltips. throttle to only 4x/second.
       window.addEventListener('scroll', throttle(hideTooltips, 250));

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -4,6 +4,8 @@ import dompurify from 'dompurify';
 import { getNumberFormatter } from '@superset-ui/number-format';
 import { smartDateFormatter } from '@superset-ui/time-format';
 
+const MAX_LABEL_LENGTH = 24;
+
 // Regexp for the label added to time shifted series
 // (1 hour offset, 2 days offset, etc.)
 const TIME_SHIFT_PATTERN = /\d+ \w+ offset/;
@@ -236,4 +238,10 @@ export function setAxisShowMaxMin(axis, showminmax) {
   if (axis && axis.showMaxMin && showminmax !== undefined) {
     axis.showMaxMin(showminmax);
   }
+}
+
+export function truncateLabel(text) {
+  return text.length > MAX_LABEL_LENGTH
+    ? text.substr(0, MAX_LABEL_LENGTH - 1) + '…'
+    : text;
 }


### PR DESCRIPTION
The padding for NVD3 charts is computed based on the length of the longest label in axes. For datasets with really long labels this results in excessive padding.

I added code to truncate the labels that are longer than 24 characters. Note that this has to be done twice: first when computing the length of the longest label, and again after the chart has been redrawn.

An example with `MAX_LABEL_LENGTH` set to 8:

<img width="581" alt="screen shot 2019-01-10 at 3 01 39 pm" src="https://user-images.githubusercontent.com/1534870/51002628-bdc0ad00-14e8-11e9-9e66-d599dd0ad9a5.png">
