### PR TITLE
Allow specifying custom width for logo

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -110,6 +110,7 @@ APP_NAME = 'Superset'
 
 # Uncomment to setup an App icon
 APP_ICON = '/static/assets/images/superset-logo@2x.png'
+APP_ICON_WIDTH = 126
 
 # Druid query timezone
 # tz.tzutc() : Using utc timezone

--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -19,6 +19,7 @@
 {% set menu = appbuilder.menu %}
 {% set languages = appbuilder.languages %}
 {% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
+{% set app_icon_width = appbuilder.app.config.get('APP_ICON_WIDTH', 126) %}
 
 <div class="navbar navbar-static-top {{menu.extra_classes}}" role="navigation">
   <div class="container-fluid">
@@ -30,7 +31,7 @@
       </button>
       <a class="navbar-brand" href="/superset/profile/{{ current_user.username }}/">
         <img
-          width="126"
+          width="{{ app_icon_width }}"
           src="{{ appbuilder.app_icon }}"
           alt="{{ appbuilder.app_name }}"
         />


### PR DESCRIPTION
We currently allow user to specify a custom logo for Superset, but the width is fixed at 126 pixels. I added an option to specify a different width in `config.py`.