### PR TITLE
Bump SQLAlchemy to 1.3

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -415,11 +415,6 @@ You can also use `PyAthena` library(no java required) like this ::
 
 See `PyAthena <https://github.com/laughingman7743/PyAthena#sqlalchemy>`_.
 
-MSSQL
------
-
-Full Unicode support requires SQLAlchemy 1.3 or later.
-
 Snowflake
 ---------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ selenium==3.141.0
 simplejson==3.15.0
 six==1.11.0               # via bleach, cryptography, isodate, pathlib2, polyline, pydruid, python-dateutil, sqlalchemy-utils, wtforms-json
 sqlalchemy-utils==0.32.21
-sqlalchemy==1.2.18
+sqlalchemy==1.3.1
 sqlparse==0.2.4
 unicodecsv==0.14.1
 urllib3==1.22             # via requests, selenium

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         'retry>=0.9.2',
         'selenium>=3.141.0',
         'simplejson>=3.15.0',
-        'sqlalchemy>=1.2.18, <1.3.0',
+        'sqlalchemy>=1.3.1,<2.0',
         'sqlalchemy-utils',
         'sqlparse',
         'unicodecsv',

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -46,7 +46,7 @@ from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.sql import quoted_name, text
 from sqlalchemy.sql.expression import TextAsFrom
-from sqlalchemy.types import UnicodeText
+from sqlalchemy.types import String, UnicodeText
 import sqlparse
 from werkzeug.utils import secure_filename
 
@@ -1423,10 +1423,16 @@ class MssqlEngineSpec(BaseEngineSpec):
             data = [[elem for elem in r] for r in data]
         return data
 
+    column_types = {
+        (String(), re.compile(r'^(?<!N)((VAR){0,1}CHAR|TEXT|STRING)', re.IGNORECASE)),
+        (UnicodeText(), re.compile(r'^N((VAR){0,1}CHAR|TEXT)', re.IGNORECASE)),
+    }
+
     @classmethod
     def get_sqla_column_type(cls, type_):
-        if isinstance(type_, str) and re.match(r'^N(VAR){0-1}CHAR', type_):
-            return UnicodeText()
+        for sqla_type, regex in cls.column_types:
+            if regex.match(type_):
+                return sqla_type
         return None
 
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1423,10 +1423,10 @@ class MssqlEngineSpec(BaseEngineSpec):
             data = [[elem for elem in r] for r in data]
         return data
 
-    column_types = {
+    column_types = [
         (String(), re.compile(r'^(?<!N)((VAR){0,1}CHAR|TEXT|STRING)', re.IGNORECASE)),
         (UnicodeText(), re.compile(r'^N((VAR){0,1}CHAR|TEXT)', re.IGNORECASE)),
-    }
+    ]
 
     @classmethod
     def get_sqla_column_type(cls, type_):

--- a/superset/migrations/versions/4451805bbaa1_remove_double_percents.py
+++ b/superset/migrations/versions/4451805bbaa1_remove_double_percents.py
@@ -66,8 +66,8 @@ def replace(source, target):
 
     query = (
         session.query(Slice, Database)
-        .join(Table)
-        .join(Database)
+        .join(Table, Slice.datasource_id == Table.id)
+        .join(Database, Table.database_id == Database.id)
         .filter(Slice.datasource_type == 'table')
         .all()
     )

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -19,6 +19,7 @@ import inspect
 import mock
 import sqlalchemy as sa
 from sqlalchemy import column, select, table
+from sqlalchemy.dialects.mssql import pymssql
 from sqlalchemy.types import String, UnicodeText
 
 from superset import db_engine_specs
@@ -367,7 +368,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         assert_type('NTEXT', UnicodeText)
 
     def test_mssql_where_clause_n_prefix(self):
-        mssql_engine = sa.create_engine('mssql://uid:pwd@localhost')
+        dialect = pymssql.dialect()
         spec = MssqlEngineSpec
         str_col = column('col', type_=spec.get_sqla_column_type('VARCHAR(10)'))
         unicode_col = column('unicode_col', type_=spec.get_sqla_column_type('NTEXT'))
@@ -377,6 +378,6 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             where(str_col == 'abc').\
             where(unicode_col == 'abc')
 
-        query = str(sel.compile(mssql_engine, compile_kwargs={"literal_binds": True}))
+        query = str(sel.compile(dialect=dialect, compile_kwargs={'literal_binds': True}))
         query_expected = "SELECT col, unicode_col \nFROM tbl \nWHERE col = 'abc' AND unicode_col = N'abc'"  # noqa
         self.assertEqual(query, query_expected)

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -17,7 +17,6 @@
 import inspect
 
 import mock
-import sqlalchemy as sa
 from sqlalchemy import column, select, table
 from sqlalchemy.dialects.mssql import pymssql
 from sqlalchemy.types import String, UnicodeText

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -18,6 +18,7 @@ import inspect
 
 import mock
 from sqlalchemy import column
+from sqlalchemy.types import String, UnicodeText
 
 from superset import db_engine_specs
 from superset.db_engine_specs import (
@@ -346,3 +347,20 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         self.assertEqual(label.quote, True)
         label_expected = '3b26974078683be078219674eeb8f5'
         self.assertEqual(label, label_expected)
+
+    def test_mssql_column_types(self):
+        def assert_type(type_string, type_expected):
+            type_assigned = MssqlEngineSpec.get_sqla_column_type(type_string)
+            if type_expected is None:
+                self.assertIsNone(type_assigned)
+            else:
+                self.assertIsInstance(type_assigned, type_expected)
+
+        assert_type('INT', None)
+        assert_type('STRING', String)
+        assert_type('CHAR', String)
+        assert_type('VARCHAR', String)
+        assert_type('TEXT', String)
+        assert_type('NCHAR', UnicodeText)
+        assert_type('NVARCHAR', UnicodeText)
+        assert_type('NTEXT', UnicodeText)


### PR DESCRIPTION
A few minor changes when going from 1.2 to 1.3:
- Stricter requirements for being explicit about JOINs: https://docs.sqlalchemy.org/en/latest/changelog/migration_13.html#change-4365
- MSSQL defaults to prefixing text WHERE clauses with `N` (=unicode) on SQLAlchemy 1.3 if type is undefined on py3, which can cause index misses. Added explicitly setting type to non-unicode `String` when column type is `CHAR`/`VARCHAR`/`TEXT`/`STRING`, and similarly to `UnicodeText` when column type is `NCHAR`/`NVARCHAR`/`NTEXT`.