### PR TITLE
Ingress template: don't remove leading new line

### DIFF
--- a/install/helm/superset/templates/ingress.yaml
+++ b/install/helm/superset/templates/ingress.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{- if .Values.ingress.enabled -}}
+{{ if .Values.ingress.enabled -}}
 {{- $fullName := include "superset.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Currently we are removing the previous carriage return which gives us the following invalid Ingress object in certain circumstances
```
#apiVersion: extensions/v1beta1
kind: Ingress
metadata:
...
```
which results in:
```
Error: validation failed: unable to recognize "": no matches for kind "Ingress" in version ""
```

We just need to make sure that the apiVersion is not commented out by `#` 
