### PR TITLE
Run in SQL Lab from Explore View doesn't work for new charts

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -249,7 +249,10 @@ export function runQuery(formData, force = false, timeout = 60, key) {
 export function redirectSQLLab(formData) {
   return (dispatch) => {
     const { url } = getExploreUrlAndPayload({ formData, endpointType: 'query' });
-    return SupersetClient.get({ url })
+    return SupersetClient.post({
+      url,
+      postPayload: { form_data: formData },
+    })
       .then(({ json }) => {
         const redirectUrl = new URL(window.location);
         redirectUrl.pathname = '/superset/sqllab';


### PR DESCRIPTION
When we try to run a query in SQL lab from the explore view, we send a request with the slice id. The backend gets the query associated with this slice id. New and unsaved charts do not have a slice id associated with it yet, and so we cannot find a query for an undefined slice id. Instead of sending a GET request with the slice id, we should send a POST request with all the form data.