### PR TITLE
[docs] Remove duplicate paragraph in celery tasks documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -660,10 +660,6 @@ users are active on the platform.
 
 Celery Tasks
 ------------
-On large analytic databases, it's common to run background jobs, reports
-and/or queries that execute for minutes or hours. In certain cases, we need
-to support long running tasks that execute beyond the typical web request's
-timeout (30-60 seconds).
 
 On large analytic databases, it's common to run queries that
 execute for minutes or hours.


### PR DESCRIPTION
### CATEGORY

- [x] Documentation

### SUMMARY

The duplicate paragraph was introduced here https://github.com/apache/incubator-superset/commit/808622414c0f901bbecc53678fca0085af41a04c#diff-548eb9ce4cac8e13a1238ad703272931R608

This commit removes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
