### PR TITLE
[SQL Lab] Improve result table rendering performance

### DIFF
--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -26,13 +26,9 @@ import {
   SortDirection,
   SortIndicator,
 } from 'react-virtualized';
-import { getTextDimension } from '@superset-ui/dimension';
 import TooltipWrapper from '../TooltipWrapper';
 
-function getTextWidth(text, font = '12px Roboto') {
-  return getTextDimension({ text, style: { font } }).width;
-}
-
+const CHARACTER_WIDTH = 8;
 const SCROLL_BAR_HEIGHT = 15;
 
 const propTypes = {
@@ -55,6 +51,10 @@ const defaultProps = {
   striped: true,
   expandedColumns: [],
 };
+
+function getDataCharacterLength(data) {
+  return `${data}`.length;
+}
 
 export default class FilterableTable extends PureComponent {
   constructor(props) {
@@ -90,10 +90,10 @@ export default class FilterableTable extends PureComponent {
     const widthsByColumnKey = {};
     this.props.orderedColumnKeys.forEach((key) => {
       const colWidths = this.list
-        .map(d => getTextWidth(d[key]) + PADDING) // get width for each value for a key
-        .push(getTextWidth(key) + PADDING); // add width of column key to end of list
-      // set max width as value for key
-      widthsByColumnKey[key] = Math.max(...colWidths);
+        .map(d => getDataCharacterLength(d[key])) // get length for each value for a key
+        .push(getDataCharacterLength(key)); // add length of column key to end of list
+      // calculate max width and set the column width
+      widthsByColumnKey[key] = (Math.max(...colWidths) * CHARACTER_WIDTH) + PADDING;
     });
     return widthsByColumnKey;
   }

--- a/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
+++ b/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
@@ -43,6 +43,11 @@
   border-right: 1px solid #ccc;
   align-self: center;
   padding: 12px;
+  font-family: monospace;
+  /*
+   * If you change the font size here, be sure to update the
+   * character width in FilterableTable.jsx
+   */
   font-size: 12px;
 }
 .ReactVirtualized__Table__headerColumn:last-of-type,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When rendering the FilterableTable component we were rendering and measuring the width of every cell to determine the width of each column. For tables with many columns or columns with large amounts of content, this would hang the page for seconds at a time:
![Screen Shot 2019-06-11 at 9 55 09 AM](https://user-images.githubusercontent.com/7409244/59292004-f0eea000-8c30-11e9-8f6a-2e594ebc9da1.png)

This fix changes the font for the FilterableTable to monospaced so that we can calculate the max width of a column without rendering the each cell. This resulted in a 665x improvement in perf for the function (>3 s down to 4.8 ms in some nasty edge cases)
![Screen Shot 2019-06-11 at 9 53 39 AM](https://user-images.githubusercontent.com/7409244/59292156-50e54680-8c31-11e9-87a0-23c95d3b62c7.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![slow query](https://user-images.githubusercontent.com/7409244/59292166-58a4eb00-8c31-11e9-8420-8fbf175a2ddd.gif)

After:
![faster query](https://user-images.githubusercontent.com/7409244/59292176-5c387200-8c31-11e9-981e-f679837a1329.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Ensure the column widths still fit all the content. Pass CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @soboko @mistercrunch @john-bodley 