### PR TITLE
Update croniter version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ chardet==3.0.4            # via requests
 click==6.7
 colorama==0.3.9
 contextlib2==0.5.5
-croniter==0.3.26
+croniter==0.3.29
 cryptography==2.4.2
 decorator==4.3.0          # via retry
 defusedxml==0.5.0         # via python3-openid


### PR DESCRIPTION
The croniter version (0.3.26) in requirements.txt is no longer available from pypi. See
https://pypi.org/project/croniter/
Updating the dependency to the new version 0.3.29
cc @mahendra 