### PR TITLE
fix:issue saving Schedule Email Reports for Dashboards  error

### DIFF
--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -90,7 +90,8 @@ class EmailScheduleView(SupersetModelView, DeleteMixin):
     edit_form_extra_fields = add_form_extra_fields
 
     def process_form(self, form, is_created):
-        recipients = form.test_email_recipients.data.strip() if form.test_email_recipients.data else None
+        recipients_data = form.test_email_recipients.data
+        recipients = recipients_data.strip() if recipients_data else None
         self._extra_data['test_email'] = form.test_email.data
         self._extra_data['test_email_recipients'] = recipients
 

--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -90,7 +90,7 @@ class EmailScheduleView(SupersetModelView, DeleteMixin):
     edit_form_extra_fields = add_form_extra_fields
 
     def process_form(self, form, is_created):
-        recipients = form.test_email_recipients.data.strip() or None
+        recipients = form.test_email_recipients.data.strip() if form.test_email_recipients.data else None
         self._extra_data['test_email'] = form.test_email.data
         self._extra_data['test_email_recipients'] = recipients
 


### PR DESCRIPTION
When Test Email Recipients is blank,save the settings will throw an error. And I found form.test_email_recipients.data is None,so it throw exceptions.
The Traceback  as follows:

superset_1  | [2019-03-25 09:14:03 +0800] [38] [ERROR] Error handling request /dashboardemailscheduleview/edit/1
superset_1  | Traceback (most recent call last):
superset_1  |   File "/usr/local/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 135, in handle
superset_1  |     self.handle_request(listener, req, client, addr)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 176, in handle_request
superset_1  |     respiter = self.wsgi(environ, resp.start_response)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 2309, in __call__
superset_1  |     return self.wsgi_app(environ, start_response)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 2295, in wsgi_app
superset_1  |     response = self.handle_exception(e)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1741, in handle_exception
superset_1  |     reraise(exc_type, exc_value, tb)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
superset_1  |     raise value
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 2292, in wsgi_app
superset_1  |     response = self.full_dispatch_request()
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1815, in full_dispatch_request
superset_1  |     rv = self.handle_user_exception(e)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1718, in handle_user_exception
superset_1  |     reraise(exc_type, exc_value, tb)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
superset_1  |     raise value
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request
superset_1  |     rv = self.dispatch_request()
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request
superset_1  |     return self.view_functions[rule.endpoint](**req.view_args)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask_appbuilder/security/decorators.py", line 26, in wraps
superset_1  |     return f(self, *args, **kwargs)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask_appbuilder/views.py", line 524, in edit
superset_1  |     widgets = self._edit(pk)
superset_1  |   File "/usr/local/lib/python3.6/site-packages/flask_appbuilder/baseviews.py", line 968, in _edit
superset_1  |     self.process_form(form, False)
superset_1  |   File "/home/superset/superset/views/schedules.py", line 93, in process_form
superset_1  |     recipients = form.test_email_recipients.data.strip() or None
superset_1  | AttributeError: 'NoneType' object has no attribute 'strip'