### PR TITLE
[dashboard] pass dashboard filters to share chart url in dropdown

### DIFF
--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -35,7 +35,12 @@ const propTypes = {
   actions: PropTypes.object,
   chartId: PropTypes.number.isRequired,
   datasource: PropTypes.object.isRequired,
-  filters: PropTypes.object,
+  // original selected values for FilterBox viz
+  // so that FilterBox can pre-populate selected values
+  // only affect UI control
+  initialValues: PropTypes.object,
+  // formData contains chart's own filter parameter
+  // and merged with extra filter that current dashboard applying
   formData: PropTypes.object.isRequired,
   height: PropTypes.number,
   width: PropTypes.number,
@@ -60,7 +65,7 @@ const BLANK = {};
 
 const defaultProps = {
   addFilter: () => BLANK,
-  filters: BLANK,
+  initialValues: BLANK,
   setControlValue() {},
   triggerRender: false,
 };

--- a/superset/assets/src/chart/ChartRenderer.jsx
+++ b/superset/assets/src/chart/ChartRenderer.jsx
@@ -29,7 +29,7 @@ const propTypes = {
   actions: PropTypes.object,
   chartId: PropTypes.number.isRequired,
   datasource: PropTypes.object.isRequired,
-  filters: PropTypes.object,
+  initialValues: PropTypes.object,
   formData: PropTypes.object.isRequired,
   height: PropTypes.number,
   width: PropTypes.number,
@@ -50,7 +50,7 @@ const BLANK = {};
 
 const defaultProps = {
   addFilter: () => BLANK,
-  filters: BLANK,
+  initialValues: BLANK,
   setControlValue() {},
   triggerRender: false,
 };
@@ -103,7 +103,7 @@ class ChartRenderer extends React.Component {
       height,
       annotationData,
       datasource,
-      filters,
+      initialValues,
       formData,
       queryResponse,
       setControlValue,
@@ -114,7 +114,7 @@ class ChartRenderer extends React.Component {
       height,
       annotationData,
       datasource,
-      filters,
+      filters: initialValues,
       formData,
       onAddFilter: this.handleAddFilter,
       onError: this.handleRenderFailure,

--- a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
@@ -283,7 +283,7 @@ class Chart extends React.Component {
             chartId={id}
             chartStatus={chart.chartStatus}
             datasource={datasource}
-            filters={filters}
+            initialValues={filters[id]}
             formData={formData}
             queryResponse={chart.queryResponse}
             timeout={timeout}

--- a/superset/assets/src/dashboard/containers/Chart.jsx
+++ b/superset/assets/src/dashboard/containers/Chart.jsx
@@ -53,7 +53,7 @@ function mapStateToProps(
       {},
     slice: sliceEntities.slices[id],
     timeout: dashboardInfo.common.conf.SUPERSET_WEBSERVER_TIMEOUT,
-    filters: filters[id] || EMPTY_FILTERS,
+    filters: filters || EMPTY_FILTERS,
     // note: this method caches filters if possible to prevent render cascades
     formData: getFormDataWithExtraFilters({
       chart,

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -205,6 +205,10 @@ export default function(bootstrapData) {
     dashboardState: {
       sliceIds: Array.from(sliceIds),
       refresh: false,
+      // All the filter_box's state in this dashboard
+      // When dashboard is first loaded into browser,
+      // its value is from preselect_filters that dashboard owner saved in dashboard's meta data
+      // When user start interacting with dashboard, it will be user picked values from all filter_box
       filters,
       directPathToChild,
       expandedSlices: dashboard.metadata.expanded_slices || {},


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<img width="1339" alt="Screen Shot 2019-06-03 at 5 17 17 PM" src="https://user-images.githubusercontent.com/27990562/58842898-140fc300-8625-11e9-8ae1-db38091c0136.png">

In dashboard, we allow user to share chart, which is a shorten url which carried current dashboard filters state, and chart's parent tab information (if it has one). But currently, dashboard's selected filters values are not included in the shorten url.

I found in dashboard's component, we used `filters` props for dashboard's selected filters state. But for `Chart` component, we used `filters` props to carry the values for the current filter_box, so that current filter_box will pre-populate selected values.

Solution:
`filter` prop should be assigned at the right place.

### TEST PLAN
CI and manual test


### REVIEWERS
@michellethomas @etr2460 @kristw @williaster 