### PR TITLE
Fix for Airbnb bug PRODUCT-62223 - Text field to edit SQL snippet of a metric is not large enough for entire snippet

### DIFF
--- a/superset/assets/src/components/EditableTitle.jsx
+++ b/superset/assets/src/components/EditableTitle.jsx
@@ -78,7 +78,8 @@ export default class EditableTitle extends React.PureComponent {
 
     // For multi-line values, we save the actual rendered height of the displayed text.
     // Later, when a textarea is constructed, we'll use this saved height.
-    this.contentHeight = this.contentRef.current.getBoundingClientRect().height;
+    this.contentHeight = (this.contentRef.current) ?
+      this.contentRef.current.getBoundingClientRect().height : null;
 
     this.setState({ isEditing: true });
   }

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -43,7 +43,6 @@ import withToasts from '../messageToasts/enhancers/withToasts';
 import './main.css';
 
 const checkboxGenerator = (d, onChange) => <CheckboxControl value={d} onChange={onChange} />;
-const styleMonospace = { fontFamily: 'monospace' };
 const DATA_TYPES = ['STRING', 'NUMBER', 'DATETIME'];
 
 function CollectionTabTitle({ title, collection }) {
@@ -540,7 +539,8 @@ export class DatasourceEditor extends React.PureComponent {
               canEdit
               title={v}
               onSaveTitle={onChange}
-              style={styleMonospace}
+              extraClasses={['datasource-sql-expression']}
+              multiLine
             />),
           description: (v, onChange, label) => (
             <StackedField

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -1,10 +1,10 @@
 @import './less/index.less';
 @import "./less/cosmo/variables.less";
 
-@datasource-sql-expression-width: 500px;
+@datasource-sql-expression-width: 450px;
 
 body {
-    margin: 0px !important;
+    margin: 0 !important;
 }
 
 .caret {
@@ -248,16 +248,19 @@ table.table-no-hover tr:hover {
 }
 
 .editable-title.datasource-sql-expression {
-  font-family: monospace;
+  font-family: @font-family-monospace;
+  font-size: 95%;
+  display: inline-block;
+  min-width: @datasource-sql-expression-width;
 }
 
 .editable-title.datasource-sql-expression input {
-  width: @datasource-sql-expression-width;
+  width: 95%;
   padding-bottom: 5px;
 }
 
 .editable-title.datasource-sql-expression textarea {
-  width: @datasource-sql-expression-width;
+  width: 95%;
 }
 
 .editable-title input[type="button"] {

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -1,6 +1,8 @@
 @import './less/index.less';
 @import "./less/cosmo/variables.less";
 
+@datasource-sql-expression-width: 500px;
+
 body {
     margin: 0px !important;
 }
@@ -230,10 +232,32 @@ table.table-no-hover tr:hover {
   cursor: initial;
 }
 
+.editable-title textarea {
+  outline: none;
+  background: transparent;
+  box-shadow: none;
+  cursor: initial;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+}
+
 .editable-title input[type="text"] {
   border: 1px solid #ccc;
   border-radius: 2px;
   padding: 2px;
+}
+
+.editable-title.datasource-sql-expression {
+  font-family: monospace;
+}
+
+.editable-title.datasource-sql-expression input {
+  width: @datasource-sql-expression-width;
+  padding-bottom: 5px;
+}
+
+.editable-title.datasource-sql-expression textarea {
+  width: @datasource-sql-expression-width;
 }
 
 .editable-title input[type="button"] {


### PR DESCRIPTION
This PR widens the field slightly and allows for (application of classes to) and (multiline editing of) EditableTitles in general. Also moves some styling from code to CSS.

Note - when it comes to CSS I'm not sure how everything is organized in SuperSet, so input is definitely welcomed. I'm also not 100% happy with the solution of setting the `textarea`'s size in code, but I couldn't figure out a way to do this in pure CSS, since the height of the `textarea` is dependent on how many lines the text being edited is (which can't really be determined until the label renders). If you have any ideas, LMK.

to: @williaster @michellethomas @graceguo-supercat @mistercrunch 