### PR TITLE
Sort Chart Types based on Usage

### DIFF
--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -89,14 +89,14 @@ export default class VizTypeControl extends React.PureComponent {
         </div>
       </div>);
   }
-  _buildVizTypeLookup(types) {
-    let lookup = new Map()
-    for (var i = 0; i < types.length; i++) {
+  buildVizTypeLookup(types) {
+    const lookup = new Map();
+    for (let i = 0; i < types.length; i++) {
       lookup.set(types[i].key, types[i]);
     }
-    return lookup
+    return lookup;
   }
-  _sortVizTypes(types) {
+  sortVizTypes(types) {
     const defaultOrder = [
       'line', 'big_number', 'table', 'filter_box', 'dist_bar', 'area', 'bar',
       'deck_polygon', 'pie', 'time_table', 'pivot_table', 'histogram',
@@ -107,16 +107,16 @@ export default class VizTypeControl extends React.PureComponent {
       'horizon', 'markup', 'deck_multi', 'compare', 'partition', 'event_flow',
       'deck_path', 'directed_force', 'world_map', 'paired_ttest', 'para',
       'iframe', 'country_map',
-    ]
+    ];
 
-    let sorted = [];
-    let loadedKeys = new Set();
-    let vizTypeLookup = this._buildVizTypeLookup(types);
+    const sorted = [];
+    const loadedKeys = new Set();
+    const vizTypeLookup = this.buildVizTypeLookup(types);
 
     // Sort based on the `defualtOrder`
-    for (var i = 0; i < defaultOrder.length; i++) {
-      let key = defaultOrder[i];
-      let t = vizTypeLookup.get(key);
+    for (let i = 0; i < defaultOrder.length; i++) {
+      const key = defaultOrder[i];
+      const t = vizTypeLookup.get(key);
       if (typeof t !== 'undefined') {
         sorted.push(t);
         loadedKeys.add(key);
@@ -124,10 +124,10 @@ export default class VizTypeControl extends React.PureComponent {
     }
 
     // Load the rest of Viz Types not mandated by the `defualtOrder`
-    for (var i = 0; i < types.length; i++) {
-      let t = types[i];
-      let key = t['key'];
-      if (! loadedKeys.has(key)) {
+    for (let i = 0; i < types.length; i++) {
+      const t = types[i];
+      const key = t.key;
+      if (!loadedKeys.has(key)) {
         sorted.push(t);
         loadedKeys.add(key);
       }
@@ -140,7 +140,7 @@ export default class VizTypeControl extends React.PureComponent {
     const { value } = this.props;
 
     const registry = getChartMetadataRegistry();
-    const types = this._sortVizTypes(registry.entries());
+    const types = this.sortVizTypes(registry.entries());
     const filteredTypes = filter.length > 0
       ? types.filter(type => type.value.name.toLowerCase().includes(filter))
       : types;

--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -23,7 +23,6 @@ import {
   Tooltip } from 'react-bootstrap';
 import { t } from '@superset-ui/translation';
 import { getChartMetadataRegistry } from '@superset-ui/chart';
-import { SupersetClient } from '@superset-ui/connection';
 
 import ControlHeader from '../ControlHeader';
 import './VizTypeControl.css';
@@ -46,7 +45,6 @@ export default class VizTypeControl extends React.PureComponent {
     this.state = {
       showModal: false,
       filter: '',
-      vizTypeStats: '',
     };
     this.toggleModal = this.toggleModal.bind(this);
     this.changeSearch = this.changeSearch.bind(this);
@@ -70,13 +68,6 @@ export default class VizTypeControl extends React.PureComponent {
     if (this.searchRef) {
       this.searchRef.focus();
     }
-  }
-  componentDidMount() {
-    SupersetClient.get({
-      endpoint: "/superset/viz_type_stats",
-    }).then(({ json }) => {
-      this.setState({ vizTypeStats: json.this_user.concat(json.overall) });
-    });
   }
   renderItem(entry) {
     const { value } = this.props;
@@ -106,21 +97,33 @@ export default class VizTypeControl extends React.PureComponent {
     return lookup
   }
   _sortVizTypes(types) {
+    const defaultOrder = [
+      'line', 'big_number', 'table', 'filter_box', 'dist_bar', 'area', 'bar',
+      'deck_polygon', 'pie', 'time_table', 'pivot_table', 'histogram',
+      'big_number_total', 'deck_scatter', 'deck_hex', 'time_pivot', 'deck_arc',
+      'heatmap', 'deck_grid', 'dual_line', 'deck_screengrid', 'line_multi',
+      'treemap', 'box_plot', 'separator', 'sunburst', 'sankey', 'word_cloud',
+      'mapbox', 'kepler', 'cal_heatmap', 'rose', 'bubble', 'deck_geojson',
+      'horizon', 'markup', 'deck_multi', 'compare', 'partition', 'event_flow',
+      'deck_path', 'directed_force', 'world_map', 'paired_ttest', 'para',
+      'iframe', 'country_map',
+    ]
+
     let sorted = [];
     let loadedKeys = new Set();
     let vizTypeLookup = this._buildVizTypeLookup(types);
-    // Sort based on existing visualization type usages statistics
-    for (var i = 0; i < this.state.vizTypeStats.length; i++) {
-      let key = this.state.vizTypeStats[i].viz_type;
-      if (loadedKeys.has(key)) continue;
+
+    // Sort based on the `defualtOrder`
+    for (var i = 0; i < defaultOrder.length; i++) {
+      let key = defaultOrder[i];
       let t = vizTypeLookup.get(key);
       if (typeof t !== 'undefined') {
         sorted.push(t);
         loadedKeys.add(key);
       }
     }
-    // For visualization types that do not have any statistics, apply the
-    // original order
+
+    // Load the rest of Viz Types not mandated by the `defualtOrder`
     for (var i = 0; i < types.length; i++) {
       let t = types[i];
       let key = t['key'];
@@ -129,6 +132,7 @@ export default class VizTypeControl extends React.PureComponent {
         loadedKeys.add(key);
       }
     }
+
     return sorted;
   }
   render() {

--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -69,26 +69,6 @@ export default class VizTypeControl extends React.PureComponent {
       this.searchRef.focus();
     }
   }
-  renderItem(entry) {
-    const { value } = this.props;
-    const { key, value: type } = entry;
-    const isSelected = key === value;
-    return (
-      <div
-        className={`viztype-selector-container ${isSelected ? 'selected' : ''}`}
-        onClick={this.onChange.bind(this, key)}
-      >
-        <img
-          alt={type.name}
-          width="100%"
-          className={`viztype-selector ${isSelected ? 'selected' : ''}`}
-          src={type.thumbnail}
-        />
-        <div className="viztype-label">
-          {type.name}
-        </div>
-      </div>);
-  }
   buildVizTypeLookup(types) {
     const lookup = new Map();
     for (let i = 0; i < types.length; i++) {
@@ -116,24 +96,44 @@ export default class VizTypeControl extends React.PureComponent {
     // Sort based on the `defualtOrder`
     for (let i = 0; i < defaultOrder.length; i++) {
       const key = defaultOrder[i];
-      const t = vizTypeLookup.get(key);
-      if (typeof t !== 'undefined') {
-        sorted.push(t);
+      const vizType = vizTypeLookup.get(key);
+      if (typeof vizType !== 'undefined') {
+        sorted.push(vizType);
         loadedKeys.add(key);
       }
     }
 
     // Load the rest of Viz Types not mandated by the `defualtOrder`
     for (let i = 0; i < types.length; i++) {
-      const t = types[i];
-      const key = t.key;
+      const vizType = types[i];
+      const key = vizType.key;
       if (!loadedKeys.has(key)) {
-        sorted.push(t);
+        sorted.push(vizType);
         loadedKeys.add(key);
       }
     }
 
     return sorted;
+  }
+  renderItem(entry) {
+    const { value } = this.props;
+    const { key, value: type } = entry;
+    const isSelected = key === value;
+    return (
+      <div
+        className={`viztype-selector-container ${isSelected ? 'selected' : ''}`}
+        onClick={this.onChange.bind(this, key)}
+      >
+        <img
+          alt={type.name}
+          width="100%"
+          className={`viztype-selector ${isSelected ? 'selected' : ''}`}
+          src={type.thumbnail}
+        />
+        <div className="viztype-label">
+          {type.name}
+        </div>
+      </div>);
   }
   render() {
     const { filter, showModal } = this.state;

--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -74,10 +74,6 @@ export default class VizTypeControl extends React.PureComponent {
     types.forEach((type) => {
       lookup.set(type.key, type);
     });
-
-    for (let i = 0; i < types.length; i++) {
-      lookup.set(types[i].key, types[i]);
-    }
     return lookup;
   }
   sortVizTypes(types) {

--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -71,6 +71,10 @@ export default class VizTypeControl extends React.PureComponent {
   }
   buildVizTypeLookup(types) {
     const lookup = new Map();
+    types.forEach((type) => {
+      lookup.set(type.key, type);
+    });
+
     for (let i = 0; i < types.length; i++) {
       lookup.set(types[i].key, types[i]);
     }
@@ -93,25 +97,22 @@ export default class VizTypeControl extends React.PureComponent {
     const loadedKeys = new Set();
     const vizTypeLookup = this.buildVizTypeLookup(types);
 
-    // Sort based on the `defualtOrder`
-    for (let i = 0; i < defaultOrder.length; i++) {
-      const key = defaultOrder[i];
+    // Sort based on the `defaultOrder`
+    defaultOrder.forEach((key) => {
       const vizType = vizTypeLookup.get(key);
       if (typeof vizType !== 'undefined') {
         sorted.push(vizType);
         loadedKeys.add(key);
       }
-    }
+    });
 
     // Load the rest of Viz Types not mandated by the `defualtOrder`
-    for (let i = 0; i < types.length; i++) {
-      const vizType = types[i];
-      const key = vizType.key;
-      if (!loadedKeys.has(key)) {
+    types.forEach((vizType) => {
+      if (!loadedKeys.has(vizType.key)) {
         sorted.push(vizType);
-        loadedKeys.add(key);
+        loadedKeys.add(vizType.key);
       }
-    }
+    });
 
     return sorted;
   }

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -36,7 +36,7 @@ from flask_babel import lazy_gettext as _
 import pandas as pd
 import simplejson as json
 import sqlalchemy as sqla
-from sqlalchemy import and_, create_engine, MetaData, or_, update
+from sqlalchemy import and_, create_engine, MetaData, or_, update, func, desc
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import IntegrityError
 from werkzeug.routing import BaseConverter
@@ -2824,6 +2824,54 @@ class Superset(BaseSupersetView):
             entry='sqllab',
             bootstrap_data=json.dumps(d, default=utils.json_iso_dttm_ser),
         )
+
+    @has_access
+    @expose('/viz_type_stats', methods=['GET'])
+    @expose('/viz_type_stats/<user_id>/', methods=['GET'])
+    def viz_type_stats(self, user_id=None):
+        """
+        This endpoint provides the statistics of the visualization type usage.
+        """
+        if not user_id:
+            user_id = g.user.id
+
+        key = self._get_viz_type_stats_cache_key(user_id)
+        payload = cache.get(key)
+        if payload is not None:
+            payload['served_from'] = 'cache'
+        else:
+            payload = {
+                'served_from': 'live',
+                'this_user': self._get_viz_type_stats(user_id=user_id),
+                'overall': self._get_viz_type_stats(),
+            }
+            cache.set(key, payload, 7 * 24 * 60 * 60)  # cache for 7 days
+        return json_success(
+            json.dumps(payload, default=utils.json_int_dttm_ser)
+        )
+
+    def _get_viz_type_stats_cache_key(self, user_id):
+        """
+        This function returns the key for caching the result of visualization
+        type usage statistics of this user.
+        """
+        return f"viz_type_stats_{user_id}"
+
+    def _get_viz_type_stats(self, user_id=None):
+        """
+        This function returns the statistics of the visualization type usage of
+        the `user_id`.  If `user_id` is not provided, this function returns the
+        same statistics across all users.
+        """
+        query = db.session.query(
+            models.Slice.viz_type,
+            func.count().label("cnt"),
+        )
+        if user_id is not None:
+            query = query.filter(models.Slice.created_by_fk == user_id)
+        query = query.group_by(models.Slice.viz_type)
+        query = query.order_by(desc("cnt"))
+        return query.all()
 
     @api
     @handle_api_exception


### PR DESCRIPTION
Currently, in the `Select a visualization type` dialog, visualization types are not sorted in any specific way.  This PR sorts visualization types based on the follow rule:

If the user has created any slice in the past, those visualization types will be displayed first and are sorted based on that user's usage statistics.

For those visualization types that the user has never used before, they will be sorted based on the usage statistics across all users.

For those visualization types that have never been used by any user, they will show up in whatever original order that is currently using.

For a more constant user experience, the sort order is cached for 7 days.