### PR TITLE
fix: SqlaColumn.type overflow on mysql

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -900,7 +900,7 @@ class SqlaTable(Model, BaseDatasource):
 
         for col in table.columns:
             try:
-                datatype = col.type.compile(dialect=db_dialect).upper()
+                datatype = db_engine_spec.column_datatype_to_string(col.type, db_dialect)
             except Exception as e:
                 datatype = 'UNKNOWN'
                 logging.error(

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -529,13 +529,6 @@ class BaseEngineSpec(object):
             label = label[:cls.max_column_name_length]
         return label
 
-    @staticmethod
-    def get_timestamp_column(expression, column_name):
-        """Return the expression if defined, otherwise return column_name. Some
-        engines require forcing quotes around column name, in which case this method
-        can be overridden."""
-        return expression or column_name
-
     @classmethod
     def column_datatype_to_string(cls, sqla_column_type, dialect):
         return sqla_column_type.compile(dialect=dialect).upper()

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -174,12 +174,15 @@ class SupersetTestCase(unittest.TestCase):
                     perm.view_menu and table.perm in perm.view_menu.name):
                 security_manager.del_permission_role(public_role, perm)
 
+    def get_main_database(self):
+        return get_main_database(db.session)
+
     def run_sql(self, sql, client_id=None, user_name=None, raise_on_error=False,
                 query_limit=None):
         if user_name:
             self.logout()
             self.login(username=(user_name if user_name else 'admin'))
-        dbid = get_main_database(db.session).id
+        dbid = self.get_main_database().id
         resp = self.get_json_resp(
             '/superset/sql_json/',
             raise_on_error=False,
@@ -195,7 +198,7 @@ class SupersetTestCase(unittest.TestCase):
         if user_name:
             self.logout()
             self.login(username=(user_name if user_name else 'admin'))
-        dbid = get_main_database(db.session).id
+        dbid = self.get_main_database().id
         resp = self.get_json_resp(
             '/superset/validate_sql_json/',
             raise_on_error=False,

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -823,4 +823,8 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             main_db.db_engine_spec.column_datatype_to_string(c.type, dialect)
             for c in sqla_table.columns
         ]
-        self.assertEquals(col_names, ['VARCHAR(255)', 'VARCHAR(255)', 'FLOAT'])
+        if main_db.backend == 'postgresql':
+            expected = ['VARCHAR(255)', 'VARCHAR(255)', 'DOUBLE PRECISION']
+        else:
+            expected = ['VARCHAR(255)', 'VARCHAR(255)', 'FLOAT']
+        self.assertEquals(col_names, expected)

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -814,3 +814,13 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         expr = PinotEngineSpec.get_timestamp_expr(col, 'epoch_s', 'P1M')
         result = str(expr.compile())
         self.assertEqual(result, 'DATETIMECONVERT(tstamp, "1:SECONDS:EPOCH", "1:SECONDS:EPOCH", "1:MONTHS")')  # noqa
+
+    def test_column_datatype_to_string(self):
+        main_db = self.get_main_database()
+        sqla_table = main_db.get_table('energy_usage')
+        dialect = main_db.get_dialect()
+        col_names = [
+            main_db.db_engine_spec.column_datatype_to_string(c.type, dialect)
+            for c in sqla_table.columns
+        ]
+        self.assertEquals(col_names, ['VARCHAR(255)', 'VARCHAR(255)', 'FLOAT'])


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix


### SUMMARY
Future proofing for `mysqlclient>=1.4`, as extracting column types becomes more verbose and overflows our 32 char liimit on `SqlaColumn.type`

Type looks like 'VARCHAR(255) COLLATE utf8mb4_general_ci' suffix which is too
verbose and not needed in that context. Adding mysql-specific code that strips out the collation information.
