### PR TITLE
Allowing withVerification to remove all options if none are valid

### DIFF
--- a/superset/assets/spec/javascripts/explore/components/withVerification_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/withVerification_spec.jsx
@@ -44,7 +44,7 @@ const defaultProps = {
 
 const VALID_METRIC = { metric_name: 'sum__value', expression: 'SUM(energy_usage.value)' };
 
-function setup(overrides) {
+function setup(overrides, validMetric) {
   const onChange = sinon.spy();
   const props = {
     onChange,
@@ -53,7 +53,7 @@ function setup(overrides) {
   };
   const VerifiedControl = withVerification(MetricsControl, 'metric_name', 'savedMetrics');
   const wrapper = shallow(<VerifiedControl {...props} />);
-  fetchMock.mock('glob:*/valid_metrics*', `["${VALID_METRIC.metric_name}"]`);
+  fetchMock.mock('glob:*/valid_metrics*', validMetric || `["${VALID_METRIC.metric_name}"]`);
   return { props, wrapper, onChange };
 }
 
@@ -100,6 +100,16 @@ describe('VerifiedMetricsControl', () => {
     wrapper.setProps({ ...props, controlValues: { metrics: 'avg__value' } });
     setTimeout(() => {
       expect(fetchMock.calls(defaultProps.getEndpoint())).toHaveLength(1);
+      fetchMock.reset();
+    }, 0);
+  });
+
+  it('Returns no verified options if none are valid', () => {
+    const { wrapper } = setup({}, []);
+    setTimeout(() => {
+      expect(fetchMock.calls(defaultProps.getEndpoint())).toHaveLength(1);
+      const child = wrapper.find(MetricsControl);
+      expect(child.props().savedMetrics).toEqual([]);
       fetchMock.reset();
     }, 0);
   });

--- a/superset/assets/src/explore/components/controls/withVerification.jsx
+++ b/superset/assets/src/explore/components/controls/withVerification.jsx
@@ -31,7 +31,7 @@ export default function withVerification(WrappedComponent, optionLabel, optionsN
     constructor(props) {
       super(props);
       this.state = {
-        validOptions: new Set(),
+        validOptions: null,
         hasRunVerification: false,
       };
 
@@ -69,7 +69,7 @@ export default function withVerification(WrappedComponent, optionLabel, optionsN
     render() {
       const { validOptions } = this.state;
       const options = this.props[optionsName];
-      const verifiedOptions = validOptions.size ?
+      const verifiedOptions = validOptions ?
         options.filter(o => (validOptions.has(o[optionLabel]))) :
         options;
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Previously, I was only allowing options to be filtered if there were existing validOptions, but it was preventing filtering out all options if none are valid.

### TEST PLAN
Set up control overrides to use one of the controls using withVerification
Call a getEndpoint with no valid options
Confirm that no options show up in the dropdown

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@kristw @graceguo-supercat 