### PR TITLE
SUPERSET-8: Update text in docs copyright footer

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: '3'
+version: '2'
 services:
   redis:
     image: redis:3.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = "Apache Superset"
-copyright = 'Copyright © 2018 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.'
+copyright = 'Copyright © 2019 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.'
 author = u'Apache Superset Dev'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -194,7 +194,7 @@ html_show_sourcelink = False
 html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-html_show_copyright = True
+html_show_copyright = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
### CATEGORY

- [ * ] Documentation

### SUMMARY
Docs footer has extra text and the year is out-dated:
© Copyright Copyright © 2018 The Apache Software Foundation, Licensed under the Apache License, Version 2.0..

### TEST PLAN
Verify footer says "Copyright © 2019 The Apache Software Foundation, Licensed under the Apache License, Version 2.0." with the correct year.