### PR TITLE
[tox] Enforcing consistent ordering

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,39 +69,39 @@ commands =
     npm install -g npm@'>=6.5.0'
     pip install -e {toxinidir}/
     {toxinidir}/superset/assets/cypress_build.sh dashboard
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
 setenv =
     PYTHONPATH = {toxinidir}
     SUPERSET_CONFIG = tests.superset_test_config
     SUPERSET_HOME = {envtmpdir}
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 
 [testenv:cypress-explore]
 commands =
     npm install -g npm@'>=6.5.0'
     pip install -e {toxinidir}/
     {toxinidir}/superset/assets/cypress_build.sh explore
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
 setenv =
     PYTHONPATH = {toxinidir}
     SUPERSET_CONFIG = tests.superset_test_config
     SUPERSET_HOME = {envtmpdir}
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 
 [testenv:cypress-sqllab]
 commands =
     npm install -g npm@'>=6.5.0'
     pip install -e {toxinidir}/
     {toxinidir}/superset/assets/cypress_build.sh sqllab
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
 setenv =
     PYTHONPATH = {toxinidir}
     SUPERSET_CONFIG = tests.superset_test_config
     SUPERSET_HOME = {envtmpdir}
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 
 [testenv:eslint]
 changedir = {toxinidir}/superset/assets
@@ -121,19 +121,19 @@ commands =
     {toxinidir}/superset/assets/js_build.sh
 deps =
 
+[testenv:license-check]
+commands =
+    {toxinidir}/scripts/check_license.sh
+passenv = *
+whitelist_externals =
+    {toxinidir}/scripts/check_license.sh
+
 [testenv:pylint]
 commands =
     pylint superset
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
-
-[testenv:license-check]
-commands =
-    {toxinidir}/scripts/check_license.sh
-whitelist_externals =
-    {toxinidir}/scripts/check_license.sh
-passenv = *
 
 [tox]
 envlist =


### PR DESCRIPTION
This PR re-orders the `tox.ini` configuration to ensure all sections (and associated items) are listed alphabetically. Note the reason for (trying) to enforce this is when configuration files are ordered alphabetically it ensures that the file structure is consistent as there is only one place to define a section and/or item.

to: @mistercrunch 