### PR TITLE
Revert "Boxplot should not require a datetime column (#5096)"

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -856,7 +856,7 @@ class BoxPlotViz(NVD3Viz):
     viz_type = 'box_plot'
     verbose_name = _('Box Plot')
     sort_series = False
-    is_timeseries = False
+    is_timeseries = True
 
     def to_series(self, df, classed='', title_suffix=''):
         label_sep = ' - '


### PR DESCRIPTION
This reverts commit 1ae000a26220c024f3f904d9049cfcd4b1e461e7.

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Box plots are no longer rendering correctly (https://github.com/apache/incubator-superset/issues/7654). This PR reverts the breaking change. I agree that box plots should not require a date time column but a different change needs to be made.

### BEFORE SCREENSHOT
<img width="892" alt="Screen Shot 2019-06-05 at 1 08 51 PM" src="https://user-images.githubusercontent.com/47833996/58989546-fc594b80-8798-11e9-8d56-8d5dec1eb93d.png">


### TEST PLAN
Tested manually


### REVIEWERS
@mistercrunch @betodealmeida @xtinec @DiggidyDave 