### PR TITLE
Bump version of cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ chardet==3.0.4            # via requests
 click==6.7
 colorama==0.3.9
 contextlib2==0.5.5
-cryptography==1.9
+cryptography==2.4
 defusedxml==0.5.0         # via python3-openid
 docutils==0.14            # via botocore
 et-xmlfile==1.0.1         # via openpyxl


### PR DESCRIPTION
Previous version of crypthography python module was not compatible
with base image thus build failed. Bumping version solve this
issue.