### PR TITLE
Disabling flask-talisman by default

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -613,7 +613,7 @@ SQL_VALIDATORS_BY_ENGINE = {
 }
 
 # Do you want Talisman enabled?
-TALISMAN_ENABLED = True
+TALISMAN_ENABLED = False
 # If you want Talisman, how do you want it configured??
 TALISMAN_CONFIG = {
     'content_security_policy': None,


### PR DESCRIPTION


### CATEGORY

Choose one
- [x] Bug Fix


### SUMMARY
flask-talisman was enabled recently and while it may be virtuous in some
cases, it seems to break things out of the box.

Locally and in dev mode, upon my first redirect it sends to HTTPS and
things it crashes.

I think it should be opt-in, maybe we can recommend turning this on in
production in the docs?

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="832" alt="Screen Shot 2019-05-16 at 9 16 24 PM" src="https://user-images.githubusercontent.com/487433/57902807-e43c7f00-781f-11e9-9eb4-11b2c8e0d81a.png">
<img width="743" alt="Screen Shot 2019-05-16 at 9 16 10 PM" src="https://user-images.githubusercontent.com/487433/57902808-e43c7f00-781f-11e9-8e22-a7c2c8b962c4.png">


