### PR TITLE
use validate.js to validate controls

### DIFF
--- a/superset/assets/package-lock.json
+++ b/superset/assets/package-lock.json
@@ -21379,6 +21379,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validate.js": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.12.0.tgz",
+      "integrity": "sha512-/x2RJSvbqEyxKj0RPN4xaRquK+EggjeVXiDDEyrJzsJogjtiZ9ov7lj/svVb4DM5Q5braQF4cooAryQbUwOxlA=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -138,6 +138,7 @@
     "shortid": "^2.2.6",
     "underscore": "^1.8.3",
     "urijs": "^1.18.10",
+    "validate.js": "^0.12.0",
     "viewport-mercator-project": "^6.1.1"
   },
   "devDependencies": {

--- a/superset/assets/src/explore/validators.js
+++ b/superset/assets/src/explore/validators.js
@@ -23,29 +23,35 @@
  * and an error message if not valid.
  * */
 import { t } from '@superset-ui/translation';
+import validate from 'validate.js';
+
+// Declare formatting
+validate.formatters.joined = errors => errors.map(error =>  error.validator).join(', ');
 
 export function numeric(v) {
-  if (v && isNaN(v)) {
-    return t('is expected to be a number');
-  }
-  return false;
+  return validate.single(v, {
+    presence: true,
+    numericality: {
+      message: t('is expected to be a number'),
+    },
+  }, { format: 'joined' }) || false;
 }
 
 export function integer(v) {
-  if (v && (isNaN(v) || parseInt(v, 10) !== +(v))) {
-    return t('is expected to be an integer');
-  }
-  return false;
+  return validate.single(v, {
+    presence: true,
+    numericality: {
+      onlyInteger: true,
+      message: t('is expected to be an integer'),
+    },
+  }, { format: 'joined' }) || false;
 }
 
 export function nonEmpty(v) {
-  if (
-      v === null ||
-      v === undefined ||
-      v === '' ||
-      (Array.isArray(v) && v.length === 0)
-  ) {
-    return t('cannot be empty');
-  }
-  return false;
+  return validate.single(v, {
+    presence: {
+      allowEmpty: false,
+      message: t('cannot be empty'),
+    },
+  }, { format: 'joined' }) || false;
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Enhancement (new features, refinement)

### SUMMARY

Use `validate.js` to perform validation instead of custom logic in Superset, which has no test.

`validate.js` seems reliable with 
* 100% test coverage 
* a lot of common validations and flexibility to define custom ones.
* `typescript` definitions

https://validatejs.org/#overview

### TEST PLAN
Select one of the heatmap chart, go to explore page and clear `X` or `Y` to see if the control name become red, hovering the `i` icon should display `cannot be empty` error message.

### REVIEWERS

@mistercrunch @conglei @williaster @graceguo-supercat 