### PR TITLE
Show scheduled queries

### DIFF
--- a/superset/assets/src/showSavedQuery/index.jsx
+++ b/superset/assets/src/showSavedQuery/index.jsx
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import ReactDom from 'react-dom';
+import Form from 'react-jsonschema-form';
+
+const scheduleInfoContainer = document.getElementById('schedule-info');
+const bootstrapData = JSON.parse(scheduleInfoContainer.getAttribute('data-bootstrap'));
+const schemas = bootstrapData.common.feature_flags.SCHEDULED_QUERIES;
+const schedule_info = bootstrapData.common.extra_json.schedule_info;
+
+if (schedule_info && schemas) {
+  // hide instructions when showing schedule info
+  schemas.JSONSCHEMA.description = '';
+
+  ReactDom.render(
+    <Form
+      schema={schemas.JSONSCHEMA}
+      uiSchema={schemas.UISCHEMA}
+      formData={schedule_info}
+      disabled
+    >
+      <br/>
+    </Form>,
+    scheduleInfoContainer,
+  );
+}

--- a/superset/assets/src/showSavedQuery/index.jsx
+++ b/superset/assets/src/showSavedQuery/index.jsx
@@ -23,9 +23,9 @@ import Form from 'react-jsonschema-form';
 const scheduleInfoContainer = document.getElementById('schedule-info');
 const bootstrapData = JSON.parse(scheduleInfoContainer.getAttribute('data-bootstrap'));
 const schemas = bootstrapData.common.feature_flags.SCHEDULED_QUERIES;
-const schedule_info = bootstrapData.common.extra_json.schedule_info;
+const scheduleInfo = bootstrapData.common.extra_json.schedule_info;
 
-if (schedule_info && schemas) {
+if (scheduleInfo && schemas) {
   // hide instructions when showing schedule info
   schemas.JSONSCHEMA.description = '';
 
@@ -33,10 +33,10 @@ if (schedule_info && schemas) {
     <Form
       schema={schemas.JSONSCHEMA}
       uiSchema={schemas.UISCHEMA}
-      formData={schedule_info}
+      formData={scheduleInfo}
       disabled
     >
-      <br/>
+      <br />
     </Form>,
     scheduleInfoContainer,
   );

--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -119,6 +119,7 @@ const config = {
     sqllab: addPreamble('/src/SqlLab/index.jsx'),
     welcome: addPreamble('/src/welcome/index.jsx'),
     profile: addPreamble('/src/profile/index.jsx'),
+    showSavedQuery: [path.join(APP_DIR, '/src/showSavedQuery/index.jsx')],
   },
   output,
   optimization: {

--- a/superset/templates/superset/models/savedquery/show.html
+++ b/superset/templates/superset/models/savedquery/show.html
@@ -1,0 +1,35 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+#}
+{% extends "appbuilder/general/model/show.html" %}
+
+{% block show_form %}
+  {{ super() }}
+  <div
+    id="schedule-info"
+    style="padding: 0 10px;"
+    data-bootstrap="{{ bootstrap_data }}"
+  ></div>
+{% endblock %}
+
+{% block tail_js %}
+  {{ super() }}
+  {% with filename="showSavedQuery" %}
+    {% include "superset/partials/_script_tag.html" %}
+  {% endwith %}
+{% endblock %}

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -153,7 +153,7 @@ class BaseSupersetView(BaseView):
             status=status,
             mimetype='application/json')
 
-    def common_bootsrap_payload(self):
+    def common_bootstrap_payload(self):
         """Common data always sent to the client"""
         messages = get_flashed_messages(with_categories=True)
         locale = str(get_locale())

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1372,7 +1372,7 @@ class Superset(BaseSupersetView):
             'standalone': standalone,
             'user_id': user_id,
             'forced_height': request.args.get('height'),
-            'common': self.common_bootsrap_payload(),
+            'common': self.common_bootstrap_payload(),
         }
         table_name = datasource.table_name \
             if datasource_type == 'table' \
@@ -2231,7 +2231,7 @@ class Superset(BaseSupersetView):
             'user_id': g.user.get_id(),
             'dashboard_data': dashboard_data,
             'datasources': {ds.uid: ds.data for ds in datasources},
-            'common': self.common_bootsrap_payload(),
+            'common': self.common_bootstrap_payload(),
             'editMode': edit_mode,
         }
 
@@ -2919,7 +2919,7 @@ class Superset(BaseSupersetView):
 
         payload = {
             'user': bootstrap_user_data(),
-            'common': self.common_bootsrap_payload(),
+            'common': self.common_bootstrap_payload(),
         }
 
         return self.render_template(
@@ -2938,7 +2938,7 @@ class Superset(BaseSupersetView):
 
         payload = {
             'user': bootstrap_user_data(username, include_perms=True),
-            'common': self.common_bootsrap_payload(),
+            'common': self.common_bootstrap_payload(),
         }
 
         return self.render_template(
@@ -2954,7 +2954,7 @@ class Superset(BaseSupersetView):
         """SQL Editor"""
         d = {
             'defaultDbId': config.get('SQLLAB_DEFAULT_DBID'),
-            'common': self.common_bootsrap_payload(),
+            'common': self.common_bootstrap_payload(),
         }
         return self.render_template(
             'superset/basic.html',

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -93,7 +93,7 @@ class SavedQueryView(SupersetModelView, DeleteMixin):
         'modified', 'pop_tab_link']
     show_columns = [
         'id', 'label', 'user', 'database',
-        'description', 'sql', 'pop_tab_link', 'extra_json']
+        'description', 'sql', 'pop_tab_link']
     search_columns = ('label', 'user', 'database', 'schema', 'changed_on')
     add_columns = ['label', 'database', 'description', 'sql']
     edit_columns = add_columns

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -122,12 +122,7 @@ class SavedQueryView(SupersetModelView, DeleteMixin):
     def show(self, pk):
         pk = self._deserialize_pk_if_composite(pk)
         widgets = self._show(pk)
-
-        # load object to get extra_json
-        session = db.create_scoped_session()
-        obj = session.query(SavedQuery).filter_by(id=pk).first()
-        extra_json = obj.extra_json
-
+        extra_json = self.datamodel.get(pk).extra_json
         payload = {
             'common': {
                 'feature_flags': get_feature_flags(),

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -117,6 +117,7 @@ class SavedQueryView(SupersetModelView, DeleteMixin):
     def pre_update(self, obj):
         self.pre_add(obj)
 
+    @has_access
     @expose('show/<pk>')
     def show(self, pk):
         pk = self._deserialize_pk_if_composite(pk)
@@ -153,6 +154,11 @@ class SavedQueryViewApi(SavedQueryView):
         'label', 'db_id', 'schema', 'description', 'sql', 'extra_json']
     add_columns = show_columns
     edit_columns = add_columns
+
+    @has_access_api
+    @expose('show/<pk>')
+    def show(self, pk):
+        return super().show(pk)
 
 
 appbuilder.add_view_no_menu(SavedQueryViewApi)

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -20,7 +20,7 @@ from typing import Callable
 from flask import g, redirect
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_appbuilder.security.decorators import has_access
+from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
 from flask_sqlalchemy import BaseQuery

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -145,7 +145,6 @@ class SavedQueryView(SupersetModelView, DeleteMixin):
         )
 
 
-
 class SavedQueryViewApi(SavedQueryView):
     list_columns = [
         'id', 'label', 'sqlalchemy_uri', 'user_email', 'schema', 'description',

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -26,7 +26,7 @@ from flask_babel import lazy_gettext as _
 from flask_sqlalchemy import BaseQuery
 import simplejson as json
 
-from superset import appbuilder, db, get_feature_flags, security_manager
+from superset import appbuilder, get_feature_flags, security_manager
 from superset.models.sql_lab import Query, SavedQuery
 from superset.utils import core as utils
 from .base import BaseSupersetView, DeleteMixin, SupersetFilter, SupersetModelView


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR shows scheduled information on saved queries that have them.

In order to do this, I created a custom template for showing the saved query, extending the native one from FAB. The template injects Javascript code and a `<div>`, and the Javascript code inserts a `<Form>` component with the scheduled information.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

It looks ugly, but I'll fix the CSS in another PR:

<img width="1698" alt="Screen Shot 2019-05-15 at 5 00 27 PM" src="https://user-images.githubusercontent.com/1534870/57817177-19b76e80-7733-11e9-9d2e-42f77c49eac7.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@mistercrunch @datability-io @DiggidyDave @khtruong 