### PR TITLE
Fix sticky tooltips on nvd3 vizzes

### DIFF
--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -166,9 +166,9 @@ export function generateBubbleTooltipContent({
 }
 
 export function hideTooltips() {
-  const target = document.querySelector('.nvtooltip');
-  if (target) {
-    target.style.opacity = 0;
+  const targets = document.querySelectorAll('.nvtooltip');
+  if (targets.length > 0) {
+    targets.forEach(t => t.remove());
   }
 }
 


### PR DESCRIPTION
Currently, we attempt to hide the nvd3 tooltips (if any were on screen) before we draw a new viz after rerunning a query. The hiding is done by selecting the first nvtooltip element and setting the opacity to 0.

This somtimes leave behind a trail of old tooltips if a tooltip is left behind by this nvd3 bug https://github.com/novus/nvd3/issues/1262. 
![image](https://user-images.githubusercontent.com/1521435/52153331-76809480-262e-11e9-8219-4740231d03cd.png)

This PR modifies the behavior of how we clean up tooltips between rerun of queries by selecting all nvd3 tooltips and removing them all from the DOM before redrawing nvd3 vizzes.