### PR TITLE
[sqllab] only override limit when user does not specify

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -149,7 +149,6 @@ def execute_sql_statement(
     db_engine_spec = database.db_engine_spec
     parsed_query = ParsedQuery(sql_statement)
     sql = parsed_query.stripped()
-    SQL_MAX_ROWS = app.config.get('SQL_MAX_ROW')
 
     if not parsed_query.is_readonly() and not database.allow_dml:
         raise SqlLabSecurityException(
@@ -166,10 +165,8 @@ def execute_sql_statement(
         sql = parsed_query.as_create_table(query.tmp_table_name)
         query.select_as_cta_used = True
     if parsed_query.is_select():
-        if SQL_MAX_ROWS and (not query.limit or query.limit > SQL_MAX_ROWS):
-            query.limit = SQL_MAX_ROWS
-        if query.limit:
-            sql = database.apply_limit_to_sql(sql, query.limit)
+        # Enforce the correct limit generated at query creation time in sql_json
+        sql = database.apply_limit_to_sql(sql, query.limit)
 
     # Hook to allow environment-specific mutation (usually comments) to the SQL
     SQL_QUERY_MUTATOR = config.get('SQL_QUERY_MUTATOR')

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -307,7 +307,7 @@ class SqlLabTests(SupersetTestCase):
             'SELECT * FROM ab_user LIMIT {}'.format(test_limit + 1),
             client_id='sql_limit_4',
             query_limit=test_limit)
-        self.assertEquals(len(data['data']), test_limit)
+        self.assertEquals(len(data['data']), test_limit + 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR cleans up the limits enforcement code and makes the behavior as follows: 

The limit in the box beneath the editor now only will override when there is no limit specified. 

If the user specifies a limit more than the maximum specified by the administrator, then the the limit gets set to the maximum the administrator specified. 

Prior to this PR, it picked the minimum of the value the user specified in the query and the limit in the dialog box at the bottom of the editor. 

@jeffreythewang @mistercrunch @john-bodley 