### PR TITLE
Explicitly declare CLI  option flags as flags

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -248,9 +248,9 @@ def refresh_druid(datasource, merge):
     help='Path to a single JSON file or path containing multiple JSON files'
          'files to import (*.json)')
 @click.option(
-    '--recursive', '-r',
+    '--recursive', '-r', is_flag=True, default=False,
     help='recursively search the path for json files')
-def import_dashboards(path, recursive=False):
+def import_dashboards(path, recursive):
     """Import dashboards from JSON"""
     p = Path(path)
     files = []
@@ -276,7 +276,7 @@ def import_dashboards(path, recursive=False):
     '--dashboard-file', '-f', default=None,
     help='Specify the the file to export to')
 @click.option(
-    '--print_stdout', '-p',
+    '--print_stdout', '-p', is_flag=True, default=False,
     help='Print JSON to stdout')
 def export_dashboards(print_stdout, dashboard_file):
     """Export dashboards to JSON"""
@@ -300,9 +300,9 @@ def export_dashboards(print_stdout, dashboard_file):
          'e.g. "metrics,columns" deletes metrics and columns in the DB '
          'that are not specified in the YAML file')
 @click.option(
-    '--recursive', '-r',
+    '--recursive', '-r', is_flag=True, default=False,
     help='recursively search the path for yaml files')
-def import_datasources(path, sync, recursive=False):
+def import_datasources(path, sync, recursive):
     """Import datasources from YAML"""
     sync_array = sync.split(',')
     p = Path(path)
@@ -333,13 +333,13 @@ def import_datasources(path, sync, recursive=False):
     '--datasource-file', '-f', default=None,
     help='Specify the the file to export to')
 @click.option(
-    '--print_stdout', '-p',
+    '--print_stdout', '-p', is_flag=True, default=False,
     help='Print YAML to stdout')
 @click.option(
-    '--back-references', '-b',
+    '--back-references', '-b', is_flag=True, default=False,
     help='Include parent back references')
 @click.option(
-    '--include-defaults', '-d',
+    '--include-defaults', '-d', is_flag=True, default=False,
     help='Include fields containing defaults')
 def export_datasources(print_stdout, datasource_file,
                        back_references, include_defaults):
@@ -359,7 +359,7 @@ def export_datasources(print_stdout, datasource_file,
 
 @app.cli.command()
 @click.option(
-    '--back-references', '-b',
+    '--back-references', '-b', is_flag=True, default=False,
     help='Include parent back references')
 def export_datasource_schema(back_references):
     """Export datasource YAML schema to stdout"""


### PR DESCRIPTION
CLI options that are flags need to be declared as such to avoid `Error: -r option requires an argument` and `Error: Got unexpected extra argument` (and related) issues.

@mistercrunch 