### PR TITLE
[migration] Fixing issue with fb13d49b72f9 downgrade

### DIFF
--- a/superset/migrations/versions/fb13d49b72f9_better_filters.py
+++ b/superset/migrations/versions/fb13d49b72f9_better_filters.py
@@ -94,7 +94,7 @@ def downgrade():
             flts = params.get('filter_configs')
             if not flts:
                 continue
-            params['metric'] = [flts[0].get('metric')]
+            params['metric'] = flts[0].get('metric')
             params['groupby'] = [o.get('column') for o in flts]
             slc.params = json.dumps(params, sort_keys=True)
         except Exception as e:

--- a/superset/migrations/versions/fb13d49b72f9_better_filters.py
+++ b/superset/migrations/versions/fb13d49b72f9_better_filters.py
@@ -94,7 +94,7 @@ def downgrade():
             flts = params.get('filter_configs')
             if not flts:
                 continue
-            params['metrics'] = [flts[0].get('metric')]
+            params['metric'] = [flts[0].get('metric')]
             params['groupby'] = [o.get('column') for o in flts]
             slc.params = json.dumps(params, sort_keys=True)
         except Exception as e:


### PR DESCRIPTION
This PR fixes an issue with the downgrade step of migration fb13d49b72f9 which wrongfully labeled the field `metrics` rather than `metric` which also should be a single item rather than a list.

to: @graceguo-supercat @michellethomas @mistercrunch