### PR TITLE
[fix] minor fix for Superset logger

### DIFF
--- a/superset/assets/src/components/OmniContainer.jsx
+++ b/superset/assets/src/components/OmniContainer.jsx
@@ -24,14 +24,11 @@ import { SupersetClient } from '@superset-ui/connection';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import Omnibar from 'omnibar';
 import {
-  Logger,
-  ActionLog,
   LOG_ACTIONS_OMNIBAR_TRIGGERED,
 } from '../logger/LogUtils';
 
 const propTypes = {
-  impressionId: PropTypes.string.isRequired,
-  dashboardId: PropTypes.number.isRequired,
+  logEvent: PropTypes.func.isRequired,
 };
 
 const getDashboards = query =>
@@ -71,20 +68,15 @@ class OmniContainer extends React.Component {
     if (controlOrCommand && isFeatureEnabled(FeatureFlag.OMNIBAR)) {
       const isK = event.key === 'k' || event.keyCode === 83;
       if (isK) {
+        this.props.logEvent(LOG_ACTIONS_OMNIBAR_TRIGGERED, {
+          show_omni: !this.state.showOmni,
+        });
+
         this.setState({ showOmni: !this.state.showOmni });
 
         document
           .getElementsByClassName('Omnibar')[0]
           .focus();
-
-        Logger.send(
-          new ActionLog({
-            impressionId: this.props.impressionId, // impo
-            source: 'dashboard',
-            sourceId: this.props.dashboardId, // sourceId: this.props.dashboardId
-            eventNames: LOG_ACTIONS_OMNIBAR_TRIGGERED,
-          }),
-        );
       }
     }
   }

--- a/superset/assets/src/dashboard/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/components/Dashboard.jsx
@@ -167,14 +167,9 @@ class Dashboard extends React.PureComponent {
   }
 
   render() {
-    const {
-      impressionId,
-      dashboardInfo: { id },
-    } = this.props;
-
     return (
       <React.Fragment>
-        <OmniContainer impressionId={impressionId} dashboardId={id} />
+        <OmniContainer logEvent={this.props.actions.logEvent} />
         <DashboardBuilder />
       </React.Fragment>
     );

--- a/superset/assets/src/dashboard/components/Header.jsx
+++ b/superset/assets/src/dashboard/components/Header.jsx
@@ -171,10 +171,10 @@ class Header extends React.PureComponent {
   }
 
   toggleEditMode() {
-    this.props.setEditMode(!this.props.editMode);
     this.props.logEvent(LOG_ACTIONS_TOGGLE_EDIT_DASHBOARD, {
-      editMode: !this.props.editMode,
+      edit_mode: !this.props.editMode,
     });
+    this.props.setEditMode(!this.props.editMode);
   }
 
   overwriteDashboard() {

--- a/superset/assets/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Tabs.jsx
@@ -109,7 +109,7 @@ class Tabs extends React.PureComponent {
       });
     } else if (tabIndex !== this.state.tabIndex) {
       this.props.logEvent(LOG_ACTIONS_SELECT_DASHBOARD_TAB, {
-        id: component.id,
+        tab_id: component.id,
         index: tabIndex,
       });
 


### PR DESCRIPTION
Add 2 minor fixes for Superset logger:

1. call logger before setState (which update state async way)
2. rename key id to tab_id
3. rename key editMode to edit_mode
4. fix log for omnibar.

@kristw @michellethomas 