### PR TITLE
Allowing editing scheduled queries

### DIFF
--- a/superset/assets/src/SqlLab/components/ScheduleQueryButton.jsx
+++ b/superset/assets/src/SqlLab/components/ScheduleQueryButton.jsx
@@ -71,25 +71,32 @@ function getValidator() {
 
 const propTypes = {
   defaultLabel: PropTypes.string,
+  defaultDescription: PropTypes.string,
   sql: PropTypes.string.isRequired,
   schema: PropTypes.string.isRequired,
   dbId: PropTypes.number.isRequired,
   animation: PropTypes.bool,
   onSchedule: PropTypes.func,
+  modalTitle: PropTypes.string,
+  formData: PropTypes.object,
 };
 const defaultProps = {
   defaultLabel: t('Undefined'),
+  defaultDescription: '',
   animation: true,
   onSchedule: () => {},
+  modalTitle: t('Schedule Query'),
+  formData: null,
 };
 
 class ScheduleQueryButton extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      description: '',
+      description: props.defaultDescription,
       label: props.defaultLabel,
       showSchedule: false,
+      formData: props.formData,
     };
     this.toggleSchedule = this.toggleSchedule.bind(this);
     this.onSchedule = this.onSchedule.bind(this);
@@ -108,6 +115,7 @@ class ScheduleQueryButton extends React.PureComponent {
     };
     this.props.onSchedule(query);
     this.saveModal.close();
+    this.setState({ formData });
   }
   onCancel() {
     this.saveModal.close();
@@ -128,6 +136,7 @@ class ScheduleQueryButton extends React.PureComponent {
         uiSchema={getUISchema()}
         onSubmit={this.onSchedule}
         validate={getValidator()}
+        formData={this.state.formData}
       />
     );
   }
@@ -136,14 +145,13 @@ class ScheduleQueryButton extends React.PureComponent {
       <span className="ScheduleQueryButton">
         <ModalTrigger
           ref={(ref) => { this.saveModal = ref; }}
-          modalTitle={t('Schedule Query')}
+          modalTitle={this.props.modalTitle}
           modalBody={this.renderModalBody()}
           triggerNode={
             <Button bsSize="small" className="toggleSchedule" onClick={this.toggleSchedule}>
-              <i className="fa fa-calendar" /> {t('Schedule Query')}
+              <i className="fa fa-calendar" /> {this.props.modalTitle}
             </Button>
           }
-          bsSize="medium"
         />
       </span>
     );

--- a/superset/assets/src/savedQuery/edit/App.jsx
+++ b/superset/assets/src/savedQuery/edit/App.jsx
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { hot } from 'react-hot-loader';
+import { initFeatureFlags } from 'src/featureFlags';
+import EditScheduledQueryContainer from './EditScheduledQueryContainer';
+
+const scheduleInfoContainer = document.getElementById('js-edit-savedquery-container');
+const bootstrapData = JSON.parse(scheduleInfoContainer.getAttribute('data-bootstrap'));
+initFeatureFlags(bootstrapData.common.feature_flags);
+const query = bootstrapData.common.query;
+
+const App = () => (
+  <EditScheduledQueryContainer query={query} />
+);
+
+export default hot(module)(App);

--- a/superset/assets/src/savedQuery/edit/EditScheduledQueryContainer.jsx
+++ b/superset/assets/src/savedQuery/edit/EditScheduledQueryContainer.jsx
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import ScheduleQueryButton from 'src/SqlLab/components/ScheduleQueryButton';
+import { t } from '@superset-ui/translation';
+
+const propTypes = {
+  query: PropTypes.object.isRequired,
+};
+
+function updateScheduleInfo(scheduleInfo) {
+  const input = document.getElementById('extra_json');
+  input.value = JSON.stringify({
+    ...JSON.parse(input.value),
+    schedule_info: scheduleInfo,
+  });
+}
+
+export default class EditScheduledQueryContainer extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onSchedule = this.onSchedule.bind(this);
+  }
+
+  onSchedule(query) {
+    updateScheduleInfo(JSON.parse(query.extra_json).schedule_info);
+    const form = document.getElementById('model_form');
+    form.submit();
+  }
+
+  render() {
+    const { query } = this.props;
+    return (query.extra_json.schedule_info
+      ? <ScheduleQueryButton
+        sql={query.sql}
+        schema={query.schema}
+        dbId={query.db_id}
+        onSchedule={this.onSchedule}
+        modalTitle={t('Edit schedule')}
+        formData={query.extra_json.schedule_info}
+        defaultLabel={query.label}
+        defaultDescription={query.description}
+      />
+      : null
+    );
+  }
+}
+
+EditScheduledQueryContainer.propTypes = propTypes;

--- a/superset/assets/src/savedQuery/edit/index.jsx
+++ b/superset/assets/src/savedQuery/edit/index.jsx
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(
+  <App />,
+  document.getElementById('js-edit-savedquery-container'),
+);

--- a/superset/assets/src/savedQuery/show/index.jsx
+++ b/superset/assets/src/savedQuery/show/index.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import Form from 'react-jsonschema-form';
 
-const scheduleInfoContainer = document.getElementById('schedule-info');
+const scheduleInfoContainer = document.getElementById('js-show-savedquery-container');
 const bootstrapData = JSON.parse(scheduleInfoContainer.getAttribute('data-bootstrap'));
 const schemas = bootstrapData.common.feature_flags.SCHEDULED_QUERIES;
 const scheduleInfo = bootstrapData.common.extra_json.schedule_info;

--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -119,7 +119,8 @@ const config = {
     sqllab: addPreamble('/src/SqlLab/index.jsx'),
     welcome: addPreamble('/src/welcome/index.jsx'),
     profile: addPreamble('/src/profile/index.jsx'),
-    showSavedQuery: [path.join(APP_DIR, '/src/showSavedQuery/index.jsx')],
+    showSavedQuery: [path.join(APP_DIR, '/src/savedQuery/show/index.jsx')],
+    editSavedQuery: [path.join(APP_DIR, '/src/savedQuery/edit/index.jsx')],
   },
   output,
   optimization: {

--- a/superset/templates/superset/models/savedquery/edit.html
+++ b/superset/templates/superset/models/savedquery/edit.html
@@ -16,12 +16,12 @@
   specific language governing permissions and limitations
   under the License.
 #}
-{% extends "appbuilder/general/model/show.html" %}
+{% extends "appbuilder/general/model/edit.html" %}
 
-{% block show_form %}
+{% block edit_form %}
   {{ super() }}
   <div
-    id="js-show-savedquery-container"
+    id="js-edit-savedquery-container"
     style="padding: 0 0 10px 10px;"
     data-bootstrap="{{ bootstrap_data }}"
   ></div>
@@ -29,7 +29,7 @@
 
 {% block tail_js %}
   {{ super() }}
-  {% with filename="showSavedQuery" %}
+  {% with filename="editSavedQuery" %}
     {% include "superset/partials/_script_tag.html" %}
   {% endwith %}
 {% endblock %}

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -178,12 +178,12 @@ class SavedQueryViewApi(SavedQueryView):
     @has_access_api
     @expose('show/<pk>')
     def show(self, pk):
-        return super().show(pk)
+        return SupersetModelView.show(self, pk)
 
     @has_access_api
     @expose('edit/<pk>')
     def edit(self, pk):
-        return super().edit(pk)
+        return SupersetModelView.edit(self, pk)
 
 
 appbuilder.add_view_no_menu(SavedQueryViewApi)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow editing `schedule_info` in saved queries that have it.

This is a bit messy because I didn't want to completely replace the current CRUD provided by FAB for saved queries (since I believe this is already in the works). Instead, I modified the template to have a button for editing the schedule, and it updates the information and submits the FAB form.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

![edit_schedule](https://user-images.githubusercontent.com/1534870/58053554-bbacd180-7b0c-11e9-8f14-7a7ae48e3fb3.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested locally. Also verified that regular, non-scheduled, queries work as before.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@mistercrunch @khtruong @DiggidyDave @datability-io 