### PR TITLE
Bump PyHive version for prod requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
         'cors': ['flask-cors>=2.0.0'],
         'console_log': ['console_log==0.2.10'],
         'hive': [
-            'pyhive>=0.4.0',
+            'pyhive>=0.6.1',
             'tableschema',
             'thrift-sasl>=0.2.1',
             'thrift>=0.9.3',


### PR DESCRIPTION
So, I encountered a few bugs when running Superset in a production environment and attempting to leverage the Hive connector. An example bug was that connection statuses were showing `RUNNING` when `FINISHED` was expected. That problem went away after I changed the version. 

It went unnoticed for me, and evidently others as well, in a dev environment because the `dev-requirements.txt` points to `>=0.6.1`, while `requirements.txt` currently points to `>=0.4.0`.

