### PR TITLE
[sql lab] Fix setting async query status to timed_out

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -37,7 +37,7 @@ from flask_babel import lazy_gettext as _
 import pandas as pd
 import simplejson as json
 import sqlalchemy as sqla
-from sqlalchemy import and_, create_engine, MetaData, or_, update
+from sqlalchemy import create_engine, MetaData, or_
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import IntegrityError
 from werkzeug.routing import BaseConverter
@@ -2752,12 +2752,10 @@ class Superset(BaseSupersetView):
         ]
 
         if queries_to_timeout:
-            update(Query).where(
-                and_(
-                    Query.user_id == g.user.get_id(),
-                    Query.client_id in queries_to_timeout,
-                ),
-            ).values(state=QueryStatus.TIMED_OUT)
+            for q in sql_queries:
+                if q.client_id in queries_to_timeout:
+                    q.status = QueryStatus.TIMED_OUT
+            db.session.commit()
 
             for client_id in queries_to_timeout:
                 dict_queries[client_id]['status'] = QueryStatus.TIMED_OUT


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In #4833, we tried to introduce a feature that setting old async query status to be `timed_out`, when the query status stuck at pending or running without updates after 6 hours. This status will help front-end (browser) not fetching very old query status. The bug i found is backend didn't commit transaction, so there is no records in query table has status `timed_out` (but keeps in running status for very very long time).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
When user's query has no updates after 6 hours, front-end should show this error message:
<img width="1097" alt="Screen Shot 2019-05-01 at 11 55 41 PM" src="https://user-images.githubusercontent.com/27990562/57094253-f5847800-6cc4-11e9-915b-0a69210a2fc3.png">

### TEST PLAN
send async query, then check query table. We should see old queries status that were `running` or `pending`,  should updated to be `timed_out`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley @michellethomas @timifasubaa @mistercrunch 