### PR TITLE
[table] highlight selected <td>s

### DIFF
--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -536,3 +536,6 @@ tr.reactable-column-header th.reactable-header-sortable {
 .align-right {
   text-align: right;
 }
+td.filtered {
+  background-color: lighten(desaturate(@brand-primary, 50%), 50%);
+}


### PR DESCRIPTION
Would fix: https://github.com/apache/incubator-superset/issues/4481, https://github.com/apache/incubator-superset/issues/6799
<img width="765" alt="Screen Shot 2019-03-12 at 12 07 55 AM" src="https://user-images.githubusercontent.com/487433/54181275-40b7a280-445b-11e9-9f7c-6e4587e5053d.png">


Maybe it should be fixed here instead, though `@brand-primary` can't be in the less/css context there:
https://github.com/apache-superset/superset-ui-plugins/blob/master/packages/superset-ui-legacy-plugin-chart-table/src/Table.css