### PR TITLE
Add extra bucket when max outside range

### DIFF
--- a/superset/assets/src/visualizations/deckgl/utils.js
+++ b/superset/assets/src/visualizations/deckgl/utils.js
@@ -38,7 +38,8 @@ export function getBreakPoints({
     const precision = delta === 0
       ? 0
       : Math.max(0, Math.ceil(Math.log10(1 / delta)));
-    return Array(numBuckets + 1)
+    const extraBucket = maxValue > maxValue.toFixed(precision) ? 1 : 0;
+    return Array(numBuckets + 1 + extraBucket)
       .fill()
       .map((_, i) => (minValue + i * delta).toFixed(precision));
   }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In the deck.gl legend we round down the values so they look nice. Depending on the metric, this makes the maximum value be outside the range of the last bucket, eg, if:

```
min = 8.4
max = 27.1
buckets = 5
```

The buckets will be:

```
8-12
12-16
16-20
20-23
23-27
```

And `27.1` will fall outside the buckets. This PR adds an extra bucket in cases like this.

<!-- ##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

##### TEST PLAN
<!--- What steps were taken to verify -->

Tested with data, an extra bucket `27-31` gets created.

Also tested with values that are identical to the upper range of the last bucket. In that case no extra bucket gets created.

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [X] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

@xtinec @khtruong @datability-io 