### PR TITLE
Sparkline dates aren't formatting in Time Series Table

### DIFF
--- a/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
@@ -148,7 +148,7 @@ class TimeTable extends React.PureComponent {
           renderTooltip={({ index }) => (
             <div>
               <strong>{formatNumber(column.d3format, sparkData[index])}</strong>
-              <div>{formatTime(column.dateFormat, entries[index].time)}</div>
+              <div>{formatTime(column.dateFormat, new Date(entries[index].time))}</div>
             </div>
           )}
         />

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ exclude =
     superset/data
     superset/migrations
     superset/templates
+    venv
 ignore =
     FI12
     FI15


### PR DESCRIPTION
We were passing a string to the smartDateFormatter function when it expects a Date object. The date displayed may still not be what the user expects but at least a NaN error is no longer displayed and the user can update the chart's date format.