### PR TITLE
bug: fix timetable viz tooltip time format

### DIFF
--- a/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
@@ -23,6 +23,7 @@ import { scaleLinear } from 'd3-scale';
 import { Table, Thead, Th, Tr, Td } from 'reactable-arc';
 import { formatNumber } from '@superset-ui/number-format';
 import { formatTime } from '@superset-ui/time-format';
+import moment from 'moment';
 
 import MetricOption from '../../components/MetricOption';
 import InfoTooltipWithTrigger from '../../components/InfoTooltipWithTrigger';
@@ -148,7 +149,7 @@ class TimeTable extends React.PureComponent {
           renderTooltip={({ index }) => (
             <div>
               <strong>{formatNumber(column.d3format, sparkData[index])}</strong>
-              <div>{formatTime(column.dateFormat, entries[index].time)}</div>
+              <div>{formatTime(column.dateFormat, moment.utc(entries[index].time).toDate())}</div>
             </div>
           )}
         />


### PR DESCRIPTION
We've been seeing issues with the tooltip on time table not showing up correctly (shows up as NaN-NaN-NaN). It seems that formatTime expects a date not a string. I can also change superset-ui to accept a string, but figured this was a pretty easy change.

Test plan
Tested the tooltips time series tables with dates formatted as (`2019-01-01` and `2019-01-01 00:00:00`)

@kristw 