### PR TITLE
[SIP-15A] Enforcing ISO 8601 date/timestamp formats

### DIFF
--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -97,14 +97,23 @@ function ColumnCollectionTable({
             <Field
               fieldKey="python_date_format"
               label={t('Datetime Format')}
-              descr={
+              descr={/* Note the fragmented translations may not work. */
                 <div>
-                  {t('The pattern of the timestamp format, use ')}
+                  {t('The pattern of timestamp format. For strings use ')}
                   <a href="https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior">
                     {t('python datetime string pattern')}
                   </a>
-                  {t(` expression. If time is stored in epoch format, put \`epoch_s\` or
-                      \`epoch_ms\`.`)}
+                  {t(' expression which needs to adhere to the ')}
+                  <a href="https://en.wikipedia.org/wiki/ISO_8601">
+                    {t('ISO 8601')}
+                  </a>
+                  {t(` standard to ensure that the lexicographical ordering
+                      coincides with the chronological ordering. If the
+                      timestamp format does not adhere to the ISO 8601 standard
+                      you will need to define an expression and type for
+                      transforming the string into a date or timestamp. Note
+                      currently time zones are not supported. If time is stored
+                      in epoch format, put \`epoch_s\` or \`epoch_ms\`.`)}
                 </div>
               }
               control={<TextControl />}

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -219,6 +219,8 @@ class TableColumn(Model, BaseColumn):
             return "'{}'".format(dttm.strftime(tf))
         else:
             s = self.table.database.db_engine_spec.convert_dttm(self.type or "", dttm)
+
+            # TODO(john-bodley): SIP-15 will explicitly require a type conversion.
             return s or "'{}'".format(dttm.strftime("%Y-%m-%d %H:%M:%S.%f"))
 
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Per [SIP-15A](https://github.com/apache/incubator-superset/issues/7656) this PR helps to ensure that  the when specifying a string like temporal column the date/timestamp `strftime` format adheres to the ISO 8601 format. The TL;DR is if we're going to filter (and thus order) dates we need to use a representation where the lexicographical order coincides with the chronological order (see the ISO 8601 section in the SIP for details). 

This PR updates the CRUD and inline datasource editor (and adds validation where appropriate). Regrettable it seems in FAB we can't couple multiple fields, i.e., if the "Is temporal" field is unchecked then disable the "Datetime Format" field (@dpgaspar may know of how to do this). Additionally the messaging seems to be omitted if the form field is invalid (I was able to make this work for the default "Detail" tab (per [here](https://github.com/apache/incubator-superset/pull/5449)) but not for the "Columns" tab. 

I originally when down the rabbit hole of replacing the `strftime` formatting to using the more restrictive ISO 8601 constructs, i.e., `YYYY-MM-DD hh:mm:ss.SSSSSS` including providing a migration. I finally opted against this as the `datetime` object doesn't support formatting using the ISO 8601 tokens (packages like `arrow` and `pendulumn` do however) and it seems like we heavily depend of the `strftime` format for transforming Pandas dataframe.

Note in the future I think there may be merit in trying to migrate to using the ISO 8601 tokens as this seems more standard and a time format which a number of engines support. 

Finally there is no migration or corrective actions for currently ill-defined formats. This PR simply ensures that new formats are correct moving forward.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1138" alt="Screen Shot 2019-10-16 at 9 22 16 AM" src="https://user-images.githubusercontent.com/4567245/66939645-534d1800-eff8-11e9-8222-c8675169d6f1.png">

<img width="199" alt="Screen Shot 2019-10-16 at 9 34 56 AM" src="https://user-images.githubusercontent.com/4567245/66939646-534d1800-eff8-11e9-9f28-090f8a2d4e14.png">

### TEST PLAN

CI and tested the regex validator. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @betodealmeida @michellethomas @mistercrunch @villebro 
