### PR TITLE
filter out all nan series

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1112,15 +1112,21 @@ class NVD3TimeSeriesViz(NVD3Viz):
                     series_title = series_title + (title_suffix,)
 
             values = []
+            non_nan_cnt = 0
             for ds in df.index:
                 if ds in ys:
                     d = {
                         'x': ds,
                         'y': ys[ds],
                     }
+                    if not np.isnan(ys[ds]):
+                        non_nan_cnt += 1
                 else:
                     d = {}
                 values.append(d)
+
+            if non_nan_cnt == 0:
+                continue
 
             d = {
                 'key': series_title,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
If there are more than one fields are selected in `Group by`, currently in the backend, we are using all combinations of each field to populate the resulting datasets, regardless if such combination has any meaningful values.

In this PR, I'm removing such series if all values are `nan`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
