### PR TITLE
Fix SQL Lab window resizing layout bug

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/SqlEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditor_spec.jsx
@@ -20,9 +20,18 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { defaultQueryEditor, initialState, queries, table } from './fixtures';
+import {
+  SQL_EDITOR_GUTTER_HEIGHT,
+  SQL_EDITOR_GUTTER_MARGIN,
+  SQL_TOOLBAR_HEIGHT,
+} from '../../../src/SqlLab/constants';
+import AceEditorWrapper from '../../../src/SqlLab/components/AceEditorWrapper';
 import LimitControl from '../../../src/SqlLab/components/LimitControl';
+import SouthPane from '../../../src/SqlLab/components/SouthPane';
 import SqlEditor from '../../../src/SqlLab/components/SqlEditor';
 import SqlEditorLeftBar from '../../../src/SqlLab/components/SqlEditorLeftBar';
+
+const MOCKED_SQL_EDITOR_HEIGHT = 500;
 
 describe('SqlEditor', () => {
   const mockedProps = {
@@ -40,7 +49,7 @@ describe('SqlEditor', () => {
   };
 
   beforeAll(() => {
-    jest.spyOn(SqlEditor.prototype, 'getSqlEditorHeight').mockImplementation(() => 500);
+    jest.spyOn(SqlEditor.prototype, 'getSqlEditorHeight').mockImplementation(() => MOCKED_SQL_EDITOR_HEIGHT);
   });
 
   it('is valid', () => {
@@ -51,6 +60,33 @@ describe('SqlEditor', () => {
   it('render a SqlEditorLeftBar', () => {
     const wrapper = shallow(<SqlEditor {...mockedProps} />);
     expect(wrapper.find(SqlEditorLeftBar)).toHaveLength(1);
+  });
+  it('render an AceEditorWrapper', () => {
+    const wrapper = shallow(<SqlEditor {...mockedProps} />);
+    expect(wrapper.find(AceEditorWrapper)).toHaveLength(1);
+  });
+  it('render an SouthPane', () => {
+    const wrapper = shallow(<SqlEditor {...mockedProps} />);
+    expect(wrapper.find(SouthPane)).toHaveLength(1);
+  });
+  it('does not overflow the editor window', () => {
+    const wrapper = shallow(<SqlEditor {...mockedProps} />);
+    const totalSize = parseFloat(wrapper.find(AceEditorWrapper).props().height)
+      + wrapper.find(SouthPane).props().height
+      + SQL_TOOLBAR_HEIGHT
+      + (SQL_EDITOR_GUTTER_MARGIN * 2)
+      + SQL_EDITOR_GUTTER_HEIGHT;
+    expect(totalSize).toEqual(MOCKED_SQL_EDITOR_HEIGHT);
+  });
+  it('does not overflow the editor window after resizing', () => {
+    const wrapper = shallow(<SqlEditor {...mockedProps} />);
+    wrapper.setState({ height: 450 });
+    const totalSize = parseFloat(wrapper.find(AceEditorWrapper).props().height)
+      + wrapper.find(SouthPane).props().height
+      + SQL_TOOLBAR_HEIGHT
+      + (SQL_EDITOR_GUTTER_MARGIN * 2)
+      + SQL_EDITOR_GUTTER_HEIGHT;
+    expect(totalSize).toEqual(450);
   });
   it('render a LimitControl with default limit', () => {
     const defaultQueryLimit = 101;

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -33,9 +33,10 @@ const propTypes = {
 };
 
 const defaultProps = {
-  tables: [],
   actions: {},
+  height: 500,
   offline: false,
+  tables: [],
 };
 
 export default class SqlEditorLeftBar extends React.PureComponent {

--- a/superset/assets/src/SqlLab/constants.js
+++ b/superset/assets/src/SqlLab/constants.js
@@ -43,3 +43,8 @@ export const TIME_OPTIONS = [
   '90 days ago',
   '1 year ago',
 ];
+
+// SqlEditor layout constants
+export const SQL_EDITOR_GUTTER_HEIGHT = 5;
+export const SQL_EDITOR_GUTTER_MARGIN = 3;
+export const SQL_TOOLBAR_HEIGHT = 51;


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a throttled event listener for window resizes to recalculate the heights of the sql editor and table pane.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![ezgif-4-1f57839b71a1](https://user-images.githubusercontent.com/7409244/58590760-b0972700-8219-11e9-8430-9a3c68c6c87c.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Tested locally by resizing the window and moving the splitter around. Also added some tests to ensure the heights of all child elements are equal to the parent (to ensure no overlaps).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #7385
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @john-bodley, @graceguo-supercat