### PR TITLE
Adding permission for can_only_access_owned_queries

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -138,6 +138,14 @@ class Query(Model, ExtraJSONMixin):
         tab = re.sub(r'\W+', '', tab)
         return f'sqllab_{tab}_{ts}'
 
+    @property
+    def database_name(self):
+        return self.database.name
+
+    @property
+    def username(self):
+        return self.user.username
+
 
 class SavedQuery(Model, AuditMixinNullable, ExtraJSONMixin):
     """ORM model for SQL query"""

--- a/superset/security.py
+++ b/superset/security.py
@@ -92,6 +92,7 @@ class SupersetSecurityManager(SecurityManager):
         'schema_access',
         'datasource_access',
         'metric_access',
+        'can_only_access_owned_queries',
     ])
 
     def get_schema_perm(self, database, schema):
@@ -104,6 +105,17 @@ class SupersetSecurityManager(SecurityManager):
         if user.is_anonymous:
             return self.is_item_public(permission_name, view_name)
         return self._has_view_access(user, permission_name, view_name)
+
+    def can_only_access_owned_queries(self) -> bool:
+        """
+        can_access check for custom can_only_access_owned_queries permissions.
+
+        :returns: True if current user can access custom permissions
+        """
+        return self.can_access(
+            'can_only_access_owned_queries',
+            'can_only_access_owned_queries',
+        )
 
     def all_datasource_access(self):
         return self.can_access('all_datasource_access', 'all_datasource_access')
@@ -268,6 +280,7 @@ class SupersetSecurityManager(SecurityManager):
         # Global perms
         self.merge_perm('all_datasource_access', 'all_datasource_access')
         self.merge_perm('all_database_access', 'all_database_access')
+        self.merge_perm('can_only_access_owned_queries', 'can_only_access_owned_queries')
 
     def create_missing_perms(self):
         """Creates missing perms for datasources, schemas and metrics"""

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2766,10 +2766,21 @@ class Superset(BaseSupersetView):
     @has_access
     @expose('/search_queries')
     @log_this
-    def search_queries(self):
-        """Search for queries."""
+    def search_queries(self) -> Response:
+        """
+        Search for previously run sqllab queries. Used for Sqllab Query Search
+        page /superset/sqllab#search.
+
+        Custom permission can_only_search_queries_owned restricts queries
+        to only queries run by current user.
+
+        :returns: Response with list of sql query dicts
+        """
         query = db.session.query(Query)
-        search_user_id = request.args.get('user_id')
+        if security_manager.can_only_access_owned_queries():
+            search_user_id = g.user.get_user_id()
+        else:
+            search_user_id = request.args.get('user_id')
         database_id = request.args.get('database_id')
         search_text = request.args.get('search_text')
         status = request.args.get('status')
@@ -2778,7 +2789,7 @@ class Superset(BaseSupersetView):
         to_time = request.args.get('to')
 
         if search_user_id:
-            # Filter on db Id
+            # Filter on user_id
             query = query.filter(Query.user_id == search_user_id)
 
         if database_id:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -83,7 +83,7 @@ ACCESS_REQUEST_MISSING_ERR = __(
     'The access requests seem to have been deleted')
 USER_MISSING_ERR = __('The user seems to have been deleted')
 
-FORM_DATA_KEY_BLACKLIST = []  # type: List[str]
+FORM_DATA_KEY_BLACKLIST: List[str] = []
 if not config.get('ENABLE_JAVASCRIPT_CONTROLS'):
     FORM_DATA_KEY_BLACKLIST = [
         'js_tooltip',

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -22,6 +22,7 @@ import os
 import re
 import time
 import traceback
+from typing import List  # noqa: F401
 from urllib import parse
 
 from flask import (
@@ -82,7 +83,7 @@ ACCESS_REQUEST_MISSING_ERR = __(
     'The access requests seem to have been deleted')
 USER_MISSING_ERR = __('The user seems to have been deleted')
 
-FORM_DATA_KEY_BLACKLIST = []
+FORM_DATA_KEY_BLACKLIST = []  # type: List[str]
 if not config.get('ENABLE_JAVASCRIPT_CONTROLS'):
     FORM_DATA_KEY_BLACKLIST = [
         'js_tooltip',

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -57,11 +57,12 @@ class QueryView(SupersetModelView):
     add_title = _('Add Query')
     edit_title = _('Edit Query')
 
-    list_columns = ['user', 'database', 'status', 'start_time', 'end_time']
+    list_columns = ['username', 'database_name', 'status', 'start_time', 'end_time']
     base_filters = [['id', QueryFilter, lambda: []]]
     label_columns = {
         'user': _('User'),
-        'database': _('Database'),
+        'username': _('User'),
+        'database_name': _('Database'),
         'status': _('Status'),
         'start_time': _('Start Time'),
         'end_time': _('End Time'),

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -23,7 +23,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
-import flask_sqlalchemy
+from flask_sqlalchemy import BaseQuery
 
 from superset import appbuilder, security_manager
 from superset.models.sql_lab import Query, SavedQuery
@@ -33,8 +33,8 @@ from .base import BaseSupersetView, DeleteMixin, SupersetFilter, SupersetModelVi
 class QueryFilter(SupersetFilter):
     def apply(
             self,
-            query: flask_sqlalchemy.BaseQuery,
-            func: Callable) -> flask_sqlalchemy.BaseQuery:
+            query: BaseQuery,
+            func: Callable) -> BaseQuery:
         """
         Filter queries to only those owned by current user if
         can_only_access_owned_queries permission is set.

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -15,16 +15,38 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
+from typing import Callable
+
 from flask import g, redirect
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
+import flask_sqlalchemy
 
-from superset import appbuilder
+from superset import appbuilder, security_manager
 from superset.models.sql_lab import Query, SavedQuery
-from .base import BaseSupersetView, DeleteMixin, SupersetModelView
+from .base import BaseSupersetView, DeleteMixin, SupersetFilter, SupersetModelView
+
+
+class QueryFilter(SupersetFilter):
+    def apply(
+            self,
+            query: flask_sqlalchemy.BaseQuery,
+            func: Callable) -> flask_sqlalchemy.BaseQuery:
+        """
+        Filter queries to only those owned by current user if
+        can_only_access_owned_queries permission is set.
+
+        :returns: query
+        """
+        if security_manager.can_only_access_owned_queries():
+            query = (
+                query
+                .filter(Query.user_id == g.user.get_user_id())
+            )
+        return query
 
 
 class QueryView(SupersetModelView):
@@ -36,6 +58,7 @@ class QueryView(SupersetModelView):
     edit_title = _('Edit Query')
 
     list_columns = ['user', 'database', 'status', 'start_time', 'end_time']
+    base_filters = [['id', QueryFilter, lambda: []]]
     label_columns = {
         'user': _('User'),
         'database': _('Database'),

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -223,6 +223,46 @@ class SqlLabTests(SupersetTestCase):
         data = json.loads(resp)
         self.assertEquals(2, len(data))
 
+    def test_search_query_with_owner_only_perms(self) -> None:
+        """
+        Test a search query with can_only_access_owned_queries perm added to
+        Admin and make sure only Admin queries show up.
+        """
+        session = db.session
+
+        # Add can_only_access_owned_queries perm to Admin user
+        owned_queries_view = security_manager.find_permission_view_menu(
+            'can_only_access_owned_queries',
+            'can_only_access_owned_queries',
+        )
+        security_manager.add_permission_role(
+            security_manager.find_role('Admin'),
+            owned_queries_view,
+        )
+        session.commit()
+
+        # Test search_queries for Admin user
+        self.run_some_queries()
+        self.login('admin')
+
+        user_id = security_manager.find_user('admin').id
+        data = self.get_json_resp('/superset/search_queries')
+        self.assertEquals(2, len(data))
+        user_ids = {k['userId'] for k in data}
+        self.assertEquals(set([user_id]), user_ids)
+
+        # Remove can_only_access_owned_queries from Admin
+        owned_queries_view = security_manager.find_permission_view_menu(
+            'can_only_access_owned_queries',
+            'can_only_access_owned_queries',
+        )
+        security_manager.del_permission_role(
+            security_manager.find_role('Admin'),
+            owned_queries_view,
+        )
+
+        session.commit()
+
     def test_alias_duplicate(self):
         self.run_sql(
             'SELECT username as col, id as col, username FROM ab_user',


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
Adding an optional restriction on query search to only allow users to access their own queries. Right now query search lets anyone access any queries. That would be the default for all roles, but if a deployment wanted to change to restrict users to only search their queries they could do that with the can_only_access_owned_queries permission.

With can_only_access_owned_queries in OBJECT_SPEC_PERMISSIONS, this permission is not added to any role by default. 

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

##### TEST PLAN
Run superset init with new can_only_access_owned_queries default off in OBJECT_SPEC_PERMISSIONS
Logged in as user1 and ran query
Logged in as user2 and confirmed that I could see all queries queries in `/superset/sqllab#search` and `/queryview/list/`
Moved perm can_only_access_owned_queries to ADMIN_ONLY_PERMISSIONS 
Run superset init
Confirmed that as user2 I could see only my queries queries in `/superset/sqllab#search` and `/queryview/list/`

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [ ] Fixes bug
    [ ] Refactors code
    [x] Adds test(s)

##### REVIEWERS
@mistercrunch @john-bodley 
