### PR TITLE
Add "Select All" to SelectControl and allow free form group by expressions

### DIFF
--- a/superset/assets/spec/javascripts/explore/components/SelectControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/SelectControl_spec.jsx
@@ -30,6 +30,7 @@ const defaultProps = {
   choices: [['1 year ago', '1 year ago'], ['today', 'today']],
   name: 'row_limit',
   label: 'Row Limit',
+  valueKey: 'value', // shallow isn't passing SelectControl.defaultProps.valueKey through
   onChange: sinon.spy(),
 };
 
@@ -43,6 +44,7 @@ describe('SelectControl', () => {
 
   beforeEach(() => {
     wrapper = shallow(<SelectControl {...defaultProps} />);
+    wrapper.setProps(defaultProps);
   });
 
   it('renders an OnPasteSelect', () => {
@@ -53,6 +55,23 @@ describe('SelectControl', () => {
     const select = wrapper.find(OnPasteSelect);
     select.simulate('change', { value: 50 });
     expect(defaultProps.onChange.calledWith(50)).toBe(true);
+  });
+
+  it('returns all options on select all', () => {
+    const expectedValues = ['one', 'two'];
+    const selectAllProps = {
+      multi: true,
+      allowAll: true,
+      choices: expectedValues,
+      name: 'row_limit',
+      label: 'Row Limit',
+      valueKey: 'value',
+      onChange: sinon.spy(),
+    };
+    wrapper.setProps(selectAllProps);
+    const select = wrapper.find(OnPasteSelect);
+    select.simulate('change', [{ meta: true, value: 'Select All' }]);
+    expect(selectAllProps.onChange.calledWith(expectedValues)).toBe(true);
   });
 
   it('passes VirtualizedSelect as selectWrap', () => {
@@ -82,19 +101,39 @@ describe('SelectControl', () => {
 
   describe('getOptions', () => {
     it('returns the correct options', () => {
+      wrapper.setProps(defaultProps);
       expect(wrapper.instance().getOptions(defaultProps)).toEqual(options);
     });
 
+    it('shows Select-All when enabled', () => {
+      const selectAllProps = {
+        choices: ['one', 'two'],
+        name: 'name',
+        freeForm: true,
+        allowAll: true,
+        multi: true,
+        valueKey: 'value',
+      };
+      wrapper.setProps(selectAllProps);
+      expect(wrapper.instance().getOptions(selectAllProps))
+        .toContainEqual({ label: 'Select All', meta: true, value: 'Select All' });
+    });
+
     it('returns the correct options when freeform is set to true', () => {
-      const freeFormProps = Object.assign(defaultProps, {
+      const freeFormProps = {
         choices: [],
         freeForm: true,
         value: ['one', 'two'],
-      });
+        name: 'row_limit',
+        label: 'Row Limit',
+        valueKey: 'value',
+        onChange: sinon.spy(),
+      };
       const newOptions = [
         { value: 'one', label: 'one' },
         { value: 'two', label: 'two' },
       ];
+      wrapper.setProps(freeFormProps);
       expect(wrapper.instance().getOptions(freeFormProps)).toEqual(newOptions);
     });
   });

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -120,6 +120,7 @@ const sortAxisChoices = [
 const groupByControl = {
   type: 'SelectControl',
   multi: true,
+  freeForm: true,
   label: t('Group by'),
   default: [],
   includeTime: false,
@@ -127,10 +128,12 @@ const groupByControl = {
   optionRenderer: c => <ColumnOption column={c} showType />,
   valueRenderer: c => <ColumnOption column={c} />,
   valueKey: 'column_name',
+  allowAll: true,
   filterOption: (opt, text) => (
-    (opt.column_name && opt.column_name.toLowerCase().indexOf(text) >= 0) ||
-    (opt.verbose_name && opt.verbose_name.toLowerCase().indexOf(text) >= 0)
+    (opt.column_name && opt.column_name.toLowerCase().indexOf(text.toLowerCase()) >= 0) ||
+    (opt.verbose_name && opt.verbose_name.toLowerCase().indexOf(text.toLowerCase()) >= 0)
   ),
+  promptTextCreator: label => label,
   mapStateToProps: (state, control) => {
     const newState = {};
     if (state.datasource) {
@@ -141,6 +144,7 @@ const groupByControl = {
     }
     return newState;
   },
+  commaChoosesOption: false,
 };
 
 const metrics = {
@@ -625,9 +629,12 @@ export const controls = {
     optionRenderer: c => <ColumnOption column={c} showType />,
     valueRenderer: c => <ColumnOption column={c} />,
     valueKey: 'column_name',
+    allowAll: true,
     mapStateToProps: state => ({
       options: (state.datasource) ? state.datasource.columns : [],
     }),
+    commaChoosesOption: false,
+    freeForm: true,
   },
 
   spatial: {

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -26,6 +26,7 @@ from superset import app, db, is_feature_enabled, security_manager
 from superset.connectors.druid.models import DruidCluster, DruidDatasource
 from superset.connectors.sqla.models import SqlaTable
 from superset.models import core as models
+from superset.models.core import Database
 from superset.utils.core import get_main_database
 
 BASE_DIR = app.config.get('BASE_DIR')
@@ -98,6 +99,9 @@ class SupersetTestCase(unittest.TestCase):
 
     def get_table_by_name(self, name):
         return db.session.query(SqlaTable).filter_by(table_name=name).one()
+
+    def get_database_by_id(self, db_id):
+        return db.session.query(Database).filter_by(id=db_id).one()
 
     def get_druid_ds_by_name(self, name):
         return db.session.query(DruidDatasource).filter_by(

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -757,7 +757,6 @@ class CoreTests(SupersetTestCase):
             {'form_data': json.dumps(form_data)},
         )
         self.assertEqual(data['status'], utils.QueryStatus.FAILED)
-        assert 'KeyError' in data['stacktrace']
 
     def test_slice_payload_viz_markdown(self):
         self.login(username='admin')


### PR DESCRIPTION
* Changes to SelectControl: Add a "Select All" feature such that you can easily show all the columns in a Table non-group-by select box
* Allow adding custom expressions to the group by select box such that we can now group by any sql expression and not just columns (no need to add them as "calculated columns first")
* Add ordering of options in the FilterBox