### PR TITLE
[migration] Using existing_type rather than type_

### DIFF
--- a/superset/migrations/versions/937d04c16b64_update_datasources.py
+++ b/superset/migrations/versions/937d04c16b64_update_datasources.py
@@ -36,8 +36,8 @@ def upgrade():
     with op.batch_alter_table('datasources') as batch_op:
         batch_op.alter_column(
             'datasource_name',
+            existing_type=sa.String(255),
             nullable=False,
-            type_=sa.String(255),
         )
 
 
@@ -47,6 +47,6 @@ def downgrade():
     with op.batch_alter_table('datasources') as batch_op:
         batch_op.alter_column(
             'datasource_name',
+            existing_type=sa.String(255),
             nullable=True,
-            type_=sa.String(255),
         )


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR uses the Alembic [`existing_type`](https://alembic.sqlalchemy.org/en/latest/ops.html?highlight=insert#alembic.operations.Operations.alter_column) as opposed to `type_` as the preferred approach for altering a column where the type is unchanged.

### TEST PLAN

CI. 

### REVIEWERS

to: @michellethomas 