### PR TITLE
[fix] SQL parsing of table names

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -181,13 +181,11 @@ class SupersetSecurityManager(SecurityManager):
 
     def get_schema_and_table(self, table_in_query, schema):
         table_name_pieces = table_in_query.split('.')
-        if len(table_name_pieces) == 2:
-            table_schema = table_name_pieces[0]
-            table_name = table_name_pieces[1]
-        else:
-            table_schema = schema
-            table_name = table_name_pieces[0]
-        return (table_schema, table_name)
+        if len(table_name_pieces) == 3:
+            return tuple(table_name_pieces[1:])
+        elif len(table_name_pieces) == 2:
+            return tuple(table_name_pieces)
+        return (schema, table_name_pieces[0])
 
     def datasource_access_by_fullname(
             self, database, table_in_query, schema):

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -29,6 +29,12 @@ class SupersetTestCase(unittest.TestCase):
         query = 'SELECT * FROM tbname'
         self.assertEquals({'tbname'}, self.extract_tables(query))
 
+        query = 'SELECT * FROM tbname foo'
+        self.assertEquals({'tbname'}, self.extract_tables(query))
+
+        query = 'SELECT * FROM tbname AS foo'
+        self.assertEquals({'tbname'}, self.extract_tables(query))
+
         # underscores
         query = 'SELECT * FROM tb_name'
         self.assertEquals({'tb_name'},
@@ -47,10 +53,39 @@ class SupersetTestCase(unittest.TestCase):
             {'schemaname.tbname'},
             self.extract_tables('SELECT * FROM schemaname.tbname'))
 
-        # Ill-defined schema/table.
+        self.assertEquals(
+            {'schemaname.tbname'},
+            self.extract_tables('SELECT * FROM "schemaname"."tbname"'))
+
+        self.assertEquals(
+            {'schemaname.tbname'},
+            self.extract_tables('SELECT * FROM schemaname.tbname foo'))
+
+        self.assertEquals(
+            {'schemaname.tbname'},
+            self.extract_tables('SELECT * FROM schemaname.tbname AS foo'))
+
+        # cluster
+        self.assertEquals(
+            {'clustername.schemaname.tbname'},
+            self.extract_tables('SELECT * FROM clustername.schemaname.tbname'))
+
+        # Ill-defined cluster/schema/table.
         self.assertEquals(
             set(),
             self.extract_tables('SELECT * FROM schemaname.'))
+
+        self.assertEquals(
+            set(),
+            self.extract_tables('SELECT * FROM clustername.schemaname.'))
+
+        self.assertEquals(
+            set(),
+            self.extract_tables('SELECT * FROM clustername..'))
+
+        self.assertEquals(
+            set(),
+            self.extract_tables('SELECT * FROM clustername..tbname'))
 
         # quotes
         query = 'SELECT field1, field2 FROM tb_name'


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Presto supports using the optional cluster when specifying the table name, i.e., `[[cluster.]schema].table` however the currently SQL parse logic only returns at most the first two components, i.e., `cluster.schema` if a cluster was defined.

This PR extends the logic to support the `[[cluster.]schema].table` construct as well as:

- Ensures the table construct is valid in terms of length and structure. 
- Ensures that the quotes are removed from each token. Previously this was only the case when only the table was specified which were removed via `get_real_name()`. 
- The `get_real_name()` logic wasn't overly apparent though it's used when a table alias is present. I felt this logic wasn't overly clear and in the case of a `TokenList` representing `schema.table AS foo` the `get_real_name()` only returns `table` (though this wasn't invoked because there was the `.` token). From a table construct validity perspective it seems more prudent to strip the alias and then extract the full table name if valid.

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @graceguo-supercat @michellethomas @mistercrunch