### PR TITLE
Fix the white background shown in SQL editor on drag

### DIFF
--- a/superset/assets/src/SqlLab/main.less
+++ b/superset/assets/src/SqlLab/main.less
@@ -294,7 +294,7 @@ div.tablePopover:hover {
     margin-top: 5px;
 }
 
-.ace_content {
+.ace_scroller {
     background-color: #f4f4f4;
 }
 


### PR DESCRIPTION
This PR sets the background-color css property on `.ace_scroller` instead of `.ace_content` to prevent the white background shown (see example below) during resizing of the SQL editor before drag ends.

![image](https://user-images.githubusercontent.com/1521435/54253170-fdb50800-450a-11e9-8c9e-c47903069ac0.png)
