### PR TITLE
Make timestamp expression native SQLAlchemy element

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -38,7 +38,7 @@ import sqlparse
 
 from superset import app, db, security_manager
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
-from superset.db_engine_specs import TimeExpression
+from superset.db_engine_specs import TimestampExpression
 from superset.jinja_context import get_template_processor
 from superset.models.annotations import Annotation
 from superset.models.core import Database
@@ -143,7 +143,7 @@ class TableColumn(Model, BaseColumn):
         return and_(*l)
 
     def get_timestamp_expression(self, time_grain: Optional[str]) \
-            -> Union[TimeExpression, Label]:
+            -> Union[TimestampExpression, Label]:
         """
         Return a SQLAlchemy Core element representation of self to be used in a query.
 
@@ -162,7 +162,7 @@ class TableColumn(Model, BaseColumn):
             col = literal_column(self.expression)
         else:
             col = column(self.column_name)
-        time_expr = db.db_engine_spec.get_time_expr(col, pdf, time_grain)
+        time_expr = db.db_engine_spec.get_timestamp_expr(col, pdf, time_grain)
         return self.table.make_sqla_column_compatible(time_expr, label)
 
     @classmethod

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -158,7 +158,7 @@ class BaseEngineSpec(object):
             time_expr = cls.time_grain_functions.get(time_grain)
             if not time_expr:
                 raise NotImplementedError(
-                    f'No grain spec for {time_grain} for database {db.database_name}')
+                    f'No grain spec for {time_grain} for database {cls.engine}')
         else:
             time_expr = '{col}'
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -36,10 +36,8 @@ import os
 import re
 import textwrap
 import time
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 from urllib import parse
-
-from typing import Optional
 
 from flask import g
 from flask_babel import lazy_gettext as _
@@ -133,7 +131,7 @@ class BaseEngineSpec(object):
     """Abstract class for database engine specific configurations"""
 
     engine = 'base'  # str as defined in sqlalchemy.engine.engine
-    time_grain_functions: dict = {}
+    time_grain_functions: Dict[str, str] = {}
     time_groupby_inline = False
     limit_method = LimitMethod.FORCE_LIMIT
     time_secondary_columns = False

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -146,15 +146,6 @@ class BaseEngineSpec(object):
     try_remove_schema_from_table_name = True
 
     @classmethod
-    def _grains_dict(cls):
-        """Allowing to lookup grain by either label or duration
-
-        For backward compatibility"""
-        d = {grain.duration: grain for grain in cls.get_time_grains()}
-        d.update({grain.label: grain for grain in cls.get_time_grains()})
-        return d
-
-    @classmethod
     def get_time_expr(cls, col: ColumnClause, pdf: Optional[str],
                       time_grain: Optional[str]) -> TimeExpression:
         """
@@ -165,7 +156,7 @@ class BaseEngineSpec(object):
         :param time_grain: Optional time grain, e.g. P1Y for 1 year
         :return: TimeExpression object
         """
-        grain = cls._grains_dict().get(time_grain) or None
+        grain = cls.time_grain_functions.get(time_grain) if time_grain else None
         if time_grain and not grain:
             raise NotImplementedError(
                 f'No grain spec for {time_grain} for database {db.database_name}')

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -131,7 +131,7 @@ class BaseEngineSpec(object):
     """Abstract class for database engine specific configurations"""
 
     engine = 'base'  # str as defined in sqlalchemy.engine.engine
-    time_grain_functions: Dict[str, str] = {}
+    time_grain_functions: Dict[Optional[str], str] = {}
     time_groupby_inline = False
     limit_method = LimitMethod.FORCE_LIMIT
     time_secondary_columns = False
@@ -811,7 +811,7 @@ class MySQLEngineSpec(BaseEngineSpec):
               'INTERVAL DAYOFWEEK(DATE_SUB({col}, INTERVAL 1 DAY)) - 1 DAY))',
     }
 
-    type_code_map: dict = {}  # loaded from get_datatype only if needed
+    type_code_map: Dict[int, str] = {}  # loaded from get_datatype only if needed
 
     @classmethod
     def convert_dttm(cls, target_type, dttm):
@@ -1830,7 +1830,7 @@ class PinotEngineSpec(BaseEngineSpec):
     supports_column_aliases = False
 
     # Pinot does its own conversion below
-    time_grain_functions = {
+    time_grain_functions: Dict[Optional[str], str] = {
         'PT1S': '1:SECONDS',
         'PT1M': '1:MINUTES',
         'PT1H': '1:HOURS',

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -156,7 +156,6 @@ class BaseEngineSpec(object):
         :param time_grain: Optional time grain, e.g. P1Y for 1 year
         :return: TimeExpression object
         """
-
         if time_grain:
             time_expr = cls.time_grain_functions.get(time_grain)
             if not time_expr:

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -156,12 +156,15 @@ class BaseEngineSpec(object):
         :param time_grain: Optional time grain, e.g. P1Y for 1 year
         :return: TimeExpression object
         """
-        grain = cls.time_grain_functions.get(time_grain) if time_grain else None
-        if time_grain and not grain:
-            raise NotImplementedError(
-                f'No grain spec for {time_grain} for database {db.database_name}')
 
-        time_expr = grain.function if grain else '{col}'
+        if time_grain:
+            time_expr = cls.time_grain_functions.get(time_grain)
+            if not time_expr:
+                raise NotImplementedError(
+                    f'No grain spec for {time_grain} for database {db.database_name}')
+        else:
+            time_expr = '{col}'
+
         # if epoch, translate to DATE using db specific conf
         if pdf == 'epoch_s':
             time_expr = time_expr.replace('{col}', cls.epoch_to_dttm())

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1029,20 +1029,12 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         """Defines time granularity database-specific expressions.
 
         The idea here is to make it easy for users to change the time grain
-        form a datetime (maybe the source grain is arbitrary timestamps, daily
+        from a datetime (maybe the source grain is arbitrary timestamps, daily
         or 5 minutes increments) to another, "truncated" datetime. Since
         each database has slightly different but similar datetime functions,
         this allows a mapping between database engines and actual functions.
         """
         return self.db_engine_spec.get_time_grains()
-
-    def grains_dict(self):
-        """Allowing to lookup grain by either label or duration
-
-        For backward compatibility"""
-        d = {grain.duration: grain for grain in self.grains()}
-        d.update({grain.label: grain for grain in self.grains()})
-        return d
 
     def get_extra(self):
         extra = {}

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -489,48 +489,48 @@ class DbEngineSpecsTestCase(SupersetTestCase):
 
     def test_pg_time_expression_literal_no_grain(self):
         col = literal_column('COALESCE(a, b)')
-        expr = PostgresEngineSpec.get_time_expr(col, None, None)
+        expr = PostgresEngineSpec.get_timestamp_expr(col, None, None)
         result = str(expr.compile(dialect=postgresql.dialect()))
         self.assertEqual(result, 'COALESCE(a, b)')
 
     def test_pg_time_expression_literal_1y_grain(self):
         col = literal_column('COALESCE(a, b)')
-        expr = PostgresEngineSpec.get_time_expr(col, None, 'P1Y')
+        expr = PostgresEngineSpec.get_timestamp_expr(col, None, 'P1Y')
         result = str(expr.compile(dialect=postgresql.dialect()))
         self.assertEqual(result, "DATE_TRUNC('year', COALESCE(a, b))")
 
     def test_pg_time_expression_lower_column_no_grain(self):
         col = column('lower_case')
-        expr = PostgresEngineSpec.get_time_expr(col, None, None)
+        expr = PostgresEngineSpec.get_timestamp_expr(col, None, None)
         result = str(expr.compile(dialect=postgresql.dialect()))
         self.assertEqual(result, 'lower_case')
 
     def test_pg_time_expression_lower_case_column_sec_1y_grain(self):
         col = column('lower_case')
-        expr = PostgresEngineSpec.get_time_expr(col, 'epoch_s', 'P1Y')
+        expr = PostgresEngineSpec.get_timestamp_expr(col, 'epoch_s', 'P1Y')
         result = str(expr.compile(dialect=postgresql.dialect()))
         self.assertEqual(result, "DATE_TRUNC('year', (timestamp 'epoch' + lower_case * interval '1 second'))")  # noqa
 
     def test_pg_time_expression_mixed_case_column_1y_grain(self):
         col = column('MixedCase')
-        expr = PostgresEngineSpec.get_time_expr(col, None, 'P1Y')
+        expr = PostgresEngineSpec.get_timestamp_expr(col, None, 'P1Y')
         result = str(expr.compile(dialect=postgresql.dialect()))
         self.assertEqual(result, "DATE_TRUNC('year', \"MixedCase\")")
 
     def test_mssql_time_expression_mixed_case_column_1y_grain(self):
         col = column('MixedCase')
-        expr = MssqlEngineSpec.get_time_expr(col, None, 'P1Y')
+        expr = MssqlEngineSpec.get_timestamp_expr(col, None, 'P1Y')
         result = str(expr.compile(dialect=mssql.dialect()))
         self.assertEqual(result, 'DATEADD(year, DATEDIFF(year, 0, [MixedCase]), 0)')
 
     def test_oracle_time_expression_reserved_keyword_1m_grain(self):
         col = column('decimal')
-        expr = OracleEngineSpec.get_time_expr(col, None, 'P1M')
+        expr = OracleEngineSpec.get_timestamp_expr(col, None, 'P1M')
         result = str(expr.compile(dialect=oracle.dialect()))
         self.assertEqual(result, "TRUNC(CAST(\"decimal\" as DATE), 'MONTH')")
 
     def test_pinot_time_expression_sec_1m_grain(self):
         col = column('tstamp')
-        expr = PinotEngineSpec.get_time_expr(col, 'epoch_s', 'P1M')
+        expr = PinotEngineSpec.get_timestamp_expr(col, 'epoch_s', 'P1M')
         result = str(expr.compile())
         self.assertEqual(result, 'DATETIMECONVERT(tstamp, "1:SECONDS:EPOCH", "1:SECONDS:EPOCH", "1:MONTHS")')  # noqa

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -17,15 +17,16 @@
 import inspect
 from unittest import mock
 
-from sqlalchemy import column, select, table
-from sqlalchemy.dialects.mssql import pymssql
+from sqlalchemy import column, literal_column, select, table
+from sqlalchemy.dialects import mssql, oracle, postgresql
 from sqlalchemy.engine.result import RowProxy
 from sqlalchemy.types import String, UnicodeText
 
 from superset import db_engine_specs
 from superset.db_engine_specs import (
     BaseEngineSpec, BQEngineSpec, HiveEngineSpec, MssqlEngineSpec,
-    MySQLEngineSpec, OracleEngineSpec, PrestoEngineSpec,
+    MySQLEngineSpec, OracleEngineSpec, PinotEngineSpec, PostgresEngineSpec,
+    PrestoEngineSpec,
 )
 from superset.models.core import Database
 from .base_tests import SupersetTestCase
@@ -451,7 +452,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         assert_type('NTEXT', UnicodeText)
 
     def test_mssql_where_clause_n_prefix(self):
-        dialect = pymssql.dialect()
+        dialect = mssql.dialect()
         spec = MssqlEngineSpec
         str_col = column('col', type_=spec.get_sqla_column_type('VARCHAR(10)'))
         unicode_col = column('unicode_col', type_=spec.get_sqla_column_type('NTEXT'))
@@ -462,7 +463,9 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             where(unicode_col == 'abc')
 
         query = str(sel.compile(dialect=dialect, compile_kwargs={'literal_binds': True}))
-        query_expected = "SELECT col, unicode_col \nFROM tbl \nWHERE col = 'abc' AND unicode_col = N'abc'"  # noqa
+        query_expected = "SELECT col, unicode_col \n" \
+                         "FROM tbl \n" \
+                         "WHERE col = 'abc' AND unicode_col = N'abc'"
         self.assertEqual(query, query_expected)
 
     def test_get_table_names(self):
@@ -483,3 +486,51 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         pg_result = db_engine_specs.PostgresEngineSpec.get_table_names(
             schema='schema', inspector=inspector)
         self.assertListEqual(pg_result_expected, pg_result)
+
+    def test_pg_time_expression_literal_no_grain(self):
+        col = literal_column('COALESCE(a, b)')
+        expr = PostgresEngineSpec.get_time_expr(col, None, None)
+        result = str(expr.compile(dialect=postgresql.dialect()))
+        self.assertEqual(result, "COALESCE(a, b)")
+
+    def test_pg_time_expression_literal_1y_grain(self):
+        col = literal_column('COALESCE(a, b)')
+        expr = PostgresEngineSpec.get_time_expr(col, None, 'P1Y')
+        result = str(expr.compile(dialect=postgresql.dialect()))
+        self.assertEqual(result, "DATE_TRUNC('year', COALESCE(a, b))")
+
+    def test_pg_time_expression_lower_column_no_grain(self):
+        col = column('lower_case')
+        expr = PostgresEngineSpec.get_time_expr(col, None, None)
+        result = str(expr.compile(dialect=postgresql.dialect()))
+        self.assertEqual(result, 'lower_case')
+
+    def test_pg_time_expression_lower_case_column_sec_1y_grain(self):
+        col = column('lower_case')
+        expr = PostgresEngineSpec.get_time_expr(col, 'epoch_s', 'P1Y')
+        result = str(expr.compile(dialect=postgresql.dialect()))
+        self.assertEqual(result, "DATE_TRUNC('year', (timestamp 'epoch' + lower_case * interval '1 second'))")  # noqa
+
+    def test_pg_time_expression_mixed_case_column_1y_grain(self):
+        col = column('MixedCase')
+        expr = PostgresEngineSpec.get_time_expr(col, None, 'P1Y')
+        result = str(expr.compile(dialect=postgresql.dialect()))
+        self.assertEqual(result, "DATE_TRUNC('year', \"MixedCase\")")
+
+    def test_mssql_time_expression_mixed_case_column_1y_grain(self):
+        col = column('MixedCase')
+        expr = MssqlEngineSpec.get_time_expr(col, None, 'P1Y')
+        result = str(expr.compile(dialect=mssql.dialect()))
+        self.assertEqual(result, "DATEADD(year, DATEDIFF(year, 0, [MixedCase]), 0)")
+
+    def test_oracle_time_expression_reserved_keyword_1m_grain(self):
+        col = column('decimal')
+        expr = OracleEngineSpec.get_time_expr(col, None, 'P1M')
+        result = str(expr.compile(dialect=oracle.dialect()))
+        self.assertEqual(result, "TRUNC(CAST(\"decimal\" as DATE), 'MONTH')")
+
+    def test_pinot_time_expression_sec_1m_grain(self):
+        col = column('tstamp')
+        expr = PinotEngineSpec.get_time_expr(col, 'epoch_s', 'P1M')
+        result = str(expr.compile())
+        self.assertEqual(result, 'DATETIMECONVERT(tstamp, "1:SECONDS:EPOCH", "1:SECONDS:EPOCH", "1:MONTHS")')  # noqa

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -463,8 +463,8 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             where(unicode_col == 'abc')
 
         query = str(sel.compile(dialect=dialect, compile_kwargs={'literal_binds': True}))
-        query_expected = "SELECT col, unicode_col \n" \
-                         "FROM tbl \n" \
+        query_expected = 'SELECT col, unicode_col \n' \
+                         'FROM tbl \n' \
                          "WHERE col = 'abc' AND unicode_col = N'abc'"
         self.assertEqual(query, query_expected)
 
@@ -491,7 +491,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         col = literal_column('COALESCE(a, b)')
         expr = PostgresEngineSpec.get_time_expr(col, None, None)
         result = str(expr.compile(dialect=postgresql.dialect()))
-        self.assertEqual(result, "COALESCE(a, b)")
+        self.assertEqual(result, 'COALESCE(a, b)')
 
     def test_pg_time_expression_literal_1y_grain(self):
         col = literal_column('COALESCE(a, b)')
@@ -521,7 +521,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         col = column('MixedCase')
         expr = MssqlEngineSpec.get_time_expr(col, None, 'P1Y')
         result = str(expr.compile(dialect=mssql.dialect()))
-        self.assertEqual(result, "DATEADD(year, DATEDIFF(year, 0, [MixedCase]), 0)")
+        self.assertEqual(result, 'DATEADD(year, DATEDIFF(year, 0, [MixedCase]), 0)')
 
     def test_oracle_time_expression_reserved_keyword_1m_grain(self):
         col = column('decimal')

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -109,14 +109,6 @@ class DatabaseModelTestCase(SupersetTestCase):
         LIMIT 100""")
         assert sql.startswith(expected)
 
-    def test_grains_dict(self):
-        uri = 'mysql://root@localhost'
-        database = Database(sqlalchemy_uri=uri)
-        d = database.grains_dict()
-        self.assertEquals(d.get('day').function, 'DATE({col})')
-        self.assertEquals(d.get('P1D').function, 'DATE({col})')
-        self.assertEquals(d.get('Time Column').function, '{col}')
-
     def test_single_statement(self):
         main_db = get_main_database(db.session)
 
@@ -183,24 +175,6 @@ class SqlaTableModelTestCase(SupersetTestCase):
         if tbl.database.backend == 'mysql':
             self.assertEquals(compiled, 'DATE(from_unixtime(DATE_ADD(ds, 1)))')
         ds_col.expression = prev_ds_expr
-
-    def test_get_timestamp_expression_backward(self):
-        tbl = self.get_table_by_name('birth_names')
-        ds_col = tbl.get_column('ds')
-
-        ds_col.expression = None
-        ds_col.python_date_format = None
-        sqla_literal = ds_col.get_timestamp_expression('day')
-        compiled = '{}'.format(sqla_literal.compile())
-        if tbl.database.backend == 'mysql':
-            self.assertEquals(compiled, 'DATE(ds)')
-
-        ds_col.expression = None
-        ds_col.python_date_format = None
-        sqla_literal = ds_col.get_timestamp_expression('Time Column')
-        compiled = '{}'.format(sqla_literal.compile())
-        if tbl.database.backend == 'mysql':
-            self.assertEquals(compiled, 'ds')
 
     def query_with_expr_helper(self, is_timeseries, inner_join=True):
         tbl = self.get_table_by_name('birth_names')

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -117,39 +117,6 @@ class DatabaseModelTestCase(SupersetTestCase):
         self.assertEquals(d.get('P1D').function, 'DATE({col})')
         self.assertEquals(d.get('Time Column').function, '{col}')
 
-    def test_postgres_expression_time_grain(self):
-        uri = 'postgresql+psycopg2://uid:pwd@localhost:5432/superset'
-        database = Database(sqlalchemy_uri=uri)
-        pdf, time_grain = '', 'P1D'
-        expression, column_name = 'COALESCE(lowercase_col, "MixedCaseCol")', ''
-        grain = database.grains_dict().get(time_grain)
-        col = database.db_engine_spec.get_timestamp_column(expression, column_name)
-        grain_expr = database.db_engine_spec.get_time_expr(col, pdf, time_grain, grain)
-        grain_expr_expected = grain.function.replace('{col}', expression)
-        self.assertEqual(grain_expr, grain_expr_expected)
-
-    def test_postgres_lowercase_col_time_grain(self):
-        uri = 'postgresql+psycopg2://uid:pwd@localhost:5432/superset'
-        database = Database(sqlalchemy_uri=uri)
-        pdf, time_grain = '', 'P1D'
-        expression, column_name = '', 'lowercase_col'
-        grain = database.grains_dict().get(time_grain)
-        col = database.db_engine_spec.get_timestamp_column(expression, column_name)
-        grain_expr = database.db_engine_spec.get_time_expr(col, pdf, time_grain, grain)
-        grain_expr_expected = grain.function.replace('{col}', column_name)
-        self.assertEqual(grain_expr, grain_expr_expected)
-
-    def test_postgres_mixedcase_col_time_grain(self):
-        uri = 'postgresql+psycopg2://uid:pwd@localhost:5432/superset'
-        database = Database(sqlalchemy_uri=uri)
-        pdf, time_grain = '', 'P1D'
-        expression, column_name = '', 'MixedCaseCol'
-        grain = database.grains_dict().get(time_grain)
-        col = database.db_engine_spec.get_timestamp_column(expression, column_name)
-        grain_expr = database.db_engine_spec.get_time_expr(col, pdf, time_grain, grain)
-        grain_expr_expected = grain.function.replace('{col}', f'"{column_name}"')
-        self.assertEqual(grain_expr, grain_expr_expected)
-
     def test_single_statement(self):
         main_db = get_main_database(db.session)
 


### PR DESCRIPTION
##### SUMMARY

The functional part of this PR makes the timestamp expression a native SQLAlchemy element that respects quoting rules for column names (based largely on https://docs.sqlalchemy.org/en/latest/core/compiler.html) . This is a continuation of what was started in #6897, which was really just a hack to make `Postgres` work, but didn't address e.g. reserved keywords or similar problems that might arise in other dbs. This PR adds a new class `TimestampExpression`, which can be used in a SQLAlchemy query, which keeps the target column as a native Core element. The column name is only rendered to text once the query is compiled, which ensures that engine specific quoting rules are respected.

Refactoring:

- Added mypy typing where code was changed.
- Moved some functional parts of `sqla/models/get_timestamp_expression()` to `db_engine_specs/get_timestamp_expr()`.
- Removed `models/core/grains()` which was no longer needed.

##### TEST PLAN
Added unit tests that test the central features and tested timeseries graphs using both column and expression, both with and without time grains.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x] Fixes bug
    [x] Refactors code
    [x] Adds test(s)

##### REVIEWERS
Comments much appreciated @betodealmeida @john-bodley. Also @agrawaldevesh: I had to change the Pinot logic for this PR. Do you have the opportunity to test if this works on your Pinot deployment (I don't have a Pinot installation handy right now)? I also added a few grains while at it, do they work?
