### PR TITLE
Do not use GET requests in Explore view

### DIFF
--- a/superset/assets/cypress/integration/dashboard/controls.js
+++ b/superset/assets/cypress/integration/dashboard/controls.js
@@ -32,18 +32,18 @@ export default () => describe('top-level controls', () => {
     cy.get('#app').then((data) => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
       const dashboard = bootstrapData.dashboard_data;
+      const sliceIds = dashboard.slices.map(slice => (slice.slice_id));
       mapId = dashboard.slices.find(slice => (slice.form_data.viz_type === 'world_map')).slice_id;
 
-      dashboard.slices
-        .forEach((slice) => {
-          const sliceRequest = `getJson_${slice.slice_id}`;
+      sliceIds
+        .forEach((id) => {
+          const sliceRequest = `getJson_${id}`;
           sliceRequests.push(`@${sliceRequest}`);
-          const formData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
-          cy.route('GET', `/superset/explore_json/?form_data=${formData}`).as(sliceRequest);
+          cy.route('GET', `/superset/explore_json/?form_data={"slice_id":${id}}`).as(sliceRequest);
 
-          const forceRefresh = `postJson_${slice.slice_id}_force`;
+          const forceRefresh = `getJson_${id}_force`;
           forceRefreshRequests.push(`@${forceRefresh}`);
-          cy.route('POST', `/superset/explore_json/?form_data={"slice_id":${slice.slice_id}}&force=true`).as(forceRefresh);
+          cy.route('POST', `/superset/explore_json/?form_data={"slice_id":${id}}&force=true`).as(forceRefresh);
         });
     });
   });
@@ -69,7 +69,7 @@ export default () => describe('top-level controls', () => {
       .parent()
       .should('have.class', 'disabled');
 
-    cy.wait(`@postJson_${mapId}_force`);
+    cy.wait(`@getJson_${mapId}_force`);
     cy.get('#save-dash-split-button').trigger('click');
     cy.contains('Force refresh dashboard').parent().not('have.class', 'disabled');
   });

--- a/superset/assets/cypress/integration/dashboard/controls.js
+++ b/superset/assets/cypress/integration/dashboard/controls.js
@@ -41,7 +41,7 @@ export default () => describe('top-level controls', () => {
           sliceRequests.push(`@${sliceRequest}`);
           cy.route('GET', `/superset/explore_json/?form_data={"slice_id":${id}}`).as(sliceRequest);
 
-          const forceRefresh = `getJson_${id}_force`;
+          const forceRefresh = `postJson_${id}_force`;
           forceRefreshRequests.push(`@${forceRefresh}`);
           cy.route('POST', `/superset/explore_json/?form_data={"slice_id":${id}}&force=true`).as(forceRefresh);
         });
@@ -69,7 +69,7 @@ export default () => describe('top-level controls', () => {
       .parent()
       .should('have.class', 'disabled');
 
-    cy.wait(`@getJson_${mapId}_force`);
+    cy.wait(`@postJson_${mapId}_force`);
     cy.get('#save-dash-split-button').trigger('click');
     cy.contains('Force refresh dashboard').parent().not('have.class', 'disabled');
   });

--- a/superset/assets/cypress/integration/dashboard/edit_mode.js
+++ b/superset/assets/cypress/integration/dashboard/edit_mode.js
@@ -28,8 +28,7 @@ export default () => describe('edit mode', () => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
       const dashboard = bootstrapData.dashboard_data;
       const boxplotChartId = dashboard.slices.find(slice => (slice.form_data.viz_type === 'box_plot')).slice_id;
-      const formData = `{"slice_id":${boxplotChartId},"viz_type":"box_plot"}`;
-      const boxplotRequest = `/superset/explore_json/?form_data=${formData}`;
+      const boxplotRequest = `/superset/explore_json/?form_data={"slice_id":${boxplotChartId}}`;
       cy.route('GET', boxplotRequest).as('boxplotRequest');
     });
 

--- a/superset/assets/cypress/integration/dashboard/filter.js
+++ b/superset/assets/cypress/integration/dashboard/filter.js
@@ -39,8 +39,7 @@ export default () => describe('dashboard filter', () => {
   it('should apply filter', () => {
     const aliases = [];
 
-    const formData = `{"slice_id":${filterId},"viz_type":"filter_box"}`;
-    const filterRoute = `/superset/explore_json/?form_data=${formData}`;
+    const filterRoute = `/superset/explore_json/?form_data={"slice_id":${filterId}}`;
     cy.route('GET', filterRoute).as('fetchFilter');
     cy.wait('@fetchFilter');
     sliceIds

--- a/superset/assets/cypress/integration/dashboard/load.js
+++ b/superset/assets/cypress/integration/dashboard/load.js
@@ -34,8 +34,7 @@ export default () => describe('load', () => {
       // then define routes and create alias for each requests
       slices.forEach((slice) => {
         const alias = `getJson_${slice.slice_id}`;
-        const formData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
-        cy.route('GET', `/superset/explore_json/?form_data=${formData}`).as(alias);
+        cy.route('GET', `/superset/explore_json/?form_data={"slice_id":${slice.slice_id}}`).as(alias);
         aliases.push(`@${alias}`);
       });
     });

--- a/superset/assets/cypress/integration/dashboard/save.js
+++ b/superset/assets/cypress/integration/dashboard/save.js
@@ -56,8 +56,7 @@ export default () => describe('save', () => {
     cy.wait('@copyRequest');
 
     // should have box_plot chart
-    const formData = `{"slice_id":${boxplotChartId},"viz_type":"box_plot"}`;
-    const boxplotRequest = `/superset/explore_json/?form_data=${formData}`;
+    const boxplotRequest = `/superset/explore_json/?form_data={"slice_id":${boxplotChartId}}`;
     cy.route('GET', boxplotRequest).as('boxplotRequest');
     cy.wait('@boxplotRequest');
     cy.get('.grid-container .box_plot').should('be.exist');

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -68,23 +68,12 @@ class Chart extends React.PureComponent {
   }
   componentDidMount() {
     if (this.props.triggerQuery) {
-      if (this.props.chartId > 0) {
-        // Load saved chart with a GET request
-        this.props.actions.getSavedChart(
-          this.props.formData,
-          false,
-          this.props.timeout,
-          this.props.chartId,
-        );
-      } else {
-        // Create chart with POST request
-        this.props.actions.postChartFormData(
-          this.props.formData,
-          false,
-          this.props.timeout,
-          this.props.chartId,
-        );
-      }
+      this.props.actions.postChartFormData(
+        this.props.formData,
+        false,
+        this.props.timeout,
+        this.props.chartId,
+      );
     }
   }
 

--- a/superset/assets/src/explore/exploreUtils.js
+++ b/superset/assets/src/explore/exploreUtils.js
@@ -119,11 +119,10 @@ export function getExploreUrlAndPayload({
 
   // Building the querystring (search) part of the URI
   const search = uri.search(true);
-  const { slice_id, extra_filters, adhoc_filters, viz_type } = formData;
+  const { slice_id, extra_filters, adhoc_filters } = formData;
   if (slice_id) {
     const form_data = { slice_id };
     if (method === 'GET') {
-      form_data.viz_type = viz_type;
       if (extra_filters && extra_filters.length) {
         form_data.extra_filters = extra_filters;
       }

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -153,8 +153,8 @@ def get_form_data(slice_id=None, use_slice_data=False):
     slice_id = form_data.get('slice_id') or slice_id
     slc = None
 
-    # Check if form data only contains slice_id, additional filters and viz type
-    valid_keys = ['slice_id', 'extra_filters', 'adhoc_filters', 'viz_type']
+    # Check if form data only contains slice_id and additional filters
+    valid_keys = ['slice_id', 'extra_filters', 'adhoc_filters']
     valid_slice_id = all(key in valid_keys for key in form_data)
 
     # Include the slice_form_data if request from explore or slice calls


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

With the new chart cache, when we first load the Explore view we perform a `GET` request, to quickly load a cached response (if any). When the user clicks "Run Query", the request is  `POST`ed to `explore_json`, bypassing the response cache but still using the data frame cache in `viz.py`.

One problem with this is that if the user modifies the visualization, saves and reloads the page, they will see the old visualization, because of the browser cache.

We can use the [Application Cache](https://developer.mozilla.org/en-US/docs/Web/HTML/Using_the_application_cache) mechanism to fix that, but it would require keeping a list of cached and invalidated resources. For now, I'd rather just turn off the `GET` requests in the Explore view.

Since we're turning off `GET` requests in Explore view, we can also revert https://github.com/apache/incubator-superset/pull/7255.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Verified that Explore view is now doing `POST`s.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [X] Removes existing feature or API

### REVIEWERS
