### PR TITLE
Fixes dashboard export button broken download

### DIFF
--- a/superset/templates/superset/export_dashboards.html
+++ b/superset/templates/superset/export_dashboards.html
@@ -18,7 +18,16 @@
 #}
 <script>
     window.onload = function() {
-        window.open(window.location += '&action=go', '_blank');
-        window.location = '{{ dashboards_url }}';
+
+        // See issue #7353, window.open fails
+        var a = document.createElement('a');
+        a.href = window.location + '&action=go';
+        a.download = 'dashboards.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+
+        window.location = '{{ dashboards_url }}';    
+
     };
 </script>


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Strangely window.open followed by changing window.location in the export dashboard page stopped working a few months ago, possibly because of changes in browser behavior. This resulted in the Dashboard export action failing. My fix is to build a link and click it, which does work consistently.

The related Python code is here: https://github.com/apache/incubator-superset/blob/master/superset/views/core.py#L675-L696 but this seems purely a Javascript issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

I verified exports work again in Chrome and Safari.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #7353
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@mistercrunch 