### PR TITLE
fix: alter sql columns to long text

### DIFF
--- a/superset/migrations/versions/afc69274c25a_alter_sql_column_data_type_in_query_mysql_table.py
+++ b/superset/migrations/versions/afc69274c25a_alter_sql_column_data_type_in_query_mysql_table.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """update the sql, select_sql, and executed_sql columns in the
-   query table to support larger text
+   query table in mysql dbs to be long text columns
 
 Revision ID: afc69274c25a
 Revises: e9df189e5c7e
@@ -23,39 +23,34 @@ Create Date: 2019-05-06 14:30:26.181449
 
 """
 from alembic import op
+from sqlalchemy.databases import mysql
+from sqlalchemy.dialects.mysql.base import MySQLDialect
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'afc69274c25a'
 down_revision = 'e9df189e5c7e'
 
-text_len = 10 ** 9 - 1
-
 
 def upgrade():
-    try:
-        # Set text length if database accepts it
+    bind = op.get_bind()
+    if isinstance(bind.dialect, MySQLDialect):
         with op.batch_alter_table('query') as batch_op:
             batch_op.alter_column(
-                'sql', existing_type=sa.Text, type_=sa.Text(length=text_len))
+                'sql', existing_type=sa.Text, type_=mysql.LONGTEXT)
             batch_op.alter_column(
-                'select_sql', existing_type=sa.Text, type_=sa.Text(length=text_len))
+                'select_sql', existing_type=sa.Text, type_=mysql.LONGTEXT)
             batch_op.alter_column(
-                'executed_sql', existing_type=sa.Text, type_=sa.Text(length=text_len))
-    except:
-        # Many databases do not have a length on text objects
-        # so skip altering for those databases
-        pass
+                'executed_sql', existing_type=sa.Text, type_=mysql.LONGTEXT)
 
 
 def downgrade():
-    try:
+    bind = op.get_bind()
+    if isinstance(bind.dialect, MySQLDialect):
         with op.batch_alter_table('query') as batch_op:
             batch_op.alter_column(
-                'sql', existing_type=sa.Text(length=text_len), type_=sa.Text)
+                'sql', existing_type=mysql.LONGTEXT, type_=sa.Text)
             batch_op.alter_column(
-                'select_sql', existing_type=sa.Text(length=text_len), type_=sa.Text)
+                'select_sql', existing_type=mysql.LONGTEXT, type_=sa.Text)
             batch_op.alter_column(
-                'executed_sql', existing_type=sa.Text(length=text_len), type_=sa.Text)
-    except:
-        pass
+                'executed_sql', existing_type=mysql.LONGTEXT, type_=sa.Text)

--- a/superset/migrations/versions/afc69274c25a_update_sql_column_data_type_in_query_.py
+++ b/superset/migrations/versions/afc69274c25a_update_sql_column_data_type_in_query_.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""update the sql, select_sql, and executed_sql columns in the
+   query table to support larger text
+
+Revision ID: afc69274c25a
+Revises: e9df189e5c7e
+Create Date: 2019-05-06 14:30:26.181449
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'afc69274c25a'
+down_revision = 'e9df189e5c7e'
+
+
+def upgrade():
+    with op.batch_alter_table('query') as batch_op:
+        batch_op.alter_column(
+            'sql', existing_type=sa.Text, type_=sa.Text(2 ** 32 - 1))
+        batch_op.alter_column(
+            'select_sql', existing_type=sa.Text, type_=sa.Text(2 ** 32 - 1))
+        batch_op.alter_column(
+            'executed_sql', existing_type=sa.Text, type_=sa.Text(2 ** 32 - 1))
+
+
+def downgrade():
+    with op.batch_alter_table('query') as batch_op:
+        batch_op.alter_column(
+            'sql', existing_type=sa.Text(2 ** 32 - 1), type_=sa.Text)
+        batch_op.alter_column(
+            'select_sql', existing_type=sa.Text(2 ** 32 - 1), type_=sa.Text)
+        batch_op.alter_column(
+            'executed_sql', existing_type=sa.Text(2 ** 32 - 1), type_=sa.Text)

--- a/superset/migrations/versions/afc69274c25a_update_sql_column_data_type_in_query_.py
+++ b/superset/migrations/versions/afc69274c25a_update_sql_column_data_type_in_query_.py
@@ -29,7 +29,7 @@ import sqlalchemy as sa
 revision = 'afc69274c25a'
 down_revision = 'e9df189e5c7e'
 
-text_len = 2 ** 32 - 1
+text_len = 10 ** 9 - 1
 
 
 def upgrade():

--- a/superset/migrations/versions/afc69274c25a_update_sql_column_data_type_in_query_.py
+++ b/superset/migrations/versions/afc69274c25a_update_sql_column_data_type_in_query_.py
@@ -29,22 +29,33 @@ import sqlalchemy as sa
 revision = 'afc69274c25a'
 down_revision = 'e9df189e5c7e'
 
+text_len = 2 ** 32 - 1
+
 
 def upgrade():
-    with op.batch_alter_table('query') as batch_op:
-        batch_op.alter_column(
-            'sql', existing_type=sa.Text, type_=sa.Text(2 ** 32 - 1))
-        batch_op.alter_column(
-            'select_sql', existing_type=sa.Text, type_=sa.Text(2 ** 32 - 1))
-        batch_op.alter_column(
-            'executed_sql', existing_type=sa.Text, type_=sa.Text(2 ** 32 - 1))
+    try:
+        # Set text length if database accepts it
+        with op.batch_alter_table('query') as batch_op:
+            batch_op.alter_column(
+                'sql', existing_type=sa.Text, type_=sa.Text(length=text_len))
+            batch_op.alter_column(
+                'select_sql', existing_type=sa.Text, type_=sa.Text(length=text_len))
+            batch_op.alter_column(
+                'executed_sql', existing_type=sa.Text, type_=sa.Text(length=text_len))
+    except:
+        # Many databases do not have a length on text objects
+        # so skip altering for those databases
+        pass
 
 
 def downgrade():
-    with op.batch_alter_table('query') as batch_op:
-        batch_op.alter_column(
-            'sql', existing_type=sa.Text(2 ** 32 - 1), type_=sa.Text)
-        batch_op.alter_column(
-            'select_sql', existing_type=sa.Text(2 ** 32 - 1), type_=sa.Text)
-        batch_op.alter_column(
-            'executed_sql', existing_type=sa.Text(2 ** 32 - 1), type_=sa.Text)
+    try:
+        with op.batch_alter_table('query') as batch_op:
+            batch_op.alter_column(
+                'sql', existing_type=sa.Text(length=text_len), type_=sa.Text)
+            batch_op.alter_column(
+                'select_sql', existing_type=sa.Text(length=text_len), type_=sa.Text)
+            batch_op.alter_column(
+                'executed_sql', existing_type=sa.Text(length=text_len), type_=sa.Text)
+    except:
+        pass


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
There were issues executing long queries because we saved the strings to text columns in the query table. The queries would be truncated based on the storage size of the text column (i.e. Text in mysql can hold 65k characters - 64 KB). I have added a migration script to update the columns to hold longer strings.

### TEST PLAN
Tested that the columns were long text columns in a mysql table after migration.

### REVIEWERS
@betodealmeida @xtinec @DiggidyDave 