### PR TITLE
adding command for seeing FAB template changes reflected.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,6 +336,9 @@ superset load_examples
 FLASK_ENV=development superset run -p 8088 --with-threads --reload --debugger
 ```
 
+If you have made changes to the FAB-managed templates, which are not built the same way as the newer, React-powered front-end assets, you need to start the app without the `--with-threads` argument like so:
+`FLASK_ENV=development superset run -p 8088 --reload --debugger`
+
 #### Logging to the browser console
 
 This feature is only available on Python 3. When debugging your application, you can have the server logs sent directly to the browser console using the [ConsoleLog](https://github.com/betodealmeida/consolelog) package. You need to mutate the app, by adding the following to your `config.py` or `superset_config.py`:


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Documentation

### SUMMARY

Even though this is a legacy portion of the app that is likely to go away one day, the FAB-managed templates still play a vital role to the application and some of its core features. When I set to fix a bug in a FAB-managed template, I could not get the template to refresh. 

I learned through a bit of head-wall-butting and searching that removing `--with-threads` from the run command might solve the problem due to a race condition. I don't have enough information to say that's exactly what's going on for sure, but removing `--with-threads` did result in my template pages being updated. 

### TEST PLAN

1. Make a change to a template file managed by FAB and check to see if the change is reflected, even after clearing your cache or browsing in incognito and start the app with:

`FLASK_ENV=development superset run -p 8088 --with-threads --reload --debugger`

2. Stop the server and try to start it again with this command:

FLASK_ENV=development superset run -p 8088 --reload --debugger

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->          
- [x] Has associated issue: "Fixes [#7493](https://github.com/apache/incubator-superset/issues/7493)"

### REVIEWERS