### PR TITLE
[fix] /superset/slice/id url is too long

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1111,7 +1111,7 @@ class Superset(BaseSupersetView):
         if not slc:
             abort(404)
         endpoint = '/superset/explore/?form_data={}'.format(
-            parse.quote(json.dumps(form_data)),
+            parse.quote(json.dumps({'slice_id': slice_id})),
         )
         if request.args.get('standalone') == 'true':
             endpoint += '&standalone=true'


### PR DESCRIPTION
Superset supports endpoint like `/superset/slice/_id_` for explore view. Currently we redirect to full url with all slice's params. But if slice has very long parameter list (> 2000 characters with url encoded), our nginx will block it.

Solution: redirect to explore view endpoint: `/superset/explore/?form_data={slice_id:_id_}`

@john-bodley @mistercrunch 