### PR TITLE
Choose encoding when export csv

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2684,7 +2684,7 @@ class Superset(BaseSupersetView):
             df = query.database.get_df(sql, query.schema)
             # TODO(bkyryliuk): add compression=gzip for big files.
             csv = df.to_csv(index=False, **config.get('CSV_EXPORT'))
-        response = Response(csv, mimetype='text/csv')
+        response = CsvResponse(csv, mimetype='text/csv')
         response.headers['Content-Disposition'] = f'attachment; filename={query.name}.csv'
         logging.info('Ready to return response')
         return response


### PR DESCRIPTION
config.py change CSV_EXPORT.encoding to gbk isn't effect download file encoding in SQL  Lab
CSV_EXPORT = {
'encoding': 'gbk',
}