### PR TITLE
Fix time filter control

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -914,7 +914,7 @@ export const controls = {
     'The options here are defined on a per database ' +
     'engine basis in the Superset source code.'),
     mapStateToProps: state => ({
-      choices: (state.datasource) ? state.datasource.time_grain_sqla : null,
+      choices: (state.datasource) ? state.datasource.timeGrainSqla : null,
     }),
   },
 


### PR DESCRIPTION
Found another bug where the snake -> camel case conversion broke things. The filter box is not showing any values for the granularity control because of this.