### PR TITLE
[annotations] Improves annotation validation, start_dttm, end_dttm

### DIFF
--- a/superset/models/annotations.py
+++ b/superset/models/annotations.py
@@ -46,7 +46,7 @@ class Annotation(Model, AuditMixinNullable):
     id = Column(Integer, primary_key=True)
     start_dttm = Column(DateTime)
     end_dttm = Column(DateTime)
-    layer_id = Column(Integer, ForeignKey('annotation_layer.id'))
+    layer_id = Column(Integer, ForeignKey('annotation_layer.id'), nullable=False)
     short_descr = Column(String(500))
     long_descr = Column(Text)
     layer = relationship(


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Enhancement (new features, refinement)

### SUMMARY
Annotations are using ``pre_add`` callback to validate form fields, the users need to refill the form
if ``start_dttm`` and/or ``end_dttm`` validation fails. Using a custom WTForm validation object
improves the user experience because the form is validated before leaving the page, and 
fields are highlighted with the error message

### SCREENSHOTS
Before:

- Dropdown accepts NULL

![Screenshot from 2019-04-19 14-20-27](https://user-images.githubusercontent.com/4025227/56425995-7186c500-62ae-11e9-841d-d586bb51bd47.png)

- dttm validation is checked after the form is submitted

![Screenshot from 2019-04-19 14-20-57](https://user-images.githubusercontent.com/4025227/56425996-721f5b80-62ae-11e9-9197-51d4154343bf.png)


After:
![Screenshot from 2019-04-19 14-17-06](https://user-images.githubusercontent.com/4025227/56425835-df7ebc80-62ad-11e9-8328-bb4bcb52c8da.png)

![Screenshot from 2019-04-19 14-13-23](https://user-images.githubusercontent.com/4025227/56425757-8e6ec880-62ad-11e9-8af1-68bc1e2e9692.png)

![Screenshot from 2019-04-19 14-14-10](https://user-images.githubusercontent.com/4025227/56425759-8e6ec880-62ad-11e9-8da9-7da943afcb4a.png)


### ADDITIONAL INFORMATION
- [x] Changes UI
