### PR TITLE
[encoding] Adding explicit encoding when opening file contain utf-8 characters 

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -45,7 +45,7 @@ CONFIG_MODULE = os.environ.get('SUPERSET_CONFIG', 'superset.config')
 if not os.path.exists(config.DATA_DIR):
     os.makedirs(config.DATA_DIR)
 
-with open(APP_DIR + '/static/assets/backendSync.json', 'r') as f:
+with open(APP_DIR + '/static/assets/backendSync.json', 'r', encoding='utf-8') as f:
     frontend_config = json.load(f)
 
 app = Flask(__name__)


### PR DESCRIPTION
We came across a situation where `open(...)` threw a `UnicodeDecodeError` as the  `backendSync.json` file now contains non ascii characters [here](https://github.com/apache/incubator-superset/blob/master/superset/assets/backendSync.json#L1189-L1190) (which was introduced in v0.31), i.e.,
```
  File "/usr/local/lib/python3.6/dist-packages/superset/__init__.py", line 48, in <module>
    frontend_config = json.load(f)
  File "/usr/lib/python3.6/json/__init__.py", line 296, in load
    return loads(fp.read(),
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 23166: ordinal not in range(128)
```

According to the [documentation] when using `open(...)` without an explicit encoding the encoding is [determined](http://python-notes.curiousefficiency.org/en/latest/python3/text_file_processing.html#files-in-a-typical-platform-specific-encoding) from the OS. It seems prudent however to explicitly define the encoding when the encoding is [known](http://python-notes.curiousefficiency.org/en/latest/python3/text_file_processing.html#files-in-a-consistent-known-encoding).

Note there are other examples in the code base where the encoding is explicitly defined and thus this doesn't seem to be an anti-pattern. 

to: @graceguo-supercat @michellethomas @mistercrunch 