### PR TITLE
Exclude venv for python linter to ignore

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ exclude =
     superset/data
     superset/migrations
     superset/templates
+    venv
 ignore =
     FI12
     FI15


### PR DESCRIPTION
When we use tox to lint python files, it fails because it looks through the directory created by virtualenv. This directory contains a file that purposely has an error for testing purposes. We should ignore this directory created by virtualenv. 

Note that we will still get linter errors if users name their directory other than "venv" but since this name is commonly used, it is still worth add this directory to the tox.ini file.

Kudos to @betodealmeida for helping me.