### PR TITLE
druid connector: avoid using 'dimensions' for scan queries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         'parsedatetime',
         'pathlib2',
         'polyline',
-        'pydruid>=0.4.3',
+        'pydruid>=0.5.2',
         'python-dateutil',
         'python-geohash',
         'pyyaml>=3.13',

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1118,7 +1118,8 @@ class DruidDatasource(Model, BaseDatasource):
             columns.append('__time')
             del qry['post_aggregations']
             del qry['aggregations']
-            qry['dimensions'] = columns
+            del qry['dimensions']
+            qry['columns'] = columns
             qry['metrics'] = []
             qry['granularity'] = 'all'
             qry['limit'] = row_limit


### PR DESCRIPTION
After the following PyDruid change (contained in version 0.5.2)
the Superset Histogram charts rendered with Druid data are
broken:

https://github.com/druid-io/pydruid/commit/0a59a70829bafc85951d05c49efb571f9f51e557

Issue: #7368

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Histogram charts worked in Superset 0.31 but not in 0.32. The culprit seems to be the following pydruid change (contained in 0.5.2, that is listed among the Superset 0.32's requirements):
https://github.com/druid-io/pydruid/commit/0a59a70829bafc85951d05c49efb571f9f51e557

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Rendering a histogram chart from Druid data. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
