### PR TITLE
Workaround for no results returned

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -41,10 +41,18 @@ class QueryAutoRefresh extends React.PureComponent {
     const { queries, queriesLastUpdate } = this.props;
     const now = new Date().getTime();
 
+    // due to a race condition, queries can be marked as successful before the
+    // results key is set; this is a workaround until we fix the underlying
+    // problem
+    const isQueryRunning = q => (
+      ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 ||
+      (q.state === 'success' && q.resultsKey === null)
+    );
+
     return (
       queriesLastUpdate > 0 &&
       Object.values(queries).some(
-        q => ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 &&
+        q => isQueryRunning(q) &&
         now - q.startDttm < MAX_QUERY_AGE_TO_POLL,
       )
     );


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/incubator-superset/pull/7198 fixed a race condition in SQL Lab where the query payload would have state `success` but the `resultsKey` was set to `null`. Because of this, SQL Lab would stop polling the queries, but would never show the results because there was no `resultsKey`.

@vylc reported that the bug is still happening. As a workaround, I changed the code so that it keeps polling when the state is `success` but `resultsKeys` is `null`. This should make the frontend poll until it can show the results from the query.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I wasn't able to reproduce the problem, which is why I did this workaround. But I tested SQL Lab with this change, and it works as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@datability-io 