### PR TITLE
[sqllab] Cancel database query on stop

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -766,3 +766,28 @@ class BaseEngineSpec:
         :return: Compiled column type
         """
         return sqla_column_type.compile(dialect=dialect).upper()
+
+    @classmethod
+    def get_cancel_query_payload(cls, cursor, query):
+        """
+        Returns None if query can not be cancelled.
+
+        :param cursor: Cursor instance in which the query will be executed
+        :param query: Query instance
+        :return: Type of the payload can vary depends on databases
+        but must be jsonable. None if query can't be cancelled.
+        """
+        return None
+
+    @classmethod
+    def cancel_query(cls, cursor, query, payload):
+        """
+        Cancels query in the underlying database.
+        The method is called only when payload is not None.
+
+        :param cursor: New cursor instance to the db of the query
+        :param query: Query instance
+        :param payload: Value returned by get_cancel_query_payload or set in
+        other life-cycle methods of the query
+        """
+        pass

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -108,3 +108,13 @@ class MySQLEngineSpec(BaseEngineSpec):
         if str_cutoff in datatype:
             datatype = datatype.split(str_cutoff)[0]
         return datatype
+
+    @classmethod
+    def get_cancel_query_payload(cls, cursor, query):
+        cursor.execute("SELECT CONNECTION_ID()")
+        row = cursor.fetchone()
+        return row[0]
+
+    @classmethod
+    def cancel_query(cls, cursor, query, payload):
+        cursor.execute("KILL CONNECTION %d" % payload)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2472,6 +2472,7 @@ class Superset(BaseSupersetView):
             query = db.session.query(Query).filter_by(client_id=client_id).one()
             query.status = QueryStatus.STOPPED
             db.session.commit()
+            sql_lab.cancel_query(query, g.user.username if g.user else None)
         except Exception:
             pass
         return self.json_response("OK")


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Sorry for submitting PR without creating an issue first. It doesn't look like a big change but I can convert the issue and proposal into SIP if needed.

#### The issue
SQL Lab has Stop button but it only updates state of superset without actually stopping the database query.
In some cases complex query can run in background for days and affect database performance.
The issue especially affect us as we use Superset with [gitbase](http://github.com/src-d/gitbase) which speeks MySQL protocol.

#### This commit solves the problem as following:

1. Add new key `cancel_payload` into extra attribute of the Query instance.
2. Add `get_cancel_query_payload` method to EngineSpec that returns some
payload from the connection which allows to cancel it later.
3. `execute_sql_statements` before executing queries retrieves and saves
cancel payload into Query
4. Stop handler calls new `cancel_query` method of EngineSpec

Both new methods are implemented only for MySQL for now but it is easy
to add support for PostgreSQL, MSSQL and maybe some other DBs.

For MySQL I use `KILL CONNECTION` to terminate multiple statements.

#### Alternative approach:

Maintain list of open connections and close them on cancel.
This solutions looks cleaner but has some disadvantages:
- would require big changes in the codebase
- implementation would get very tricky in distributed mode
- some drivers can keep query running even after `close()` call.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Run complex log-running query with MySQL using SQL lab. Press stop. The query should be killed.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
