### PR TITLE
Improve cache

### DIFF
--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -62,9 +62,9 @@ def etag_cache(max_age, check_perms=bool):
             # check if the user can access the resource
             check_perms(*args, **kwargs)
 
-            # for POST requests we can't set headers, use the response cache
-            # nor use conditional requests; this will still use the dataframe
-            # cache in `superset/viz.py`, though.
+            # for POST requests we can't set cache headers, use the response
+            # cache nor use conditional requests; this will still use the
+            # dataframe cache in `superset/viz.py`, though.
             if request.method == 'POST':
                 return f(*args, **kwargs)
 
@@ -83,8 +83,7 @@ def etag_cache(max_age, check_perms=bool):
                         raise
                     logging.exception('Exception possibly due to cache backend.')
 
-            # if this is not a GET, or if no response was cached, compute the
-            # response using the wrapped function
+            # if no response was cached, compute it using the wrapped function
             if response is None:
                 response = f(*args, **kwargs)
 
@@ -96,7 +95,7 @@ def etag_cache(max_age, check_perms=bool):
                     response.last_modified + timedelta(seconds=expiration)
                 response.add_etag()
 
-                # if we have a cache, store the response from the GET request
+                # if we have a cache, store the response from the request
                 if cache:
                     try:
                         cache.set(cache_key, response, timeout=max_age)


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Some improvements to the ETag cache:

- Superset works in debug mode if no cache is set (before it would raise an exception).
- We only use the response cache on `GET` requests (doesn't make sense on `POST` requests).

Note that we still use the dataframe cache on `POST` requests, which is something we want. The dataframe cache is useful when the HTTP request is different but the generated SQL query is unaltered.

<!-- ##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

##### TEST PLAN
<!--- What steps were taken to verify -->

Tested the "Misc Charts" dashboard, saw cache working. I also ran a local server without any cache, and verified that it works.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [ ] Fixes bug
    [x] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

@xtinec @khtruong @DiggidyDave @datability-io 