### PR TITLE
fix: deck.gl polygon tooltip

### DIFF
--- a/superset/assets/package-lock.json
+++ b/superset/assets/package-lock.json
@@ -8684,7 +8684,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8705,12 +8706,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8725,17 +8728,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8852,7 +8858,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8864,6 +8871,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8878,6 +8886,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8885,12 +8894,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8909,6 +8920,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8989,7 +9001,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9001,6 +9014,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9086,7 +9100,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9122,6 +9137,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9141,6 +9157,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9184,12 +9201,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/superset/assets/src/visualizations/Legend.css
+++ b/superset/assets/src/visualizations/Legend.css
@@ -22,7 +22,7 @@ div.legend {
     background: #fff;
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
     margin: 24px;
-    padding: 12px 24px;
+    padding: 12px 20px;
     outline: none;
     overflow-y: scroll;
     max-height: 200px;
@@ -37,4 +37,8 @@ ul.categories {
 ul.categories li a {
     color: rgb(51, 51, 51);
     text-decoration: none;
+}
+
+ul.categories li a span {
+    margin-right: 10px;
 }

--- a/superset/assets/src/visualizations/Legend.jsx
+++ b/superset/assets/src/visualizations/Legend.jsx
@@ -43,7 +43,7 @@ export default class Legend extends React.PureComponent {
 
     const categories = Object.entries(this.props.categories).map(([k, v]) => {
       const style = { color: 'rgba(' + v.color.join(', ') + ')' };
-      const icon = v.enabled ? '\u25CF' : '\u25CB';
+      const icon = v.enabled ? '\u25FC' : '\u25FB';
       return (
         <li key={k}>
           <a

--- a/superset/assets/src/visualizations/deckgl/utils.js
+++ b/superset/assets/src/visualizations/deckgl/utils.js
@@ -106,9 +106,9 @@ export function getBuckets(fd, features, accessor) {
   const buckets = {};
   breakPoints.slice(1).forEach((value, i) => {
     const range = breakPoints[i] + ' - ' + breakPoints[i + 1];
-    const mid = 0.5 * (parseInt(breakPoints[i], 10) + parseInt(breakPoints[i + 1], 10));
-   // fix polygon doesn't show
-   const metricLabel = fd.metric ? fd.metric.label || fd.metric : null;
+    const mid = 0.5 * (parseFloat(breakPoints[i]) + parseFloat(breakPoints[i + 1]));
+    // fix polygon doesn't show
+    const metricLabel = fd.metric ? fd.metric.label || fd.metric : null;
     buckets[range] = {
       color: colorScaler({ [metricLabel || fd.metric]: mid }),
       enabled: true,


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
This PR fixes the `deck.gl Polygon` chart tooltip having issues when the underlying data range is less than 1.  This PR also change the legend to use squares to align w/ tooltips used by other charts.

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before 
![image](https://user-images.githubusercontent.com/17309187/55306588-a0c1b900-5409-11e9-9a9f-1dacff96ad9f.png)

After:
![image](https://user-images.githubusercontent.com/17309187/55306558-88ea3500-5409-11e9-8560-d7d30de174e9.png)

##### TEST PLAN
Eyeball

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [ ] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

