### PR TITLE
[schema] Ensuring that the slice datasource fields are non-nullable

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -27,10 +27,14 @@ assists people when migrating to a new version.
   run `pip install superset[presto]` and/or `pip install superset[hive]` as
   required.
 
-* [5445](https://github.com/apache/incubator-superset/pull/5445) : a change 
-which prevents encoding of empty string from form data in the datanbase. 
+* [5445](https://github.com/apache/incubator-superset/pull/5445) : a change
+which prevents encoding of empty string from form data in the database.
 This involves a non-schema changing migration which does potentially impact
 a large number of records. Scheduled downtime may be advised.
+
+* [7114](https://github.com/apache/incubator-superset/pull/7114): a change
+which adds missing non-nullable fields to the slices table. Depending on the
+integrity of the data, manual intervention may be required.
 
 ## Superset 0.31.0
 * boto3 / botocore was removed from the dependency list. If you use s3

--- a/superset/migrations/versions/1be0344d4b76_slice_non_nullable.py
+++ b/superset/migrations/versions/1be0344d4b76_slice_non_nullable.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""slice non-nullable
+
+Revision ID: 1be0344d4b76
+Revises: c82ee8a39623
+Create Date: 2019-03-25 10:02:38.055193
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1be0344d4b76'
+down_revision = 'c82ee8a39623'
+
+from alembic import op
+from sqlalchemy import Integer, String
+
+
+def upgrade():
+
+    # Enforce that the slices.datasource_id, slices.datasource_name, and
+    # slices.datasource_type columns be non-nullable.
+    with op.batch_alter_table('slices') as batch_op:
+        batch_op.alter_column(
+            'slice_id',
+            existing_type=Integer,
+            nullable=False,
+        )
+
+        batch_op.alter_column(
+            'datasource_name',
+            existing_type=String(2000),
+            nullable=False,
+        )
+
+        batch_op.alter_column(
+            'datasource_type',
+            existing_type=String(200),
+            nullable=False,
+        )
+
+
+def downgrade():
+
+    # Forego that the slices.datasource_id, slices.datasource_name, and
+    # slices.datasource_type columns be non-nullable.
+    with op.batch_alter_table('slices') as batch_op:
+        batch_op.alter_column(
+            'slice_id',
+            existing_type=Integer,
+            nullable=True,
+        )
+
+        batch_op.alter_column(
+            'datasource_name',
+            existing_type=String(2000),
+            nullable=True,
+        )
+
+        batch_op.alter_column(
+            'datasource_type',
+            existing_type=String(200),
+            nullable=True,
+        )

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -149,9 +149,9 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
     __tablename__ = 'slices'
     id = Column(Integer, primary_key=True)
     slice_name = Column(String(250))
-    datasource_id = Column(Integer)
-    datasource_type = Column(String(200))
-    datasource_name = Column(String(2000))
+    datasource_id = Column(Integer, nullable=False)
+    datasource_type = Column(String(200), nullable=False)
+    datasource_name = Column(String(2000), nullable=False)
     viz_type = Column(String(250))
     params = Column(Text)
     description = Column(Text)


### PR DESCRIPTION
We've noticed a number of anomalies in our database caused by ill-defined forms and/or table schema definitions. This PR resolves a number of issues related to the `slices` table including:

- Ensures that the `datasource_id` column is not-NULL.
- Ensures that the `datasource_name` column is not-NULL.
- Ensures that the `datasource_type` column is non-NULL. 

Long terms we should look at trying to deprecate the denormalized `datasource_name` column which can (and should) be inferred from the (`datasource_id`, `datasource_type`) tuple. I believe the reason for its existence is mostly legacy however it may be required for importing/exporting of slices where one must identify entities by name rather than ID.  

Note this migration _will_ fail if the `slices.datasource_id`, `slices.datasource_name`, or `slices.datasource_type` column is NULL. One **must** manually fix these records as programmatically trying to remedy these invalid records is difficult as it may not be apparent what the corresponding datasource should be given the possibly lack of information. The following query determines which records are problematic:
```
SELECT 
    * 
FROM 
    slices
WHERE 
    datasource_id IS NULL OR 
    datasource_name IS NULL OR 
    datasource_type IS NULL
```

Note this PR is gated by https://github.com/apache/incubator-superset/pull/5445 and https://github.com/apache/incubator-superset/pull/7084 which ensure that empty strings associated with form-data wont persist in the database and is necessary for ensuring that the relevant entries are non-NULL.

to: @graceguo-supercat @michellethomas @mistercrunch 

