### PR TITLE
Add support for postgres bytea type

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -340,6 +340,8 @@ def base_json_conv(obj):
         return str(obj)
     elif isinstance(obj, timedelta):
         return str(obj)
+    elif isinstance(obj, memoryview):
+        return str(obj.tobytes(), 'utf8')
     elif isinstance(obj, bytes):
         try:
             return '{}'.format(obj)


### PR DESCRIPTION
Psycopg2 returns a `memoryview` object for `bytea` type, which can be read by calling `.tobytes()`. Fixes #6981 

# Before:
<img width="779" alt="screenshot 2019-03-07 at 7 33 45" src="https://user-images.githubusercontent.com/33317356/53934440-8f57ec00-40ab-11e9-868a-a16b419c5aa7.png">
<img width="705" alt="screenshot 2019-03-07 at 7 33 57" src="https://user-images.githubusercontent.com/33317356/53934446-93840980-40ab-11e9-98be-8f948f9782ca.png">

# After
<img width="947" alt="screenshot 2019-03-06 at 21 33 04" src="https://user-images.githubusercontent.com/33317356/53908363-d916e700-4057-11e9-8763-baf6dbe14ffb.png">
<img width="702" alt="screenshot 2019-03-07 at 7 33 10" src="https://user-images.githubusercontent.com/33317356/53934428-79e2c200-40ab-11e9-87a3-6371db88a7d1.png">