### PR TITLE
[cypress] fix accessing a cross-origin frame error

### DIFF
--- a/superset/assets/cypress/integration/dashboard/save.js
+++ b/superset/assets/cypress/integration/dashboard/save.js
@@ -20,6 +20,8 @@ import readResponseBlob from '../../utils/readResponseBlob';
 import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
 
 export default () => describe('save', () => {
+  Cypress.config('chromeWebSecurity', false);
+
   let dashboardId;
   let boxplotChartId;
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
Cypress dashboard tests randomly failed with error message: 
`Error: Blocked a frame with origin "https://*******.com" from accessing a cross-origin frame.`

<img width="1188" alt="Screen Shot 2019-05-19 at 6 57 28 PM" src="https://user-images.githubusercontent.com/27990562/57998231-67aada00-7a85-11e9-84a4-75992ede2af2.png">

This issues is reported here, and it also gave a solution: 
https://github.com/cypress-io/cypress/issues/1951

(There might have other error message, use #7538 track all cypress flaky issues)
### TEST PLAN
CI


### REVIEWERS
@mistercrunch @michellethomas 