### PR TITLE
fix: make the bot more descriptive

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -3,6 +3,7 @@
 # *Required* Comment to reply with
 requestInfoReplyComment: >
   We would appreciate it if you could provide us with more info about this issue/pr!
+  Please do not leave the `title` or `description` empty.
 
 # *OPTIONAL* default titles to check against for lack of descriptiveness
 # MUST BE ALL LOWERCASE


### PR DESCRIPTION
### CATEGORY

- [x] Build / Development Environment

### SUMMARY
Make the `request-info` bot be more specific about what field is missing.

### REVIEWERS
@john-bodley @mistercrunch 