### PR TITLE
Fixes #6842: Refreshes all metadata and datasource

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -329,20 +329,23 @@ class Druid(BaseSupersetView):
         DruidCluster = ConnectorRegistry.sources['druid'].cluster_class
         for cluster in session.query(DruidCluster).all():
             cluster_name = cluster.cluster_name
+            valid_cluster = True
             try:
                 cluster.refresh_datasources(refreshAll=refreshAll)
             except Exception as e:
+                valid_cluster = False
                 flash(
                     "Error while processing cluster '{}'\n{}".format(
                         cluster_name, utils.error_msg_from_exception(e)),
                     'danger')
                 logging.exception(e)
-                return redirect('/druidclustermodelview/list/')
-            cluster.metadata_last_refreshed = datetime.now()
-            flash(
-                _('Refreshed metadata from cluster [{}]').format(
-                    cluster.cluster_name),
-                'info')
+                pass
+            if valid_cluster:
+                cluster.metadata_last_refreshed = datetime.now()
+                flash(
+                    _('Refreshed metadata from cluster [{}]').format(
+                        cluster.cluster_name),
+                    'info')
         session.commit()
         return redirect('/druiddatasourcemodelview/list/')
 


### PR DESCRIPTION
Fixes for #6842. I, myself, encountered this issue when one of the druid clusters IPs was wrong, I was not able to refresh metadata or load up the list of latest datasources.

Added logic to not throw any exceptions but set a `valid_cluster` boolean to just flash a warning for the invalid or irresponsive clusters.