### PR TITLE
 Store last selected dashboard in sessionStorage

### DIFF
--- a/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { bindActionCreators } from 'redux';
 
 import { shallow, mount } from 'enzyme';
 import { Modal, Button, Radio } from 'react-bootstrap';
@@ -52,7 +53,12 @@ describe('SaveModal', () => {
 
   const defaultProps = {
     onHide: () => ({}),
-    actions: saveModalActions,
+    actions: bindActionCreators(saveModalActions, (arg) => {
+      if (typeof arg === 'function') {
+        return arg(jest.fn);
+      }
+      return arg;
+    }),
     form_data: { datasource: '107__table' },
   };
   const mockEvent = {
@@ -108,15 +114,15 @@ describe('SaveModal', () => {
 
   it('componentDidMount', () => {
     sinon.spy(SaveModal.prototype, 'componentDidMount');
-    sinon.spy(saveModalActions, 'fetchDashboards');
+    sinon.spy(defaultProps.actions, 'fetchDashboards');
     mount(<SaveModal {...defaultProps} />, {
       context: { store },
     });
     expect(SaveModal.prototype.componentDidMount.calledOnce).toBe(true);
-    expect(saveModalActions.fetchDashboards.calledOnce).toBe(true);
+    expect(defaultProps.actions.fetchDashboards.calledOnce).toBe(true);
 
     SaveModal.prototype.componentDidMount.restore();
-    saveModalActions.fetchDashboards.restore();
+    defaultProps.actions.fetchDashboards.restore();
   });
 
   it('onChange', () => {
@@ -139,7 +145,7 @@ describe('SaveModal', () => {
         .callsFake(() => ({ url: 'mockURL', payload: defaultProps.form_data }));
 
       sinon
-        .stub(saveModalActions, 'saveSlice')
+        .stub(defaultProps.actions, 'saveSlice')
         .callsFake(() =>
           Promise.resolve({ data: { dashboard: '/mock/', slice: { slice_url: '/mock/' } } }),
         );
@@ -147,13 +153,13 @@ describe('SaveModal', () => {
 
     afterEach(() => {
       exploreUtils.getExploreUrlAndPayload.restore();
-      saveModalActions.saveSlice.restore();
+      defaultProps.actions.saveSlice.restore();
     });
 
     it('should save slice', () => {
       const wrapper = getWrapper();
       wrapper.instance().saveOrOverwrite(true);
-      const args = saveModalActions.saveSlice.getCall(0).args;
+      const args = defaultProps.actions.saveSlice.getCall(0).args;
       expect(args[0]).toEqual(defaultProps.form_data);
     });
 
@@ -167,7 +173,7 @@ describe('SaveModal', () => {
 
       wrapper.setState({ saveToDashboardId });
       wrapper.instance().saveOrOverwrite(true);
-      const args = saveModalActions.saveSlice.getCall(0).args;
+      const args = defaultProps.actions.saveSlice.getCall(0).args;
       expect(args[1].save_to_dashboard_id).toBe(saveToDashboardId);
     });
 
@@ -181,7 +187,7 @@ describe('SaveModal', () => {
 
       wrapper.setState({ newDashboardName });
       wrapper.instance().saveOrOverwrite(true);
-      const args = saveModalActions.saveSlice.getCall(0).args;
+      const args = defaultProps.actions.saveSlice.getCall(0).args;
       expect(args[1].new_dashboard_name).toBe(newDashboardName);
     });
   });
@@ -251,13 +257,13 @@ describe('SaveModal', () => {
   });
 
   it('removeAlert', () => {
-    sinon.spy(saveModalActions, 'removeSaveModalAlert');
+    sinon.spy(defaultProps.actions, 'removeSaveModalAlert');
     const wrapper = getWrapper();
     wrapper.setProps({ alert: 'old alert' });
 
     wrapper.instance().removeAlert();
-    expect(saveModalActions.removeSaveModalAlert.callCount).toBe(1);
+    expect(defaultProps.actions.removeSaveModalAlert.callCount).toBe(1);
     expect(wrapper.state().alert).toBeNull();
-    saveModalActions.removeSaveModalAlert.restore();
+    defaultProps.actions.removeSaveModalAlert.restore();
   });
 });

--- a/superset/assets/src/explore/components/SaveModal.jsx
+++ b/superset/assets/src/explore/components/SaveModal.jsx
@@ -54,7 +54,14 @@ class SaveModal extends React.Component {
     };
   }
   componentDidMount() {
-    this.props.actions.fetchDashboards(this.props.userId);
+    this.props.actions.fetchDashboards(this.props.userId).then(() => {
+      let dashboardIds = this.props.dashboards.map(dashboard => dashboard.value);
+      let recentDashboard = sessionStorage.getItem("save_chart_recent_dashboard");
+      recentDashboard = recentDashboard && parseInt(recentDashboard, 10);
+      if (recentDashboard !== null && dashboardIds.indexOf(recentDashboard) !== -1) {
+        this.setState( { saveToDashboardId: recentDashboard, addToDash: 'existing' } );
+      }
+    });
   }
   onChange(name, event) {
     switch (name) {
@@ -125,6 +132,11 @@ class SaveModal extends React.Component {
     sliceParams.goto_dash = gotodash;
 
     this.props.actions.saveSlice(this.props.form_data, sliceParams).then(({ data }) => {
+      if (data.dashboard_id === null) {
+        sessionStorage.removeItem("save_chart_recent_dashboard");
+      } else {
+        sessionStorage.setItem("save_chart_recent_dashboard", data.dashboard_id);
+      }
       // Go to new slice url or dashboard url
       if (gotodash) {
         window.location = supersetURL(data.dashboard);

--- a/superset/assets/src/explore/components/SaveModal.jsx
+++ b/superset/assets/src/explore/components/SaveModal.jsx
@@ -55,11 +55,11 @@ class SaveModal extends React.Component {
   }
   componentDidMount() {
     this.props.actions.fetchDashboards(this.props.userId).then(() => {
-      let dashboardIds = this.props.dashboards.map(dashboard => dashboard.value);
-      let recentDashboard = sessionStorage.getItem("save_chart_recent_dashboard");
+      const dashboardIds = this.props.dashboards.map(dashboard => dashboard.value);
+      let recentDashboard = sessionStorage.getItem('save_chart_recent_dashboard');
       recentDashboard = recentDashboard && parseInt(recentDashboard, 10);
       if (recentDashboard !== null && dashboardIds.indexOf(recentDashboard) !== -1) {
-        this.setState( { saveToDashboardId: recentDashboard, addToDash: 'existing' } );
+        this.setState({ saveToDashboardId: recentDashboard, addToDash: 'existing' });
       }
     });
   }
@@ -133,9 +133,9 @@ class SaveModal extends React.Component {
 
     this.props.actions.saveSlice(this.props.form_data, sliceParams).then(({ data }) => {
       if (data.dashboard_id === null) {
-        sessionStorage.removeItem("save_chart_recent_dashboard");
+        sessionStorage.removeItem('save_chart_recent_dashboard');
       } else {
-        sessionStorage.setItem("save_chart_recent_dashboard", data.dashboard_id);
+        sessionStorage.setItem('save_chart_recent_dashboard', data.dashboard_id);
       }
       // Go to new slice url or dashboard url
       if (gotodash) {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1506,6 +1506,7 @@ class Superset(BaseSupersetView):
             'can_overwrite': is_owner(slc, g.user),
             'form_data': slc.form_data,
             'slice': slc.data,
+            'dashboard_id': dash.id if dash else None,
         }
 
         if request.args.get('goto_dash') == 'true':


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
This is a PR for https://github.com/apache/incubator-superset/issues/5939.

Added storing the ID of a selected dashboard in `sessionStorage`.

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![5939](https://user-images.githubusercontent.com/45320817/55279382-fec2a380-5318-11e9-9f30-bf5f728d8f3f.gif)

##### TEST PLAN
1. Selecting Don't add to dashboard => sessionStorage's key is removed => next time when launching the modal, the default option remains checked
2. Selecting existing dashboard => sessionStorage's key is set => when launching the modal, appropriate dashboard is preselected (see gif above)
3. Adding new dashboard => same scenario as above.

Additionally, made sure that the state is consistent, i.e. if user doesn't have access to a given dashboard ID anymore (e.g. it was deleted), preselecting doesn't happen.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [x] Has associated issue: #5939
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [x] Introduces new feature or API
    [ ] Removes existing feature or API
    [ ] Fixes bug
    [x] Refactors code
    [ ] Adds test(s)
    [x] Fixes #5939 

I had to refactor the test file a little bit - the `fetchDashboards` function was not bound properly and therefore tests were failing because I was calling `.then()` on the returned value. If there's a better way to solve this problem than what I came up with, please let me know.

##### REVIEWERS

