### PR TITLE
User can turn off download - export csv from a dashboard

### DIFF
--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -3717,6 +3717,15 @@
       "description": "Whether to fill the objects",
       "default": true
     },
+    "filter_configs": {
+      "type": "CollectionControl",
+      "label": "Filters",
+      "description": "Filter configuration for the filter box",
+      "validators": [
+        null
+      ],
+      "controlName": "FilterBoxItemControl"
+    },
     "normalized": {
       "type": "CheckboxControl",
       "label": "Normalized",

--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -3717,15 +3717,6 @@
       "description": "Whether to fill the objects",
       "default": true
     },
-    "filter_configs": {
-      "type": "CollectionControl",
-      "label": "Filters",
-      "description": "Filter configuration for the filter box",
-      "validators": [
-        null
-      ],
-      "controlName": "FilterBoxItemControl"
-    },
     "normalized": {
       "type": "CheckboxControl",
       "label": "Normalized",

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
@@ -57,6 +57,7 @@ describe('Chart', () => {
     editMode: false,
     isExpanded: false,
     supersetCanExplore: false,
+    supersetCanCSV: false,
     sliceCanEdit: false,
   };
 

--- a/superset/assets/src/dashboard/components/SliceHeader.jsx
+++ b/superset/assets/src/dashboard/components/SliceHeader.jsx
@@ -41,6 +41,7 @@ const propTypes = {
   annotationError: PropTypes.object,
   sliceName: PropTypes.string,
   supersetCanExplore: PropTypes.bool,
+  supersetCanCSV: PropTypes.bool,
   sliceCanEdit: PropTypes.bool,
 };
 
@@ -61,6 +62,7 @@ const defaultProps = {
   isExpanded: false,
   sliceName: '',
   supersetCanExplore: false,
+  supersetCanCSV: false,
   sliceCanEdit: false,
 };
 
@@ -82,6 +84,7 @@ class SliceHeader extends React.PureComponent {
       innerRef,
       sliceName,
       supersetCanExplore,
+      supersetCanCSV,
       sliceCanEdit,
       editMode,
       updateSliceName,
@@ -133,6 +136,7 @@ class SliceHeader extends React.PureComponent {
               exploreChart={exploreChart}
               exportCSV={exportCSV}
               supersetCanExplore={supersetCanExplore}
+              supersetCanCSV={supersetCanCSV}
               sliceCanEdit={sliceCanEdit}
             />
           )}

--- a/superset/assets/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset/assets/src/dashboard/components/SliceHeaderControls.jsx
@@ -164,9 +164,7 @@ class SliceHeaderControls extends React.PureComponent {
           )}
 
           {this.props.supersetCanCSV && (
-            <MenuItem onClick={this.exportCSV}>
-              {t('Export CSV')}
-            </MenuItem>
+            <MenuItem onClick={this.exportCSV}>{t('Export CSV')}</MenuItem>
           )}
 
           {this.props.supersetCanExplore && (

--- a/superset/assets/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset/assets/src/dashboard/components/SliceHeaderControls.jsx
@@ -36,6 +36,7 @@ const propTypes = {
   cachedDttm: PropTypes.string,
   updatedDttm: PropTypes.number,
   supersetCanExplore: PropTypes.bool,
+  supersetCanCSV: PropTypes.bool,
   sliceCanEdit: PropTypes.bool,
   toggleExpandSlice: PropTypes.func,
   forceRefresh: PropTypes.func,
@@ -53,6 +54,7 @@ const defaultProps = {
   isCached: false,
   isExpanded: false,
   supersetCanExplore: false,
+  supersetCanCSV: false,
   sliceCanEdit: false,
 };
 
@@ -161,7 +163,11 @@ class SliceHeaderControls extends React.PureComponent {
             </MenuItem>
           )}
 
-          <MenuItem onClick={this.exportCSV}>{t('Export CSV')}</MenuItem>
+          {this.props.supersetCanCSV && (
+            <MenuItem onClick={this.exportCSV}>
+              {t('Export CSV')}
+            </MenuItem>
+          )}
 
           {this.props.supersetCanExplore && (
             <MenuItem onClick={this.exploreChart}>

--- a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
@@ -45,6 +45,7 @@ const propTypes = {
   editMode: PropTypes.bool.isRequired,
   isExpanded: PropTypes.bool.isRequired,
   supersetCanExplore: PropTypes.bool.isRequired,
+  supersetCanCSV: PropTypes.bool.isRequired,
   sliceCanEdit: PropTypes.bool.isRequired,
 };
 
@@ -164,6 +165,7 @@ class Chart extends React.Component {
       toggleExpandSlice,
       timeout,
       supersetCanExplore,
+      supersetCanCSV,
       sliceCanEdit,
     } = this.props;
 
@@ -198,6 +200,7 @@ class Chart extends React.Component {
           updateSliceName={updateSliceName}
           sliceName={sliceName}
           supersetCanExplore={supersetCanExplore}
+          supersetCanCSV={supersetCanCSV}
           sliceCanEdit={sliceCanEdit}
         />
 

--- a/superset/assets/src/dashboard/containers/Chart.jsx
+++ b/superset/assets/src/dashboard/containers/Chart.jsx
@@ -62,6 +62,7 @@ function mapStateToProps(
     editMode: dashboardState.editMode,
     isExpanded: !!dashboardState.expandedSlices[id],
     supersetCanExplore: !!dashboardInfo.superset_can_explore,
+    supersetCanCSV: !!dashboardInfo.superset_can_csv,
     sliceCanEdit: !!dashboardInfo.slice_can_edit,
   };
 }

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -174,6 +174,7 @@ export default function(bootstrapData) {
       dash_edit_perm: dashboard.dash_edit_perm,
       dash_save_perm: dashboard.dash_save_perm,
       superset_can_explore: dashboard.superset_can_explore,
+      superset_can_csv: dashboard.superset_can_csv,
       slice_can_edit: dashboard.slice_can_edit,
       common: {
         flash_messages: common.flash_messages,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2146,6 +2146,7 @@ class Superset(BaseSupersetView):
             security_manager.can_access('can_save_dash', 'Superset')
         dash_save_perm = security_manager.can_access('can_save_dash', 'Superset')
         superset_can_explore = security_manager.can_access('can_explore', 'Superset')
+        superset_can_csv = security_manager.can_access('can_csv', 'Superset')
         slice_can_edit = security_manager.can_access('can_edit', 'SliceModelView')
 
         standalone_mode = request.args.get('standalone') == 'true'
@@ -2167,6 +2168,7 @@ class Superset(BaseSupersetView):
             'dash_save_perm': dash_save_perm,
             'dash_edit_perm': dash_edit_perm,
             'superset_can_explore': superset_can_explore,
+            'superset_can_csv': superset_can_csv,
             'slice_can_edit': slice_can_edit,
         })
 


### PR DESCRIPTION
Adding variable `supersetCanCSV` to check if the user has permission to download CSV in the dashboard. 
Superset has a permission `can_csv` to check if we are allowed to export CSV or not.
This commit should fix the issues #6116, #6110  

Screenshots:

Admin user with can_csv permission can export csv.
![screenshot 2019-02-06 at 17 03 04](https://user-images.githubusercontent.com/472178/52359347-a1edef80-2a31-11e9-98d7-50ad507a837f.png)

Remove can_csv permission from Gamma role.
![screenshot 2019-02-06 at 17 03 39](https://user-images.githubusercontent.com/472178/52359504-f2fde380-2a31-11e9-8238-65c822ca3847.png)

Gamma user access to dashboard options without the export csv option.
![screenshot 2019-02-06 at 17 04 21](https://user-images.githubusercontent.com/472178/52359585-1b85dd80-2a32-11e9-9152-4e7d10f90048.png)
