### PR TITLE
chore: Truncate progressbar percentage decimals

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/src/SqlLab/components/QueryTable.jsx
@@ -41,8 +41,8 @@ const propTypes = {
 const defaultProps = {
   columns: ['started', 'duration', 'rows'],
   queries: [],
-  onUserClicked: () => {},
-  onDbClicked: () => {},
+  onUserClicked: () => { },
+  onDbClicked: () => { },
 };
 
 class QueryTable extends React.PureComponent {
@@ -169,7 +169,7 @@ class QueryTable extends React.PureComponent {
             style={{ width: '75px' }}
             striped
             now={q.progress}
-            label={`${q.progress}%`}
+            label={`${q.progress.toFixed(0)}%`}
           />
         );
         let errorTooltip;

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -241,7 +241,7 @@ export default class ResultSet extends React.PureComponent {
         <ProgressBar
           striped
           now={query.progress}
-          label={`${query.progress}%`}
+          label={`${query.progress.toFixed(0)}%`}
         />);
     }
     if (query.trackingUrl) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This change makes the query progress bar only show
whole number percentage changes, instead of numbers
like 12.13168276%.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
It's a little tricky to catch this one in action for a screenshot. Slow sample queries welcome...

### TEST PLAN
Run a slow query or table preview and watch the progress bar display a crazy number

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@betodealmeida @khtruong 