### PR TITLE
Fix extra_filters in `LineMulti.jsx`

### DIFF
--- a/superset/assets/src/visualizations/nvd3/LineMulti/LineMulti.jsx
+++ b/superset/assets/src/visualizations/nvd3/LineMulti/LineMulti.jsx
@@ -94,9 +94,9 @@ class LineMulti extends React.Component {
       const combinedFormData = {
         ...subslice.form_data,
         filters: (subsliceFormData.filters || [])
-          .concat(filters || [])
-          .concat(extraFilters || []),
+          .concat(filters || []),
         time_range: timeRange,
+        extra_filters: extraFilters || [],
       };
       const addPrefix = prefixMetricWithSliceName;
       return getJson(getExploreLongUrl(combinedFormData, 'json'))


### PR DESCRIPTION
The "Multiple Line Charts" visualization is currently not responding to events from the "Filter Box", since the extra filters were not applied correctly. This PR fixes it.

I tested by creating a simple dashboard, and changing the time filter now works as expected.