### PR TITLE
Separate vis-specific controls from centralized controls

### DIFF
--- a/superset/assets/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset/assets/src/explore/components/ControlPanelsContainer.jsx
@@ -46,10 +46,12 @@ class ControlPanelsContainer extends React.Component {
   constructor(props) {
     super(props);
 
+    this.getControlData = this.getControlData.bind(this);
     this.removeAlert = this.removeAlert.bind(this);
     this.renderControl = this.renderControl.bind(this);
     this.renderControlPanelSection = this.renderControlPanelSection.bind(this);
   }
+
   getControlData(controlName) {
     if (React.isValidElement(controlName)) {
       return controlName;
@@ -71,12 +73,15 @@ class ControlPanelsContainer extends React.Component {
     }
     return control;
   }
+
   sectionsToRender() {
     return sectionsToRender(this.props.form_data.viz_type, this.props.datasource_type);
   }
+
   removeAlert() {
     this.props.actions.removeControlPanelAlert();
   }
+
   renderControl(name, config) {
     const { actions, controls, exploreState, form_data: formData } = this.props;
 
@@ -110,6 +115,7 @@ class ControlPanelsContainer extends React.Component {
       />
     );
   }
+
   renderControlPanelSection(section) {
     const { controls } = this.props;
 
@@ -160,6 +166,7 @@ class ControlPanelsContainer extends React.Component {
       </ControlPanelSection>
     );
   }
+
   render() {
     const allSectionsToRender = this.sectionsToRender();
     const querySectionsToRender = [];

--- a/superset/assets/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset/assets/src/explore/components/ControlPanelsContainer.jsx
@@ -45,7 +45,9 @@ const propTypes = {
 class ControlPanelsContainer extends React.Component {
   constructor(props) {
     super(props);
+
     this.removeAlert = this.removeAlert.bind(this);
+    this.renderControl = this.renderControl.bind(this);
     this.renderControlPanelSection = this.renderControlPanelSection.bind(this);
   }
   getControlData(controlName) {
@@ -96,15 +98,17 @@ class ControlPanelsContainer extends React.Component {
 
     const { validationErrors, provideFormDataToProps } = controlData;
 
-    return (<Control
-      name={name}
-      key={`control-${name}`}
-      value={formData[name]}
-      validationErrors={validationErrors}
-      actions={actions}
-      formData={provideFormDataToProps ? formData : null}
-      {...additionalProps}
-    />);
+    return (
+      <Control
+        name={name}
+        key={`control-${name}`}
+        value={formData[name]}
+        validationErrors={validationErrors}
+        actions={actions}
+        formData={provideFormDataToProps ? formData : null}
+        {...additionalProps}
+      />
+    );
   }
   renderControlPanelSection(section) {
     const { controls } = this.props;
@@ -135,12 +139,16 @@ class ControlPanelsContainer extends React.Component {
                 // When the item is a React element
                 return controlItem;
               } else if (isPlainObject(controlItem) && controlItem.name && controlItem.config) {
-                // When the item is { name, config }
+                // When the item is { name, config }, meaning the control config
+                // is specified directly. Do not have to look up by name from
+                // centralized configs.
                 const { name, config } = controlItem;
 
                 return this.renderControl(name, config);
               } else if (controls[controlItem]) {
-                // When the item is string name;
+                // When the item is string name, meaning the control config
+                // is not specified directly. Have to look up the config from
+                // centralized configs.
                 const name = controlItem;
 
                 return this.renderControl(name, controlConfigs[name]);

--- a/superset/assets/src/explore/controlPanels/PairedTtest.js
+++ b/superset/assets/src/explore/controlPanels/PairedTtest.js
@@ -27,9 +27,33 @@ export default {
       label: t('Paired t-test'),
       expanded: false,
       controlSetRows: [
-        ['significance_level'],
-        ['pvalue_precision'],
-        ['liftvalue_precision'],
+        [{
+          name: 'significance_level',
+          config: {
+            type: 'TextControl',
+            label: t('Significance Level'),
+            default: 0.05,
+            description: t('Threshold alpha level for determining significance'),
+          },
+        }],
+        [{
+          name: 'pvalue_precision',
+          config: {
+            type: 'TextControl',
+            label: t('p-value precision'),
+            default: 6,
+            description: t('Number of decimal places with which to display p-values'),
+          },
+        }],
+        [{
+          name: 'liftvalue_precision',
+          config: {
+            type: 'TextControl',
+            label: t('Lift percent precision'),
+            default: 4,
+            description: t('Number of decimal places with which to display lift values'),
+          },
+        }],
       ],
     },
   ],

--- a/superset/assets/src/explore/controlPanels/Rose.js
+++ b/superset/assets/src/explore/controlPanels/Rose.js
@@ -29,7 +29,19 @@ export default {
       controlSetRows: [
         ['color_scheme', 'label_colors'],
         ['number_format', 'date_time_format'],
-        ['rich_tooltip', 'rose_area_proportion'],
+        ['rich_tooltip', {
+          name: 'rose_area_proportion',
+          config: {
+            type: 'CheckboxControl',
+            label: t('Use Area Proportions'),
+            description: t(
+              'Check if the Rose Chart should use segment area instead of ' +
+              'segment radius for proportioning',
+            ),
+            default: false,
+            renderTrigger: true,
+          },
+        }],
       ],
     },
     NVD3TimeSeries[1],

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2101,43 +2101,11 @@ export const controls = {
     }),
   },
 
-  significance_level: {
-    type: 'TextControl',
-    label: t('Significance Level'),
-    default: 0.05,
-    description: t('Threshold alpha level for determining significance'),
-  },
-
-  pvalue_precision: {
-    type: 'TextControl',
-    label: t('p-value precision'),
-    default: 6,
-    description: t('Number of decimal places with which to display p-values'),
-  },
-
-  liftvalue_precision: {
-    type: 'TextControl',
-    label: t('Lift percent precision'),
-    default: 4,
-    description: t('Number of decimal places with which to display lift values'),
-  },
-
   column_collection: {
     type: 'CollectionControl',
     label: t('Time Series Columns'),
     validators: [v.nonEmpty],
     controlName: 'TimeSeriesColumnControl',
-  },
-
-  rose_area_proportion: {
-    type: 'CheckboxControl',
-    label: t('Use Area Proportions'),
-    description: t(
-      'Check if the Rose Chart should use segment area instead of ' +
-      'segment radius for proportioning',
-    ),
-    default: false,
-    renderTrigger: true,
   },
 
   time_series_option: {


### PR DESCRIPTION
### Summary

Allow each visualization to define its own controls, instead of storing all controls in centralized `controls.jsx`

![image](https://user-images.githubusercontent.com/1659771/56396250-ca912300-61f2-11e9-862e-a13a4405fe49.png)

### Test plan

Verified that the `rose` and `paired t-test` charts that are modified in this PR are working correctly.

![image](https://user-images.githubusercontent.com/1659771/56396544-388a1a00-61f4-11e9-86e4-b6d4c07d80bf.png)

![image](https://user-images.githubusercontent.com/1659771/56396555-45a70900-61f4-11e9-980a-74f3524f7abd.png)


@mistercrunch @williaster @michellethomas @graceguo-supercat @conglei @khtruong @xtinec 