### PR TITLE
Fix groupable only columns populating in filters

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1966,7 +1966,7 @@ export const controls = {
     default: null,
     description: '',
     mapStateToProps: state => ({
-      columns: state.datasource ? state.datasource.columns : [],
+      columns: state.datasource ? state.datasource.columns.filter(c => c.filterable) : [],
       savedMetrics: state.datasource ? state.datasource.metrics : [],
       datasource: state.datasource,
     }),


### PR DESCRIPTION
This pull requests fixes an issue where columns defined as groupable only, show up in the filters as well

Fixes this issue #6949