### PR TITLE
fix(Chart data in Edit mode): Chart data is not shown after charts being added in Dashboard edit mode

### DIFF
--- a/superset/assets/src/dashboard/actions/datasources.js
+++ b/superset/assets/src/dashboard/actions/datasources.js
@@ -46,7 +46,7 @@ export function fetchDatasourceMetadata(key) {
     return SupersetClient.get({
       endpoint: `/superset/fetch_datasource_metadata?datasourceKey=${key}`,
     })
-      .then(data => dispatch(setDatasource(data, key)))
+      .then(({ json }) => dispatch(setDatasource(json, key)))
       .catch(response =>
         getClientErrorObject(response).then(({ error }) =>
           dispatch(fetchDatasourceFailed(error, key)),


### PR DESCRIPTION
Chart data is not shown after charts being added by dashboard edit mode event by force refresh option it is not showing —it required browser refresh

**Scenario:**
Chart data is not shown after charts being added in dashboard edit mode event by force refresh option it is not showing —it required browser refresh

**Test Steps:**
Chart data is not shown after charts being added in dashboard edit mode event by force refresh option it is not showing —it required browser refresh

**Expected Result:**
Data should be displayed