### PR TITLE
Add disclaimer and remove counter

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -12,6 +12,7 @@
 .*pyc
 .*lock
 .*geojson
+DISCLAIMER
 licenses/*
 node_modules/*
 rat-results.txt

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,11 @@
+DISCLAIMER
+
+Apache Superset (incubating) is an effort undergoing incubation at the Apache
+Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+Incubation is required of all newly accepted projects until a further review
+indicates that the infrastructure, communications, and decision making process
+have stabilized in a manner consistent with other successful ASF projects.
+
+While incubation status is not necessarily a reflection of the completeness or
+stability of the code, it does indicate that the project has yet to be fully
+endorsed by the ASF.

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -88,20 +88,7 @@ ERRORS="$(cat rat-results.txt | grep -e "??")"
 if test ! -z "$ERRORS"; then
     echo >&2 "Could not find Apache license headers in the following files:"
     echo >&2 "$ERRORS"
-    COUNT=`echo "${ERRORS}" | wc -l`
-    if [ ! -f ${TRAVIS_CACHE}/rat-error-count-builds ]; then
-        [ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo ${COUNT} > ${TRAVIS_CACHE}/rat-error-count-builds
-        OLD_COUNT=${COUNT}
-    else
-        typeset -i OLD_COUNT=$(cat ${TRAVIS_CACHE}/rat-error-count-builds)
-    fi
-    if [ ${COUNT} -gt ${OLD_COUNT} ]; then
-        echo "New missing licenses (${COUNT} vs ${OLD_COUNT}) detected. Please correct them by adding them to to header of your files"
-        exit 1
-    else
-        [ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo ${COUNT} > ${TRAVIS_CACHE}/rat-error-count-builds
-    fi
-    exit 0
+    exit 1
 else
     echo -e "RAT checks passed."
 fi


### PR DESCRIPTION
This adds the disclaimer and removes the counter for licenses. Any license missing will now fail the builds.

cc @mistercrunch @kristw 