### PR TITLE
[SQL Lab] Increase timeout threshold for offline check

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -27,7 +27,7 @@ import * as Actions from '../actions/sqlLab';
 const QUERY_UPDATE_FREQ = 2000;
 const QUERY_UPDATE_BUFFER_MS = 5000;
 const MAX_QUERY_AGE_TO_POLL = 21600000;
-const QUERY_TIMEOUT_LIMIT = 7000;
+const QUERY_TIMEOUT_LIMIT = 10000;
 
 class QueryAutoRefresh extends React.PureComponent {
   componentWillMount() {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In #6013, we introduced a feature: in sql lab, after user sent out query, if there is no response from backend in a few seconds, sql lab will display `offline` label, to remind user to check network connection or VPN connection. This feature was trying to fix an issue like, a user might open sql lab in an environment without internet connection, or move computer from one place to another,  when he run sql lab, the query may stuck in `pending` state for a long time, but user may not be aware it's network connection issue or sql lab performance issue.

The threshold for waiting backend response was 7 seconds. But we found many users in slow internet connect (or VPN) environment, 7 seconds is too short. So they will see `offline` label first, then query response come back later, this experience is very confusing. 

In this PR, i want to increase the wait threshold from 7 second to 10 seconds.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
no

### TEST PLAN
manual test


### REVIEWERS
@john-bodley @timifasubaa @michellethomas 