### PR TITLE
Erase previously shown chart on error

### DIFF
--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -88,12 +88,21 @@ class Chart extends React.PureComponent {
     });
   }
 
+  renderStackTraceMessage() {
+    const { chartAlert, chartStackTrace } = this.props;
+    return (
+      <StackTraceMessage
+        message={chartAlert}
+        link={queryResponse ? queryResponse.link : null}
+        stackTrace={chartStackTrace}
+      />);
+  }
+
   render() {
     const {
       width,
       height,
       chartAlert,
-      chartStackTrace,
       chartStatus,
       errorMessage,
       onQuery,
@@ -108,12 +117,7 @@ class Chart extends React.PureComponent {
     const isFaded = refreshOverlayVisible && !errorMessage;
     this.renderContainerStartTime = Logger.getTimestamp();
     if (chartStatus === 'failed') {
-      return (
-        <StackTraceMessage
-          message={chartAlert}
-          link={queryResponse ? queryResponse.link : null}
-          stackTrace={chartStackTrace}
-        />);
+      return this.renderStackTraceMessage();
     }
 
     return (

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -89,7 +89,7 @@ class Chart extends React.PureComponent {
   }
 
   renderStackTraceMessage() {
-    const { chartAlert, chartStackTrace } = this.props;
+    const { chartAlert, chartStackTrace, queryResponse } = this.props;
     return (
       <StackTraceMessage
         message={chartAlert}
@@ -106,7 +106,6 @@ class Chart extends React.PureComponent {
       chartStatus,
       errorMessage,
       onQuery,
-      queryResponse,
       refreshOverlayVisible,
     } = this.props;
 

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -107,6 +107,14 @@ class Chart extends React.PureComponent {
     const containerStyles = isLoading ? { height, width } : null;
     const isFaded = refreshOverlayVisible && !errorMessage;
     this.renderContainerStartTime = Logger.getTimestamp();
+    if (chartStatus === 'failed') {
+      return (
+        <StackTraceMessage
+          message={chartAlert}
+          link={queryResponse ? queryResponse.link : null}
+          stackTrace={chartStackTrace}
+        />);
+    }
 
     return (
       <ErrorBoundary onError={this.handleRenderContainerFailure} showMessage={false}>
@@ -116,14 +124,6 @@ class Chart extends React.PureComponent {
         >
 
           {isLoading && <Loading size={50} />}
-
-          {chartAlert && (
-            <StackTraceMessage
-              message={chartAlert}
-              link={queryResponse ? queryResponse.link : null}
-              stackTrace={chartStackTrace}
-            />
-          )}
 
           {!isLoading && !chartAlert && isFaded && (
             <RefreshChartOverlay

--- a/superset/assets/src/chart/chartReducer.js
+++ b/superset/assets/src/chart/chartReducer.js
@@ -48,6 +48,7 @@ export default function chartReducer(charts = {}, action) {
         chartStatus: 'success',
         queryResponse: action.queryResponse,
         chartUpdateEndTime: now(),
+        chartAlert: null,
       };
     },
     [actions.CHART_UPDATE_STARTED](state) {


### PR DESCRIPTION
### before
<img width="1614" alt="screen shot 2019-02-17 at 9 56 25 pm" src="https://user-images.githubusercontent.com/487433/52930842-f0876d80-32fe-11e9-8729-7ff909a1f5f7.png">

### after
<img width="1622" alt="screen shot 2019-02-17 at 9 54 56 pm" src="https://user-images.githubusercontent.com/487433/52930843-f41af480-32fe-11e9-8a2d-6cc62e7dfac4.png">

closes https://github.com/apache/incubator-superset/issues/6896