### PR TITLE
fix: calendar heatmap examples

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -213,7 +213,7 @@ class BaseViz(object):
                     try:
                         int(one_ts_val)
                         is_integral = True
-                    except ValueError:
+                    except (ValueError, TypeError):
                         is_integral = False
                     if is_integral:
                         unit = 's' if timestamp_format == 'epoch_s' else 'ms'


### PR DESCRIPTION
### CATEGORY
- [x] Bug Fix

### SUMMARY
Fixing a set of examples that trip on ValueError vs TypeError, related to https://github.com/apache/incubator-superset/pull/6719

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="762" alt="Screen Shot 2019-04-24 at 9 34 47 PM" src="https://user-images.githubusercontent.com/487433/56709988-f1f75c80-66d8-11e9-9445-c29adfa9d5f7.png">
