### PR TITLE
[SQL Lab] Clarify SQL Lab query and display limits

### DIFF
--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -346,7 +346,11 @@ class SqlEditor extends React.PureComponent {
     }
     const qe = this.props.queryEditor;
     let limitWarning = null;
-    if (this.props.latestQuery && this.props.latestQuery.limit_reached) {
+    if (
+      this.props.latestQuery
+      && this.props.latestQuery.results
+      && this.props.latestQuery.results.displayLimitReached
+    ) {
       const tooltip = (
         <Tooltip id="tooltip">
           {t(`It appears that the number of rows in the query results displayed

--- a/superset/config.py
+++ b/superset/config.py
@@ -351,7 +351,13 @@ MAPBOX_API_KEY = os.environ.get('MAPBOX_API_KEY', '')
 # in the results backend. This also becomes the limit when exporting CSVs
 SQL_MAX_ROW = 100000
 
-# Default row limit for SQL Lab queries
+# Maximum number of rows displayed in SQL Lab UI
+# Is set to avoid out of memory/localstorage issues in browsers. Does not affect
+# exported CSVs
+DISPLAY_MAX_ROW = 10000
+
+# Default row limit for SQL Lab queries. Is overridden by setting a new limit in
+# the SQL Lab UI
 DEFAULT_SQLLAB_LIMIT = 1000
 
 # Maximum number of tables/views displayed in the dropdown window in SQL Lab.

--- a/superset/migrations/versions/d7c1a0d6f2da_remove_limit_used_from_query_model.py
+++ b/superset/migrations/versions/d7c1a0d6f2da_remove_limit_used_from_query_model.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Remove limit used from query model
+
+Revision ID: d7c1a0d6f2da
+Revises: afc69274c25a
+Create Date: 2019-06-04 10:12:36.675369
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd7c1a0d6f2da'
+down_revision = 'afc69274c25a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('query') as batch_op:
+        batch_op.drop_column('limit_used')
+
+
+def downgrade():
+    op.add_column('query', sa.Column('limit_used', sa.BOOLEAN(), nullable=True))

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -59,7 +59,6 @@ class Query(Model, ExtraJSONMixin):
     executed_sql = Column(Text)
     # Could be configured in the superset config.
     limit = Column(Integer)
-    limit_used = Column(Boolean, default=False)
     select_as_cta = Column(Boolean)
     select_as_cta_used = Column(Boolean, default=False)
 
@@ -94,10 +93,6 @@ class Query(Model, ExtraJSONMixin):
         sqla.Index('ti_user_id_changed_on', user_id, changed_on),
     )
 
-    @property
-    def limit_reached(self):
-        return self.rows == self.limit if self.limit_used else False
-
     def to_dict(self):
         return {
             'changedOn': self.changed_on,
@@ -122,7 +117,6 @@ class Query(Model, ExtraJSONMixin):
             'tempTable': self.tmp_table_name,
             'userId': self.user_id,
             'user': user_label(self.user),
-            'limit_reached': self.limit_reached,
             'resultsKey': self.results_key,
             'trackingUrl': self.tracking_url,
             'extra': self.extra,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -67,7 +67,9 @@ from .base import (
     get_error_msg, handle_api_exception, json_error_response, json_success,
     SupersetFilter, SupersetModelView, YamlExportMixin,
 )
-from .utils import bootstrap_user_data, get_datasource_info, get_form_data, get_viz
+from .utils import (
+    apply_display_max_row_limit, bootstrap_user_data, get_datasource_info, get_form_data,
+    get_viz)
 
 config = app.config
 CACHE_DEFAULT_TIMEOUT = config.get('CACHE_DEFAULT_TIMEOUT', 0)
@@ -2498,13 +2500,11 @@ class Superset(BaseSupersetView):
                 '{}'.format(rejected_tables)), status=403)
 
         payload = utils.zlib_decompress_to_string(blob)
-        display_limit = app.config.get('DEFAULT_SQLLAB_LIMIT', None)
-        if display_limit:
-            payload_json = json.loads(payload)
-            payload_json['data'] = payload_json['data'][:display_limit]
+        payload_json = json.loads(payload)
+
         return json_success(
             json.dumps(
-                payload_json,
+                apply_display_max_row_limit(payload_json),
                 default=utils.json_iso_dttm_ser,
                 ignore_nan=True,
             ),
@@ -2710,8 +2710,9 @@ class Superset(BaseSupersetView):
                     rendered_query,
                     return_results=True,
                     user_name=g.user.username if g.user else None)
+
             payload = json.dumps(
-                data,
+                apply_display_max_row_limit(data),
                 default=utils.pessimistic_json_iso_dttm_ser,
                 ignore_nan=True,
                 encoding=None,

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -205,7 +205,6 @@ class CeleryTestCase(SupersetTestCase):
             'LIMIT 666', query.executed_sql)
         self.assertEqual(sql_where, query.sql)
         self.assertEqual(0, query.rows)
-        self.assertEqual(False, query.limit_used)
         self.assertEqual(True, query.select_as_cta)
         self.assertEqual(True, query.select_as_cta_used)
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Builds off of comments in https://github.com/apache/incubator-superset/pull/6942. Sets three row limits for the following uses.

SQL_MAX_ROW: The upper limit for rows returned from any query. Prevents excessive load on the database
DISPLAY_MAX_ROW: The upper limit for rows displayed in SQL Lab. Prevents browser crashes. Should be <= SQL_MAX_ROW
DEFAULT_SQLLAB_LIMIT: The default limit for queries in SQL Lab. Can be overwritten by the user to any value between 1 and DISPLAY_MAX_ROW

If anyone has other ideas to simplify this, I'm happy to take another stab at it. However, I think that with these three variables we can represent all levers required for admins and also prevent users from crashing their browsers.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Warning text + tooltip if DISPLAY_MAX_ROW cuts off displayed results:
<img width="1576" alt="Screen Shot 2019-06-03 at 1 14 12 PM" src="https://user-images.githubusercontent.com/7409244/58831406-81a9f800-8601-11e9-9604-908e50ac0c61.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. Set the DISPLAY_MAX_ROW value to something smaller
1. Set your query limit in the SQL Lab UI higher than the DISPLAY_MAX_ROW value
1. See LIMIT warning label with the warning message

Also test:
- Limits below the DISPLAY_MAX_ROW still work
- CSV download isn't affected by DISPLAY_MAX_ROW
- The limits are applied on both sync and async queries

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #7590
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley, @michellethomas, @mistercrunch 