### PR TITLE
[SQL Lab] fix table metadata loading spinner

### DIFF
--- a/superset/assets/src/SqlLab/components/TableElement.jsx
+++ b/superset/assets/src/SqlLab/components/TableElement.jsx
@@ -40,6 +40,8 @@ const defaultProps = {
   timeout: 500,
 };
 
+const STYLE_ZERO_MARGIN = { margin: 0 };
+
 class TableElement extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -190,7 +192,11 @@ class TableElement extends React.PureComponent {
         </div>
         <div className="pull-right">
           {table.isMetadataLoading || table.isExtraMetadataLoading ?
-            <Loading size={50} />
+            <Loading
+              size={50}
+              position="normal"
+              styleOverrides={STYLE_ZERO_MARGIN}
+            />
             :
             this.renderControls()
           }
@@ -239,7 +245,6 @@ class TableElement extends React.PureComponent {
       <Collapse
         in={this.state.expanded}
         timeout={this.props.timeout}
-        transitionAppear
         onExited={this.removeFromStore.bind(this)}
       >
         <div className="TableElement table-schema m-b-10">

--- a/superset/assets/src/SqlLab/components/TableElement.jsx
+++ b/superset/assets/src/SqlLab/components/TableElement.jsx
@@ -40,8 +40,6 @@ const defaultProps = {
   timeout: 500,
 };
 
-const STYLE_ZERO_MARGIN = { margin: 0 };
-
 class TableElement extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -195,7 +193,7 @@ class TableElement extends React.PureComponent {
             <Loading
               size={50}
               position="normal"
-              styleOverrides={STYLE_ZERO_MARGIN}
+              className="margin-zero"
             />
             :
             this.renderControls()

--- a/superset/assets/src/components/Loading.css
+++ b/superset/assets/src/components/Loading.css
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 img.loading.margin-zero {
   margin: 0px;
 }

--- a/superset/assets/src/components/Loading.css
+++ b/superset/assets/src/components/Loading.css
@@ -1,0 +1,3 @@
+img.loading.margin-zero {
+  margin: 0px;
+}

--- a/superset/assets/src/components/Loading.jsx
+++ b/superset/assets/src/components/Loading.jsx
@@ -22,12 +22,12 @@ import PropTypes from 'prop-types';
 const propTypes = {
   size: PropTypes.number,
   position: PropTypes.oneOf(['floating', 'normal']),
-  styleOverrides: PropTypes.object,
+  className: PropTypes.string,
 };
 const defaultProps = {
   size: 50,
   position: 'floating',
-  styleOverrides: {},
+  className: '',
 };
 
 const FLOATING_STYLE = {
@@ -39,17 +39,15 @@ const FLOATING_STYLE = {
   transform: 'translate(-50%, -50%)',
 };
 
-export default function Loading({ size, position, styleOverrides }) {
+export default function Loading({ size, position, className }) {
   const style = position === 'floating' ? FLOATING_STYLE : {};
   const styleWithWidth = {
     ...style,
-    ...styleOverrides,
     size,
   };
-
   return (
     <img
-      className="loading"
+      className={'loading ' + className}
       alt="Loading..."
       src="/static/assets/images/loading.gif"
       style={styleWithWidth}

--- a/superset/assets/src/components/Loading.jsx
+++ b/superset/assets/src/components/Loading.jsx
@@ -22,10 +22,12 @@ import PropTypes from 'prop-types';
 const propTypes = {
   size: PropTypes.number,
   position: PropTypes.oneOf(['floating', 'normal']),
+  styleOverrides: PropTypes.object,
 };
 const defaultProps = {
   size: 50,
   position: 'floating',
+  styleOverrides: {},
 };
 
 const FLOATING_STYLE = {
@@ -37,12 +39,14 @@ const FLOATING_STYLE = {
   transform: 'translate(-50%, -50%)',
 };
 
-export default function Loading({ size, position }) {
+export default function Loading({ size, position, styleOverrides }) {
   const style = position === 'floating' ? FLOATING_STYLE : {};
   const styleWithWidth = {
     ...style,
+    ...styleOverrides,
     size,
   };
+
   return (
     <img
       className="loading"

--- a/superset/assets/src/components/Loading.jsx
+++ b/superset/assets/src/components/Loading.jsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import './Loading.css';
+
 const propTypes = {
   size: PropTypes.number,
   position: PropTypes.oneOf(['floating', 'normal']),
@@ -47,7 +49,7 @@ export default function Loading({ size, position, className }) {
   };
   return (
     <img
-      className={'loading ' + className}
+      className={`loading ${className}`}
       alt="Loading..."
       src="/static/assets/images/loading.gif"
       style={styleWithWidth}

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -580,3 +580,6 @@ tr.reactable-column-header th.reactable-header-sortable {
 .align-right {
   text-align: right;
 }
+.margin-zero {
+  margin: 0px;
+}

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -581,5 +581,5 @@ tr.reactable-column-header th.reactable-header-sortable {
   text-align: right;
 }
 .margin-zero {
-  margin: 0px;
+  margin: 0px !important;
 }

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -580,6 +580,3 @@ tr.reactable-column-header th.reactable-header-sortable {
 .align-right {
   text-align: right;
 }
-.margin-zero {
-  margin: 0px !important;
-}


### PR DESCRIPTION
![meta](https://user-images.githubusercontent.com/487433/54959915-eb2dcc00-4f17-11e9-8623-250c4153cad8.gif)

The loading spinner used to be close to the new table name that was just
added, and recently flickers and disappears early.

This puts the spinner where it's expected to be.