### PR TITLE
Add "Auto" option to Mapbox visualization point radius

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1850,7 +1850,7 @@ export const controls = {
     'on the largest cluster'),
     mapStateToProps: state => ({
       choices: formatSelectOptions(['Auto']).concat(columnChoices(state.datasource)),
-    }), 
+    }),
   },
 
   point_radius_unit: {

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1849,8 +1849,8 @@ export const controls = {
     'Either a numerical column or `Auto`, which scales the point based ' +
     'on the largest cluster'),
     mapStateToProps: state => ({
-      choices: columnChoices(state.datasource),
-    }),
+      choices: formatSelectOptions(['Auto']).concat(columnChoices(state.datasource)),
+    }), 
   },
 
   point_radius_unit: {


### PR DESCRIPTION
It was intended to make it work as expected since exploring the corresponding example (misc -> mapbox chart) using this didn't work because lacking it (and also as the tooltip says the "Auto" is an option and hence should be available)

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
