### PR TITLE
Add `extra` column to `SavedQuery`

### DIFF
--- a/superset/migrations/versions/a33a03f16c4a_add_extra_column_to_savedquery.py
+++ b/superset/migrations/versions/a33a03f16c4a_add_extra_column_to_savedquery.py
@@ -1,0 +1,24 @@
+"""Add extra column to SavedQuery
+
+Revision ID: a33a03f16c4a
+Revises: fb13d49b72f9
+Create Date: 2019-01-14 16:00:26.344439
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a33a03f16c4a'
+down_revision = 'fb13d49b72f9'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('saved_query') as batch_op:
+        batch_op.add_column(sa.Column('extra_json', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('saved_query') as batch_op:
+        batch_op.drop_column('extra_json')

--- a/superset/migrations/versions/a33a03f16c4a_add_extra_column_to_savedquery.py
+++ b/superset/migrations/versions/a33a03f16c4a_add_extra_column_to_savedquery.py
@@ -1,5 +1,20 @@
 """Add extra column to SavedQuery
 
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 Revision ID: a33a03f16c4a
 Revises: fb13d49b72f9
 Create Date: 2019-01-14 16:00:26.344439

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -122,7 +122,7 @@ class Query(Model, ExtraJSONMixin):
         return f'sqllab_{tab}_{ts}'
 
 
-class SavedQuery(Model, AuditMixinNullable):
+class SavedQuery(Model, AuditMixinNullable, ExtraJSONMixin):
     """ORM model for SQL query"""
 
     __tablename__ = 'saved_query'

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -149,3 +149,11 @@ class SavedQuery(Model, AuditMixinNullable):
                 <i class="fa fa-link"></i>
             </a>
         """)
+
+    @property
+    def user_email(self):
+        return self.user.email
+
+    @property
+    def sqlalchemy_uri(self):
+        return self.database.sqlalchemy_uri

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -75,6 +75,9 @@ class SavedQueryView(SupersetModelView, DeleteMixin):
 
 
 class SavedQueryViewApi(SavedQueryView):
+    list_columns = [
+        'label', 'sqlalchemy_uri', 'user_email', 'schema', 'description',
+        'sql']
     show_columns = ['label', 'db_id', 'schema', 'description', 'sql']
     add_columns = show_columns
     edit_columns = add_columns


### PR DESCRIPTION
Similar to https://github.com/apache/incubator-superset/pull/6112, this PR adds an `extra` column to `SavedQuery`.

Note that this PR depends on https://github.com/apache/incubator-superset/pull/6686, so the extra columns in the API are being shown here.