### PR TITLE
[security] Adding Flask-Talisman

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt setup.py
 #
+
 alembic==1.0.0            # via flask-migrate
 amqp==2.3.2               # via kombu
 apispec[yaml]==1.2.0      # via flask-appbuilder
@@ -32,6 +33,7 @@ flask-login==0.4.1        # via flask-appbuilder
 flask-migrate==2.1.1
 flask-openid==1.2.5       # via flask-appbuilder
 flask-sqlalchemy==2.3.2   # via flask-appbuilder, flask-migrate
+flask-talisman==0.6.0
 flask-wtf==0.14.2
 flask==1.0.2
 geopy==1.11.0
@@ -70,7 +72,7 @@ requests==2.20.0
 retry==0.9.2
 selenium==3.141.0
 simplejson==3.15.0
-six==1.11.0               # via bleach, cryptography, flask-jwt-extended, isodate, jsonschema, pathlib2, polyline, prison, pydruid, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
+six==1.11.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, pathlib2, polyline, prison, pydruid, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
 sqlalchemy-utils==0.32.21
 sqlalchemy==1.3.1
 sqlparse==0.2.4

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'flask-appbuilder>=2.0.0, <2.3.0',
         'flask-caching',
         'flask-compress',
+        'flask-talisman',
         'flask-migrate',
         'flask-wtf',
         'geopy',

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -27,6 +27,7 @@ from flask_appbuilder import AppBuilder, IndexView, SQLA
 from flask_appbuilder.baseviews import expose
 from flask_compress import Compress
 from flask_migrate import Migrate
+from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
 from werkzeug.contrib.fixers import ProxyFix
 import wtforms_json
@@ -228,6 +229,8 @@ def is_feature_enabled(feature):
 # Flask-Compress
 if conf.get('ENABLE_FLASK_COMPRESS'):
     Compress(app)
+
+Talisman(app, content_security_policy=None)
 
 # Hook that provides administrators a handle on the Flask APP
 # after initialization

--- a/superset/config.py
+++ b/superset/config.py
@@ -406,13 +406,9 @@ CELERY_CONFIG = CeleryConfig
 CELERY_CONFIG = None
 """
 
-# static http headers to be served by your Superset server.
-# This header prevents iFrames from other domains and
-# "clickjacking" as a result
-HTTP_HEADERS = {'X-Frame-Options': 'SAMEORIGIN'}
-# If you need to allow iframes from other domains (and are
-# aware of the risks), you can disable this header:
-# HTTP_HEADERS = {}
+# Additional static HTTP headers to be served by your Superset server. Note
+# Flask-Talisman aplies the relevant security HTTP headers.
+HTTP_HEADERS = {}
 
 # The db id here results in selecting this one as a default in SQL Lab
 DEFAULT_DB_ID = None

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -3014,7 +3014,7 @@ appbuilder.add_separator('Sources')
 
 
 @app.after_request
-def apply_caching(response):
+def apply_http_headers(response):
     """Applies the configuration's http headers to all responses"""
     for k, v in config.get('HTTP_HEADERS').items():
         response.headers[k] = v


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

As discussed in the Meetup on [2019-05-03](https://docs.google.com/document/d/1xRLqmUn-G7WiPe8qZnfuvbrYHZ1jmk9aSv9Bhjis2tg/edit#) a security audit at Airbnb surfaced a few recommendations in terms of security header settings. Specifically they recommended:

- Setting the secure flag on session cookies
- Support HTTP Strict Transport Security (HSTS)

Reading through the Flask security [documentation](http://flask.pocoo.org/docs/1.0/security/#security-headers) on security header they mention that the [Flask-Talisman](https://github.com/GoogleCloudPlatform/flask-talisman) package can be used to manage various security headers.   

It mentions that a subset of default configuration/options handles: 

> - Sets X-Frame-Options to SAMEORIGIN to avoid clickjacking.
> - Sets Flask's session cookie to secure, so it will never be set if your application is somehow accessed via a non-secure connection.
> - strict_transport_security, default True, whether to send HSTS headers.

The first one was already enabled for Superset and the later two addresses the two security concerns mentioned above.  Unless we have dedicated or knowledgable security personnel, using something like Flask-Talisman with a blanket type approach to best practices around security seems like a good approach. 

Note it's not apparent whether each Superset installation would want to handle security differently and currently the package is configurable only via the `Talisman` class or `Talisman.init_app(...)` options. In the future if we require this to be more configurable we could expose some of these configurations in Superset's configuration or leverage the mutator, i.e., 

```
# superset/__init__.py

talisman = Talisman()
```

```
# superset_config.py

FLASK_APP_MUTATOR = mutator

def mutator(app):
    from superset import talisman 
   
    talisman.init_app(app, force_https=False)
```

### TEST PLAN

CI. 

### REVIEWERS

to: @betodealmeida @DiggidyDave @dpgaspar @graceguo-supercat @michellethomas @mistercrunch 
