### PR TITLE
fix(filterbox): fixed  runtime exception in filterbox for allow multiple selection false

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -808,7 +808,7 @@ def merge_extra_filters(form_data):
             if date_options.get(filtr['col']):
                 if filtr.get('val'):
                     form_data[date_options[filtr['col']]] = filtr['val']
-            elif filtr['val'] and len(filtr['val']):
+            elif filtr['val']:
                 # Merge column filters
                 filter_key = get_filter_key(filtr)
                 if filter_key in existing_filters:


### PR DESCRIPTION
<img width="1428" alt="Screenshot 2019-03-01 at 9 33 25 AM" src="https://user-images.githubusercontent.com/13414728/54177381-09c3aa00-44b8-11e9-9a55-507e4edb5c88.png">

```
Exception message 
2019-03-11 09:48:21,130:ERROR:root:object of type 'int' has no len()
Traceback (most recent call last):
  File "//projects/open-source/incubator-superset/superset/views/base.py", line 113, in wraps
    return f(self, *args, **kwargs)
  File "/projects/open-source/incubator-superset/superset/views/core.py", line 1251, in explore_json
    samples=samples,
  File "/projects/open-source/incubator-superset/superset/views/core.py", line 1182, in generate_json
    payload = viz_obj.get_payload()
  File "/projects/open-source/incubator-superset/superset/viz.py", line 387, in get_payload
    payload = self.get_df_payload(query_obj)
  File "/projects/open-source/incubator-superset/superset/viz.py", line 402, in get_df_payload
    query_obj = self.query_obj()
  File "/projects/open-source/incubator-superset/superset/viz.py", line 543, in query_obj
    d = super(TableViz, self).query_obj()
  File "/projects/open-source/incubator-superset/superset/viz.py", line 276, in query_obj
    self.process_query_filters()
  File "/projects/open-source/incubator-superset/superset/viz.py", line 270, in process_query_filters
    merge_extra_filters(self.form_data)
  File "/projects/open-source/incubator-superset/superset/utils/core.py", line 811, in merge_extra_filters
    elif filtr['val'] and len(filtr['val']):
TypeError: object of type 'int' has no len()
```