### PR TITLE
Pass viz type to GET requests

### DIFF
--- a/superset/assets/cypress/integration/dashboard/controls.js
+++ b/superset/assets/cypress/integration/dashboard/controls.js
@@ -32,18 +32,18 @@ export default () => describe('top-level controls', () => {
     cy.get('#app').then((data) => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
       const dashboard = bootstrapData.dashboard_data;
-      const sliceIds = dashboard.slices.map(slice => (slice.slice_id));
       mapId = dashboard.slices.find(slice => (slice.form_data.viz_type === 'world_map')).slice_id;
 
-      sliceIds
-        .forEach((id) => {
-          const sliceRequest = `getJson_${id}`;
+      dashboard.slices
+        .forEach((slice) => {
+          const sliceRequest = `getJson_${slice.slice_id}`;
           sliceRequests.push(`@${sliceRequest}`);
-          cy.route('GET', `/superset/explore_json/?form_data={"slice_id":${id}}`).as(sliceRequest);
+          const formData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
+          cy.route('GET', `/superset/explore_json/?form_data=${formData}`).as(sliceRequest);
 
-          const forceRefresh = `getJson_${id}_force`;
+          const forceRefresh = `postJson_${slice.slice_id}_force`;
           forceRefreshRequests.push(`@${forceRefresh}`);
-          cy.route('POST', `/superset/explore_json/?form_data={"slice_id":${id}}&force=true`).as(forceRefresh);
+          cy.route('POST', `/superset/explore_json/?form_data={"slice_id":${slice.slice_id}}&force=true`).as(forceRefresh);
         });
     });
   });
@@ -69,7 +69,7 @@ export default () => describe('top-level controls', () => {
       .parent()
       .should('have.class', 'disabled');
 
-    cy.wait(`@getJson_${mapId}_force`);
+    cy.wait(`@postJson_${mapId}_force`);
     cy.get('#save-dash-split-button').trigger('click');
     cy.contains('Force refresh dashboard').parent().not('have.class', 'disabled');
   });

--- a/superset/assets/cypress/integration/dashboard/edit_mode.js
+++ b/superset/assets/cypress/integration/dashboard/edit_mode.js
@@ -28,7 +28,8 @@ export default () => describe('edit mode', () => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
       const dashboard = bootstrapData.dashboard_data;
       const boxplotChartId = dashboard.slices.find(slice => (slice.form_data.viz_type === 'box_plot')).slice_id;
-      const boxplotRequest = `/superset/explore_json/?form_data={"slice_id":${boxplotChartId}}`;
+      const formData = `{"slice_id":${boxplotChartId},"viz_type":"box_plot"}`;
+      const boxplotRequest = `/superset/explore_json/?form_data=${formData}`;
       cy.route('GET', boxplotRequest).as('boxplotRequest');
     });
 

--- a/superset/assets/cypress/integration/dashboard/filter.js
+++ b/superset/assets/cypress/integration/dashboard/filter.js
@@ -39,7 +39,8 @@ export default () => describe('dashboard filter', () => {
   it('should apply filter', () => {
     const aliases = [];
 
-    const filterRoute = `/superset/explore_json/?form_data={"slice_id":${filterId}}`;
+    const formData = `{"slice_id":${filterId},"viz_type":"filter_box"}`;
+    const filterRoute = `/superset/explore_json/?form_data=${formData}`;
     cy.route('GET', filterRoute).as('fetchFilter');
     cy.wait('@fetchFilter');
     sliceIds

--- a/superset/assets/cypress/integration/dashboard/load.js
+++ b/superset/assets/cypress/integration/dashboard/load.js
@@ -34,7 +34,8 @@ export default () => describe('load', () => {
       // then define routes and create alias for each requests
       slices.forEach((slice) => {
         const alias = `getJson_${slice.slice_id}`;
-        cy.route('GET', `/superset/explore_json/?form_data={"slice_id":${slice.slice_id}}`).as(alias);
+        const formData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
+        cy.route('GET', `/superset/explore_json/?form_data=${formData}`).as(alias);
         aliases.push(`@${alias}`);
       });
     });

--- a/superset/assets/cypress/integration/dashboard/save.js
+++ b/superset/assets/cypress/integration/dashboard/save.js
@@ -56,7 +56,8 @@ export default () => describe('save', () => {
     cy.wait('@copyRequest');
 
     // should have box_plot chart
-    const boxplotRequest = `/superset/explore_json/?form_data={"slice_id":${boxplotChartId}}`;
+    const formData = `{"slice_id":${boxplotChartId},"viz_type":"box_plot"}`;
+    const boxplotRequest = `/superset/explore_json/?form_data=${formData}`;
     cy.route('GET', boxplotRequest).as('boxplotRequest');
     cy.wait('@boxplotRequest');
     cy.get('.grid-container .box_plot').should('be.exist');

--- a/superset/assets/src/explore/exploreUtils.js
+++ b/superset/assets/src/explore/exploreUtils.js
@@ -119,9 +119,9 @@ export function getExploreUrlAndPayload({
 
   // Building the querystring (search) part of the URI
   const search = uri.search(true);
-  const { slice_id, extra_filters, adhoc_filters } = formData;
+  const { slice_id, extra_filters, adhoc_filters, viz_type } = formData;
   if (slice_id) {
-    const form_data = { slice_id };
+    const form_data = { slice_id, viz_type };
     if (method === 'GET') {
       if (extra_filters && extra_filters.length) {
         form_data.extra_filters = extra_filters;

--- a/superset/assets/src/explore/exploreUtils.js
+++ b/superset/assets/src/explore/exploreUtils.js
@@ -121,8 +121,9 @@ export function getExploreUrlAndPayload({
   const search = uri.search(true);
   const { slice_id, extra_filters, adhoc_filters, viz_type } = formData;
   if (slice_id) {
-    const form_data = { slice_id, viz_type };
+    const form_data = { slice_id };
     if (method === 'GET') {
+      form_data.viz_type = viz_type;
       if (extra_filters && extra_filters.length) {
         form_data.extra_filters = extra_filters;
       }

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -153,8 +153,8 @@ def get_form_data(slice_id=None, use_slice_data=False):
     slice_id = form_data.get('slice_id') or slice_id
     slc = None
 
-    # Check if form data only contains slice_id and additional filters
-    valid_keys = ['slice_id', 'extra_filters', 'adhoc_filters']
+    # Check if form data only contains slice_id, additional filters and viz type
+    valid_keys = ['slice_id', 'extra_filters', 'adhoc_filters', 'viz_type']
     valid_slice_id = all(key in valid_keys for key in form_data)
 
     # Include the slice_form_data if request from explore or slice calls


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We need to pass the visualization type to the initial `GET` request in the Explore view, since the payload is dependent on it.

<!-- ##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

##### TEST PLAN
<!--- What steps were taken to verify -->

We had a problem where:

1. User would create a new chart in Explore, using table view.
2. User would switch to a different visualization type.
3. Client would run a `GET` based only on the slice id, returning the wrong payload type. In our case, the Mapbox API key was not sent.

I changed the `GET` request to pass the visualization type. Another alternative might be to not use `GET` requests in the Explore view, at the cost of the initial load being slow. I'll monitor this during the first days of GA.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [X] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

@xtinec 
