### PR TITLE
[filter_box] allow empty filters list

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2382,7 +2382,7 @@ export const controls = {
     type: 'CollectionControl',
     label: 'Filters',
     description: t('Filter configuration for the filter box'),
-    validators: [v.nonEmpty],
+    validators: [],
     controlName: 'FilterBoxItemControl',
     mapStateToProps: ({ datasource }) => ({ datasource }),
   },


### PR DESCRIPTION
in some cases, people want a time filter only on filter box, without
specifying dimensions (filters), this allows that
