### PR TITLE
FIX Hive Database connection  - TTransportException: TSocket read 0 bytes

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get install -y apt-transport-https apt-utils
 # Install superset dependencies
 # https://superset.incubator.apache.org/installation.html#os-dependencies
 RUN apt-get install -y build-essential libssl-dev \
-    libffi-dev python3-dev libsasl2-dev libldap2-dev libxi-dev
+    libffi-dev python3-dev libsasl2-dev libldap2-dev libsasl2-2 libsasl2-modules-gssapi-mit libxi-dev
 
 # Install extra useful tool for development
 RUN apt-get install -y vim less postgresql-client redis-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,6 +29,8 @@ pyhive==0.6.1
 pylint==1.9.2
 python-dotenv==0.10.1
 redis==2.10.6
+sasl==0.2.1
 statsd==3.3.0
 thrift==0.11.0
+thrift_sasl==0.3.0
 tox==3.5.3


### PR DESCRIPTION
We were unable to connect to our cluster until we added additional dependencies.

We dived into following errors: 
`SASL Error: no mechanism available: No worthy mechs found`
or `thrift.transport.TTransport.TTransportException: TSocket read 0 bytes ` 
I found this solution at https://github.com/cloudera/impyla/issues/149 and successfully tested it.
