### PR TITLE
Add a safety check before getting clientHeight

### DIFF
--- a/superset/assets/src/SqlLab/components/SouthPane.jsx
+++ b/superset/assets/src/SqlLab/components/SouthPane.jsx
@@ -64,7 +64,7 @@ export class SouthPane extends React.PureComponent {
   }
   // One layer of abstraction for easy spying in unit tests
   getSouthPaneHeight() {
-    return this.southPaneRef.current.clientHeight;
+    return this.southPaneRef.current ? this.southPaneRef.current.clientHeight : 0;
   }
   switchTab(id) {
     this.props.actions.setActiveSouthPaneTab(id);

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -122,7 +122,7 @@ class SqlEditor extends React.PureComponent {
   }
   // One layer of abstraction for easy spying in unit tests
   getSqlEditorHeight() {
-    return this.sqlEditorRef.current.clientHeight;
+    return this.sqlEditorRef.current ? this.sqlEditorRef.current.clientHeight : 0;
   }
   // Return the heights for the ace editor and the south pane as an object
   // given the height of the sql editor, north pane percent and south pane percent.


### PR DESCRIPTION
Seeing an intermittent repro of the `current` nodes of the sql editor and south pane refs returning null. Adding a safety check for both nodes.