### PR TITLE
Fix time filter

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -916,7 +916,7 @@ export const controls = {
     'The options here are defined on a per database ' +
     'engine basis in the Superset source code.'),
     mapStateToProps: state => ({
-      choices: (state.datasource) ? state.datasource.timeGrainSqla : null,
+      choices: (state.datasource) ? state.datasource.time_grain_sqla : null,
     }),
   },
 

--- a/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
@@ -93,9 +93,26 @@ class FilterBox extends React.Component {
       actions: { setControlValue: this.changeFilter },
     });
     const mapFunc = control.mapStateToProps;
+    const props = {
+      ...this.props,
+      // the control expects datasource attributes to be snake case
+      datasource: this.snakeCaseAttributes(this.props.datasource),
+    };
     return mapFunc
-      ? Object.assign({}, control, mapFunc(this.props))
+      ? Object.assign({}, control, mapFunc(props))
       : control;
+  }
+
+  snakeCaseAttributes(obj) {
+    return Object.keys(obj)
+      .reduce((o, k) => Object.assign(o, { [this.camelCaseToSnakeCase(k)]: obj[k] }), {});
+  }
+
+  camelCaseToSnakeCase(attribute) {
+    return attribute
+      .split('')
+      .map(c => c === c.toUpperCase() ? `_${c.toLowerCase()}` : c)
+      .join('');
   }
 
   clickApply() {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, attributes in the payload have different styles. Visualizations use `camelCase`, and the Python backend uses `snake_case`. There are a few exceptions: controls in the explore view still use `snake_case`.

The problem is that the filter box is a visualization that repurposes controls. So the visualization receives the payload in `camelCase`, passes it to the control, which fails to understand it.

I fixed it by adding a function to convert from one style to the other. This is a temporary workaround, until we make everything more consistent.

<!--- ##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

##### TEST PLAN
<!--- What steps were taken to verify -->
Filter boxes now work as expected. Before, it would fail to render time grains, and possibly other fields.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

@xtinec @kristw 