### PR TITLE
Raise exception if long or lat not set in mapbox viz

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1982,6 +1982,8 @@ class MapboxViz(BaseViz):
         label_col = fd.get('mapbox_label')
 
         if not fd.get('groupby'):
+            if fd.get('all_columns_x') is None or fd.get('all_columns_y') is None:
+                raise Exception(_('[Longitude] and [Latitude] must be set'))
             d['columns'] = [fd.get('all_columns_x'), fd.get('all_columns_y')]
 
             if label_col and len(label_col) >= 1:


### PR DESCRIPTION
If long or lat aren't set, a `None` is pushed into the `columns` object, which causes problems in `connectors/sqla/models.py`. Fixes #6866