### PR TITLE
Quick fix to address deadlock issue

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -195,13 +195,14 @@ if not issubclass(custom_sm, SupersetSecurityManager):
          not FAB's security manager.
          See [4565] in UPDATING.md""")
 
-appbuilder = AppBuilder(
-    app,
-    db.session,
-    base_template='superset/base.html',
-    indexview=MyIndexView,
-    security_manager_class=custom_sm,
-)
+with app.app_context():
+    appbuilder = AppBuilder(
+        app,
+        db.session,
+        base_template='superset/base.html',
+        indexview=MyIndexView,
+        security_manager_class=custom_sm,
+    )
 
 security_manager = appbuilder.sm
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This is a fix to address an issue where FAB fails to release its underlying DB session after initializing. We are seeing an issue where locks are open to tables that need to be migrated by another process.


### REVIEWERS
@mistercrunch 
