### PR TITLE
Revert "Truncate long labels (#6631)"

### DIFF
--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -44,7 +44,6 @@ import {
   tryNumify,
   setAxisShowMaxMin,
   stringifyTimeRange,
-  truncateLabel,
   wrapTooltip,
 } from './utils';
 import {
@@ -627,8 +626,6 @@ function nvd3Vis(element, props) {
       if (chart.xAxis) {
         margins.bottom = 28;
       }
-      // truncate labels that are too long
-      d3.selectAll('.nv-x.nv-axis .tick text').text(truncateLabel);
       const maxYAxisLabelWidth = getMaxLabelSize(svg, chart.yAxis2 ? 'nv-y1' : 'nv-y');
       const maxXAxisLabelHeight = getMaxLabelSize(svg, 'nv-x');
       margins.left = maxYAxisLabelWidth + marginPad;
@@ -713,9 +710,6 @@ function nvd3Vis(element, props) {
         .attr('width', width)
         .attr('height', height)
         .call(chart);
-
-      // truncate labels that are too long
-      d3.selectAll('.nv-x.nv-axis .tick text').text(truncateLabel);
 
       // on scroll, hide tooltips. throttle to only 4x/second.
       window.addEventListener('scroll', throttle(hideTooltips, 250));

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -22,8 +22,6 @@ import dompurify from 'dompurify';
 import { getNumberFormatter } from '@superset-ui/number-format';
 import { smartDateFormatter } from '@superset-ui/time-format';
 
-const MAX_LABEL_LENGTH = 24;
-
 // Regexp for the label added to time shifted series
 // (1 hour offset, 2 days offset, etc.)
 const TIME_SHIFT_PATTERN = /\d+ \w+ offset/;
@@ -256,10 +254,4 @@ export function setAxisShowMaxMin(axis, showminmax) {
   if (axis && axis.showMaxMin && showminmax !== undefined) {
     axis.showMaxMin(showminmax);
   }
-}
-
-export function truncateLabel(text) {
-  return text.length > MAX_LABEL_LENGTH
-    ? text.substr(0, MAX_LABEL_LENGTH - 1) + '…'
-    : text;
 }


### PR DESCRIPTION
This reverts commit 5055157b64e93f716cf1b93730cd0eb9a6dd010e. That PR breaks the display of line charts, area charts and other NVD3 charts.
<img width="1102" alt="screen shot 2019-01-15 at 5 19 49 pm" src="https://user-images.githubusercontent.com/487433/51401324-4d74e580-1aff-11e9-909c-5fc26aa68a62.png">
