### PR TITLE
[fix] `pandas`>=0.24.0 datetimelike API changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,8 +42,8 @@ kombu==4.2.1              # via celery
 mako==1.0.7               # via alembic
 markdown==3.0
 markupsafe==1.0           # via jinja2, mako
-numpy==1.15.2             # via pandas
-pandas==0.23.1
+numpy==1.15.2             # via numpy
+pandas==0.23.4            # via pandas
 parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     install_requires=[
         'bleach>=3.0.2, <4.0.0',
         'celery>=4.2.0, <5.0.0',
-        'click>=6.0, <7.0.0',  # click >=7 forces "-" instead of "_"
+        'click>=6.0, <7.0.0',  # `click`>=7 forces "-" instead of "_"
         'colorama',
         'contextlib2',
         'croniter>=0.3.26',
@@ -88,7 +88,7 @@ setup(
         'idna',
         'isodate',
         'markdown>=3.0',
-        'pandas>=0.18.0',
+        'pandas>=0.18.0, <0.24.0',  # `pandas`>=0.24.0 changes datetimelike API
         'parsedatetime',
         'pathlib2',
         'polyline',


### PR DESCRIPTION
The latest released version of `pandas` *v0.24.0* changed `datetimelike` API. It causes some **serious** bugs.
Before Superset adapted `pandas` new API, we should use older version instead, `pandas` *v0.23.4* works fine.
![screen shot 2019-01-27 at 12 24 56](https://user-images.githubusercontent.com/19472493/51796750-f378cc00-2232-11e9-837b-6b33927e2d0e.png)

> Note: `pandas` what's new in *v0.24.0*

<img width="1541" alt="screen shot 2019-01-27 at 12 11 30" src="https://user-images.githubusercontent.com/19472493/51796761-199e6c00-2233-11e9-95d5-2602f1967e3d.png">

> Note: bug occurred in`pandas` *v0.24.0*

<img width="1541" alt="screen shot 2019-01-27 at 12 11 49" src="https://user-images.githubusercontent.com/19472493/51796767-2753f180-2233-11e9-909e-bd1a5d68105c.png">

> Note: bug fixed in older version of `pandas`