### PR TITLE
[api/v1][query_obj] add default prequeries array

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -32,6 +32,7 @@ class QueryObject:
     The query object's schema matches the interfaces of DB connectors like sqla
     and druid. The query objects are constructed on the client.
     """
+
     def __init__(
             self,
             granularity: str,
@@ -46,7 +47,7 @@ class QueryObject:
             timeseries_limit_metric: Optional[Dict] = None,
             order_desc: bool = True,
             extras: Optional[Dict] = None,
-            prequeries: Optional[Dict] = None,
+            prequeries: List[List] = None,
             is_prequery: bool = False,
             columns: List[str] = None,
             orderby: List[List] = None,
@@ -67,7 +68,7 @@ class QueryObject:
         self.timeseries_limit = timeseries_limit
         self.timeseries_limit_metric = timeseries_limit_metric
         self.order_desc = order_desc
-        self.prequeries = prequeries
+        self.prequeries = prequeries if prequeries is not None else []
         self.is_prequery = is_prequery
         self.extras = extras if extras is not None else {}
         self.columns = columns if columns is not None else []

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -47,7 +47,7 @@ class QueryObject:
             timeseries_limit_metric: Optional[Dict] = None,
             order_desc: bool = True,
             extras: Optional[Dict] = None,
-            prequeries: List[List] = None,
+            prequeries: Optional[List[Dict]] = None,
             is_prequery: bool = False,
             columns: List[str] = None,
             orderby: List[List] = None,


### PR DESCRIPTION
This PR only affects the embeddable charts `/api/v1/query` endpoint. I'm working on adding `react` `<ChartDataProvider />` components in `@superset-ui` and when I use the new (non-legacy) `WordCloudPlugin` together with `SuperChart` + `ChartClient` I get the following stack trace from Python in the Superset App:

`POST /api/v1/query/` => `{"datasource":{"id":3,"type":"table"},"queries":[{"granularity":"ds","metrics":[{"label":"sum__num"}],"groupby":["name"]}]}`

```bash
2019-03-14 17:24:21,854:ERROR:root:'NoneType' object has no attribute 'append'
Traceback (most recent call last):
  File "/Users/chris_williams/dev/superset/superset/common/query_context.py", line 206, in get_df_payload
    query_result = self.get_query_result(query_obj)
  File "/Users/chris_williams/dev/superset/superset/common/query_context.py", line 82, in get_query_result
    result = self.datasource.query(query_object.to_dict())
  File "/Users/chris_williams/dev/superset/superset/connectors/sqla/models.py", line 861, in query
    query_obj['prequeries'].append(sql)
```

This is because `prequeries` is not passed for this chart, and there is no default on the Python side. This PR adds a default and updates the type, I think it's an optional `List` of `Dict`s, setting the default to `{}` errored downstream as something was trying to append to it 😄 so maybe it was typed wrong?

@xtinec @conglei @kristw 