### PR TITLE
fixes #6353 by changing tag on base image

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.6
+FROM python:3.6-jessie
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The python:3.6 tag would fail when running `apt-get update -y` due to an issue with supported version of jessie on debian. The python:3.6-jessie tag resolves this issue and allows the image to be built successfully.

### TEST PLAN
Run through docker installation with this version of the dockerfile

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #6353 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
