### PR TITLE
Force quotes on non-expression time grains on Postgres

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -156,9 +156,8 @@ class TableColumn(Model, BaseColumn):
             if not grain:
                 raise NotImplementedError(
                     f'No grain spec for {time_grain} for database {db.database_name}')
-        expr = db.db_engine_spec.get_time_expr(
-            self.expression or self.column_name,
-            pdf, time_grain, grain)
+        col = db.db_engine_spec.get_timestamp_column(self.expression, self.column_name)
+        expr = db.db_engine_spec.get_time_expr(col, pdf, time_grain, grain)
         sqla_col = literal_column(expr, type_=DateTime)
         return self.table.make_sqla_column_compatible(sqla_col, label)
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -468,7 +468,7 @@ class BaseEngineSpec(object):
         """Return the expression if defined, otherwise return column_name. Some
         engines require forcing quotes around column name, in which case this method
         can be overridden."""
-        return expression if expression else column_name
+        return expression or column_name
 
 
 class PostgresBaseEngineSpec(BaseEngineSpec):
@@ -520,7 +520,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
     def get_timestamp_column(expression, column_name):
         """Postgres is unable to identify mixed case column names unless they
         are quoted."""
-        return expression if expression else f'"{column_name}"'
+        return expression or f'"{column_name}"'
 
 
 class SnowflakeEngineSpec(PostgresBaseEngineSpec):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -463,6 +463,13 @@ class BaseEngineSpec(object):
             label = label[:cls.max_column_name_length]
         return label
 
+    @staticmethod
+    def get_timestamp_column(expression, column_name):
+        """Return the expression if defined, otherwise return column_name. Some
+        engines require forcing quotes around column name, in which case this method
+        can be overridden."""
+        return expression if expression else column_name
+
 
 class PostgresBaseEngineSpec(BaseEngineSpec):
     """ Abstract class for Postgres 'like' databases """
@@ -508,6 +515,12 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
         tables = inspector.get_table_names(schema)
         tables.extend(inspector.get_foreign_table_names(schema))
         return sorted(tables)
+
+    @staticmethod
+    def get_timestamp_column(expression, column_name):
+        """Postgres is unable to identify mixed case column names unless they
+        are quoted."""
+        return expression if expression else f'"{column_name}"'
 
 
 class SnowflakeEngineSpec(PostgresBaseEngineSpec):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -520,7 +520,11 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
     def get_timestamp_column(expression, column_name):
         """Postgres is unable to identify mixed case column names unless they
         are quoted."""
-        return expression or f'"{column_name}"'
+        if expression:
+            return expression
+        elif column_name.lower() != column_name:
+            return f'"{column_name}"'
+        return column_name
 
 
 class SnowflakeEngineSpec(PostgresBaseEngineSpec):

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -117,6 +117,39 @@ class DatabaseModelTestCase(SupersetTestCase):
         self.assertEquals(d.get('P1D').function, 'DATE({col})')
         self.assertEquals(d.get('Time Column').function, '{col}')
 
+    def test_postgres_expression_time_grain(self):
+        uri = 'postgresql+psycopg2://uid:pwd@localhost:5432/superset'
+        database = Database(sqlalchemy_uri=uri)
+        pdf, time_grain = '', 'P1D'
+        expression, column_name = 'coalesce(col1, col2)', ''
+        grain = database.grains_dict().get(time_grain)
+        col = database.db_engine_spec.get_timestamp_column(expression, column_name)
+        grain_expr = database.db_engine_spec.get_time_expr(col, pdf, time_grain, grain)
+        grain_expr_expected = grain.function.replace('{col}', expression)
+        self.assertEqual(grain_expr, grain_expr_expected)
+
+    def test_postgres_lowercase_col_time_grain(self):
+        uri = 'postgresql+psycopg2://uid:pwd@localhost:5432/superset'
+        database = Database(sqlalchemy_uri=uri)
+        pdf, time_grain = '', 'P1D'
+        expression, column_name = '', 'lowercase_col'
+        grain = database.grains_dict().get(time_grain)
+        col = database.db_engine_spec.get_timestamp_column(expression, column_name)
+        grain_expr = database.db_engine_spec.get_time_expr(col, pdf, time_grain, grain)
+        grain_expr_expected = grain.function.replace('{col}', column_name)
+        self.assertEqual(grain_expr, grain_expr_expected)
+
+    def test_postgres_mixedcase_col_time_grain(self):
+        uri = 'postgresql+psycopg2://uid:pwd@localhost:5432/superset'
+        database = Database(sqlalchemy_uri=uri)
+        pdf, time_grain = '', 'P1D'
+        expression, column_name = '', 'MixedCaseCol'
+        grain = database.grains_dict().get(time_grain)
+        col = database.db_engine_spec.get_timestamp_column(expression, column_name)
+        grain_expr = database.db_engine_spec.get_time_expr(col, pdf, time_grain, grain)
+        grain_expr_expected = grain.function.replace('{col}', f'"{column_name}"')
+        self.assertEqual(grain_expr, grain_expr_expected)
+
     def test_single_statement(self):
         main_db = get_main_database(db.session)
 

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -121,7 +121,7 @@ class DatabaseModelTestCase(SupersetTestCase):
         uri = 'postgresql+psycopg2://uid:pwd@localhost:5432/superset'
         database = Database(sqlalchemy_uri=uri)
         pdf, time_grain = '', 'P1D'
-        expression, column_name = 'coalesce(col1, col2)', ''
+        expression, column_name = 'COALESCE(lowercase_col, "MixedCaseCol")', ''
         grain = database.grains_dict().get(time_grain)
         col = database.db_engine_spec.get_timestamp_column(expression, column_name)
         grain_expr = database.db_engine_spec.get_time_expr(col, pdf, time_grain, grain)


### PR DESCRIPTION
Due to time grains being rendered as literal columns in `sqla/models.py`, engine-specific quoting logic is not applied. This causes mixed-case columns to fail on Postgres in timeseries graphs if a time grain is applied. There have been attempts to fix this by forcing quotes in the time grain; however, this caused time grains on expressions to stop working (see #3844 for context). This PR introduces a function in `db_engine_specs.py` to handle rendering of the expression being passed to the time grain, which for Postgres forces quotes around MixedCase column names, but not lower_case. This has been tested to work in all scenarios:
- expression with time grain
- expression without time grain
- column with time grain
- column without time grain

Fixes #5886

Before:
<img width="1198" alt="screenshot 2019-02-16 at 8 48 41" src="https://user-images.githubusercontent.com/33317356/52895840-97b5b900-31c8-11e9-9e85-5ab28f6e3871.png">
After:
<img width="1199" alt="screenshot 2019-02-16 at 8 49 55" src="https://user-images.githubusercontent.com/33317356/52895836-87054300-31c8-11e9-9fa5-4e1977e4584b.png">
