### PR TITLE
Add Bulgaria map to superset-ui-legacy-plugin-chart-country-map

### DIFF
--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -803,6 +803,10 @@
           "Brazil"
         ],
         [
+          "Bulgaria",
+          "Bulgaria"
+        ],
+        [
           "China",
           "China"
         ],

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -546,6 +546,7 @@ export const controls = {
     choices: [
       'Belgium',
       'Brazil',
+      'Bulgaria',
       'China',
       'Egypt',
       'France',


### PR DESCRIPTION
This pull request adds Bulgaria map to superset-ui-legacy-plugin-chart-country-map

[PR#2@apache-superset/superset-ui-plugins](https://github.com/apache-superset/superset-ui-plugins/pull/2) adds geojson