### PR TITLE
Remove unused "get_or_create_main_db" statements

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -49,7 +49,6 @@ def make_shell_context():
 @app.cli.command()
 def init():
     """Inits the Superset application"""
-    utils.get_or_create_main_db()
     security_manager.sync_role_definitions()
 
 
@@ -457,7 +456,6 @@ def load_test_users_run():
         gamma_sqllab_role = security_manager.add_role('gamma_sqllab')
         for perm in security_manager.find_role('Gamma').permissions:
             security_manager.add_permission_role(gamma_sqllab_role, perm)
-        utils.get_or_create_main_db()
         db_perm = utils.get_main_database(security_manager.get_session).perm
         security_manager.merge_perm('database_access', db_perm)
         db_pvm = security_manager.find_permission_view_menu(


### PR DESCRIPTION
@michellethomas @timifasubaa , any idea why this was added originally? `git blame` points to there SHAs:
* 8dd052de4 - PR: https://github.com/apache/incubator-superset/pull/4565/files
* d40ded0be - PR: https://github.com/apache/incubator-superset/pull/5693 (appears unrelated, statement was only moved here...)