### PR TITLE
add kerberos authentication for druid kerberos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',
         'unicodecsv',
-        'requests_kerberos',
         'urllib_kerberos'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,11 @@ setup(
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',
         'unicodecsv',
-        'urllib_kerberos'
+        'urllib_kerberos',
+        'requests_kerberos',
+        'pykerberos',
+        'urllib3'
+
     ],
     extras_require={
         'cors': ['flask-cors>=2.0.0'],

--- a/setup.py
+++ b/setup.py
@@ -94,10 +94,8 @@ setup(
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',
         'unicodecsv',
-        'urllib_kerberos',
-        'requests_kerberos',
-        'pykerberos',
-        'urllib3'
+        'urllib_kerberos>=0.2.0',
+        'requests_kerberos>=0.12.0'
 
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,8 @@ setup(
         'thrift>=0.9.3',
         'thrift-sasl>=0.2.1',
         'unicodecsv',
+        'requests_kerberos',
+        'urllib_kerberos'
     ],
     extras_require={
         'cors': ['flask-cors>=2.0.0'],

--- a/superset/config.py
+++ b/superset/config.py
@@ -542,6 +542,14 @@ WEBDRIVER_CONFIGURATION = {}
 # The base URL to query for accessing the user interface
 WEBDRIVER_BASEURL = 'http://0.0.0.0:8080/'
 
+# Add the kerberos for druid
+# ENABLE_KERBEROS_AUTHENTICATION = True
+# KERBEROS_KEYTAB = "/etc/security/keytabs/superset.headless.keytab"
+# KERBEROS_PRINCIPAL = "superset-hadoop@WESURE.CN"
+# KERBEROS_REINIT_TIME_SEC = 3600
+
+ENABLE_KERBEROS_AUTHENTICATION = False
+
 
 try:
     if CONFIG_PATH_ENV_VAR in os.environ:


### PR DESCRIPTION
When druid starts kerberos authentication, superset needs kerberos authentication.

the pr can get druid's datasource when the druid is enable the kerberos