### PR TITLE
fix: 'Unhashable type' in paired t-test chart

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2555,7 +2555,7 @@ class PairedTTestViz(BaseViz):
         """
         fd = self.form_data
         groups = fd.get('groupby')
-        metrics = fd.get('metrics')
+        metrics = self.metric_labels
         df = df.pivot_table(
             index=DTTM_ALIAS,
             columns=groups,


### PR DESCRIPTION
fixes https://github.com/apache/incubator-superset/issues/7056

Hopefully this is the last metric-related bug. 