### PR TITLE
Speed up CI by caching TerserPlugin cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,4 +95,4 @@ cache:
     - ~/.npm
     - ~/.cache
     - ~/.travis_cache/
-    - superset/assets/node_modules/.cache/
+    - superset/assets/node_modules/.cache/terser-webpack-plugin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,3 +95,4 @@ cache:
     - ~/.npm
     - ~/.cache
     - ~/.travis_cache/
+    - superset/assets/node_modules/.cache/


### PR DESCRIPTION
This should accelerate the `npm run build` part of the build by ~5 minutes or so I believe. I'm not sure which conditions need to be met for travis to reuse the cache, but I know it's picking the changes up per the travis logs:
<img width="1079" alt="screen shot 2019-02-14 at 12 02 46 am" src="https://user-images.githubusercontent.com/487433/52771872-f540de80-2feb-11e9-9227-092ea7dfbf2a.png">