### PR TITLE
fix: Gunicorn raise encoding error

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -320,7 +320,8 @@ class CsvResponse(Response):
     """
     Override Response to take into account csv encoding from config.py
     """
-    charset = conf.get('CSV_EXPORT').get('encoding', 'utf-8')
+    _charset = conf.get('CSV_EXPORT').get('encoding', 'utf-8')
+    charset = 'utf-8' if _charset.lower() == 'utf-8-sig' else _charset
 
 
 def check_ownership(obj, raise_if_false=True):


### PR DESCRIPTION
according to: 
https://github.com/apache/incubator-superset/issues/5377
https://github.com/benoitc/gunicorn/issues/1778

on Python3 gunicorn encoding header by ascii, not support 'utf-8-sig' charset, 
![image](https://user-images.githubusercontent.com/2016594/54177221-7648a400-44cc-11e9-916f-e604c9e986d1.png), so we need replace utf-8-sig charset for header encoding