### PR TITLE
[datasource editor] Add description and label fields

### DIFF
--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -83,6 +83,11 @@ function ColumnCollectionTable({
               label={t('Label')}
               control={<TextControl />}
             />
+            <Field
+              fieldKey="description"
+              label={t('Description')}
+              control={<TextControl />}
+            />
             {allowEditDataType &&
               <Field
                 fieldKey="type"

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -516,6 +516,11 @@ export class DatasourceEditor extends React.PureComponent {
           <FormContainer>
             <Fieldset>
               <Field
+                fieldKey="verbose_name"
+                label={t('Label')}
+                control={<TextControl />}
+              />
+              <Field
                 fieldKey="description"
                 label={t('Description')}
                 control={<TextControl />}


### PR DESCRIPTION
@mistercrunch 

Adds description field to Columns in datasource editor. Also adds label field to metrics.

Github Issue: https://github.com/apache/incubator-superset/issues/6926

