### PR TITLE
Reduce db queries in /queries/ endpoint

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -21,7 +21,6 @@ import inspect
 import logging
 import os
 import re
-import time
 import traceback
 from typing import List  # noqa: F401
 from urllib import parse
@@ -37,8 +36,7 @@ from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
 import pandas as pd
 import simplejson as json
-import sqlalchemy as sqla
-from sqlalchemy import and_, create_engine, MetaData, or_, select, update
+from sqlalchemy import and_, create_engine, MetaData, or_, select
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import IntegrityError
 from werkzeug.routing import BaseConverter
@@ -1846,7 +1844,7 @@ class Superset(BaseSupersetView):
                 M.Slice.id == M.Log.slice_id,
             )
             .filter(
-                sqla.and_(
+                and_(
                     ~M.Log.action.in_(('queries', 'shortner', 'sql_json')),
                     M.Log.user_id == user_id,
                 ),
@@ -1916,7 +1914,7 @@ class Superset(BaseSupersetView):
             )
             .join(
                 models.FavStar,
-                sqla.and_(
+                and_(
                     models.FavStar.user_id == int(user_id),
                     models.FavStar.class_name == 'Dashboard',
                     models.Dashboard.id == models.FavStar.obj_id,
@@ -1954,7 +1952,7 @@ class Superset(BaseSupersetView):
                 Dash,
             )
             .filter(
-                sqla.or_(
+                or_(
                     Dash.created_by_fk == user_id,
                     Dash.changed_by_fk == user_id,
                 ),
@@ -1987,13 +1985,13 @@ class Superset(BaseSupersetView):
             db.session.query(Slice,
                              FavStar.dttm).join(
                 models.FavStar,
-                sqla.and_(
+                and_(
                     models.FavStar.user_id == int(user_id),
                     models.FavStar.class_name == 'slice',
                     models.Slice.id == models.FavStar.obj_id,
                 ),
                 isouter=True).filter(
-                sqla.or_(
+                or_(
                     Slice.created_by_fk == user_id,
                     Slice.changed_by_fk == user_id,
                     FavStar.user_id == user_id,
@@ -2024,7 +2022,7 @@ class Superset(BaseSupersetView):
         qry = (
             db.session.query(Slice)
             .filter(
-                sqla.or_(
+                or_(
                     Slice.created_by_fk == user_id,
                     Slice.changed_by_fk == user_id,
                 ),
@@ -2056,7 +2054,7 @@ class Superset(BaseSupersetView):
             )
             .join(
                 models.FavStar,
-                sqla.and_(
+                and_(
                     models.FavStar.user_id == int(user_id),
                     models.FavStar.class_name == 'slice',
                     models.Slice.id == models.FavStar.obj_id,
@@ -2803,35 +2801,6 @@ class Superset(BaseSupersetView):
             .all()
         )
         dict_queries = {q.client_id: q.to_dict() for q in sql_queries}
-
-        now = int(round(time.time() * 1000))
-
-        unfinished_states = [
-            QueryStatus.PENDING,
-            QueryStatus.RUNNING,
-        ]
-
-        queries_to_timeout = [
-            client_id for client_id, query_dict in dict_queries.items()
-            if (
-                query_dict['state'] in unfinished_states and (
-                    now - query_dict['startDttm'] >
-                    config.get('SQLLAB_ASYNC_TIME_LIMIT_SEC') * 1000
-                )
-            )
-        ]
-
-        if queries_to_timeout:
-            update(Query).where(
-                and_(
-                    Query.user_id == g.user.get_id(),
-                    Query.client_id in queries_to_timeout,
-                ),
-            ).values(state=QueryStatus.TIMED_OUT)
-
-            for client_id in queries_to_timeout:
-                dict_queries[client_id]['status'] = QueryStatus.TIMED_OUT
-
         return json_success(
             json.dumps(dict_queries, default=utils.json_int_dttm_ser))
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In #4833, we tried to introduce a feature that setting old async query status to be timed_out, when the query status stuck at pending or running after 6 hours. This status update will help front-end (browser) not fetching very old query status. But i found that backend actually didn't commit transaction, so the whole query/update logic seems no use.

In #7429 I was trying to fix this issue by adding db commit.  But I also found in front-end javascript, we have logic that don't poll query status after `SQLLAB_ASYNC_TIME_LIMIT_SEC` reached. I feel the additional query/update in backend every second, seems expensive and not necessary. So I propose to remove this query/update logic from every polling request.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
n/a

### TEST PLAN
CI and watch query polling.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@john-bodley @timifasubaa @mistercrunch @michellethomas 
