### PR TITLE
feat: add warning message when saving title from explore

### DIFF
--- a/superset/assets/src/explore/components/ExploreChartHeader.jsx
+++ b/superset/assets/src/explore/components/ExploreChartHeader.jsx
@@ -104,6 +104,11 @@ class ExploreChartHeader extends React.PureComponent {
           title={this.renderChartTitle()}
           canEdit={!this.props.slice || this.props.can_overwrite}
           onSaveTitle={this.updateChartTitleOrSaveSlice.bind(this)}
+          warningOnSave={
+            this.props.slice ?
+            'Editing the title will save over this chart. Are you sure you want to save?' :
+            null
+          }
         />
 
         {this.props.slice &&


### PR DESCRIPTION
It's not super clear that editing the title overrides the chart. If you are trying to create a new chart by changing the params of an existing chart and you edit the title before "saving as" a new chart, you'll save over the existing chart. This adds a warning message when a title change will save over the existing chart. 

The cancel action reverts the title back to the previously saved title.

Tested by
Testing save and cancel on an existing chart
Testing editing the title on a new chart (with no popup)
Testing editing title on dashboard chart (with no popup)

![superset_title_change](https://user-images.githubusercontent.com/817955/54468772-81f6cd80-474d-11e9-9db9-6a76a5972769.gif)
