### PR TITLE
[bubbles] issue when using duplicated metrics

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -954,11 +954,11 @@ class BubbleViz(NVD3Viz):
         self.series = form_data.get('series') or self.entity
         d['row_limit'] = form_data.get('limit')
 
-        d['metrics'] = [
+        d['metrics'] = list(set([
             self.z_metric,
             self.x_metric,
             self.y_metric,
-        ]
+        ]))
         if not all(d['metrics'] + [self.entity]):
             raise Exception(_('Pick a metric for x, y and size'))
         return d


### PR DESCRIPTION
closes https://github.com/apache/incubator-superset/issues/7079

I think that Pandas might have changed behavior when two Series in a dataframe have the same name. When accessing the column based on name, it returns two columns instead of just one.

This fixes this issue by getting the metric only once, so no 2 columns with the same name get created in the first place.