### PR TITLE
Fixing issue where tooltip gets hidden on dashboard for all charts

### DIFF
--- a/superset/assets/src/visualizations/nvd3/NVD3Vis.js
+++ b/superset/assets/src/visualizations/nvd3/NVD3Vis.js
@@ -712,7 +712,7 @@ function nvd3Vis(element, props) {
         .call(chart);
 
       // on scroll, hide tooltips. throttle to only 4x/second.
-      window.addEventListener('scroll', throttle(hideTooltips, 250));
+      window.addEventListener('scroll', throttle(() => hideTooltips(element), 250));
 
       // The below code should be run AFTER rendering because chart is updated in call()
       if (isTimeSeries && activeAnnotationLayers.length > 0) {
@@ -936,7 +936,7 @@ function nvd3Vis(element, props) {
   // hide tooltips before rendering chart, if the chart is being re-rendered sometimes
   // there are left over tooltips in the dom,
   // this will clear them before rendering the chart again.
-  hideTooltips();
+  hideTooltips(element);
 
   nv.addGraph(drawGraph);
 }

--- a/superset/assets/src/visualizations/nvd3/utils.js
+++ b/superset/assets/src/visualizations/nvd3/utils.js
@@ -165,10 +165,12 @@ export function generateBubbleTooltipContent({
   return s;
 }
 
-export function hideTooltips() {
-  const targets = document.querySelectorAll('.nvtooltip');
-  if (targets.length > 0) {
-    targets.forEach(t => t.remove());
+export function hideTooltips(element) {
+  if (element) {
+    const targets = element.querySelectorAll('.nvtooltip');
+    if (targets.length > 0) {
+      targets.forEach(t => t.remove());
+    }
   }
 }
 


### PR DESCRIPTION
We've noticed an issue where the tooltip doesn't show up for some charts on a dashboard. The [recent change](https://github.com/apache/incubator-superset/pull/6805) to hideTooltips is removing tooltips for different charts on dashboard. This change removes tooltip for the specific chart element. 

@kristw @xtinec @graceguo-supercat 