### PR TITLE
Add .standalone class to <body> when in standalone mode

### DIFF
--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -41,7 +41,7 @@
     >
   </head>
 
-  <body>
+  <body {% if standalone_mode %}class="standalone"{% endif %}>
     {% block navbar %}
       {% if not standalone_mode %}
         <header class="top" role="header">

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -67,6 +67,7 @@ class DashboardTests(SupersetTestCase):
         resp = self.get_resp(url + 'edit=true&standalone=true')
         self.assertIn('editMode&#34;: true', resp)
         self.assertIn('standalone_mode&#34;: true', resp)
+        self.assertIn('<body class="standalone">', resp)
 
     def test_save_dash(self, username='admin'):
         self.login(username=username)


### PR DESCRIPTION
Closes #6810 

Add a `standalone` class to the html `<body>` element when in standalone mode, so that one can add custom dashboard CSS that only applies in standalone mode.