### PR TITLE
Add all database access permission to 'Alpha' role

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -68,7 +68,6 @@ class SupersetSecurityManager(SecurityManager):
     }
 
     ADMIN_ONLY_PERMISSIONS = {
-        'all_database_access',
         'can_sql_json',  # TODO: move can_sql_json to sql_lab role
         'can_override_role_permissions',
         'can_sync_druid_source',
@@ -84,6 +83,7 @@ class SupersetSecurityManager(SecurityManager):
 
     ALPHA_ONLY_PERMISSIONS = set([
         'muldelete',
+        'all_database_access',
         'all_datasource_access',
     ])
 

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -129,9 +129,6 @@ class RolePermissionTests(SupersetTestCase):
         self.assertTrue(security_manager.is_admin_only(
             security_manager.find_permission_view_menu(
                 'can_approve', 'Superset')))
-        self.assertTrue(security_manager.is_admin_only(
-            security_manager.find_permission_view_menu(
-                'all_database_access', 'all_database_access')))
 
     def test_is_alpha_only(self):
         self.assertFalse(security_manager.is_alpha_only(
@@ -148,6 +145,9 @@ class RolePermissionTests(SupersetTestCase):
         self.assertTrue(security_manager.is_alpha_only(
             security_manager.find_permission_view_menu(
                 'can_delete', 'DruidMetricInlineView')))
+        self.assertTrue(security_manager.is_alpha_only(
+            security_manager.find_permission_view_menu(
+                'all_database_access', 'all_database_access')))
 
     def test_is_gamma_pvm(self):
         self.assertTrue(security_manager.is_gamma_pvm(


### PR DESCRIPTION
Recently added a DatabaseFilter construct that allows to limit database *list* access per-role in SQL Lab. Without this fix, by default `Alpha` sees no database by default in their database dropdown list.

related to https://github.com/apache/incubator-superset/pull/7009