### PR TITLE
fix user specified JSON metadata not updating dashboard on refresh

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -633,8 +633,9 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
     }
 
     def pre_add(self, obj):
-        obj.slug = obj.slug.strip() or None
+        obj.slug = obj.slug or None
         if obj.slug:
+            obj.slug = obj.slug.strip()
             obj.slug = obj.slug.replace(' ', '-')
             obj.slug = re.sub(r'[^\w\-]+', '', obj.slug)
         if g.user not in obj.owners:


### PR DESCRIPTION
[Issue referenced](https://github.com/apache/incubator-superset/issues/6961)

This PR aims to fix a bug which prevented a user from overriding chart colors by editing dashboard JSON Metadata. User received an error when clicking Save in the Edit Dashboard screen which prevented users from adding user defined chart colors.

