### PR TITLE
[mypy] Adding mypy type checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
       python: 3.6
       env: TOXENV=pylint
     - language: python
+      python: 3.6
       env:
         - TOXENV=license-check
         - TRAVIS_CACHE=$HOME/.travis_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -462,6 +462,35 @@ Note that the test environment uses a temporary directory for defining the
 SQLite databases which will be cleared each time before the group of test
 commands are invoked.
 
+#### Typing
+
+To ensure clarity, consistency, all readability, _all_ new functions should use
+[type hints](https://docs.python.org/3/library/typing.html) and include a
+docstring using Sphinx documentation.
+
+Note per [PEP-484](https://www.python.org/dev/peps/pep-0484/#exceptions) no
+syntax for listing explicitly raised exceptions is proposed and thus the
+recommendation is to put this information in a docstring, i.e.,
+
+
+```python
+import math
+from typing import Union
+
+
+def sqrt(x: Union[float, int]) -> Union[float, int]:
+    """
+    Return the square root of x.
+
+    :param x: A number
+    :returns: The square root of the given number
+    :raises ValueError: If the number is negative
+    """
+
+    return math.sqrt(x)
+```
+
+
 ### JavaScript Testing
 
 We use [Jest](https://jestjs.io/) and [Enzyme](https://airbnb.io/enzyme/) to test Javascript. Tests can be run with:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,10 +17,12 @@
 console_log==0.2.10
 flake8-commas==2.0.0
 flake8-import-order==0.18
+flake8-mypy==17.8.0
 flake8-quotes==1.0.0
 flake8==3.6.0
 flask-cors==3.0.6
 ipdb==0.11
+mypy==0.670
 mysqlclient==1.3.13
 pip-tools==3.1.0
 psycopg2-binary==2.7.5

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -55,7 +55,7 @@ class QueryContext:
             custom_cache_timeout: int = None,
     ):
         self.datasource = ConnectorRegistry.get_datasource(datasource.get('type'),
-                                                           int(datasource.get('id')),
+                                                           int(datasource.get('id')),  # noqa: E501, T400
                                                            db.session)
         self.queries = list(map(lambda query_obj: QueryObject(**query_obj), queries))
 

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -61,8 +61,10 @@ class QueryObject:
 
         # Temporal solution for backward compatability issue
         # due the new format of non-ad-hoc metric.
-        self.metrics = [metric if 'expressionType' in metric else metric['label']
-                        for metric in metrics]
+        self.metrics = [
+            metric if 'expressionType' in metric else metric['label']   # noqa: T484
+            for metric in metrics
+        ]
         self.row_limit = row_limit
         self.filter = filters if filters is not None else []
         self.timeseries_limit = timeseries_limit

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -31,7 +31,7 @@ import os
 import signal
 import smtplib
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 import uuid
 import zlib
 
@@ -925,7 +925,7 @@ def get_since_until(time_range: Optional[str] = None,
                     since: Optional[str] = None,
                     until: Optional[str] = None,
                     time_shift: Optional[str] = None,
-                    relative_end: Optional[str] = None) -> (datetime, datetime):
+                    relative_end: Optional[str] = None) -> Tuple[datetime, datetime]:
     """Return `since` and `until` date time tuple from string representations of
     time_range, since, until and time_shift.
 
@@ -953,11 +953,11 @@ def get_since_until(time_range: Optional[str] = None,
     separator = ' : '
     relative_end = parse_human_datetime(relative_end if relative_end else 'today')
     common_time_frames = {
-        'Last day': (relative_end - relativedelta(days=1), relative_end),
-        'Last week': (relative_end - relativedelta(weeks=1), relative_end),
-        'Last month': (relative_end - relativedelta(months=1), relative_end),
-        'Last quarter': (relative_end - relativedelta(months=3), relative_end),
-        'Last year': (relative_end - relativedelta(years=1), relative_end),
+        'Last day': (relative_end - relativedelta(days=1), relative_end),  # noqa: T400
+        'Last week': (relative_end - relativedelta(weeks=1), relative_end),  # noqa: T400
+        'Last month': (relative_end - relativedelta(months=1), relative_end),  # noqa: E501, T400
+        'Last quarter': (relative_end - relativedelta(months=3), relative_end),  # noqa: E501, T400
+        'Last year': (relative_end - relativedelta(years=1), relative_end),  # noqa: T400
     }
 
     if time_range:
@@ -974,11 +974,11 @@ def get_since_until(time_range: Optional[str] = None,
         else:
             rel, num, grain = time_range.split()
             if rel == 'Last':
-                since = relative_end - relativedelta(**{grain: int(num)})
+                since = relative_end - relativedelta(**{grain: int(num)})  # noqa: T400
                 until = relative_end
             else:  # rel == 'Next'
                 since = relative_end
-                until = relative_end + relativedelta(**{grain: int(num)})
+                until = relative_end + relativedelta(**{grain: int(num)})  # noqa: T400
     else:
         since = since or ''
         if since:
@@ -988,13 +988,13 @@ def get_since_until(time_range: Optional[str] = None,
 
     if time_shift:
         time_shift = parse_human_timedelta(time_shift)
-        since = since if since is None else (since - time_shift)
-        until = until if until is None else (until - time_shift)
+        since = since if since is None else (since - time_shift)  # noqa: T400
+        until = until if until is None else (until - time_shift)  # noqa: T400
 
     if since and until and since > until:
         raise ValueError(_('From date cannot be larger than to date'))
 
-    return since, until
+    return since, until  # noqa: T400
 
 
 def add_ago_to_since(since):


### PR DESCRIPTION
This PR adds `mypy` (courtesy of `flake8`) for checking Python type hints. Additionally it updates the `CONTRIBUTING.md` to strongly encourage new Python functions to use type hints.

Note I corrected some `mypy` issues but ignored others as I don't have full context into the code. The `get_since_until` method seems to be especially problematic partially because `since`, `until`, and `relative_end` are being re-typed in the function (which is probably non-ideal). 

to: @betodealmeida @michellethomas @mistercrunch @xtinec 