### PR TITLE
[SQL Lab] Removing display limit

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2437,13 +2437,9 @@ class Superset(BaseSupersetView):
                 '{}'.format(rejected_tables)), status=403)
 
         payload = utils.zlib_decompress_to_string(blob)
-        display_limit = app.config.get('DEFAULT_SQLLAB_LIMIT', None)
-        if display_limit:
-            payload_json = json.loads(payload)
-            payload_json['data'] = payload_json['data'][:display_limit]
         return json_success(
             json.dumps(
-                payload_json,
+                json.loads(payload),
                 default=utils.json_iso_dttm_ser,
                 ignore_nan=True,
             ),


### PR DESCRIPTION
We're run into issues were users in SQL Lab are expecting the number of records to be displayed to equal that of the `LIMIT` defined either in i) the SQL query, or ii) the UI limit component, however this is truncated to display only the default limit, and there's no mention of this to the user. Note when exporting to CSV the display limit is not applied.

Given that the `LIMIT` has already been applied during the compute (defaulting to the `DEFAULT_SQLLAB_LIMIT` if neither the query or UI component have been augmented) it seems prudent to not re-apply any additional limit when displaying the results. 

to: @jeffreythewang @kristw @michellethomas @mistercrunch @timifasubaa 