### PR TITLE
[dashboard] trigger query for chart in nested tab only after chart becomes visible

### DIFF
--- a/superset/assets/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Tabs.jsx
@@ -168,6 +168,7 @@ class Tabs extends React.PureComponent {
       handleComponentDrop,
       renderTabContent,
       renderHoverMenu,
+      isComponentVisible: isCurrentTabVisible,
       editMode,
     } = this.props;
 
@@ -238,7 +239,9 @@ class Tabs extends React.PureComponent {
                       onResize={onResize}
                       onResizeStop={onResizeStop}
                       onDropOnTab={this.handleDropOnTab}
-                      isComponentVisible={selectedTabIndex === tabIndex}
+                      isComponentVisible={
+                        selectedTabIndex === tabIndex && isCurrentTabVisible
+                      }
                     />
                   )}
                 </BootstrapTab>

--- a/superset/data/tabbed_dashboard.py
+++ b/superset/data/tabbed_dashboard.py
@@ -90,7 +90,9 @@ def load_tabbed_dashboard():
           "ROOT_ID",
           "TABS-lV0r00f4H1",
           "TAB-gcQJxApOZS",
-          "ROW-3PphCz4GD"
+          "TABS-afnrUvdxYF",
+          "TAB-jNNd4WWar1",
+          "ROW-7ygtDczaQ"
         ],
         "type": "CHART"
       },
@@ -152,21 +154,6 @@ def load_tabbed_dashboard():
         "id": "ROOT_ID",
         "type": "ROOT"
       },
-      "ROW-3PphCz4GD": {
-        "children": [
-          "CHART-dxV7Il74hH"
-        ],
-        "id": "ROW-3PphCz4GD",
-        "meta": {
-          "background": "BACKGROUND_TRANSPARENT"
-        },
-        "parents": [
-          "ROOT_ID",
-          "TABS-lV0r00f4H1",
-          "TAB-gcQJxApOZS"
-        ],
-        "type": "ROW"
-      },
       "ROW-7G2o5uDvfo": {
         "children": [
           "CHART-c0EjR-OZ0n"
@@ -179,6 +166,23 @@ def load_tabbed_dashboard():
           "ROOT_ID",
           "TABS-lV0r00f4H1",
           "TAB-NF3dlrWGS"
+        ],
+        "type": "ROW"
+      },
+      "ROW-7ygtDczaQ": {
+        "children": [
+          "CHART-dxV7Il74hH"
+        ],
+        "id": "ROW-7ygtDczaQ",
+        "meta": {
+          "background": "BACKGROUND_TRANSPARENT"
+        },
+        "parents": [
+          "ROOT_ID",
+          "TABS-lV0r00f4H1",
+          "TAB-gcQJxApOZS",
+          "TABS-afnrUvdxYF",
+          "TAB-jNNd4WWar1"
         ],
         "type": "ROW"
       },
@@ -249,7 +253,7 @@ def load_tabbed_dashboard():
       },
       "TAB-gcQJxApOZS": {
         "children": [
-          "ROW-3PphCz4GD"
+          "TABS-afnrUvdxYF"
         ],
         "id": "TAB-gcQJxApOZS",
         "meta": {
@@ -258,6 +262,22 @@ def load_tabbed_dashboard():
         "parents": [
           "ROOT_ID",
           "TABS-lV0r00f4H1"
+        ],
+        "type": "TAB"
+      },
+      "TAB-jNNd4WWar1": {
+        "children": [
+          "ROW-7ygtDczaQ"
+        ],
+        "id": "TAB-jNNd4WWar1",
+        "meta": {
+          "text": "New Tab"
+        },
+        "parents": [
+          "ROOT_ID",
+          "TABS-lV0r00f4H1",
+          "TAB-gcQJxApOZS",
+          "TABS-afnrUvdxYF"
         ],
         "type": "TAB"
       },
@@ -288,6 +308,19 @@ def load_tabbed_dashboard():
           "ROOT_ID",
           "TABS-lV0r00f4H1",
           "TAB-NF3dlrWGS"
+        ],
+        "type": "TABS"
+      },
+      "TABS-afnrUvdxYF": {
+        "children": [
+          "TAB-jNNd4WWar1"
+        ],
+        "id": "TABS-afnrUvdxYF",
+        "meta": {},
+        "parents": [
+          "ROOT_ID",
+          "TABS-lV0r00f4H1",
+          "TAB-gcQJxApOZS"
         ],
         "type": "TABS"
       },


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In #7233 I added a feature that only trigger query when chart is visible to user. If user apply filter in 1 tab, all the charts in another tab (not visible right now) should delay query update until user click to see the tab.

I found there is a bug for nested tab case: when chart in the nested tab, update filter (in another tab) will trigger new query right away. Please see before/after gif. Also updated integration test to cover this case.

Note: charts outside nested tab behaves good, and is covered in the existed unit tests.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![7vPeK22UdR](https://user-images.githubusercontent.com/27990562/59387623-8025b180-8d1e-11e9-92ea-faea1c462dfc.gif)

After:
![XC43pU6gQU](https://user-images.githubusercontent.com/27990562/59387598-6be1b480-8d1e-11e9-8daa-43c33f679c85.gif)



### TEST PLAN
CI and manual test. 


### REVIEWERS
@etr2460 @williaster 
