### PR TITLE
[cache] Render label when cached

### DIFF
--- a/superset/assets/src/explore/components/ExploreChartHeader.jsx
+++ b/superset/assets/src/explore/components/ExploreChartHeader.jsx
@@ -94,7 +94,7 @@ class ExploreChartHeader extends React.PureComponent {
       chartUpdateStartTime,
       latestQueryFormData,
       queryResponse } = this.props.chart;
-    const chartSucceeded = ['success', 'rendered'].indexOf(this.props.chart.chartStatus) > 0;
+      const chartFinished = ['failed', 'rendered', 'success'].includes(this.props.chart.chartStatus);
     return (
       <div
         id="slice-header"
@@ -135,12 +135,12 @@ class ExploreChartHeader extends React.PureComponent {
           />
         }
         <div className="pull-right">
-          {chartSucceeded && queryResponse &&
+          {chartFinished && queryResponse &&
             <RowCountLabel
               rowcount={queryResponse.rowcount}
               limit={formData.row_limit}
             />}
-          {chartSucceeded && queryResponse && queryResponse.is_cached &&
+          {chartFinished && queryResponse && queryResponse.is_cached &&
             <CachedLabel
               onClick={this.runQuery.bind(this)}
               cachedTimestamp={queryResponse.cached_dttm}


### PR DESCRIPTION
A result set may return zero rows which is then cached (as expected) however this isn't evident in the explorer UI and thus there's no way to force refresh the query.

Note this also fixes an issue where the `success` state was ignored given we were checking an `indexOf` being strictly greater than zero.

**Before**
![Screen Shot 2019-03-28 at 5 30 58 PM](https://user-images.githubusercontent.com/4567245/55201236-4f9e9480-517f-11e9-8576-5b1d6c3ffef2.png)

**After**
![Screen Shot 2019-03-28 at 5 31 47 PM](https://user-images.githubusercontent.com/4567245/55201255-6513be80-517f-11e9-9de1-6d26760f72ba.png)

to: @kristw @michellethomas @mistercrunch 