### PR TITLE
Insert a space after auto complete

### DIFF
--- a/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
+++ b/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
@@ -124,8 +124,13 @@ class AceEditorWrapper extends React.PureComponent {
     this.props.onChange(text);
   }
   getCompletions(aceEditor, session, pos, prefix, callback) {
-    console.log('here');
-    callback(null, this.state.words);
+    const completer = {
+      insertMatch: (editor, data) => {
+        editor.completer.insertMatch({ value: data.caption + ' ' });
+      },
+    };
+    const words = this.state.words.map(word => ({ ...word, completer }));
+    callback(null, words);
   }
   setAutoCompleter(props) {
     // Loading table and column names as auto-completable words
@@ -146,10 +151,6 @@ class AceEditorWrapper extends React.PureComponent {
     this.setState({ words }, () => {
       const completer = {
         getCompletions: this.getCompletions.bind(this),
-        insertMatch: (editor, data) => {
-          console.log('HERE IT IS');
-          editor.completer.insertMatch({ value: data.value + ' ' });
-        },
       };
       if (langTools) {
         langTools.setCompleters([completer]);

--- a/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
+++ b/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
@@ -124,6 +124,7 @@ class AceEditorWrapper extends React.PureComponent {
     this.props.onChange(text);
   }
   getCompletions(aceEditor, session, pos, prefix, callback) {
+    console.log('here');
     callback(null, this.state.words);
   }
   setAutoCompleter(props) {
@@ -145,6 +146,10 @@ class AceEditorWrapper extends React.PureComponent {
     this.setState({ words }, () => {
       const completer = {
         getCompletions: this.getCompletions.bind(this),
+        insertMatch: (editor, data) => {
+          console.log('HERE IT IS');
+          editor.completer.insertMatch({ value: data.value + ' ' });
+        },
       };
       if (langTools) {
         langTools.setCompleters([completer]);


### PR DESCRIPTION
As the title says, this automatically inserts a space after selecting a word from the autocomplete dropdown.

The only downside I see here is when autocompleting a table name, where the user wants to specify `table.column` in a query, since it force them to erase the space. We can optionally not add the space after table completions, but I think the inconsistency is bad.