### PR TITLE
[filter_box] allow empty filters list (#7220)

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2319,7 +2319,7 @@ export const controls = {
     type: 'CollectionControl',
     label: 'Filters',
     description: t('Filter configuration for the filter box'),
-    validators: [v.nonEmpty],
+    validators: [],
     controlName: 'FilterBoxItemControl',
     mapStateToProps: ({ datasource }) => ({ datasource }),
   },


### PR DESCRIPTION
in some cases, people want a time filter only on filter box, without
specifying dimensions (filters), this allows that

(cherry picked from commit e39b16994946b2a7975af3ed76245e77303329e2)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
Cherry picking fix that got into lyftga and we need in 0.31. Time only filters do not work because filter box requires filters.

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

##### TEST PLAN
Check that filter box can have only time filters

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS
@mistercrunch @john-bodley @graceguo-supercat 
