### PR TITLE
Improve handling of bytes data

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -328,6 +328,8 @@ def datetime_f(dttm):
 
 
 def base_json_conv(obj):
+    if isinstance(obj, memoryview):
+        obj = obj.tobytes()
     if isinstance(obj, numpy.int64):
         return int(obj)
     elif isinstance(obj, numpy.bool_):
@@ -340,11 +342,9 @@ def base_json_conv(obj):
         return str(obj)
     elif isinstance(obj, timedelta):
         return str(obj)
-    elif isinstance(obj, memoryview):
-        return str(obj.tobytes(), 'utf8')
     elif isinstance(obj, bytes):
         try:
-            return '{}'.format(obj)
+            return obj.decode('utf-8')
         except Exception:
             return '[bytes]'
 


### PR DESCRIPTION
This is a continuation of #6987 which caused a regression when selecting non-`utf-8` bytes data on Postgres. Also improves and harmonizes rendering of `utf-8` compliant bytes data when possible.

# Before
- Postgres `utf-8` bytes data: `🐍` shows up as `🐍`
- Postgres non-`utf-8` bytes data: `åäöÅÄÖ` encoded as `latin-1` throws exception
- Non-Postgres `utf-8` bytes data: `🐍` shows up as `b'\\xf0\\x9f\\x90\\x8d'`
- Non-Postgres non-`utf-8` bytes data: `åäöÅÄÖ` encoded as `latin-1` shows up as `b'\\xe5\\xe4\\xf6\\xc5\\xc4\\xd6'`

# After
- Postgres `utf-8` bytes data: `🐍` shows up as `🐍`
- Postgres non-`utf-8` bytes data: `åäöÅÄÖ` encoded as `latin-1` shows up as `[bytes]`
- Non-Postgres `utf-8` bytes data: `🐍` shows up as `🐍`
- Non-Postgres non-`utf-8` bytes data: `åäöÅÄÖ` encoded as `latin-1` shows up as `[bytes]`

<img width="744" alt="Screenshot 2019-03-19 at 19 07 13" src="https://user-images.githubusercontent.com/33317356/54626646-42482280-4a7a-11e9-8db7-0c4e37e86e46.png">

Ping @mistercrunch  @john-bodley @mmuru 