### PR TITLE
[sql lab] Fix new query stuck at pending state

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -38,7 +38,7 @@ class QueryAutoRefresh extends React.PureComponent {
   }
   shouldCheckForQueries() {
     // if there are started or running queries, this method should return true
-    const { queries, queriesLastUpdate } = this.props;
+    const { queries } = this.props;
     const now = new Date().getTime();
 
     // due to a race condition, queries can be marked as successful before the
@@ -50,7 +50,6 @@ class QueryAutoRefresh extends React.PureComponent {
     );
 
     return (
-      queriesLastUpdate > 0 &&
       Object.values(queries).some(
         q => isQueryRunning(q) &&
         now - q.startDttm < MAX_QUERY_AGE_TO_POLL,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
I found a very strange corner case: some user didn't use sql lab for a long time, and they didn't have any old query tab in Sql Lab. When recently they started to use sql lab, their async query may stuck at pending state forever. From browser console I can see the query was sent to back end, but browser didn't start polling query results at all. So that even backend finished query, front end is still showing pending state. This issue can't be consistently reproduced, it only happened on few users, but those users are totally blocked and can't run any async queries successfully.

After debug I found polling was stopped by this line:

> return (
      queriesLastUpdate > 0 &&
      Object.values(queries).some(
        q => isQueryRunning(q) &&
        now - q.startDttm < MAX_QUERY_AGE_TO_POLL,
      )
    );


For those users got stuck at pending state, when sql lab was initialized, `queriesLastUpdate` was 0. There was a change for initial value introduced in #5896. `queriesLastUpdate` was set to 0 before this PR. So i am thinking probably those users' sql lab state was persisted into localStorage. And now they open sql lab with new code base that requires `queriesLastUpdate > 0`, then their sql lab can't poll anymore.

I don't think  `queriesLastUpdate > 0` is really necessary for polling query results. So my solution for this issue is just remove this requirement.

### TEST PLAN
ci and check with users stuck at pending state. 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@williaster @michellethomas