### PR TITLE
Permission driven database access

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -186,12 +186,14 @@ class DashboardFilter(SupersetFilter):
         )
         return query
 
+
 class DatabaseViewFilter(SupersetFilter):
     def apply(self, query, func):  # noqa
         if security_manager.all_datasource_access():
             return query
         perms = self.get_view_menus('datasource_access')
         return query.filter(self.model.perm.in_(perms))
+
 
 class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
     datamodel = SQLAInterface(models.Database)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -186,6 +186,12 @@ class DashboardFilter(SupersetFilter):
         )
         return query
 
+class DatabaseViewFilter(SupersetFilter):
+    def apply(self, query, func):  # noqa
+        if security_manager.all_datasource_access():
+            return query
+        perms = self.get_view_menus('datasource_access')
+        return query.filter(self.model.perm.in_(perms))
 
 class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
     datamodel = SQLAInterface(models.Database)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
By default, database list is not permission driven. It shows all databases to all users. This filter allows us to restrict that view. After applying this filter, user will only see the databases that they have
datasource_access permission.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Tested that the database access is controlled by permission

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
