### PR TITLE
Fix database typeahead in SQL Lab

### DIFF
--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -111,7 +111,11 @@ export default class TableSelector extends React.PureComponent {
     if (data.result.length === 0) {
       this.props.handleError(t("It seems you don't have access to any database"));
     }
-    return data.result;
+    return data.result.map(row => ({
+      ...row,
+      // label is used for the typeahead
+      label: row.backend + ' ' + row.database_name,
+    }));
   }
   fetchTables(force, substr) {
     // This can be large so it shouldn't be put in the Redux store

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -114,7 +114,7 @@ export default class TableSelector extends React.PureComponent {
     return data.result.map(row => ({
       ...row,
       // label is used for the typeahead
-      label: row.backend + ' ' + row.database_name,
+      label: `${row.backend} ${row.database_name}`,
     }));
   }
   fetchTables(force, substr) {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1524,12 +1524,16 @@ class Superset(BaseSupersetView):
             db.session
             .query(models.Database)
             .filter_by(id=db_id)
-            .one()
+            .first()
         )
-        schemas = database.all_schema_names(cache=database.schema_cache_enabled,
+        if database:
+            schemas = database.all_schema_names(cache=database.schema_cache_enabled,
                                             cache_timeout=database.schema_cache_timeout,
                                             force=force_refresh)
-        schemas = security_manager.schemas_accessible_by_user(database, schemas)
+            schemas = security_manager.schemas_accessible_by_user(database, schemas)
+        else:
+            schemas = []
+
         return Response(
             json.dumps({'schemas': schemas}),
             mimetype='application/json')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1527,9 +1527,10 @@ class Superset(BaseSupersetView):
             .first()
         )
         if database:
-            schemas = database.all_schema_names(cache=database.schema_cache_enabled,
-                                            cache_timeout=database.schema_cache_timeout,
-                                            force=force_refresh)
+            schemas = database.all_schema_names(
+                cache=database.schema_cache_enabled,
+                cache_timeout=database.schema_cache_timeout,
+                force=force_refresh)
             schemas = security_manager.schemas_accessible_by_user(database, schemas)
         else:
             schemas = []


### PR DESCRIPTION
The typeahead for databases is currently not working in SQL Lab. This happens because the `options` passed to the component are missing a `label` attribute, which is used to power the typeahead.

I fixed this by adding a label composed of the database backend and name. This allows users to choose a database by typing its name, eg, "main", or by typing a backend type, eg, "mysql".

I also made the database async endpoint more robust when no databases are found. I came across an error while testing and decided to fix it, since it's somewhat related.