### PR TITLE
fixing dictionary keys reference in export_to_dict

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -212,7 +212,7 @@ class ImportMixin(object):
                             include_defaults=include_defaults,
                         ) for child in getattr(self, c)
                     ],
-                    key=lambda k: sorted(k.items()))
+                    key=lambda k: sorted(k.keys()))
 
         return dict_rep
 


### PR DESCRIPTION
The data source export CLI fails on a dictionary sorting error. (A Python 2 -> 3 syntax bug?)

Same issue as: https://github.com/apache/incubator-superset/issues/6265