### PR TITLE
chore: Truncate progressbar percentage decimals (#7499) (#7517)

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/src/SqlLab/components/QueryTable.jsx
@@ -41,8 +41,8 @@ const propTypes = {
 const defaultProps = {
   columns: ['started', 'duration', 'rows'],
   queries: [],
-  onUserClicked: () => {},
-  onDbClicked: () => {},
+  onUserClicked: () => { },
+  onDbClicked: () => { },
 };
 
 class QueryTable extends React.PureComponent {
@@ -169,7 +169,7 @@ class QueryTable extends React.PureComponent {
             style={{ width: '75px' }}
             striped
             now={q.progress}
-            label={`${q.progress}%`}
+            label={`${q.progress.toFixed(0)}%`}
           />
         );
         let errorTooltip;

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -241,7 +241,7 @@ export default class ResultSet extends React.PureComponent {
         <ProgressBar
           striped
           now={query.progress}
-          label={`${query.progress}%`}
+          label={`${query.progress.toFixed(0)}%`}
         />);
     }
     if (query.trackingUrl) {


### PR DESCRIPTION
## REGARGET TO MASTER (#7499 / #7517)

This change makes the query progress bar only show
whole number percentage changes, instead of numbers
like 12.13168276%.
