### PR TITLE
Refactor dataframe and column name mutation logic

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -117,13 +117,13 @@ class TableColumn(Model, BaseColumn):
 
     def get_sqla_col(self, label=None):
         label = label if label else self.column_name
-        label = self.table.get_label(label)
         if not self.expression:
             db_engine_spec = self.table.database.db_engine_spec
             type_ = db_engine_spec.get_sqla_column_type(self.type)
-            col = column(self.column_name, type_=type_).label(label)
+            col = column(self.column_name, type_=type_)
         else:
-            col = literal_column(self.expression).label(label)
+            col = literal_column(self.expression)
+        col = self.table.make_sqla_column_compatible(col, label)
         return col
 
     @property
@@ -142,13 +142,14 @@ class TableColumn(Model, BaseColumn):
 
     def get_timestamp_expression(self, time_grain):
         """Getting the time component of the query"""
-        label = self.table.get_label(utils.DTTM_ALIAS)
+        label = utils.DTTM_ALIAS
 
         db = self.table.database
         pdf = self.python_date_format
         is_epoch = pdf in ('epoch_s', 'epoch_ms')
         if not self.expression and not time_grain and not is_epoch:
-            return column(self.column_name, type_=DateTime).label(label)
+            sqla_col = column(self.column_name, type_=DateTime)
+            return self.table.make_sqla_column_compatible(sqla_col, label)
         grain = None
         if time_grain:
             grain = db.grains_dict().get(time_grain)
@@ -158,7 +159,8 @@ class TableColumn(Model, BaseColumn):
         expr = db.db_engine_spec.get_time_expr(
             self.expression or self.column_name,
             pdf, time_grain, grain)
-        return literal_column(expr, type_=DateTime).label(label)
+        sqla_col = literal_column(expr, type_=DateTime)
+        return self.table.make_sqla_column_compatible(sqla_col, label)
 
     @classmethod
     def import_obj(cls, i_column):
@@ -219,8 +221,8 @@ class SqlMetric(Model, BaseMetric):
 
     def get_sqla_col(self, label=None):
         label = label if label else self.metric_name
-        label = self.table.get_label(label)
-        return literal_column(self.expression).label(label)
+        sqla_col = literal_column(self.expression)
+        return self.table.make_sqla_column_compatible(sqla_col, label)
 
     @property
     def perm(self):
@@ -298,20 +300,14 @@ class SqlaTable(Model, BaseDatasource):
         'MAX': sa.func.MAX,
     }
 
-    def get_label(self, label):
-        """Conditionally mutate a label to conform to db engine requirements
-        and store mapping from mutated label to original label
-
-        :param label: original label
-        :return: Either a string or sqlalchemy.sql.elements.quoted_name if required
-        by db engine
-        """
+    def make_sqla_column_compatible(self, sqla_col, label=None):
+        original_label = label if label else sqla_col.name
         db_engine_spec = self.database.db_engine_spec
-        sqla_label = db_engine_spec.make_label_compatible(label)
-        mutated_label = str(sqla_label)
-        if label != mutated_label:
-            self.mutated_labels[mutated_label] = label
-        return sqla_label
+        if db_engine_spec.supports_column_aliases:
+            label = db_engine_spec.make_label_compatible(original_label)
+            sqla_col = sqla_col.label(label)
+        sqla_col._expected_df_label = original_label
+        return sqla_col
 
     def __repr__(self):
         return self.name
@@ -516,7 +512,6 @@ class SqlaTable(Model, BaseDatasource):
         """
         expression_type = metric.get('expressionType')
         label = utils.get_metric_name(metric)
-        label = self.get_label(label)
 
         if expression_type == utils.ADHOC_METRIC_EXPRESSION_TYPES['SIMPLE']:
             column_name = metric.get('column').get('column_name')
@@ -526,14 +521,12 @@ class SqlaTable(Model, BaseDatasource):
             else:
                 sqla_column = column(column_name)
             sqla_metric = self.sqla_aggregations[metric.get('aggregate')](sqla_column)
-            sqla_metric = sqla_metric.label(label)
-            return sqla_metric
         elif expression_type == utils.ADHOC_METRIC_EXPRESSION_TYPES['SQL']:
             sqla_metric = literal_column(metric.get('sqlExpression'))
-            sqla_metric = sqla_metric.label(label)
-            return sqla_metric
         else:
             return None
+
+        return self.make_sqla_column_compatible(sqla_metric, label)
 
     def get_sqla_query(  # sqla
             self,
@@ -568,9 +561,6 @@ class SqlaTable(Model, BaseDatasource):
         template_processor = self.get_template_processor(**template_kwargs)
         db_engine_spec = self.database.db_engine_spec
 
-        # Initialize empty cache to store mutated labels
-        self.mutated_labels = {}
-
         orderby = orderby or []
 
         # For backward compatibility
@@ -600,8 +590,9 @@ class SqlaTable(Model, BaseDatasource):
         if metrics_exprs:
             main_metric_expr = metrics_exprs[0]
         else:
-            label = self.get_label('ccount')
-            main_metric_expr = literal_column('COUNT(*)').label(label)
+            label = 'ccount'
+            main_metric_expr = literal_column('COUNT(*)')
+            main_metric_expr = self.make_sqla_column_compatible(main_metric_expr, label)
 
         select_exprs = []
         groupby_exprs_sans_timestamp = OrderedDict()
@@ -612,7 +603,8 @@ class SqlaTable(Model, BaseDatasource):
                 if s in cols:
                     outer = cols[s].get_sqla_col()
                 else:
-                    outer = literal_column(f'({s})').label(self.get_label(s))
+                    outer = literal_column(f'({s})')
+                    outer = self.make_sqla_column_compatible(outer, s)
 
                 groupby_exprs_sans_timestamp[outer.name] = outer
                 select_exprs.append(outer)
@@ -643,7 +635,10 @@ class SqlaTable(Model, BaseDatasource):
 
         select_exprs += metrics_exprs
 
-        labels_expected = [str(c.name) for c in select_exprs]
+        labels_expected = None
+        if not db_engine_spec.supports_column_aliases or \
+                any([c._expected_df_label != c.name for c in select_exprs]):
+            labels_expected = [c._expected_df_label for c in select_exprs]
 
         select_exprs = db_engine_spec.make_select_compatible(
             groupby_exprs_with_timestamp.values(),
@@ -731,8 +726,8 @@ class SqlaTable(Model, BaseDatasource):
                 # some sql dialects require for order by expressions
                 # to also be in the select clause -- others, e.g. vertica,
                 # require a unique inner alias
-                label = self.get_label('mme_inner__')
-                inner_main_metric_expr = main_metric_expr.label(label)
+                inner_main_metric_expr = self.make_sqla_column_compatible(
+                    main_metric_expr, 'mme_inner__')
                 inner_groupby_exprs = []
                 inner_select_exprs = []
                 for gby_name, gby_obj in groupby_exprs_sans_timestamp.items():
@@ -769,7 +764,7 @@ class SqlaTable(Model, BaseDatasource):
                     # in this case the column name, not the alias, needs to be
                     # conditionally mutated, as it refers to the column alias in
                     # the inner query
-                    col_name = self.get_label(gby_name + '__')
+                    col_name = db_engine_spec.mutate_label(gby_name + '__')
                     on_clause.append(gby_obj == column(col_name))
 
                 tbl = tbl.join(subq.alias(), and_(*on_clause))
@@ -821,15 +816,21 @@ class SqlaTable(Model, BaseDatasource):
         status = utils.QueryStatus.SUCCESS
         error_message = None
         df = None
-        db_engine_spec = self.database.db_engine_spec
         try:
             df = self.database.get_df(sql, self.schema)
-            if self.mutated_labels:
-                df = df.rename(index=str, columns=self.mutated_labels)
-            db_engine_spec.mutate_df_columns(df, sql, query_str_ext.labels_expected)
+            labels_expected = query_str_ext.labels_expected
+            if df is not None and \
+                    not df.empty and \
+                    labels_expected is not None:
+                if len(df.columns) != len(labels_expected):
+                    raise Exception(f'For {sql}, df.columns: {df.columns}'
+                                    f' differs from {labels_expected}')
+                else:
+                    df.columns = labels_expected
         except Exception as e:
             status = utils.QueryStatus.FAILED
             logging.exception(f'Query {sql} on schema {self.schema} failed')
+            db_engine_spec = self.database.db_engine_spec
             error_message = db_engine_spec.extract_error_message(e)
 
         # if this is a main query with prequeries, combine them together

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -615,7 +615,8 @@ class SqlaTable(Model, BaseDatasource):
         elif columns:
             for s in columns:
                 select_exprs.append(
-                    cols[s].get_sqla_col() if s in cols else literal_column(s))
+                    cols[s].get_sqla_col() if s in cols else
+                    self.make_sqla_column_compatible(literal_column(s)))
             metrics_exprs = []
 
         groupby_exprs_with_timestamp = OrderedDict(groupby_exprs_sans_timestamp.items())
@@ -754,7 +755,6 @@ class SqlaTable(Model, BaseDatasource):
                             timeseries_limit_metric,
                         )
                         ob = timeseries_limit_metric.get_sqla_col()
-                        ob = self.make_sqla_column_compatible(ob)
                     else:
                         raise Exception(_("Metric '{}' is not valid".format(m)))
                 direction = desc if order_desc else asc

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -634,10 +634,7 @@ class SqlaTable(Model, BaseDatasource):
 
         select_exprs += metrics_exprs
 
-        labels_expected = None
-        if not db_engine_spec.supports_column_aliases or \
-                any([c._df_label_expected != c.name for c in select_exprs]):
-            labels_expected = [c._df_label_expected for c in select_exprs]
+        labels_expected = [c._df_label_expected for c in select_exprs]
 
         select_exprs = db_engine_spec.make_select_compatible(
             groupby_exprs_with_timestamp.values(),
@@ -818,9 +815,7 @@ class SqlaTable(Model, BaseDatasource):
         try:
             df = self.database.get_df(sql, self.schema)
             labels_expected = query_str_ext.labels_expected
-            if df is not None and \
-                    not df.empty and \
-                    labels_expected is not None:
+            if df is not None and not df.empty:
                 if len(df.columns) != len(labels_expected):
                     raise Exception(f'For {sql}, df.columns: {df.columns}'
                                     f' differs from {labels_expected}')

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -116,7 +116,7 @@ class TableColumn(Model, BaseColumn):
     export_parent = 'table'
 
     def get_sqla_col(self, label=None):
-        label = label if label else self.column_name
+        label = label or self.column_name
         if not self.expression:
             db_engine_spec = self.table.database.db_engine_spec
             type_ = db_engine_spec.get_sqla_column_type(self.type)
@@ -220,7 +220,7 @@ class SqlMetric(Model, BaseMetric):
     export_parent = 'table'
 
     def get_sqla_col(self, label=None):
-        label = label if label else self.metric_name
+        label = label or self.metric_name
         sqla_col = literal_column(self.expression)
         return self.table.make_sqla_column_compatible(sqla_col, label)
 
@@ -306,7 +306,7 @@ class SqlaTable(Model, BaseDatasource):
         :param label: alias/label that column is expected to have
         :return: either a sql alchemy column or label instance if supported by engine
         """
-        label_expected = label if label else sqla_col.name
+        label_expected = label or sqla_col.name
         db_engine_spec = self.database.db_engine_spec
         if db_engine_spec.supports_column_aliases:
             label = db_engine_spec.make_label_compatible(label_expected)

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1567,7 +1567,6 @@ class BQEngineSpec(BaseEngineSpec):
         with a number are prefixed with an underscore. Any unsupported characters are
         replaced with underscores and an md5 hash is added to the end of the label to
         avoid possible collisions.
-
         :param str label: the original label which might include unsupported characters
         :return: String that is supported by the database
         """

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -572,20 +572,6 @@ class OracleEngineSpec(PostgresBaseEngineSpec):
             """TO_TIMESTAMP('{}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""
         ).format(dttm.isoformat())
 
-    @staticmethod
-    def mutate_label(label):
-        """
-        Oracle 12.1 and earlier support a maximum of 30 byte length object names, which
-        usually means 30 characters.
-        :param str label: Original label which might include unsupported characters
-        :return: String that is supported by the database
-        """
-        if len(label) > 30:
-            hashed_label = hashlib.md5(label.encode('utf-8')).hexdigest()
-            # truncate the hash to first 30 characters
-            return hashed_label[:30]
-        return label
-
 
 class Db2EngineSpec(BaseEngineSpec):
     engine = 'ibm_db_sa'

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1597,12 +1597,11 @@ class BQEngineSpec(BaseEngineSpec):
 
     @classmethod
     def truncate_label(cls, label):
-        """ BigQuery requires that column names start with either a letter or
+        """BigQuery requires column names start with either a letter or
         underscore. To make sure this is always the case, an underscore is prefixed
         to the truncated label.
         """
         return '_' + hashlib.md5(label.encode('utf-8')).hexdigest()
-
 
     @classmethod
     def extra_table_metadata(cls, database, table_name, schema_name):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -421,12 +421,12 @@ class BaseEngineSpec(object):
         regular string. If maxmimum supported column name length is exceeded,
         generate a truncated label by calling truncate_label().
         """
-        mutated_label = cls.mutate_label(label)
-        if cls.max_column_name_length and len(mutated_label) > cls.max_column_name_length:
-            mutated_label = cls.truncate_label(label)
+        label_mutated = cls.mutate_label(label)
+        if cls.max_column_name_length and len(label_mutated) > cls.max_column_name_length:
+            label_mutated = cls.truncate_label(label)
         if cls.force_column_alias_quotes:
-            mutated_label = quoted_name(mutated_label, True)
-        return mutated_label
+            label_mutated = quoted_name(label_mutated, True)
+        return label_mutated
 
     @classmethod
     def get_sqla_column_type(cls, type_):
@@ -1582,18 +1582,18 @@ class BQEngineSpec(BaseEngineSpec):
         :param str label: the original label which might include unsupported characters
         :return: String that is supported by the database
         """
-        hashed_label = '_' + hashlib.md5(label.encode('utf-8')).hexdigest()
+        label_hashed = '_' + hashlib.md5(label.encode('utf-8')).hexdigest()
 
         # if label starts with number, add underscore as first character
-        mutated_label = '_' + label if re.match(r'^\d', label) else label
+        label_mutated = '_' + label if re.match(r'^\d', label) else label
 
         # replace non-alphanumeric characters with underscores
-        mutated_label = re.sub(r'[^\w]+', '_', mutated_label)
-        if mutated_label != label:
+        label_mutated = re.sub(r'[^\w]+', '_', label_mutated)
+        if label_mutated != label:
             # add md5 hash to label to avoid possible collisions
-            mutated_label += hashed_label
+            label_mutated += label_hashed
 
-        return mutated_label
+        return label_mutated
 
     @classmethod
     def truncate_label(cls, label):

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -17,6 +17,7 @@
 import inspect
 
 import mock
+from sqlalchemy import column
 
 from superset import db_engine_specs
 from superset.db_engine_specs import (
@@ -25,9 +26,6 @@ from superset.db_engine_specs import (
 )
 from superset.models.core import Database
 from .base_tests import SupersetTestCase
-
-from sqlalchemy import column
-from sqlalchemy.sql import quoted_name
 
 
 class DbEngineSpecsTestCase(SupersetTestCase):

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -20,11 +20,14 @@ import mock
 
 from superset import db_engine_specs
 from superset.db_engine_specs import (
-    BaseEngineSpec, HiveEngineSpec, MssqlEngineSpec,
-    MySQLEngineSpec, PrestoEngineSpec,
+    BaseEngineSpec, BQEngineSpec, HiveEngineSpec, MssqlEngineSpec,
+    MySQLEngineSpec, OracleEngineSpec, PrestoEngineSpec,
 )
 from superset.models.core import Database
 from .base_tests import SupersetTestCase
+
+from sqlalchemy import column
+from sqlalchemy.sql import quoted_name
 
 
 class DbEngineSpecsTestCase(SupersetTestCase):
@@ -307,3 +310,27 @@ class DbEngineSpecsTestCase(SupersetTestCase):
 
     def test_hive_get_view_names_return_empty_list(self):
         self.assertEquals([], HiveEngineSpec.get_view_names(mock.ANY, mock.ANY))
+
+    def test_bigquery_sqla_column_label(self):
+        label = BQEngineSpec.make_label_compatible(column('Col').name)
+        label_expected = 'Col'
+        self.assertEqual(label, label_expected)
+
+        label = BQEngineSpec.make_label_compatible(column('SUM(x)').name)
+        label_expected = 'SUM_x__5f110b965a993675bc4953bb3e03c4a5'
+        self.assertEqual(label, label_expected)
+
+        label = BQEngineSpec.make_label_compatible(column('SUM[x]').name)
+        label_expected = 'SUM_x__7ebe14a3f9534aeee125449b0bc083a8'
+        self.assertEqual(label, label_expected)
+
+        label = BQEngineSpec.make_label_compatible(column('12345_col').name)
+        label_expected = '_12345_col_8d3906e2ea99332eb185f7f8ecb2ffd6'
+        self.assertEqual(label, label_expected)
+
+    def test_oracle_sqla_column_name_length_exceeded(self):
+        col = column('This_Is_32_Character_Column_Name')
+        label = OracleEngineSpec.make_label_compatible(col.name)
+        self.assertEqual(label.quote, True)
+        label_expected = '3b26974078683be078219674eeb8f5'
+        self.assertEqual(label, label_expected)


### PR DESCRIPTION
Several small refactors, features and fixes related to SQLAlchemy engines:
- Add flag to disable aliases in `db_engine_specs`. By default engines support aliases; this is only disabled on Pinot for now. If the engine doesn't support aliases, labels aren't added to columns (see screenshot below). This is done by replacing the `self.get_label()` function with a `self.make_sqla_column_compatible()`, that returns a label if those are supported and the original column if not.
- Merge old column name mutation logic with the new one via `query_str_ext.labels_expected`.
- Move dataframe logic back to `connectors/sqla/models.py` from `db_engine_specs.py` and merge it with the column renaming logic from before.
- Add `max_column_name_length` property to `db_engine_specs`, and default to MD5 hash if column name is exceeded. Add max lengths to engines that were easy to find by googling.
- Fix a few edge cases where subqueries with double underscored aliases would not render properly if column length restriction was exceeded.
- Fix a few linting errors in `db_engine_specs`.

# Example

When creating a chart on Pinot where `COUNT(*)` is calculated grouping by `playerID`, the result shows up like before:

<img width="1262" alt="screenshot 2019-02-09 at 16 09 37" src="https://user-images.githubusercontent.com/33317356/52521935-a1e72d00-2c87-11e9-8461-2b6d6240a43f.png">

Looking at the query, the alias is gone, making it regular PQL:

<img width="897" alt="screenshot 2019-02-09 at 16 09 25" src="https://user-images.githubusercontent.com/33317356/52521966-01453d00-2c88-11e9-8708-6071ed861240.png">

FYI @agrawaldevesh please check this and give comments when you have the time. I tested this with your fork of `pinot_dbapi` (I assume that's the one you are using for now).