### PR TITLE
[main] Disable resetting main DB attributes

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -865,10 +865,12 @@ def get_or_create_main_db():
     logging.info('Creating database reference')
     dbobj = get_main_database(db.session)
     if not dbobj:
-        dbobj = models.Database(database_name='main')
+        dbobj = models.Database(
+            database_name='main',
+            allow_csv_upload=True,
+            expose_in_sqllab=True,
+        )
     dbobj.set_sqlalchemy_uri(conf.get('SQLALCHEMY_DATABASE_URI'))
-    dbobj.expose_in_sqllab = True
-    dbobj.allow_csv_upload = True
     db.session.add(dbobj)
     db.session.commit()
     return dbobj

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -646,15 +646,14 @@ class CoreTests(SupersetTestCase):
         main_db_uri = (
             db.session.query(models.Database)
             .filter_by(database_name='main')
-            .all()
+            .one()
         )
-
         test_file = open(filename, 'rb')
         form_data = {
             'csv_file': test_file,
             'sep': ',',
             'name': table_name,
-            'con': main_db_uri[0].id,
+            'con': main_db_uri.id,
             'if_exists': 'append',
             'index_label': 'test_label',
             'mangle_dupe_cols': False,


### PR DESCRIPTION
This PR resolves an issue where if you re-run `superset init` the main database resets the following attributes to true:
- `allow_csv_upload`
- `expose_in_sqllab`

If the database exists I sense one shouldn't changes these attributes (we've run into issues were users have uploaded CSV files to the main database) which was possible after every deploy (which runs the `superset init` command).

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa @youngyjd 