### PR TITLE
Add Table List Refresh Button

### DIFF
--- a/superset/templates/appbuilder/general/widgets/search.html
+++ b/superset/templates/appbuilder/general/widgets/search.html
@@ -39,6 +39,7 @@
             <button type="submit" class="btn btn-sm btn-primary" id="search-action">
                 Search&nbsp;&nbsp;<i class="fa fa-search"></i>
             </button>
+	    <br />
             </div>
         </div>
     </form>
@@ -53,7 +54,7 @@
                 $('.filters a.remove-filter').on('click', checkSearchButton);
                 $('.filter-action').toggle(true);
             } else {
-                $('.filter-action').text("Refresh");
+                $('.filter-action > button').html('Refresh&nbsp;&nbsp;<i class="fa fa-refresh"></i>');
             }
         }
 

--- a/superset/templates/appbuilder/general/widgets/search.html
+++ b/superset/templates/appbuilder/general/widgets/search.html
@@ -45,30 +45,30 @@
 </div>
 
 <script>
-(function($) {
-    function checkSearchButton() {
-        var hasFilter = $('.filters tr').length;
-        if (hasFilter) {
-            $('.filters a.remove-filter').off('click', checkSearchButton);
-            $('.filters a.remove-filter').on('click', checkSearchButton);
-            $('.filter-action').toggle(true);
-        } else {
-            $('.filter-action').toggle(false);
+    (function($) {
+        function checkSearchButton() {
+            var hasFilter = $('.filters tr').length;
+            if (hasFilter) {
+                $('.filters a.remove-filter').off('click', checkSearchButton);
+                $('.filters a.remove-filter').on('click', checkSearchButton);
+                $('.filter-action').toggle(true);
+            } else {
+                $('.filter-action').text("Refresh");
+            }
         }
-    }
 
-    $('.list-search-container').on('hidden.bs.dropdown', checkSearchButton);
-    $(document).ready(function() {
-        checkSearchButton();
-    });
+        $('.list-search-container').on('hidden.bs.dropdown', checkSearchButton);
+        $(document).ready(function() {
+            checkSearchButton();
+        });
 
-    var filter = new AdminFilters(
-        '#filter_form',
-        {{ label_columns | tojson | safe }},
-        {{ form_fields | tojson | safe }},
-        {{ search_filters | tojson | safe }},
-        {{ active_filters | tojson | safe }}
-    );
-})(jQuery);
+        var filter = new AdminFilters(
+            '#filter_form',
+            {{ label_columns | tojson | safe }},
+            {{ form_fields | tojson | safe }},
+            {{ search_filters | tojson | safe }},
+            {{ active_filters | tojson | safe }}
+        );
+    })(jQuery);
 
 </script>

--- a/superset/templates/appbuilder/general/widgets/search.html
+++ b/superset/templates/appbuilder/general/widgets/search.html
@@ -39,37 +39,37 @@
             <button type="submit" class="btn btn-sm btn-primary" id="search-action">
                 Search&nbsp;&nbsp;<i class="fa fa-search"></i>
             </button>
-	    <br />
             </div>
         </div>
     </form>
 </div>
 
 <script>
-    (function($) {
-        function checkSearchButton() {
-            var hasFilter = $('.filters tr').length;
-            if (hasFilter) {
-                $('.filters a.remove-filter').off('click', checkSearchButton);
-                $('.filters a.remove-filter').on('click', checkSearchButton);
-                $('.filter-action').toggle(true);
-            } else {
-                $('.filter-action > button').html('Refresh&nbsp;&nbsp;<i class="fa fa-refresh"></i>');
-            }
+(function($) {
+    function checkSearchButton() {
+        var hasFilter = $('.filters tr').length;
+        if (hasFilter) {
+            $('.filters a.remove-filter').off('click', checkSearchButton);
+            $('.filters a.remove-filter').on('click', checkSearchButton);
+            $('.filter-action').toggle(true);
+        } else {
+            $('.filter-action').toggle(true);
+            $('.filter-action > button').html('Refresh&nbsp;&nbsp;<i class="fa fa-refresh"></i>');
         }
+    }
 
-        $('.list-search-container').on('hidden.bs.dropdown', checkSearchButton);
-        $(document).ready(function() {
-            checkSearchButton();
-        });
+    $('a.btn.remove-filter').on('click', checkSearchButton);
+    $(document).ready(function() {
+        checkSearchButton();
+    });
 
-        var filter = new AdminFilters(
-            '#filter_form',
-            {{ label_columns | tojson | safe }},
-            {{ form_fields | tojson | safe }},
-            {{ search_filters | tojson | safe }},
-            {{ active_filters | tojson | safe }}
-        );
-    })(jQuery);
+    var filter = new AdminFilters(
+        '#filter_form',
+        {{ label_columns | tojson | safe }},
+        {{ form_fields | tojson | safe }},
+        {{ search_filters | tojson | safe }},
+        {{ active_filters | tojson | safe }}
+    );
+})(jQuery);
 
 </script>

--- a/superset/templates/appbuilder/general/widgets/search.html
+++ b/superset/templates/appbuilder/general/widgets/search.html
@@ -45,31 +45,31 @@
 </div>
 
 <script>
-(function($) {
-    function checkSearchButton() {
-        var hasFilter = $('.filters tr').length;
-        if (hasFilter) {
-            $('.filters a.remove-filter').off('click', checkSearchButton);
-            $('.filters a.remove-filter').on('click', checkSearchButton);
-            $('.filter-action').toggle(true);
-        } else {
-            $('.filter-action').toggle(true);
-            $('.filter-action > button').html('Refresh&nbsp;&nbsp;<i class="fa fa-refresh"></i>');
+    (function($) {
+        function checkSearchButton() {
+            var hasFilter = $('.filters tr').length;
+            if (hasFilter) {
+                $('.filters a.remove-filter').off('click', checkSearchButton);
+                $('.filters a.remove-filter').on('click', checkSearchButton);
+                $('.filter-action').toggle(true);
+            } else {
+                $('.filter-action').toggle(true);
+                $('.filter-action > button').html('Refresh&nbsp;&nbsp;<i class="fa fa-refresh"></i>');
+            }
         }
-    }
 
-    $('a.btn.remove-filter').on('click', checkSearchButton);
-    $(document).ready(function() {
-        checkSearchButton();
-    });
+        $('a.btn.remove-filter').on('click', checkSearchButton);
+        $(document).ready(function() {
+            checkSearchButton();
+        });
 
-    var filter = new AdminFilters(
-        '#filter_form',
-        {{ label_columns | tojson | safe }},
-        {{ form_fields | tojson | safe }},
-        {{ search_filters | tojson | safe }},
-        {{ active_filters | tojson | safe }}
-    );
-})(jQuery);
+        var filter = new AdminFilters(
+            '#filter_form',
+            {{ label_columns | tojson | safe }},
+            {{ form_fields | tojson | safe }},
+            {{ search_filters | tojson | safe }},
+            {{ active_filters | tojson | safe }}
+        );
+    })(jQuery);
 
 </script>


### PR DESCRIPTION
### CATEGORY



Choose one



- [x] Bug Fix

- [x] Enhancement (new features, refinement)



### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

When there are no filters active, to see the filter-less list of tables, you have to do a browser refresh. It would be helpful in the UI for some business users to be able to simply refresh with the search button, but it goes away. Search here is really refresh (usually with filters enabled), so it seems natural. 

That is the main change here. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!--- Skip this if not applicable -->

cannot get fab to update template. 

### TEST PLAN

<!--- What steps should be taken to verify the changes -->

Refresh the template through re-initialization of the app and render the new table search page. 

### ADDITIONAL INFORMATION

<!--- Check any relevant boxes with "x" -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- [x] Has associated issue: [#7493](https://github.com/apache/incubator-superset/issues/7493#issuecomment-491667962)

- [x] Changes UI




### REVIEWERS

