### PR TITLE
Change kv content-type to text/plain

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -806,7 +806,7 @@ class KV(BaseSupersetView):
             kv = db.session.query(models.KeyValue).filter_by(id=key_id).one()
         except Exception as e:
             return json_error_response(e)
-        return Response(kv.value, status=200)
+        return Response(kv.value, status=200, content_type="text/plain")
 
 
 appbuilder.add_view_no_menu(KV)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -806,7 +806,7 @@ class KV(BaseSupersetView):
             kv = db.session.query(models.KeyValue).filter_by(id=key_id).one()
         except Exception as e:
             return json_error_response(e)
-        return Response(kv.value, status=200, content_type="text/plain")
+        return Response(kv.value, status=200, content_type='text/plain')
 
 
 appbuilder.add_view_no_menu(KV)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Superset provides endpoints for storing and retrieving key-value pairs from database storage. For example, /explore/kv/store takes a data POST parameter for an arbitrary string to store and returns the corresponding key, which is a simple integer counter. To retrieve the saved data, users issue a GET request to /explore/kv/<key>. The application returns the associated value with the response Content-Type set to text/html, meaning it is possible for users to construct arbitrary HTML pages.
The attacker can simply create another key-value pair with JavaScript source code in the value and include it from the constructed HTML page. Since the script source comes from the same origin as the HTML page, the CSP permits the browser to execute it

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Tested that the value returned is text/plain

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
