### PR TITLE
[bugfix] SQL Lab 'Filter Results' doesn't stick

### DIFF
--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -153,8 +153,9 @@ export default class ResultSet extends React.PureComponent {
                 <input
                   type="text"
                   onChange={this.changeSearch.bind(this)}
+                  value={this.state.searchText}
                   className="form-control input-sm"
-                  placeholder={t('Search Results')}
+                  placeholder={t('Filter Results')}
                 />
               }
             </div>


### PR DESCRIPTION
<img width="293" alt="Screen Shot 2019-03-24 at 9 13 54 PM" src="https://user-images.githubusercontent.com/487433/54894819-bff49f80-4e79-11e9-97e5-5ae0b0045732.png">

When using a "Search Results" criteria, the subset of rows that match
the criteria get displayed. While this the filter is applied, if another
query is run, the filter is still active, but not displayed in the input
text box. After this change, the state of the input box sticks after
subsequent queries.