### PR TITLE
[Bug Fix]Inaccurate data calculation with data rolling and contribution together

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1184,10 +1184,6 @@ class NVD3TimeSeriesViz(NVD3Viz):
             dfs.sort_values(ascending=False, inplace=True)
             df = df[dfs.index]
 
-        if fd.get('contribution'):
-            dft = df.T
-            df = (dft / dft.sum()).T
-
         rolling_type = fd.get('rolling_type')
         rolling_periods = int(fd.get('rolling_periods') or 0)
         min_periods = int(fd.get('min_periods') or 0)
@@ -1206,6 +1202,10 @@ class NVD3TimeSeriesViz(NVD3Viz):
             df = df.cumsum()
         if min_periods:
             df = df[min_periods:]
+
+        if fd.get('contribution'):
+            dft = df.T
+            df = (dft / dft.sum()).T
 
         return df
 


### PR DESCRIPTION
This PR is to fix the inaccurate data calculation when users use the advanced data rolling functions and `contribution` together.  

Before:  contribution is calculated before applying rolling window, which could cause the sum of contributions for one date is not equal to 1.

After:  apply rolling window first, then calculate contribution. 

@john-bodley @mistercrunch @soboko 