### PR TITLE
[migration] Patch c617da68de7d_form_nullable.py

### DIFF
--- a/superset/migrations/versions/c617da68de7d_form_nullable.py
+++ b/superset/migrations/versions/c617da68de7d_form_nullable.py
@@ -179,7 +179,7 @@ def upgrade():
         for record in session.query(table).all():
             for col in record.__table__.columns.values():
                 if not col.primary_key:
-                    if getattr(record, col.name) == '':
+                    if getattr(record, col.name).strip() == '':
                         setattr(record, col.name, None)
 
         session.commit()


### PR DESCRIPTION
This PR updates migration to ensure that both empty strings and strings containing only whitespace are transformed to NULL. This issue surfaced when we realized that a handful of our slices had a non-zero length name containing only whitespace.

@mistercrunch I realize that augmenting migrations is somewhat non-standard however this PR is still pre-release. Please let me know how you think I should best proceed and whether a second migration makes more sense. 

to: @graceguo-supercat @michellethomas @mistercrunch 