### PR TITLE
Show expanded columns in gray in SQL Editor

### DIFF
--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -216,6 +216,7 @@ export default class ResultSet extends React.PureComponent {
               orderedColumnKeys={results.columns.map(col => col.name)}
               height={height}
               filterText={this.state.searchText}
+              expandedColumns={results.expanded_columns.map(col => col.name)}
             />
           </React.Fragment>
         );

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -207,6 +207,9 @@ export default class ResultSet extends React.PureComponent {
         data = results.data;
       }
       if (data && data.length > 0) {
+        const expandendColumns = results.expanded_columns
+          ? results.expanded_columns.map(col => col.name)
+          : [];
         return (
           <React.Fragment>
             {this.renderControls.bind(this)()}
@@ -216,7 +219,7 @@ export default class ResultSet extends React.PureComponent {
               orderedColumnKeys={results.columns.map(col => col.name)}
               height={height}
               filterText={this.state.searchText}
-              expandedColumns={results.expanded_columns.map(col => col.name)}
+              expandedColumns={expandendColumns}
             />
           </React.Fragment>
         );

--- a/superset/assets/src/SqlLab/components/ResultSet.jsx
+++ b/superset/assets/src/SqlLab/components/ResultSet.jsx
@@ -207,7 +207,7 @@ export default class ResultSet extends React.PureComponent {
         data = results.data;
       }
       if (data && data.length > 0) {
-        const expandendColumns = results.expanded_columns
+        const expandedColumns = results.expanded_columns
           ? results.expanded_columns.map(col => col.name)
           : [];
         return (
@@ -219,7 +219,7 @@ export default class ResultSet extends React.PureComponent {
               orderedColumnKeys={results.columns.map(col => col.name)}
               height={height}
               filterText={this.state.searchText}
-              expandedColumns={expandendColumns}
+              expandedColumns={expandedColumns}
             />
           </React.Fragment>
         );

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -44,6 +44,7 @@ const propTypes = {
   overscanRowCount: PropTypes.number,
   rowHeight: PropTypes.number,
   striped: PropTypes.bool,
+  expandedColumns: PropTypes.array,
 };
 
 const defaultProps = {
@@ -52,6 +53,7 @@ const defaultProps = {
   overscanRowCount: 10,
   rowHeight: 32,
   striped: true,
+  expandedColumns: [],
 };
 
 export default class FilterableTable extends PureComponent {
@@ -141,7 +143,15 @@ export default class FilterableTable extends PureComponent {
     return (
       <TooltipWrapper label="header" tooltip={label}>
         <div className="header-style">
-          {label}
+          <span
+            className={
+              this.props.expandedColumns.indexOf(label) > -1
+                ? 'header-style-disabled'
+                : ''
+            }
+          >
+            {label}
+          </span>
           {sortBy === dataKey &&
             <SortIndicator sortDirection={sortDirection} />
           }

--- a/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
+++ b/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
@@ -77,3 +77,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.header-style-disabled {
+  color: #aaa;
+}

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2502,7 +2502,6 @@ class Superset(BaseSupersetView):
         if display_limit:
             payload_json = json.loads(payload)
             payload_json['data'] = payload_json['data'][:display_limit]
-
         return json_success(
             json.dumps(
                 payload_json,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -21,7 +21,6 @@ import inspect
 import logging
 import os
 import re
-import string
 import traceback
 from typing import Dict, List  # noqa: F401
 from urllib import parse
@@ -2503,21 +2502,6 @@ class Superset(BaseSupersetView):
         if display_limit:
             payload_json = json.loads(payload)
             payload_json['data'] = payload_json['data'][:display_limit]
-
-        # mock new payload
-        payload_json['selected_columns'] = payload_json['columns']
-        payload_json['expanded_columns'] = []
-        for col in payload_json['columns']:
-            for i in range(2):
-                # 0: {name: "event_id", agg: "count_distinct", type: "VARCHAR", is_date: false, is_dim: false}
-                letter = string.ascii_lowercase[i]
-                expanded_col = col.copy()
-                expanded_col['name'] = f'{col["name"]}.{letter}'
-                payload_json['expanded_columns'].append(expanded_col)
-                for j in range(len(payload_json['data'])):
-                    payload_json['data'][j][expanded_col['name']] = i + j * 10
-        payload_json['columns'] = \
-            payload_json['selected_columns'] + payload_json['expanded_columns']
 
         return json_success(
             json.dumps(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -21,6 +21,7 @@ import inspect
 import logging
 import os
 import re
+import string
 import traceback
 from typing import Dict, List  # noqa: F401
 from urllib import parse
@@ -2502,6 +2503,22 @@ class Superset(BaseSupersetView):
         if display_limit:
             payload_json = json.loads(payload)
             payload_json['data'] = payload_json['data'][:display_limit]
+
+        # mock new payload
+        payload_json['selected_columns'] = payload_json['columns']
+        payload_json['expanded_columns'] = []
+        for col in payload_json['columns']:
+            for i in range(2):
+                # 0: {name: "event_id", agg: "count_distinct", type: "VARCHAR", is_date: false, is_dim: false}
+                letter = string.ascii_lowercase[i]
+                expanded_col = col.copy()
+                expanded_col['name'] = f'{col["name"]}.{letter}'
+                payload_json['expanded_columns'].append(expanded_col)
+                for j in range(len(payload_json['data'])):
+                    payload_json['data'][j][expanded_col['name']] = i + j * 10
+        payload_json['columns'] = \
+            payload_json['selected_columns'] + payload_json['expanded_columns']
+
         return json_success(
             json.dumps(
                 payload_json,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In SQL Editor, if the payload has data from expanded columns (from nested types), show the headers as grayed out, since they are not actual columns.

This PR complements https://github.com/apache/incubator-superset/pull/7625.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="458" alt="Screen Shot 2019-05-30 at 3 13 44 PM" src="https://user-images.githubusercontent.com/1534870/58668424-b3634c00-82ed-11e9-869c-659437339312.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I mocked the payload, creating two expanded columns with suffixes `a` and `b`, and data `0` and `1`. See screenshot above.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 