### PR TITLE
Fix race condition when fetching results in SQL Lab (#7198)

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -141,9 +141,7 @@ def get_sql_results(
             return handle_query_error(str(e), query, session)
 
 
-def execute_sql_statement(
-        sql_statement, query, user_name, session,
-        cursor, return_results=False):
+def execute_sql_statement(sql_statement, query, user_name, session, cursor):
     """Executes a single SQL statement"""
     database = query.database
     db_engine_spec = database.db_engine_spec
@@ -256,11 +254,9 @@ def execute_sql_statements(
                 logging.info(msg)
                 query.set_extra_json_key('progress', msg)
                 session.commit()
-                is_last_statement = i == len(statements) - 1
                 try:
                     cdf = execute_sql_statement(
-                        statement, query, user_name, session, cursor,
-                        return_results=is_last_statement and return_results)
+                        statement, query, user_name, session, cursor)
                     msg = f'Running statement {i+1} out of {statement_count}'
                 except Exception as e:
                     msg = str(e)
@@ -282,7 +278,6 @@ def execute_sql_statements(
             show_cols=False,
             latest_partition=False)
     query.end_time = now_as_float()
-    session.commit()
 
     payload.update({
         'status': query.status,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2564,7 +2564,7 @@ class Superset(BaseSupersetView):
             limit=min(lim for lim in limits if lim is not None),
             sql=sql,
             schema=schema,
-            select_as_cta=request.form.get('select_as_cta') == 'true',
+            select_as_cta=select_as_cta,
             start_time=now_as_float(),
             tab_name=request.form.get('tab'),
             status=QueryStatus.PENDING if async_ else QueryStatus.RUNNING,


### PR DESCRIPTION
* Fix race condition when fetching results in SQL Lab

* Fix lint

(cherry picked from commit ca6a73b028a1954c8e8d1dfa077bc7ee0a2694c0)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
Cherry picking change that got into lyftga and is impacting superset users running sql queries. Queries get to 100% and don't return results because the query is marked as successful but has no `resultsKey`.

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

##### TEST PLAN
Run multiple queries in a row with large payloads
Confirm that they hit 100% and return results

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS
@john-bodley @graceguo-supercat @betodealmeida @xtinec 
