### PR TITLE
Only allow GET method for explore_json by feature flag

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -203,6 +203,7 @@ LANGUAGES = {
 DEFAULT_FEATURE_FLAGS = {
     # Experimental feature introducing a client (browser) cache
     'CLIENT_CACHE': False,
+    'ENABLE_EXPLORE_JSON_CSRF_PROTECTION': False,
 }
 
 # A function that receives a dict of all feature flags

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -32,6 +32,7 @@ from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
 from flask_wtf.form import FlaskForm
 import simplejson as json
+from werkzeug.exceptions import HTTPException
 from wtforms.fields.core import Field, UnboundField
 import yaml
 
@@ -127,6 +128,12 @@ def handle_api_exception(f):
             return json_error_response(utils.error_msg_from_exception(e),
                                        stacktrace=traceback.format_exc(),
                                        status=e.status)
+        except HTTPException as e:
+            logging.exception(e)
+            return json_error_response(utils.error_msg_from_exception(e),
+                                       stacktrace=traceback.format_exc(),
+                                       status=e.code)
+
         except Exception as e:
             logging.exception(e)
             return json_error_response(utils.error_msg_from_exception(e),

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -40,12 +40,13 @@ import sqlalchemy as sqla
 from sqlalchemy import and_, create_engine, MetaData, or_, update
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import IntegrityError
+from werkzeug.exceptions import MethodNotAllowed
 from werkzeug.routing import BaseConverter
 from werkzeug.utils import secure_filename
 
 from superset import (
-    app, appbuilder, cache, conf, db, get_feature_flags, results_backend,
-    security_manager, sql_lab, viz)
+    app, appbuilder, cache, conf, db, get_feature_flags, is_feature_enabled,
+    results_backend, security_manager, sql_lab, viz)
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.sqla.models import AnnotationDatasource, SqlaTable
 from superset.exceptions import SupersetException
@@ -1238,9 +1239,12 @@ class Superset(BaseSupersetView):
         requests that GETs or POSTs a form_data.
 
         `self.generate_json` receives this input and returns different
-        payloads based on the request args in the first block
+        payloads based on the request args in the first block"""
+        if (request.method != 'POST' and
+                is_feature_enabled('ENABLE_EXPLORE_JSON_CSRF_PROTECTION')):
+            raise MethodNotAllowed(valid_methods=['POST'])
 
-        TODO: break into one endpoint for each return shape"""
+        # TODO: break into one endpoint for each return shape
         csv = request.args.get('csv') == 'true'
         query = request.args.get('query') == 'true'
         results = request.args.get('results') == 'true'


### PR DESCRIPTION
### CATEGORY

Choose one

- [] Bug Fix
- [x] Enhancement (new features, refinement)
- [x] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In some companies they need to product query requests again CSRF, while other companies may not need it. Airbnb security team requested that explore_json endpoint should only allow POST method (with CSRF protection), and should not expose data parameters in request url. Currently even with feature flag to disable GET request, the backend will respond to both GET and POST requests regardless of the flag value. 

**Solution**: 
when **ENABLE_EXPLORE_JSON_CSRF_PROTECTION** feature flag is set to `True`, GETs are disabled in explore_json endpoint, and the backend does nothing and responds with a **405 MethodNotAllowed**

### TEST PLAN
CI and regression tests for all Superset

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@paulbramsen @betodealmeida @michellethomas @john-bodley 
