### PR TITLE
Trim query before parsing

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -34,7 +34,7 @@ class ParsedQuery(object):
         self._limit = None
 
         logging.info('Parsing with sqlparse statement {}'.format(self.sql))
-        self._parsed = sqlparse.parse(self.sql.strip())
+        self._parsed = sqlparse.parse(self.stripped())
         for statement in self._parsed:
             self.__extract_from_token(statement)
             self._limit = self._extract_limit_from_query(statement)

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -34,7 +34,7 @@ class ParsedQuery(object):
         self._limit = None
 
         logging.info('Parsing with sqlparse statement {}'.format(self.sql))
-        self._parsed = sqlparse.parse(self.sql)
+        self._parsed = sqlparse.parse(self.sql.strip())
         for statement in self._parsed:
             self.__extract_from_token(statement)
             self._limit = self._extract_limit_from_query(statement)

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -218,7 +218,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
                     , b
                 FROM
                 table
-                LIMIT         1000            ;""",
+                LIMIT         1000""",
         )
 
     def test_get_datatype(self):

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -196,8 +196,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             FROM
             table
             LIMIT 99990""",
-            """
-            SELECT
+            """SELECT
                 'LIMIT 777' AS a
                 , b
             FROM
@@ -214,8 +213,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
                 FROM
                 table
                 LIMIT         99990            ;""",
-            """
-                SELECT
+            """SELECT
                     'LIMIT 777' AS a
                     , b
                 FROM
@@ -238,8 +236,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
                 FROM
                 table
                 LIMIT 99990, 999999""",
-            """
-                SELECT
+            """SELECT
                     'LIMIT 777' AS a
                     , b
                 FROM
@@ -257,8 +254,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
                 table
                 LIMIT 99990
                 OFFSET 999999""",
-            """
-                SELECT
+            """SELECT
                     'LIMIT 777' AS a
                     , b
                 FROM


### PR DESCRIPTION
The `ParsedQuery` init does not ignore empty lines. If we have a query with a trailing line, eg:

```sql
SELECT a FROM b LIMIT 1;
 
```

The parser will set `self._limit` to `None`:

```python
       self._parsed = sqlparse.parse(self.sql)
       for statement in self._parsed:
            self.__extract_from_token(statement)
            self._limit = self._extract_limit_from_query(statement)
```

Since the loop will run twice, first for `'SELECT a FROM b LIMIT 1;'` and again for `''`.

This PR fixes this by trimming the SQL before parsing it.