### PR TITLE
[forms] Fix handling of NULLs for chart or dashboard name

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -163,7 +163,7 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
                      'viz_type', 'params', 'cache_timeout')
 
     def __repr__(self):
-        return self.slice_name
+        return self.slice_name or str(self.id)
 
     @property
     def cls_model(self):
@@ -292,9 +292,13 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
         return '/chart/edit/{}'.format(self.id)
 
     @property
+    def chart(self):
+        return self.slice_name or '<empty>'
+
+    @property
     def slice_link(self):
         url = self.slice_url
-        name = escape(self.slice_name)
+        name = escape(self.chart)
         return Markup(f'<a href="{url}">{name}</a>')
 
     def get_viz(self, force=False):
@@ -407,7 +411,7 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
                      'description', 'css', 'slug')
 
     def __repr__(self):
-        return self.dashboard_title
+        return self.dashboard_title or str(self.id)
 
     @property
     def table_names(self):
@@ -437,13 +441,17 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         return {slc.datasource for slc in self.slices}
 
     @property
+    def charts(self):
+        return [slc.chart for slc in self.slices]
+
+    @property
     def sqla_metadata(self):
         # pylint: disable=no-member
         metadata = MetaData(bind=self.get_sqla_engine())
         return metadata.reflect()
 
     def dashboard_link(self):
-        title = escape(self.dashboard_title)
+        title = escape(self.dashboard_title or '<empty>')
         return Markup(f'<a href="{self.url}">{title}</a>')
 
     @property

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -605,7 +605,7 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
     edit_columns = [
         'dashboard_title', 'slug', 'owners', 'position_json', 'css',
         'json_metadata']
-    show_columns = edit_columns + ['table_names', 'slices']
+    show_columns = edit_columns + ['table_names', 'charts']
     search_columns = ('dashboard_title', 'slug', 'owners')
     add_columns = edit_columns
     base_order = ('changed_on', 'desc')
@@ -632,7 +632,7 @@ class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
         'dashboard_link': _('Dashboard'),
         'dashboard_title': _('Title'),
         'slug': _('Slug'),
-        'slices': _('Charts'),
+        'charts': _('Charts'),
         'owners': _('Owners'),
         'creator': _('Creator'),
         'modified': _('Modified'),


### PR DESCRIPTION
This PR resolves a couple of issues related to either a chart or dashboard name being `None`. Prior to https://github.com/apache/incubator-superset/pull/5445 these fields were encoded as empty strings and thus certain issues didn't surface. 

Since https://github.com/apache/incubator-superset/pull/5445 it is impossible to filter by either dashboard or chart in which the name (title) is undefined as there is no mechanism to filter either in/out `NULL` values. Furthermore sorting by either chart of dashboard name isn't viable due to an issue with Flask-AppBuilder as mentioned in https://github.com/apache/incubator-superset/issues/3673. On the flip side when empty strings were allowed it was possible to filter these entities however itwas not possible to navigate to said entity from the CRUD view as there was no link present.

This PR additionally renames undefined names to `<empty>` in the CRUD view as this is consistent with both the Dashboard and Explorer views. 

**Charts**
<img width="241" alt="Screen Shot 2019-03-21 at 12 15 42 AM" src="https://user-images.githubusercontent.com/4567245/54737784-bebc2d80-4b6e-11e9-9b3a-473104a3313f.png">
<img width="224" alt="Screen Shot 2019-03-21 at 12 15 55 AM" src="https://user-images.githubusercontent.com/4567245/54737790-c54aa500-4b6e-11e9-8d4c-bb6aea2d3e7f.png">

**Dashboards**
<img width="252" alt="Screen Shot 2019-03-21 at 12 16 04 AM" src="https://user-images.githubusercontent.com/4567245/54737917-43a74700-4b6f-11e9-9ba0-13ae8ee074d6.png">
<img width="202" alt="Screen Shot 2019-03-21 at 12 16 19 AM" src="https://user-images.githubusercontent.com/4567245/54737766-a9df9a00-4b6e-11e9-9a15-6b0f1cd8d37b.png">

to: @graceguo-supercat @michellethomas @mistercrunch @xtinec 