### PR TITLE
Added docs on proper function call for db mutator

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -489,7 +489,7 @@ DASHBOARD_TEMPLATE_ID = None
 # username. The function receives the connection uri object, connection
 # params, the username, and returns the mutated uri and params objects.
 # Example:
-#   def DB_CONNECTION_MUTATOR(uri, params, username, security_manager):
+#   def DB_CONNECTION_MUTATOR(uri, params, username, security_manager, source):
 #       user = security_manager.find_user(username=username)
 #       if user and user.email:
 #           uri.username = user.email


### PR DESCRIPTION
DB_CONNECTION_MUTATOR take 5 paramaters not 4 now. Updated docs to reflect the actual function call.

Reference:
https://github.com/apache/incubator-superset/pull/6497 