### PR TITLE
[csv-upload] Fixing message encoding

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -401,7 +401,7 @@ class CsvToDatabaseView(SimpleFormView):
             except OSError:
                 pass
             message = 'Table name {} already exists. Please pick another'.format(
-                form.name.data) if isinstance(e, IntegrityError) else e
+                form.name.data) if isinstance(e, IntegrityError) else str(e)
             flash(
                 message,
                 'danger')


### PR DESCRIPTION
This PR fixes an issue where if an error was thrown whilst trying to upload a CSV it would result in a 500 error with the following error, 
```
builtins:TypeError: Object of type Exception is not JSON serializable
```
which provided no context to the user what was invalid with their configuration. The reason for the error was the message which was being flashed was of type `Exception` (which is not JSON encodable) rather than `str`.

to: @graceguo-supercat @michellethomas @mistercrunch @timifasubaa 