### PR TITLE
[WIP] Add new escape characters to OnPasteSelect

### DIFF
--- a/superset/assets/src/components/OnPasteSelect.jsx
+++ b/superset/assets/src/components/OnPasteSelect.jsx
@@ -96,7 +96,7 @@ OnPasteSelect.propTypes = {
   isValidNewOption: PropTypes.func,
 };
 OnPasteSelect.defaultProps = {
-  separator: [',','\n','\t'],
+  separator: [',' ,'\n' ,'\t' ],
   selectWrap: Select,
   valueKey: 'value',
   labelKey: 'label',

--- a/superset/assets/src/components/OnPasteSelect.jsx
+++ b/superset/assets/src/components/OnPasteSelect.jsx
@@ -84,7 +84,7 @@ export default class OnPasteSelect extends React.Component {
 }
 
 OnPasteSelect.propTypes = {
-  separator: PropTypes.string.isRequired,
+  separator: PropTypes.array.isRequired,
   selectWrap: PropTypes.func.isRequired,
   refFunc: PropTypes.func,
   onChange: PropTypes.func.isRequired,
@@ -96,7 +96,7 @@ OnPasteSelect.propTypes = {
   isValidNewOption: PropTypes.func,
 };
 OnPasteSelect.defaultProps = {
-  separator: ',',
+  separator: [',','\n','\t'],
   selectWrap: Select,
   valueKey: 'value',
   labelKey: 'label',


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Our internal users love pasting stuff info filters from CSVs or excel docs.
Currently onPasteSelect only parses comma separated values. I added new line and tabs (you never know) to the separator array

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
In order to test the implementation I pasted the following values into the filter sections in the charts
regression test:
12345,45678,78906

new values tests
12345,
45678,
78906

12345
45678
78906

All values got parsed correctly 

### REVIEWERS