### PR TITLE
[WIP] SIP #7380: Add optional, user-friendly label to Filter Box

### DIFF
--- a/superset/assets/src/explore/components/controls/FilterBoxItemControl.jsx
+++ b/superset/assets/src/explore/components/controls/FilterBoxItemControl.jsx
@@ -50,8 +50,8 @@ const STYLE_WIDTH = { width: 350 };
 export default class FilterBoxItemControl extends React.Component {
   constructor(props) {
     super(props);
-    const { column, metric, asc, clearable, multiple, defaultValue } = props;
-    const state = { column, metric, asc, clearable, multiple, defaultValue };
+    const { column, option_label, metric, asc, clearable, multiple, defaultValue } = props;
+    const state = { column, option_label, metric, asc, clearable, multiple, defaultValue };
     this.state = state;
     this.onChange = this.onChange.bind(this);
     this.onControlChange = this.onControlChange.bind(this);
@@ -82,6 +82,21 @@ export default class FilterBoxItemControl extends React.Component {
                 label: col.column_name,
               }))}
               onChange={v => this.onControlChange('column', v)}
+            />
+          }
+        />
+        <FormRow
+          label={t('Single Option Label')}
+          control={
+            <SelectControl
+              value={this.state.option_label}
+              name="option_label"
+              clearable={false}
+              options={this.props.datasource.columns.map(col => ({
+                value: col.column_name,
+                label: col.column_name,
+              }))}
+              onChange={v => this.onControlChange('option_label', v)}
             />
           }
         />

--- a/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
@@ -19,9 +19,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import VirtualizedSelect from 'react-virtualized-select';
-import {Creatable} from 'react-select';
-import {Button} from 'react-bootstrap';
-import {t} from '@superset-ui/translation';
+import { Creatable } from 'react-select';
+import { Button } from 'react-bootstrap';
+import { t } from '@superset-ui/translation';
 
 import DateFilterControl from '../../explore/components/controls/DateFilterControl';
 import ControlRow from '../../explore/components/ControlRow';
@@ -33,270 +33,263 @@ import './FilterBox.css';
 
 // maps control names to their key in extra_filters
 const TIME_FILTER_MAP = {
-    time_range: '__time_range',
-    granularity_sqla: '__time_col',
-    time_grain_sqla: '__time_grain',
-    druid_time_origin: '__time_origin',
-    granularity: '__granularity',
+  time_range: '__time_range',
+  granularity_sqla: '__time_col',
+  time_grain_sqla: '__time_grain',
+  druid_time_origin: '__time_origin',
+  granularity: '__granularity',
 };
 
 const TIME_RANGE = '__time_range';
 
 const propTypes = {
-    origSelectedValues: PropTypes.object,
-    datasource: PropTypes.object.isRequired,
-    instantFiltering: PropTypes.bool,
-    filtersFields: PropTypes.arrayOf(PropTypes.shape({
-        field: PropTypes.string,
-        label: PropTypes.string,
-    })),
-    filtersChoices: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
-        id: PropTypes.string,
-        text: PropTypes.string,
-        filter: PropTypes.string,
-        metric: PropTypes.number,
-    }))),
-    onChange: PropTypes.func,
-    showDateFilter: PropTypes.bool,
-    showSqlaTimeGrain: PropTypes.bool,
-    showSqlaTimeColumn: PropTypes.bool,
-    showDruidTimeGrain: PropTypes.bool,
-    showDruidTimeOrigin: PropTypes.bool,
+  origSelectedValues: PropTypes.object,
+  datasource: PropTypes.object.isRequired,
+  instantFiltering: PropTypes.bool,
+  filtersFields: PropTypes.arrayOf(PropTypes.shape({
+    field: PropTypes.string,
+    label: PropTypes.string,
+  })),
+  filtersChoices: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string,
+    text: PropTypes.string,
+    filter: PropTypes.string,
+    metric: PropTypes.number,
+  }))),
+  onChange: PropTypes.func,
+  showDateFilter: PropTypes.bool,
+  showSqlaTimeGrain: PropTypes.bool,
+  showSqlaTimeColumn: PropTypes.bool,
+  showDruidTimeGrain: PropTypes.bool,
+  showDruidTimeOrigin: PropTypes.bool,
 };
 const defaultProps = {
-    origSelectedValues: {},
-    onChange: () => {
-    },
-    showDateFilter: false,
-    showSqlaTimeGrain: false,
-    showSqlaTimeColumn: false,
-    showDruidTimeGrain: false,
-    showDruidTimeOrigin: false,
-    instantFiltering: true,
+  origSelectedValues: {},
+  onChange: () => {},
+  showDateFilter: false,
+  showSqlaTimeGrain: false,
+  showSqlaTimeColumn: false,
+  showDruidTimeGrain: false,
+  showDruidTimeOrigin: false,
+  instantFiltering: true,
 };
 
 class FilterBox extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            selectedValues: props.origSelectedValues,
-            hasChanged: false,
-        };
-        this.changeFilter = this.changeFilter.bind(this);
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedValues: props.origSelectedValues,
+      hasChanged: false,
+    };
+    this.changeFilter = this.changeFilter.bind(this);
+  }
+
+  getControlData(controlName) {
+    const { selectedValues } = this.state;
+    const control = Object.assign({}, controls[controlName], {
+      name: controlName,
+      key: `control-${controlName}`,
+      value: selectedValues[TIME_FILTER_MAP[controlName]],
+      actions: { setControlValue: this.changeFilter },
+    });
+    const mapFunc = control.mapStateToProps;
+    return mapFunc
+      ? Object.assign({}, control, mapFunc(this.props))
+      : control;
+  }
+
+  clickApply() {
+    const { selectedValues } = this.state;
+    Object.keys(selectedValues).forEach((fltr, i, arr) => {
+      let refresh = false;
+      if (i === arr.length - 1) {
+        refresh = true;
+      }
+      this.props.onChange(fltr, selectedValues[fltr], false, refresh);
+    });
+    this.setState({ hasChanged: false });
+  }
+
+  changeFilter(filter, options) {
+    const fltr = TIME_FILTER_MAP[filter] || filter;
+    let vals = null;
+    if (options !== null) {
+      if (Array.isArray(options)) {
+        vals = options.map(opt => opt.value);
+      } else if (options.value) {
+        vals = options.value;
+      } else {
+        vals = options;
+      }
     }
-
-    getControlData(controlName) {
-        const {selectedValues} = this.state;
-        const control = Object.assign({}, controls[controlName], {
-            name: controlName,
-            key: `control-${controlName}`,
-            value: selectedValues[TIME_FILTER_MAP[controlName]],
-            actions: {setControlValue: this.changeFilter},
-        });
-        const mapFunc = control.mapStateToProps;
-        return mapFunc
-            ? Object.assign({}, control, mapFunc(this.props))
-            : control;
+    const selectedValues = Object.assign({}, this.state.selectedValues);
+    selectedValues[fltr] = vals;
+    this.setState({ selectedValues, hasChanged: true });
+    if (this.props.instantFiltering) {
+      this.props.onChange(fltr, vals, false, true);
     }
+  }
 
-    clickApply() {
-        const {selectedValues} = this.state;
-        Object.keys(selectedValues).forEach((fltr, i, arr) => {
-            let refresh = false;
-            if (i === arr.length - 1) {
-                refresh = true;
-            }
-            this.props.onChange(fltr, selectedValues[fltr], false, refresh);
-        });
-        this.setState({hasChanged: false});
+  renderDateFilter() {
+    const { showDateFilter } = this.props;
+    if (showDateFilter) {
+      return (
+        <div className="row space-1">
+          <div className="col-lg-12 col-xs-12">
+            <DateFilterControl
+              name={TIME_RANGE}
+              label={t('Time range')}
+              description={t('Select start and end date')}
+              onChange={(...args) => { this.changeFilter(TIME_RANGE, ...args); }}
+              value={this.state.selectedValues[TIME_RANGE] || 'No filter'}
+            />
+          </div>
+        </div>
+      );
     }
+    return null;
+  }
 
-    changeFilter(filter, options) {
-        const fltr = TIME_FILTER_MAP[filter] || filter;
-        let vals = null;
-        if (options !== null) {
-            if (Array.isArray(options)) {
-                vals = options.map(opt => opt.value);
-            } else if (options.value) {
-                vals = options.value;
-            } else {
-                vals = options;
-            }
-        }
-        const selectedValues = Object.assign({}, this.state.selectedValues);
-        selectedValues[fltr] = vals;
-        this.setState({selectedValues, hasChanged: true});
-        if (this.props.instantFiltering) {
-            this.props.onChange(fltr, vals, false, true);
-        }
+  renderDatasourceFilters() {
+    const {
+      showSqlaTimeGrain,
+      showSqlaTimeColumn,
+      showDruidTimeGrain,
+      showDruidTimeOrigin,
+    } = this.props;
+    const datasourceFilters = [];
+    const sqlaFilters = [];
+    const druidFilters = [];
+    if (showSqlaTimeGrain) sqlaFilters.push('time_grain_sqla');
+    if (showSqlaTimeColumn) sqlaFilters.push('granularity_sqla');
+    if (showDruidTimeGrain) druidFilters.push('granularity');
+    if (showDruidTimeOrigin) druidFilters.push('druid_time_origin');
+    if (sqlaFilters.length) {
+      datasourceFilters.push(
+        <ControlRow
+          key="sqla-filters"
+          className="control-row"
+          controls={sqlaFilters.map(control => (
+            <Control {...this.getControlData(control)} />
+          ))}
+        />,
+      );
     }
-
-    renderDateFilter() {
-        const {showDateFilter} = this.props;
-        if (showDateFilter) {
-            return (
-                <div className="row space-1">
-                    <div className="col-lg-12 col-xs-12">
-                        <DateFilterControl
-                            name={TIME_RANGE}
-                            label={t('Time range')}
-                            description={t('Select start and end date')}
-                            onChange={(...args) => {
-                                this.changeFilter(TIME_RANGE, ...args);
-                            }}
-                            value={this.state.selectedValues[TIME_RANGE] || 'No filter'}
-                        />
-                    </div>
-                </div>
-            );
-        }
-        return null;
+    if (druidFilters.length) {
+      datasourceFilters.push(
+        <ControlRow
+          key="druid-filters"
+          className="control-row"
+          controls={druidFilters.map(control => (
+            <Control {...this.getControlData(control)} />
+          ))}
+        />,
+      );
     }
+    return datasourceFilters;
+  }
+  renderSelect(filterConfig) {
+    const { filtersChoices } = this.props;
+    const { selectedValues } = this.state;
 
-    renderDatasourceFilters() {
-        const {
-            showSqlaTimeGrain,
-            showSqlaTimeColumn,
-            showDruidTimeGrain,
-            showDruidTimeOrigin,
-        } = this.props;
-        const datasourceFilters = [];
-        const sqlaFilters = [];
-        const druidFilters = [];
-        if (showSqlaTimeGrain) sqlaFilters.push('time_grain_sqla');
-        if (showSqlaTimeColumn) sqlaFilters.push('granularity_sqla');
-        if (showDruidTimeGrain) druidFilters.push('granularity');
-        if (showDruidTimeOrigin) druidFilters.push('druid_time_origin');
-        if (sqlaFilters.length) {
-            datasourceFilters.push(
-                <ControlRow
-                    key="sqla-filters"
-                    className="control-row"
-                    controls={sqlaFilters.map(control => (
-                        <Control {...this.getControlData(control)} />
-                    ))}
-                />,
-            );
-        }
-        if (druidFilters.length) {
-            datasourceFilters.push(
-                <ControlRow
-                    key="druid-filters"
-                    className="control-row"
-                    controls={druidFilters.map(control => (
-                        <Control {...this.getControlData(control)} />
-                    ))}
-                />,
-            );
-        }
-        return datasourceFilters;
-    }
-
-    renderSelect(filterConfig) {
-        const {filtersChoices} = this.props;
-        const {selectedValues} = this.state;
-
-        // Add created options to filtersChoices, even though it doesn't exist,
-        // or these options will exist in query sql but invisible to end user.
-        Object.keys(selectedValues)
-            .filter(key => selectedValues.hasOwnProperty(key) && (key in filtersChoices))
-            .forEach((key) => {
-                const choices = filtersChoices[key] || [];
-                const choiceIds = new Set(choices.map(f => f.id));
-                const selectedValuesForKey = Array.isArray(selectedValues[key])
-                    ? selectedValues[key]
-                    : [selectedValues[key]];
-                selectedValuesForKey
-                    .filter(value => !choiceIds.has(value))
-                    .forEach((value) => {
-                        choices.unshift({
-                            filter: key,
-                            id: value,
-                            text: value,
-                            metric: 0,
-                        });
-                    });
+    // Add created options to filtersChoices, even though it doesn't exist,
+    // or these options will exist in query sql but invisible to end user.
+    Object.keys(selectedValues)
+      .filter(key => selectedValues.hasOwnProperty(key) && (key in filtersChoices))
+      .forEach((key) => {
+        const choices = filtersChoices[key] || [];
+        const choiceIds = new Set(choices.map(f => f.id));
+        const selectedValuesForKey = Array.isArray(selectedValues[key])
+          ? selectedValues[key]
+          : [selectedValues[key]];
+        selectedValuesForKey
+          .filter(value => !choiceIds.has(value))
+          .forEach((value) => {
+            choices.unshift({
+              filter: key,
+              id: value,
+              text: value,
+              metric: 0,
             });
-        const {key, label} = filterConfig;
-        const data = this.props.filtersChoices[key];
-        const max = Math.max(...data.map(d => d.metric));
-        let value = selectedValues[key] || null;
+          });
+      });
+    const { key, label } = filterConfig;
+    const data = this.props.filtersChoices[key];
+    const max = Math.max(...data.map(d => d.metric));
+    let value = selectedValues[key] || null;
 
-        // Assign default value if required
-        if (!value && filterConfig.defaultValue) {
-            if (filterConfig.multiple) {
-                // Support for semicolon-delimited multiple values
-                value = filterConfig.defaultValue.split(';');
-            } else {
-                value = filterConfig.defaultValue;
-            }
-        }
-
-        return (
-            <OnPasteSelect
-                placeholder={t('Select [%s]', label)}
-                key={key}
-                multi={filterConfig.multiple}
-                clearable={filterConfig.clearable}
-                value={value}
-                options={data.map((opt) => {
-                    const perc = Math.round((opt.metric / max) * 100);
-                    const backgroundImage = (
-                        'linear-gradient(to right, lightgrey, ' +
-                        `lightgrey ${perc}%, rgba(0,0,0,0) ${perc}%`
-                    );
-                    const style = {
-                        backgroundImage,
-                        padding: '2px 5px',
-                    };
-                    return {value: opt.id, label: opt.text, style};
-                })}
-                onChange={(...args) => {
-                    this.changeFilter(key, ...args);
-                }}
-                selectComponent={Creatable}
-                selectWrap={VirtualizedSelect}
-                optionRenderer={VirtualizedRendererWrap(opt => opt.label)}
-            />);
+    // Assign default value if required
+    if (!value && filterConfig.defaultValue) {
+      if (filterConfig.multiple) {
+        // Support for semicolon-delimited multiple values
+        value = filterConfig.defaultValue.split(';');
+      } else {
+        value = filterConfig.defaultValue;
+      }
     }
+    return (
+      <OnPasteSelect
+        placeholder={t('Select [%s]', label)}
+        key={key}
+        multi={filterConfig.multiple}
+        clearable={filterConfig.clearable}
+        value={value}
+        options={data.map((opt) => {
+          const perc = Math.round((opt.metric / max) * 100);
+          const backgroundImage = (
+            'linear-gradient(to right, lightgrey, ' +
+            `lightgrey ${perc}%, rgba(0,0,0,0) ${perc}%`
+          );
+          const style = {
+            backgroundImage,
+            padding: '2px 5px',
+          };
+            return {value: opt.id, label: opt.text, style};
+        })}
+        onChange={(...args) => { this.changeFilter(key, ...args); }}
+        selectComponent={Creatable}
+        selectWrap={VirtualizedSelect}
+        optionRenderer={VirtualizedRendererWrap(opt => opt.label)}
+      />);
+  }
 
-    renderFilters() {
+  renderFilters() {
 
-        const {filtersFields} = this.props;
-        return filtersFields.map((filterConfig) => {
-            const {label, key} = filterConfig;
-            return (
-                <div key={key} className="m-b-5">
-                    {label}
-                    {this.renderSelect(filterConfig)}
-                </div>
-            );
-        });
-    }
+    const { filtersFields } = this.props;
+    return filtersFields.map((filterConfig) => {
+      const { label, key } = filterConfig;
+      return (
+        <div key={key} className="m-b-5">
+          {label}
+          {this.renderSelect(filterConfig)}
+        </div>
+      );
+    });
+  }
 
-    render() {
-        const {instantFiltering} = this.props;
+  render() {
+    const { instantFiltering } = this.props;
 
-        return (
-            <div className="scrollbar-container">
-                <div className="scrollbar-content">
-                    {this.renderDateFilter()}
-                    {this.renderDatasourceFilters()}
-                    {this.renderFilters()}
-                    {!instantFiltering &&
-                    <Button
-                        bsSize="small"
-                        bsStyle="primary"
-                        onClick={this.clickApply.bind(this)}
-                        disabled={!this.state.hasChanged}
-                    >
-                        {t('Apply')}
-                    </Button>
-                    }
-                </div>
-            </div>
-        );
-    }
+    return (
+      <div className="scrollbar-container">
+        <div className="scrollbar-content">
+          {this.renderDateFilter()}
+          {this.renderDatasourceFilters()}
+          {this.renderFilters()}
+          {!instantFiltering &&
+            <Button
+              bsSize="small"
+              bsStyle="primary"
+              onClick={this.clickApply.bind(this)}
+              disabled={!this.state.hasChanged}
+            >
+              {t('Apply')}
+            </Button>
+          }
+        </div>
+      </div>
+    );
+  }
 }
 
 FilterBox.propTypes = propTypes;

--- a/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
@@ -19,9 +19,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import VirtualizedSelect from 'react-virtualized-select';
-import { Creatable } from 'react-select';
-import { Button } from 'react-bootstrap';
-import { t } from '@superset-ui/translation';
+import {Creatable} from 'react-select';
+import {Button} from 'react-bootstrap';
+import {t} from '@superset-ui/translation';
 
 import DateFilterControl from '../../explore/components/controls/DateFilterControl';
 import ControlRow from '../../explore/components/ControlRow';
@@ -33,263 +33,270 @@ import './FilterBox.css';
 
 // maps control names to their key in extra_filters
 const TIME_FILTER_MAP = {
-  time_range: '__time_range',
-  granularity_sqla: '__time_col',
-  time_grain_sqla: '__time_grain',
-  druid_time_origin: '__time_origin',
-  granularity: '__granularity',
+    time_range: '__time_range',
+    granularity_sqla: '__time_col',
+    time_grain_sqla: '__time_grain',
+    druid_time_origin: '__time_origin',
+    granularity: '__granularity',
 };
 
 const TIME_RANGE = '__time_range';
 
 const propTypes = {
-  origSelectedValues: PropTypes.object,
-  datasource: PropTypes.object.isRequired,
-  instantFiltering: PropTypes.bool,
-  filtersFields: PropTypes.arrayOf(PropTypes.shape({
-    field: PropTypes.string,
-    label: PropTypes.string,
-  })),
-  filtersChoices: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string,
-    text: PropTypes.string,
-    filter: PropTypes.string,
-    metric: PropTypes.number,
-  }))),
-  onChange: PropTypes.func,
-  showDateFilter: PropTypes.bool,
-  showSqlaTimeGrain: PropTypes.bool,
-  showSqlaTimeColumn: PropTypes.bool,
-  showDruidTimeGrain: PropTypes.bool,
-  showDruidTimeOrigin: PropTypes.bool,
+    origSelectedValues: PropTypes.object,
+    datasource: PropTypes.object.isRequired,
+    instantFiltering: PropTypes.bool,
+    filtersFields: PropTypes.arrayOf(PropTypes.shape({
+        field: PropTypes.string,
+        label: PropTypes.string,
+    })),
+    filtersChoices: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string,
+        text: PropTypes.string,
+        filter: PropTypes.string,
+        metric: PropTypes.number,
+    }))),
+    onChange: PropTypes.func,
+    showDateFilter: PropTypes.bool,
+    showSqlaTimeGrain: PropTypes.bool,
+    showSqlaTimeColumn: PropTypes.bool,
+    showDruidTimeGrain: PropTypes.bool,
+    showDruidTimeOrigin: PropTypes.bool,
 };
 const defaultProps = {
-  origSelectedValues: {},
-  onChange: () => {},
-  showDateFilter: false,
-  showSqlaTimeGrain: false,
-  showSqlaTimeColumn: false,
-  showDruidTimeGrain: false,
-  showDruidTimeOrigin: false,
-  instantFiltering: true,
+    origSelectedValues: {},
+    onChange: () => {
+    },
+    showDateFilter: false,
+    showSqlaTimeGrain: false,
+    showSqlaTimeColumn: false,
+    showDruidTimeGrain: false,
+    showDruidTimeOrigin: false,
+    instantFiltering: true,
 };
 
 class FilterBox extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedValues: props.origSelectedValues,
-      hasChanged: false,
-    };
-    this.changeFilter = this.changeFilter.bind(this);
-  }
-
-  getControlData(controlName) {
-    const { selectedValues } = this.state;
-    const control = Object.assign({}, controls[controlName], {
-      name: controlName,
-      key: `control-${controlName}`,
-      value: selectedValues[TIME_FILTER_MAP[controlName]],
-      actions: { setControlValue: this.changeFilter },
-    });
-    const mapFunc = control.mapStateToProps;
-    return mapFunc
-      ? Object.assign({}, control, mapFunc(this.props))
-      : control;
-  }
-
-  clickApply() {
-    const { selectedValues } = this.state;
-    Object.keys(selectedValues).forEach((fltr, i, arr) => {
-      let refresh = false;
-      if (i === arr.length - 1) {
-        refresh = true;
-      }
-      this.props.onChange(fltr, selectedValues[fltr], false, refresh);
-    });
-    this.setState({ hasChanged: false });
-  }
-
-  changeFilter(filter, options) {
-    const fltr = TIME_FILTER_MAP[filter] || filter;
-    let vals = null;
-    if (options !== null) {
-      if (Array.isArray(options)) {
-        vals = options.map(opt => opt.value);
-      } else if (options.value) {
-        vals = options.value;
-      } else {
-        vals = options;
-      }
+    constructor(props) {
+        super(props);
+        this.state = {
+            selectedValues: props.origSelectedValues,
+            hasChanged: false,
+        };
+        this.changeFilter = this.changeFilter.bind(this);
     }
-    const selectedValues = Object.assign({}, this.state.selectedValues);
-    selectedValues[fltr] = vals;
-    this.setState({ selectedValues, hasChanged: true });
-    if (this.props.instantFiltering) {
-      this.props.onChange(fltr, vals, false, true);
-    }
-  }
 
-  renderDateFilter() {
-    const { showDateFilter } = this.props;
-    if (showDateFilter) {
-      return (
-        <div className="row space-1">
-          <div className="col-lg-12 col-xs-12">
-            <DateFilterControl
-              name={TIME_RANGE}
-              label={t('Time range')}
-              description={t('Select start and end date')}
-              onChange={(...args) => { this.changeFilter(TIME_RANGE, ...args); }}
-              value={this.state.selectedValues[TIME_RANGE] || 'No filter'}
-            />
-          </div>
-        </div>
-      );
+    getControlData(controlName) {
+        const {selectedValues} = this.state;
+        const control = Object.assign({}, controls[controlName], {
+            name: controlName,
+            key: `control-${controlName}`,
+            value: selectedValues[TIME_FILTER_MAP[controlName]],
+            actions: {setControlValue: this.changeFilter},
+        });
+        const mapFunc = control.mapStateToProps;
+        return mapFunc
+            ? Object.assign({}, control, mapFunc(this.props))
+            : control;
     }
-    return null;
-  }
 
-  renderDatasourceFilters() {
-    const {
-      showSqlaTimeGrain,
-      showSqlaTimeColumn,
-      showDruidTimeGrain,
-      showDruidTimeOrigin,
-    } = this.props;
-    const datasourceFilters = [];
-    const sqlaFilters = [];
-    const druidFilters = [];
-    if (showSqlaTimeGrain) sqlaFilters.push('time_grain_sqla');
-    if (showSqlaTimeColumn) sqlaFilters.push('granularity_sqla');
-    if (showDruidTimeGrain) druidFilters.push('granularity');
-    if (showDruidTimeOrigin) druidFilters.push('druid_time_origin');
-    if (sqlaFilters.length) {
-      datasourceFilters.push(
-        <ControlRow
-          key="sqla-filters"
-          className="control-row"
-          controls={sqlaFilters.map(control => (
-            <Control {...this.getControlData(control)} />
-          ))}
-        />,
-      );
+    clickApply() {
+        const {selectedValues} = this.state;
+        Object.keys(selectedValues).forEach((fltr, i, arr) => {
+            let refresh = false;
+            if (i === arr.length - 1) {
+                refresh = true;
+            }
+            this.props.onChange(fltr, selectedValues[fltr], false, refresh);
+        });
+        this.setState({hasChanged: false});
     }
-    if (druidFilters.length) {
-      datasourceFilters.push(
-        <ControlRow
-          key="druid-filters"
-          className="control-row"
-          controls={druidFilters.map(control => (
-            <Control {...this.getControlData(control)} />
-          ))}
-        />,
-      );
-    }
-    return datasourceFilters;
-  }
-  renderSelect(filterConfig) {
-    const { filtersChoices } = this.props;
-    const { selectedValues } = this.state;
 
-    // Add created options to filtersChoices, even though it doesn't exist,
-    // or these options will exist in query sql but invisible to end user.
-    Object.keys(selectedValues)
-      .filter(key => selectedValues.hasOwnProperty(key) && (key in filtersChoices))
-      .forEach((key) => {
-        const choices = filtersChoices[key] || [];
-        const choiceIds = new Set(choices.map(f => f.id));
-        const selectedValuesForKey = Array.isArray(selectedValues[key])
-          ? selectedValues[key]
-          : [selectedValues[key]];
-        selectedValuesForKey
-          .filter(value => !choiceIds.has(value))
-          .forEach((value) => {
-            choices.unshift({
-              filter: key,
-              id: value,
-              text: value,
-              metric: 0,
+    changeFilter(filter, options) {
+        const fltr = TIME_FILTER_MAP[filter] || filter;
+        let vals = null;
+        if (options !== null) {
+            if (Array.isArray(options)) {
+                vals = options.map(opt => opt.value);
+            } else if (options.value) {
+                vals = options.value;
+            } else {
+                vals = options;
+            }
+        }
+        const selectedValues = Object.assign({}, this.state.selectedValues);
+        selectedValues[fltr] = vals;
+        this.setState({selectedValues, hasChanged: true});
+        if (this.props.instantFiltering) {
+            this.props.onChange(fltr, vals, false, true);
+        }
+    }
+
+    renderDateFilter() {
+        const {showDateFilter} = this.props;
+        if (showDateFilter) {
+            return (
+                <div className="row space-1">
+                    <div className="col-lg-12 col-xs-12">
+                        <DateFilterControl
+                            name={TIME_RANGE}
+                            label={t('Time range')}
+                            description={t('Select start and end date')}
+                            onChange={(...args) => {
+                                this.changeFilter(TIME_RANGE, ...args);
+                            }}
+                            value={this.state.selectedValues[TIME_RANGE] || 'No filter'}
+                        />
+                    </div>
+                </div>
+            );
+        }
+        return null;
+    }
+
+    renderDatasourceFilters() {
+        const {
+            showSqlaTimeGrain,
+            showSqlaTimeColumn,
+            showDruidTimeGrain,
+            showDruidTimeOrigin,
+        } = this.props;
+        const datasourceFilters = [];
+        const sqlaFilters = [];
+        const druidFilters = [];
+        if (showSqlaTimeGrain) sqlaFilters.push('time_grain_sqla');
+        if (showSqlaTimeColumn) sqlaFilters.push('granularity_sqla');
+        if (showDruidTimeGrain) druidFilters.push('granularity');
+        if (showDruidTimeOrigin) druidFilters.push('druid_time_origin');
+        if (sqlaFilters.length) {
+            datasourceFilters.push(
+                <ControlRow
+                    key="sqla-filters"
+                    className="control-row"
+                    controls={sqlaFilters.map(control => (
+                        <Control {...this.getControlData(control)} />
+                    ))}
+                />,
+            );
+        }
+        if (druidFilters.length) {
+            datasourceFilters.push(
+                <ControlRow
+                    key="druid-filters"
+                    className="control-row"
+                    controls={druidFilters.map(control => (
+                        <Control {...this.getControlData(control)} />
+                    ))}
+                />,
+            );
+        }
+        return datasourceFilters;
+    }
+
+    renderSelect(filterConfig) {
+        const {filtersChoices} = this.props;
+        const {selectedValues} = this.state;
+
+        // Add created options to filtersChoices, even though it doesn't exist,
+        // or these options will exist in query sql but invisible to end user.
+        Object.keys(selectedValues)
+            .filter(key => selectedValues.hasOwnProperty(key) && (key in filtersChoices))
+            .forEach((key) => {
+                const choices = filtersChoices[key] || [];
+                const choiceIds = new Set(choices.map(f => f.id));
+                const selectedValuesForKey = Array.isArray(selectedValues[key])
+                    ? selectedValues[key]
+                    : [selectedValues[key]];
+                selectedValuesForKey
+                    .filter(value => !choiceIds.has(value))
+                    .forEach((value) => {
+                        choices.unshift({
+                            filter: key,
+                            id: value,
+                            text: value,
+                            metric: 0,
+                        });
+                    });
             });
-          });
-      });
-    const { key, label } = filterConfig;
-    const data = this.props.filtersChoices[key];
-    const max = Math.max(...data.map(d => d.metric));
-    let value = selectedValues[key] || null;
+        const {key, label} = filterConfig;
+        const data = this.props.filtersChoices[key];
+        const max = Math.max(...data.map(d => d.metric));
+        let value = selectedValues[key] || null;
 
-    // Assign default value if required
-    if (!value && filterConfig.defaultValue) {
-      if (filterConfig.multiple) {
-        // Support for semicolon-delimited multiple values
-        value = filterConfig.defaultValue.split(';');
-      } else {
-        value = filterConfig.defaultValue;
-      }
+        // Assign default value if required
+        if (!value && filterConfig.defaultValue) {
+            if (filterConfig.multiple) {
+                // Support for semicolon-delimited multiple values
+                value = filterConfig.defaultValue.split(';');
+            } else {
+                value = filterConfig.defaultValue;
+            }
+        }
+
+        return (
+            <OnPasteSelect
+                placeholder={t('Select [%s]', label)}
+                key={key}
+                multi={filterConfig.multiple}
+                clearable={filterConfig.clearable}
+                value={value}
+                options={data.map((opt) => {
+                    const perc = Math.round((opt.metric / max) * 100);
+                    const backgroundImage = (
+                        'linear-gradient(to right, lightgrey, ' +
+                        `lightgrey ${perc}%, rgba(0,0,0,0) ${perc}%`
+                    );
+                    const style = {
+                        backgroundImage,
+                        padding: '2px 5px',
+                    };
+                    return {value: opt.id, label: opt.text, style};
+                })}
+                onChange={(...args) => {
+                    this.changeFilter(key, ...args);
+                }}
+                selectComponent={Creatable}
+                selectWrap={VirtualizedSelect}
+                optionRenderer={VirtualizedRendererWrap(opt => opt.label)}
+            />);
     }
-    return (
-      <OnPasteSelect
-        placeholder={t('Select [%s]', label)}
-        key={key}
-        multi={filterConfig.multiple}
-        clearable={filterConfig.clearable}
-        value={value}
-        options={data.map((opt) => {
-          const perc = Math.round((opt.metric / max) * 100);
-          const backgroundImage = (
-            'linear-gradient(to right, lightgrey, ' +
-            `lightgrey ${perc}%, rgba(0,0,0,0) ${perc}%`
-          );
-          const style = {
-            backgroundImage,
-            padding: '2px 5px',
-          };
-          return { value: opt.id, label: opt.id, style };
-        })}
-        onChange={(...args) => { this.changeFilter(key, ...args); }}
-        selectComponent={Creatable}
-        selectWrap={VirtualizedSelect}
-        optionRenderer={VirtualizedRendererWrap(opt => opt.label)}
-      />);
-  }
 
-  renderFilters() {
+    renderFilters() {
 
-    const { filtersFields } = this.props;
-    return filtersFields.map((filterConfig) => {
-      const { label, key } = filterConfig;
-      return (
-        <div key={key} className="m-b-5">
-          {label}
-          {this.renderSelect(filterConfig)}
-        </div>
-      );
-    });
-  }
+        const {filtersFields} = this.props;
+        return filtersFields.map((filterConfig) => {
+            const {label, key} = filterConfig;
+            return (
+                <div key={key} className="m-b-5">
+                    {label}
+                    {this.renderSelect(filterConfig)}
+                </div>
+            );
+        });
+    }
 
-  render() {
-    const { instantFiltering } = this.props;
+    render() {
+        const {instantFiltering} = this.props;
 
-    return (
-      <div className="scrollbar-container">
-        <div className="scrollbar-content">
-          {this.renderDateFilter()}
-          {this.renderDatasourceFilters()}
-          {this.renderFilters()}
-          {!instantFiltering &&
-            <Button
-              bsSize="small"
-              bsStyle="primary"
-              onClick={this.clickApply.bind(this)}
-              disabled={!this.state.hasChanged}
-            >
-              {t('Apply')}
-            </Button>
-          }
-        </div>
-      </div>
-    );
-  }
+        return (
+            <div className="scrollbar-container">
+                <div className="scrollbar-content">
+                    {this.renderDateFilter()}
+                    {this.renderDatasourceFilters()}
+                    {this.renderFilters()}
+                    {!instantFiltering &&
+                    <Button
+                        bsSize="small"
+                        bsStyle="primary"
+                        onClick={this.clickApply.bind(this)}
+                        disabled={!this.state.hasChanged}
+                    >
+                        {t('Apply')}
+                    </Button>
+                    }
+                </div>
+            </div>
+        );
+    }
 }
 
 FilterBox.propTypes = propTypes;

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1788,6 +1788,7 @@ class WorldMapViz(BaseViz):
 
 
 class FilterBoxViz(BaseViz):
+
     """A multi filter, multi-choice filter box to make dashboards interactive"""
 
     viz_type = 'filter_box'

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1811,7 +1811,7 @@ class FilterBoxViz(BaseViz):
             if not col:
                 raise Exception(_(
                     'Invalid filter configuration, please select a column'))
-            qry['groupby'] = [col]
+            qry['groupby'] = [col, 'pipeline_name'] # @todo: when reading-in the label field, apply it here.
             metric = flt.get('metric')
             qry['metrics'] = [metric] if metric else []
             df = self.get_df_payload(query_obj=qry).get('df')
@@ -1831,15 +1831,15 @@ class FilterBoxViz(BaseViz):
                 )
                 d[col] = [{
                     'id': row[0],
-                    'text': row[0],
-                    'metric': row[1]}
+                    'text': row[1],
+                    'metric': row[2]}
                     for row in df.itertuples(index=False)
                 ]
             else:
                 df = df.sort_values(col, ascending=flt.get('asc'))
                 d[col] = [{
                     'id': row[0],
-                    'text': row[0]}
+                    'text': row[1]}
                     for row in df.itertuples(index=False)
                 ]
         return d


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This PR corresponds to SIP https://github.com/apache/incubator-superset/issues/7380   
It allows the Filter Box to optionally source its option labels from a different field than the filter value. 

*Notes:* 

- this is backwards-compatible/non-breaking. The fallback/default behavior is to use the original label=value strategy. This also doesn't interfere with the metric property implementation. 

### ~~BEFORE/~~ AFTER SCREENSHOTS

**New Filter Box configuration** 
*Note the second select box, labeled "Single Option Label". It's a poor name for the option, but "Label" is more relevant where it is, and clarification was needed.* 

![Screenshot from 2019-04-25 09-17-59](https://user-images.githubusercontent.com/12756908/56738681-11bf6c80-673b-11e9-84fe-4fd483ffa42a.png)

**Filter Box using the friendly labels.** 
![Screenshot from 2019-04-25 09-16-07](https://user-images.githubusercontent.com/12756908/56738589-eb013600-673a-11e9-8d22-6d30ac9ab5fd.png)


### TEST PLAN
_all code/config here is from my personal reference implementation. of course, adjust field names/sql as needed_  

1. Setup a query that returns at least 2 fields: one for the filter value, and a separate one for the filter label 
- The source query from my reference use-case is:
```sql
select array_agg(gorm_pipeline_resources.tokenized_resource_id) as pipeline_datasets, pipelines.name as pipeline_name
from pipelines
         left join users on pipelines.owner_id = users.id
         left join gorm_pipeline_resources on pipelines.id = gorm_pipeline_resources.pipeline_id
where owner_id = 1
group by pipelines.id
order by pipeline_name ASC
```
- its sql lab output is
![Screenshot from 2019-04-25 09-27-25](https://user-images.githubusercontent.com/12756908/56739333-6a433980-673c-11e9-94fb-845d325531e0.png)

2. Configure a filter box using this datasource, according to the screenshots above. 
- For the filter in question, select Column: `pipeline_datasets` Single Option Label: `pipeline_name`

3. Create a datasource that references the filter: 
```jinja2
{% set vals = filter_values('pipeline_datasets', '0')[0] %}
SELECT  datasource_id as "ds_id",
        other_fields,
from some_table
WHERE datasource_id in ({{ vals|replace("[",'')|replace("]",'') }})
```

4. As usual, add the filter box, and chart(s) whose datasets reference the filter param. 


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI: optionally, allows filter box labels to come from a different field than the values. 
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API: resolves SIP #7380 (pending) 
- [ ] Removes existing feature or API

### REVIEWERS