### PR TITLE
[fix] a typo in variable name

### DIFF
--- a/superset/assets/src/chart/ChartRenderer.jsx
+++ b/superset/assets/src/chart/ChartRenderer.jsx
@@ -62,7 +62,7 @@ class ChartRenderer extends React.Component {
     this.state = {};
 
     this.createChartProps = ChartProps.createSelector();
-    this.hasQueryResponseChnage = false;
+    this.hasQueryResponseChange = false;
 
     this.setTooltip = this.setTooltip.bind(this);
     this.handleAddFilter = this.handleAddFilter.bind(this);
@@ -79,10 +79,10 @@ class ChartRenderer extends React.Component {
       !nextProps.refreshOverlayVisible;
 
     if (resultsReady) {
-      this.hasQueryResponseChnage =
+      this.hasQueryResponseChange =
         nextProps.queryResponse !== this.props.queryResponse;
 
-      if (this.hasQueryResponseChnage ||
+      if (this.hasQueryResponseChange ||
         nextProps.annotationData !== this.props.annotationData ||
         nextProps.height !== this.props.height ||
         nextProps.width !== this.props.width ||
@@ -137,7 +137,7 @@ class ChartRenderer extends React.Component {
 
     // only log chart render time which is triggered by query results change
     // currently we don't log chart re-render time, like window resize etc
-    if (this.hasQueryResponseChnage) {
+    if (this.hasQueryResponseChange) {
       actions.logEvent(LOG_ACTIONS_RENDER_CHART, {
         slice_id: chartId,
         viz_type: vizType,
@@ -154,7 +154,7 @@ class ChartRenderer extends React.Component {
     actions.chartRenderingFailed(error.toString(), chartId, info ? info.componentStack : null);
 
     // only trigger render log when query is changed
-    if (this.hasQueryResponseChnage) {
+    if (this.hasQueryResponseChange) {
       actions.logEvent(LOG_ACTIONS_RENDER_CHART, {
         slice_id: chartId,
         has_err: true,


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
fix a variable typo: `hasQueryResponseChnage` should be`hasQueryResponseChange`

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

##### TEST PLAN
<!--- What steps were taken to verify -->

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS
@williaster @michellethomas @conglei @kristw 
