### PR TITLE
Render columns dynamically on wide tables

### DIFF
--- a/superset/assets/spec/javascripts/components/FilterableTable/FilterableTable_spec.jsx
+++ b/superset/assets/spec/javascripts/components/FilterableTable/FilterableTable_spec.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import { mount } from 'enzyme';
-import FilterableTable from '../../../../src/components/FilterableTable/FilterableTable';
+import FilterableTable, { MAX_COLUMNS_FOR_TABLE } from '../../../../src/components/FilterableTable/FilterableTable';
 
 describe('FilterableTable', () => {
   const mockedProps = {
@@ -36,9 +36,21 @@ describe('FilterableTable', () => {
   it('is valid element', () => {
     expect(React.isValidElement(<FilterableTable {...mockedProps} />)).toBe(true);
   });
-  it('renders a grid with 2 rows', () => {
+  it('renders a grid with 2 Table rows', () => {
     expect(wrapper.find('.ReactVirtualized__Grid')).toHaveLength(1);
     expect(wrapper.find('.ReactVirtualized__Table__row')).toHaveLength(2);
+  });
+  it('renders a grid with 2 Grid rows for wide tables', () => {
+    const wideTableColumns = MAX_COLUMNS_FOR_TABLE + 1;
+    const wideTableMockedProps = {
+      orderedColumnKeys: Array.from(Array(wideTableColumns), (_, x) => `col_${x}`),
+      data: [
+        Object.assign(...Array.from(Array(wideTableColumns)).map((val, x) => ({ [`col_${x}`]: x }))),
+      ],
+      height: 500,
+    };
+    const wideTableWrapper = mount(<FilterableTable {...wideTableMockedProps} />);
+    expect(wideTableWrapper.find('.ReactVirtualized__Grid')).toHaveLength(2);
   });
   it('filters on a string', () => {
     const props = {

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -46,6 +46,7 @@ const propTypes = {
   height: PropTypes.number.isRequired,
   filterText: PropTypes.string,
   headerHeight: PropTypes.number,
+  overscanColumnCount: PropTypes.number,
   overscanRowCount: PropTypes.number,
   rowHeight: PropTypes.number,
   striped: PropTypes.bool,
@@ -55,6 +56,7 @@ const propTypes = {
 const defaultProps = {
   filterText: '',
   headerHeight: 32,
+  overscanColumnCount: 10,
   overscanRowCount: 10,
   rowHeight: 32,
   striped: true,
@@ -205,7 +207,7 @@ export default class FilterableTable extends PureComponent {
   }
 
   renderGrid() {
-    const { orderedColumnKeys, rowHeight } = this.props;
+    const { orderedColumnKeys, overscanColumnCount, overscanRowCount, rowHeight } = this.props;
 
     let { height } = this.props;
     let totalTableHeight = height;
@@ -232,7 +234,6 @@ export default class FilterableTable extends PureComponent {
                 columnCount={orderedColumnKeys.length}
                 columnWidth={getColumnWidth}
                 height={rowHeight}
-                onScroll={onScroll}
                 ref={(ref) => { this.container = ref; }}
                 rowCount={1}
                 rowHeight={rowHeight}
@@ -247,6 +248,8 @@ export default class FilterableTable extends PureComponent {
                 columnWidth={getColumnWidth}
                 height={totalTableHeight}
                 onScroll={onScroll}
+                overscanColumnCount={overscanColumnCount}
+                overscanRowCount={overscanRowCount}
                 ref={(ref) => { this.container = ref; }}
                 rowCount={this.list.size}
                 rowHeight={rowHeight}

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -39,7 +39,7 @@ const SCROLL_BAR_HEIGHT = 15;
 const GRID_POSITION_ADJUSTMENT = 4;
 
 // when more than MAX_COLUMNS_FOR_TABLE are returned, switch from table to grid view
-export const MAX_COLUMNS_FOR_TABLE = 20;
+export const MAX_COLUMNS_FOR_TABLE = 50;
 
 const propTypes = {
   orderedColumnKeys: PropTypes.array.isRequired,

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -37,6 +37,7 @@ function getTextWidth(text, font = '12px Roboto') {
 
 const SCROLL_BAR_HEIGHT = 15;
 const GRID_EXTRA_HEIGHT = 6;
+const GRID_POSITION_ADJUSTMENT = 4;
 
 // when more than MAX_COLUMNS_FOR_TABLE are returned, switch from table to grid view
 export const MAX_COLUMNS_FOR_TABLE = 50;
@@ -187,7 +188,7 @@ export default class FilterableTable extends PureComponent {
     return (
       <TooltipWrapper key={key} label="header" tooltip={label}>
         <div
-          style={{ ...style, top: style.top - 4 }}
+          style={{ ...style, top: style.top - GRID_POSITION_ADJUSTMENT }}
           className={`${className} grid-cell grid-header-cell`}
         >
           {label}
@@ -201,7 +202,7 @@ export default class FilterableTable extends PureComponent {
     return (
       <div
         key={key}
-        style={{ ...style, top: style.top - 4 }}
+        style={{ ...style, top: style.top - GRID_POSITION_ADJUSTMENT }}
         className={`grid-cell ${this.rowClassName({ index: rowIndex })}`}
       >
         {this.list.get(rowIndex)[columnKey]}

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -22,9 +22,11 @@ import JSONbig from 'json-bigint';
 import React, { PureComponent } from 'react';
 import {
   Column,
-  Table,
+  Grid,
+  ScrollSync,
   SortDirection,
   SortIndicator,
+  Table,
 } from 'react-virtualized';
 import { getTextDimension } from '@superset-ui/dimension';
 import TooltipWrapper from '../TooltipWrapper';
@@ -34,6 +36,9 @@ function getTextWidth(text, font = '12px Roboto') {
 }
 
 const SCROLL_BAR_HEIGHT = 15;
+
+// when more than MAX_COLUMNS are returned, switch from table to grid view
+const MAX_COLUMNS = 3;
 
 const propTypes = {
   orderedColumnKeys: PropTypes.array.isRequired,
@@ -60,7 +65,11 @@ export default class FilterableTable extends PureComponent {
   constructor(props) {
     super(props);
     this.list = List(this.formatTableData(props.data));
+    this.renderCell = this.renderCell.bind(this);
+    this.renderCellHeader = this.renderCellHeader.bind(this);
+    this.renderGrid = this.renderGrid.bind(this);
     this.renderHeader = this.renderHeader.bind(this);
+    this.renderTable = this.renderTable.bind(this);
     this.rowClassName = this.rowClassName.bind(this);
     this.sort = this.sort.bind(this);
 
@@ -167,7 +176,90 @@ export default class FilterableTable extends PureComponent {
     );
   }
 
-  render() {
+  renderCellHeader({ columnIndex, key, style }) {
+    const label = this.props.orderedColumnKeys[columnIndex];
+    return (
+      <TooltipWrapper label="header" tooltip={label}>
+        <div
+          key={key}
+          style={{ ...style, top: style.top - 4 }}
+          className="grid-cell grid-header-cell"
+        >
+          {label}
+        </div>
+      </TooltipWrapper>
+    );
+  }
+
+  renderCell({ columnIndex, key, rowIndex, style }) {
+    const columnKey = this.props.orderedColumnKeys[columnIndex];
+    return (
+      <div
+        key={key}
+        style={{ ...style, top: style.top - 4 }}
+        className={`grid-cell ${this.rowClassName({ index: rowIndex })}`}
+      >
+        {this.list.get(rowIndex)[columnKey]}
+      </div>
+    );
+  }
+
+  renderGrid() {
+    const { orderedColumnKeys, rowHeight } = this.props;
+
+    let { height } = this.props;
+    let totalTableHeight = height;
+    if (this.container && this.totalTableWidth > this.container.clientWidth) {
+      // exclude the height of the horizontal scroll bar from the height of the table
+      // and the height of the table container if the content overflows
+      height -= SCROLL_BAR_HEIGHT;
+      totalTableHeight -= SCROLL_BAR_HEIGHT;
+    }
+
+    const getColumnWidth = ({ index }) => this.widthsForColumnsByKey[orderedColumnKeys[index]];
+
+    return (
+      <ScrollSync>
+        {({ onScroll, scrollTop }) => (
+          <div
+            style={{ height }}
+            className="filterable-table-container"
+            ref={(ref) => { this.container = ref; }}
+          >
+            <div className="LeftColumn">
+              <Grid
+                cellRenderer={this.renderCellHeader}
+                columnCount={orderedColumnKeys.length}
+                columnWidth={getColumnWidth}
+                height={rowHeight}
+                onScroll={onScroll}
+                ref={(ref) => { this.container = ref; }}
+                rowCount={1}
+                rowHeight={rowHeight}
+                scrollTop={scrollTop}
+                width={this.totalTableWidth}
+              />
+            </div>
+            <div className="RightColumn">
+              <Grid
+                cellRenderer={this.renderCell}
+                columnCount={orderedColumnKeys.length}
+                columnWidth={getColumnWidth}
+                height={totalTableHeight}
+                onScroll={onScroll}
+                ref={(ref) => { this.container = ref; }}
+                rowCount={this.list.size}
+                rowHeight={rowHeight}
+                width={this.totalTableWidth}
+              />
+            </div>
+          </div>
+        )}
+      </ScrollSync>
+    );
+  }
+
+  renderTable() {
     const { sortBy, sortDirection } = this.state;
     const {
       filterText,
@@ -234,6 +326,13 @@ export default class FilterableTable extends PureComponent {
         }
       </div>
     );
+  }
+
+  render() {
+    if (this.props.orderedColumnKeys.length > MAX_COLUMNS) {
+      return this.renderGrid();
+    }
+    return this.renderTable();
   }
 }
 

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -36,11 +36,10 @@ function getTextWidth(text, font = '12px Roboto') {
 }
 
 const SCROLL_BAR_HEIGHT = 15;
-const GRID_EXTRA_HEIGHT = 6;
 const GRID_POSITION_ADJUSTMENT = 4;
 
 // when more than MAX_COLUMNS_FOR_TABLE are returned, switch from table to grid view
-export const MAX_COLUMNS_FOR_TABLE = 50;
+export const MAX_COLUMNS_FOR_TABLE = 20;
 
 const propTypes = {
   orderedColumnKeys: PropTypes.array.isRequired,
@@ -216,7 +215,6 @@ export default class FilterableTable extends PureComponent {
     const { orderedColumnKeys, overscanColumnCount, overscanRowCount, rowHeight } = this.props;
 
     let { height } = this.props;
-    height -= GRID_EXTRA_HEIGHT;
     let totalTableHeight = height;
     if (this.container && this.totalTableWidth > this.container.clientWidth) {
       // exclude the height of the horizontal scroll bar from the height of the table
@@ -242,7 +240,6 @@ export default class FilterableTable extends PureComponent {
                 columnCount={orderedColumnKeys.length}
                 columnWidth={getColumnWidth}
                 height={rowHeight}
-                ref={this.container}
                 rowCount={1}
                 rowHeight={rowHeight}
                 scrollTop={scrollTop}
@@ -258,7 +255,6 @@ export default class FilterableTable extends PureComponent {
                 onScroll={onScroll}
                 overscanColumnCount={overscanColumnCount}
                 overscanRowCount={overscanRowCount}
-                ref={this.container}
                 rowCount={this.list.size}
                 rowHeight={rowHeight}
                 width={this.totalTableWidth}

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -38,8 +38,8 @@ function getTextWidth(text, font = '12px Roboto') {
 const SCROLL_BAR_HEIGHT = 15;
 const GRID_EXTRA_HEIGHT = 6;
 
-// when more than MAX_COLUMNS are returned, switch from table to grid view
-const MAX_COLUMNS = 50;
+// when more than MAX_COLUMNS_FOR_TABLE are returned, switch from table to grid view
+export const MAX_COLUMNS_FOR_TABLE = 50;
 
 const propTypes = {
   orderedColumnKeys: PropTypes.array.isRequired,
@@ -337,7 +337,7 @@ export default class FilterableTable extends PureComponent {
   }
 
   render() {
-    if (this.props.orderedColumnKeys.length > MAX_COLUMNS) {
+    if (this.props.orderedColumnKeys.length > MAX_COLUMNS_FOR_TABLE) {
       return this.renderGrid();
     }
     return this.renderTable();

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -36,9 +36,10 @@ function getTextWidth(text, font = '12px Roboto') {
 }
 
 const SCROLL_BAR_HEIGHT = 15;
+const GRID_EXTRA_HEIGHT = 6;
 
 // when more than MAX_COLUMNS are returned, switch from table to grid view
-const MAX_COLUMNS = 3;
+const MAX_COLUMNS = 50;
 
 const propTypes = {
   orderedColumnKeys: PropTypes.array.isRequired,
@@ -67,10 +68,10 @@ export default class FilterableTable extends PureComponent {
   constructor(props) {
     super(props);
     this.list = List(this.formatTableData(props.data));
-    this.renderCell = this.renderCell.bind(this);
-    this.renderCellHeader = this.renderCellHeader.bind(this);
+    this.renderGridCell = this.renderGridCell.bind(this);
+    this.renderGridCellHeader = this.renderGridCellHeader.bind(this);
     this.renderGrid = this.renderGrid.bind(this);
-    this.renderHeader = this.renderHeader.bind(this);
+    this.renderTableHeader = this.renderTableHeader.bind(this);
     this.renderTable = this.renderTable.bind(this);
     this.rowClassName = this.rowClassName.bind(this);
     this.sort = this.sort.bind(this);
@@ -162,7 +163,7 @@ export default class FilterableTable extends PureComponent {
     this.setState({ sortBy, sortDirection });
   }
 
-  renderHeader({ dataKey, label, sortBy, sortDirection }) {
+  renderTableHeader({ dataKey, label, sortBy, sortDirection }) {
     const className = this.props.expandedColumns.indexOf(label) > -1
       ? 'header-style-disabled'
       : 'header-style';
@@ -178,14 +179,16 @@ export default class FilterableTable extends PureComponent {
     );
   }
 
-  renderCellHeader({ columnIndex, key, style }) {
+  renderGridCellHeader({ columnIndex, key, style }) {
     const label = this.props.orderedColumnKeys[columnIndex];
+    const className = this.props.expandedColumns.indexOf(label) > -1
+      ? 'header-style-disabled'
+      : 'header-style';
     return (
-      <TooltipWrapper label="header" tooltip={label}>
+      <TooltipWrapper key={key} label="header" tooltip={label}>
         <div
-          key={key}
           style={{ ...style, top: style.top - 4 }}
-          className="grid-cell grid-header-cell"
+          className={`${className} grid-cell grid-header-cell`}
         >
           {label}
         </div>
@@ -193,7 +196,7 @@ export default class FilterableTable extends PureComponent {
     );
   }
 
-  renderCell({ columnIndex, key, rowIndex, style }) {
+  renderGridCell({ columnIndex, key, rowIndex, style }) {
     const columnKey = this.props.orderedColumnKeys[columnIndex];
     return (
       <div
@@ -210,6 +213,7 @@ export default class FilterableTable extends PureComponent {
     const { orderedColumnKeys, overscanColumnCount, overscanRowCount, rowHeight } = this.props;
 
     let { height } = this.props;
+    height -= GRID_EXTRA_HEIGHT;
     let totalTableHeight = height;
     if (this.container && this.totalTableWidth > this.container.clientWidth) {
       // exclude the height of the horizontal scroll bar from the height of the table
@@ -220,17 +224,18 @@ export default class FilterableTable extends PureComponent {
 
     const getColumnWidth = ({ index }) => this.widthsForColumnsByKey[orderedColumnKeys[index]];
 
+    // fix height of filterable table
     return (
       <ScrollSync>
         {({ onScroll, scrollTop }) => (
           <div
             style={{ height }}
-            className="filterable-table-container"
+            className="filterable-table-container Table"
             ref={(ref) => { this.container = ref; }}
           >
             <div className="LeftColumn">
               <Grid
-                cellRenderer={this.renderCellHeader}
+                cellRenderer={this.renderGridCellHeader}
                 columnCount={orderedColumnKeys.length}
                 columnWidth={getColumnWidth}
                 height={rowHeight}
@@ -243,10 +248,10 @@ export default class FilterableTable extends PureComponent {
             </div>
             <div className="RightColumn">
               <Grid
-                cellRenderer={this.renderCell}
+                cellRenderer={this.renderGridCell}
                 columnCount={orderedColumnKeys.length}
                 columnWidth={getColumnWidth}
-                height={totalTableHeight}
+                height={totalTableHeight - rowHeight}
                 onScroll={onScroll}
                 overscanColumnCount={overscanColumnCount}
                 overscanRowCount={overscanRowCount}
@@ -319,7 +324,7 @@ export default class FilterableTable extends PureComponent {
               <Column
                 dataKey={columnKey}
                 disableSort={false}
-                headerRenderer={this.renderHeader}
+                headerRenderer={this.renderTableHeader}
                 width={this.widthsForColumnsByKey[columnKey]}
                 label={columnKey}
                 key={columnKey}

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -88,6 +88,8 @@ export default class FilterableTable extends PureComponent {
       sortDirection: SortDirection.ASC,
       fitted: false,
     };
+
+    this.container = React.createRef();
   }
 
   componentDidMount() {
@@ -232,7 +234,7 @@ export default class FilterableTable extends PureComponent {
           <div
             style={{ height }}
             className="filterable-table-container Table"
-            ref={(ref) => { this.container = ref; }}
+            ref={this.container}
           >
             <div className="LeftColumn">
               <Grid
@@ -240,7 +242,7 @@ export default class FilterableTable extends PureComponent {
                 columnCount={orderedColumnKeys.length}
                 columnWidth={getColumnWidth}
                 height={rowHeight}
-                ref={(ref) => { this.container = ref; }}
+                ref={this.container}
                 rowCount={1}
                 rowHeight={rowHeight}
                 scrollTop={scrollTop}
@@ -256,7 +258,7 @@ export default class FilterableTable extends PureComponent {
                 onScroll={onScroll}
                 overscanColumnCount={overscanColumnCount}
                 overscanRowCount={overscanRowCount}
-                ref={(ref) => { this.container = ref; }}
+                ref={this.container}
                 rowCount={this.list.size}
                 rowHeight={rowHeight}
                 width={this.totalTableWidth}
@@ -304,7 +306,7 @@ export default class FilterableTable extends PureComponent {
       <div
         style={{ height }}
         className="filterable-table-container"
-        ref={(ref) => { this.container = ref; }}
+        ref={this.container}
       >
         {this.state.fitted &&
           <Table

--- a/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
+++ b/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
@@ -38,12 +38,16 @@
   overflow: hidden;
 }
 .ReactVirtualized__Table__headerColumn,
-.ReactVirtualized__Table__rowColumn {
+.ReactVirtualized__Table__rowColumn,
+.grid-cell {
   min-width: 0px;
   border-right: 1px solid #ccc;
   align-self: center;
   padding: 12px;
   font-size: 12px;
+}
+.grid-header-cell {
+  font-weight: 700;
 }
 .ReactVirtualized__Table__headerColumn:last-of-type,
 .ReactVirtualized__Table__rowColumn:last-of-type {

--- a/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
+++ b/superset/assets/src/components/FilterableTable/FilterableTableStyles.css
@@ -30,7 +30,8 @@
   display: flex;
   flex-direction: row;
 }
-.ReactVirtualized__Table__headerTruncatedText {
+.ReactVirtualized__Table__headerTruncatedText,
+.grid-header-cell {
   display: inline-block;
   max-width: 100%;
   white-space: nowrap;


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

With https://github.com/apache/incubator-superset/pull/7625 SQL Lab now displays complex column types as extended columns. This might result in very wide tables that degrade performance when visualizing preview samples or query results.

This PR modifies SQL Lab so that wide tables (greater than 50 columns) are displayed using `react-virtualized`'s `Grid` instead of a `Table`. This ensures that columns are loaded dynamically as the user scrolls horizontally. The only downside is that the user is no longer able to sort the data by clicking on a column header.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Here's a demo showing the `Grid` component with the `query` table (the table has only 27 columns, but I modified the threshold temporarily in order to test):

![grid-view](https://user-images.githubusercontent.com/1534870/59305062-50a77400-8c4e-11e9-87bc-7c484aa93eac.gif)

I also tested with a table with over 300 columns, but I can't share the data.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested locally (see above). Added unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [X] Removes existing feature or API

This removes the ability of sorting on the client side on tables with more than 50 columns.

### REVIEWERS

@mistercrunch @khtruong 