### PR TITLE
Fix: Click OK button cannot close error message modal

### DIFF
--- a/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
@@ -184,19 +184,21 @@ class ExploreResultsButton extends React.PureComponent {
   render() {
     const allowsSubquery = this.props.database && this.props.database.allows_subquery;
     return (
-      <Button
-        bsSize="small"
-        onClick={this.onClick}
-        disabled={!allowsSubquery}
-        tooltip={t('Explore the result set in the data exploration view')}
-      >
+      <React.Fragment>
+        <Button
+          bsSize="small"
+          onClick={this.onClick}
+          disabled={!allowsSubquery}
+          tooltip={t('Explore the result set in the data exploration view')}
+        >
+          <InfoTooltipWithTrigger icon="line-chart" placement="top" label="explore" /> {t('Explore')}
+        </Button>
         <Dialog
           ref={(el) => {
             this.dialog = el;
           }}
         />
-        <InfoTooltipWithTrigger icon="line-chart" placement="top" label="explore" /> {t('Explore')}
-      </Button>
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change fixes a bug where if the error modal popped up when a user wanted to explore their data in SQL Lab, they modal would not disappear when they clicked the ok button.

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Screen Recording 2019-03-29 at 5 14 08 PM](https://user-images.githubusercontent.com/8145843/55268496-47119100-5247-11e9-897b-1b6bbfa7f2b9.gif)

After:
![Screen Recording 2019-03-29 at 7 04 16 PM](https://user-images.githubusercontent.com/8145843/55271603-bb126000-526c-11e9-8900-f0c3fdf4c5c8.gif)

##### TEST PLAN
<!--- What steps were taken to verify -->
To test this change, I ran everything locally.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x ] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS
