### PR TITLE
Remove the use of Pandas' iloc() in WorldMapViz

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1765,9 +1765,7 @@ class WorldMapViz(BaseViz):
         columns = ['country', 'm1', 'm2']
         if metric == secondary_metric:
             ndf = df[cols]
-            # df[metric] will be a DataFrame
-            # because there are duplicate column names
-            ndf['m1'] = df[metric].iloc[:, 0]
+            ndf['m1'] = df[metric]
             ndf['m2'] = ndf['m1']
         else:
             if secondary_metric:


### PR DESCRIPTION
This [commit](https://github.com/apache/incubator-superset/commit/71e0c079041c4f955e8529349baa17058e70d256#diff-f451672348fc6071e8d627778bdc4e96) changed the value of df[metric]
when the same metric is used in a World Map panel for both bubble size
and an axis (either X or Y). This change removes the use of .iloc that is not needed anymore (and causes exceptions while rendering world maps).

Should fix #7006

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
WorldMap charts, using the the same metric for X/Y axis and bubble size, are not working anymore from 0.29+ due to [commit](https://github.com/apache/incubator-superset/commit/71e0c079041c4f955e8529349baa17058e70d256#diff-f451672348fc6071e8d627778bdc4e96L1730-L1731). If I add the following snipped to the WorldMapViz in superset/viz.py everything works as expected again:

```
        qry['metrics'] = [
            self.form_data['metric'], self.form_data['secondary_metric']]
```

The .iloc functionality in WorldMap is not needed anymore.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
