### PR TITLE
Allow bigint to be used as time column in Presto

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -832,6 +832,8 @@ class PrestoEngineSpec(BaseEngineSpec):
             return "from_iso8601_date('{}')".format(dttm.isoformat()[:10])
         if tt == 'TIMESTAMP':
             return "from_iso8601_timestamp('{}')".format(dttm.isoformat())
+        if tt == 'BIGINT':
+            return "to_unixtime(from_iso8601_timestamp('{}'))".format(dttm.isoformat())
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
     @classmethod


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We have a table in Presto where the temporal column is a `BIGINT`, representing a unix timestamp. This allows us to use it as a temporal column in the explore view.

<!-- ##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

##### TEST PLAN
<!--- What steps were taken to verify -->

Previous query:

```sql
SELECT COUNT(*) AS "count"
FROM "superset"."logs"
WHERE "dttm" >= '2019-03-27 00:00:00'
  AND "dttm" <= '2019-04-03 00:00:00'
ORDER BY "count" DESC
LIMIT 10000;
```

Now:

```sql
SELECT COUNT(*) AS "count"
FROM "superset"."logs"
WHERE "dttm" >= to_unixtime(from_iso8601_timestamp('2019-03-27T00:00:00'))
  AND "dttm" <= to_unixtime(from_iso8601_timestamp('2019-04-03T00:00:00'))
ORDER BY "count" DESC
LIMIT 10000;
```

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [x] Introduces new feature or API
    [ ] Removes existing feature or API
    [ ] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

@xtinec @DiggidyDave @datability-io @khtruong 