### PR TITLE
Fix SQLParse when query has reserved word

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -86,6 +86,9 @@ class ParsedQuery(object):
         return isinstance(token, (IdentifierList, Identifier))
 
     def __process_identifier(self, identifier):
+        if not self.__is_identifier(identifier):
+            identifier = Identifier([identifier])
+
         # exclude subselects
         if '(' not in str(identifier):
             table_name = self.__get_full_name(identifier)

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -471,14 +471,14 @@ class SupersetTestCase(unittest.TestCase):
 
     def test_extract_from_statement_with_reserved(self):
         query = """
-	WITH
+        WITH
             columns AS (SELECT metric FROM a),
             rows AS (SELECT metric FROM b)
-	SELECT
-	    c.metric AS m1,
-	    r.metric AS m2
-	FROM columns c
-	JOIN rows r
+        SELECT
+            c.metric AS m1,
+            r.metric AS m2
+        FROM columns c
+        JOIN rows r
         """
         result = sql_parse.ParsedQuery(query)._table_names
         expected = {'a', 'b'}

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -462,3 +462,28 @@ class SupersetTestCase(unittest.TestCase):
             'SELECT * FROM ab_user LIMIT 1',
         ]
         self.assertEquals(statements, expected)
+
+    def test_extract_from_statement(self):
+        query = 'SELECT a, b FROM c WHERE d'
+        result = sql_parse.ParsedQuery(query)._table_names
+        expected = {'c'}
+        self.assertEquals(result, expected)
+
+    def test_extract_from_statement_with_reserved(self):
+        query = """
+	WITH
+            columns AS (SELECT metric FROM a),
+            rows AS (SELECT metric FROM b)
+	SELECT
+	    c.metric AS m1,
+	    r.metric AS m2
+	FROM columns c
+	JOIN rows r
+        """
+        result = sql_parse.ParsedQuery(query)._table_names
+        expected = {'a', 'b'}
+        self.assertEquals(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [X] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The following query cannot be parsed by `sqlparse`, even though it's valid:

```sql
WITH
    columns AS (SELECT metric FROM a),
    rows AS (SELECT metric FROM b)
SELECT
    c.metric AS m1,
    r.metric AS m2
FROM columns c
JOIN rows r
```

This happens because `sqlparse` treats `rows` as a reserved word, even though the query is valid in Presto.

Our users have been overcoming the problem by quoting `rows`. This prevents `sqlparse` from treating it as a reserved word. But it's confusing to users, because the underlying engine (Presto) doesn't require it.

Instead, I fixed it by following [Postel's Law](https://en.wikipedia.org/wiki/Robustness_principle), and being liberal about user input.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I added a unit test that covers the bug, and another basic one.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
