### PR TITLE
[docs] Fix, flask fab cli does not need app parameter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,7 +319,7 @@ pip install -r requirements-dev.txt
 pip install -e .
 
 # Create an admin user in your metadata database
-flask fab create-admin --app superset
+flask fab create-admin
 
 # Initialize the database
 superset db upgrade

--- a/contrib/docker/docker-init.sh
+++ b/contrib/docker/docker-init.sh
@@ -18,7 +18,7 @@
 set -ex
 
 # Create an admin user (you will be prompted to set username, first and last name before setting a password)
-flask fab create-admin --app superset
+flask fab create-admin
 
 # Initialize the database
 superset db upgrade


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [X] Documentation

### SUMMARY
New `flask fab` cli does not need `app` parameter

Fixes: #7689 