### PR TITLE
feat: view presto row objects in data grid

### DIFF
--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -138,7 +138,7 @@ export default class FilterableTable extends PureComponent {
 
   headerRenderer({ dataKey, label, sortBy, sortDirection }) {
     return (
-      <div>
+      <div className="header-style">
         {label}
         {sortBy === dataKey &&
           <SortIndicator sortDirection={sortDirection} />

--- a/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
+++ b/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
@@ -73,9 +73,7 @@
 .even-row { background: #f2f2f2; }
 .odd-row { background: #ffffff; }
 .header-style {
-  direction: rtl;
   overflow: hidden;
-  text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
+++ b/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
@@ -72,3 +72,10 @@
 }
 .even-row { background: #f2f2f2; }
 .odd-row { background: #ffffff; }
+.header-style {
+  direction: rtl;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -49,6 +49,7 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.result import RowProxy
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.sql import quoted_name, text
+from sqlalchemy.sql.expression import ColumnClause
 from sqlalchemy.sql.expression import TextAsFrom
 from sqlalchemy.types import String, UnicodeText
 import sqlparse
@@ -981,18 +982,81 @@ class PrestoEngineSpec(BaseEngineSpec):
         return result
 
     @classmethod
+    def _is_column_name_quoted(cls, column_name: str) -> bool:
+        """
+        Check if column name is in quotes
+        :param column_name: column name
+        :return: boolean
+        """
+        return column_name.startswith('"') and column_name.endswith('"')
+
+    @classmethod
+    def _get_fields(cls, cols: List[dict]) -> List[ColumnClause]:
+        """
+        Format column clauses where names are in quotes and labels are specified
+        :param cols: columns
+        :return: column clauses
+        """
+        column_clauses = []
+        dot_regex = r'\.(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)'
+        for col in cols:
+            # get individual column names
+            col_names = re.split(dot_regex, col['name'])
+            # quote each column name if it is not already quoted
+            for index, col_name in enumerate(col_names):
+                if not cls._is_column_name_quoted(col_name):
+                    col_names[index] = '"{}"'.format(col_name)
+            quoted_col_name = '.'.join(col_names)
+            # create column clause in the format "name"."name" AS "name.name"
+            column_clause = sqla.literal_column(quoted_col_name).label(col['name'])
+            column_clauses.append(column_clause)
+        return column_clauses
+
+    @classmethod
+    def _filter_presto_cols(cls, cols: List[dict]) -> List[dict]:
+        """
+        We want to filter out columns that correspond to array content because you cannot
+        select array content without an index, which will lead to a large and complicated
+        query. We know which columns to skip because cols is a list provided to us in a
+        specific order where a structural column is positioned right before its content.
+
+        Example: Column Name: ColA, Column Data Type: array(row(nest_obj int))
+                 cols = [ ..., ColA, ColA.nest_obj, ... ]
+
+        When we run across an array, check if subsequent column names start with the
+        array name and skip them.
+        :param cols: columns
+        :return: filtered list of columns
+        """
+        filtered_cols = []
+        curr_array_col_name = ''
+        for col in cols:
+            # col corresponds to an array's content and should be skipped
+            if curr_array_col_name and col['name'].startswith(curr_array_col_name):
+                continue
+            # col is an array so we need to check if subsequent
+            # columns correspond to the array's contents
+            elif str(col['type']) == 'ARRAY':
+                curr_array_col_name = col['name']
+                filtered_cols.append(col)
+            else:
+                curr_array_col_name = ''
+                filtered_cols.append(col)
+        return filtered_cols
+
+    @classmethod
     def select_star(cls, my_db, table_name: str, engine: Engine, schema: str = None,
                     limit: int = 100, show_cols: bool = False, indent: bool = True,
                     latest_partition: bool = True, cols: List[dict] = []) -> str:
         """
-        Temporary method until we have a function that can handle row and array columns
+        Include selecting properties of row objects. We cannot easily break arrays into
+        rows, so render the whole array in its own row and skip columns that correspond
+        to an array's contents.
         """
         presto_cols = cols
         if show_cols:
-            dot_regex = r'\.(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)'
-            presto_cols = [
-                col for col in presto_cols if re.search(dot_regex, col['name']) is None]
-        return BaseEngineSpec.select_star(
+            presto_cols = cls._filter_presto_cols(cols)
+        return super(PrestoEngineSpec, cls).select_star(
             my_db, table_name, engine, schema, limit,
             show_cols, indent, latest_partition, presto_cols,
         )
@@ -1525,6 +1589,10 @@ class HiveEngineSpec(PrestoEngineSpec):
                 if c.get('name') == col_name:
                     return qry.where(Column(col_name) == value)
         return False
+
+    @classmethod
+    def _get_fields(cls, cols: List[dict]) -> List[ColumnClause]:
+        return BaseEngineSpec._get_fields(cols)
 
     @classmethod
     def latest_sub_partition(cls, table_name, schema, database, **kwargs):

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1002,10 +1002,10 @@ class PrestoEngineSpec(BaseEngineSpec):
         # if they are not enclosed in quotes because if a period is enclosed in quotes,
         # then that period is part of a column name.
         dot_pattern = r"""\.                # split on period
-                        (?=                 # look ahead
-                        (?:                 # create non-capture group
-                        [^\"]*\"[^\"]*\"    # two quotes
-                        )*[^\"]*$)          # end regex"""
+                          (?=               # look ahead
+                          (?:               # create non-capture group
+                          [^\"]*\"[^\"]*\"  # two quotes
+                          )*[^\"]*$)        # end regex"""
         dot_regex = re.compile(dot_pattern, re.VERBOSE)
         for col in cols:
             # get individual column names

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -383,6 +383,29 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             ('column_name.nested_obj', 'FLOAT')]
         self.verify_presto_column(presto_column, expected_results)
 
+    def test_presto_get_fields(self):
+        cols = [
+            {'name': 'column'},
+            {'name': 'column.nested_obj'},
+            {'name': 'column."quoted.nested obj"'}]
+        actual_results = PrestoEngineSpec._get_fields(cols)
+        expected_results = [
+            {'name': '"column"', 'label': 'column'},
+            {'name': '"column"."nested_obj"', 'label': 'column.nested_obj'},
+            {'name': '"column"."quoted.nested obj"',
+             'label': 'column."quoted.nested obj"'}]
+        for actual_result, expected_result in zip(actual_results, expected_results):
+            self.assertEqual(actual_result.element.name, expected_result['name'])
+            self.assertEqual(actual_result.name, expected_result['label'])
+
+    def test_presto_filter_presto_cols(self):
+        cols = [
+            {'name': 'column', 'type': 'ARRAY'},
+            {'name': 'column.nested_obj', 'type': 'FLOAT'}]
+        actual_results = PrestoEngineSpec._filter_presto_cols(cols)
+        expected_results = [cols[0]]
+        self.assertEqual(actual_results, expected_results)
+
     def test_hive_get_view_names_return_empty_list(self):
         self.assertEquals([], HiveEngineSpec.get_view_names(mock.ANY, mock.ANY))
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A row or array column is displayed in a single column. This was difficult to comprehend if there were many fields in the row or array.

**Example:**
Name: ColumnA
Data type: row(nested_column1 float, rowA row(rowB row(nested_column2 int)))

Previous Data Grid Display:
<img width="86" alt="Screen Shot 2019-05-02 at 2 49 51 PM" src="https://user-images.githubusercontent.com/47833996/57109142-8ff6b280-6ce9-11e9-914c-469b91cfa0da.png">

This change will separate out row fields into its own column.

New Data Grid Display: 
<img width="463" alt="Screen Shot 2019-05-02 at 2 49 36 PM" src="https://user-images.githubusercontent.com/47833996/57109145-938a3980-6ce9-11e9-8137-6d7714cb6f50.png">

If the array is an array of row objects, we just display the whole thing like before. Ideally we would like to see that information more clearly but that is tracked by another story.

The changes look like a lot but really we are just doing the following 2 things:
1. Filter out any columns related to arrays of row objects. For example:
Name: ColumnB
Data type: array(row(nested_column int))
We have column objects for ColumnB and ColumnB.nested_column but we ignore the object corresponding to ColumnB.nested_column because we cannot easily create a select statement for such columns.
2. Create column clauses correctly where column names in dot notation are quoted and we provide a label for the column. For example:
ColumnA.nested_object would be represented as "ColumnA"."nested_object" AS "ColumnA.nested_object"

### TEST PLAN
Manually and added unit tests

### REVIEWERS
@betodealmeida @DiggidyDave @bearcage @xtinec @datability-io @john-bodley @michellethomas @graceguo-supercat @mistercrunch 

@williaster @kristw I made a small change to the data grid where headers are elided from the left if they are too long.