### PR TITLE
[datasource] Ensuring consistent behavior of datasource editing/saving.

### DIFF
--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -25,7 +25,7 @@ from flask_babel import gettext as __
 from superset import appbuilder, db
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.models.core import Database
-from .base import BaseSupersetView, check_ownership, json_error_response
+from .base import BaseSupersetView, json_error_response
 
 
 class Datasource(BaseSupersetView):
@@ -38,14 +38,6 @@ class Datasource(BaseSupersetView):
         datasource_type = datasource.get('type')
         orm_datasource = ConnectorRegistry.get_datasource(
             datasource_type, datasource_id, db.session)
-
-        if not check_ownership(orm_datasource, raise_if_false=False):
-            return json_error_response(
-                __(
-                    'You are not authorized to modify '
-                    'this data source configuration'),
-                status='401',
-            )
 
         if 'owners' in datasource:
             datasource['owners'] = db.session.query(orm_datasource.owner_class).filter(

--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -20,7 +20,6 @@ import json
 from flask import request
 from flask_appbuilder import expose
 from flask_appbuilder.security.decorators import has_access_api
-from flask_babel import gettext as __
 
 from superset import appbuilder, db
 from superset.connectors.connector_registry import ConnectorRegistry


### PR DESCRIPTION
This PR removes the check when saving a datasource via the React component of whether said user is an owner (according to the rubric specified [here](https://github.com/apache/incubator-superset/blob/3ae02d1a542ed66522f6a0a51433490e7da9ea30/superset/views/base.py#L326)). reverting to using FAB `@has_api_access` decorator checking the `can_save` permission. 

This ensures that the behavior is consistent with the datasource CRUD views (`DruidDatasourceModelView` and `TableModelView`) which also do not explicitly check the ownership but rather rely on the equivalent FAB `can_edit` permission.

I'm aware that the CRUD views may be deprecated in the future and that the permission model may change, but fundamentally datasources differ from other entities in Superset (charts and dashboards) and debating ownership models should occur in a future forum. For now this PR ensures that there is consistency between the various mechanisms around editing/saving datasource metadata.

to: @graceguo-supercat @michellethomas @mistercrunch 