### PR TITLE
Bump python lib croniter to an existing version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ chardet==3.0.4            # via requests
 click==6.7
 colorama==0.3.9
 contextlib2==0.5.5
-croniter==0.3.26
+croniter==0.3.29
 cryptography==2.4.2
 decorator==4.3.0          # via retry
 defusedxml==0.5.0         # via python3-openid

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'click>=6.0, <7.0.0',  # `click`>=7 forces "-" instead of "_"
         'colorama',
         'contextlib2',
-        'croniter>=0.3.26',
+        'croniter>=0.3.28',
         'cryptography>=2.4.2',
         'flask>=1.0.0, <2.0.0',
         'flask-appbuilder>=1.12.5, <2.0.0',


### PR DESCRIPTION
Package maintainers should really never delete packages, but it appears
this happened with `croniter==0.3.26` and resulted in breaking our builds.

This PR bumps to a more recent existing version of the library