### PR TITLE
[epoch] Remove non-UTC epoch logic

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,10 @@ assists people when migrating to a new version.
 
 ## Next Version
 
+* [7667](https://github.com/apache/incubator-superset/pull/7667): a change to
+make all Unix timestamp (which by definition are in UTC) comparisons refer
+to a timestamp in UTC as opposed to local time.
+
 * [5451](https://github.com/apache/incubator-superset/pull/5451): a change
 which adds missing non-nullable fields to the `datasources` table. Depending on
 the integrity of the data, manual intervention may be required.
@@ -33,7 +37,7 @@ which adds missing non-nullable fields and uniqueness constraints to the
 manual intervention may be required.
 * `fabmanager` command line is deprecated since Flask-AppBuilder 2.0.0, use
 the new `flask fab <command>` integrated with *Flask cli*.
-* `SUPERSET_UPDATE_PERMS` environment variable was replaced by 
+* `SUPERSET_UPDATE_PERMS` environment variable was replaced by
 `FAB_UPDATE_PERMS` config boolean key. To disable automatic
 creation of permissions set `FAB_UPDATE_PERMS = False` on config.
 * [5453](https://github.com/apache/incubator-superset/pull/5453): a change

--- a/superset/config.py
+++ b/superset/config.py
@@ -608,11 +608,6 @@ DOCUMENTATION_URL = None
 DEFAULT_RELATIVE_START_TIME = 'today'
 DEFAULT_RELATIVE_END_TIME = 'today'
 
-# Is epoch_s/epoch_ms datetime format supposed to be considered since UTC ?
-# If not, it is sassumed then the epoch_s/epoch_ms is seconds since 1/1/1970
-# localtime (in the tz where the superset webserver is running)
-IS_EPOCH_S_TRULY_UTC = False
-
 # Configure which SQL validator to use for each engine
 SQL_VALIDATORS_BY_ENGINE = {
     'presto': 'PrestoDBSQLValidator',

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -133,13 +133,12 @@ class TableColumn(Model, BaseColumn):
         return self.table
 
     def get_time_filter(self, start_dttm, end_dttm):
-        is_epoch_in_utc = config.get('IS_EPOCH_S_TRULY_UTC', False)
         col = self.get_sqla_col(label='__time')
         l = []  # noqa: E741
         if start_dttm:
-            l.append(col >= text(self.dttm_sql_literal(start_dttm, is_epoch_in_utc)))
+            l.append(col >= text(self.dttm_sql_literal(start_dttm)))
         if end_dttm:
-            l.append(col <= text(self.dttm_sql_literal(end_dttm, is_epoch_in_utc)))
+            l.append(col <= text(self.dttm_sql_literal(end_dttm)))
         return and_(*l)
 
     def get_timestamp_expression(self, time_grain: Optional[str]) \
@@ -173,7 +172,7 @@ class TableColumn(Model, BaseColumn):
                 TableColumn.column_name == lookup_column.column_name).first()
         return import_datasource.import_simple_obj(db.session, i_column, lookup_obj)
 
-    def dttm_sql_literal(self, dttm, is_epoch_in_utc):
+    def dttm_sql_literal(self, dttm):
         """Convert datetime object to a SQL expression string
 
         If database_expression is empty, the internal dttm
@@ -186,11 +185,7 @@ class TableColumn(Model, BaseColumn):
         if self.database_expression:
             return self.database_expression.format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
         elif tf:
-            if is_epoch_in_utc:
-                seconds_since_epoch = dttm.timestamp()
-            else:
-                seconds_since_epoch = (dttm - datetime(1970, 1, 1)).total_seconds()
-            seconds_since_epoch = int(seconds_since_epoch)
+            seconds_since_epoch = int(dttm.timestamp())
             if tf == 'epoch_s':
                 return str(seconds_since_epoch)
             elif tf == 'epoch_ms':


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

As @agrawaldevesh correctly identified in https://github.com/apache/incubator-superset/pull/6721 previously we were computing the Unix timestamp for the _right-hand-side_ (RHS) of the temporal filter condition using the local time zone as opposed to UTC which is the [definition](https://en.wikipedia.org/wiki/Unix_time) of a Unix timestamp (or epoch). 

@agrawaldevesh's change was behind a feature flag and disabled by default however this clearly is a bug and I sense we should remedy the problem by merely replacing the previously incorrect logic. Note I strongly believe users were probably unaware of the issue as Unix timestamps aren't human readable. 

### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @agrawaldevesh @betodealmeida @michellethomas @mistercrunch @villebro 