### PR TITLE
Allow user to specify a URL for bug reporting

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -558,6 +558,9 @@ WEBDRIVER_CONFIGURATION = {}
 # The base URL to query for accessing the user interface
 WEBDRIVER_BASEURL = 'http://0.0.0.0:8080/'
 
+# Send user to a link where they can report bugs
+BUG_REPORT_URL = None
+
 
 try:
     if CONFIG_PATH_ENV_VAR in os.environ:

--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -17,6 +17,7 @@
   under the License.
 #}
 
+{% set bug_report_url = appbuilder.app.config.get('BUG_REPORT_URL') %}
 {% set locale = session['locale'] %}
 {% if not locale %}
     {% set locale = 'en' %}
@@ -33,6 +34,17 @@
             <li><a href="/dashboard/new/"><span class="fa fa-fw fa-dashboard"></span> {{_("Dashboard")}}</a></li>
         </ul>
     </li>
+{% endif %}
+{% if bug_report_url %}
+<li>
+  <a
+    tabindex="-1"
+    href="{{ bug_report_url }}"
+    title="Report a bug"
+  >
+    <i class="fa fa-bug"></i>&nbsp;
+  </a>
+</li>
 {% endif %}
 {% if languages.keys()|length > 1 %}
 <li class="dropdown">


### PR DESCRIPTION
We've been using this at Lyft and it's pretty useful: add a button taking the user to a place (Jira, in our case) where they can report bugs. See the screenshot:

<img width="1698" alt="screen shot 2019-01-22 at 11 34 36 am" src="https://user-images.githubusercontent.com/1534870/51560711-2b9a9c00-1e3a-11e9-97c7-dd153d6c24e0.png">
