### PR TITLE
make filter_values() macro accept single-selection filter box value

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -113,8 +113,11 @@ def filter_values(column, default=None):
 
         for f in form_data[filter_type]:
             if f['col'] == column:
-                for v in f['val']:
-                    return_val.append(v)
+                if isinstance(f['val'], list):
+                    for v in f['val']:
+                        return_val.append(v)
+                else:
+                    return_val.append(f['val'])
 
     if return_val:
         return return_val

--- a/tests/macro_tests.py
+++ b/tests/macro_tests.py
@@ -48,9 +48,19 @@ class MacroTestCase(SupersetTestCase):
             ],
         }
 
+        form_data4 = {
+            'extra_filters': [
+                {'col': 'my_special_filter', 'op': 'in', 'val': 'foo'},
+            ],
+            'filters': [
+                {'col': 'my_special_filter', 'op': 'in', 'val': 'savage'},
+            ],
+        }
+
         data1 = {'form_data': json.dumps(form_data1)}
         data2 = {'form_data': json.dumps(form_data2)}
         data3 = {'form_data': json.dumps(form_data3)}
+        data4 = {'form_data': json.dumps(form_data4)}
 
         with app.test_request_context(data=data1):
             filter_values = jinja_context.filter_values('my_special_filter')
@@ -73,3 +83,7 @@ class MacroTestCase(SupersetTestCase):
         with app.test_request_context():
             filter_values = jinja_context.filter_values('nonexistent_filter', 'foo')
             self.assertEqual(filter_values, ['foo'])
+
+        with app.test_request_context(data=data4):
+            filter_values = jinja_context.filter_values('my_special_filter')
+            self.assertEqual(filter_values, ['savage', 'foo'])


### PR DESCRIPTION
### CATEGORY
- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
* Before: filter_values() parse form post's `filters` , `extra_filters` 's column value as list only (sent from filter box's filter value)

* After: filter_values() parse form post's `filters` , `extra_filters` 's column value as list + single value (non-list) and add back to returning list.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
1. create a chart with SQL containing filter_values() macro which gets value from field `abc`
1. create a filter box with a filter as `abc` and set as single-selection
1. add both to dashboard
1. change filter box's filter value and see if it reflects on the chart

### ADDITIONAL INFORMATION
- [X] Has associated issue: fix #7486 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch 