### PR TITLE
Fix link to SQLAlchemy docs about database URLs format

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -187,7 +187,7 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
         'sqlalchemy_uri': utils.markdown(
             'Refer to the '
             '[SqlAlchemy docs]'
-            '(http://docs.sqlalchemy.org/en/rel_1_0/core/engines.html#'
+            '(http://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#'
             'database-urls) '
             'for more information on how to structure your URI.', True),
         'expose_in_sqllab': _('Expose this DB in SQL Lab'),


### PR DESCRIPTION
'Add database' grid refers to SQLAchemy docs, where database URL format is described. 
Documentation for 1.0 does not exist on https://docs.sqlalchemy.org/, which results in 404 when following the current URL.
The link is fixed taking into account [SQLAlchemy 1.2](https://github.com/apache/incubator-superset/blob/master/requirements.txt#L87) as a project dependency.