### PR TITLE
Adding template_params to datasource editor for sqla tables

### DIFF
--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -448,6 +448,14 @@ export class DatasourceEditor extends React.PureComponent {
           label={t('Hours offset')}
           control={<TextControl />}
         />
+        { this.state.isSqla &&
+          <Field
+            fieldKey="template_params"
+            label={t('Template parameters')}
+            descr={t('A set of parameters that become available in the query using Jinja templating syntax')}
+            control={<TextControl />}
+          />
+        }
       </Fieldset>);
   }
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -431,6 +431,7 @@ class SqlaTable(Model, BaseDatasource):
             d['time_grain_sqla'] = grains
             d['main_dttm_col'] = self.main_dttm_col
             d['fetch_values_predicate'] = self.fetch_values_predicate
+            d['template_params'] = self.template_params
         return d
 
     def values_for_column(self, column_name, limit=10000):


### PR DESCRIPTION
If a sqla table previously had template_params, saving changes in the datasource editor will override template_params. To fix this, I'm adding the template_params field to the "Advanced" section of the table editor.

Tested by:
Created a sqllab datasource based on birth names with jinja params.
Edited the template_params using the datasource editor and confirmed that the param was getting updated.

@mistercrunch @graceguo-supercat @john-bodley 