### PR TITLE
[db-engine-spec] Aligning Hive/Presto partition logic

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -977,16 +977,16 @@ class PrestoEngineSpec(BaseEngineSpec):
         except Exception:
             # table is not partitioned
             return False
-        for c in columns:
-            if c.get('name') == col_name:
-                return qry.where(Column(col_name) == value)
+        if value is not None:
+            for c in columns:
+                if c.get('name') == col_name:
+                    return qry.where(Column(col_name) == value)
         return False
 
     @classmethod
     def _latest_partition_from_df(cls, df):
-        recs = df.to_records(index=False)
-        if recs:
-            return recs[0][0]
+        if not df.empty:
+            return df.to_records(index=False)[0][0]
 
     @classmethod
     def latest_partition(cls, table_name, schema, database, show_first=False):
@@ -1003,7 +1003,7 @@ class PrestoEngineSpec(BaseEngineSpec):
         :type show_first: bool
 
         >>> latest_partition('foo_table')
-        '2018-01-01'
+        ('ds', '2018-01-01')
         """
         indexes = database.get_indexes(table_name, schema)
         if len(indexes[0]['column_names']) < 1:
@@ -1321,9 +1321,10 @@ class HiveEngineSpec(PrestoEngineSpec):
         except Exception:
             # table is not partitioned
             return False
-        for c in columns:
-            if c.get('name') == col_name:
-                return qry.where(Column(col_name) == value)
+        if value is not None:
+            for c in columns:
+                if c.get('name') == col_name:
+                    return qry.where(Column(col_name) == value)
         return False
 
     @classmethod
@@ -1334,7 +1335,8 @@ class HiveEngineSpec(PrestoEngineSpec):
     @classmethod
     def _latest_partition_from_df(cls, df):
         """Hive partitions look like ds={partition name}"""
-        return df.ix[:, 0].max().split('=')[1]
+        if not df.empty:
+            return df.ix[:, 0].max().split('=')[1]
 
     @classmethod
     def _partition_query(


### PR DESCRIPTION
This PR remedies a couple of issues related to Hive/Presto partitions. Specifically:

1. For Hive there was no check to see whether the Pandas Dataframe was empty and thus an exception was raised when trying to obtain the `_latest_partition_from_df`. For context this same issue was resolved for Presto in https://github.com/apache/incubator-superset/pull/2740.

2. Added a check that if the partition value is explicitly `None` to ensure that the query isn't mutated to include a non-valid `WHERE` clause. The methods simply return `False` (which is somewhat of a strange return value) which is consistent with other invalid scenarios. 

Note for (1) this wasn't an issue for [`where_latest_partition`](https://github.com/apache/incubator-superset/blob/master/superset/db_engine_specs.py#L1325) as the exception was caught, however it was problematic for the `extra_table_metadata` which is used in SQL Lab for fetching the preview. 

to: @michellethomas @mistercrunch 