### PR TITLE
Allow Gamma and Alpha to access '/users/userinfo/'

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -81,19 +81,24 @@ class SupersetSecurityManager(SecurityManager):
         'can_list',
     }
 
-    ALPHA_ONLY_PERMISSIONS = set([
+    ALPHA_ONLY_PERMISSIONS = {
         'muldelete',
         'all_database_access',
         'all_datasource_access',
-    ])
+    }
 
-    OBJECT_SPEC_PERMISSIONS = set([
+    OBJECT_SPEC_PERMISSIONS = {
         'database_access',
         'schema_access',
         'datasource_access',
         'metric_access',
         'can_only_access_owned_queries',
-    ])
+    }
+
+    ACCESSIBLE_PERMS = {
+        'can_userinfo',
+    }
+
 
     def get_schema_perm(self, database, schema):
         if schema:
@@ -386,15 +391,21 @@ class SupersetSecurityManager(SecurityManager):
             pvm.permission.name in self.ALPHA_ONLY_PERMISSIONS
         )
 
+    def is_accessible_to_all(self, pvm):
+        return pvm.permission.name in self.ACCESSIBLE_PERMS
+
     def is_admin_pvm(self, pvm):
         return not self.is_user_defined_permission(pvm)
 
     def is_alpha_pvm(self, pvm):
-        return not (self.is_user_defined_permission(pvm) or self.is_admin_only(pvm))
+        return (
+            not (self.is_user_defined_permission(pvm) or self.is_admin_only(pvm)) or
+            self.is_accessible_to_all(pvm)
+        )
 
     def is_gamma_pvm(self, pvm):
         return not (self.is_user_defined_permission(pvm) or self.is_admin_only(pvm) or
-                    self.is_alpha_only(pvm))
+                    self.is_alpha_only(pvm)) or self.is_accessible_to_all(pvm)
 
     def is_sql_lab_pvm(self, pvm):
         return (

--- a/superset/security.py
+++ b/superset/security.py
@@ -99,7 +99,6 @@ class SupersetSecurityManager(SecurityManager):
         'can_userinfo',
     }
 
-
     def get_schema_perm(self, database, schema):
         if schema:
             return '[{}].[{}]'.format(database, schema)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -189,7 +189,6 @@ class CoreTests(SupersetTestCase):
             assert_func('ResetPasswordView', view_menus)
             assert_func('RoleModelView', view_menus)
             assert_func('Security', view_menus)
-            assert_func('UserDBModelView', view_menus)
             assert_func('SQL Lab',
                         view_menus)
 

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -76,7 +76,7 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(('can_slice', 'Superset'), perm_set)
         self.assertIn(('can_explore', 'Superset'), perm_set)
         self.assertIn(('can_explore_json', 'Superset'), perm_set)
-        self.assertIn(('can_userinfo', 'Superset'), perm_set)
+        self.assertIn(('can_userinfo', 'UserDBModelView'), perm_set)
 
     def assert_can_alpha(self, perm_set):
         self.assert_can_all('SqlMetricInlineView', perm_set)
@@ -232,7 +232,7 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(('can_fave_slices', 'Superset'), gamma_perm_set)
         self.assertIn(('can_save_dash', 'Superset'), gamma_perm_set)
         self.assertIn(('can_slice', 'Superset'), gamma_perm_set)
-        self.assertIn(('can_userinfo', 'Superset'), gamma_perm_set)
+        self.assertIn(('can_userinfo', 'UserDBModelView'), gamma_perm_set)
 
     def test_views_are_secured(self):
         """Preventing the addition of unsecured views without has_access decorator"""

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -76,6 +76,7 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(('can_slice', 'Superset'), perm_set)
         self.assertIn(('can_explore', 'Superset'), perm_set)
         self.assertIn(('can_explore_json', 'Superset'), perm_set)
+        self.assertIn(('can_userinfo', 'Superset'), perm_set)
 
     def assert_can_alpha(self, perm_set):
         self.assert_can_all('SqlMetricInlineView', perm_set)
@@ -231,6 +232,7 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(('can_fave_slices', 'Superset'), gamma_perm_set)
         self.assertIn(('can_save_dash', 'Superset'), gamma_perm_set)
         self.assertIn(('can_slice', 'Superset'), gamma_perm_set)
+        self.assertIn(('can_userinfo', 'Superset'), gamma_perm_set)
 
     def test_views_are_secured(self):
         """Preventing the addition of unsecured views without has_access decorator"""


### PR DESCRIPTION
closes https://github.com/apache/incubator-superset/issues/4919