### PR TITLE
Fixes World Bank example Rural Population chart

### DIFF
--- a/superset/data/world_bank.py
+++ b/superset/data/world_bank.py
@@ -71,7 +71,7 @@ def load_world_bank_health_n_pop():
 
     metrics = [
         'sum__SP_POP_TOTL', 'sum__SH_DYN_AIDS', 'sum__SH_DYN_AIDS',
-        'sum__SP_RUR_TOTL_ZS', 'sum__SP_DYN_LE00_IN',
+        'sum__SP_RUR_TOTL_ZS', 'sum__SP_DYN_LE00_IN', 'sum__SP_RUR_TOTL'
     ]
     for m in metrics:
         if not any(col.metric_name == m for col in tbl.metrics):


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

The Rural breakdown chart is broken because the metric 'sum__SP_RUR_TOTL' is missing. This pull request adds it and fixes the chart. See #7451.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

`tox -e py36 tests/load_examples_test.py` passes
Manual testing shows the chart is now visible (ooooh, pretty!)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #7451
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@mistercrunch 