### PR TITLE
Improve Unicode support for MSSQL

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -405,6 +405,11 @@ You can also use `PyAthena` library(no java required) like this ::
 
 See `PyAthena <https://github.com/laughingman7743/PyAthena#sqlalchemy>`_.
 
+MSSQL
+-----
+
+Full Unicode support requires SQLAlchemy 1.3 or later.
+
 Snowflake
 ---------
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -115,7 +115,9 @@ class TableColumn(Model, BaseColumn):
         label = label if label else self.column_name
         label = self.table.get_label(label)
         if not self.expression:
-            col = column(self.column_name).label(label)
+            db_engine_spec = self.table.database.db_engine_spec
+            type_ = db_engine_spec.get_sqla_column_type(self.type)
+            col = column(self.column_name, type_=type_).label(label)
         else:
             col = literal_column(self.expression).label(label)
         return col


### PR DESCRIPTION
The upcoming SQLAlchemy 1.3 release introduces N-prefixed Unicode string handling on MSSQL (see https://github.com/sqlalchemy/sqlalchemy/commit/e1b299df819bc1a48ed565bd6efa8ee406ea7efa ). This PR introduces support for that feature and has been tested on `master` branch of SQLAlchemy. This is backwards compatible with earlier versions of SQLAlchemy, so doesn't explicitly require 1.3, it just won't handle unicode values correctly on <1.3. Does not impact other db engines, aka minimal risk of regressions. Fixes #6624

Before:

<img width="337" alt="screenshot 2019-01-16 at 17 43 35" src="https://user-images.githubusercontent.com/33317356/51260697-8c981f00-19b7-11e9-82e3-772acf65dc43.png">

After:

<img width="339" alt="screenshot 2019-01-16 at 17 46 58" src="https://user-images.githubusercontent.com/33317356/51260713-928e0000-19b7-11e9-9b12-e504a4d25092.png">
