### PR TITLE
[fix] JS error out when inline edit a new time-series chart title

### DIFF
--- a/superset/assets/src/explore/components/controls/AnnotationLayerControl.jsx
+++ b/superset/assets/src/explore/components/controls/AnnotationLayerControl.jsx
@@ -176,10 +176,12 @@ AnnotationLayerControl.defaultProps = defaultProps;
 // directly, could not figure out how to get access to the color_scheme
 function mapStateToProps({ charts, explore }) {
   const chartKey = getChartKey(explore);
+  const chart = charts[chartKey] || charts[0] || {};
+
   return {
     colorScheme: (explore.controls || {}).color_scheme.value,
-    annotationError: charts[chartKey].annotationError,
-    annotationQuery: charts[chartKey].annotationQuery,
+    annotationError: chart.annotationError,
+    annotationQuery: chart.annotationQuery,
     vizType: explore.controls.viz_type.value,
   };
 }


### PR DESCRIPTION

<img width="1095" alt="screen shot 2019-01-22 at 3 52 55 pm" src="https://user-images.githubusercontent.com/27990562/51725979-ef259680-2019-11e9-9122-d2242a104aae.png">
Step to reproduce:
sql lab -> explore -> change to time-series viz type -> inline edit chart title
will see JS error out

Root cause:
New chart doesn't have a slice_id. When user inline edit chart title, new chart will be saved into slice table and assigned a slice_id. At this moment, explore reducer updated its state, but chart reducer didn't know this change. Then annotation component is triggered update, it is looking for chart with new slice_id, which will cause null exception.

@michellethomas @kristw @williaster 