### PR TITLE
Fix: shim for import error due to pandas 0.24 update, fixes #6770

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -27,8 +27,12 @@ import logging
 
 import numpy as np
 import pandas as pd
-from pandas.core.common import _maybe_box_datetimelike
 from pandas.core.dtypes.dtypes import ExtensionDtype
+try:
+    from pandas.core.common import maybe_box_datetimelike
+except ImportError:
+    from pandas.core.common import _maybe_box_datetimelike as maybe_box_datetimelike
+
 
 from superset.utils.core import JS_MAX_INTEGER
 
@@ -106,7 +110,7 @@ class SupersetDataFrame(object):
     @property
     def data(self):
         # work around for https://github.com/pandas-dev/pandas/issues/18372
-        data = [dict((k, _maybe_box_datetimelike(v))
+        data = [dict((k, maybe_box_datetimelike(v))
                 for k, v in zip(self.df.columns, np.atleast_1d(row)))
                 for row in self.df.values]
         for d in data:


### PR DESCRIPTION
This is a not-super-elegant fix for a pandas import error that's causing installation fails on 0.29.0rc7. The issue stems from a pandas function being renamed from `_maybe_box_datetimelike` to `maybe_box_datetimelike` when pandas updated to 0.24.

Not sure if a try/except block is the right way to go about this, just thought it could be a quick fix.