### PR TITLE
Use metric name instead of metric in filter box

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1825,7 +1825,10 @@ class FilterBoxViz(BaseViz):
             metric = flt.get('metric')
             df = self.dataframes.get(col)
             if metric:
-                df = df.sort_values(metric, ascending=flt.get('asc'))
+                df = df.sort_values(
+                    utils.get_metric_name(metric),
+                    ascending=flt.get('asc'),
+                )
                 d[col] = [{
                     'id': row[0],
                     'text': row[0],


### PR DESCRIPTION
Filter box charts break if they are using adhoc metrics, so changing viz.py to sort_values on metric name instead of metric. 

Existing filter boxes could use adhoc metrics (because it was previously a metric control), so any charts migrated that previously used adhoc metrics would break. It looks like the new filter boxes don't have the ability to use adhoc metrics, but support for adhoc metrics should be added back.

@graceguo-supercat @john-bodley @mistercrunch 