### PR TITLE
fix: handle presto column names with whitespace

### DIFF
--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -350,7 +350,14 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             ('column_name.nested_obj', 'FLOAT')]
         self.verify_presto_column(presto_column, expected_results)
 
-    def test_presto_get_simple_row_column_with_tricky_name(self):
+    def test_presto_get_simple_row_column_with_name_containing_whitespace(self):
+        presto_column = ('column name', 'row(nested_obj double)', '')
+        expected_results = [
+            ('column name', 'ROW'),
+            ('column name.nested_obj', 'FLOAT')]
+        self.verify_presto_column(presto_column, expected_results)
+
+    def test_presto_get_simple_row_column_with_tricky_nested_field_name(self):
         presto_column = ('column_name', 'row("Field Name(Tricky, Name)" double)', '')
         expected_results = [
             ('column_name', 'ROW'),


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
A recent change went in that displayed Presto rows and arrays more clearly. To do this, we had to parse the data type format "<column name> <data type>(<column name> <data type> ...)". We parsed it according to parentheses and whitespace. 

This did not take into account column names with whitespace and would break. This fix will quote column names with whitespace and then remove the quotes after parsing the data type.

### TEST PLAN
Tested manually and added unit test

### REVIEWERS
@betodealmeida @DiggidyDave @xtinec 