### PR TITLE
[db migration] add parent ids into Dashboard layout metadata

### DIFF
--- a/superset/migrations/versions/80669c0097a6_add_parent_ids_in_dashboard_layout.py
+++ b/superset/migrations/versions/80669c0097a6_add_parent_ids_in_dashboard_layout.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add Parent ids in dashboard layout metadata
+
+Revision ID: 80669c0097a6
+Revises: c82ee8a39623
+Create Date: 2019-02-25 15:43:02.488328
+
+"""
+import json
+import logging
+
+from alembic import op
+from sqlalchemy import (
+    Column,
+    Integer,
+    Text,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+from alembic import op
+import sqlalchemy as sa
+
+from superset import db
+
+# revision identifiers, used by Alembic.
+revision = '80669c0097a6'
+down_revision = 'c82ee8a39623'
+
+Base = declarative_base()
+
+
+class Dashboard(Base):
+    """Declarative class to do query in upgrade"""
+    __tablename__ = 'dashboards'
+    id = Column(Integer, primary_key=True)
+    position_json = Column(Text)
+
+
+def add_parent_ids(node, layout):
+    if node:
+        current_id = node.get('id')
+        parents = list(node.get('parents') or [])
+        child_ids = node.get('children')
+
+        if child_ids and len(child_ids) > 0:
+            parents.append(current_id)
+            for child_id in child_ids:
+                child_node = layout.get(child_id)
+                child_node['parents'] = parents
+                add_parent_ids(child_node, layout)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    dashboards = session.query(Dashboard).all()
+    for i, dashboard in enumerate(dashboards):
+        print('adding parents for dashboard layout, id = {} ({}/{}) >>>>'.format(
+            dashboard.id,
+            i + 1,
+            len(dashboards),
+        ))
+        try:
+            layout = json.loads(dashboard.position_json or '{}')
+            if layout and layout['ROOT_ID']:
+                add_parent_ids(layout['ROOT_ID'], layout)
+
+            dashboard.position_json = json.dumps(
+                layout, indent=None, separators=(',', ':'), sort_keys=True)
+            session.merge(dashboard)
+        except Exception as e:
+            logging.exception(e)
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    dashboards = session.query(Dashboard).all()
+    for i, dashboard in enumerate(dashboards):
+        print('remove parents from dashboard layout, id = {} ({}/{}) >>>>'.format(
+            dashboard.id,
+            i + 1,
+            len(dashboards),
+        ))
+        try:
+            layout = json.loads(dashboard.position_json or '{}')
+            for key, item in layout.items():
+                if not isinstance(item, dict):
+                    continue
+                item.pop('parents', None)
+                layout[key] = item
+
+            dashboard.position_json = json.dumps(
+                layout, indent=None, separators=(',', ':'), sort_keys=True)
+            session.merge(dashboard)
+        except Exception as e:
+            logging.exception(e)
+
+    session.commit()
+    session.close()

--- a/superset/migrations/versions/c8beba38d316_.py
+++ b/superset/migrations/versions/c8beba38d316_.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""empty message
+
+Revision ID: c8beba38d316
+Revises: ('80669c0097a6', '45e7da7cfeba')
+Create Date: 2019-04-04 13:17:34.790917
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c8beba38d316'
+down_revision = ('80669c0097a6', '45e7da7cfeba')
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
This migration is to add parent ids for each UI element in dashboard layout metadata. This will be used by another feature (#6964): to provide a redirect link that can open dashboard in any tab.

Expected output:
<img width="421" alt="screen shot 2019-03-01 at 3 14 32 pm" src="https://user-images.githubusercontent.com/27990562/53791131-7bf72600-3edd-11e9-8cca-8913e0841c08.png">

We store dashboard layout metadata in a flatted tree structure. In old layout metadata, we only store children node for each UI component. This information is good enough for render dashboard from root element, and we always render first tab when dashboard opens. But If user want to see some information in other tab (or any chart in a nested tab), it will takes a few clicks to navigate to the point of interest.

This problem can be resolved if each UI component carries its parent node information. When we have parents list for each UI component, it's easy from dashboard root to render each parent id, and at last render the point of interest chart/tab.

Because this db migration is independent of UI change (do not block dashboard display), I will send out UI change in a different PR.

@john-bodley @michellethomas @kristw @williaster 