### PR TITLE
Resolved SQL Lab Query Search scrolling issue (Fixes #7526)

### DIFF
--- a/superset/assets/src/SqlLab/main.less
+++ b/superset/assets/src/SqlLab/main.less
@@ -204,6 +204,10 @@ div.Workspace {
     .SouthPane {
         height: 100%;
     }
+
+    .scrollbar-container {
+      overflow: auto;
+    }
 }
 
 .SqlEditorTabs li {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The `.scrollbar-container` class used in this view didn't have any `overflow` property set. Following the pattern of the instance within `.SqlEditorLeftBar`, I added `.SqlLab{ overflow: auto ;}` under `.SqlLab` and it now seems to behave correctly. This should not affect the class in other contexts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![scroll](https://user-images.githubusercontent.com/812905/59138118-00739d80-8940-11e9-99e4-1ca73eca207d.gif)

### TEST PLAN
Create a handful of queries, view the list, and make your window short enough to necessitate scrolling. It should then scroll as intended.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch 