### PR TITLE
[fix] handle null column_name in druid/sqla models

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -86,7 +86,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
 
     @property
     def column_names(self):
-        return sorted([c.column_name for c in self.columns])
+        return sorted([c.column_name for c in self.columns], key=lambda x: x or '')
 
     @property
     def columns_types(self):
@@ -166,7 +166,9 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
     def data(self):
         """Data representation of the datasource sent to the frontend"""
         order_by_choices = []
-        for s in sorted(self.column_names):
+        # self.column_names return sorted column_names
+        for s in self.column_names:
+            s = str(s or '')
             order_by_choices.append((json.dumps([s, True]), s + ' [asc]'))
             order_by_choices.append((json.dumps([s, False]), s + ' [desc]'))
 

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -280,7 +280,7 @@ class DruidColumn(Model, BaseColumn):
     export_parent = 'datasource'
 
     def __repr__(self):
-        return self.column_name
+        return self.column_name or str(self.id)
 
     @property
     def expression(self):


### PR DESCRIPTION
when sqla table column is null, see following exception:

<img width="913" alt="Screen Shot 2019-03-19 at 11 59 31 AM" src="https://user-images.githubusercontent.com/27990562/54634065-9e8d5100-4a3e-11e9-9e4b-9b2869f0454f.png">

may related with #5445 
@john-bodley @michellethomas @soboko @mistercrunch 
