### PR TITLE
Implement data access policy modal

### DIFF
--- a/superset/assets/src/setup/setupApp.js
+++ b/superset/assets/src/setup/setupApp.js
@@ -72,4 +72,16 @@ export default function setupApp() {
   window.$ = $;
   window.jQuery = $;
   require('bootstrap');
+
+  // Manage the data access policy modal if needed
+  if ($('#data-access-policy-modal')) {
+    $('#data-access-policy-modal').modal({ backdrop: 'static' });
+    $('#data-access-policy-modal').on('hide.bs.modal', () => {
+      // Fire and forget the acceptance. If it fails for some reason, then we'll
+      // just reprompt the user when they reload the page.
+      SupersetClient.post({
+        endpoint: '/superset/accept_data_access_policy',
+      });
+    });
+  }
 }

--- a/superset/config.py
+++ b/superset/config.py
@@ -627,6 +627,16 @@ TALISMAN_CONFIG = {
     'force_https_permanent': False,
 }
 
+# Turns on the data access policy modal. Users must agree to the policy to use superset.
+# Agreements are logged on the backend for audit purposes. The modal contents and time
+# between required re-agreements can be configured below.
+ENABLE_DATA_ACCESS_POLICY = False
+DATA_ACCESS_POLICY_MODAL_CONTENT = """
+    The data in this tool is confidental and for internal use only.
+"""
+# Set to None if you don't want to require re-agreements
+DATA_ACCESS_POLICY_VALID_DURATION_SECONDS = 60 * 60 * 24 * 30
+
 try:
     if CONFIG_PATH_ENV_VAR in os.environ:
         # Explicitly import config module that is not in pythonpath; useful

--- a/superset/migrations/versions/0d0c0e69e87a_add_data_access_policy_agree_date.py
+++ b/superset/migrations/versions/0d0c0e69e87a_add_data_access_policy_agree_date.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add data_access_policy_agree_date to UserAttribute
+
+Revision ID: 0d0c0e69e87a
+Revises: afc69274c25a
+Create Date: 2019-06-05 14:46:21.059509
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0d0c0e69e87a'
+down_revision = 'afc69274c25a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(
+        'user_attribute',
+        sa.Column('data_access_policy_agree_date', sa.DateTime()))
+
+
+def downgrade():
+    with op.batch_alter_table('user_attribute') as batch_op:
+        batch_op.drop_column('data_access_policy_agree_date')

--- a/superset/models/user_attributes.py
+++ b/superset/models/user_attributes.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from flask_appbuilder import Model
-from sqlalchemy import Column, ForeignKey, Integer
+from sqlalchemy import Column, DateTime, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
 from superset import security_manager
@@ -42,5 +42,6 @@ class UserAttribute(Model, AuditMixinNullable):
         foreign_keys=[user_id],
     )
 
+    data_access_policy_agree_date = Column(DateTime)
     welcome_dashboard_id = Column(Integer, ForeignKey('dashboards.id'))
     welcome_dashboard = relationship('Dashboard')

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -92,6 +92,25 @@
         </div>
       </div>
     </div>
+
+    {% if show_data_access_policy_modal %}
+    <div id="data-access-policy-modal" class="misc-modal modal fade" tabindex="-1" role="dialog" aria-labelledby="dataAccessPolicyModalLabel">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title">Data Access Policy</h4>
+          </div>
+          <div class="modal-body">
+            {{ data_access_policy_modal_content }}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-dismiss="modal">Ok</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
     {% block tail_js %}
       {% if entry %}
         {% with filename=entry %}

--- a/superset/templates/superset/dashboard.html
+++ b/superset/templates/superset/dashboard.html
@@ -19,5 +19,5 @@
 {% extends "superset/basic.html" %}
 
 {% block body %}
-  <div id="app" data-bootstrap="{{ bootstrap_data }}" />
+  <div id="app" data-bootstrap="{{ bootstrap_data }}"></div>
 {% endblock %}


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In corporate deployments of BI tools, it's common to alert users of the confidential nature of data accessible within the tool and to require users to agree to a data use policy. This PR introduces a configurable modal and an audit-able log of what users have agreed to the policy and when.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1680" alt="Screen Shot 2019-06-07 at 3 17 30 PM" src="https://user-images.githubusercontent.com/7409244/59136739-4f6a0480-8939-11e9-87c8-d27c8f0b2dd2.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- run db upgrade
- test different values for all config params
- see modal on welcome page, dashboard, explore, profile, sqllab
- test db downgrade

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [x] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley, @michellethomas, @graceguo-supercat