### PR TITLE
[fix] Fixing SQL parsing issue

### DIFF
--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -462,3 +462,12 @@ class SupersetTestCase(unittest.TestCase):
             'SELECT * FROM ab_user LIMIT 1',
         ]
         self.assertEquals(statements, expected)
+
+    def test_identifier_list_with_keyword_as_alias(self):
+        query = """
+        WITH
+            f AS (SELECT * FROM foo),
+            match AS (SELECT * FROM f)
+        SELECT * FROM match
+        """
+        self.assertEquals({'foo'}, self.extract_tables(query))


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes an issue with parsing SQL where iterating over the identifiers associated with a `sqlparser` `IdentifierList` yields a `Token` (as opposed to a `TokenList`) resulting in the following error:
```
builtins:AttributeError: 'Token' object has no attribute 'tokens'
```

Note I worked somewhat extensively with `sqlparse` on an unrelated project and there's probably some merit in restructuring some of this logic in the future. 

### TEST PLAN

CI. 

### REVIEWERS

to: @michellethomas @mistercrunch 