### PR TITLE
Add version info back into the navbar

### DIFF
--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -23,6 +23,18 @@
     {% set locale = 'en' %}
 {% endif %}
 
+<script>
+  window.onload = () => {
+    var json_url = '/static/assets/version_info.json';
+
+    $.get(json_url)
+      .then(resp => {
+        var version = resp.GIT_SHA ? "GIT_SHA: " + resp.GIT_SHA.substring(0,8) : "Version: " + resp.version;
+        $("#version").attr("data-original-title", version);
+      });
+  }
+</script>
+
 {% if not current_user.is_anonymous %}
     <li class="dropdown">
         <button type="button" style="margin-top: 12px; margin-right: 30px;" data-toggle="dropdown" class="dropdown-toggle btn btn-sm btn-primary">
@@ -87,3 +99,19 @@
     <li><a href="{{appbuilder.get_url_for_login}}">
     <i class="fa fa-fw fa-sign-in"></i>{{_("Login")}}</a></li>
 {% endif %}
+
+<li>
+  <a href="javascript:void(0)" title="Version info" id="version">
+    <i class="fa fa-code-fork"></i> &nbsp;
+  </a>
+</li>
+ <li>
+  <a href="https://github.com/apache/incubator-superset" title="Superset's Github" target="_blank">
+    <i class="fa fa-github"></i> &nbsp;
+  </a>
+</li>
+<li>
+  <a href="https://superset.incubator.apache.org" title="Documentation" target="_blank">
+    <i class="fa fa-book"></i> &nbsp;
+  </a>
+</li>


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ x ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Adds back a button for version info into the navbar. Instead of opening up a new tab that shows the JSON page, it displays the version or the truncated git hash on hover.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="404" alt="Screen Shot 2019-04-15 at 3 58 00 PM" src="https://user-images.githubusercontent.com/8096320/56161830-8efb1c80-5f98-11e9-94ad-04c0d563281b.png">

After:
<img width="299" alt="Screen Shot 2019-04-19 at 2 40 07 PM" src="https://user-images.githubusercontent.com/8096320/56438470-10142580-62b1-11e9-8335-32bd8a3a79eb.png">

<img width="302" alt="Screen Shot 2019-04-19 at 2 41 10 PM" src="https://user-images.githubusercontent.com/8096320/56438523-31751180-62b1-11e9-8fea-0061031ad1af.png">


### TEST PLAN
Start up webserver and look for version, github and documentation buttons in the navbar on the right

### ADDITIONAL INFORMATION
- [ x ] Has associated issue: Fixes #6992 
- [ x ] Changes UI

### REVIEWERS
