### PR TITLE
Make the target path of the superset logo configuable

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -112,6 +112,10 @@ APP_NAME = 'Superset'
 APP_ICON = '/static/assets/images/superset-logo@2x.png'
 APP_ICON_WIDTH = 126
 
+# Uncomment to specify where clicking the logo would take the user
+# e.g. setting it to '/welcome' would take the user to '/superset/welcome'
+LOGO_TARGET_PATH = None
+
 # Druid query timezone
 # tz.tzutc() : Using utc timezone
 # tz.tzlocal() : Using local timezone

--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -20,7 +20,7 @@
 {% set languages = appbuilder.languages %}
 {% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
 {% set app_icon_width = appbuilder.app.config.get('APP_ICON_WIDTH', 126) %}
-{% set logo_target_path = appbuilder.app.config.get('LOGO_TARGET_PATH', '/profile/{}/'.format(current_user.username)) %}
+{% set logo_target_path = appbuilder.app.config.get('LOGO_TARGET_PATH') or '/profile/{}/'.format(current_user.username) %}
 
 <div class="navbar navbar-static-top {{menu.extra_classes}}" role="navigation">
   <div class="container-fluid">

--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -20,6 +20,7 @@
 {% set languages = appbuilder.languages %}
 {% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
 {% set app_icon_width = appbuilder.app.config.get('APP_ICON_WIDTH', 126) %}
+{% set logo_target_path = appbuilder.app.config.get('LOGO_TARGET_PATH', '/profile/{}/'.format(current_user.username)) %}
 
 <div class="navbar navbar-static-top {{menu.extra_classes}}" role="navigation">
   <div class="container-fluid">
@@ -29,7 +30,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/superset/profile/{{ current_user.username }}/">
+      <a class="navbar-brand" href="/superset{{ logo_target_path }}">
         <img
           width="{{ app_icon_width }}"
           src="{{ appbuilder.app_icon }}"


### PR DESCRIPTION
There is a need to have the target path of the logo go to different places in different installations of superset. The PR makes the target path (after `/superset`) configurable via the LOGO_TARGET_PATH configuration key and sets the default to the existing `/profile/{{ current_user.username }}/`