### PR TITLE
Fix for polling queries

### DIFF
--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -46,7 +46,7 @@ class QueryAutoRefresh extends React.PureComponent {
     // problem
     const isQueryRunning = q => (
       ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 ||
-      (q.state === 'success' && q.resultsKey === null)
+      (q.state === 'success' && q.asyncRun && q.resultsKey === null)
     );
 
     return (

--- a/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
+++ b/superset/assets/src/SqlLab/components/QueryAutoRefresh.jsx
@@ -40,13 +40,8 @@ class QueryAutoRefresh extends React.PureComponent {
     // if there are started or running queries, this method should return true
     const { queries } = this.props;
     const now = new Date().getTime();
-
-    // due to a race condition, queries can be marked as successful before the
-    // results key is set; this is a workaround until we fix the underlying
-    // problem
     const isQueryRunning = q => (
-      ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0 ||
-      (q.state === 'success' && q.asyncRun && q.resultsKey === null)
+      ['running', 'started', 'pending', 'fetching'].indexOf(q.state) >= 0
     );
 
     return (

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -126,6 +126,7 @@ class Query(Model, ExtraJSONMixin):
             'resultsKey': self.results_key,
             'trackingUrl': self.tracking_url,
             'extra': self.extra,
+            'asyncRun': self.database.allow_run_async,
         }
 
     @property

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -126,7 +126,6 @@ class Query(Model, ExtraJSONMixin):
             'resultsKey': self.results_key,
             'trackingUrl': self.tracking_url,
             'extra': self.extra,
-            'asyncRun': self.database.allow_run_async,
         }
 
     @property


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/incubator-superset/pull/7446#pullrequestreview-238146228 changed the polling mechanism to keep polling when a query succeeds but doesn't have a `resultsKey`, to work around a race condition in SQL Lab. @graceguo-supercat pointed out that synchronous queries **do not** have `resultsKey`, and when they run the frontend keeps polling the backend unnecessarily.

This PR changes the logic so that the frontend keeps polling only for async queries that succeeded but don't have `resultsKeys` set.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Without this PR, this happens:

1. Run a sync query in SQL Lab, wait for results.
2. Create new tab, run async query.
3. Browser keeps polling after async query finished, since the sync query from (1) has no `resultsKey`.

With this PR, the browser stops polling once the async query finishes.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@graceguo-supercat 