### PR TITLE
[ad-hoc] Fixing type for COUNT DISTINCT

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -932,7 +932,7 @@ class DruidDatasource(Model, BaseDatasource):
         if aggregate == 'count':
             return 'count'
         if aggregate == 'count_distinct':
-            return 'cardinality'
+            return 'hyperUnique' if column_type == 'hyperunique' else 'cardinality'
         else:
             return column_type + aggregate.capitalize()
 

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -771,6 +771,13 @@ class DruidFuncTestCase(unittest.TestCase):
         })
         assert(druid_type == 'cardinality')
 
+        druid_type = DruidDatasource.druid_type_from_adhoc_metric({
+            'column': {'type': 'hyperUnique', 'column_name': 'value'},
+            'aggregate': 'COUNT_DISTINCT',
+            'label': 'My Adhoc Metric',
+        })
+        assert(druid_type == 'hyperUnique')
+
     def test_run_query_order_by_metrics(self):
         client = Mock()
         client.query_builder.last_query.query_dict = {'mock': 0}


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes an issue with ad-hoc metrics using the Druid REST API related to `COUNT DISTINCT`. Specifically per the [documentation](http://druid.io/docs/latest/querying/hll-old.html) the type should be `hyperUnique` when 

> ... that has been aggregated as a "hyperUnique" metric at indexing time.

as opposed to `cardinality`. Both use HyperLogLog however the former is specific to Druid metrics which are of type `hyperUnique` (per the indexing aggregation) vs computing the cardinality of non-complex types.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI.

### REVIEWERS

to: @gabe-lyons @michellethomas @mistercrunch 
