### PR TITLE
feat: use strict ISO8601 datetime format in postgres engine spec

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -535,6 +535,10 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
             return f'"{column_name}"'
         return column_name
 
+    @classmethod
+    def convert_dttm(cls, target_type, dttm):
+        return "'{}'".format(dttm.strftime('%Y-%m-%dT%H:%M:%S'))
+
 
 class SnowflakeEngineSpec(PostgresBaseEngineSpec):
     engine = 'snowflake'


### PR DESCRIPTION
The `PostgresEngineSpec` have the default implementation of the `convert_dttm` method that follows the `%Y-%m-%d %H:%M:%S` date time format. Despite the fact that the particular format is supported by PostgreSQL, it is not ISO8601 compliant, see section [4.3.2](http://dotat.at/tmp/ISO_8601-2004_E.pdf). The standard permits to omit the time designator `T`, but does not imply permission to replace it with a whitespace.

Therefore, it would be harder to use Superset with databases that support the PostgreSQL Wire Protocol and strictly follow ISO8601. This PR improves Superset integration with such databases.