### PR TITLE
Hit cache when viewing results in explore view

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1142,7 +1142,7 @@ class Superset(BaseSupersetView):
 
     def get_raw_results(self, viz_obj):
         return self.json_response({
-            'data': viz_obj.get_df().to_dict('records'),
+            'data': viz_obj.get_df_payload()['df'].to_dict('records'),
         })
 
     def get_samples(self, viz_obj):


### PR DESCRIPTION
Currently pressing `View results` in Explore view calls `viz.get_df()`, which forces retrieval of data from the source. By calling `viz.get_df_payload()`, we can first check if the result is already cached.