### PR TITLE
Fix Postgres time shifting problems

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -431,14 +431,14 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
 
     time_grain_functions = {
         None: '{col}',
-        'PT1S': "DATE_TRUNC('second', {col}) AT TIME ZONE 'UTC'",
-        'PT1M': "DATE_TRUNC('minute', {col}) AT TIME ZONE 'UTC'",
-        'PT1H': "DATE_TRUNC('hour', {col}) AT TIME ZONE 'UTC'",
-        'P1D': "DATE_TRUNC('day', {col}) AT TIME ZONE 'UTC'",
-        'P1W': "DATE_TRUNC('week', {col}) AT TIME ZONE 'UTC'",
-        'P1M': "DATE_TRUNC('month', {col}) AT TIME ZONE 'UTC'",
-        'P0.25Y': "DATE_TRUNC('quarter', {col}) AT TIME ZONE 'UTC'",
-        'P1Y': "DATE_TRUNC('year', {col}) AT TIME ZONE 'UTC'",
+        'PT1S': "DATE_TRUNC('second', {col})",
+        'PT1M': "DATE_TRUNC('minute', {col})",
+        'PT1H': "DATE_TRUNC('hour', {col})",
+        'P1D': "DATE_TRUNC('day', {col})",
+        'P1W': "DATE_TRUNC('week', {col})",
+        'P1M': "DATE_TRUNC('month', {col})",
+        'P0.25Y': "DATE_TRUNC('quarter', {col})",
+        'P1Y': "DATE_TRUNC('year', {col})",
     }
 
     @classmethod


### PR DESCRIPTION
The time grain functions on postgres have an unnecessary `AT TIME ZONE 'UTC'` cast which causes the following problems:
1. Causes timestamps with a non-UTC timezone to be shifted by the UTC offset.
1. Makes time grained vs non time grained temporal handling inconsistent (no UTC casting when time grain isn't applied).

Fixes #6763 .