### PR TITLE
Revert "Allow bigint to be used as time column in Presto" #7670

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -355,8 +355,6 @@ class PrestoEngineSpec(BaseEngineSpec):
             return "from_iso8601_date('{}')".format(dttm.isoformat()[:10])
         if tt == 'TIMESTAMP':
             return "from_iso8601_timestamp('{}')".format(dttm.isoformat())
-        if tt == 'BIGINT':
-            return "to_unixtime(from_iso8601_timestamp('{}'))".format(dttm.isoformat())
         return "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S'))
 
     @classmethod


### PR DESCRIPTION
Per https://github.com/apache/incubator-superset/pull/7218#issuecomment-499250400 including a `BIGINT` column type as a time column in Presto is problematic as it could represent either a Unix time in seconds or milliseconds. 

The current correct way to handle Unix time columns is to set the `python_date_format` as either `epoch` or `epoch_ms` (depending on the encoding) which results in queries comprising the correct fidelity: 

```sql
SELECT COUNT(*) AS "count"
FROM "superset"."logs"
WHERE "dttm" >= 1553644800
  AND "dttm" <= 1554249600
ORDER BY "count" DESC
LIMIT 10000;
```

Note https://github.com/apache/incubator-superset/issues/7656 plans to auto-detect the encoding of temporal columns.

to: @betodealmeida @mistercrunch 
