### PR TITLE
Allow leading and trailing spaces in simple filter values

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -220,7 +220,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
         def handle_single_value(v):
             # backward compatibility with previous <select> components
             if isinstance(v, str):
-                v = v.strip('\t\n \'"')
+                v = v.strip('\t\n\'"')
                 if target_column_is_numeric:
                     # For backwards compatibility and edge cases
                     # where a column data type might have changed

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -234,11 +234,18 @@ class DruidFuncTestCase(unittest.TestCase):
         self.assertIsNone(res)
 
     def test_get_filters_extracts_values_in_quotes(self):
-        filtr = {'col': 'A', 'op': 'in', 'val': ['  "a" ']}
+        filtr = {'col': 'A', 'op': 'in', 'val': ['"a"']}
         col = DruidColumn(column_name='A')
         column_dict = {'A': col}
         res = DruidDatasource.get_filters([filtr], [], column_dict)
         self.assertEqual('a', res.filter['filter']['value'])
+
+    def test_get_filters_keeps_trailing_spaces(self):
+        filtr = {'col': 'A', 'op': 'in', 'val': ['a ']}
+        col = DruidColumn(column_name='A')
+        column_dict = {'A': col}
+        res = DruidDatasource.get_filters([filtr], [], column_dict)
+        self.assertEqual('a ', res.filter['filter']['value'])
 
     def test_get_filters_converts_strings_to_num(self):
         filtr = {'col': 'A', 'op': 'in', 'val': ['6']}


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes an issue when trying to create a filter for values that match a string with a trailing space (e.g. "test "). Previously, the trailing space would get stripped out, turning a filter with value: `"test "` into a where clause of format: `WHERE column_name = 'test'`.

Sometimes data comes with trailing spaces, and we should respect the user's request to filter with the trailing space. This is especially important when making Filter Boxes for dashboards, as they populate with actual data values yet currently return no data if the value ends with a space.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Running tests in CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @john-bodley, @michellethomas, @mistercrunch, @betodealmeida 