### PR TITLE
fix: do not save colors without a color scheme

### DIFF
--- a/superset/assets/src/dashboard/components/Header.jsx
+++ b/superset/assets/src/dashboard/components/Header.jsx
@@ -222,7 +222,7 @@ class Header extends React.PureComponent {
       colorScheme,
       colorNamespace,
     );
-    const labelColors = scale.getColorMap();
+    const labelColors = colorScheme ? scale.getColorMap() : {};
     const data = {
       positions,
       expanded_slices: expandedSlices,

--- a/superset/assets/src/dashboard/components/SaveModal.jsx
+++ b/superset/assets/src/dashboard/components/SaveModal.jsx
@@ -110,7 +110,7 @@ class SaveModal extends React.PureComponent {
       colorScheme,
       colorNamespace,
     );
-    const labelColors = scale.getColorMap();
+    const labelColors = colorScheme ? scale.getColorMap() : {};
     const data = {
       positions,
       css,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The color mapping was saved every time whether or not a user chose a color scheme for their dashboard. We should not save a color mapping unless the user specifies a color scheme.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Tested manually

### REVIEWERS
@betodealmeida @datability-io @xtinec 