### PR TITLE
Add epoch functions for BigQuery

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1957,6 +1957,14 @@ class BQEngineSpec(BaseEngineSpec):
         return [sqla.literal_column(c.get('name')).label(c.get('name').replace('.', '__'))
                 for c in cols]
 
+    @classmethod
+    def epoch_to_dttm(cls):
+        return 'TIMESTAMP_SECONDS({col})'
+
+    @classmethod
+    def epoch_ms_to_dttm(cls):
+        return 'TIMESTAMP_MILLIS({col})'
+
 
 class ImpalaEngineSpec(BaseEngineSpec):
     """Engine spec for Cloudera's Impala"""


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Enhancement (new features, refinement)

### SUMMARY
Add second and millisecond epoch functions to BigQuery spec. Based on official docs: https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#timestamp_seconds

### TEST PLAN
Test locally

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #7553
