### PR TITLE
[ci] take #2, improve build times by saving TerserPlugin cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ celerybeat.pid
 geckodriver.log
 ghostdriver.log
 testCSV.csv
+.terser-plugin-cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,4 +95,4 @@ cache:
     - ~/.npm
     - ~/.cache
     - ~/.travis_cache/
-    - superset/assets/node_modules/.cache/terser-webpack-plugin/
+    - superset/assets/.terser-plugin-cache/

--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -270,7 +270,7 @@ const config = {
 if (!isDevMode) {
   config.optimization.minimizer = [
     new TerserPlugin({
-      cache: true,
+      cache: '.terser-plugin-cache/',
       parallel: true,
       extractComments: true,
     }),


### PR DESCRIPTION
The problem with the previous solution was that the `npm ci` command
nuke the `node_modules` folder, including the `.cache` that was used by
default. By moving the cache out of `node_modules`  we get to both run
`npm ci` and accelerate `TerserPlugin`

Looks like it works now, shaves ~5 minutes of the 4 longest items in the matrix

## before
<img width="1056" alt="screen shot 2019-02-14 at 9 43 34 pm" src="https://user-images.githubusercontent.com/487433/52836953-99d12800-30a1-11e9-8d6d-9a4eb1beead5.png">

## after
<img width="1053" alt="screen shot 2019-02-14 at 9 42 55 pm" src="https://user-images.githubusercontent.com/487433/52836938-8c1ba280-30a1-11e9-96ed-1faf8591ef41.png">
