### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ _modules
 _static
 build
 app.db
+apache_superset.egg-info/
 changelog.sh
 dist
 dump.rdb


### PR DESCRIPTION
Add `apache_superset.egg-info/` to `.gitignore`. This directory appears recently after `pip install` from master.

@mistercrunch @john-bodley @graceguo-supercat @michellethomas 