### PR TITLE
[connectors] Make cluster/database and datasource/table read-only in views

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -21,10 +21,12 @@ import logging
 
 from flask import flash, Markup, redirect
 from flask_appbuilder import CompactCRUDMixin, expose
+from flask_appbuilder.fieldwidgets import Select2Widget
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
+from wtforms.ext.sqlalchemy.fields import QuerySelectField
 
 from superset import appbuilder, db, security_manager
 from superset.connectors.base.views import DatasourceModelView
@@ -75,6 +77,17 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
             'above.',
             True),
     }
+
+    add_form_extra_fields = {
+        'datasource': QuerySelectField(
+            'Datasource',
+            query_factory=lambda: db.session().query(models.DruidDatasource),
+            allow_blank=True,
+            widget=Select2Widget(extra_classes='readonly'),
+        ),
+    }
+
+    edit_form_extra_fields = add_form_extra_fields
 
     def pre_update(self, col):
         # If a dimension spec JSON is given, ensure that it is
@@ -145,6 +158,17 @@ class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
         'is_restricted': _('Is Restricted'),
     }
 
+    add_form_extra_fields = {
+        'datasource': QuerySelectField(
+            'Datasource',
+            query_factory=lambda: db.session().query(models.DruidDatasource),
+            allow_blank=True,
+            widget=Select2Widget(extra_classes='readonly'),
+        ),
+    }
+
+    edit_form_extra_fields = add_form_extra_fields
+
     def post_add(self, metric):
         if metric.is_restricted:
             security_manager.merge_perm('metric_access', metric.get_perm())
@@ -186,6 +210,14 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):  #
             'Duration (in seconds) of the caching timeout for this cluster. '
             'A timeout of 0 indicates that the cache never expires. '
             'Note this defaults to the global timeout if undefined.'),
+    }
+
+    edit_form_extra_fields = {
+        'cluster_name': QuerySelectField(
+            'Cluster',
+            query_factory=lambda: db.session().query(models.DruidCluster),
+            widget=Select2Widget(extra_classes='readonly'),
+        ),
     }
 
     def pre_add(self, cluster):

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -21,10 +21,12 @@ import logging
 from flask import flash, Markup, redirect
 from flask_appbuilder import CompactCRUDMixin, expose
 from flask_appbuilder.actions import action
+from flask_appbuilder.fieldwidgets import Select2Widget
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
+from wtforms.ext.sqlalchemy.fields import QuerySelectField
 
 from superset import appbuilder, db, security_manager
 from superset.connectors.base.views import DatasourceModelView
@@ -107,6 +109,17 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
         'type': _('Type'),
     }
 
+    add_form_extra_fields = {
+        'table': QuerySelectField(
+            'Table',
+            query_factory=lambda: db.session().query(models.SqlaTable),
+            allow_blank=True,
+            widget=Select2Widget(extra_classes='readonly'),
+        ),
+    }
+
+    edit_form_extra_fields = add_form_extra_fields
+
 
 appbuilder.add_view_no_menu(TableColumnInlineView)
 
@@ -152,6 +165,17 @@ class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
         'is_restricted': _('Is Restricted'),
         'warning_text': _('Warning Message'),
     }
+
+    add_form_extra_fields = {
+        'table': QuerySelectField(
+            'Table',
+            query_factory=lambda: db.session().query(models.SqlaTable),
+            allow_blank=True,
+            widget=Select2Widget(extra_classes='readonly'),
+        ),
+    }
+
+    edit_form_extra_fields = add_form_extra_fields
 
     def post_add(self, metric):
         if metric.is_restricted:
@@ -258,6 +282,14 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
         'is_sqllab_view': _('SQL Lab View'),
         'template_params': _('Template parameters'),
         'modified': _('Modified'),
+    }
+
+    edit_form_extra_fields = {
+        'database': QuerySelectField(
+            'Database',
+            query_factory=lambda: db.session().query(models.Database),
+            widget=Select2Widget(extra_classes='readonly'),
+        ),
     }
 
     def pre_add(self, table):


### PR DESCRIPTION
In the CRUD views the cluster/database and datasource/table are required in the forms to ensure that either an added or edited entity is correctly assigned to the parent. This value is normally left blank however it does provide the ability for the user to re-assign (possibly without intent) an entity to another parent which is undesirable. 

@mistercrunch ideally it would be great to simply hide these fields from the views, however this doesn't seem to be possible. The only viable solution I am aware of is simply to make the fields read-only per the suggestion outlined [here](https://flask-appbuilder.readthedocs.io/en/latest/advanced.html#forms-readonly-fields).

**Edit**

![Screen Shot 2019-03-20 at 11 18 55 AM](https://user-images.githubusercontent.com/4567245/54709598-060cd480-4b03-11e9-96a1-80228fff68fd.png)
![Screen Shot 2019-03-20 at 11 18 43 AM](https://user-images.githubusercontent.com/4567245/54709596-05743e00-4b03-11e9-9961-b9fa1dceb491.png)
![Screen Shot 2019-03-20 at 11 20 39 AM](https://user-images.githubusercontent.com/4567245/54709599-060cd480-4b03-11e9-96d6-5fe954e3c685.png)

**Add**

Note for adding we allow blanks otherwise the default displayed value is ill-defined entity even though the entity is correctly parented.

![Screen Shot 2019-03-20 at 11 28 43 AM](https://user-images.githubusercontent.com/4567245/54709765-58e68c00-4b03-11e9-8a62-eb92aa3a6579.png)


to: @graceguo-supercat @michellethomas @mistercrunch @xtinec 