### PR TITLE
fix: Better error message for dashboard import

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -42,6 +42,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import CompileError
 from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql import column, literal_column, table, text
 from sqlalchemy.sql.expression import Label, TextAsFrom
@@ -50,6 +51,7 @@ import sqlparse
 from superset import app, db, security_manager
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
 from superset.db_engine_specs.base import TimestampExpression
+from superset.exceptions import DatabaseNotFound
 from superset.jinja_context import get_template_processor
 from superset.models.annotations import Annotation
 from superset.models.core import Database
@@ -1016,11 +1018,19 @@ class SqlaTable(Model, BaseDatasource):
             )
 
         def lookup_database(table):
-            return (
-                db.session.query(Database)
-                .filter_by(database_name=table.params_dict["database_name"])
-                .one()
-            )
+            try:
+                return (
+                    db.session.query(Database)
+                    .filter_by(database_name=table.params_dict["database_name"])
+                    .one()
+                )
+            except NoResultFound:
+                raise DatabaseNotFound(
+                    _(
+                        "Database '%(name)s' is not found",
+                        name=table.params_dict["database_name"],
+                    )
+                )
 
         return import_datasource.import_datasource(
             db.session, i_datasource, lookup_database, lookup_sqlatable, import_time

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -54,3 +54,7 @@ class SupersetTemplateException(SupersetException):
 
 class SpatialException(SupersetException):
     pass
+
+
+class DatabaseNotFound(SupersetException):
+    status = 400


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Common mistake is trying to import dashboard without creating
datasources first. Currently it causes error 500 with a message

> sqlalchemy.orm.exc.NoResultFound: No row was found for one()

which is difficult to understand.

This commit catches NoResultFound error and returns human readable error
using flash('danger').

Ref: #2992

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1095" alt="Screenshot 2019-05-30 at 16 04 50" src="https://user-images.githubusercontent.com/406916/58638611-8fa40400-82f5-11e9-9c84-952fe3140c7d.png">
<img width="1122" alt="Screenshot 2019-05-30 at 16 03 59" src="https://user-images.githubusercontent.com/406916/58638615-929ef480-82f5-11e9-936d-6d9530474c1d.png">

### TEST PLAN

Export dashboard on one instance of Superset. Try to import it on another one without creating datasources first.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
