### PR TITLE
[SQL Lab] Old query showing success state but not showing results

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/SouthPane_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SouthPane_spec.jsx
@@ -25,6 +25,7 @@ import { shallow } from 'enzyme';
 import { STATUS_OPTIONS } from '../../../src/SqlLab/constants';
 import { initialState } from './fixtures';
 import SouthPaneContainer, { SouthPane } from '../../../src/SqlLab/components/SouthPane';
+import ResultSet from '../../../src/SqlLab/components/ResultSet';
 
 describe('SouthPane', () => {
   const middlewares = [thunk];
@@ -32,7 +33,13 @@ describe('SouthPane', () => {
   const store = mockStore(initialState);
 
   const mockedProps = {
-    editorQueries: [],
+    editorQueries: [
+      { cached: false, changedOn: 1559238552333, db: 'main', dbId: 1, id: 'LCly_kkIN' },
+      { cached: false, changedOn: 1559238500401, db: 'main', dbId: 1, id: 'lXJa7F9_r' },
+      { cached: false, changedOn: 1559238506925, db: 'main', dbId: 1, id: '2g2_iRFMl' },
+      { cached: false, changedOn: 1559238516395, db: 'main', dbId: 1, id: 'erWdqEWPm' },
+    ],
+    latestQueryId: 'LCly_kkIN',
     dataPreviewQueries: [],
     actions: {},
     activeSouthPaneTab: '',
@@ -56,5 +63,10 @@ describe('SouthPane', () => {
     wrapper = getWrapper();
     wrapper.setProps({ offline: true });
     expect(wrapper.find('.m-r-3').render().text()).toBe(STATUS_OPTIONS.offline);
+  });
+  it('should pass latest query down to ResultSet component', () => {
+    wrapper = getWrapper();
+    expect(wrapper.find(ResultSet)).toHaveLength(1);
+    expect(wrapper.find(ResultSet).props().query.id).toEqual(mockedProps.latestQueryId);
   });
 });

--- a/superset/assets/src/SqlLab/components/SouthPane.jsx
+++ b/superset/assets/src/SqlLab/components/SouthPane.jsx
@@ -37,6 +37,7 @@ const TAB_HEIGHT = 44;
 */
 const propTypes = {
   editorQueries: PropTypes.array.isRequired,
+  latestQueryId: PropTypes.string.isRequired,
   dataPreviewQueries: PropTypes.array.isRequired,
   actions: PropTypes.object.isRequired,
   activeSouthPaneTab: PropTypes.string,
@@ -82,7 +83,8 @@ export class SouthPane extends React.PureComponent {
     let latestQuery;
     const props = this.props;
     if (props.editorQueries.length > 0) {
-      latestQuery = props.editorQueries[props.editorQueries.length - 1];
+      // get the latest query
+      latestQuery = props.editorQueries.find(q => q.id === this.props.latestQueryId);
     }
     let results;
     if (latestQuery) {

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -306,6 +306,7 @@ class SqlEditor extends React.PureComponent {
         </div>
         <SouthPane
           editorQueries={this.props.editorQueries}
+          latestQueryId={this.props.latestQuery ? this.props.latestQuery.id : 0}
           dataPreviewQueries={this.props.dataPreviewQueries}
           actions={this.props.actions}
           height={southPaneHeight}


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
A few users reported SQL Lab has issue like:
- user open sql lab with old queries
- sql lab shows query has `success` state and progress bar shows 100%
- but sql lab doesn't show query results.

This issue is not consistently re-produceable. When I hit this screen, I open browser's console to see what is wrong. In this line: https://github.com/apache/incubator-superset/blob/71f1bbd2ec59b99d6ba6d9a4a2f9cfceaf922b80/superset/assets/src/SqlLab/components/SouthPane.jsx#L85
SQL lab tries to display the last query in the list (all queries belongs to the current editor id), but sometimes the last query element in the list doesn't have `results`, and it seems not the latest query that user played. 

**Solution**
I found SQL Lab record `latestQueryId` in redux state, and we had `latestQuery` props in `TabbedSqlEditors`. 


### BEFORE FIX
![NTyOGS4fhq](https://user-images.githubusercontent.com/27990562/58671223-a565f900-82f6-11e9-9cf3-da94039c09e2.gif)


### TEST PLAN
CI and manual test


### REVIEWERS
@mistercrunch @michellethomas @etr2460