### PR TITLE
feat: improvements to "big number" visualization

### DIFF
--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -2493,9 +2493,9 @@
       "default": "150",
       "description": "Font size for the biggest value in the list"
     },
-    "big_num_font_size": {
+    "header_font_size": {
       "type": "SelectControl",
-      "label": "Big Number Font Size",
+      "label": "Header Font Size",
       "renderTrigger": true,
       "clearable": false,
       "default": 0.3,

--- a/superset/assets/backendSync.json
+++ b/superset/assets/backendSync.json
@@ -2493,6 +2493,64 @@
       "default": "150",
       "description": "Font size for the biggest value in the list"
     },
+    "big_num_font_size": {
+      "type": "SelectControl",
+      "label": "Big Number Font Size",
+      "renderTrigger": true,
+      "clearable": false,
+      "default": 0.3,
+      "options": [
+        {
+          "label": "Tiny",
+          "value": 0.125
+        },
+        {
+          "label": "Small",
+          "value": 0.2
+        },
+        {
+          "label": "Normal",
+          "value": 0.3
+        },
+        {
+          "label": "Large",
+          "value": 0.4
+        },
+        {
+          "label": "Huge",
+          "value": 0.5
+        }
+      ]
+    },
+    "subheader_font_size": {
+      "type": "SelectControl",
+      "label": "Subheader Font Size",
+      "renderTrigger": true,
+      "clearable": false,
+      "default": 0.125,
+      "options": [
+        {
+          "label": "Tiny",
+          "value": 0.125
+        },
+        {
+          "label": "Small",
+          "value": 0.2
+        },
+        {
+          "label": "Normal",
+          "value": 0.3
+        },
+        {
+          "label": "Large",
+          "value": 0.4
+        },
+        {
+          "label": "Huge",
+          "value": 0.5
+        }
+      ]
+    },
     "instant_filtering": {
       "type": "CheckboxControl",
       "label": "Instant Filtering",

--- a/superset/assets/src/explore/controlPanels/BigNumber.js
+++ b/superset/assets/src/explore/controlPanels/BigNumber.js
@@ -29,13 +29,21 @@ export default {
       ],
     },
     {
-      label: t('Chart Options'),
+      label: t('Options'),
       expanded: true,
       controlSetRows: [
         ['compare_lag', 'compare_suffix'],
         ['y_axis_format', null],
         ['show_trend_line', 'start_y_axis_at_zero'],
+      ],
+    },
+    {
+      label: t('Chart Options'),
+      expanded: true,
+      controlSetRows: [
         ['color_picker', null],
+        ['big_num_font_size'],
+        ['subheader_font_size'],
       ],
     },
   ],

--- a/superset/assets/src/explore/controlPanels/BigNumber.js
+++ b/superset/assets/src/explore/controlPanels/BigNumber.js
@@ -42,7 +42,7 @@ export default {
       expanded: true,
       controlSetRows: [
         ['color_picker', null],
-        ['big_num_font_size'],
+        ['header_font_size'],
         ['subheader_font_size'],
       ],
     },
@@ -50,6 +50,9 @@ export default {
   controlOverrides: {
     y_axis_format: {
       label: t('Number format'),
+    },
+    header_font_size: {
+      label: t('Big Number Font Size'),
     },
   },
 };

--- a/superset/assets/src/explore/controlPanels/BigNumberTotal.js
+++ b/superset/assets/src/explore/controlPanels/BigNumberTotal.js
@@ -29,11 +29,19 @@ export default {
       ],
     },
     {
-      label: t('Chart Options'),
+      label: t('Options'),
       expanded: true,
       controlSetRows: [
         ['subheader'],
         ['y_axis_format'],
+      ],
+    },
+    {
+      label: t('Chart Options'),
+      expanded: true,
+      controlSetRows: [
+        ['big_num_font_size'],
+        ['subheader_font_size'],
       ],
     },
   ],

--- a/superset/assets/src/explore/controlPanels/BigNumberTotal.js
+++ b/superset/assets/src/explore/controlPanels/BigNumberTotal.js
@@ -40,7 +40,7 @@ export default {
       label: t('Chart Options'),
       expanded: true,
       controlSetRows: [
-        ['big_num_font_size'],
+        ['header_font_size'],
         ['subheader_font_size'],
       ],
     },
@@ -48,6 +48,9 @@ export default {
   controlOverrides: {
     y_axis_format: {
       label: t('Number format'),
+    },
+    header_font_size: {
+      label: t('Big Number Font Size'),
     },
   },
 };

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1399,9 +1399,9 @@ export const controls = {
     description: t('Font size for the biggest value in the list'),
   },
 
-  big_num_font_size: {
+  header_font_size: {
     type: 'SelectControl',
-    label: t('Big Number Font Size'),
+    label: t('Header Font Size'),
     renderTrigger: true,
     clearable: false,
     default: 0.3,

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1405,6 +1405,7 @@ export const controls = {
     renderTrigger: true,
     clearable: false,
     default: 0.3,
+    // Values represent the percentage of space a header should take
     options: [
       {
         label: t('Tiny'),
@@ -1435,6 +1436,7 @@ export const controls = {
     renderTrigger: true,
     clearable: false,
     default: 0.125,
+    // Values represent the percentage of space a subheader should take
     options: [
       {
         label: t('Tiny'),

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1399,6 +1399,66 @@ export const controls = {
     description: t('Font size for the biggest value in the list'),
   },
 
+  big_num_font_size: {
+    type: 'SelectControl',
+    label: t('Big Number Font Size'),
+    renderTrigger: true,
+    clearable: false,
+    default: 0.3,
+    options: [
+      {
+        label: t('Tiny'),
+        value: 0.125,
+      },
+      {
+        label: t('Small'),
+        value: 0.2,
+      },
+      {
+        label: t('Normal'),
+        value: 0.3,
+      },
+      {
+        label: t('Large'),
+        value: 0.4,
+      },
+      {
+        label: t('Huge'),
+        value: 0.5,
+      },
+    ],
+  },
+
+  subheader_font_size: {
+    type: 'SelectControl',
+    label: t('Subheader Font Size'),
+    renderTrigger: true,
+    clearable: false,
+    default: 0.125,
+    options: [
+      {
+        label: t('Tiny'),
+        value: 0.125,
+      },
+      {
+        label: t('Small'),
+        value: 0.2,
+      },
+      {
+        label: t('Normal'),
+        value: 0.3,
+      },
+      {
+        label: t('Large'),
+        value: 0.4,
+      },
+      {
+        label: t('Huge'),
+        value: 0.5,
+      },
+    ],
+  },
+
   instant_filtering: {
     type: 'CheckboxControl',
     label: t('Instant Filtering'),


### PR DESCRIPTION
Corresponding PR to https://github.com/apache-superset/superset-ui-plugins/pull/10.

I have added some dropdowns to allow font sizing for Big Number and its subheader. Because the font size is dynamic, the choices are tiny, small, normal, large, or huge font. I chose numbers that seemed reasonable but can definitely update them if there are objections.

Screenshots:

<img width="1196" alt="Big Number Tiny Font Size" src="https://user-images.githubusercontent.com/47833996/54060688-8d2c8500-41b2-11e9-81b8-8b9832fccb13.png">

<img width="1199" alt="Big Number Small Font Size" src="https://user-images.githubusercontent.com/47833996/54060693-90277580-41b2-11e9-9a31-ca65e8209261.png">

<img width="1199" alt="Default Font Sizes" src="https://user-images.githubusercontent.com/47833996/54060697-91f13900-41b2-11e9-9194-fe54e89a8e80.png">

<img width="1196" alt="Big Number Large Font Size" src="https://user-images.githubusercontent.com/47833996/54060701-9584c000-41b2-11e9-8376-4c3448ee355c.png">

<img width="1198" alt="Big Number Huge Font Size" src="https://user-images.githubusercontent.com/47833996/54060707-99184700-41b2-11e9-83c1-eb578a032435.png">
