### PR TITLE
[sqla] Handling subquery error

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -795,6 +795,10 @@ class SqlaTable(Model, BaseDatasource):
                     'order_desc': True,
                 }
                 result = self.query(subquery_obj)
+
+                if result.status == utils.QueryStatus.FAILED:
+                    raise Exception(result.error_message)
+
                 dimensions = [
                     c for c in result.df.columns
                     if c not in metrics and c in groupby_exprs_sans_timestamp


### PR DESCRIPTION
This PR remedies an issue when a timeseries SQLAlchemy sub-query fails. Previously the status remained uncheck and thus the following exception would be thrown, 
```
'NoneType' object has no attribute 'columns'
```

I'm not certain what the best approach of handling this is, however given that: 

1. The `get_sqla_query` method is expected to return a named tuple containing a SQLAlchemy object (which isn't feasible given this context)
2. It's not apparent if the `SqlaTable.query` method is called in other contexts, i.e., I'm not certain it make sense to mutate this method.
3. Other exceptions (of type `Exception`) are thrown in the `get_sqla_query` method.

it seemed prudent to simply throw the error as an exception.

to: @betodealmeida @michellethomas @mistercrunch 