### PR TITLE
Show charts and dashboards based also on database permissions

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -105,7 +105,7 @@ SQLTable = Table(
     'tables',
     Model.metadata,
     Column('id', Integer, primary_key=True),
-    Column('database_id', Integer, ForeignKey('databases.id')),
+    Column('database_id', Integer, ForeignKey('dbs.id')),
     extend_existing=True)
 
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -156,15 +156,12 @@ class DashboardFilter(SupersetFilter):
             .filter(User.id == User.get_user_id())
         )
         query = query.filter(
-            or_(
-                Dash.id.in_(
-                    db.session.query(Dash.id)
-                    .distinct()
-                    .join(Dash.slices)
-                    .filter(Slice.id.in_(slice_ids_qry)),
-                ),
-                Dash.id.in_(owner_ids_qry),
-            ),
+            or_(Dash.id.in_(
+                db.session.query(Dash.id)
+                .distinct()
+                .join(Dash.slices)
+                .filter(Slice.id.in_(slice_ids_qry)),
+            ), Dash.id.in_(owner_ids_qry)),
         )
         return query
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -103,7 +103,7 @@ def is_owner(obj, user):
 
 SQLTable = Table(
     'tables',
-    Model.metadata,
+    Model.metadata,  # pylint: disable=no-member
     Column('id', Integer, primary_key=True),
     Column('database_id', Integer, ForeignKey('dbs.id')),
     extend_existing=True)


### PR DESCRIPTION
Currently, if a user has permission access to a given database, say `db1`, they will not see charts or dashboards created with datasources from that database unless they also have explicit permission to the datasource. For example, if we have:

1. A chart `chart1` created from a table `db1.table`;
2. A dashboard `dash1` containing `chart1`;
3. A user with permissions `database access on [db1].(id:2)`.

Currently, the user will not see `chart1` in the list of charts, nor `dash1` in the list of dashboards.

I fixed it by bringing additional permissions, joining chart to datasource to table to database. I tested by creating a new DB `db1`, and a new role that has permissions `[datasource access on [db1].(id:2), database access on [db1].(id:2)`. The user could see the chart and the dashboard correctly.

@mistercrunch not sure if this was a bug, but when I added `db1` the permission-view `database access on [db1].(id:2)` was not automatically created (the permission `database_access` obviously existed, and the view menu `[db1].(id:2)` was created correctly). I had to manually add a row to `ab_permission_view` connecting them.