### PR TITLE
Setting renderTrigger on label_colors

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2095,6 +2095,7 @@ export const controls = {
     type: 'ColorMapControl',
     label: t('Color Map'),
     default: {},
+    renderTrigger: true,
     mapStateToProps: state => ({
       colorNamespace: state.form_data.color_namespace,
       colorScheme: state.form_data.color_scheme,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The "Chart Options" section is showing up under the data tab which looks confusing because it contains controls for the color, legend (things that don't affect the data). The section is moved to the data tab if any of the controls don't have renderTrigger true, so if label_colors is set to `renderTrigger` the "Chart Options" goes back to the Visual tab. 

### TEST PLAN
Go to explore, verify "Chart options" is under the "Visual Properties" tab

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #7393
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @khtruong 