### PR TITLE
[api] add `available_domains/` endpoint

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -44,7 +44,7 @@ from werkzeug.routing import BaseConverter
 from werkzeug.utils import secure_filename
 
 from superset import (
-    app, appbuilder, cache, db, results_backend,
+    app, appbuilder, cache, conf, db, results_backend,
     security_manager, sql_lab, viz)
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.models import AnnotationDatasource, SqlaTable
@@ -1866,6 +1866,20 @@ class Superset(BaseSupersetView):
     def csrf_token(self):
         return Response(
             self.render_template('superset/csrf_token.json'),
+            mimetype='text/json',
+        )
+
+    @api
+    @has_access_api
+    @expose('/available_domains/', methods=['GET'])
+    def available_domains(self):
+        """
+        Returns the list of available Superset Webserver domains (if any)
+        defined in config. This enables charts embedded in other apps to 
+        leverage domain sharding if appropriately configured.
+        """
+        return Response(
+            json.dumps(conf.get('SUPERSET_WEBSERVER_DOMAINS')),
             mimetype='text/json',
         )
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1875,7 +1875,7 @@ class Superset(BaseSupersetView):
     def available_domains(self):
         """
         Returns the list of available Superset Webserver domains (if any)
-        defined in config. This enables charts embedded in other apps to 
+        defined in config. This enables charts embedded in other apps to
         leverage domain sharding if appropriately configured.
         """
         return Response(


### PR DESCRIPTION
This PR adds a new api endpoint `superset/available_domains/` which simply returns the value of the `config` variable `SUPERSET_WEBSERVER_DOMAINS`. 

`SUPERSET_WEBSERVER_DOMAINS` allows a Superset deployment to use domain sharding to effectively increase the number of parallel data requests and improve dashboard loading times. When embedding Superset charts in other applications, developers may want to use a similar technique to improve data loading times. However without exposing the available domains through an endpoint, the developers would have to duplicate / hard-code the domains in their app which is not ideal.

Tested the endpoint locally.

@kristw @conglei @xtinec @soboko @mistercrunch 
cc @graceguo-supercat @john-bodley 