### PR TITLE
Fix colors in ellipsis

### DIFF
--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -139,6 +139,18 @@ export default class FilterableTable extends PureComponent {
     return values.some(v => v.includes(lowerCaseText));
   }
 
+  rowClassName({ index }) {
+    let className = '';
+    if (this.props.striped) {
+      className = index % 2 === 0 ? 'even-row' : 'odd-row';
+    }
+    return className;
+  }
+
+  sort({ sortBy, sortDirection }) {
+    this.setState({ sortBy, sortDirection });
+  }
+
   renderHeader({ dataKey, label, sortBy, sortDirection }) {
     const className = this.props.expandedColumns.indexOf(label) > -1
       ? 'header-style-disabled'
@@ -153,18 +165,6 @@ export default class FilterableTable extends PureComponent {
         </div>
       </TooltipWrapper>
     );
-  }
-
-  rowClassName({ index }) {
-    let className = '';
-    if (this.props.striped) {
-      className = index % 2 === 0 ? 'even-row' : 'odd-row';
-    }
-    return className;
-  }
-
-  sort({ sortBy, sortDirection }) {
-    this.setState({ sortBy, sortDirection });
   }
 
   render() {

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -140,18 +140,13 @@ export default class FilterableTable extends PureComponent {
   }
 
   headerRenderer({ dataKey, label, sortBy, sortDirection }) {
+    const className = this.props.expandedColumns.indexOf(label) > -1
+      ? 'header-style-disabled'
+      : 'header-style';
     return (
       <TooltipWrapper label="header" tooltip={label}>
-        <div className="header-style">
-          <span
-            className={
-              this.props.expandedColumns.indexOf(label) > -1
-                ? 'header-style-disabled'
-                : ''
-            }
-          >
-            {label}
-          </span>
+        <div className={className}>
+          {label}
           {sortBy === dataKey &&
             <SortIndicator sortDirection={sortDirection} />
           }

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -60,7 +60,7 @@ export default class FilterableTable extends PureComponent {
   constructor(props) {
     super(props);
     this.list = List(this.formatTableData(props.data));
-    this.headerRenderer = this.headerRenderer.bind(this);
+    this.renderHeader = this.renderHeader.bind(this);
     this.rowClassName = this.rowClassName.bind(this);
     this.sort = this.sort.bind(this);
 
@@ -139,7 +139,7 @@ export default class FilterableTable extends PureComponent {
     return values.some(v => v.includes(lowerCaseText));
   }
 
-  headerRenderer({ dataKey, label, sortBy, sortDirection }) {
+  renderHeader({ dataKey, label, sortBy, sortDirection }) {
     const className = this.props.expandedColumns.indexOf(label) > -1
       ? 'header-style-disabled'
       : 'header-style';
@@ -224,7 +224,7 @@ export default class FilterableTable extends PureComponent {
               <Column
                 dataKey={columnKey}
                 disableSort={false}
-                headerRenderer={this.headerRenderer}
+                headerRenderer={this.renderHeader}
                 width={this.widthsForColumnsByKey[columnKey]}
                 label={columnKey}
                 key={columnKey}

--- a/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
+++ b/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
@@ -78,5 +78,8 @@
   white-space: nowrap;
 }
 .header-style-disabled {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: #aaa;
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

For expanded columns in SQL Lab, the ellipsis had the wrong color.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before it was black, while the label was gray. Now:

<img width="821" alt="Screen Shot 2019-05-31 at 4 54 09 PM" src="https://user-images.githubusercontent.com/1534870/58740351-d3b20a00-83c4-11e9-9eea-02dd8a6ad7bd.png">


<!-- ### TEST PLAN -->
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 