### PR TITLE
[WiP] Simplify Superset's permissions

### DIFF
--- a/superset/connectors/base/views.py
+++ b/superset/connectors/base/views.py
@@ -22,6 +22,9 @@ from superset.views.base import SupersetModelView
 
 
 class DatasourceModelView(SupersetModelView):
+
+    class_permission_name = "Datasource"
+
     def pre_delete(self, obj):
         if obj.slices:
             raise SupersetException(

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -48,6 +48,8 @@ from . import models
 class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
     datamodel = SQLAInterface(models.DruidColumn)
 
+    class_permission_name = "Datasource"
+
     list_title = _("Columns")
     show_title = _("Show Druid Column")
     add_title = _("Add Druid Column")
@@ -137,6 +139,8 @@ appbuilder.add_view_no_menu(DruidColumnInlineView)
 class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
     datamodel = SQLAInterface(models.DruidMetric)
 
+    class_permission_name = "Datasource"
+
     list_title = _("Metrics")
     show_title = _("Show Druid Metric")
     add_title = _("Add Druid Metric")
@@ -211,6 +215,8 @@ appbuilder.add_view_no_menu(DruidMetricInlineView)
 
 class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
     datamodel = SQLAInterface(models.DruidCluster)
+
+    class_permission_name = "Database"
 
     list_title = _("Druid Clusters")
     show_title = _("Show Druid Cluster")
@@ -292,6 +298,8 @@ class DruidDatasourceModelView(
     DatasourceModelView, DeleteMixin, YamlExportMixin
 ):  # noqa
     datamodel = SQLAInterface(models.DruidDatasource)
+
+    class_permission_name = "Datasource"
 
     list_title = _("Druid Datasources")
     show_title = _("Show Druid Datasource")

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -47,6 +47,8 @@ logger = logging.getLogger(__name__)
 class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
     datamodel = SQLAInterface(models.TableColumn)
 
+    class_permission_name = "Datasource"
+
     list_title = _("Columns")
     show_title = _("Show Column")
     add_title = _("Add Column")
@@ -140,6 +142,8 @@ appbuilder.add_view_no_menu(TableColumnInlineView)
 class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
     datamodel = SQLAInterface(models.SqlMetric)
 
+    class_permission_name = "Datasource"
+
     list_title = _("Metrics")
     show_title = _("Show Metric")
     add_title = _("Add Metric")
@@ -221,6 +225,8 @@ appbuilder.add_view_no_menu(SqlMetricInlineView)
 
 class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
     datamodel = SQLAInterface(models.SqlaTable)
+
+    class_permission_name = "Datasource"
 
     list_title = _("Tables")
     show_title = _("Show Table")

--- a/superset/security.py
+++ b/superset/security.py
@@ -65,7 +65,7 @@ PermissionModelView.list_widget = SupersetSecurityListWidget
 
 
 class SupersetSecurityManager(SecurityManager):
-    READ_ONLY_MODEL_VIEWS = {"DatabaseAsync", "DatabaseView", "DruidClusterModelView"}
+    READ_ONLY_MODEL_VIEWS = {"Database"}
 
     USER_MODEL_VIEWS = {
         "UserDBModelView",
@@ -75,14 +75,7 @@ class SupersetSecurityManager(SecurityManager):
         "UserRemoteUserModelView",
     }
 
-    GAMMA_READ_ONLY_MODEL_VIEWS = {
-        "SqlMetricInlineView",
-        "TableColumnInlineView",
-        "TableModelView",
-        "DruidColumnInlineView",
-        "DruidDatasourceModelView",
-        "DruidMetricInlineView",
-    } | READ_ONLY_MODEL_VIEWS
+    GAMMA_READ_ONLY_MODEL_VIEWS = {"Datasource"} | READ_ONLY_MODEL_VIEWS
 
     ADMIN_ONLY_VIEW_MENUS = {
         "AccessRequestsModelView",
@@ -106,7 +99,7 @@ class SupersetSecurityManager(SecurityManager):
         "can_update_role",
     }
 
-    READ_ONLY_PERMISSION = {"can_show", "can_list"}
+    READ_ONLY_PERMISSION = {"can_show", "can_list", "can_read"}
 
     ALPHA_ONLY_PERMISSIONS = {
         "muldelete",
@@ -503,3 +496,9 @@ class SupersetSecurityManager(SecurityManager):
                 self.get_datasource_access_error_msg(datasource),
                 self.get_datasource_access_link(datasource),
             )
+
+    '''
+    def security_cleanup(self, baseview, menu):
+        """Preventing FAB from clearing Superset-defined perms"""
+        raise NotImplementedError("Preventing FAB from clearing Superset-defined perms")
+    '''

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -33,7 +33,7 @@ import smtplib
 import sys
 from time import struct_time
 import traceback
-from typing import List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from urllib.parse import unquote_plus
 import uuid
 import zlib
@@ -1203,3 +1203,10 @@ class DatasourceName(NamedTuple):
 def get_stacktrace():
     if current_app.config.get("SHOW_STACKTRACE"):
         return traceback.format_exc()
+
+
+def merge_dicts(*args) -> dict:
+    target: Dict[Any, Any] = dict()
+    for d in args:
+        target.update(d)
+    return target

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -46,6 +46,8 @@ class StartEndDttmValidator(object):
 class AnnotationModelView(SupersetModelView, DeleteMixin):  # noqa
     datamodel = SQLAInterface(Annotation)
 
+    class_permission_name = "Annotation"
+
     list_title = _("List Annotation")
     show_title = _("Show Annotation")
     add_title = _("Add Annotation")
@@ -91,6 +93,8 @@ class AnnotationModelView(SupersetModelView, DeleteMixin):  # noqa
 
 class AnnotationLayerModelView(SupersetModelView, DeleteMixin):
     datamodel = SQLAInterface(AnnotationLayer)
+
+    class_permission_name = "Annotation"
 
     list_title = _("List Annotation Layer")
     show_title = _("Show Annotation Layer")

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -180,8 +180,33 @@ class SupersetListWidget(ListWidget):
 
 
 class SupersetModelView(ModelView):
+    """This mixin should be used in every Superset ModelView"""
+
     page_size = 100
     list_widget = SupersetListWidget
+
+    # simplifying / aggregating model perms
+    method_permission_name = {
+        "add": "write",
+        "delete": "write",
+        "download": "write",
+        "edit": "write",
+        "get": "read",
+        "list": "read",
+        "muldelete": "write",
+        "save": "write",
+        "show": "read",
+        "yaml_export": "read",
+        "api": "read",
+        "api_column_add": "write",
+        "api_column_edit": "write",
+        "api_create": "write",
+        "api_delete": "write",
+        "api_get": "read",
+        "api_read": "read",
+        "api_readvalues": "read",
+        "api_update": "write",
+    }
 
 
 class ListWidgetWithCheckboxes(ListWidget):

--- a/superset/views/database/__init__.py
+++ b/superset/views/database/__init__.py
@@ -36,6 +36,8 @@ class DatabaseFilter(SupersetFilter):
 
 
 class DatabaseMixin:  # noqa
+    class_permission_name = "Database"
+
     list_title = _("Databases")
     show_title = _("Show Database")
     add_title = _("Add Database")

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -19,21 +19,25 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 
 from superset import appbuilder
 import superset.models.core as models
+from superset.utils.core import merge_dicts
+from superset.views.base import SupersetModelView
 from . import DatabaseFilter, DatabaseMixin
 
 
 class DatabaseRestApi(DatabaseMixin, ModelRestApi):
     datamodel = SQLAInterface(models.Database)
 
-    class_permission_name = "DatabaseAsync"
-    method_permission_name = {
-        "get_list": "list",
-        "get": "show",
-        "post": "add",
-        "put": "edit",
-        "delete": "delete",
-        "info": "list",
-    }
+    method_permission_name = merge_dicts(
+        SupersetModelView.method_permission_name,
+        {
+            "get_list": "read",
+            "get": "read",
+            "post": "write",
+            "put": "write",
+            "delete": "write",
+            "info": "read",
+        },
+    )
     resource_name = "database"
     allow_browser_login = True
     base_filters = [["id", DatabaseFilter, lambda: []]]

--- a/superset/views/log/__init__.py
+++ b/superset/views/log/__init__.py
@@ -17,8 +17,12 @@
 # pylint: disable=C,R,W
 from flask_babel import lazy_gettext as _
 
+from superset.views.base import SupersetModelView
 
-class LogMixin:
+
+class LogMixin(SupersetModelView):
+    class_permission_name = "Log"
+
     list_title = _("Logs")
     show_title = _("Show Log")
     add_title = _("Add Log")

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -25,7 +25,6 @@ from . import LogMixin
 class LogRestApi(LogMixin, ModelRestApi):
     datamodel = SQLAInterface(models.Log)
 
-    class_permission_name = "LogModelView"
     method_permission_name = {
         "get_list": "list",
         "get": "show",

--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -43,6 +43,9 @@ from .base import DeleteMixin, SupersetModelView
 
 
 class EmailScheduleView(SupersetModelView, DeleteMixin):
+
+    class_permission_name = "ScheduleEmail"
+
     _extra_data = {"test_email": False, "test_email_recipients": None}
     schedule_type = None
     schedule_type_model = None

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -48,6 +48,8 @@ class QueryFilter(SupersetFilter):
 class QueryView(SupersetModelView):
     datamodel = SQLAInterface(Query)
 
+    class_permission_name = "Query"
+
     list_title = _("List Query")
     show_title = _("Show Query")
     add_title = _("Add Query")
@@ -78,6 +80,8 @@ appbuilder.add_view(
 
 class SavedQueryView(SupersetModelView, DeleteMixin):
     datamodel = SQLAInterface(SavedQuery)
+
+    class_permission_name = "SavedQuery"
 
     list_title = _("List Saved Query")
     show_title = _("Show Saved Query")

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -31,21 +31,13 @@ class RolePermissionTests(SupersetTestCase):
     """Testing export import functionality for dashboards"""
 
     def assert_can_read(self, view_menu, permissions_set):
-        self.assertIn(("can_show", view_menu), permissions_set)
-        self.assertIn(("can_list", view_menu), permissions_set)
+        self.assertIn(("can_read", view_menu), permissions_set)
 
     def assert_can_write(self, view_menu, permissions_set):
-        self.assertIn(("can_add", view_menu), permissions_set)
-        self.assertIn(("can_download", view_menu), permissions_set)
-        self.assertIn(("can_delete", view_menu), permissions_set)
-        self.assertIn(("can_edit", view_menu), permissions_set)
+        self.assertIn(("can_write", view_menu), permissions_set)
 
     def assert_cannot_write(self, view_menu, permissions_set):
-        self.assertNotIn(("can_add", view_menu), permissions_set)
-        self.assertNotIn(("can_download", view_menu), permissions_set)
-        self.assertNotIn(("can_delete", view_menu), permissions_set)
-        self.assertNotIn(("can_edit", view_menu), permissions_set)
-        self.assertNotIn(("can_save", view_menu), permissions_set)
+        self.assertNotIn(("can_write", view_menu), permissions_set)
 
     def assert_can_all(self, view_menu, permissions_set):
         self.assert_can_read(view_menu, permissions_set)
@@ -55,12 +47,12 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_cannot_write("DruidColumnInlineView", perm_set)
 
     def assert_can_gamma(self, perm_set):
-        self.assert_can_read("DatabaseAsync", perm_set)
-        self.assert_can_read("TableModelView", perm_set)
+        self.assert_can_read("Database", perm_set)
+        self.assert_can_read("Datasource", perm_set)
 
         # make sure that user can create slices and dashboards
-        self.assert_can_all("SliceModelView", perm_set)
-        self.assert_can_all("DashboardModelView", perm_set)
+        self.assert_can_all("Slice", perm_set)
+        self.assert_can_all("Dashboard", perm_set)
 
         self.assertIn(("can_add_slices", "Superset"), perm_set)
         self.assertIn(("can_copy_dash", "Superset"), perm_set)
@@ -79,12 +71,7 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(("can_userinfo", "UserDBModelView"), perm_set)
 
     def assert_can_alpha(self, perm_set):
-        self.assert_can_all("SqlMetricInlineView", perm_set)
-        self.assert_can_all("TableColumnInlineView", perm_set)
-        self.assert_can_all("TableModelView", perm_set)
-        self.assert_can_all("DruidColumnInlineView", perm_set)
-        self.assert_can_all("DruidDatasourceModelView", perm_set)
-        self.assert_can_all("DruidMetricInlineView", perm_set)
+        self.assert_can_all("Datasource", perm_set)
 
         self.assertIn(("all_datasource_access", "all_datasource_access"), perm_set)
         self.assertIn(("muldelete", "DruidDatasourceModelView"), perm_set)
@@ -98,11 +85,11 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_cannot_write("UserDBModelView", perm_set)
 
     def assert_can_admin(self, perm_set):
-        self.assert_can_read("DatabaseAsync", perm_set)
-        self.assert_can_all("DatabaseView", perm_set)
-        self.assert_can_all("DruidClusterModelView", perm_set)
-        self.assert_can_all("RoleModelView", perm_set)
-        self.assert_can_all("UserDBModelView", perm_set)
+        self.assert_can_all("Database", perm_set)
+        self.assertIn(("can_edit", "RoleModelView"), perm_set)
+        self.assertIn(("can_show", "RoleModelView"), perm_set)
+        self.assertIn(("can_edit", "UserDBModelView"), perm_set)
+        self.assertIn(("can_show", "UserDBModelView"), perm_set)
 
         self.assertIn(("all_database_access", "all_database_access"), perm_set)
         self.assertIn(("can_override_role_permissions", "Superset"), perm_set)
@@ -113,7 +100,7 @@ class RolePermissionTests(SupersetTestCase):
     def test_is_admin_only(self):
         self.assertFalse(
             security_manager.is_admin_only(
-                security_manager.find_permission_view_menu("can_show", "TableModelView")
+                security_manager.find_permission_view_menu("can_read", "Datasource")
             )
         )
         self.assertFalse(
@@ -126,14 +113,14 @@ class RolePermissionTests(SupersetTestCase):
 
         self.assertTrue(
             security_manager.is_admin_only(
-                security_manager.find_permission_view_menu("can_delete", "DatabaseView")
+                security_manager.find_permission_view_menu("can_delete", "Database")
             )
         )
         if app.config.get("ENABLE_ACCESS_REQUEST"):
             self.assertTrue(
                 security_manager.is_admin_only(
                     security_manager.find_permission_view_menu(
-                        "can_show", "AccessRequestsModelView"
+                        "can_read", "AccessRequestsModelView"
                     )
                 )
             )
@@ -153,15 +140,13 @@ class RolePermissionTests(SupersetTestCase):
     def test_is_alpha_only(self):
         self.assertFalse(
             security_manager.is_alpha_only(
-                security_manager.find_permission_view_menu("can_show", "TableModelView")
+                security_manager.find_permission_view_menu("can_read", "Datasource")
             )
         )
 
         self.assertTrue(
             security_manager.is_alpha_only(
-                security_manager.find_permission_view_menu(
-                    "muldelete", "TableModelView"
-                )
+                security_manager.find_permission_view_menu("muldelete", "Datasource")
             )
         )
         self.assertTrue(
@@ -173,16 +158,12 @@ class RolePermissionTests(SupersetTestCase):
         )
         self.assertTrue(
             security_manager.is_alpha_only(
-                security_manager.find_permission_view_menu(
-                    "can_edit", "SqlMetricInlineView"
-                )
+                security_manager.find_permission_view_menu("can_edit", "Datasource")
             )
         )
         self.assertTrue(
             security_manager.is_alpha_only(
-                security_manager.find_permission_view_menu(
-                    "can_delete", "DruidMetricInlineView"
-                )
+                security_manager.find_permission_view_menu("can_delete", "Datasource")
             )
         )
         self.assertTrue(
@@ -196,7 +177,7 @@ class RolePermissionTests(SupersetTestCase):
     def test_is_gamma_pvm(self):
         self.assertTrue(
             security_manager.is_gamma_pvm(
-                security_manager.find_permission_view_menu("can_show", "TableModelView")
+                security_manager.find_permission_view_menu("can_read", "Datasource")
             )
         )
 
@@ -206,14 +187,16 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_cannot_alpha(get_perm_tuples("Alpha"))
 
     def test_alpha_permissions(self):
-        self.assert_can_gamma(get_perm_tuples("Alpha"))
-        self.assert_can_alpha(get_perm_tuples("Alpha"))
-        self.assert_cannot_alpha(get_perm_tuples("Alpha"))
+        pvms = get_perm_tuples("Alpha")
+        self.assert_can_gamma(pvms)
+        self.assert_can_alpha(pvms)
+        self.assert_cannot_alpha(pvms)
 
     def test_admin_permissions(self):
-        self.assert_can_gamma(get_perm_tuples("Admin"))
-        self.assert_can_alpha(get_perm_tuples("Admin"))
-        self.assert_can_admin(get_perm_tuples("Admin"))
+        pvms = get_perm_tuples("Admin")
+        self.assert_can_gamma(pvms)
+        self.assert_can_alpha(pvms)
+        self.assert_can_admin(pvms)
 
     def test_sql_lab_permissions(self):
         sql_lab_set = get_perm_tuples("sql_lab")
@@ -233,38 +216,34 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_cannot_alpha(granter_set)
 
     def test_gamma_permissions(self):
-        def assert_can_read(view_menu):
-            self.assertIn(("can_show", view_menu), gamma_perm_set)
-            self.assertIn(("can_list", view_menu), gamma_perm_set)
-
-        def assert_can_write(view_menu):
-            self.assertIn(("can_add", view_menu), gamma_perm_set)
-            self.assertIn(("can_download", view_menu), gamma_perm_set)
-            self.assertIn(("can_delete", view_menu), gamma_perm_set)
-            self.assertIn(("can_edit", view_menu), gamma_perm_set)
-
-        def assert_cannot_write(view_menu):
-            self.assertNotIn(("can_add", view_menu), gamma_perm_set)
-            self.assertNotIn(("can_download", view_menu), gamma_perm_set)
-            self.assertNotIn(("can_delete", view_menu), gamma_perm_set)
-            self.assertNotIn(("can_edit", view_menu), gamma_perm_set)
-            self.assertNotIn(("can_save", view_menu), gamma_perm_set)
-
-        def assert_can_all(view_menu):
-            assert_can_read(view_menu)
-            assert_can_write(view_menu)
 
         gamma_perm_set = set()
         for perm in security_manager.find_role("Gamma").permissions:
             gamma_perm_set.add((perm.permission.name, perm.view_menu.name))
 
-        # check read only perms
-        assert_can_read("TableModelView")
-        assert_cannot_write("DruidColumnInlineView")
+        def assert_can_read(view_menu):
+            self.assertIn(("can_read", view_menu), gamma_perm_set)
 
-        # make sure that user can create slices and dashboards
-        assert_can_all("SliceModelView")
-        assert_can_all("DashboardModelView")
+        def assert_can_write(view_menu):
+            self.assertIn(("can_write", view_menu), gamma_perm_set)
+
+        def assert_cannot_write(view_menu):
+            self.assertNotIn(("can_write", view_menu), gamma_perm_set)
+
+        def assert_can_all(view_menu):
+            assert_can_read(view_menu)
+            assert_can_write(view_menu)
+
+        # check read only perms
+        self.assertIn(("can_read", "Datasource"), gamma_perm_set)
+        self.assertNotIn(("can_write", "Datasource"), gamma_perm_set)
+        self.assertNotIn(("can_edit", "Datasource"), gamma_perm_set)
+
+        # make sure that user can read & write slices and dashboards
+        self.assertIn(("can_read", "Slice"), gamma_perm_set)
+        self.assertIn(("can_write", "Slice"), gamma_perm_set)
+        self.assertIn(("can_read", "Dashboard"), gamma_perm_set)
+        self.assertIn(("can_write", "Dashboard"), gamma_perm_set)
 
         self.assertIn(("can_add_slices", "Superset"), gamma_perm_set)
         self.assertIn(("can_copy_dash", "Superset"), gamma_perm_set)


### PR DESCRIPTION
A new feature in FAB 2.1 allows us to assign permission names.

This allows us to greatly simplify the security model in Superset, by
redefining the atomicity of permissions, and effectively aggregating
sets of permissions to individual ones.

FAB docs about this feature
https://flask-appbuilder.readthedocs.io/en/latest/security.html#permission-customization

Note that this requires running commands:
```bash
flask fab security-converge
```
These commands will reassign and merge old permissions to new ones appropriately.

# TODO
* [ ] further aggregate and cleanup perms
* [ ] out-of-scope for this PR, migrate individual views, and assign perms that match related ModelViews perms
* [ ] break down the main `views/core.py` module into smaller modules, assign proper perms
