### PR TITLE
[fix] explore newly-added chart from dashboard => miss slice title in explore view

### DIFF
--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -236,7 +236,10 @@ export function addSliceToDashboard(id) {
         ),
       );
     }
-    const form_data = selectedSlice.form_data;
+    const form_data = {
+      ...selectedSlice.form_data,
+      slice_id: selectedSlice.slice_id,
+    };
     const newChart = {
       ...initChart,
       id,


### PR DESCRIPTION
To reproduce this bug: 

1. Edit dashboard

2. Add a newly created slice, and make sure slice had a title (when slice is recently created from sql_lab -> explore view, in slice's params, it doesn't have slice_id param)

3. Save dashboard

4. Go to explore from newly-added slice, slice title displays as "untitled"

Root cause:
when slice_id is not in query parameter, Superset just run the query, but doesn't have slice related info (like slice title, owner, created_time, these information is part of slice object).


@michellethomas @kristw @williaster 