### PR TITLE
Fix partition query in Presto

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -953,7 +953,6 @@ class PrestoEngineSpec(BaseEngineSpec):
             that determines if that field should be sorted in descending
             order
         :type order_by: list of (str, bool) tuples
-        :param filters: a list of filters to apply
         :param filters: dict of field name and filter value combinations
         """
         limit_clause = 'LIMIT {}'.format(limit) if limit else ''
@@ -972,7 +971,8 @@ class PrestoEngineSpec(BaseEngineSpec):
             where_clause = 'WHERE ' + ' AND '.join(l)
 
         sql = textwrap.dedent(f"""\
-            SHOW PARTITIONS FROM {table_name}
+            SELECT * FROM "{table_name}$partitions"
+
             {where_clause}
             {order_by_clause}
             {limit_clause}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Our Presto cluster doesn't support `SHOW PARTITIONS`. Reading the Presto docs, it's unclear to me if Presto supports this at all (cc: @nishantrayan). I changed the query that loads partitions to use the `table_name$partitions` hidden table instead.

<!-- ##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

##### TEST PLAN
<!--- What steps were taken to verify -->

SQL Lab is now able to load metadata correctly.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [X] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

@xtinec @datability-io @khtruong @nishantrayan