### PR TITLE
fix: time series table

### DIFF
--- a/superset/assets/src/explore/components/controls/CollectionControl.jsx
+++ b/superset/assets/src/explore/components/controls/CollectionControl.jsx
@@ -101,8 +101,8 @@ export default class CollectionControl extends React.Component {
             </div>
             <div className="pull-left">
               <Control
-                label={this.props.label}
-                value={o}
+                {...this.props}
+                {...o}
                 onChange={this.onChange.bind(this, i)}
               />
             </div>

--- a/superset/assets/src/explore/components/controls/CollectionControl.jsx
+++ b/superset/assets/src/explore/components/controls/CollectionControl.jsx
@@ -101,8 +101,8 @@ export default class CollectionControl extends React.Component {
             </div>
             <div className="pull-left">
               <Control
-                {...this.props}
-                {...o}
+                label={this.props.label}
+                value={o}
                 onChange={this.onChange.bind(this, i)}
               />
             </div>

--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -30,13 +30,35 @@ import CheckboxControl from './CheckboxControl';
 
 const propTypes = {
   label: PropTypes.string,
-  value: PropTypes.object,
+  tooltip: PropTypes.string,
+  colType: PropTypes.string,
+  width: PropTypes.string,
+  height: PropTypes.string,
+  timeLag: PropTypes.string,
+  timeRatio: PropTypes.string,
+  comparisonType: PropTypes.string,
+  showYAxis: PropTypes.bool,
+  yAxisBounds: PropTypes.array,
+  bounds: PropTypes.array,
+  d3format: PropTypes.string,
+  dateFormat: PropTypes.string,
   onChange: PropTypes.func,
 };
 
 const defaultProps = {
   label: t('Time Series Columns'),
-  value: {},
+  tooltip: '',
+  colType: '',
+  width: '',
+  height: '',
+  timeLag: '',
+  timeRatio: '',
+  comparisonType: '',
+  showYAxis: false,
+  yAxisBounds: [null, null],
+  bounds: [null, null],
+  d3format: '',
+  dateFormat: '',
   onChange: () => {},
 };
 
@@ -59,18 +81,18 @@ export default class TimeSeriesColumnControl extends React.Component {
     super(props);
     const state = {
       label: this.props.label,
-      tooltip: this.props.value.tooltip || '',
-      colType: this.props.value.colType || '',
-      width: this.props.value.width || '',
-      height: this.props.value.height || '',
-      timeLag: this.props.value.timeLag || '',
-      timeRatio: this.props.value.timeRatio || '',
-      comparisonType: this.props.value.comparisonType || '',
-      showYAxis: this.props.value.showYAxis || false,
-      yAxisBounds: this.props.value.yAxisBounds || [null, null],
-      bounds: this.props.value.bounds || [null, null],
-      d3format: this.props.value.d3format || '',
-      dateFormat: this.props.value.dateFormat || '',
+      tooltip: this.props.tooltip,
+      colType: this.props.colType,
+      width: this.props.width,
+      height: this.props.height,
+      timeLag: this.props.timeLag,
+      timeRatio: this.props.timeRatio,
+      comparisonType: this.props.comparisonType,
+      showYAxis: this.props.showYAxis,
+      yAxisBounds: this.props.yAxisBounds,
+      bounds: this.props.bounds,
+      d3format: this.props.d3format,
+      dateFormat: this.props.dateFormat,
     };
     delete state.onChange;
     this.state = state;

--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -28,6 +28,7 @@ import BoundsControl from './BoundsControl';
 import CheckboxControl from './CheckboxControl';
 
 const propTypes = {
+  label: PropTypes.string,
   onChange: PropTypes.func,
 };
 
@@ -52,7 +53,21 @@ const colTypeOptions = [
 export default class TimeSeriesColumnControl extends React.Component {
   constructor(props) {
     super(props);
-    const state = { ...props };
+    const state = {
+      label: this.props.label,
+      tooltip: '',
+      colType: '',
+      width: '',
+      height: '',
+      timeLag: '',
+      timeRatio: '',
+      comparisonType: '',
+      showYAxis: false,
+      yAxisBounds: [null, null],
+      bounds: [null, null],
+      d3format: '',
+      dateFormat: '',
+    };
     delete state.onChange;
     this.state = state;
     this.onChange = this.onChange.bind(this);

--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -22,6 +22,7 @@ import {
   Row, Col, FormControl, OverlayTrigger, Popover,
 } from 'react-bootstrap';
 import Select from 'react-select';
+import { t } from '@superset-ui/translation';
 
 import InfoTooltipWithTrigger from '../../../components/InfoTooltipWithTrigger';
 import BoundsControl from './BoundsControl';
@@ -33,6 +34,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  label: t('Time Series Columns'),
   onChange: () => {},
 };
 

--- a/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
+++ b/superset/assets/src/explore/components/controls/TimeSeriesColumnControl.jsx
@@ -30,11 +30,13 @@ import CheckboxControl from './CheckboxControl';
 
 const propTypes = {
   label: PropTypes.string,
+  value: PropTypes.object,
   onChange: PropTypes.func,
 };
 
 const defaultProps = {
   label: t('Time Series Columns'),
+  value: {},
   onChange: () => {},
 };
 
@@ -57,18 +59,18 @@ export default class TimeSeriesColumnControl extends React.Component {
     super(props);
     const state = {
       label: this.props.label,
-      tooltip: '',
-      colType: '',
-      width: '',
-      height: '',
-      timeLag: '',
-      timeRatio: '',
-      comparisonType: '',
-      showYAxis: false,
-      yAxisBounds: [null, null],
-      bounds: [null, null],
-      d3format: '',
-      dateFormat: '',
+      tooltip: this.props.value.tooltip || '',
+      colType: this.props.value.colType || '',
+      width: this.props.value.width || '',
+      height: this.props.value.height || '',
+      timeLag: this.props.value.timeLag || '',
+      timeRatio: this.props.value.timeRatio || '',
+      comparisonType: this.props.value.comparisonType || '',
+      showYAxis: this.props.value.showYAxis || false,
+      yAxisBounds: this.props.value.yAxisBounds || [null, null],
+      bounds: this.props.value.bounds || [null, null],
+      d3format: this.props.value.d3format || '',
+      dateFormat: this.props.value.dateFormat || '',
     };
     delete state.onChange;
     this.state = state;


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are various issues with the time series table:
1. Cannot create a time series table
2. Cannot save a time series table

The problem is that we pass and save all props as state properties in the TimeSeriesColumnControl. When we make a backend request, we pass all the state properties as form data. Some of these properties do not make sense (i.e. a function to render the tooltip) and thus the request fails. 

The fix is to be explicit about the state properties so that we only pass back relevant and comprehensible properties to the backend.

@mistercrunch This addresses some of the issues you were trying to fix in https://github.com/apache/incubator-superset/pull/6959. I think we should be explicit in our state properties versus adding the prop passthroughProps.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Tested manually

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch @xtinec @betodealmeida @DiggidyDave @datability-io 