### PR TITLE
[sql lab] fix stuck offline

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -72,6 +72,8 @@ class QueryAutoRefresh extends React.PureComponent {
         }).catch(() => {
           this.props.actions.setUserOffline(true);
         });
+    } else {
+      this.props.actions.setUserOffline(false);
     }
   }
   render() {


### PR DESCRIPTION
Hit this weird bug where I got stuck `offline`, there appeared to be no easy way to get out of that bad state. Couldn't create a new tab for reasons I don't understand. Probably the only solution would be to nuke `localstorage` in the browser (and loose all unsaved tabs/queries)

<img width="393" alt="screen shot 2019-01-29 at 10 22 52 pm" src="https://user-images.githubusercontent.com/487433/51962395-d4399480-2414-11e9-8f5c-51e12414fca4.png">

Polling only happens when there are running queries, so I'm guessing there are race conditions where there's no more polling happening and the UI is stuck reporting `offline`

Likely the bug was introduced here https://github.com/apache/incubator-superset/pull/6013

This was reported at Lyft earlier this week too I think

@timifasubaa @vylc @betodealmeida 

This could also be improved by polling while `offline`, but I think it's also imperfect as it would not report on a case where no queries are running and the computer becomes offline. We could also poll all the time, but that's not a great idea as it would generate significantly more [not super useful] traffic in large environments.

I'd say merge this asap to fix the bug and re-think what `offline` means and the requirements around it.