### PR TITLE
fix: do not crash when a vis type is disabled.

### DIFF
--- a/superset/assets/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset/assets/src/explore/components/ControlPanelsContainer.jsx
@@ -58,8 +58,8 @@ class ControlPanelsContainer extends React.Component {
     let mapF = controls[controlName].mapStateToProps;
 
     // Looking to find mapStateToProps override for this viz type
-    const config = controlPanelConfigs[this.props.controls.viz_type.value].controlOverrides;
-    const controlOverrides = config || {};
+    const config = controlPanelConfigs[this.props.controls.viz_type.value] || {};
+    const controlOverrides = config.controlOverrides || {};
     if (controlOverrides[controlName] && controlOverrides[controlName].mapStateToProps) {
       mapF = controlOverrides[controlName].mapStateToProps;
     }

--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -130,8 +130,6 @@ export default class VizTypeControl extends React.PureComponent {
       .concat(registry.entries().filter(({ key }) => !typesWithDefaultOrder.has(key)))
       .filter(entry => entry.value.name.toLowerCase().includes(filterString));
 
-    const selectedType = registry.get(value);
-
     const rows = [];
     for (let i = 0; i <= filteredTypes.length; i += IMAGE_PER_ROW) {
       rows.push(
@@ -155,11 +153,11 @@ export default class VizTypeControl extends React.PureComponent {
         >
           <React.Fragment>
             <Label onClick={this.toggleModal} style={LABEL_STYLE}>
-              {selectedType ? selectedType.name : `${value}`}
+              {registry.has(value) ? registry.get(value).name : `${value}`}
             </Label>
-            <div className="text-danger">
+            {(!registry.has(value) && <div className="text-danger">
               <i className="fa fa-exclamation-circle text-danger" /> <small>This visualization type is not supported.</small>
-            </div>
+            </div>)}
           </React.Fragment>
         </OverlayTrigger>
         <Modal

--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -37,7 +37,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  onChange: () => { },
+  onChange: () => {},
 };
 
 const registry = getChartMetadataRegistry();
@@ -156,7 +156,7 @@ export default class VizTypeControl extends React.PureComponent {
               {registry.has(value) ? registry.get(value).name : `${value}`}
             </Label>
             {(!registry.has(value) && <div className="text-danger">
-              <i className="fa fa-exclamation-circle text-danger" /> <small>This visualization type is not supported.</small>
+              <i className="fa fa-exclamation-circle text-danger" /> <small>{t('This visualization type is not supported.')}</small>
             </div>)}
           </React.Fragment>
         </OverlayTrigger>

--- a/superset/assets/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset/assets/src/explore/components/controls/VizTypeControl.jsx
@@ -20,7 +20,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Label, Row, Col, FormControl, Modal, OverlayTrigger,
-  Tooltip } from 'react-bootstrap';
+  Tooltip,
+} from 'react-bootstrap';
 import { t } from '@superset-ui/translation';
 import { getChartMetadataRegistry } from '@superset-ui/chart';
 
@@ -36,8 +37,26 @@ const propTypes = {
 };
 
 const defaultProps = {
-  onChange: () => {},
+  onChange: () => { },
 };
+
+const registry = getChartMetadataRegistry();
+
+const IMAGE_PER_ROW = 6;
+const LABEL_STYLE = { cursor: 'pointer' };
+const DEFAULT_ORDER = [
+  'line', 'big_number', 'table', 'filter_box', 'dist_bar', 'area', 'bar',
+  'deck_polygon', 'pie', 'time_table', 'pivot_table', 'histogram',
+  'big_number_total', 'deck_scatter', 'deck_hex', 'time_pivot', 'deck_arc',
+  'heatmap', 'deck_grid', 'dual_line', 'deck_screengrid', 'line_multi',
+  'treemap', 'box_plot', 'separator', 'sunburst', 'sankey', 'word_cloud',
+  'mapbox', 'kepler', 'cal_heatmap', 'rose', 'bubble', 'deck_geojson',
+  'horizon', 'markup', 'deck_multi', 'compare', 'partition', 'event_flow',
+  'deck_path', 'directed_force', 'world_map', 'paired_ttest', 'para',
+  'iframe', 'country_map',
+];
+
+const typesWithDefaultOrder = new Set(DEFAULT_ORDER);
 
 export default class VizTypeControl extends React.PureComponent {
   constructor(props) {
@@ -51,71 +70,35 @@ export default class VizTypeControl extends React.PureComponent {
     this.setSearchRef = this.setSearchRef.bind(this);
     this.focusSearch = this.focusSearch.bind(this);
   }
+
   onChange(vizType) {
     this.props.onChange(vizType);
     this.setState({ showModal: false });
   }
+
   setSearchRef(searchRef) {
     this.searchRef = searchRef;
   }
+
   toggleModal() {
     this.setState({ showModal: !this.state.showModal });
   }
+
   changeSearch(event) {
     this.setState({ filter: event.target.value });
   }
+
   focusSearch() {
     if (this.searchRef) {
       this.searchRef.focus();
     }
   }
-  buildVizTypeLookup(types) {
-    const lookup = new Map();
-    types.forEach((type) => {
-      lookup.set(type.key, type);
-    });
-    return lookup;
-  }
-  sortVizTypes(types) {
-    const defaultOrder = [
-      'line', 'big_number', 'table', 'filter_box', 'dist_bar', 'area', 'bar',
-      'deck_polygon', 'pie', 'time_table', 'pivot_table', 'histogram',
-      'big_number_total', 'deck_scatter', 'deck_hex', 'time_pivot', 'deck_arc',
-      'heatmap', 'deck_grid', 'dual_line', 'deck_screengrid', 'line_multi',
-      'treemap', 'box_plot', 'separator', 'sunburst', 'sankey', 'word_cloud',
-      'mapbox', 'kepler', 'cal_heatmap', 'rose', 'bubble', 'deck_geojson',
-      'horizon', 'markup', 'deck_multi', 'compare', 'partition', 'event_flow',
-      'deck_path', 'directed_force', 'world_map', 'paired_ttest', 'para',
-      'iframe', 'country_map',
-    ];
 
-    const sorted = [];
-    const loadedKeys = new Set();
-    const vizTypeLookup = this.buildVizTypeLookup(types);
-
-    // Sort based on the `defaultOrder`
-    defaultOrder.forEach((key) => {
-      const vizType = vizTypeLookup.get(key);
-      if (typeof vizType !== 'undefined') {
-        sorted.push(vizType);
-        loadedKeys.add(key);
-      }
-    });
-
-    // Load the rest of Viz Types not mandated by the `defualtOrder`
-    types.forEach((vizType) => {
-      if (!loadedKeys.has(vizType.key)) {
-        sorted.push(vizType);
-        loadedKeys.add(vizType.key);
-      }
-    });
-
-    return sorted;
-  }
   renderItem(entry) {
     const { value } = this.props;
     const { key, value: type } = entry;
     const isSelected = key === value;
+
     return (
       <div
         className={`viztype-selector-container ${isSelected ? 'selected' : ''}`}
@@ -132,44 +115,52 @@ export default class VizTypeControl extends React.PureComponent {
         </div>
       </div>);
   }
+
   render() {
     const { filter, showModal } = this.state;
     const { value } = this.props;
 
-    const registry = getChartMetadataRegistry();
-    const types = this.sortVizTypes(registry.entries());
-    const filteredTypes = filter.length > 0
-      ? types.filter(type => type.value.name.toLowerCase().includes(filter.toLowerCase()))
-      : types;
+    const filterString = filter.toLowerCase();
+    const filteredTypes = DEFAULT_ORDER
+      .filter(type => registry.has(type))
+      .map(type => ({
+        key: type,
+        value: registry.get(type),
+      }))
+      .concat(registry.entries().filter(({ key }) => !typesWithDefaultOrder.has(key)))
+      .filter(entry => entry.value.name.toLowerCase().includes(filterString));
 
     const selectedType = registry.get(value);
 
-    const imgPerRow = 6;
     const rows = [];
-    for (let i = 0; i <= filteredTypes.length; i += imgPerRow) {
+    for (let i = 0; i <= filteredTypes.length; i += IMAGE_PER_ROW) {
       rows.push(
         <Row key={`row-${i}`}>
-          {filteredTypes.slice(i, i + imgPerRow).map(entry => (
-            <Col md={12 / imgPerRow} key={`grid-col-${entry.key}`}>
+          {filteredTypes.slice(i, i + IMAGE_PER_ROW).map(entry => (
+            <Col md={12 / IMAGE_PER_ROW} key={`grid-col-${entry.key}`}>
               {this.renderItem(entry)}
             </Col>
           ))}
         </Row>);
     }
+
     return (
       <div>
-        <ControlHeader
-          {...this.props}
-        />
+        <ControlHeader {...this.props} />
         <OverlayTrigger
           placement="right"
           overlay={
-            <Tooltip id={'error-tooltip'}>{t('Click to change visualization type')}</Tooltip>
+            <Tooltip id="error-tooltip">{t('Click to change visualization type')}</Tooltip>
           }
         >
-          <Label onClick={this.toggleModal} style={{ cursor: 'pointer' }}>
-            {selectedType.name}
-          </Label>
+          <React.Fragment>
+            <Label onClick={this.toggleModal} style={LABEL_STYLE}>
+              {selectedType ? selectedType.name : `${value}`}
+            </Label>
+            <div className="text-danger">
+              <i className="fa fa-exclamation-circle text-danger" /> <small>This visualization type is not supported.</small>
+            </div>
+          </React.Fragment>
         </OverlayTrigger>
         <Modal
           show={showModal}

--- a/superset/assets/src/explore/controlPanels/index.js
+++ b/superset/assets/src/explore/controlPanels/index.js
@@ -122,32 +122,32 @@ export const controlPanelConfigs = extraOverrides({
   deck_polygon: DeckPolygon,
   deck_scatter: DeckScatter,
   deck_screengrid: DeckScreengrid,
-
 });
 
 export default controlPanelConfigs;
 
 export function sectionsToRender(vizType, datasourceType) {
-  const config = controlPanelConfigs[vizType];
+  const { sectionOverrides = {}, controlPanelSections = [] } = controlPanelConfigs[vizType] || {};
 
   const sectionsCopy = { ...sections };
-  if (config.sectionOverrides) {
-    Object.entries(config.sectionOverrides).forEach(([section, overrides]) => {
-      if (typeof overrides === 'object' && overrides.constructor === Object) {
-        sectionsCopy[section] = {
-          ...sectionsCopy[section],
-          ...overrides,
-        };
-      } else {
-        sectionsCopy[section] = overrides;
-      }
-    });
-  }
+
+  Object.entries(sectionOverrides).forEach(([section, overrides]) => {
+    if (typeof overrides === 'object' && overrides.constructor === Object) {
+      sectionsCopy[section] = {
+        ...sectionsCopy[section],
+        ...overrides,
+      };
+    } else {
+      sectionsCopy[section] = overrides;
+    }
+  });
+
+  const { datasourceAndVizType, sqlaTimeSeries, druidTimeSeries, filters } = sectionsCopy;
 
   return [].concat(
-    sectionsCopy.datasourceAndVizType,
-    datasourceType === 'table' ? sectionsCopy.sqlaTimeSeries : sectionsCopy.druidTimeSeries,
-    isFeatureEnabled(FeatureFlag.SCOPED_FILTER) ? sectionsCopy.filters : undefined,
-    config.controlPanelSections,
+    datasourceAndVizType,
+    datasourceType === 'table' ? sqlaTimeSeries : druidTimeSeries,
+    isFeatureEnabled(FeatureFlag.SCOPED_FILTER) ? filters : undefined,
+    controlPanelSections,
   ).filter(section => section);
 }

--- a/superset/assets/src/explore/store.js
+++ b/superset/assets/src/explore/store.js
@@ -65,7 +65,7 @@ export function getControlsState(state, form_data) {
 
   const controlNames = getControlNames(vizType, state.datasource.type);
 
-  const viz = controlPanelConfigs[vizType];
+  const viz = controlPanelConfigs[vizType] || {};
   const controlOverrides = viz.controlOverrides || {};
   const controlsState = {};
   controlNames.forEach((k) => {
@@ -120,7 +120,7 @@ export function getControlsState(state, form_data) {
 export function applyDefaultFormData(form_data) {
   const datasourceType = form_data.datasource.split('__')[1];
   const vizType = form_data.viz_type || 'table';
-  const viz = controlPanelConfigs[vizType];
+  const viz = controlPanelConfigs[vizType] || {};
   const controlNames = getControlNames(vizType, datasourceType);
   const controlOverrides = viz.controlOverrides || {};
   const formData = {};


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

As part of an effort to reduce amount of vis types, we have to make sure that once some vis types are disabled, the app can continue working properly.
* The control panel on explore page should not crash when it cannot find the specified `viz_type`
* The `VizTypeControl` should not crash when it cannot find the specified `viz_type`

This PR also refactors and cleans up the code in `VizTypeControl.jsx`

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

###### Before 

The app crashed

###### After
![image](https://user-images.githubusercontent.com/1659771/55266655-6c989d80-523b-11e9-8e4d-6a85141dbf51.png)

##### TEST PLAN
Navigate to 
http://localhost:9000/superset/explore/?form_data=%7B%22datasource%22%3A%222__table%22%2C%22viz_type%22%3A%224d_pie_chart%22%2C%22slice_id%22%3A48%2C%22url_params%22%3A%7B%7D%2C%22granularity_sqla%22%3A%22year%22%2C%22time_grain_sqla%22%3A%22P1D%22%2C%22time_range%22%3A%221960-01-01+%3A+now%22%2C%22metrics%22%3A%5B%22sum__SP_POP_TOTL%22%5D%2C%22adhoc_filters%22%3A%5B%5D%2C%22groupby%22%3A%5B%22region%22%5D%2C%22limit%22%3A%2225%22%2C%22color_scheme%22%3A%22bnbColors%22%2C%22whisker_options%22%3A%22Min%2Fmax+%28no+outliers%29%22%2C%22x_ticks_layout%22%3A%22auto%22%7D

This url set the `viz_type` to `4d_pie_chart` which does not exist.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [x] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

@graceguo-supercat @michellethomas @williaster @xtinec @conglei @khtruong 