### PR TITLE
Add celery task to refresh SQL Lab datasources cache

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -32,7 +32,7 @@ from superset import (
 )
 from superset.utils import (
     core as utils, dashboard_import_export, dict_import_export)
-from superset.tasks.cache import update_datasources
+from superset.utils.cache import update_datasources
 
 config = app.config
 celery_app = utils.get_celery_app(config)

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -320,7 +320,7 @@ def cache_warmup(strategy_name, *args, **kwargs):
 def update_datasources_cache(cache_timeout=24 * 60 * 60):
     for database in db.session.query(Database).all():
         if database.allow_multi_schema_metadata_fetch:
-            logger.info('Fetching {} datasources ...'.format(database.name))
+            logger.info(f'Fetching {database.name} datasources')
             try:
                 database.all_table_names_in_database(
                     force=True, cache=True, cache_timeout=cache_timeout)

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -30,6 +30,7 @@ from superset import app, db
 from superset.models.core import Dashboard, Database, Log, Slice
 from superset.models.tags import Tag, TaggedObject
 from superset.tasks.celery_app import app as celery_app
+from superset.utils.cache import update_datasources
 from superset.utils.core import parse_human_datetime
 
 
@@ -316,22 +317,5 @@ def cache_warmup(strategy_name, *args, **kwargs):
     return results
 
 
-def update_datasources(cache_timeout=24 * 60 * 60):
-    """
-    This function refreshes cached table/view names for fast lookup in SQL Lab.
-
-    """
-    for database in db.session.query(Database).all():
-        if database.allow_multi_schema_metadata_fetch:
-            logger.info(f'Fetching {database.name} datasources')
-            try:
-                database.all_table_names_in_database(
-                    force=True, cache=True, cache_timeout=cache_timeout)
-                database.all_view_names_in_database(
-                    force=True, cache=True, cache_timeout=cache_timeout)
-            except Exception:  # pylint: disable=broad-except
-                logger.exception('An error occurred!')
-
-# register `update_datasources` as a Celery task; we don't use a decorator in
-# the function because it can be called directly by `superset/cli.py`
+# register `update_datasources` as a Celery task
 celery_app.task(name='datasources-cache')(update_datasources)

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -326,5 +326,5 @@ def update_datasources_cache(cache_timeout=24 * 60 * 60):
                     force=True, cache=True, cache_timeout=cache_timeout)
                 database.all_view_names_in_database(
                     force=True, cache=True, cache_timeout=cache_timeout)
-            except Exception as e:
+            except Exception:
                 logger.exception('An error occurred!')


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Added a new celery task to refresh the datasource cache in SQL Lab. Should be used like this:

```python
CELERYBEAT_SCHEDULE = {
    'refresh-sqllab-datasources-cache-daily': 
        'task': 'datasources-cache',
        'schedule': crontab(minute=0, hour=8),
    } 
}
```

I'm still testing this.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

In progress.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@datability-io @khtruong @DiggidyDave 