### PR TITLE
[query] Fix, remove not possible to order columns

### DIFF
--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -60,6 +60,7 @@ class QueryView(SupersetModelView):
     edit_title = _('Edit Query')
 
     list_columns = ['username', 'database_name', 'status', 'start_time', 'end_time']
+    order_columns = ['status', 'start_time', 'end_time']
     base_filters = [['id', QueryFilter, lambda: []]]
     label_columns = {
         'user': _('User'),
@@ -91,6 +92,9 @@ class SavedQueryView(SupersetModelView, DeleteMixin):
     list_columns = [
         'label', 'user', 'database', 'schema', 'description',
         'modified', 'pop_tab_link']
+    order_columns = [
+        'label', 'schema', 'description',
+        'modified']
     show_columns = [
         'id', 'label', 'user', 'database',
         'description', 'sql', 'pop_tab_link']


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Order by fields are not possible for functions has properties, these are not getting excluded in FAB so the default will make them eligible for order. When a user tries (for example) to order a Query by username, superset will raise an exception. This simple fix, will define the allowed order by fields on `ModelViews` for `QueryView` and `SavedQueryView`.

The following fields, were removed has order by fields:

- QueryView.username
- QueryView.database_name
- SavedQueryView.user
- SavedQueryView.database
- SavedQueryView.pop_tab_link

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
