### PR TITLE
Pinning werkzeug to 0.14.1 / Restoring Talisman defaults

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
         'unicodecsv',
         # Pinning werkzeug due to problems encountered with
         # new config options added in 0.15.x
-        'werkzeug==0.14.1',
+        'werkzeug<0.15.0',
         'wtforms-json',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,9 @@ setup(
         'sqlalchemy-utils',
         'sqlparse',
         'unicodecsv',
+        # Pinning werkzeug due to problems encountered with
+        # new config options added in 0.15.x
+        'werkzeug==0.14.1',
         'wtforms-json',
     ],
     extras_require={

--- a/superset/config.py
+++ b/superset/config.py
@@ -617,8 +617,6 @@ TALISMAN_ENABLED = True
 # If you want Talisman, how do you want it configured??
 TALISMAN_CONFIG = {
     'content_security_policy': None,
-    'force_https': True,
-    'force_https_permanent': False,
 }
 
 try:


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Ran into problems running Superset with newer werkzeug as installed by pip transitively through Flask. In order to deal with this, pinning  should be in place in order to retain a working setup in the event that pip-compile is re-run

Also addressing a minor Talisman config change as suggested by @john-bodley 

### REVIEWERS

@mistercrunch 
