### PR TITLE
[Data Source Editor][Bugfix] Use type of NUMERIC instead of NUMBER

### DIFF
--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -43,7 +43,7 @@ import withToasts from '../messageToasts/enhancers/withToasts';
 import './main.css';
 
 const checkboxGenerator = (d, onChange) => <CheckboxControl value={d} onChange={onChange} />;
-const DATA_TYPES = ['STRING', 'NUMBER', 'DATETIME'];
+const DATA_TYPES = ['STRING', 'NUMERIC', 'DATETIME'];
 
 function CollectionTabTitle({ title, collection }) {
   return (
@@ -92,7 +92,7 @@ function ColumnCollectionTable({
               <Field
                 fieldKey="type"
                 label={t('Data Type')}
-                control={<SelectControl choices={DATA_TYPES} name="type" />}
+                control={<SelectControl choices={DATA_TYPES} name="type" freeForm />}
               />}
             <Field
               fieldKey="python_date_format"

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -363,7 +363,7 @@ class BaseColumn(AuditMixinNullable, ImportMixin):
         return self.column_name
 
     num_types = (
-        'DOUBLE', 'FLOAT', 'INT', 'BIGINT',
+        'DOUBLE', 'FLOAT', 'INT', 'BIGINT', 'NUMBER',
         'LONG', 'REAL', 'NUMERIC', 'DECIMAL', 'MONEY',
     )
     date_types = ('DATE', 'TIME', 'DATETIME')


### PR DESCRIPTION
I noticed that the calculated columns created on the datasource editor, when populated using the dropdown type "NUMBER" weren't actually being treated as numeric using the BaseColumn.is_num method. 

On digging further, the problem is with the DataSourceEditor using the string "NUMBER" instead of "NUMERIC". The latter is the proper SQLAlchemy type (as needed by the backend). 

With that I also exposed INT and BIGINT types as well. Should I add all of the SQLAlchemy types as listed in the superset/connectors/base/models.py file ? (I also made the editor accept freeform types)

We should probably add validation for these sort of updates. But I don't know how to do that in the TableModelView CRUD.

cc: @xtinec @mistercrunch 
