### PR TITLE
Add support for period character in table names

### DIFF
--- a/superset/assets/spec/javascripts/components/TableSelector_spec.jsx
+++ b/superset/assets/spec/javascripts/components/TableSelector_spec.jsx
@@ -209,18 +209,19 @@ describe('TableSelector', () => {
     it('test 1', () => {
       wrapper.instance().changeTable({
         value: { schema: 'main', table: 'birth_names' },
-        label: 'main.birth_names',
+        label: 'birth_names',
       });
       expect(wrapper.state().tableName).toBe('birth_names');
     });
 
-    it('test 2', () => {
+    it('should call onTableChange with schema from table object', () => {
+      wrapper.setProps({ schema: null });
       wrapper.instance().changeTable({
-        value: { schema: 'main', table: 'my_table' },
-        label: 'my_table',
+        value: { schema: 'other_schema', table: 'my_table' },
+        label: 'other_schema.my_table',
       });
       expect(mockedProps.onTableChange.getCall(0).args[0]).toBe('my_table');
-      expect(mockedProps.onTableChange.getCall(0).args[1]).toBe('main');
+      expect(mockedProps.onTableChange.getCall(0).args[1]).toBe('other_schema');
     });
   });
 

--- a/superset/assets/spec/javascripts/components/TableSelector_spec.jsx
+++ b/superset/assets/spec/javascripts/components/TableSelector_spec.jsx
@@ -208,15 +208,15 @@ describe('TableSelector', () => {
 
     it('test 1', () => {
       wrapper.instance().changeTable({
-        value: 'birth_names',
-        label: 'birth_names',
+        value: { schema: 'main', table: 'birth_names' },
+        label: 'main.birth_names',
       });
       expect(wrapper.state().tableName).toBe('birth_names');
     });
 
     it('test 2', () => {
       wrapper.instance().changeTable({
-        value: 'main.my_table',
+        value: { schema: 'main', table: 'my_table' },
         label: 'my_table',
       });
       expect(mockedProps.onTableChange.getCall(0).args[0]).toBe('my_table');

--- a/superset/assets/spec/javascripts/sqllab/fixtures.js
+++ b/superset/assets/spec/javascripts/sqllab/fixtures.js
@@ -329,15 +329,15 @@ export const databases = {
 export const tables = {
   options: [
     {
-      value: 'birth_names',
+      value: {'schema': 'main', 'table': 'birth_names'},
       label: 'birth_names',
     },
     {
-      value: 'energy_usage',
+      value: {'schema': 'main', 'table': 'energy_usage'},
       label: 'energy_usage',
     },
     {
-      value: 'wb_health_population',
+      value: {'schema': 'main', 'table': 'wb_health_population'},
       label: 'wb_health_population',
     },
   ],

--- a/superset/assets/spec/javascripts/sqllab/fixtures.js
+++ b/superset/assets/spec/javascripts/sqllab/fixtures.js
@@ -329,15 +329,15 @@ export const databases = {
 export const tables = {
   options: [
     {
-      value: {'schema': 'main', 'table': 'birth_names'},
+      value: { schema: 'main', table: 'birth_names' },
       label: 'birth_names',
     },
     {
-      value: {'schema': 'main', 'table': 'energy_usage'},
+      value: { schema: 'main', table: 'energy_usage' },
       label: 'energy_usage',
     },
     {
-      value: {'schema': 'main', 'table': 'wb_health_population'},
+      value: { schema: 'main', table: 'wb_health_population' },
       label: 'wb_health_population',
     },
   ],

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -83,8 +83,8 @@ export default class SqlEditorLeftBar extends React.PureComponent {
       this.setState({ tableName: '' });
       return;
     }
-    const schemaName = tableOpt.value['schema'];
-    const tableName = tableOpt.value['table'];
+    const schemaName = tableOpt.value.schema;
+    const tableName = tableOpt.value.table;
     this.setState({ tableName });
     this.props.actions.queryEditorSetSchema(this.props.queryEditor, schemaName);
     this.props.actions.addTable(this.props.queryEditor, tableName, schemaName);

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -83,17 +83,10 @@ export default class SqlEditorLeftBar extends React.PureComponent {
       this.setState({ tableName: '' });
       return;
     }
-    const namePieces = tableOpt.value.split('.');
-    let tableName = namePieces[0];
-    let schemaName = this.props.queryEditor.schema;
-    if (namePieces.length === 1) {
-      this.setState({ tableName });
-    } else {
-      schemaName = namePieces[0];
-      tableName = namePieces[1];
-      this.setState({ tableName });
-      this.props.actions.queryEditorSetSchema(this.props.queryEditor, schemaName);
-    }
+    const schemaName = tableOpt.value['schema'];
+    const tableName = tableOpt.value['table'];
+    this.setState({ tableName });
+    this.props.actions.queryEditorSetSchema(this.props.queryEditor, schemaName);
     this.props.actions.addTable(this.props.queryEditor, tableName, schemaName);
   }
 

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -170,13 +170,8 @@ export default class TableSelector extends React.PureComponent {
       this.setState({ tableName: '' });
       return;
     }
-    const namePieces = tableOpt.value.split('.');
-    let tableName = namePieces[0];
-    let schemaName = this.props.schema;
-    if (namePieces.length > 1) {
-      schemaName = namePieces[0];
-      tableName = namePieces[1];
-    }
+    const schemaName = tableOpt.value['schema'];
+    const tableName = tableOpt.value['table'];
     if (this.props.tableNameSticky) {
       this.setState({ tableName }, this.onChange);
     }

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -170,8 +170,8 @@ export default class TableSelector extends React.PureComponent {
       this.setState({ tableName: '' });
       return;
     }
-    const schemaName = tableOpt.value['schema'];
-    const tableName = tableOpt.value['table'];
+    const schemaName = tableOpt.value.schema;
+    const tableName = tableOpt.value.table;
     if (this.props.tableNameSticky) {
       this.setState({ tableName }, this.onChange);
     }

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -288,9 +288,9 @@ def update_datasources_cache():
         if database.allow_multi_schema_metadata_fetch:
             print('Fetching {} datasources ...'.format(database.name))
             try:
-                database.all_table_names_in_database(
+                database.get_all_table_names_in_database(
                     force=True, cache=True, cache_timeout=24 * 60 * 60)
-                database.all_view_names_in_database(
+                database.get_all_view_names_in_database(
                     force=True, cache=True, cache_timeout=24 * 60 * 60)
             except Exception as e:
                 print('{}'.format(str(e)))

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -122,7 +122,7 @@ class BaseEngineSpec(object):
     force_column_alias_quotes = False
     arraysize = 0
     max_column_name_length = 0
-    remove_schema_from_table_name = True
+    try_remove_schema_from_table_name = True
 
     @classmethod
     def get_time_expr(cls, expr, pdf, time_grain, grain):
@@ -353,14 +353,14 @@ class BaseEngineSpec(object):
     @classmethod
     def get_table_names(cls, inspector, schema):
         tables = inspector.get_table_names(schema)
-        if schema and cls.remove_schema_from_table_name:
+        if schema and cls.try_remove_schema_from_table_name:
             tables = [re.sub(f'^{schema}\\.', '', table) for table in tables]
         return sorted(tables)
 
     @classmethod
     def get_view_names(cls, inspector, schema):
         views = inspector.get_view_names(schema)
-        if schema and cls.remove_schema_from_table_name:
+        if schema and cls.try_remove_schema_from_table_name:
             views = [re.sub(f'^{schema}\\.', '', view) for view in views]
         return sorted(views)
 
@@ -534,6 +534,7 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
 class PostgresEngineSpec(PostgresBaseEngineSpec):
     engine = 'postgresql'
     max_column_name_length = 63
+    try_remove_schema_from_table_name = False
 
     @classmethod
     def get_table_names(cls, inspector, schema):

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -186,7 +186,7 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
             description=self.description,
             cache_timeout=self.cache_timeout)
 
-    @datasource.getter
+    @datasource.getter  # type: ignore
     @utils.memoized
     def get_datasource(self):
         return (
@@ -212,7 +212,7 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
         datasource = self.datasource
         return datasource.url if datasource else None
 
-    @property
+    @property  # type: ignore
     @utils.memoized
     def viz(self):
         d = json.loads(self.params)
@@ -938,7 +938,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         """Parameters need to be passed as keyword arguments."""
         if not self.allow_multi_schema_metadata_fetch:
             return []
-        return self.db_engine_spec.fetch_result_sets(self, 'table')
+        return self.db_engine_spec.get_all_datasource_names(self, 'table')
 
     @cache_util.memoized_func(
         key=lambda *args, **kwargs: 'db:{}:schema:None:view_list',
@@ -949,15 +949,14 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         """Parameters need to be passed as keyword arguments."""
         if not self.allow_multi_schema_metadata_fetch:
             return []
-        return self.db_engine_spec.fetch_result_sets(self, 'view')
+        return self.db_engine_spec.get_all_datasource_names(self, 'view')
 
     @cache_util.memoized_func(
         key=lambda *args, **kwargs: 'db:{{}}:schema:{}:table_list'.format(
             kwargs.get('schema')),
         attribute_in_key='id')
     def get_all_table_names_in_schema(self, schema: str, cache: bool = False,
-                                      cache_timeout: int = None,
-                                      force: bool = False) -> List[utils.DatasourceName]:
+                                      cache_timeout: int = None, force: bool = False):
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
@@ -981,8 +980,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             kwargs.get('schema')),
         attribute_in_key='id')
     def get_all_view_names_in_schema(self, schema: str, cache: bool = False,
-                                     cache_timeout: int = None,
-                                     force: bool = False) -> List[utils.DatasourceName]:
+                                     cache_timeout: int = None, force: bool = False):
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
@@ -1223,7 +1221,7 @@ class DatasourceAccessRequest(Model, AuditMixinNullable):
     def datasource(self):
         return self.get_datasource
 
-    @datasource.getter
+    @datasource.getter  # type: ignore
     @utils.memoized
     def get_datasource(self):
         # pylint: disable=no-member

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1004,8 +1004,8 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     @cache_util.memoized_func(
         key=lambda *args, **kwargs: 'db:{}:schema_list',
         attribute_in_key='id')
-    def all_schema_names(self, cache: bool = False, cache_timeout: int = None,
-                         force: bool = False) -> List[str]:
+    def get_all_schema_names(self, cache: bool = False, cache_timeout: int = None,
+                             force: bool = False) -> List[str]:
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in

--- a/superset/security.py
+++ b/superset/security.py
@@ -17,6 +17,7 @@
 # pylint: disable=C,R,W
 """A set of constants and methods to manage permissions and security"""
 import logging
+from typing import List
 
 from flask import g
 from flask_appbuilder.security.sqla import models as ab_models
@@ -26,6 +27,7 @@ from sqlalchemy import or_
 from superset import sql_parse
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.exceptions import SupersetSecurityException
+from superset.utils.core import DatasourceName
 
 
 class SupersetSecurityManager(SecurityManager):
@@ -240,7 +242,9 @@ class SupersetSecurityManager(SecurityManager):
                     subset.add(t.schema)
         return sorted(list(subset))
 
-    def accessible_by_user(self, database, datasource_names, schema=None):
+    def get_datasources_accessible_by_user(
+            self, database, datasource_names: List[DatasourceName],
+            schema: str = None) -> List[DatasourceName]:
         from superset import db
         if self.database_access(database) or self.all_datasource_access():
             return datasource_names

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -32,7 +32,7 @@ import signal
 import smtplib
 import sys
 from time import struct_time
-from typing import List, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 from urllib.parse import unquote_plus
 import uuid
 import zlib
@@ -1100,3 +1100,8 @@ def MediumText() -> Variant:
 
 def shortid() -> str:
     return '{}'.format(uuid.uuid4())[-12:]
+
+
+class DatasourceName(NamedTuple):
+    table: str
+    schema: str

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -22,7 +22,7 @@ import os
 import re
 import time
 import traceback
-from typing import List  # noqa: F401
+from typing import Dict, List  # noqa: F401
 from urllib import parse
 
 from flask import (
@@ -1571,50 +1571,57 @@ class Superset(BaseSupersetView):
         database = db.session.query(models.Database).filter_by(id=db_id).one()
 
         if schema:
-            table_names = database.all_table_names_in_schema(
+            tables = database.get_all_table_names_in_schema(
                 schema=schema, force=force_refresh,
                 cache=database.table_cache_enabled,
-                cache_timeout=database.table_cache_timeout)
-            view_names = database.all_view_names_in_schema(
+                cache_timeout=database.table_cache_timeout) or []
+            views = database.get_all_view_names_in_schema(
                 schema=schema, force=force_refresh,
                 cache=database.table_cache_enabled,
-                cache_timeout=database.table_cache_timeout)
+                cache_timeout=database.table_cache_timeout) or []
         else:
-            table_names = database.all_table_names_in_database(
+            tables = database.get_all_table_names_in_database(
                 cache=True, force=False, cache_timeout=24 * 60 * 60)
-            view_names = database.all_view_names_in_database(
+            views = database.get_all_view_names_in_database(
                 cache=True, force=False, cache_timeout=24 * 60 * 60)
-        table_names = security_manager.accessible_by_user(database, table_names, schema)
-        view_names = security_manager.accessible_by_user(database, view_names, schema)
+        tables = security_manager.get_datasources_accessible_by_user(
+            database, tables, schema)
+        views = security_manager.get_datasources_accessible_by_user(
+            database, views, schema)
+
+        def get_datasource_label(ds_name: utils.DatasourceName) -> str:
+            return ds_name.table if schema else f'{ds_name.schema}.{ds_name.table}'
 
         if substr:
-            table_names = [tn for tn in table_names if substr in tn]
-            view_names = [vn for vn in view_names if substr in vn]
+            tables = [tn for tn in tables if substr in get_datasource_label(tn)]
+            views = [vn for vn in views if substr in get_datasource_label(vn)]
 
         if not schema and database.default_schemas:
-            def get_schema(tbl_or_view_name):
-                return tbl_or_view_name.split('.')[0] if '.' in tbl_or_view_name else None
-
             user_schema = g.user.email.split('@')[0]
             valid_schemas = set(database.default_schemas + [user_schema])
 
-            table_names = [tn for tn in table_names if get_schema(tn) in valid_schemas]
-            view_names = [vn for vn in view_names if get_schema(vn) in valid_schemas]
+            tables = [tn for tn in tables if tn.schema in valid_schemas]
+            views = [vn for vn in views if vn.schema in valid_schemas]
 
-        max_items = config.get('MAX_TABLE_NAMES') or len(table_names)
-        total_items = len(table_names) + len(view_names)
-        max_tables = len(table_names)
-        max_views = len(view_names)
+        max_items = config.get('MAX_TABLE_NAMES') or len(tables)
+        total_items = len(tables) + len(views)
+        max_tables = len(tables)
+        max_views = len(views)
         if total_items and substr:
-            max_tables = max_items * len(table_names) // total_items
-            max_views = max_items * len(view_names) // total_items
+            max_tables = max_items * len(tables) // total_items
+            max_views = max_items * len(views) // total_items
 
-        table_options = [{'value': tn, 'label': tn}
-                         for tn in table_names[:max_tables]]
-        table_options.extend([{'value': vn, 'label': '[view] {}'.format(vn)}
-                              for vn in view_names[:max_views]])
+        def get_datasource_value(ds_name: utils.DatasourceName) -> Dict[str, str]:
+            return {'schema': ds_name.schema, 'table': ds_name.table}
+
+        table_options = [{'value': get_datasource_value(tn),
+                          'label': get_datasource_label(tn)}
+                         for tn in tables[:max_tables]]
+        table_options.extend([{'value': get_datasource_value(vn),
+                               'label': f'[view] {get_datasource_label(vn)}'}
+                              for vn in views[:max_views]])
         payload = {
-            'tableLength': len(table_names) + len(view_names),
+            'tableLength': len(tables) + len(views),
             'options': table_options,
         }
         return json_success(json.dumps(payload))

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -312,7 +312,7 @@ class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
         db.set_sqlalchemy_uri(db.sqlalchemy_uri)
         security_manager.add_permission_view_menu('database_access', db.perm)
         # adding a new database we always want to force refresh schema list
-        for schema in db.all_schema_names():
+        for schema in db.get_all_schema_names():
             security_manager.add_permission_view_menu(
                 'schema_access', security_manager.get_schema_perm(db, schema))
 
@@ -1546,7 +1546,7 @@ class Superset(BaseSupersetView):
             .first()
         )
         if database:
-            schemas = database.all_schema_names(
+            schemas = database.get_all_schema_names(
                 cache=database.schema_cache_enabled,
                 cache_timeout=database.schema_cache_timeout,
                 force=force_refresh)


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [x] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
In SQL Lab, table names are currently assumed to follow the following convention:
- `schema.table` or
- `table`

This is handled in the frontend by assuming that a period in the table name always implies a separator between schema and table name. Since there is no standardized way for SQLAlchemy inspectors to return table names (some return `schema.table`, others only `table`), they can be in either format. Since some databases (at least Apache Drill and Postgres) support periods in schema and table names, and their respective inspectors don't return schema prefixed table names, this causes problems when querying tables, as `TableSelector` strips away everything before the period character. This PR moves this logic from the frontend to the backend, and makes it possible to configure this behavior per engine.

This proposal changes table name handling in the following way:
1. An attribute `try_remove_schema_from_table_name` is added to `db_engine_specs` (defaults to `True`). By default, when `True`, `get_table_names()` and `get_view_names()` checks if a table name starts with the schema name followed by a period, and if so, removes the schema name from the table name. Example: `schema.table` becomes `table`, while `table` remains unchanged.
2. Table names are passed as dicts `{'schema': 'schema_name', 'table': 'table_name'}` when handed to the frontend. Previously they were either of the format `table` or `schema.table`. This removes any ambiguity in the frontend.
3. SQL Lab UI now works in the following way:
   - If no schema is selected, table/view names are displayed in the dropdown as `schema.table`.
   - If a schema is selected, tables are shown as `table` only in the dropdown.
Filtering also supports this, i.e. when no schema is chosen, the filter substring makes the comparison assuming that the table name is `schema.table`, making it possible to include the schema name in the filter string.

### SCREENSHOTS
When no schema is chosen, table names are displayed as `schema.table`:
<img width="313" alt="Screenshot 2019-05-09 at 21 09 07" src="https://user-images.githubusercontent.com/33317356/57547924-59174100-7368-11e9-917d-2ed26ad161c3.png">

If a schema is selected, only the table name is shown (in this case the table name is `test.table`, not `table` in schema `test`):
<img width="302" alt="Screenshot 2019-05-09 at 21 09 43" src="https://user-images.githubusercontent.com/33317356/57547948-66ccc680-7368-11e9-86da-8e858acbf97b.png">

### TEST PLAN
Tested locally on Postgres and sqlite. Js unit tests updated to correspond to new data structures and python unit tests added to test table name fetching.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@cgivre