### PR TITLE
[docker] Fix docker-init missing FLASK_APP

### DIFF
--- a/contrib/docker/docker-init.sh
+++ b/contrib/docker/docker-init.sh
@@ -18,6 +18,7 @@
 set -ex
 
 # Create an admin user (you will be prompted to set username, first and last name before setting a password)
+export FLASK_APP=superset:app
 flask fab create-admin
 
 # Initialize the database


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix

### SUMMARY
New `flask fab ...` cli needs FLASK_APP env var to be set

### TEST PLAN
Run:
`docker-compose build`
`docker-compose run --rm superset  ./docker-init.sh`

### ADDITIONAL INFORMATION
- [x] Has associated issue: #7707
