### PR TITLE
[dashboard editor] use the theme's btn-primary

### DIFF
--- a/superset/assets/src/dashboard/stylesheets/builder.less
+++ b/superset/assets/src/dashboard/stylesheets/builder.less
@@ -60,13 +60,6 @@
   position: relative;
 }
 
-/* @TODO remove upon new theme */
-.btn.btn-primary {
-  background: @almost-black !important;
-  border-color: @almost-black;
-  color: white !important;
-}
-
 .dropdown-toggle.btn.btn-primary .caret {
   color: white;
 }


### PR DESCRIPTION
I'm not sure why `btn-primary` was made black for dashboard specifically, but want to bring back consistency.

# before
<img width="474" alt="screen shot 2019-02-12 at 9 13 52 am" src="https://user-images.githubusercontent.com/487433/52654299-902fa080-2ea6-11e9-9244-44a5f35d9686.png">

# after
<img width="526" alt="screen shot 2019-02-12 at 9 12 09 am" src="https://user-images.githubusercontent.com/487433/52654301-902fa080-2ea6-11e9-82f8-b8e1802faef2.png">
