### PR TITLE
Fixes problem in Datasource YAML export of sorting by lists of varying types by stringifying the list

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -212,7 +212,7 @@ class ImportMixin(object):
                             include_defaults=include_defaults,
                         ) for child in getattr(self, c)
                     ],
-                    key=lambda k: sorted(k.items()))
+                    key=lambda k: sorted(str(k.items())))
 
         return dict_rep
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Exporting the main sqlite database to YAML via the List Databases interface and its Export to YAML option fails with the error TypeError: '<' not supported between instances of 'dict' and 'dict'. See #7437.

The problem/solution: We're sorting exported things by lists of lists of fields. The inner lists sometimes have different types which created this bug. So I stringify them and it fixes them. The outer sort doesn't care about the type of the inner sort, only that it is deterministic. Which, it still is :)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

`tox -e py36 tests/import_export_tests.py` all pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #7437
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@mistercrunch 