### PR TITLE
[WIP] Repair and improve sample data functionality

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -398,15 +398,6 @@ existence of a functional SqlAlchemy dialect and Python driver. Googling
 the keyword ``sqlalchemy`` in addition of a keyword that describes the
 database you want to connect to should get you to the right place.
 
-Google BigQuery
----------------
-
-The connection string for BigQuery looks like this ::
-
-    bigquery://{project_id}
-
-To be able to upload data, e.g. sample data, the python library `pandas_gbq` is required.
-
 (AWS) Athena
 ------------
 
@@ -423,6 +414,21 @@ You can also use `PyAthena` library(no java required) like this ::
     awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com/{schema_name}?s3_staging_dir={s3_staging_dir}&...
 
 See `PyAthena <https://github.com/laughingman7743/PyAthena#sqlalchemy>`_.
+
+(Google) BigQuery
+-----------------
+
+The connection string for BigQuery looks like this ::
+
+    bigquery://{project_id}
+
+To be able to upload data, e.g. sample data, the python library `pandas_gbq` is required.
+
+MySQL
+-----
+
+By default Superset uses `utf8m4` charset on MySQL. To change this specify a custom
+charset in the connection string, e.g. `mysql://hostname?charset=latin1`.
 
 Snowflake
 ---------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -398,6 +398,15 @@ existence of a functional SqlAlchemy dialect and Python driver. Googling
 the keyword ``sqlalchemy`` in addition of a keyword that describes the
 database you want to connect to should get you to the right place.
 
+Google BigQuery
+---------------
+
+The connection string for BigQuery looks like this ::
+
+    bigquery://{project_id}
+
+To be able to upload data, e.g. sample data, the python library `pandas_gbq` is required.
+
 (AWS) Athena
 ------------
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -80,6 +80,10 @@ SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'superset.db')
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 
+# Name of database and schema for sample data
+SAMPLE_DATA_DB_DATASOURCE_NAME = None
+SAMPLE_DATA_DB_SCHEMA_NAME = None
+
 # In order to hook up a custom password store for all SQLACHEMY connections
 # implement a function that takes a single argument of type 'sqla.engine.url',
 # returns a password and set SQLALCHEMY_CUSTOM_PASSWORD_STORE.

--- a/superset/config.py
+++ b/superset/config.py
@@ -80,7 +80,7 @@ SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'superset.db')
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 
-# Name of database and schema for sample data
+# Name of database and schema for sample data. If none defaults to `main` database
 SAMPLE_DATA_DB_DATASOURCE_NAME = None
 SAMPLE_DATA_DB_SCHEMA_NAME = None
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -717,6 +717,8 @@ class SqlaTable(Model, BaseDatasource):
             direction = asc if ascending else desc
             if utils.is_adhoc_metric(col):
                 col = self.adhoc_metric_to_sqla(col, cols)
+            elif isinstance(col, str):
+                col = metrics_dict.get(col).get_sqla_col()
             qry = qry.order_by(direction(col))
 
         if row_limit:

--- a/superset/data/README.md
+++ b/superset/data/README.md
@@ -1,0 +1,28 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Sample Data
+===========
+
+This directory contains scripts used for loading sample data into Superset.
+When adding a new sample dataset, charts and/or dashboards, refer to e.g. `energy.py` 
+as a template. All column names in Chart metadata should be handled with the 
+`mlc()` function (shorthand for `db_engine_spec.make_label_compatible()`), which
+ensures that column names conform to the limitations of each respective engine.
+Note that metric names need not be mutated (Superset takes care of those at runtime).

--- a/superset/data/bart_lines.py
+++ b/superset/data/bart_lines.py
@@ -21,7 +21,7 @@ import polyline
 from sqlalchemy import String, Text
 
 from superset import db
-from superset.utils.core import get_or_create_main_db
+from superset.utils.core import get_sample_data_db
 from .helpers import TBL, get_example_data
 
 
@@ -50,7 +50,7 @@ def load_bart_lines():
     if not tbl:
         tbl = TBL(table_name=tbl_name)
     tbl.description = 'BART lines'
-    tbl.database = get_or_create_main_db()
+    tbl.database = get_sample_data_db()
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()

--- a/superset/data/bart_lines.py
+++ b/superset/data/bart_lines.py
@@ -42,11 +42,11 @@ def load_bart_lines():
     del df['path']
     df = make_df_columns_compatible(df, sample_db.db_engine_spec)
     dtypes = make_dtype_columns_compatible({
-            'color': String(255),
-            'name': String(255),
-            'polyline': Text,
-            'path_json': Text,
-        }, sample_db.db_engine_spec)
+        'color': String(255),
+        'name': String(255),
+        'polyline': Text(),
+        'path_json': Text(),
+    }, sample_db.db_engine_spec)
 
     df.to_sql(
         name=tbl_name,

--- a/superset/data/bart_lines.py
+++ b/superset/data/bart_lines.py
@@ -47,15 +47,14 @@ def load_bart_lines():
         'polyline': Text(),
         'path_json': Text(),
     }, sample_db.db_engine_spec)
-
-    df.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(df,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     print('Creating table {} reference'.format(tbl_name))
     tbl = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
                                           schema=schema).first()

--- a/superset/data/birth_names.py
+++ b/superset/data/birth_names.py
@@ -44,18 +44,18 @@ def load_birth_names():
     """Loading birth name dataset from a zip file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
-    tbl_name='birth_names'
+    cm = sample_db.db_engine_spec.make_label_compatible
+    tbl_name = 'birth_names'
     data = get_example_data('birth_names.json.gz')
     pdf = pd.read_json(data)
     pdf.ds = pd.to_datetime(pdf.ds, unit='ms')
     pdf = make_df_columns_compatible(pdf, sample_db.db_engine_spec)
     dtypes = make_dtype_columns_compatible({
-            'ds': DateTime,
-            'gender': String(16),
-            'state': String(10),
-            'name': String(255),
-        }, sample_db.db_engine_spec)
+        'ds': DateTime,
+        'gender': String(16),
+        'state': String(10),
+        'name': String(255),
+    }, sample_db.db_engine_spec)
     pdf.to_sql(
         name=tbl_name,
         con=sample_db.get_sqla_engine(),
@@ -72,11 +72,11 @@ def load_birth_names():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = c('ds')
+    obj.main_dttm_col = cm('ds')
     obj.filter_select_enabled = True
 
-    col_state = str(column(c('state')).compile(db.engine))
-    col_num = str(column(c('num')).compile(db.engine))
+    col_state = str(column(cm('state')).compile(db.engine))
+    col_num = str(column(cm('num')).compile(db.engine))
     if not any(col.column_name == 'num_california' for col in obj.columns):
         obj.columns.append(TableColumn(
             column_name='num_california',
@@ -99,7 +99,7 @@ def load_birth_names():
         'compare_lag': '10',
         'compare_suffix': 'o10Y',
         'limit': '25',
-        'granularity_sqla': c('ds'),
+        'granularity_sqla': cm('ds'),
         'groupby': [],
         'metric': 'sum__num',
         'metrics': ['sum__num'],
@@ -122,9 +122,9 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                groupby=[c('name')],
+                groupby=[cm('name')],
                 filters=[{
-                    'col': c('gender'),
+                    'col': cm('gender'),
                     'op': 'in',
                     'val': ['girl'],
                 }],
@@ -137,9 +137,9 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                groupby=[c('name')],
+                groupby=[cm('name')],
                 filters=[{
-                    'col': c('gender'),
+                    'col': cm('gender'),
                     'op': 'in',
                     'val': ['boy'],
                 }],
@@ -151,7 +151,7 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                viz_type='big_number', granularity_sqla=c('ds'),
+                viz_type='big_number', granularity_sqla=cm('ds'),
                 compare_lag='5', compare_suffix='over 5Y')),
         Slice(
             slice_name='Genders',
@@ -160,7 +160,7 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                viz_type='pie', groupby=[c('gender')])),
+                viz_type='pie', groupby=[cm('gender')])),
         Slice(
             slice_name='Genders by State',
             viz_type='dist_bar',
@@ -175,7 +175,7 @@ def load_birth_names():
                         'filterOptionName': '2745eae5',
                         'comparator': ['other'],
                         'operator': 'not in',
-                        'subject': c('state'),
+                        'subject': cm('state'),
                     },
                 ],
                 viz_type='dist_bar',
@@ -183,7 +183,7 @@ def load_birth_names():
                     {
                         'expressionType': 'SIMPLE',
                         'column': {
-                            'column_name': c('sum_boys'),
+                            'column_name': cm('sum_boys'),
                             'type': 'BIGINT(20)',
                         },
                         'aggregate': 'SUM',
@@ -193,7 +193,7 @@ def load_birth_names():
                     {
                         'expressionType': 'SIMPLE',
                         'column': {
-                            'column_name': c('sum_girls'),
+                            'column_name': cm('sum_girls'),
                             'type': 'BIGINT(20)',
                         },
                         'aggregate': 'SUM',
@@ -201,7 +201,7 @@ def load_birth_names():
                         'optionName': 'metric_12',
                     },
                 ],
-                groupby=[c('state')])),
+                groupby=[cm('state')])),
         Slice(
             slice_name='Trends',
             viz_type='line',
@@ -209,8 +209,8 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                viz_type='line', groupby=[c('name')],
-                granularity_sqla=c('ds'), rich_tooltip=True, show_legend=True)),
+                viz_type='line', groupby=[cm('name')],
+                granularity_sqla=cm('ds'), rich_tooltip=True, show_legend=True)),
         Slice(
             slice_name='Average and Sum Trends',
             viz_type='dual_line',
@@ -222,7 +222,7 @@ def load_birth_names():
                 metric={
                     'expressionType': 'SIMPLE',
                     'column': {
-                        'column_name': c('num'),
+                        'column_name': cm('num'),
                         'type': 'BIGINT(20)',
                     },
                     'aggregate': 'AVG',
@@ -230,7 +230,7 @@ def load_birth_names():
                     'optionName': 'metric_vgops097wej_g8uff99zhk7',
                 },
                 metric_2='sum__num',
-                granularity_sqla=c('ds'))),
+                granularity_sqla=cm('ds'))),
         Slice(
             slice_name='Title',
             viz_type='markup',
@@ -257,7 +257,7 @@ def load_birth_names():
             params=get_slice_json(
                 defaults,
                 viz_type='word_cloud', size_from='10',
-                series=c('name'), size_to='70', rotation='square',
+                series=cm('name'), size_to='70', rotation='square',
                 limit='100')),
         Slice(
             slice_name='Pivot Table',
@@ -267,7 +267,7 @@ def load_birth_names():
             params=get_slice_json(
                 defaults,
                 viz_type='pivot_table', metrics=['sum__num'],
-                groupby=[c('name')], columns=[c('state')])),
+                groupby=[cm('name')], columns=[cm('state')])),
         Slice(
             slice_name='Number of Girls',
             viz_type='big_number_total',
@@ -275,9 +275,9 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                viz_type='big_number_total', granularity_sqla=c('ds'),
+                viz_type='big_number_total', granularity_sqla=cm('ds'),
                 filters=[{
-                    'col': c('gender'),
+                    'col': cm('gender'),
                     'op': 'in',
                     'val': ['girl'],
                 }],
@@ -293,13 +293,14 @@ def load_birth_names():
                     'expressionType': 'SIMPLE',
                     'column': {
                         'column_name': 'num_california',
-                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} ELSE 0 END",  # noqa
+                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
+                        f"ELSE 0 END",
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
                 },
                 viz_type='big_number_total',
-                granularity_sqla=c('ds'))),
+                granularity_sqla=cm('ds'))),
         Slice(
             slice_name='Top 10 California Names Timeseries',
             viz_type='line',
@@ -311,19 +312,21 @@ def load_birth_names():
                     'expressionType': 'SIMPLE',
                     'column': {
                         'column_name': 'num_california',
-                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} ELSE 0 END",  # noqa
+                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
+                        f"ELSE 0 END",
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
                 }],
                 viz_type='line',
-                granularity_sqla=c('ds'),
-                groupby=[c('name')],
+                granularity_sqla=cm('ds'),
+                groupby=[cm('name')],
                 timeseries_limit_metric={
                     'expressionType': 'SIMPLE',
                     'column': {
                         'column_name': 'num_california',
-                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} ELSE 0 END",  # noqa
+                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
+                        f"ELSE 0 END",
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
@@ -336,13 +339,14 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                groupby=[c('name')],
+                groupby=[cm('name')],
                 row_limit=50,
                 timeseries_limit_metric={
                     'expressionType': 'SIMPLE',
                     'column': {
                         'column_name': 'num_california',
-                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} ELSE 0 END",  # noqa
+                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
+                        f"ELSE 0 END",
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
@@ -363,7 +367,7 @@ def load_birth_names():
             created_by=admin,
             params=get_slice_json(
                 defaults,
-                groupby=[c('ds')],
+                groupby=[cm('ds')],
                 since='40 years ago',
                 until='now',
                 viz_type='table')),

--- a/superset/data/birth_names.py
+++ b/superset/data/birth_names.py
@@ -294,7 +294,7 @@ def load_birth_names():
                     'column': {
                         'column_name': 'num_california',
                         'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
-                        f"ELSE 0 END",
+                                      'ELSE 0 END',
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
@@ -313,7 +313,7 @@ def load_birth_names():
                     'column': {
                         'column_name': 'num_california',
                         'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
-                        f"ELSE 0 END",
+                                      'ELSE 0 END',
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
@@ -326,7 +326,7 @@ def load_birth_names():
                     'column': {
                         'column_name': 'num_california',
                         'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
-                        f"ELSE 0 END",
+                                      'ELSE 0 END',
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
@@ -346,7 +346,7 @@ def load_birth_names():
                     'column': {
                         'column_name': 'num_california',
                         'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
-                        f"ELSE 0 END",
+                                      'ELSE 0 END',
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',

--- a/superset/data/birth_names.py
+++ b/superset/data/birth_names.py
@@ -23,7 +23,7 @@ from sqlalchemy.sql import column
 
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlMetric, TableColumn
-from superset.utils.core import get_or_create_main_db
+from superset.utils.core import get_sample_data_db
 from .helpers import (
     config,
     Dash,
@@ -61,7 +61,7 @@ def load_birth_names():
     if not obj:
         obj = TBL(table_name='birth_names')
     obj.main_dttm_col = 'ds'
-    obj.database = get_or_create_main_db()
+    obj.database = get_sample_data_db()
     obj.filter_select_enabled = True
 
     if not any(col.column_name == 'num_california' for col in obj.columns):

--- a/superset/data/birth_names.py
+++ b/superset/data/birth_names.py
@@ -27,7 +27,7 @@ from .helpers import (
     config,
     Dash,
     get_example_data,
-    get_expression,
+    get_aggr_expression,
     get_sample_data_db,
     get_sample_data_schema,
     get_slice_json,
@@ -38,13 +38,13 @@ from .helpers import (
     TBL,
     update_slice_ids,
 )
+from superset.models.core import Database
 
 
 def load_birth_names():
     """Loading birth name dataset from a zip file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'birth_names'
     data = get_example_data('birth_names.json.gz')
     pdf = pd.read_json(data)
@@ -66,8 +66,12 @@ def load_birth_names():
                                        index=False)
     print('Done loading table!')
     print('-' * 80)
+    create_metadata(tbl_name, sample_db, schema)
 
+
+def create_metadata(tbl_name: str, sample_db: Database, schema: str):
     print('Creating table [birth_names] reference')
+    mlc = sample_db.db_engine_spec.make_label_compatible
     obj = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
                                           schema=schema).first()
     if not obj:
@@ -87,7 +91,7 @@ def load_birth_names():
         metric_name = 'sum__num'
         obj.metrics.append(SqlMetric(
             metric_name=metric_name,
-            expression=get_expression(metric_name, sample_db),
+            expression=get_aggr_expression(metric_name, sample_db),
         ))
 
     db.session.merge(obj)

--- a/superset/data/birth_names.py
+++ b/superset/data/birth_names.py
@@ -56,14 +56,14 @@ def load_birth_names():
         'state': String(10),
         'name': String(255),
     }, sample_db.db_engine_spec)
-    pdf.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(pdf,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     print('Done loading table!')
     print('-' * 80)
 

--- a/superset/data/birth_names.py
+++ b/superset/data/birth_names.py
@@ -44,7 +44,7 @@ def load_birth_names():
     """Loading birth name dataset from a zip file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'birth_names'
     data = get_example_data('birth_names.json.gz')
     pdf = pd.read_json(data)
@@ -72,11 +72,11 @@ def load_birth_names():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = cm('ds')
+    obj.main_dttm_col = mlc('ds')
     obj.filter_select_enabled = True
 
-    col_state = str(column(cm('state')).compile(db.engine))
-    col_num = str(column(cm('num')).compile(db.engine))
+    col_state = str(column(mlc('state')).compile(db.engine))
+    col_num = str(column(mlc('num')).compile(db.engine))
     if not any(col.column_name == 'num_california' for col in obj.columns):
         obj.columns.append(TableColumn(
             column_name='num_california',
@@ -99,7 +99,7 @@ def load_birth_names():
         'compare_lag': '10',
         'compare_suffix': 'o10Y',
         'limit': '25',
-        'granularity_sqla': cm('ds'),
+        'granularity_sqla': mlc('ds'),
         'groupby': [],
         'metric': 'sum__num',
         'metrics': ['sum__num'],
@@ -122,9 +122,9 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                groupby=[cm('name')],
+                groupby=[mlc('name')],
                 filters=[{
-                    'col': cm('gender'),
+                    'col': mlc('gender'),
                     'op': 'in',
                     'val': ['girl'],
                 }],
@@ -137,9 +137,9 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                groupby=[cm('name')],
+                groupby=[mlc('name')],
                 filters=[{
-                    'col': cm('gender'),
+                    'col': mlc('gender'),
                     'op': 'in',
                     'val': ['boy'],
                 }],
@@ -151,7 +151,7 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                viz_type='big_number', granularity_sqla=cm('ds'),
+                viz_type='big_number', granularity_sqla=mlc('ds'),
                 compare_lag='5', compare_suffix='over 5Y')),
         Slice(
             slice_name='Genders',
@@ -160,7 +160,7 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                viz_type='pie', groupby=[cm('gender')])),
+                viz_type='pie', groupby=[mlc('gender')])),
         Slice(
             slice_name='Genders by State',
             viz_type='dist_bar',
@@ -175,7 +175,7 @@ def load_birth_names():
                         'filterOptionName': '2745eae5',
                         'comparator': ['other'],
                         'operator': 'not in',
-                        'subject': cm('state'),
+                        'subject': mlc('state'),
                     },
                 ],
                 viz_type='dist_bar',
@@ -183,7 +183,7 @@ def load_birth_names():
                     {
                         'expressionType': 'SIMPLE',
                         'column': {
-                            'column_name': cm('sum_boys'),
+                            'column_name': mlc('sum_boys'),
                             'type': 'BIGINT(20)',
                         },
                         'aggregate': 'SUM',
@@ -193,7 +193,7 @@ def load_birth_names():
                     {
                         'expressionType': 'SIMPLE',
                         'column': {
-                            'column_name': cm('sum_girls'),
+                            'column_name': mlc('sum_girls'),
                             'type': 'BIGINT(20)',
                         },
                         'aggregate': 'SUM',
@@ -201,7 +201,7 @@ def load_birth_names():
                         'optionName': 'metric_12',
                     },
                 ],
-                groupby=[cm('state')])),
+                groupby=[mlc('state')])),
         Slice(
             slice_name='Trends',
             viz_type='line',
@@ -209,8 +209,8 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                viz_type='line', groupby=[cm('name')],
-                granularity_sqla=cm('ds'), rich_tooltip=True, show_legend=True)),
+                viz_type='line', groupby=[mlc('name')],
+                granularity_sqla=mlc('ds'), rich_tooltip=True, show_legend=True)),
         Slice(
             slice_name='Average and Sum Trends',
             viz_type='dual_line',
@@ -222,7 +222,7 @@ def load_birth_names():
                 metric={
                     'expressionType': 'SIMPLE',
                     'column': {
-                        'column_name': cm('num'),
+                        'column_name': mlc('num'),
                         'type': 'BIGINT(20)',
                     },
                     'aggregate': 'AVG',
@@ -230,7 +230,7 @@ def load_birth_names():
                     'optionName': 'metric_vgops097wej_g8uff99zhk7',
                 },
                 metric_2='sum__num',
-                granularity_sqla=cm('ds'))),
+                granularity_sqla=mlc('ds'))),
         Slice(
             slice_name='Title',
             viz_type='markup',
@@ -257,7 +257,7 @@ def load_birth_names():
             params=get_slice_json(
                 defaults,
                 viz_type='word_cloud', size_from='10',
-                series=cm('name'), size_to='70', rotation='square',
+                series=mlc('name'), size_to='70', rotation='square',
                 limit='100')),
         Slice(
             slice_name='Pivot Table',
@@ -267,7 +267,7 @@ def load_birth_names():
             params=get_slice_json(
                 defaults,
                 viz_type='pivot_table', metrics=['sum__num'],
-                groupby=[cm('name')], columns=[cm('state')])),
+                groupby=[mlc('name')], columns=[mlc('state')])),
         Slice(
             slice_name='Number of Girls',
             viz_type='big_number_total',
@@ -275,9 +275,9 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                viz_type='big_number_total', granularity_sqla=cm('ds'),
+                viz_type='big_number_total', granularity_sqla=mlc('ds'),
                 filters=[{
-                    'col': cm('gender'),
+                    'col': mlc('gender'),
                     'op': 'in',
                     'val': ['girl'],
                 }],
@@ -300,7 +300,7 @@ def load_birth_names():
                     'label': 'SUM(num_california)',
                 },
                 viz_type='big_number_total',
-                granularity_sqla=cm('ds'))),
+                granularity_sqla=mlc('ds'))),
         Slice(
             slice_name='Top 10 California Names Timeseries',
             viz_type='line',
@@ -319,8 +319,8 @@ def load_birth_names():
                     'label': 'SUM(num_california)',
                 }],
                 viz_type='line',
-                granularity_sqla=cm('ds'),
-                groupby=[cm('name')],
+                granularity_sqla=mlc('ds'),
+                groupby=[mlc('name')],
                 timeseries_limit_metric={
                     'expressionType': 'SIMPLE',
                     'column': {
@@ -339,7 +339,7 @@ def load_birth_names():
             datasource_id=tbl.id,
             params=get_slice_json(
                 defaults,
-                groupby=[cm('name')],
+                groupby=[mlc('name')],
                 row_limit=50,
                 timeseries_limit_metric={
                     'expressionType': 'SIMPLE',
@@ -367,7 +367,7 @@ def load_birth_names():
             created_by=admin,
             params=get_slice_json(
                 defaults,
-                groupby=[cm('ds')],
+                groupby=[mlc('ds')],
                 since='40 years ago',
                 until='now',
                 viz_type='table')),

--- a/superset/data/birth_names.py
+++ b/superset/data/birth_names.py
@@ -23,6 +23,7 @@ from sqlalchemy.sql import column
 
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlMetric, TableColumn
+from superset.models.core import Database
 from .helpers import (
     config,
     Dash,
@@ -38,7 +39,6 @@ from .helpers import (
     TBL,
     update_slice_ids,
 )
-from superset.models.core import Database
 
 
 def load_birth_names():
@@ -79,12 +79,13 @@ def create_metadata(tbl_name: str, sample_db: Database, schema: str):
     obj.main_dttm_col = mlc('ds')
     obj.filter_select_enabled = True
 
-    col_state = str(column(mlc('state')).compile(db.engine))
-    col_num = str(column(mlc('num')).compile(db.engine))
+    cols = {}
+    cols['state'] = str(column(mlc('state')).compile(db.engine))
+    cols['num'] = str(column(mlc('num')).compile(db.engine))
     if not any(col.column_name == 'num_california' for col in obj.columns):
         obj.columns.append(TableColumn(
             column_name='num_california',
-            expression=f"CASE WHEN {col_state} = 'CA' THEN {col_num} ELSE 0 END",
+            expression=f"CASE WHEN {cols['state']} = 'CA' THEN {cols['num']} ELSE 0 END",
         ))
 
     if not any(col.metric_name == 'sum__num' for col in obj.metrics):
@@ -297,8 +298,8 @@ def create_metadata(tbl_name: str, sample_db: Database, schema: str):
                     'expressionType': 'SIMPLE',
                     'column': {
                         'column_name': 'num_california',
-                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
-                                      'ELSE 0 END',
+                        'expression': f"CASE WHEN {cols['state']} = 'CA' THEN "
+                                      f"{cols['num']} ELSE 0 END",
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
@@ -316,8 +317,8 @@ def create_metadata(tbl_name: str, sample_db: Database, schema: str):
                     'expressionType': 'SIMPLE',
                     'column': {
                         'column_name': 'num_california',
-                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
-                                      'ELSE 0 END',
+                        'expression': f"CASE WHEN {cols['state']} = 'CA' THEN "
+                                      f"{cols['num']} ELSE 0 END",
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
@@ -329,8 +330,8 @@ def create_metadata(tbl_name: str, sample_db: Database, schema: str):
                     'expressionType': 'SIMPLE',
                     'column': {
                         'column_name': 'num_california',
-                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
-                                      'ELSE 0 END',
+                        'expression': f"CASE WHEN {cols['state']} = 'CA' THEN "
+                                      f"{cols['num']} ELSE 0 END",
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',
@@ -349,8 +350,8 @@ def create_metadata(tbl_name: str, sample_db: Database, schema: str):
                     'expressionType': 'SIMPLE',
                     'column': {
                         'column_name': 'num_california',
-                        'expression': f"CASE WHEN {col_state} = 'CA' THEN {col_num} "
-                                      'ELSE 0 END',
+                        'expression': f"CASE WHEN {cols['state']} = 'CA' THEN "
+                                      f"{cols['num']} ELSE 0 END",
                     },
                     'aggregate': 'SUM',
                     'label': 'SUM(num_california)',

--- a/superset/data/country_map.py
+++ b/superset/data/country_map.py
@@ -18,6 +18,7 @@ import datetime
 
 import pandas as pd
 from sqlalchemy import BigInteger, Date, String
+from sqlalchemy.sql import column
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
@@ -69,9 +70,10 @@ def load_country_map_data():
     obj.main_dttm_col = 'dttm'
     obj.database = utils.get_or_create_main_db()
     if not any(col.metric_name == 'avg__2004' for col in obj.metrics):
+        col = str(column('2004').compile(db.engine))
         obj.metrics.append(SqlMetric(
             metric_name='avg__2004',
-            expression='AVG(2004)',
+            expression=f'AVG({col})',
         ))
     db.session.merge(obj)
     db.session.commit()

--- a/superset/data/country_map.py
+++ b/superset/data/country_map.py
@@ -63,14 +63,14 @@ def load_country_map_data():
         '2014': BigInteger,
         'dttm': Date(),
     }, sample_db.db_engine_spec)
-    data.to_sql(  # pylint: disable=no-member
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(data,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     print('Done loading table!')
     print('-' * 80)
     print('Creating table reference')

--- a/superset/data/country_map.py
+++ b/superset/data/country_map.py
@@ -23,7 +23,7 @@ from superset import db
 from superset.connectors.sqla.models import SqlMetric
 from .helpers import (
     get_example_data,
-    get_expression,
+    get_aggr_expression,
     get_sample_data_db,
     get_sample_data_schema,
     get_slice_json,
@@ -83,7 +83,7 @@ def load_country_map_data():
         metric_name = 'avg__2004'
         obj.metrics.append(SqlMetric(
             metric_name=metric_name,
-            expression=get_expression(metric_name, sample_db),
+            expression=get_aggr_expression(metric_name, sample_db),
         ))
     db.session.merge(obj)
     db.session.commit()

--- a/superset/data/country_map.py
+++ b/superset/data/country_map.py
@@ -40,7 +40,7 @@ def load_country_map_data():
     """Loading data for map with country map"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
+    cm = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'birth_france_by_region'
     csv_bytes = get_example_data(
         'birth_france_data_for_country_map.csv', is_gzip=False, make_bytes=True)
@@ -48,21 +48,21 @@ def load_country_map_data():
     data['dttm'] = datetime.datetime.now().date()
     data = make_df_columns_compatible(data, sample_db.db_engine_spec)
     dtypes = make_dtype_columns_compatible({
-            'DEPT_ID': String(10),
-            '2003': BigInteger,
-            '2004': BigInteger,
-            '2005': BigInteger,
-            '2006': BigInteger,
-            '2007': BigInteger,
-            '2008': BigInteger,
-            '2009': BigInteger,
-            '2010': BigInteger,
-            '2011': BigInteger,
-            '2012': BigInteger,
-            '2013': BigInteger,
-            '2014': BigInteger,
-            'dttm': Date(),
-        }, sample_db.db_engine_spec)
+        'DEPT_ID': String(10),
+        '2003': BigInteger,
+        '2004': BigInteger,
+        '2005': BigInteger,
+        '2006': BigInteger,
+        '2007': BigInteger,
+        '2008': BigInteger,
+        '2009': BigInteger,
+        '2010': BigInteger,
+        '2011': BigInteger,
+        '2012': BigInteger,
+        '2013': BigInteger,
+        '2014': BigInteger,
+        'dttm': Date(),
+    }, sample_db.db_engine_spec)
     data.to_sql(  # pylint: disable=no-member
         name=tbl_name,
         con=sample_db.get_sqla_engine(),
@@ -78,7 +78,7 @@ def load_country_map_data():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = c('dttm')
+    obj.main_dttm_col = cm('dttm')
     if not any(col.metric_name == 'avg__2004' for col in obj.metrics):
         metric_name = 'avg__2004'
         obj.metrics.append(SqlMetric(
@@ -96,12 +96,12 @@ def load_country_map_data():
         'until': '',
         'where': '',
         'viz_type': 'country_map',
-        'entity': c('DEPT_ID'),
+        'entity': cm('DEPT_ID'),
         'metric': {
             'expressionType': 'SIMPLE',
             'column': {
                 'type': 'INT',
-                'column_name': c('2004'),
+                'column_name': cm('2004'),
             },
             'aggregate': 'AVG',
             'label': 'Boys',

--- a/superset/data/country_map.py
+++ b/superset/data/country_map.py
@@ -68,7 +68,7 @@ def load_country_map_data():
     if not obj:
         obj = TBL(table_name='birth_france_by_region')
     obj.main_dttm_col = 'dttm'
-    obj.database = utils.get_or_create_main_db()
+    obj.database = utils.get_sample_data_db()
     if not any(col.metric_name == 'avg__2004' for col in obj.metrics):
         col = str(column('2004').compile(db.engine))
         obj.metrics.append(SqlMetric(

--- a/superset/data/country_map.py
+++ b/superset/data/country_map.py
@@ -18,14 +18,17 @@ import datetime
 
 import pandas as pd
 from sqlalchemy import BigInteger, Date, String
-from sqlalchemy.sql import column
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
-from superset.utils import core as utils
 from .helpers import (
     get_example_data,
+    get_expression,
+    get_sample_data_db,
+    get_sample_data_schema,
     get_slice_json,
+    make_df_columns_compatible,
+    make_dtype_columns_compatible,
     merge_slice,
     misc_dash_slices,
     Slice,
@@ -35,16 +38,16 @@ from .helpers import (
 
 def load_country_map_data():
     """Loading data for map with country map"""
+    sample_db = get_sample_data_db()
+    schema = get_sample_data_schema()
+    c = sample_db.db_engine_spec.make_label_compatible
+    tbl_name = 'birth_france_by_region'
     csv_bytes = get_example_data(
         'birth_france_data_for_country_map.csv', is_gzip=False, make_bytes=True)
     data = pd.read_csv(csv_bytes, encoding='utf-8')
     data['dttm'] = datetime.datetime.now().date()
-    data.to_sql(  # pylint: disable=no-member
-        'birth_france_by_region',
-        db.engine,
-        if_exists='replace',
-        chunksize=500,
-        dtype={
+    data = make_df_columns_compatible(data, sample_db.db_engine_spec)
+    dtypes = make_dtype_columns_compatible({
             'DEPT_ID': String(10),
             '2003': BigInteger,
             '2004': BigInteger,
@@ -59,21 +62,28 @@ def load_country_map_data():
             '2013': BigInteger,
             '2014': BigInteger,
             'dttm': Date(),
-        },
+        }, sample_db.db_engine_spec)
+    data.to_sql(  # pylint: disable=no-member
+        name=tbl_name,
+        con=sample_db.get_sqla_engine(),
+        schema=schema,
+        if_exists='replace',
+        chunksize=500,
+        dtype=dtypes,
         index=False)
     print('Done loading table!')
     print('-' * 80)
     print('Creating table reference')
-    obj = db.session.query(TBL).filter_by(table_name='birth_france_by_region').first()
+    obj = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
+                                          schema=schema).first()
     if not obj:
-        obj = TBL(table_name='birth_france_by_region')
-    obj.main_dttm_col = 'dttm'
-    obj.database = utils.get_sample_data_db()
+        obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
+    obj.main_dttm_col = c('dttm')
     if not any(col.metric_name == 'avg__2004' for col in obj.metrics):
-        col = str(column('2004').compile(db.engine))
+        metric_name = 'avg__2004'
         obj.metrics.append(SqlMetric(
-            metric_name='avg__2004',
-            expression=f'AVG({col})',
+            metric_name=metric_name,
+            expression=get_expression(metric_name, sample_db),
         ))
     db.session.merge(obj)
     db.session.commit()
@@ -86,12 +96,12 @@ def load_country_map_data():
         'until': '',
         'where': '',
         'viz_type': 'country_map',
-        'entity': 'DEPT_ID',
+        'entity': c('DEPT_ID'),
         'metric': {
             'expressionType': 'SIMPLE',
             'column': {
                 'type': 'INT',
-                'column_name': '2004',
+                'column_name': c('2004'),
             },
             'aggregate': 'AVG',
             'label': 'Boys',

--- a/superset/data/country_map.py
+++ b/superset/data/country_map.py
@@ -40,7 +40,7 @@ def load_country_map_data():
     """Loading data for map with country map"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'birth_france_by_region'
     csv_bytes = get_example_data(
         'birth_france_data_for_country_map.csv', is_gzip=False, make_bytes=True)
@@ -78,7 +78,7 @@ def load_country_map_data():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = cm('dttm')
+    obj.main_dttm_col = mlc('dttm')
     if not any(col.metric_name == 'avg__2004' for col in obj.metrics):
         metric_name = 'avg__2004'
         obj.metrics.append(SqlMetric(
@@ -96,12 +96,12 @@ def load_country_map_data():
         'until': '',
         'where': '',
         'viz_type': 'country_map',
-        'entity': cm('DEPT_ID'),
+        'entity': mlc('DEPT_ID'),
         'metric': {
             'expressionType': 'SIMPLE',
             'column': {
                 'type': 'INT',
-                'column_name': cm('2004'),
+                'column_name': mlc('2004'),
             },
             'aggregate': 'AVG',
             'label': 'Boys',

--- a/superset/data/deck.py
+++ b/superset/data/deck.py
@@ -182,15 +182,15 @@ def load_deck_dash():
     print('Loading deck.gl dashboard')
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     slices = []
     tbl = db.session.query(TBL).filter_by(table_name='long_lat', database=sample_db,
                                           schema=schema).first()
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': cm('LON'),
-            'latCol': cm('LAT'),
+            'lonCol': mlc('LON'),
+            'latCol': mlc('LAT'),
         },
         'color_picker': COLOR_RED,
         'datasource': '5__table',
@@ -235,8 +235,8 @@ def load_deck_dash():
         'row_limit': 5000,
         'spatial': {
             'type': 'latlong',
-            'lonCol': cm('LON'),
-            'latCol': cm('LAT'),
+            'lonCol': mlc('LON'),
+            'latCol': mlc('LAT'),
         },
         'mapbox_style': 'mapbox://styles/mapbox/dark-v9',
         'granularity_sqla': None,
@@ -279,8 +279,8 @@ def load_deck_dash():
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': cm('LON'),
-            'latCol': cm('LAT'),
+            'lonCol': mlc('LON'),
+            'latCol': mlc('LAT'),
         },
         'filters': [],
         'row_limit': 5000,
@@ -327,8 +327,8 @@ def load_deck_dash():
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': cm('LON'),
-            'latCol': cm('LAT'),
+            'lonCol': mlc('LON'),
+            'latCol': mlc('LAT'),
         },
         'filters': [],
         'row_limit': 5000,
@@ -381,7 +381,7 @@ def load_deck_dash():
         'granularity_sqla': None,
         'time_grain_sqla': None,
         'time_range': ' : ',
-        'line_column': cm('contour'),
+        'line_column': mlc('contour'),
         'metric': 'count',
         'line_type': 'json',
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
@@ -419,13 +419,13 @@ def load_deck_dash():
         'extruded': True,
         'point_radius_scale': 100,
         'js_columns': [
-            cm('population'),
-            cm('area'),
+            mlc('population'),
+            mlc('area'),
         ],
         'js_data_mutator':
             'data => data.map(d => ({'
             '    ...d,'
-            f'    elevation: d.extraProps.{cm("population")}/d.extraProps.{cm("area")}/10,'  # noqa
+            f'    elevation: d.extraProps.{mlc("population")}/d.extraProps.{mlc("area")}/10,'  # noqa
             '}));',
         'js_tooltip': '',
         'js_onclick_href': '',
@@ -454,13 +454,13 @@ def load_deck_dash():
         'time_range': ' : ',
         'start_spatial': {
             'type': 'latlong',
-            'latCol': cm('LATITUDE'),
-            'lonCol': cm('LONGITUDE'),
+            'latCol': mlc('LATITUDE'),
+            'lonCol': mlc('LONGITUDE'),
         },
         'end_spatial': {
             'type': 'latlong',
-            'latCol': cm('LATITUDE_DEST'),
-            'lonCol': cm('LONGITUDE_DEST'),
+            'latCol': mlc('LATITUDE_DEST'),
+            'lonCol': mlc('LONGITUDE_DEST'),
         },
         'row_limit': 5000,
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
@@ -509,7 +509,7 @@ def load_deck_dash():
         'viz_type': 'deck_path',
         'time_grain_sqla': None,
         'time_range': ' : ',
-        'line_column': cm('path_json'),
+        'line_column': mlc('path_json'),
         'line_type': 'json',
         'row_limit': 5000,
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
@@ -538,11 +538,11 @@ def load_deck_dash():
         'line_width': 150,
         'reverse_long_lat': False,
         'js_columns': [
-            cm('color'),
+            mlc('color'),
         ],
         'js_data_mutator': 'data => data.map(d => ({\n'
                            '    ...d,\n'
-                           f'    color: colors.hexToRGB(d.extraProps.{cm("color")})\n'
+                           f'    color: colors.hexToRGB(d.extraProps.{mlc("color")})\n'
                            '}));',
         'js_tooltip': '',
         'js_onclick_href': '',

--- a/superset/data/deck.py
+++ b/superset/data/deck.py
@@ -382,7 +382,7 @@ def load_deck_dash():
         'time_grain_sqla': None,
         'time_range': ' : ',
         'line_column': cm('contour'),
-        'metric': None,
+        'metric': 'count',
         'line_type': 'json',
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
         'viewport': {
@@ -422,10 +422,11 @@ def load_deck_dash():
             cm('population'),
             cm('area'),
         ],
-        'js_datapoint_mutator':
-            '(d) => {\n    d.elevation = d.extraProps.population/d.extraProps.area/10\n \
-         d.fillColor = [d.extraProps.population/d.extraProps.area/60,140,0]\n \
-         return d;\n}',
+        'js_data_mutator':
+            'data => data.map(d => ({'
+            '    ...d,'
+            f'    elevation: d.extraProps.{cm("population")}/d.extraProps.{cm("area")}/10,'  # noqa
+            '}));',
         'js_tooltip': '',
         'js_onclick_href': '',
         'where': '',
@@ -508,7 +509,7 @@ def load_deck_dash():
         'viz_type': 'deck_path',
         'time_grain_sqla': None,
         'time_range': ' : ',
-        'line_column': 'path_json',
+        'line_column': cm('path_json'),
         'line_type': 'json',
         'row_limit': 5000,
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
@@ -539,8 +540,10 @@ def load_deck_dash():
         'js_columns': [
             cm('color'),
         ],
-        'js_datapoint_mutator': 'd => {\n    return {\n        ...d,\n        color: \
-            colors.hexToRGB(d.extraProps.color),\n    }\n}',
+        'js_data_mutator': 'data => data.map(d => ({\n'
+                           '    ...d,\n'
+                           f'    color: colors.hexToRGB(d.extraProps.{cm("color")})\n'
+                           '}));',
         'js_tooltip': '',
         'js_onclick_href': '',
         'where': '',

--- a/superset/data/deck.py
+++ b/superset/data/deck.py
@@ -425,7 +425,8 @@ def load_deck_dash():
         'js_data_mutator':
             'data => data.map(d => ({'
             '    ...d,'
-            f'    elevation: d.extraProps.{mlc("population")}/d.extraProps.{mlc("area")}/10,'  # noqa
+            f'    elevation: d.extraProps.{mlc("population")}/'
+            f'd.extraProps.{mlc("area")}/10,'
             '}));',
         'js_tooltip': '',
         'js_onclick_href': '',

--- a/superset/data/deck.py
+++ b/superset/data/deck.py
@@ -537,7 +537,7 @@ def load_deck_dash():
         'line_width': 150,
         'reverse_long_lat': False,
         'js_columns': [
-            'color',
+            c('color'),
         ],
         'js_datapoint_mutator': 'd => {\n    return {\n        ...d,\n        color: \
             colors.hexToRGB(d.extraProps.color),\n    }\n}',

--- a/superset/data/deck.py
+++ b/superset/data/deck.py
@@ -20,6 +20,8 @@ import json
 from superset import db
 from .helpers import (
     Dash,
+    get_sample_data_db,
+    get_sample_data_schema,
     get_slice_json,
     merge_slice,
     Slice,
@@ -178,13 +180,17 @@ POSITION_JSON = """\
 
 def load_deck_dash():
     print('Loading deck.gl dashboard')
+    sample_db = get_sample_data_db()
+    schema = get_sample_data_schema()
+    c = sample_db.db_engine_spec.make_label_compatible
     slices = []
-    tbl = db.session.query(TBL).filter_by(table_name='long_lat').first()
+    tbl = db.session.query(TBL).filter_by(table_name='long_lat', database=sample_db,
+                                          schema=schema).first()
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': 'LON',
-            'latCol': 'LAT',
+            'lonCol': c('LON'),
+            'latCol': c('LAT'),
         },
         'color_picker': COLOR_RED,
         'datasource': '5__table',
@@ -229,8 +235,8 @@ def load_deck_dash():
         'row_limit': 5000,
         'spatial': {
             'type': 'latlong',
-            'lonCol': 'LON',
-            'latCol': 'LAT',
+            'lonCol': c('LON'),
+            'latCol': c('LAT'),
         },
         'mapbox_style': 'mapbox://styles/mapbox/dark-v9',
         'granularity_sqla': None,
@@ -273,8 +279,8 @@ def load_deck_dash():
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': 'LON',
-            'latCol': 'LAT',
+            'lonCol': c('LON'),
+            'latCol': c('LAT'),
         },
         'filters': [],
         'row_limit': 5000,
@@ -321,8 +327,8 @@ def load_deck_dash():
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': 'LON',
-            'latCol': 'LAT',
+            'lonCol': c('LON'),
+            'latCol': c('LAT'),
         },
         'filters': [],
         'row_limit': 5000,
@@ -375,7 +381,7 @@ def load_deck_dash():
         'granularity_sqla': None,
         'time_grain_sqla': None,
         'time_range': ' : ',
-        'line_column': 'contour',
+        'line_column': c('contour'),
         'metric': None,
         'line_type': 'json',
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
@@ -413,8 +419,8 @@ def load_deck_dash():
         'extruded': True,
         'point_radius_scale': 100,
         'js_columns': [
-            'population',
-            'area',
+            c('population'),
+            c('area'),
         ],
         'js_datapoint_mutator':
             '(d) => {\n    d.elevation = d.extraProps.population/d.extraProps.area/10\n \
@@ -447,13 +453,13 @@ def load_deck_dash():
         'time_range': ' : ',
         'start_spatial': {
             'type': 'latlong',
-            'latCol': 'LATITUDE',
-            'lonCol': 'LONGITUDE',
+            'latCol': c('LATITUDE'),
+            'lonCol': c('LONGITUDE'),
         },
         'end_spatial': {
             'type': 'latlong',
-            'latCol': 'LATITUDE_DEST',
-            'lonCol': 'LONGITUDE_DEST',
+            'latCol': c('LATITUDE_DEST'),
+            'lonCol': c('LONGITUDE_DEST'),
         },
         'row_limit': 5000,
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',

--- a/superset/data/deck.py
+++ b/superset/data/deck.py
@@ -182,15 +182,15 @@ def load_deck_dash():
     print('Loading deck.gl dashboard')
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
+    cm = sample_db.db_engine_spec.make_label_compatible
     slices = []
     tbl = db.session.query(TBL).filter_by(table_name='long_lat', database=sample_db,
                                           schema=schema).first()
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': c('LON'),
-            'latCol': c('LAT'),
+            'lonCol': cm('LON'),
+            'latCol': cm('LAT'),
         },
         'color_picker': COLOR_RED,
         'datasource': '5__table',
@@ -235,8 +235,8 @@ def load_deck_dash():
         'row_limit': 5000,
         'spatial': {
             'type': 'latlong',
-            'lonCol': c('LON'),
-            'latCol': c('LAT'),
+            'lonCol': cm('LON'),
+            'latCol': cm('LAT'),
         },
         'mapbox_style': 'mapbox://styles/mapbox/dark-v9',
         'granularity_sqla': None,
@@ -279,8 +279,8 @@ def load_deck_dash():
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': c('LON'),
-            'latCol': c('LAT'),
+            'lonCol': cm('LON'),
+            'latCol': cm('LAT'),
         },
         'filters': [],
         'row_limit': 5000,
@@ -327,8 +327,8 @@ def load_deck_dash():
     slice_data = {
         'spatial': {
             'type': 'latlong',
-            'lonCol': c('LON'),
-            'latCol': c('LAT'),
+            'lonCol': cm('LON'),
+            'latCol': cm('LAT'),
         },
         'filters': [],
         'row_limit': 5000,
@@ -381,7 +381,7 @@ def load_deck_dash():
         'granularity_sqla': None,
         'time_grain_sqla': None,
         'time_range': ' : ',
-        'line_column': c('contour'),
+        'line_column': cm('contour'),
         'metric': None,
         'line_type': 'json',
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
@@ -419,8 +419,8 @@ def load_deck_dash():
         'extruded': True,
         'point_radius_scale': 100,
         'js_columns': [
-            c('population'),
-            c('area'),
+            cm('population'),
+            cm('area'),
         ],
         'js_datapoint_mutator':
             '(d) => {\n    d.elevation = d.extraProps.population/d.extraProps.area/10\n \
@@ -453,13 +453,13 @@ def load_deck_dash():
         'time_range': ' : ',
         'start_spatial': {
             'type': 'latlong',
-            'latCol': c('LATITUDE'),
-            'lonCol': c('LONGITUDE'),
+            'latCol': cm('LATITUDE'),
+            'lonCol': cm('LONGITUDE'),
         },
         'end_spatial': {
             'type': 'latlong',
-            'latCol': c('LATITUDE_DEST'),
-            'lonCol': c('LONGITUDE_DEST'),
+            'latCol': cm('LATITUDE_DEST'),
+            'lonCol': cm('LONGITUDE_DEST'),
         },
         'row_limit': 5000,
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
@@ -537,7 +537,7 @@ def load_deck_dash():
         'line_width': 150,
         'reverse_long_lat': False,
         'js_columns': [
-            c('color'),
+            cm('color'),
         ],
         'js_datapoint_mutator': 'd => {\n    return {\n        ...d,\n        color: \
             colors.hexToRGB(d.extraProps.color),\n    }\n}',

--- a/superset/data/energy.py
+++ b/superset/data/energy.py
@@ -20,6 +20,7 @@ import textwrap
 
 import pandas as pd
 from sqlalchemy import Float, String
+from sqlalchemy.sql import column
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
@@ -54,9 +55,10 @@ def load_energy():
     tbl.database = utils.get_or_create_main_db()
 
     if not any(col.metric_name == 'sum__value' for col in tbl.metrics):
+        col = str(column('value').compile(db.engine))
         tbl.metrics.append(SqlMetric(
             metric_name='sum__value',
-            expression='SUM(value)',
+            expression=f'SUM({col})',
         ))
 
     db.session.merge(tbl)

--- a/superset/data/energy.py
+++ b/superset/data/energy.py
@@ -28,6 +28,7 @@ from .helpers import (
     get_expression,
     get_sample_data_db,
     get_sample_data_schema,
+    get_slice_json,
     make_df_columns_compatible,
     make_dtype_columns_compatible,
     merge_slice,
@@ -78,79 +79,77 @@ def load_energy():
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()
+    
+    slice_data = {
+        'collapsed_fieldsets': '',
+        'groupby': [
+            c('source'),
+            c('target'),
+        ],
+        'having': '',
+        'metric': 'sum__value',
+        'row_limit': '5000',
+        'slice_name': 'Energy Sankey',
+        'viz_type': 'sankey',
+        'where': ''
+    }
 
     slc = Slice(
         slice_name='Energy Sankey',
         viz_type='sankey',
         datasource_type='table',
         datasource_id=tbl.id,
-        params=textwrap.dedent(f"""\
-        {{
-            "collapsed_fieldsets": "",
-            "groupby": [
-                "{c('source')}",
-                "{c('target')}"
-            ],
-            "having": "",
-            "metric": "sum__value",
-            "row_limit": "5000",
-            "slice_name": "Energy Sankey",
-            "viz_type": "sankey",
-            "where": ""
-        }}
-        """),
+        params=get_slice_json(slice_data)
     )
     misc_dash_slices.add(slc.slice_name)
     merge_slice(slc)
 
+    slice_data = {
+        'charge': '-500',
+        'collapsed_fieldsets': '',
+        'groupby': [
+            c('source'),
+            c('target'),
+        ],
+        'having': '',
+        'link_length': '200',
+        'metric': 'sum__value',
+        'row_limit': '5000',
+        'slice_name': 'Force',
+        'viz_type': 'directed_force',
+        'where': ''
+    }
     slc = Slice(
         slice_name='Energy Force Layout',
         viz_type='directed_force',
         datasource_type='table',
         datasource_id=tbl.id,
-        params=textwrap.dedent(f"""\
-        {{
-            "charge": "-500",
-            "collapsed_fieldsets": "",
-            "groupby": [
-                "{c('source')}",
-                "{c('target')}"
-            ],
-            "having": "",
-            "link_length": "200",
-            "metric": "sum__value",
-            "row_limit": "5000",
-            "slice_name": "Force",
-            "viz_type": "directed_force",
-            "where": ""
-        }}
-        """),
+        params=get_slice_json(slice_data),
     )
     misc_dash_slices.add(slc.slice_name)
     merge_slice(slc)
 
+    slice_data = {
+        'all_columns_x': c('source'),
+        'all_columns_y': c('target'),
+        'canvas_image_rendering': 'pixelated',
+        'collapsed_fieldsets': '',
+        'having': '',
+        'linear_color_scheme': 'blue_white_yellow',
+        'metric': 'sum__value',
+        'normalize_across': 'heatmap',
+        'slice_name': 'Heatmap',
+        'viz_type': 'heatmap',
+        'where': '',
+        'xscale_interval': '1',
+        'yscale_interval': '1'
+    }
     slc = Slice(
         slice_name='Heatmap',
         viz_type='heatmap',
         datasource_type='table',
         datasource_id=tbl.id,
-        params=textwrap.dedent(f"""\
-        {{
-            "all_columns_x": "{c('source')}",
-            "all_columns_y": "{c('target')}",
-            "canvas_image_rendering": "pixelated",
-            "collapsed_fieldsets": "",
-            "having": "",
-            "linear_color_scheme": "blue_white_yellow",
-            "metric": "sum__value",
-            "normalize_across": "heatmap",
-            "slice_name": "Heatmap",
-            "viz_type": "heatmap",
-            "where": "",
-            "xscale_interval": "1",
-            "yscale_interval": "1"
-        }}
-        """),
+        params=get_slice_json(slice_data),
     )
     misc_dash_slices.add(slc.slice_name)
     merge_slice(slc)

--- a/superset/data/energy.py
+++ b/superset/data/energy.py
@@ -16,8 +16,6 @@
 # under the License.
 """Loads datasets, dashboards and slices in a new superset instance"""
 # pylint: disable=C,R,W
-import textwrap
-
 import pandas as pd
 from sqlalchemy import Float, String
 
@@ -52,14 +50,15 @@ def load_energy():
         'target': String(255),
         'value': Float(),
     }, sample_db.db_engine_spec)
-    pdf.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(pdf,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False,
+                                       )
 
     print('Creating table [wb_health_population] reference')
     tbl = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,

--- a/superset/data/energy.py
+++ b/superset/data/energy.py
@@ -42,7 +42,7 @@ def load_energy():
     """Loads an energy related dataset to use with sankey and graphs"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
+    cm = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'energy_usage'
     data = get_example_data('energy.json.gz')
     pdf = pd.read_json(data)
@@ -83,8 +83,8 @@ def load_energy():
     slice_data = {
         'collapsed_fieldsets': '',
         'groupby': [
-            c('source'),
-            c('target'),
+            cm('source'),
+            cm('target'),
         ],
         'having': '',
         'metric': 'sum__value',
@@ -108,8 +108,8 @@ def load_energy():
         'charge': '-500',
         'collapsed_fieldsets': '',
         'groupby': [
-            c('source'),
-            c('target'),
+            cm('source'),
+            cm('target'),
         ],
         'having': '',
         'link_length': '200',
@@ -130,8 +130,8 @@ def load_energy():
     merge_slice(slc)
 
     slice_data = {
-        'all_columns_x': c('source'),
-        'all_columns_y': c('target'),
+        'all_columns_x': cm('source'),
+        'all_columns_y': cm('target'),
         'canvas_image_rendering': 'pixelated',
         'collapsed_fieldsets': '',
         'having': '',

--- a/superset/data/energy.py
+++ b/superset/data/energy.py
@@ -52,7 +52,7 @@ def load_energy():
     if not tbl:
         tbl = TBL(table_name=tbl_name)
     tbl.description = 'Energy consumption'
-    tbl.database = utils.get_or_create_main_db()
+    tbl.database = utils.get_sample_data_db()
 
     if not any(col.metric_name == 'sum__value' for col in tbl.metrics):
         col = str(column('value').compile(db.engine))

--- a/superset/data/energy.py
+++ b/superset/data/energy.py
@@ -23,7 +23,7 @@ from superset import db
 from superset.connectors.sqla.models import SqlMetric
 from .helpers import (
     get_example_data,
-    get_expression,
+    get_aggr_expression,
     get_sample_data_db,
     get_sample_data_schema,
     get_slice_json,
@@ -69,7 +69,7 @@ def load_energy():
 
     if not any(col.metric_name == 'sum__value' for col in tbl.metrics):
         metric_name = 'sum__value'
-        expression = get_expression(metric_name, sample_db)
+        expression = get_aggr_expression(metric_name, sample_db)
         tbl.metrics.append(SqlMetric(
             metric_name=metric_name,
             expression=expression,

--- a/superset/data/energy.py
+++ b/superset/data/energy.py
@@ -40,7 +40,7 @@ def load_energy():
     """Loads an energy related dataset to use with sankey and graphs"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'energy_usage'
     data = get_example_data('energy.json.gz')
     pdf = pd.read_json(data)
@@ -82,8 +82,8 @@ def load_energy():
     slice_data = {
         'collapsed_fieldsets': '',
         'groupby': [
-            cm('source'),
-            cm('target'),
+            mlc('source'),
+            mlc('target'),
         ],
         'having': '',
         'metric': 'sum__value',
@@ -107,8 +107,8 @@ def load_energy():
         'charge': '-500',
         'collapsed_fieldsets': '',
         'groupby': [
-            cm('source'),
-            cm('target'),
+            mlc('source'),
+            mlc('target'),
         ],
         'having': '',
         'link_length': '200',
@@ -129,8 +129,8 @@ def load_energy():
     merge_slice(slc)
 
     slice_data = {
-        'all_columns_x': cm('source'),
-        'all_columns_y': cm('target'),
+        'all_columns_x': mlc('source'),
+        'all_columns_y': mlc('target'),
         'canvas_image_rendering': 'pixelated',
         'collapsed_fieldsets': '',
         'having': '',

--- a/superset/data/flights.py
+++ b/superset/data/flights.py
@@ -54,7 +54,7 @@ def load_flights():
     if not tbl:
         tbl = TBL(table_name=tbl_name)
     tbl.description = 'Random set of flights in the US'
-    tbl.database = utils.get_or_create_main_db()
+    tbl.database = utils.get_sample_data_db()
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()

--- a/superset/data/flights.py
+++ b/superset/data/flights.py
@@ -52,14 +52,14 @@ def load_flights():
     dtypes = make_dtype_columns_compatible({
         'ds': DateTime(),
     }, sample_db.db_engine_spec)
-    pdf.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(pdf,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     tbl = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
                                           schema=schema).first()
     if not tbl:

--- a/superset/data/helpers.py
+++ b/superset/data/helpers.py
@@ -158,5 +158,3 @@ def get_sample_data_schema() -> Optional[str]:
     """
     from superset import conf
     return conf.get('SAMPLE_DATA_DB_SCHEMA_NAME')
-
-

--- a/superset/data/helpers.py
+++ b/superset/data/helpers.py
@@ -29,7 +29,7 @@ from sqlalchemy import func
 from sqlalchemy.sql.type_api import TypeEngine
 from sqlalchemy.sql import column
 
-from typing import Dict
+from typing import Dict, Optional
 
 from superset import app, conf, db
 from superset.connectors.connector_registry import ConnectorRegistry
@@ -106,18 +106,40 @@ def make_df_columns_compatible(df: pd.DataFrame,
 
 
 def get_compiled_column_name(colname: str, db: models.Database) -> str:
+    """ Compile a SQL column name using dialect-specific quoting rules.
+    If colname is `MyMixedCaseColumn`, the function would return `"MyMixedCaseColumn"` on
+    Postgres. Similarly the column `lowercase_col` would return `lowercase_col`.
+
+    :param colname: column name
+    :param db: Database instance with an engine and dialect
+    :return: compiled column name
+    """
     col = column(db.db_engine_spec.make_label_compatible(colname))
     return str(col.compile(db.get_sqla_engine()))
 
 
-def get_expression(metric_name: str, db: models.Database) -> str:
+def get_aggr_expression(metric_name: str, db: models.Database) -> str:
+    """ Compile a SQL expression using dialect-specific quoting rules.
+    Assumes that the first three letters in metric name define the aggretation
+    function, followed by two underscores and the reference column. Example:
+    `avg__MyMixedCaseColumn` would be rendered to `AVG("MyMixedCaseColumn")` on
+    Postgres. Similarly the column `avg_lowercase_col` would return `AVG(lowercase_col)`.
+
+    :param metric_name: The alias of the metric
+    :param db: Database instance with an engine and dialect
+    :return: compiled aggregate expression
+    """
     aggregate_func = metric_name[:3]
     col = db.db_engine_spec.make_label_compatible(metric_name[5:])
     sqla_expr = SQLA_FUNCS[aggregate_func.lower()](column(col))
     return str(sqla_expr.compile(db.get_sqla_engine()))
 
 
-def get_sample_data_db():
+def get_sample_data_db() -> models.Database:
+    """ Get sample data database if defined, otherwise use main database.
+
+    :return: Database instance
+    """
     db_name = conf.get('SAMPLE_DATA_DB_DATASOURCE_NAME')
     if db_name:
         return (
@@ -129,7 +151,11 @@ def get_sample_data_db():
         return utils.get_or_create_main_db()
 
 
-def get_sample_data_schema():
+def get_sample_data_schema() -> Optional[str]:
+    """ Get sample data schema if defined.
+
+    :return: schema name if defined, otherwise None
+    """
     from superset import conf
     return conf.get('SAMPLE_DATA_DB_SCHEMA_NAME')
 

--- a/superset/data/long_lat.py
+++ b/superset/data/long_lat.py
@@ -41,7 +41,7 @@ def load_long_lat_data():
     """Loading lat/long data from a csv file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
+    cm = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'long_lat'
     data = get_example_data('san_francisco.csv.gz', make_bytes=True)
     pdf = pd.read_csv(data, encoding='utf-8')
@@ -90,7 +90,7 @@ def load_long_lat_data():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = c('datetime')
+    obj.main_dttm_col = cm('datetime')
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -102,10 +102,10 @@ def load_long_lat_data():
         'until': 'now',
         'where': '',
         'viz_type': 'mapbox',
-        'all_columns_x': c('LON'),
-        'all_columns_y': c('LAT'),
+        'all_columns_x': cm('LON'),
+        'all_columns_y': cm('LAT'),
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
-        'all_columns': [c('occupancy')],
+        'all_columns': [cm('occupancy')],
         'row_limit': 500000,
     }
 

--- a/superset/data/long_lat.py
+++ b/superset/data/long_lat.py
@@ -74,14 +74,15 @@ def load_long_lat_data():
         'geohash': String(12),
         'delimited': String(60),
     }, sample_db.db_engine_spec)
-    pdf.to_sql(  # pylint: disable=no-member
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(pdf,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False,
+                                       )
     print('Done loading table!')
     print('-' * 80)
 

--- a/superset/data/long_lat.py
+++ b/superset/data/long_lat.py
@@ -34,13 +34,13 @@ from .helpers import (
     Slice,
     TBL,
 )
+from superset.models.core import Database
 
 
 def load_long_lat_data():
     """Loading lat/long data from a csv file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'long_lat'
     data = get_example_data('san_francisco.csv.gz', make_bytes=True)
     pdf = pd.read_csv(data, encoding='utf-8')
@@ -80,12 +80,15 @@ def load_long_lat_data():
                                        if_exists='replace',
                                        chunksize=500,
                                        dtype=dtypes,
-                                       index=False,
-                                       )
+                                       index=False)
     print('Done loading table!')
     print('-' * 80)
+    create_metadata(tbl_name, sample_db, schema)
 
+
+def create_metadata(tbl_name: str, sample_db: Database, schema: str):
     print('Creating table reference')
+    mlc = sample_db.db_engine_spec.make_label_compatible
     obj = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
                                           schema=schema).first()
     if not obj:

--- a/superset/data/long_lat.py
+++ b/superset/data/long_lat.py
@@ -41,7 +41,7 @@ def load_long_lat_data():
     """Loading lat/long data from a csv file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'long_lat'
     data = get_example_data('san_francisco.csv.gz', make_bytes=True)
     pdf = pd.read_csv(data, encoding='utf-8')
@@ -91,7 +91,7 @@ def load_long_lat_data():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = cm('datetime')
+    obj.main_dttm_col = mlc('datetime')
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()
@@ -103,10 +103,10 @@ def load_long_lat_data():
         'until': 'now',
         'where': '',
         'viz_type': 'mapbox',
-        'all_columns_x': cm('LON'),
-        'all_columns_y': cm('LAT'),
+        'all_columns_x': mlc('LON'),
+        'all_columns_y': mlc('LAT'),
         'mapbox_style': 'mapbox://styles/mapbox/light-v9',
-        'all_columns': [cm('occupancy')],
+        'all_columns': [mlc('occupancy')],
         'row_limit': 500000,
     }
 

--- a/superset/data/long_lat.py
+++ b/superset/data/long_lat.py
@@ -22,6 +22,7 @@ import pandas as pd
 from sqlalchemy import DateTime, Float, String
 
 from superset import db
+from superset.models.core import Database
 from .helpers import (
     get_example_data,
     get_sample_data_db,
@@ -34,7 +35,6 @@ from .helpers import (
     Slice,
     TBL,
 )
-from superset.models.core import Database
 
 
 def load_long_lat_data():

--- a/superset/data/long_lat.py
+++ b/superset/data/long_lat.py
@@ -79,7 +79,7 @@ def load_long_lat_data():
     if not obj:
         obj = TBL(table_name='long_lat')
     obj.main_dttm_col = 'datetime'
-    obj.database = utils.get_or_create_main_db()
+    obj.database = utils.get_sample_data_db()
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()

--- a/superset/data/long_lat.py
+++ b/superset/data/long_lat.py
@@ -24,7 +24,6 @@ from sqlalchemy import DateTime, Float, String
 from superset import db
 from .helpers import (
     get_example_data,
-    get_expression,
     get_sample_data_db,
     get_sample_data_schema,
     get_slice_json,

--- a/superset/data/multiformat_time_series.py
+++ b/superset/data/multiformat_time_series.py
@@ -38,7 +38,7 @@ def load_multiformat_time_series():
     """Loading time series data from a zip file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
+    cm = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'multiformat_time_series'
     data = get_example_data('multiformat_time_series.json.gz')
     pdf = pd.read_json(data)
@@ -47,15 +47,15 @@ def load_multiformat_time_series():
     pdf.ds2 = pd.to_datetime(pdf.ds2, unit='s')
     pdf = make_df_columns_compatible(pdf, sample_db.db_engine_spec)
     dtypes = make_dtype_columns_compatible({
-            'ds': Date(),
-            'ds2': DateTime(),
-            'epoch_s': BigInteger(),
-            'epoch_ms': BigInteger(),
-            'string0': String(100),
-            'string1': String(100),
-            'string2': String(100),
-            'string3': String(100),
-        }, sample_db.db_engine_spec)
+        'ds': Date(),
+        'ds2': DateTime(),
+        'epoch_s': BigInteger(),
+        'epoch_ms': BigInteger(),
+        'string0': String(100),
+        'string1': String(100),
+        'string2': String(100),
+        'string3': String(100),
+    }, sample_db.db_engine_spec)
     pdf.to_sql(
         name=tbl_name,
         con=sample_db.get_sqla_engine(),
@@ -71,16 +71,16 @@ def load_multiformat_time_series():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = c('ds')
+    obj.main_dttm_col = cm('ds')
     dttm_and_expr_dict = {
-        c('ds'): [None, None],
-        c('ds2'): [None, None],
-        c('epoch_s'): ['epoch_s', None],
-        c('epoch_ms'): ['epoch_ms', None],
-        c('string2'): ['%Y%m%d-%H%M%S', None],
-        c('string1'): ['%Y-%m-%d^%H:%M:%S', None],
-        c('string0'): ['%Y-%m-%d %H:%M:%S.%f', None],
-        c('string3'): ['%Y/%m/%d%H:%M:%S.%f', None],
+        cm('ds'): [None, None],
+        cm('ds2'): [None, None],
+        cm('epoch_s'): ['epoch_s', None],
+        cm('epoch_ms'): ['epoch_ms', None],
+        cm('string2'): ['%Y%m%d-%H%M%S', None],
+        cm('string1'): ['%Y-%m-%d^%H:%M:%S', None],
+        cm('string0'): ['%Y-%m-%d %H:%M:%S.%f', None],
+        cm('string3'): ['%Y/%m/%d%H:%M:%S.%f', None],
     }
     for col in obj.columns:
         dttm_and_expr = dttm_and_expr_dict[col.column_name]

--- a/superset/data/multiformat_time_series.py
+++ b/superset/data/multiformat_time_series.py
@@ -56,14 +56,14 @@ def load_multiformat_time_series():
         'string2': String(100),
         'string3': String(100),
     }, sample_db.db_engine_spec)
-    pdf.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(pdf,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     print('Done loading table!')
     print('-' * 80)
     print('Creating table [multiformat_time_series] reference')

--- a/superset/data/multiformat_time_series.py
+++ b/superset/data/multiformat_time_series.py
@@ -61,7 +61,7 @@ def load_multiformat_time_series():
     if not obj:
         obj = TBL(table_name='multiformat_time_series')
     obj.main_dttm_col = 'ds'
-    obj.database = utils.get_or_create_main_db()
+    obj.database = utils.get_sample_data_db()
     dttm_and_expr_dict = {
         'ds': [None, None],
         'ds2': [None, None],

--- a/superset/data/multiformat_time_series.py
+++ b/superset/data/multiformat_time_series.py
@@ -38,7 +38,7 @@ def load_multiformat_time_series():
     """Loading time series data from a zip file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'multiformat_time_series'
     data = get_example_data('multiformat_time_series.json.gz')
     pdf = pd.read_json(data)
@@ -71,16 +71,16 @@ def load_multiformat_time_series():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = cm('ds')
+    obj.main_dttm_col = mlc('ds')
     dttm_and_expr_dict = {
-        cm('ds'): [None, None],
-        cm('ds2'): [None, None],
-        cm('epoch_s'): ['epoch_s', None],
-        cm('epoch_ms'): ['epoch_ms', None],
-        cm('string2'): ['%Y%m%d-%H%M%S', None],
-        cm('string1'): ['%Y-%m-%d^%H:%M:%S', None],
-        cm('string0'): ['%Y-%m-%d %H:%M:%S.%f', None],
-        cm('string3'): ['%Y/%m/%d%H:%M:%S.%f', None],
+        mlc('ds'): [None, None],
+        mlc('ds2'): [None, None],
+        mlc('epoch_s'): ['epoch_s', None],
+        mlc('epoch_ms'): ['epoch_ms', None],
+        mlc('string2'): ['%Y%m%d-%H%M%S', None],
+        mlc('string1'): ['%Y-%m-%d^%H:%M:%S', None],
+        mlc('string0'): ['%Y-%m-%d %H:%M:%S.%f', None],
+        mlc('string3'): ['%Y/%m/%d%H:%M:%S.%f', None],
     }
     for col in obj.columns:
         dttm_and_expr = dttm_and_expr_dict[col.column_name]

--- a/superset/data/paris.py
+++ b/superset/data/paris.py
@@ -44,15 +44,14 @@ def load_paris_iris_geojson():
         'features': Text,
         'type': Text,
     }, sample_db.db_engine_spec)
-
-    df.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(df,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     print('Creating table {} reference'.format(tbl_name))
     tbl = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
                                           schema=schema).first()

--- a/superset/data/paris.py
+++ b/superset/data/paris.py
@@ -48,7 +48,7 @@ def load_paris_iris_geojson():
     if not tbl:
         tbl = TBL(table_name=tbl_name)
     tbl.description = 'Map of Paris'
-    tbl.database = utils.get_or_create_main_db()
+    tbl.database = utils.get_sample_data_db()
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()

--- a/superset/data/random_time_series.py
+++ b/superset/data/random_time_series.py
@@ -46,14 +46,14 @@ def load_random_time_series_data():
     dtypes = make_dtype_columns_compatible({
         'ds': DateTime(),
     }, sample_db.db_engine_spec)
-    pdf.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(pdf,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     print('Done loading table!')
     print('-' * 80)
 

--- a/superset/data/random_time_series.py
+++ b/superset/data/random_time_series.py
@@ -52,7 +52,7 @@ def load_random_time_series_data():
     if not obj:
         obj = TBL(table_name='random_time_series')
     obj.main_dttm_col = 'ds'
-    obj.database = utils.get_or_create_main_db()
+    obj.database = utils.get_sample_data_db()
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()

--- a/superset/data/random_time_series.py
+++ b/superset/data/random_time_series.py
@@ -37,7 +37,7 @@ def load_random_time_series_data():
     """Loading random time series data from a zip file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
+    cm = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'random_time_series'
     data = get_example_data('random_time_series.json.gz')
     pdf = pd.read_json(data)
@@ -62,7 +62,7 @@ def load_random_time_series_data():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = c('ds')
+    obj.main_dttm_col = cm('ds')
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()

--- a/superset/data/random_time_series.py
+++ b/superset/data/random_time_series.py
@@ -37,7 +37,7 @@ def load_random_time_series_data():
     """Loading random time series data from a zip file in the repo"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'random_time_series'
     data = get_example_data('random_time_series.json.gz')
     pdf = pd.read_json(data)
@@ -62,7 +62,7 @@ def load_random_time_series_data():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = cm('ds')
+    obj.main_dttm_col = mlc('ds')
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()

--- a/superset/data/sf_population_polygons.py
+++ b/superset/data/sf_population_polygons.py
@@ -48,7 +48,7 @@ def load_sf_population_polygons():
     if not tbl:
         tbl = TBL(table_name=tbl_name)
     tbl.description = 'Population density of San Francisco'
-    tbl.database = utils.get_or_create_main_db()
+    tbl.database = utils.get_sample_data_db()
     db.session.merge(tbl)
     db.session.commit()
     tbl.fetch_metadata()

--- a/superset/data/sf_population_polygons.py
+++ b/superset/data/sf_population_polygons.py
@@ -44,14 +44,14 @@ def load_sf_population_polygons():
         'contour': Text(),
         'area': BigInteger(),
     }, sample_db.db_engine_spec)
-    df.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(df,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     print('Creating table {} reference'.format(tbl_name))
     tbl = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
                                           schema=schema).first()

--- a/superset/data/unicode_test_data.py
+++ b/superset/data/unicode_test_data.py
@@ -27,7 +27,7 @@ from .helpers import (
     config,
     Dash,
     get_example_data,
-    get_expression,
+    get_aggr_expression,
     get_sample_data_db,
     get_sample_data_schema,
     get_slice_json,
@@ -80,7 +80,7 @@ def load_unicode_test_data():
 
     if not any(col.metric_name == 'sum__value' for col in obj.metrics):
         metric_name = 'sum__value'
-        expression = get_expression(metric_name, sample_db)
+        expression = get_aggr_expression(metric_name, sample_db)
         obj.metrics.append(SqlMetric(
             metric_name=metric_name,
             expression=expression,

--- a/superset/data/unicode_test_data.py
+++ b/superset/data/unicode_test_data.py
@@ -45,7 +45,7 @@ def load_unicode_test_data():
     tbl_name = 'unicode_test'
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     data = get_example_data(
         'unicode_utf8_unixnl_test.csv', is_gzip=False, make_bytes=True)
     df = pd.read_csv(data, encoding='utf-8')
@@ -76,7 +76,7 @@ def load_unicode_test_data():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = cm('dttm')
+    obj.main_dttm_col = mlc('dttm')
 
     if not any(col.metric_name == 'sum__value' for col in obj.metrics):
         metric_name = 'sum__value'
@@ -92,7 +92,7 @@ def load_unicode_test_data():
     tbl = obj
 
     slice_data = {
-        'granularity_sqla': cm('dttm'),
+        'granularity_sqla': mlc('dttm'),
         'groupby': [],
         'metric': 'sum__value',
         'row_limit': config.get('ROW_LIMIT'),
@@ -101,7 +101,7 @@ def load_unicode_test_data():
         'where': '',
         'viz_type': 'word_cloud',
         'size_from': '10',
-        'series': cm('short_phrase'),
+        'series': mlc('short_phrase'),
         'size_to': '70',
         'rotation': 'square',
         'limit': '100',

--- a/superset/data/unicode_test_data.py
+++ b/superset/data/unicode_test_data.py
@@ -23,6 +23,7 @@ from sqlalchemy import Date, Float, Unicode
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
+from superset.models.core import Database
 from .helpers import (
     config,
     Dash,
@@ -45,7 +46,6 @@ def load_unicode_test_data():
     tbl_name = 'unicode_test'
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    mlc = sample_db.db_engine_spec.make_label_compatible
     data = get_example_data(
         'unicode_utf8_unixnl_test.csv', is_gzip=False, make_bytes=True)
     df = pd.read_csv(data, encoding='utf-8')
@@ -75,6 +75,7 @@ def load_unicode_test_data():
 
 def create_metadata(tbl_name: str, sample_db: Database, schema: str):
     print('Creating table [unicode_test] reference')
+    mlc = sample_db.db_engine_spec.make_label_compatible
     obj = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
                                           schema=schema).first()
     if not obj:

--- a/superset/data/unicode_test_data.py
+++ b/superset/data/unicode_test_data.py
@@ -45,7 +45,7 @@ def load_unicode_test_data():
     tbl_name = 'unicode_test'
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
+    cm = sample_db.db_engine_spec.make_label_compatible
     data = get_example_data(
         'unicode_utf8_unixnl_test.csv', is_gzip=False, make_bytes=True)
     df = pd.read_csv(data, encoding='utf-8')
@@ -76,7 +76,7 @@ def load_unicode_test_data():
                                           schema=schema).first()
     if not obj:
         obj = TBL(table_name=tbl_name, database=sample_db, schema=schema)
-    obj.main_dttm_col = c('dttm')
+    obj.main_dttm_col = cm('dttm')
 
     if not any(col.metric_name == 'sum__value' for col in obj.metrics):
         metric_name = 'sum__value'
@@ -92,7 +92,7 @@ def load_unicode_test_data():
     tbl = obj
 
     slice_data = {
-        'granularity_sqla': c('dttm'),
+        'granularity_sqla': cm('dttm'),
         'groupby': [],
         'metric': 'sum__value',
         'row_limit': config.get('ROW_LIMIT'),
@@ -101,7 +101,7 @@ def load_unicode_test_data():
         'where': '',
         'viz_type': 'word_cloud',
         'size_from': '10',
-        'series': c('short_phrase'),
+        'series': cm('short_phrase'),
         'size_to': '70',
         'rotation': 'square',
         'limit': '100',

--- a/superset/data/unicode_test_data.py
+++ b/superset/data/unicode_test_data.py
@@ -60,14 +60,14 @@ def load_unicode_test_data():
         'dttm': Date(),
         'value': Float(),
     }, sample_db.db_engine_spec)
-    df.to_sql(  # pylint: disable=no-member
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=500,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(df,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=500,
+                                       dtype=dtypes,
+                                       index=False)
     print('Done loading table!')
     print('-' * 80)
 

--- a/superset/data/unicode_test_data.py
+++ b/superset/data/unicode_test_data.py
@@ -70,7 +70,10 @@ def load_unicode_test_data():
                                        index=False)
     print('Done loading table!')
     print('-' * 80)
+    create_metadata(tbl_name, sample_db, schema)
 
+
+def create_metadata(tbl_name: str, sample_db: Database, schema: str):
     print('Creating table [unicode_test] reference')
     obj = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,
                                           schema=schema).first()

--- a/superset/data/unicode_test_data.py
+++ b/superset/data/unicode_test_data.py
@@ -64,7 +64,7 @@ def load_unicode_test_data():
     if not obj:
         obj = TBL(table_name='unicode_test')
     obj.main_dttm_col = 'dttm'
-    obj.database = utils.get_or_create_main_db()
+    obj.database = utils.get_sample_data_db()
     db.session.merge(obj)
     db.session.commit()
     obj.fetch_metadata()

--- a/superset/data/unicode_test_data.py
+++ b/superset/data/unicode_test_data.py
@@ -19,7 +19,7 @@ import json
 import random
 
 import pandas as pd
-from sqlalchemy import Date, Float, String
+from sqlalchemy import Date, Float, Unicode
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
@@ -54,9 +54,9 @@ def load_unicode_test_data():
     df['value'] = [random.randint(1, 100) for _ in range(len(df))]
     df = make_df_columns_compatible(df, sample_db.db_engine_spec)
     dtypes = make_dtype_columns_compatible({
-        'phrase': String(500),
-        'short_phrase': String(10),
-        'with_missing': String(100),
+        'phrase': Unicode(500),
+        'short_phrase': Unicode(10),
+        'with_missing': Unicode(100),
         'dttm': Date(),
         'value': Float(),
     }, sample_db.db_engine_spec)

--- a/superset/data/world_bank.py
+++ b/superset/data/world_bank.py
@@ -22,6 +22,7 @@ import textwrap
 
 import pandas as pd
 from sqlalchemy import DateTime, String
+from sqlalchemy.sql import column
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
@@ -75,9 +76,11 @@ def load_world_bank_health_n_pop():
     ]
     for m in metrics:
         if not any(col.metric_name == m for col in tbl.metrics):
+            aggr_func = m[:3]
+            col = str(column(m[5:]).compile(db.engine))
             tbl.metrics.append(SqlMetric(
                 metric_name=m,
-                expression=f'{m[:3]}({m[5:]})',
+                expression=f'{aggr_func}({col})',
             ))
 
     db.session.merge(tbl)

--- a/superset/data/world_bank.py
+++ b/superset/data/world_bank.py
@@ -31,7 +31,7 @@ from .helpers import (
     Dash,
     DATA_FOLDER,
     get_example_data,
-    get_expression,
+    get_aggr_expression,
     get_sample_data_db,
     get_sample_data_schema,
     get_slice_json,
@@ -88,7 +88,7 @@ def load_world_bank_health_n_pop():
         if not any(col.metric_name == metric_name for col in tbl.metrics):
             tbl.metrics.append(SqlMetric(
                 metric_name=metric_name,
-                expression=get_expression(metric_name, sample_db),
+                expression=get_aggr_expression(metric_name, sample_db),
             ))
 
     db.session.merge(tbl)

--- a/superset/data/world_bank.py
+++ b/superset/data/world_bank.py
@@ -49,7 +49,7 @@ def load_world_bank_health_n_pop():
     """Loads the world bank health dataset, slices and a dashboard"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    c = sample_db.db_engine_spec.make_label_compatible
+    cm = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'wb_health_population'
     data = get_example_data('countries.json.gz')
     pdf = pd.read_json(data)
@@ -77,7 +77,7 @@ def load_world_bank_health_n_pop():
     if not tbl:
         tbl = TBL(table_name=tbl_name, database=sample_db, schema=schema)
     tbl.description = utils.readfile(os.path.join(DATA_FOLDER, 'countries.md'))
-    tbl.main_dttm_col = c('year')
+    tbl.main_dttm_col = cm('year')
     tbl.filter_select_enabled = True
 
     metrics = [
@@ -99,7 +99,7 @@ def load_world_bank_health_n_pop():
         'compare_lag': '10',
         'compare_suffix': 'o10Y',
         'limit': '25',
-        'granularity_sqla': c('year'),
+        'granularity_sqla': cm('year'),
         'groupby': [],
         'metric': 'sum__SP_POP_TOTL',
         'metrics': ['sum__SP_POP_TOTL'],
@@ -111,7 +111,7 @@ def load_world_bank_health_n_pop():
         'markup_type': 'markdown',
         'country_fieldtype': 'cca3',
         'secondary_metric': 'sum__SP_POP_TOTL',
-        'entity': c('country_code'),
+        'entity': cm('country_code'),
         'show_bubbles': True,
     }
 
@@ -130,7 +130,7 @@ def load_world_bank_health_n_pop():
                     {
                         'asc': False,
                         'clearable': True,
-                        'column': c('region'),
+                        'column': cm('region'),
                         'key': '2s98dfu',
                         'metric': 'sum__SP_POP_TOTL',
                         'multiple': True,
@@ -138,7 +138,7 @@ def load_world_bank_health_n_pop():
                         'asc': False,
                         'clearable': True,
                         'key': 'li3j2lk',
-                        'column': c('country_name'),
+                        'column': cm('country_name'),
                         'metric': 'sum__SP_POP_TOTL',
                         'multiple': True,
                     },
@@ -164,7 +164,7 @@ def load_world_bank_health_n_pop():
                 defaults,
                 viz_type='table',
                 metrics=['sum__SP_POP_TOTL'],
-                groupby=[c('country_name')])),
+                groupby=[cm('country_name')])),
         Slice(
             slice_name='Growth Rate',
             viz_type='line',
@@ -176,7 +176,7 @@ def load_world_bank_health_n_pop():
                 since='1960-01-01',
                 metrics=['sum__SP_POP_TOTL'],
                 num_period_compare='10',
-                groupby=[c('country_name')])),
+                groupby=[cm('country_name')])),
         Slice(
             slice_name='% Rural',
             viz_type='world_map',
@@ -197,15 +197,15 @@ def load_world_bank_health_n_pop():
                 viz_type='bubble',
                 since='2011-01-01',
                 until='2011-01-02',
-                series=c('region'),
+                series=cm('region'),
                 limit=0,
-                entity=c('country_name'),
+                entity=cm('country_name'),
                 x='sum__SP_RUR_TOTL_ZS',
                 y='sum__SP_DYN_LE00_IN',
                 size='sum__SP_POP_TOTL',
                 max_bubble_size='50',
                 filters=[{
-                    'col': c('country_code'),
+                    'col': cm('country_code'),
                     'val': [
                         'TCA', 'MNP', 'DMA', 'MHL', 'MCO', 'SXM', 'CYM',
                         'TUV', 'IMY', 'KNA', 'ASM', 'ADO', 'AMA', 'PLW',
@@ -220,7 +220,7 @@ def load_world_bank_health_n_pop():
             params=get_slice_json(
                 defaults,
                 viz_type='sunburst',
-                groupby=[c('region'), c('country_name')],
+                groupby=[cm('region'), cm('country_name')],
                 secondary_metric='sum__SP_RUR_TOTL',
                 since='2011-01-01',
                 until='2011-01-01')),
@@ -234,7 +234,7 @@ def load_world_bank_health_n_pop():
                 since='1960-01-01',
                 until='now',
                 viz_type='area',
-                groupby=[c('region')])),
+                groupby=[cm('region')])),
         Slice(
             slice_name='Box plot',
             viz_type='box_plot',
@@ -247,7 +247,7 @@ def load_world_bank_health_n_pop():
                 whisker_options='Min/max (no outliers)',
                 x_ticks_layout='staggered',
                 viz_type='box_plot',
-                groupby=[c('region')])),
+                groupby=[cm('region')])),
         Slice(
             slice_name='Treemap',
             viz_type='treemap',
@@ -259,7 +259,7 @@ def load_world_bank_health_n_pop():
                 until='now',
                 viz_type='treemap',
                 metrics=['sum__SP_POP_TOTL'],
-                groupby=[c('region'), c('country_code')])),
+                groupby=[cm('region'), cm('country_code')])),
         Slice(
             slice_name='Parallel Coordinates',
             viz_type='para',
@@ -276,7 +276,7 @@ def load_world_bank_health_n_pop():
                     'sum__SP_RUR_TOTL_ZS',
                     'sum__SH_DYN_AIDS'],
                 secondary_metric='sum__SP_POP_TOTL',
-                series=c('country_name'))),
+                series=cm('country_name'))),
     ]
     misc_dash_slices.add(slices[-1].slice_name)
     for slc in slices:

--- a/superset/data/world_bank.py
+++ b/superset/data/world_bank.py
@@ -67,7 +67,7 @@ def load_world_bank_health_n_pop():
         tbl = TBL(table_name=tbl_name)
     tbl.description = utils.readfile(os.path.join(DATA_FOLDER, 'countries.md'))
     tbl.main_dttm_col = 'year'
-    tbl.database = utils.get_or_create_main_db()
+    tbl.database = utils.get_sample_data_db()
     tbl.filter_select_enabled = True
 
     metrics = [

--- a/superset/data/world_bank.py
+++ b/superset/data/world_bank.py
@@ -49,7 +49,7 @@ def load_world_bank_health_n_pop():
     """Loads the world bank health dataset, slices and a dashboard"""
     sample_db = get_sample_data_db()
     schema = get_sample_data_schema()
-    cm = sample_db.db_engine_spec.make_label_compatible
+    mlc = sample_db.db_engine_spec.make_label_compatible
     tbl_name = 'wb_health_population'
     data = get_example_data('countries.json.gz')
     pdf = pd.read_json(data)
@@ -77,7 +77,7 @@ def load_world_bank_health_n_pop():
     if not tbl:
         tbl = TBL(table_name=tbl_name, database=sample_db, schema=schema)
     tbl.description = utils.readfile(os.path.join(DATA_FOLDER, 'countries.md'))
-    tbl.main_dttm_col = cm('year')
+    tbl.main_dttm_col = mlc('year')
     tbl.filter_select_enabled = True
 
     metrics = [
@@ -99,7 +99,7 @@ def load_world_bank_health_n_pop():
         'compare_lag': '10',
         'compare_suffix': 'o10Y',
         'limit': '25',
-        'granularity_sqla': cm('year'),
+        'granularity_sqla': mlc('year'),
         'groupby': [],
         'metric': 'sum__SP_POP_TOTL',
         'metrics': ['sum__SP_POP_TOTL'],
@@ -111,7 +111,7 @@ def load_world_bank_health_n_pop():
         'markup_type': 'markdown',
         'country_fieldtype': 'cca3',
         'secondary_metric': 'sum__SP_POP_TOTL',
-        'entity': cm('country_code'),
+        'entity': mlc('country_code'),
         'show_bubbles': True,
     }
 
@@ -130,7 +130,7 @@ def load_world_bank_health_n_pop():
                     {
                         'asc': False,
                         'clearable': True,
-                        'column': cm('region'),
+                        'column': mlc('region'),
                         'key': '2s98dfu',
                         'metric': 'sum__SP_POP_TOTL',
                         'multiple': True,
@@ -138,7 +138,7 @@ def load_world_bank_health_n_pop():
                         'asc': False,
                         'clearable': True,
                         'key': 'li3j2lk',
-                        'column': cm('country_name'),
+                        'column': mlc('country_name'),
                         'metric': 'sum__SP_POP_TOTL',
                         'multiple': True,
                     },
@@ -164,7 +164,7 @@ def load_world_bank_health_n_pop():
                 defaults,
                 viz_type='table',
                 metrics=['sum__SP_POP_TOTL'],
-                groupby=[cm('country_name')])),
+                groupby=[mlc('country_name')])),
         Slice(
             slice_name='Growth Rate',
             viz_type='line',
@@ -176,7 +176,7 @@ def load_world_bank_health_n_pop():
                 since='1960-01-01',
                 metrics=['sum__SP_POP_TOTL'],
                 num_period_compare='10',
-                groupby=[cm('country_name')])),
+                groupby=[mlc('country_name')])),
         Slice(
             slice_name='% Rural',
             viz_type='world_map',
@@ -197,15 +197,15 @@ def load_world_bank_health_n_pop():
                 viz_type='bubble',
                 since='2011-01-01',
                 until='2011-01-02',
-                series=cm('region'),
+                series=mlc('region'),
                 limit=0,
-                entity=cm('country_name'),
+                entity=mlc('country_name'),
                 x='sum__SP_RUR_TOTL_ZS',
                 y='sum__SP_DYN_LE00_IN',
                 size='sum__SP_POP_TOTL',
                 max_bubble_size='50',
                 filters=[{
-                    'col': cm('country_code'),
+                    'col': mlc('country_code'),
                     'val': [
                         'TCA', 'MNP', 'DMA', 'MHL', 'MCO', 'SXM', 'CYM',
                         'TUV', 'IMY', 'KNA', 'ASM', 'ADO', 'AMA', 'PLW',
@@ -220,7 +220,7 @@ def load_world_bank_health_n_pop():
             params=get_slice_json(
                 defaults,
                 viz_type='sunburst',
-                groupby=[cm('region'), cm('country_name')],
+                groupby=[mlc('region'), mlc('country_name')],
                 secondary_metric='sum__SP_RUR_TOTL',
                 since='2011-01-01',
                 until='2011-01-01')),
@@ -234,7 +234,7 @@ def load_world_bank_health_n_pop():
                 since='1960-01-01',
                 until='now',
                 viz_type='area',
-                groupby=[cm('region')])),
+                groupby=[mlc('region')])),
         Slice(
             slice_name='Box plot',
             viz_type='box_plot',
@@ -247,7 +247,7 @@ def load_world_bank_health_n_pop():
                 whisker_options='Min/max (no outliers)',
                 x_ticks_layout='staggered',
                 viz_type='box_plot',
-                groupby=[cm('region')])),
+                groupby=[mlc('region')])),
         Slice(
             slice_name='Treemap',
             viz_type='treemap',
@@ -259,7 +259,7 @@ def load_world_bank_health_n_pop():
                 until='now',
                 viz_type='treemap',
                 metrics=['sum__SP_POP_TOTL'],
-                groupby=[cm('region'), cm('country_code')])),
+                groupby=[mlc('region'), mlc('country_code')])),
         Slice(
             slice_name='Parallel Coordinates',
             viz_type='para',
@@ -276,7 +276,7 @@ def load_world_bank_health_n_pop():
                     'sum__SP_RUR_TOTL_ZS',
                     'sum__SH_DYN_AIDS'],
                 secondary_metric='sum__SP_POP_TOTL',
-                series=cm('country_name'))),
+                series=mlc('country_name'))),
     ]
     misc_dash_slices.add(slices[-1].slice_name)
     for slc in slices:

--- a/superset/data/world_bank.py
+++ b/superset/data/world_bank.py
@@ -62,14 +62,14 @@ def load_world_bank_health_n_pop():
         'country_name': String(255),
         'region': String(255),
     }, sample_db.db_engine_spec)
-    pdf.to_sql(
-        name=tbl_name,
-        con=sample_db.get_sqla_engine(),
-        schema=schema,
-        if_exists='replace',
-        chunksize=50,
-        dtype=dtypes,
-        index=False)
+    sample_db.db_engine_spec.df_to_sql(pdf,
+                                       name=tbl_name,
+                                       con=sample_db.get_sqla_engine(),
+                                       schema=schema,
+                                       if_exists='replace',
+                                       chunksize=50,
+                                       dtype=dtypes,
+                                       index=False)
 
     print('Creating table [wb_health_population] reference')
     tbl = db.session.query(TBL).filter_by(table_name=tbl_name, database=sample_db,

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -868,6 +868,21 @@ def user_label(user: User) -> Optional[str]:
     return None
 
 
+def get_sample_data_db():
+    from superset import conf, db
+    from superset.models import core as models
+
+    db_name = conf.get('SAMPLE_DATA_DB_DATASOURCE_NAME')
+    if db_name:
+        return (
+            db.session.query(models.Database)
+            .filter_by(database_name=db_name)
+            .first()
+        )
+    else:
+        return get_or_create_main_db()
+
+
 def get_or_create_main_db():
     from superset import conf, db
     from superset.models import core as models

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -868,21 +868,6 @@ def user_label(user: User) -> Optional[str]:
     return None
 
 
-def get_sample_data_db():
-    from superset import conf, db
-    from superset.models import core as models
-
-    db_name = conf.get('SAMPLE_DATA_DB_DATASOURCE_NAME')
-    if db_name:
-        return (
-            db.session.query(models.Database)
-            .filter_by(database_name=db_name)
-            .first()
-        )
-    else:
-        return get_or_create_main_db()
-
-
 def get_or_create_main_db():
     from superset import conf, db
     from superset.models import core as models


### PR DESCRIPTION
### CATEGORY

- [x] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation
- [x] Bug Fix

### SUMMARY
A summary of changes:
- Fix a handful of encountered bugs:
   - Compile column names in expressions to ensure quotes are present when needed, the lack of which causes problems on (at least) Postgres.
   - `sum__SP_RUR_TOTL` metric was missing from `wb_health_population`.
   - `sum__value` metric was missing from `unicode_test`.
   - Text columns in `unicode_test` defined as non-Unicode SQLAlchemy type `String`, should be `Unicode`.
   - MySQL fails to import Unicode text due to defaulting to currently using `latin1` charset. Changed default charset to `utf8m4` (per official recommendation). 
   - Polygon chart broken due to missing metric.
   - Incorrect height on Polygon chart due to wrong metadata (reference to `js_datapoint_mutator`, should be `js_data_mutator` and incorrect syntax in mutator code).
   - Incorrect color on Path chart due to wrong metadata (same as Polygon chart).
   - Fix edge case in `sqla/models.py` when ordering by a metric whose label has been mutated.
- Add `SAMPLE_DATA_DB_DATASOURCE_NAME` and `SAMPLE_DATA_DB_SCHEMA_NAME` to make it possible to load sample data into any database/schema with csv upload support. Currently loading is only supported into main backend database.
- Make sample data work on all databases. This is made possible by leveraging column label mutation logic found in `db_engine_specs` by conditionally mutating any unsupported column names in sample data and references thereof in the chart metadata. A few examples of columns that need to be mutated:
   - BigQuery: Columns starting with a number, e.g. columns `2004`-`2014` in `birth_france_by_region`
   - Redshift: non-lowercase columns, e.g. column `DEPT_ID` in `birth_france_by_region`
- Move `DataFrame` uploading logic to `db_engine_specs` to enable uploading to engines that don't support vanilla `DataFrame.to_sql()` like BigQuery (requires use of `to_gbq()`). As a biproduct BigQuery now also supports CSV uploading.
- Add `README.md` explaining the steps needed to add a new sample dataset and the more complex parts like conditional mutating of column names.

By being able to deploy sample data & charts/dashboards on any db will make it easier to make sure that an engine really works, spot regressions/bugs and also reduce clutter in the main backend database.

### SCREENSHOTS
<img width="591" alt="Screenshot 2019-04-24 at 11 28 21" src="https://user-images.githubusercontent.com/33317356/56649582-137f2680-668e-11e9-8f4c-63fac0bc392d.png">
Polygon heights now work.

<img width="586" alt="Screenshot 2019-04-24 at 11 28 40" src="https://user-images.githubusercontent.com/33317356/56649613-2265d900-668e-11e9-95ef-924caf8b0c01.png">
Path colors now work

<img width="1235" alt="Screenshot 2019-04-24 at 11 29 56" src="https://user-images.githubusercontent.com/33317356/56649638-2bef4100-668e-11e9-85d1-a3f63aa3e6d7.png">
Picture taken from from sample dataset deployed to BigQuery. Notice the mutated column names (original name `2004`, now prefixed with undescore and trailing md5 hash as per logic in `db_engine_specs`). Having the full md5 hash is slightly overkill, but can be changed later (first 5 few chars should suffice to avoid realistic collision risk).

### TEST PLAN
Tested on Sqlite, Postgres and BigQuery, all of which work well.

### ADDITIONAL INFORMATION
- [x] Has associated issue: fixes #6009, fixes #7339

### REVIEWERS
@dostiharise @andy-clapson @trrahul @michaldul please give this a try if you can.