### PR TITLE
Do not add tag to non-saved objects

### DIFF
--- a/superset/views/tags.py
+++ b/superset/views/tags.py
@@ -77,6 +77,9 @@ class TagView(BaseSupersetView):
     @expose('/tags/<object_type:object_type>/<int:object_id>/', methods=['GET'])
     def get(self, object_type, object_id):
         """List all tags a given object has."""
+        if object_id == 0:
+            return json_success(json.dumps([]))
+
         query = db.session.query(TaggedObject).filter(and_(
             TaggedObject.object_type == object_type,
             TaggedObject.object_id == object_id))
@@ -87,6 +90,9 @@ class TagView(BaseSupersetView):
     @expose('/tags/<object_type:object_type>/<int:object_id>/', methods=['POST'])
     def post(self, object_type, object_id):
         """Add new tags to an object."""
+        if object_id == 0:
+            return Response(status=404)
+
         tagged_objects = []
         for name in request.get_json(force=True):
             if ':' in name:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR prevents people from adding tags to unsaved charts, and in case those tags have been created in the past it prevents them from showing up in new charts.

<!-- ##### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

<!-- ##### TEST PLAN -->
<!--- What steps were taken to verify -->

##### ADDITIONAL INFORMATION
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
<!--- Check any relevant boxes with "x" -->
    [ ] Has associated issue:
    [ ] Changes UI
    [ ] Requires DB Migration. Confirm DB Migration upgrade and downgrade tested.
    [ ] Introduces new feature or API
    [ ] Removes existing feature or API
    [X] Fixes bug
    [ ] Refactors code
    [ ] Adds test(s)

##### REVIEWERS

@xtinec @datability-io @khtruong 