### PR TITLE
[SIP-15A] Presto types (PoC)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ colorama==0.3.9
 contextlib2==0.5.5
 croniter==0.3.29
 cryptography==2.4.2
-decorator==4.3.0          # via retry
+decorator==4.3.0          # via networkx, retry
 defusedxml==0.5.0         # via python3-openid
 flask-appbuilder==2.1.4
 flask-babel==0.11.1       # via flask-appbuilder
@@ -50,6 +50,7 @@ markupsafe==1.0           # via jinja2, mako
 marshmallow-enum==1.4.1   # via flask-appbuilder
 marshmallow-sqlalchemy==0.16.2  # via flask-appbuilder
 marshmallow==2.19.2       # via flask-appbuilder, marshmallow-enum, marshmallow-sqlalchemy
+networkx==2.3
 numpy==1.15.2             # via pandas
 pandas==0.23.4
 parsedatetime==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         'idna',
         'isodate',
         'markdown>=3.0',
+        'networkx',
         'pandas>=0.18.0, <0.24.0',  # `pandas`>=0.24.0 changes datetimelike API
         'parsedatetime',
         'pathlib2',

--- a/superset/config.py
+++ b/superset/config.py
@@ -654,3 +654,7 @@ try:
             superset_config.__file__))
 except ImportError:
     pass
+
+# Whether to enable SIP-15 functionality. Note currently this should never be
+# set to True as these features are not ready for prime time.
+SIP_15_ENABLED = False

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -195,11 +195,21 @@ class TableColumn(Model, BaseColumn):
                 return str(seconds_since_epoch)
             elif tf == 'epoch_ms':
                 return str(seconds_since_epoch * 1000)
-            return "'{}'".format(dttm.strftime(tf))
+
+            # TODO(john-bodley): SIP-15 will only support ISO 8601 formats as this adheres
+            # to the lexigraphical ordering.
+            return f"'{dttm.strftime(tf)}'"
         else:
             s = self.table.database.db_engine_spec.convert_dttm(
                 self.type or '', dttm)
-            return s or "'{}'".format(dttm.strftime('%Y-%m-%d %H:%M:%S.%f'))
+
+            if s:
+                return s
+
+            if app.config['SIP_15_ENABLED']:
+                raise TypeError(f"The '{type}' type is unsupported.")
+            else:
+                return f"'{dttm.strftime('%Y-%m-%d %H:%M:%S.%f')}'"
 
 
 class SqlMetric(Model, BaseMetric):

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -65,7 +65,7 @@ class PrestoEngineSpec(BaseEngineSpec):
             "date_add('day', -1, date_trunc('week', "
             "date_add('day', 1, {col})))",
     }
-    
+
     type_graph = nx.DiGraph()
     type_graph.add_edge(DATE, TIMESTAMP, sql='CAST({col} AS TIMESTAMP)')
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This is very much a Proof-of-Concept (PoC) but I though there was merit in sharing early my thoughts as to how I would implement aspects of [SIP-15A](https://github.com/apache/incubator-superset/issues/7656) in relation to how we could think about type conversions in the future. 

The premise is Superset needs to transform either Python types (such as `datetime`) or either a SQL type (`DATE`, `TIMESTAMP`, etc.), Python type (`str`, `int`, `float`, etc.), or time grain (`P1D`, `P1W` etc). Rather than depending on methods like `convert_dttm`, `epoch_to_dttm`, etc. I felt it would make more sense to define an engine specific graph where the nodes are the various temporal types and the edges represents the SQL expression required to convert between the types. A shortest path algorithm is used to define the path (and thus SQL) between the types.

I though the merits are:
- Helps to ensure all the mappings reside in the same place. Note it's still somewhat fragmented due the constraints on the existing API. 
- Removes redundancy, i.e., in Hive there's a bug in the `from_unixtime` UDF which actually requires that the unix time be a float rather than an integer and thus one would define two edges with minimal SQL, i.e.,

```
graph = nx.DiGraph()
graph.add_edge(BigInteger, Float, sql='CAST({col} AS DOUBLE)')
graph.add_edge(Float, TIMESTAMP, sql='CAST({col} AS TIMESTAMP)')
```
    
which would provide these mappings; (`BigInteger`, `TIMESTAMP`) and (`Float`, `TIMESTAMP`).

Note this PR does not address several aspects of SIP-15A including type inferencing and enforcing ISO 8601 encoding. Additionally if rolled out there would be additional major refactoring of the`BaseEngineSpec` and `TableColumn` classes.

### TEST PLAN

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @agrawaldevesh @betodealmeida @michellethomas @mistercrunch @villebro 