### PR TITLE
fix: search for visualizations with case-insensitive keyword

### DIFF
--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -139,7 +139,7 @@ export default class VizTypeControl extends React.PureComponent {
     const registry = getChartMetadataRegistry();
     const types = this.sortVizTypes(registry.entries());
     const filteredTypes = filter.length > 0
-      ? types.filter(type => type.value.name.toLowerCase().includes(filter))
+      ? types.filter(type => type.value.name.toLowerCase().includes(filter.toLowerCase()))
       : types;
 
     const selectedType = registry.get(value);


### PR DESCRIPTION
#bug Fixed searching the visual components with case-insensitive key on "Select a visualization type" window.

- [✔️] I have checked the superset logs for python stack traces and included it here as text if there are any.
- [✔️] I have reproduced the issue with at least the latest released version of superset.
- [✔️] I have checked the issue tracker for the same issue and I haven't found one similar.


### Superset version
0.29

### Expected results
Visual components list should be filtered with case-insensitive search key on "Select a visualization type" window.

### Actual results
Visual components list not getting filtered with case-insensitive search key on "Select a visualization type" window.

### Steps to reproduce
Open Visualization Type list, and then filter Visualization components list with search key, enter search string in lower case, it will get filtered but when search string is entered in upper case or Camel case, the list is not getting filtered. Attached is the screenshot for reference

<img width="898" alt="Screenshot 2019-03-18 at 3 03 40 PM" src="https://user-images.githubusercontent.com/18305698/54520777-7a266b80-498f-11e9-896b-aa68726679a7.png">

<img width="899" alt="Screenshot 2019-03-18 at 3 03 22 PM" src="https://user-images.githubusercontent.com/18305698/54520778-7a266b80-498f-11e9-82bd-c314fa7df837.png">

