### PR TITLE
Compile example column names

### DIFF
--- a/superset/data/country_map.py
+++ b/superset/data/country_map.py
@@ -18,6 +18,7 @@ import datetime
 
 import pandas as pd
 from sqlalchemy import BigInteger, Date, String
+from sqlalchemy.sql import column
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
@@ -69,9 +70,10 @@ def load_country_map_data():
     obj.main_dttm_col = 'dttm'
     obj.database = utils.get_or_create_main_db()
     if not any(col.metric_name == 'avg__2004' for col in obj.metrics):
+        col = str(column('2004').compile(db.engine))
         obj.metrics.append(SqlMetric(
             metric_name='avg__2004',
-            expression='AVG(2004)',
+            expression=f'AVG({col})',
         ))
     db.session.merge(obj)
     db.session.commit()

--- a/superset/data/energy.py
+++ b/superset/data/energy.py
@@ -20,6 +20,7 @@ import textwrap
 
 import pandas as pd
 from sqlalchemy import Float, String
+from sqlalchemy.sql import column
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
@@ -54,9 +55,10 @@ def load_energy():
     tbl.database = utils.get_or_create_main_db()
 
     if not any(col.metric_name == 'sum__value' for col in tbl.metrics):
+        col = str(column('value').compile(db.engine))
         tbl.metrics.append(SqlMetric(
             metric_name='sum__value',
-            expression='SUM(value)',
+            expression=f'SUM({col})',
         ))
 
     db.session.merge(tbl)

--- a/superset/data/world_bank.py
+++ b/superset/data/world_bank.py
@@ -22,6 +22,7 @@ import textwrap
 
 import pandas as pd
 from sqlalchemy import DateTime, String
+from sqlalchemy.sql import column
 
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
@@ -75,9 +76,11 @@ def load_world_bank_health_n_pop():
     ]
     for m in metrics:
         if not any(col.metric_name == m for col in tbl.metrics):
+            aggr_func = m[:3]
+            col = str(column(m[5:]).compile(db.engine))
             tbl.metrics.append(SqlMetric(
                 metric_name=m,
-                expression=f'{m[:3]}({m[5:]})',
+                expression=f'{aggr_func}({col})',
             ))
 
     db.session.merge(tbl)


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix

### SUMMARY
This PR makes sure that column names are conditionally quoted. Without compilation some examples don't work on Postgres, namely the ones with metrics referencing uppercase columns.

### TEST PLAN
Tested locally.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixe #6009

### REVIEWERS
@dostiharise @andy-clapson @trrahul @michaldul
