### PR TITLE
[migration] Fixing issue with c82ee8a39623 downgrade

### DIFF
--- a/superset/migrations/versions/c82ee8a39623_add_implicit_tags.py
+++ b/superset/migrations/versions/c82ee8a39623_add_implicit_tags.py
@@ -71,5 +71,5 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_table('tag')
     op.drop_table('tagged_object')
+    op.drop_table('tag')


### PR DESCRIPTION
This PR fixes an issue with the downgrade step of migration `c82ee8a39623` which causes the following error, 
```
sqlalchemy.exc.IntegrityError: (_mysql_exceptions.IntegrityError) (1217, 'Cannot delete or update a parent row: a foreign key constraint fails') [SQL: '\nDROP TABLE tag'] (Background on this error at: http://sqlalche.me/e/gkpj)
```

This was caused by the fact that there's a foreign key to the `tag` table in the `tagged_object` table and thus the `tagged_object` table needs to be dropped first, i.e., the downgrade should generally reverse the order of operations defined in the upgrade.

to: @betodealmeida @graceguo-supercat @michellethomas @mistercrunch @xtinec 