### PR TITLE
fix: issue running chrome in docker throw error

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -155,6 +155,7 @@ def create_webdriver():
     elif config.get('EMAIL_REPORTS_WEBDRIVER') == 'chrome':
         driver_class = chrome.webdriver.WebDriver
         options = chrome.options.Options()
+        options.add_argument('--no-sandbox')
 
     options.add_argument('--headless')
 

--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -90,7 +90,7 @@ class EmailScheduleView(SupersetModelView, DeleteMixin):
     edit_form_extra_fields = add_form_extra_fields
 
     def process_form(self, form, is_created):
-        recipients = form.test_email_recipients.data.strip() or None
+        recipients = form.test_email_recipients.data.strip() if form.test_email_recipients.data else None
         self._extra_data['test_email'] = form.test_email.data
         self._extra_data['test_email_recipients'] = recipients
 


### PR DESCRIPTION
Running chrome  headless mode in docker, throw an error. Add argument --no-sandbox  to chrome, will fix it.
```
superset_1  | [2019-03-19 08:55:46,614: ERROR/MainProcess] Task email_reports.send[7255492f-8274-4026-a26b-64ff856c77a2] raised unexpected: WebDriverException("unknown error: Chrome failed to start: crashed\n  (unknown error: DevToolsActivePort file doesn't exist)\n  (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)\n  (Driver info: chromedriver=2.46.628388 (4a34a70827ac54148e092aafb70504c4ea7ae926),platform=Linux 3.10.0-514.el7.x86_64 x86_64)", None, None)
superset_1  | Traceback (most recent call last):
superset_1  |   File "/usr/local/lib/python3.6/site-packages/celery/app/trace.py", line 382, in trace_task
superset_1  |     R = retval = fun(*args, **kwargs)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/celery/app/trace.py", line 641, in __protected_call__
superset_1  |     return self.run(*args, **kwargs)
superset_1  |   File "/home/superset/superset/tasks/schedules.py", line 395, in schedule_email_report
superset_1  |     deliver_slice(schedule)
superset_1  |   File "/home/superset/superset/tasks/schedules.py", line 364, in deliver_slice
superset_1  |     email = _get_slice_visualization(schedule)
superset_1  |   File "/home/superset/superset/tasks/schedules.py", line 318, in _get_slice_visualization
superset_1  |     driver = create_webdriver()
superset_1  |   File "/home/superset/superset/tasks/schedules.py", line 169, in create_webdriver
superset_1  |     driver = driver_class(**kwargs)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/selenium/webdriver/chrome/webdriver.py", line 81, in __init__
superset_1  |     desired_capabilities=desired_capabilities)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py", line 157, in __init__
superset_1  |     self.start_session(capabilities, browser_profile)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py", line 252, in start_session
superset_1  |     response = self.execute(Command.NEW_SESSION, parameters)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py", line 321, in execute
superset_1  |     self.error_handler.check_response(response)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
superset_1  |     raise exception_class(message, screen, stacktrace)
superset_1  | selenium.common.exceptions.WebDriverException: Message: unknown error: Chrome failed to start: crashed
superset_1  |   (unknown error: DevToolsActivePort file doesn't exist)
superset_1  |   (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
superset_1  |   (Driver info: chromedriver=2.46.628388 (4a34a70827ac54148e092aafb70504c4ea7ae926),platform=Linux 3.10.0-514.el7.x86_64 x86_64)
```