### PR TITLE
fix: Handle rendering a single point

### DIFF
--- a/superset/assets/spec/javascripts/visualizations/deckgl/layers/common_spec.jsx
+++ b/superset/assets/spec/javascripts/visualizations/deckgl/layers/common_spec.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { max } from 'd3-array';
-import { getAggFunc } from '../../../../../src/visualizations/deckgl/layers/common';
+import { getAggFunc, getBounds } from '../../../../../src/visualizations/deckgl/layers/common';
 
 describe('deckgl layers common', () => {
   it('getAggFunc', () => {
@@ -45,5 +45,66 @@ describe('deckgl layers common', () => {
     expect(getAggFunc('p5', accessor)(arr)).toEqual(1.1);
     expect(getAggFunc('p95', accessor)(arr)).toEqual(2.9);
     expect(getAggFunc('p99', accessor)(arr)).toEqual(2.98);
+  });
+
+  describe('getBounds', () => {
+    it('should return valid bounds for multiple points', () => {
+      const points = [
+        [0, 20],
+        [5, 25],
+        [10, 15],
+      ];
+      expect(getBounds(points)).toEqual([
+        [0, 15],
+        [10, 25],
+      ]);
+    });
+    it('should return valid bounds for single latitude point', () => {
+      const points = [
+        [0, 0],
+        [5, 0],
+      ];
+      expect(getBounds(points)).toEqual([
+        [0, -0.25],
+        [5, 0.25],
+      ]);
+    });
+    it('should return valid bounds for single longitude point', () => {
+      const points = [
+        [0, 0],
+        [0, 5],
+      ];
+      expect(getBounds(points)).toEqual([
+        [-0.25, 0],
+        [0.25, 5],
+      ]);
+    });
+    it('should return valid bounds for single point', () => {
+      const points = [
+        [0, 0],
+      ];
+      expect(getBounds(points)).toEqual([
+        [-0.25, -0.25],
+        [0.25, 0.25],
+      ]);
+    });
+    it('should return valid bounds for point 90, 180', () => {
+      const points = [
+        [180, 90],
+      ];
+      expect(getBounds(points)).toEqual([
+        [179.75, 89.75],
+        [180, 90],
+      ]);
+    });
+    it('should return valid bounds for point -90, -180', () => {
+      const points = [
+        [-180, -90],
+      ];
+      expect(getBounds(points)).toEqual([
+        [-180, -90],
+        [-179.75, -89.75],
+      ]);
+    });
   });
 });

--- a/superset/assets/src/visualizations/deckgl/layers/common.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/common.jsx
@@ -20,12 +20,50 @@ import { fitBounds } from 'viewport-mercator-project';
 import * as d3array from 'd3-array';
 import sandboxedEval from '../../../modules/sandbox';
 
+const PADDING = 0.25;
+const GEO_BOUNDS = {
+  LAT_MIN: -90,
+  LAT_MAX: 90,
+  LNG_MIN: -180,
+  LNG_MAX: 180,
+};
+
+/**
+ * Get the latitude bounds if latitiude is a single coordinate
+ * @param latExt Latitiude range
+ */
+function getLatBoundsForSingleCoordinate(latExt) {
+  const latMin = latExt[0] - PADDING < GEO_BOUNDS.LAT_MIN
+    ? GEO_BOUNDS.LAT_MIN
+    : latExt[0] - PADDING;
+  const latMax = latExt[1] + PADDING > GEO_BOUNDS.LAT_MAX
+    ? GEO_BOUNDS.LAT_MAX
+    : latExt[1] + PADDING;
+  return [latMin, latMax];
+}
+
+/**
+ * Get the longitude bounds if longitude is a single coordinate
+ * @param lngExt Longitude range
+ */
+function getLngBoundsForSingleCoordinate(lngExt) {
+  const lngMin = lngExt[0] - PADDING < GEO_BOUNDS.LNG_MIN
+    ? GEO_BOUNDS.LNG_MIN
+    : lngExt[0] - PADDING;
+  const lngMax = lngExt[1] + PADDING > GEO_BOUNDS.LNG_MAX
+    ? GEO_BOUNDS.LNG_MAX
+    : lngExt[1] + PADDING;
+  return [lngMin, lngMax];
+}
+
 export function getBounds(points) {
   const latExt = d3array.extent(points, d => d[1]);
   const lngExt = d3array.extent(points, d => d[0]);
+  const latBounds = latExt[0] === latExt[1] ? getLatBoundsForSingleCoordinate(latExt) : latExt;
+  const lngBounds = lngExt[0] === lngExt[1] ? getLngBoundsForSingleCoordinate(lngExt) : lngExt;
   return [
-    [lngExt[0], latExt[0]],
-    [lngExt[1], latExt[1]],
+    [lngBounds[0], latBounds[0]],
+    [lngBounds[1], latBounds[1]],
   ];
 }
 

--- a/superset/assets/src/visualizations/deckgl/layers/common.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/common.jsx
@@ -29,8 +29,8 @@ const GEO_BOUNDS = {
 };
 
 /**
- * Get the latitude bounds if latitiude is a single coordinate
- * @param latExt Latitiude range
+ * Get the latitude bounds if latitude is a single coordinate
+ * @param latExt Latitude range
  */
 function getLatBoundsForSingleCoordinate(latExt) {
   const latMin = latExt[0] - PADDING < GEO_BOUNDS.LAT_MIN


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deck gl scales the x and y axis based on the bounds we pass it. The scaling involves dividing a target size by the range. But since the range is 0 for a single point, we throw an error if our data is a single coordinate. This change will check if we have a single coordinate. If so, then the bounds we pass to deck gl will be the point's coordinates with padding.

##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1211" alt="Screen Shot 2019-04-09 at 2 53 45 PM" src="https://user-images.githubusercontent.com/47833996/55838068-0c75e700-5ad8-11e9-9829-3588d5a1eec8.png">

After:
<img width="1375" alt="Screen Shot 2019-04-09 at 2 48 45 PM" src="https://user-images.githubusercontent.com/47833996/55838073-113a9b00-5ad8-11e9-84cc-da6840852437.png">


##### TEST PLAN
Manual testing and unit tests.

I tested manually with normal single points, boundary cases, and various viz types. I noticed that it does not render the single point for boundary cases and certain aggregated viz types like hexagon, But I believe this is more of a deck gl issue.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [x] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS
@xtinec @betodealmeida @datability-io
@williaster @kristw 
