### PR TITLE
Feature flag for client cache

### DIFF
--- a/superset/assets/cypress/integration/dashboard/controls.js
+++ b/superset/assets/cypress/integration/dashboard/controls.js
@@ -39,7 +39,7 @@ export default () => describe('top-level controls', () => {
           const sliceRequest = `getJson_${slice.slice_id}`;
           sliceRequests.push(`@${sliceRequest}`);
           const formData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
-          cy.route('GET', `/superset/explore_json/?form_data=${formData}`).as(sliceRequest);
+          cy.route('POST', `/superset/explore_json/?form_data=${formData}`).as(sliceRequest);
 
           const forceRefresh = `postJson_${slice.slice_id}_force`;
           forceRefreshRequests.push(`@${forceRefresh}`);

--- a/superset/assets/cypress/integration/dashboard/controls.js
+++ b/superset/assets/cypress/integration/dashboard/controls.js
@@ -38,7 +38,7 @@ export default () => describe('top-level controls', () => {
         .forEach((slice) => {
           const sliceRequest = `getJson_${slice.slice_id}`;
           sliceRequests.push(`@${sliceRequest}`);
-          const formData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
+          const formData = `{"slice_id":${slice.slice_id}}`;
           cy.route('POST', `/superset/explore_json/?form_data=${formData}`).as(sliceRequest);
 
           const forceRefresh = `postJson_${slice.slice_id}_force`;

--- a/superset/assets/cypress/integration/dashboard/edit_mode.js
+++ b/superset/assets/cypress/integration/dashboard/edit_mode.js
@@ -30,7 +30,7 @@ export default () => describe('edit mode', () => {
       const boxplotChartId = dashboard.slices.find(slice => (slice.form_data.viz_type === 'box_plot')).slice_id;
       const formData = `{"slice_id":${boxplotChartId},"viz_type":"box_plot"}`;
       const boxplotRequest = `/superset/explore_json/?form_data=${formData}`;
-      cy.route('GET', boxplotRequest).as('boxplotRequest');
+      cy.route('POST', boxplotRequest).as('boxplotRequest');
     });
 
     cy.get('.dashboard-header').contains('Edit dashboard').click();

--- a/superset/assets/cypress/integration/dashboard/edit_mode.js
+++ b/superset/assets/cypress/integration/dashboard/edit_mode.js
@@ -28,7 +28,7 @@ export default () => describe('edit mode', () => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
       const dashboard = bootstrapData.dashboard_data;
       const boxplotChartId = dashboard.slices.find(slice => (slice.form_data.viz_type === 'box_plot')).slice_id;
-      const formData = `{"slice_id":${boxplotChartId},"viz_type":"box_plot"}`;
+      const formData = `{"slice_id":${boxplotChartId}}`;
       const boxplotRequest = `/superset/explore_json/?form_data=${formData}`;
       cy.route('POST', boxplotRequest).as('boxplotRequest');
     });

--- a/superset/assets/cypress/integration/dashboard/filter.js
+++ b/superset/assets/cypress/integration/dashboard/filter.js
@@ -19,7 +19,7 @@
 import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
 
 export default () => describe('dashboard filter', () => {
-  let sliceIds = [];
+  let slices = [];
   let filterId;
 
   beforeEach(() => {
@@ -31,7 +31,7 @@ export default () => describe('dashboard filter', () => {
     cy.get('#app').then((data) => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
       const dashboard = bootstrapData.dashboard_data;
-      sliceIds = dashboard.slices.map(slice => (slice.slice_id));
+      slices = [...dashboard.slices];
       filterId = dashboard.slices.find(slice => (slice.form_data.viz_type === 'filter_box')).slice_id;
     });
   });
@@ -43,13 +43,13 @@ export default () => describe('dashboard filter', () => {
     const filterRoute = `/superset/explore_json/?form_data=${formData}`;
     cy.route('GET', filterRoute).as('fetchFilter');
     cy.wait('@fetchFilter');
-    sliceIds
-      .filter(id => (parseInt(id, 10) !== filterId))
-      .forEach((id) => {
-        const alias = `getJson_${id}`;
+    slices
+      .filter(slice => (parseInt(slice.slice_id, 10) !== filterId))
+      .forEach((slice) => {
+        const alias = `getJson_${slice.slice_id}`;
         aliases.push(`@${alias}`);
-
-        cy.route('POST', `/superset/explore_json/?form_data={"slice_id":${id}}`).as(alias);
+        const chartFormData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
+        cy.route('POST', `/superset/explore_json/?form_data=${chartFormData}`).as(alias);
       });
 
     // select filter_box and apply

--- a/superset/assets/cypress/integration/dashboard/filter.js
+++ b/superset/assets/cypress/integration/dashboard/filter.js
@@ -19,7 +19,7 @@
 import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
 
 export default () => describe('dashboard filter', () => {
-  let slices = [];
+  let sliceIds = [];
   let filterId;
 
   beforeEach(() => {
@@ -31,7 +31,7 @@ export default () => describe('dashboard filter', () => {
     cy.get('#app').then((data) => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
       const dashboard = bootstrapData.dashboard_data;
-      slices = [...dashboard.slices];
+      sliceIds = dashboard.slices.map(slice => (slice.slice_id));
       filterId = dashboard.slices.find(slice => (slice.form_data.viz_type === 'filter_box')).slice_id;
     });
   });
@@ -43,13 +43,13 @@ export default () => describe('dashboard filter', () => {
     const filterRoute = `/superset/explore_json/?form_data=${formData}`;
     cy.route('GET', filterRoute).as('fetchFilter');
     cy.wait('@fetchFilter');
-    slices
-      .filter(slice => (parseInt(slice.slice_id, 10) !== filterId))
-      .forEach((slice) => {
-        const alias = `getJson_${slice.slice_id}`;
+    sliceIds
+      .filter(id => (parseInt(id, 10) !== filterId))
+      .forEach((id) => {
+        const alias = `getJson_${id}`;
         aliases.push(`@${alias}`);
-        const chartFormData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
-        cy.route('POST', `/superset/explore_json/?form_data=${chartFormData}`).as(alias);
+
+        cy.route('POST', `/superset/explore_json/?form_data={"slice_id":${id}}`).as(alias);
       });
 
     // select filter_box and apply

--- a/superset/assets/cypress/integration/dashboard/filter.js
+++ b/superset/assets/cypress/integration/dashboard/filter.js
@@ -39,7 +39,7 @@ export default () => describe('dashboard filter', () => {
   it('should apply filter', () => {
     const aliases = [];
 
-    const formData = `{"slice_id":${filterId},"viz_type":"filter_box"}`;
+    const formData = `{"slice_id":${filterId}}`;
     const filterRoute = `/superset/explore_json/?form_data=${formData}`;
     cy.route('POST', filterRoute).as('fetchFilter');
     cy.wait('@fetchFilter');

--- a/superset/assets/cypress/integration/dashboard/filter.js
+++ b/superset/assets/cypress/integration/dashboard/filter.js
@@ -41,7 +41,7 @@ export default () => describe('dashboard filter', () => {
 
     const formData = `{"slice_id":${filterId},"viz_type":"filter_box"}`;
     const filterRoute = `/superset/explore_json/?form_data=${formData}`;
-    cy.route('GET', filterRoute).as('fetchFilter');
+    cy.route('POST', filterRoute).as('fetchFilter');
     cy.wait('@fetchFilter');
     sliceIds
       .filter(id => (parseInt(id, 10) !== filterId))

--- a/superset/assets/cypress/integration/dashboard/load.js
+++ b/superset/assets/cypress/integration/dashboard/load.js
@@ -35,7 +35,7 @@ export default () => describe('load', () => {
       slices.forEach((slice) => {
         const alias = `getJson_${slice.slice_id}`;
         const formData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
-        cy.route('GET', `/superset/explore_json/?form_data=${formData}`).as(alias);
+        cy.route('POST', `/superset/explore_json/?form_data=${formData}`).as(alias);
         aliases.push(`@${alias}`);
       });
     });

--- a/superset/assets/cypress/integration/dashboard/load.js
+++ b/superset/assets/cypress/integration/dashboard/load.js
@@ -34,7 +34,7 @@ export default () => describe('load', () => {
       // then define routes and create alias for each requests
       slices.forEach((slice) => {
         const alias = `getJson_${slice.slice_id}`;
-        const formData = `{"slice_id":${slice.slice_id},"viz_type":"${slice.form_data.viz_type}"}`;
+        const formData = `{"slice_id":${slice.slice_id}}`;
         cy.route('POST', `/superset/explore_json/?form_data=${formData}`).as(alias);
         aliases.push(`@${alias}`);
       });

--- a/superset/assets/cypress/integration/dashboard/save.js
+++ b/superset/assets/cypress/integration/dashboard/save.js
@@ -56,7 +56,7 @@ export default () => describe('save', () => {
     cy.wait('@copyRequest');
 
     // should have box_plot chart
-    const formData = `{"slice_id":${boxplotChartId},"viz_type":"box_plot"}`;
+    const formData = `{"slice_id":${boxplotChartId}}`;
     const boxplotRequest = `/superset/explore_json/?form_data=${formData}`;
     cy.route('POST', boxplotRequest).as('boxplotRequest');
     cy.wait('@boxplotRequest');

--- a/superset/assets/cypress/integration/dashboard/save.js
+++ b/superset/assets/cypress/integration/dashboard/save.js
@@ -58,7 +58,7 @@ export default () => describe('save', () => {
     // should have box_plot chart
     const formData = `{"slice_id":${boxplotChartId},"viz_type":"box_plot"}`;
     const boxplotRequest = `/superset/explore_json/?form_data=${formData}`;
-    cy.route('GET', boxplotRequest).as('boxplotRequest');
+    cy.route('POST', boxplotRequest).as('boxplotRequest');
     cy.wait('@boxplotRequest');
     cy.get('.grid-container .box_plot').should('be.exist');
 

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -20,6 +20,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { Logger, LOG_ACTIONS_RENDER_CHART_CONTAINER } from '../logger/LogUtils';
 import Loading from '../components/Loading';
 import RefreshChartOverlay from '../components/RefreshChartOverlay';
@@ -70,7 +71,7 @@ class Chart extends React.PureComponent {
   }
   componentDidMount() {
     if (this.props.triggerQuery) {
-      if (this.props.chartId > 0) {
+      if (this.props.chartId > 0 && isFeatureEnabled(FeatureFlag.CLIENT_CACHE)) {
         // Load saved chart with a GET request
         this.props.actions.getSavedChart(
           this.props.formData,

--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -21,6 +21,7 @@
 /* eslint no-param-reassign: ["error", { "props": false }] */
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { getExploreUrlAndPayload, getAnnotationJsonUrl } from '../explore/exploreUtils';
 import { requiresQuery, ANNOTATION_SOURCE_TYPES } from '../modules/AnnotationTypes';
 import { addDangerToast } from '../messageToasts/actions';
@@ -194,7 +195,9 @@ export function exploreJSON(formData, force = false, timeout = 60, key, method) 
       };
     }
 
-    const clientMethod = method === 'GET' ? SupersetClient.get : SupersetClient.post;
+    const clientMethod = method === 'GET' && isFeatureEnabled(FeatureFlag.CLIENT_CACHE)
+      ? SupersetClient.get
+      : SupersetClient.post;
     const queryPromise = clientMethod(querySettings)
       .then(({ json }) => {
         dispatch(logEvent(LOG_ACTIONS_LOAD_CHART, {

--- a/superset/assets/src/featureFlags.ts
+++ b/superset/assets/src/featureFlags.ts
@@ -21,6 +21,7 @@
 export enum FeatureFlag {
   SCOPED_FILTER = 'SCOPED_FILTER',
   OMNIBAR = 'OMNIBAR',
+  CLIENT_CACHE = 'CLIENT_CACHE',
 }
 
 export type FeatureFlagMap = {

--- a/superset/config.py
+++ b/superset/config.py
@@ -200,7 +200,10 @@ LANGUAGES = {
 # For example, DEFAULT_FEATURE_FLAGS = { 'FOO': True, 'BAR': False } here
 # and FEATURE_FLAGS = { 'BAR': True, 'BAZ': True } in superset_config.py
 # will result in combined feature flags of { 'FOO': True, 'BAR': True, 'BAZ': True }
-DEFAULT_FEATURE_FLAGS = {}
+DEFAULT_FEATURE_FLAGS = {
+    # Experimental feature introducing a client (browser) cache
+    'CLIENT_CACHE': False,
+}
 
 # A function that receives a dict of all feature flags
 # (DEFAULT_FEATURE_FLAGS merged with FEATURE_FLAGS)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Put the client cache behind a feature flag. If it's not set, all requests for chart/slice data will be `POST`s.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Loaded a dashboard. Without the flag all charts are requests via `POST` requests. With the flag, `GET`s are done.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
