### PR TITLE
[sqlparse] Fixing table name extraction for ill-defined query

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -76,7 +76,7 @@ class ParsedQuery(object):
 
     @staticmethod
     def __get_full_name(identifier):
-        if len(identifier.tokens) > 1 and identifier.tokens[1].value == '.':
+        if len(identifier.tokens) > 2 and identifier.tokens[1].value == '.':
             return '{}.{}'.format(identifier.tokens[0].value,
                                   identifier.tokens[2].value)
         return identifier.get_real_name()
@@ -89,8 +89,8 @@ class ParsedQuery(object):
         # exclude subselects
         if '(' not in str(identifier):
             table_name = self.__get_full_name(identifier)
-            if not table_name.startswith(CTE_PREFIX):
-                self._table_names.add(self.__get_full_name(identifier))
+            if table_name and not table_name.startswith(CTE_PREFIX):
+                self._table_names.add(table_name)
             return
 
         # store aliases

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -47,6 +47,11 @@ class SupersetTestCase(unittest.TestCase):
             {'schemaname.tbname'},
             self.extract_tables('SELECT * FROM schemaname.tbname'))
 
+        # Ill-defined schema/table.
+        self.assertEquals(
+            set(),
+            self.extract_tables('SELECT * FROM schemaname.'))
+
         # quotes
         query = 'SELECT field1, field2 FROM tb_name'
         self.assertEquals({'tb_name'}, self.extract_tables(query))


### PR DESCRIPTION
This PR fixes an issue is someone has an ill-defined table name in SQL Lab i.e. `schema.` resulting in a IndexError being thrown because of an incorrect check. 

to: @betodealmeida @michellethomas @mistercrunch  