### PR TITLE
fix: [lyftga] pass the latest deckgl props

### DIFF
--- a/superset/assets/src/visualizations/deckgl/AnimatableDeckGLContainer.jsx
+++ b/superset/assets/src/visualizations/deckgl/AnimatableDeckGLContainer.jsx
@@ -34,6 +34,9 @@ const propTypes = {
   disabled: PropTypes.bool,
   viewport: PropTypes.object.isRequired,
   children: PropTypes.node,
+  mapStyle: PropTypes.string,
+  mapboxApiAccessToken: PropTypes.string.isRequired,
+  setControlValue: PropTypes.func,
   onViewportChange: PropTypes.func,
   onValuesChange: PropTypes.func,
 };
@@ -41,6 +44,8 @@ const propTypes = {
 const defaultProps = {
   aggregation: false,
   disabled: false,
+  mapStyle: 'light',
+  setControlValue: () => {},
   onViewportChange: () => {},
   onValuesChange: () => {},
 };
@@ -48,9 +53,6 @@ const defaultProps = {
 export default class AnimatableDeckGLContainer extends React.Component {
   constructor(props) {
     super(props);
-    const { getLayers, start, end, getStep, values, disabled, viewport, ...other } = props;
-    this.other = other;
-
     this.onViewportChange = this.onViewportChange.bind(this);
   }
   onViewportChange(viewport) {
@@ -71,6 +73,9 @@ export default class AnimatableDeckGLContainer extends React.Component {
       values,
       onValuesChange,
       viewport,
+      setControlValue,
+      mapStyle,
+      mapboxApiAccessToken,
     } = this.props;
     const layers = getLayers(values);
 
@@ -83,9 +88,11 @@ export default class AnimatableDeckGLContainer extends React.Component {
     return (
       <div>
         <DeckGLContainer
-          {...this.other}
           viewport={modifiedViewport}
           layers={layers}
+          setControlValue={setControlValue}
+          mapStyle={mapStyle}
+          mapboxApiAccessToken={mapboxApiAccessToken}
           onViewportChange={this.onViewportChange}
         />
         {!disabled &&


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Map styles would not update for a few deck.gl viz types. This is because we saved map style and other props as class variables once in the AnimatableDeckGLContainer constructor and never updated these properties even if the user changed things like the map style. Instead of referring to class variables, I explicitly list out the props and pass the props thru.

##### TEST PLAN
<!--- What steps were taken to verify -->
Manually tested

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS
@xtinec @betodealmeida @williaster @kristw 
