### PR TITLE
[core] Logo profile link should be disabled for unauthenticated user

### DIFF
--- a/superset/assets/src/explore/main.css
+++ b/superset/assets/src/explore/main.css
@@ -259,3 +259,4 @@ h2.section-header {
   padding-bottom: 5px;
 }
 
+

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -536,3 +536,7 @@ tr.reactable-column-header th.reactable-header-sortable {
 .align-right {
   text-align: right;
 }
+.disabled {
+    pointer-events: none;
+    cursor: auto;
+  }

--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -21,7 +21,11 @@
 {% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
 {% set app_icon_width = appbuilder.app.config.get('APP_ICON_WIDTH', 126) %}
 {% set logo_target_path = appbuilder.app.config.get('LOGO_TARGET_PATH') or '/profile/{}/'.format(current_user.username) %}
-{% set brand_classes = current_user.username ? 'navbar-brand' : 'navbar-brand disabled' %}
+{% if current_user.username %}
+  {% set brand_classes = 'navbar-brand' %}
+{% else %}
+  {% set brand_classes = 'navbar-brand disabled' %}
+{% endif %}
 
 <div class="navbar navbar-static-top {{menu.extra_classes}}" role="navigation">
   <div class="container-fluid">

--- a/superset/templates/appbuilder/navbar.html
+++ b/superset/templates/appbuilder/navbar.html
@@ -21,6 +21,7 @@
 {% set WARNING_MSG = appbuilder.app.config.get('WARNING_MSG') %}
 {% set app_icon_width = appbuilder.app.config.get('APP_ICON_WIDTH', 126) %}
 {% set logo_target_path = appbuilder.app.config.get('LOGO_TARGET_PATH') or '/profile/{}/'.format(current_user.username) %}
+{% set brand_classes = current_user.username ? 'navbar-brand' : 'navbar-brand disabled' %}
 
 <div class="navbar navbar-static-top {{menu.extra_classes}}" role="navigation">
   <div class="container-fluid">
@@ -30,7 +31,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/superset{{ logo_target_path }}">
+      <a class="{{brand_classes}}" href="/superset{{ logo_target_path }}">
         <img
           width="{{ app_icon_width }}"
           src="{{ appbuilder.app_icon }}"


### PR DESCRIPTION
This PR fixes #7107 

- Disabled the click when user is on login page
- After logged is existing behaviour is preserved

Images Before

1. Login screen
<img width="1424" alt="1_Login_screen" src="https://user-images.githubusercontent.com/13412230/54899286-47332900-4ef5-11e9-814d-8fe5bf938b78.png">
2. Error after clicking logo
<img width="1431" alt="2_After Click on superste logo" src="https://user-images.githubusercontent.com/13412230/54899302-5dd98000-4ef5-11e9-84ac-331546c37835.png">


After Fix
1. Non clickable logo
<img width="1440" alt="3_No clickable logo on login screen" src="https://user-images.githubusercontent.com/13412230/54899320-6df15f80-4ef5-11e9-9739-ac365dc28c4b.png">
2.  Clickable logo 
<img width="1440" alt="4_Clickable_after_login" src="https://user-images.githubusercontent.com/13412230/54899347-8792a700-4ef5-11e9-93e7-08047cde535c.png">
3. Existing profile page after click
<img width="1440" alt="profile_screen" src="https://user-images.githubusercontent.com/13412230/54899375-a729cf80-4ef5-11e9-97f4-ea01e3fe2aa9.png">






GIF with before and after the fix

![profile_url](https://user-images.githubusercontent.com/13412230/54899096-bd835b80-4ef4-11e9-9f08-1de23cb7fe90.gif)

