### PR TITLE
[SQL Lab] Prevent failed query error from disappearing

### DIFF
--- a/superset/assets/src/SqlLab/reducers/sqlLab.js
+++ b/superset/assets/src/SqlLab/reducers/sqlLab.js
@@ -322,7 +322,10 @@ export default function sqlLabReducer(state = {}, action) {
       let queriesLastUpdate = state.queriesLastUpdate;
       for (const id in action.alteredQueries) {
         const changedQuery = action.alteredQueries[id];
-        if (!state.queries.hasOwnProperty(id) || state.queries[id].state !== 'stopped') {
+        if (
+          !state.queries.hasOwnProperty(id)
+          || (state.queries[id].state !== 'stopped' && state.queries[id].state !== 'failed')
+        ) {
           if (changedQuery.changedOn > queriesLastUpdate) {
             queriesLastUpdate = changedQuery.changedOn;
           }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For some failed queries, the error message would briefly flash for the user, then transition back into the running state. Just as we don't refresh stopped queries, we should also not refresh failed queries. This PR makes that change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![May-30-2019 14-16-13](https://user-images.githubusercontent.com/7409244/58666468-384b6700-82e8-11e9-8510-40af3c4f29b6.gif)

After:
![May-30-2019 14-18-21](https://user-images.githubusercontent.com/7409244/58666473-3c778480-82e8-11e9-9eb0-0c154cc3cc4e.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Test a failing query with the change and see the error message displayed. Ensure previously functional queries still work.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @graceguo-supercat, @john-bodley, @michellethomas