### PR TITLE
feat: allow LIMIT to be specified in parameters

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2531,10 +2531,8 @@ class Superset(BaseSupersetView):
             )
 
         client_id = request.form.get('client_id') or utils.shortid()[:10]
-        limits = [mydb.db_engine_spec.get_limit_from_sql(sql), limit]
         query = Query(
             database_id=int(database_id),
-            limit=min(lim for lim in limits if lim is not None),
             sql=sql,
             schema=schema,
             select_as_cta=request.form.get('select_as_cta') == 'true',
@@ -2563,6 +2561,10 @@ class Superset(BaseSupersetView):
         except Exception as e:
             return json_error_response(
                 'Template rendering failed: {}'.format(utils.error_msg_from_exception(e)))
+
+        # set LIMIT after template processing
+        limits = [mydb.db_engine_spec.get_limit_from_sql(rendered_query), limit]
+        query.limit = min(lim for lim in limits if lim is not None)
 
         # Async request.
         if async_:


### PR DESCRIPTION
Currently the query limit is extracted from the SQL **before** it's processed with the template parameters. If we have the following query in SQL Lab:

```sql
SELECT * FROM logs LIMIT {{ limit }}
```

And we set the parameters to `{"limit": 5}`, what happens is:

1. Superset tries to extract a LIMIT from the query before any parameters are applied ("raw").
2. Since it can't it extract the query limit it uses the limit from the UI (default 1000).
3. It builds a query **object** with the raw query, with limit 1000.
4. It translates the query to `SELECT * FROM logs LIMIT 5`.
5. It dispatches the translated query and the query object.
6. it sees that the query object has a limit of 1000.
7. It replaces `LIMIT 5` with `LIMIT 1000`.

This PR changes the flow so that the limits are extracted after the template processing.
