### PR TITLE
[FAB] set AppBuilder to update_perms=False

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -203,6 +203,7 @@ with app.app_context():
         base_template='superset/base.html',
         indexview=MyIndexView,
         security_manager_class=custom_sm,
+        update_perms=False,  # Run `superset init` to update FAB's perms
     )
 
 security_manager = appbuilder.sm

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ require-code = true
 [testenv]
 commands =
     {toxinidir}/superset/bin/superset db upgrade
+    {toxinidir}/superset/bin/superset init
     nosetests tests/load_examples_test.py
     nosetests -e load_examples_test {posargs}
 deps =


### PR DESCRIPTION
### CATEGORY
- [x] Build / Development Environment

### SUMMARY
Upon start, by default, FAB tries to go and update the permission list
in the database based on the list of views, models and menu items that
exist in the code.

Really this should happen once per deployment/upgrade and
not in module scope, so we have `superset init` for this.

The intent was always to set to False by default, but I think we forgot
to add this flag back in
https://github.com/apache/incubator-superset/pull/7323
