### PR TITLE
Remove super verbose `logging.debug` call

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -127,7 +127,6 @@ class ParsedQuery(object):
         table_name_preceding_token = False
 
         for item in token.tokens:
-            logging.debug(('  ' * depth) + str(item.ttype) + str(item.value))
             if item.is_group and not self.__is_identifier(item):
                 self.__extract_from_token(item, depth=depth + 1)
 


### PR DESCRIPTION
I left this behind on a previous PR, and it gets kind of crazy on large
SQL statements, so decided it's probably a good thing to clean this up.