### PR TITLE
[WiP] feat: backend for thumnail computation + caching + endpoints

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -108,6 +108,7 @@ def get_manifest():
 # Setup the cache prior to registering the blueprints.
 cache = setup_cache(app, conf.get("CACHE_CONFIG"))
 tables_cache = setup_cache(app, conf.get("TABLE_NAMES_CACHE_CONFIG"))
+thumbnail_cache = setup_cache(app, conf.get("THUMBNAIL_CACHE_CONFIG"))
 
 for bp in conf.get("BLUEPRINTS"):
     try:
@@ -119,6 +120,10 @@ for bp in conf.get("BLUEPRINTS"):
 
 if conf.get("SILENCE_FAB"):
     logging.getLogger("flask_appbuilder").setLevel(logging.ERROR)
+
+logging.getLogger("urllib3").setLevel(logging.ERROR)
+logging.getLogger("selenium").setLevel(logging.ERROR)
+logging.getLogger("PIL").setLevel(logging.ERROR)
 
 if app.debug:
     app.logger.setLevel(logging.DEBUG)  # pylint: disable=no-member

--- a/superset/assets/stylesheets/less/cosmo/variables.less
+++ b/superset/assets/stylesheets/less/cosmo/variables.less
@@ -29,8 +29,8 @@
 @gray-darker:            lighten(@gray-base, 13.5%);
 @gray-dark:              lighten(@gray-base, 20%);
 @gray:                   lighten(@gray-base, 33.5%);
-@gray-light:             lighten(@gray-base, 70%);
-@gray-lighter:           lighten(@gray-base, 95%);
+@gray-light:             lighten(@gray-base, 80%);
+@gray-lighter:           lighten(@gray-base, 90%);
 
 @brand-primary:         #00A699;
 @brand-success:         #4AC15F;

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -423,6 +423,75 @@ def load_test_users():
     load_test_users_run()
 
 
+@app.cli.command()
+@click.option(
+    "--asynchronous",
+    "-a",
+    is_flag=True,
+    default=False,
+    help="Trigger commands to run remotely on a worker",
+)
+@click.option(
+    "--dashboards_only",
+    "-d",
+    is_flag=True,
+    default=False,
+    help="Only process dashboards",
+)
+@click.option(
+    "--charts_only", "-c", is_flag=True, default=False, help="Only process charts"
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Force refresh, even if previously cached",
+)
+@click.option("--id", "-i", multiple=True)
+def compute_thumbnails(asynchronous, dashboards_only, charts_only, force, id):
+    """Compute thumbnails"""
+    from superset.models import core as models
+    from superset.tasks.thumbnails import (
+        cache_chart_thumbnail,
+        cache_dashboard_thumbnail,
+    )
+
+    if not charts_only:
+        query = db.session.query(models.Dashboard)
+        if id:
+            query = query.filter(models.Dashboard.id.in_(id))
+        dashboards = query.all()
+        count = len(dashboards)
+        for i, dash in enumerate(dashboards):
+            if asynchronous:
+                func = cache_dashboard_thumbnail.delay
+                action = "Triggering"
+            else:
+                func = cache_dashboard_thumbnail
+                action = "Processing"
+            msg = f'{action} dashboard "{dash.dashboard_title}" ({i+1}/{count})'
+            click.secho(msg, fg="green")
+            func(dash.id, force=force)
+
+    if not dashboards_only:
+        query = db.session.query(models.Slice)
+        if id:
+            query = query.filter(models.Slice.id.in_(id))
+        slices = query.all()
+        count = len(slices)
+        for i, slc in enumerate(slices):
+            if asynchronous:
+                func = cache_chart_thumbnail.delay
+                action = "Triggering"
+            else:
+                func = cache_chart_thumbnail
+                action = "Processing"
+            msg = f'{action} chart "{slc.slice_name}" ({i+1}/{count})'
+            click.secho(msg, fg="green")
+            func(slc.id, force=force)
+
+
 def load_test_users_run():
     """
     Loads admin, alpha, and gamma user for testing purposes

--- a/superset/config.py
+++ b/superset/config.py
@@ -380,6 +380,8 @@ WARNING_MSG = None
 # you'll want to use a proper broker as specified here:
 # http://docs.celeryproject.org/en/latest/getting-started/brokers/index.html
 
+CELERYD_LOG_LEVEL = "DEBUG"
+
 
 class CeleryConfig(object):
     BROKER_URL = "sqla+sqlite:///celerydb.sqlite"

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -158,6 +158,16 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
         pass
 
     @property
+    def data_summary(self):
+        return {
+            "datasource_name": self.datasource_name,
+            "type": self.type,
+            "schema": self.schema,
+            "id": self.id,
+            "explore_url": self.explore_url,
+        }
+
+    @property
     def data(self):
         """Data representation of the datasource sent to the frontend"""
         order_by_choices = []

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -58,6 +58,7 @@ from superset.legacy import update_time_range
 from superset.models.helpers import AuditMixinNullable, ImportMixin
 from superset.models.tags import ChartUpdater, DashboardUpdater, FavStarUpdater
 from superset.models.user_attributes import UserAttribute
+from superset.tasks.thumbnails import cache_dashboard_thumbnail
 from superset.utils import cache as cache_util, core as utils
 from superset.viz import viz_types
 from urllib import parse  # noqa
@@ -186,6 +187,26 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
     @property
     def datasource(self):
         return self.get_datasource
+
+    @property
+    def thumbnail_url(self):
+        # SHA here is to force bypassing the browser cache when chart has changed
+        sha = utils.md5_hex(self.params, 6)
+        return f"/thumb/chart/{self.id}/{sha}/"
+
+    @property
+    def thumbnail_img(self):
+        return Markup(f'<img width="75" src="{self.thumbnail_url}">')
+
+    @property
+    def thumbnail_link(self):
+        return Markup(
+            f"""
+            <a href="{self.thumbnail_url}?force=true">
+                {self.thumbnail_img}
+            </a>
+        """
+        )
 
     def clone(self):
         return Slice(
@@ -710,6 +731,34 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
             cls=utils.DashboardEncoder,
             indent=4,
         )
+
+    @property
+    def thumbnail_url(self):
+        # SHA here is to force bypassing the browser cache when chart has changed
+        sha = utils.md5_hex(self.position_json, 6)
+        return f"/thumb/dashboard/{self.id}/{sha}/"
+
+    @property
+    def thumbnail_img(self):
+        return Markup(f'<img width="150" src="{self.thumbnail_url}">')
+
+    @property
+    def thumbnail_link(self):
+        return Markup(
+            f"""
+            <a href="{self.thumbnail_url}?force=true">
+                {self.thumbnail_img}
+            </a>
+        """
+        )
+
+
+def event_after_dashboard_changed(mapper, connection, target):
+    cache_dashboard_thumbnail.delay(target.id, force=True)
+
+
+sqla.event.listen(Dashboard, "before_insert", event_after_dashboard_changed)
+sqla.event.listen(Dashboard, "before_update", event_after_dashboard_changed)
 
 
 class Database(Model, AuditMixinNullable, ImportMixin):

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -25,7 +25,6 @@ from celery.utils.log import get_task_logger
 from sqlalchemy import and_, func
 
 from superset import app, db
-from superset.models.core import Dashboard, Log, Slice
 from superset.models.tags import Tag, TaggedObject
 from superset.tasks.celery_app import app as celery_app
 from superset.utils.core import parse_human_datetime
@@ -132,6 +131,8 @@ class DummyStrategy(Strategy):
 
     def get_urls(self):
         session = db.create_scoped_session()
+        from superset.models.core import Slice
+
         charts = session.query(Slice).all()
 
         return [get_url(chart) for chart in charts]
@@ -165,6 +166,8 @@ class TopNDashboardsStrategy(Strategy):
     def get_urls(self):
         urls = []
         session = db.create_scoped_session()
+
+        from superset.models.core import Dashboard, Log
 
         records = (
             session.query(Log.dashboard_id, func.count(Log.dashboard_id))
@@ -223,6 +226,8 @@ class DashboardTagsStrategy(Strategy):
             )
             .all()
         )
+        from superset.models.core import Dashboard, Slice
+
         dash_ids = [tagged_object.object_id for tagged_object in tagged_objects]
         tagged_dashboards = session.query(Dashboard).filter(Dashboard.id.in_(dash_ids))
         for dashboard in tagged_dashboards:

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=C,R,W
+
+"""Utility functions used across Superset"""
+
+import logging
+
+from superset import app, security_manager, thumbnail_cache
+from superset.tasks.celery_app import app as celery_app
+from superset.utils.selenium import DashboardScreenshot, SliceScreenshot
+
+
+@celery_app.task(name="cache_chart_thumbnail", soft_time_limit=300)
+def cache_chart_thumbnail(chart_id, force=False):
+    with app.app_context():
+        logging.info(f"Caching chart {chart_id}")
+        screenshot = SliceScreenshot(id=chart_id)
+        user = security_manager.find_user("Admin")
+        screenshot.compute_and_cache(user=user, cache=thumbnail_cache, force=force)
+
+
+@celery_app.task(name="cache_dashboard_thumbnail", soft_time_limit=300)
+def cache_dashboard_thumbnail(dashboard_id, force=False):
+    with app.app_context():
+        logging.info(f"Caching dashboard {dashboard_id}")
+        screenshot = DashboardScreenshot(id=dashboard_id)
+        user = security_manager.find_user("Admin")
+        screenshot.compute_and_cache(user=user, cache=thumbnail_cache, force=force)

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -25,6 +25,7 @@ from email.mime.text import MIMEText
 from email.utils import formatdate
 import errno
 import functools
+import hashlib
 import json
 import logging
 import os

--- a/superset/utils/selenium.py
+++ b/superset/utils/selenium.py
@@ -1,0 +1,275 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=C,R,W
+from io import BytesIO
+import logging
+import time
+import urllib
+
+from flask import current_app, request, Response, session, url_for
+from flask_login import login_user
+from PIL import Image
+from retry.api import retry_call
+from selenium.common.exceptions import TimeoutException, WebDriverException
+from selenium.webdriver import chrome, firefox
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+from werkzeug.utils import parse_cookie
+
+# Time in seconds, we will wait for the page to load and render
+SELENIUM_CHECK_INTERVAL = 2
+SELENIUM_RETRIES = 5
+SELENIUM_HEADSTART = 3
+
+
+def headless_url(path):
+    return urllib.parse.urljoin(current_app.config.get("WEBDRIVER_BASEURL"), path)
+
+
+def get_url_path(view, **kwargs):
+    with current_app.test_request_context():
+        return headless_url(url_for(view, **kwargs))
+
+
+class BaseScreenshot:
+    thumbnail_type = None
+    orm_class = None
+    element = None
+    window_size = (800, 600)
+    thumb_size = (400, 300)
+
+    def __init__(self, id):
+        self.id = id
+        self.screenshot = None
+
+    @property
+    def cache_key(self):
+        return f"thumb__{self.thumbnail_type}__{self.id}"
+
+    @property
+    def url(self):
+        raise NotImplementedError()
+
+    def fetch_screenshot(self, user, window_size=None):
+        window_size = window_size or self.window_size
+        self.screenshot = get_png_from_url(
+            self.url, window_size, self.element, user=user
+        )
+        return self.screenshot
+
+    def get_thumb_as_bytes(self, *args, **kwargs):
+        payload = self.get_thumb(*args, **kwargs)
+        return BytesIO(payload)
+
+    def get_from_cache(self, cache):
+        payload = cache.get(self.cache_key)
+        if payload:
+            return BytesIO(payload)
+
+    def compute_and_cache(
+        self, user, cache, window_size=None, thumb_size=None, force=True
+    ):
+        cache_key = self.cache_key
+        if not force and cache.get(cache_key):
+            logging.info("Thumb already cached, skipping...")
+            return
+        window_size = window_size or self.window_size
+        thumb_size = thumb_size or self.thumb_size
+        logging.info(f"Processing url for thumbnail: {cache_key}")
+
+        payload = None
+
+        # Assuming all sorts of things can go wrong with Selenium
+        try:
+            payload = self.fetch_screenshot(window_size=window_size, user=user)
+        except Exception as e:
+            logging.error("Failed at generating thumbnail")
+            logging.exception(e)
+
+        if payload and window_size != thumb_size:
+            try:
+                payload = self.resize_image(payload, size=thumb_size)
+            except Exception as e:
+                logging.error("Failed at resizing thumbnail")
+                logging.exception(e)
+                payload = None
+
+        if payload and cache:
+            logging.info(f"Caching thumbnail: {cache_key}")
+            cache.set(cache_key, payload)
+
+        return payload
+
+    def get_thumb(self, user, window_size=None, thumb_size=None, cache=None):
+        payload = None
+        cache_key = self.cache_key
+        window_size = window_size or self.window_size
+        thumb_size = thumb_size or self.thumb_size
+        if cache:
+            payload = cache.get(cache_key)
+        if not payload:
+            payload = self.compute_and_cache(user, cache, window_size, thumb_size)
+        else:
+            logging.info(f"Loaded thumbnail from cache: {cache_key}")
+        return payload
+
+    @classmethod
+    def resize_image(cls, img_bytes, output="png", size=None, crop=True):
+        size = size or cls.thumb_size
+        img = Image.open(BytesIO(img_bytes))
+        logging.debug(f"Selenium image size: {img.size}")
+        if crop and img.size[1] != cls.window_size[1]:
+            desired_ratio = float(cls.window_size[1]) / cls.window_size[0]
+            desired_width = int(img.size[0] * desired_ratio)
+            logging.debug(f"Cropping to: {img.size[0]}*{desired_width}")
+            img = img.crop((0, 0, img.size[0], desired_width))
+        logging.debug(f"Resizing to {size}")
+        img = img.resize(size, Image.ANTIALIAS)
+        new_img = BytesIO()
+        if output != "png":
+            img = img.convert("RGB")
+        img.save(new_img, output)
+        new_img.seek(0)
+        return new_img.read()
+
+
+class SliceScreenshot(BaseScreenshot):
+    thumbnail_type = "slice"
+    element = "chart-container"
+    window_size = (600, int(600 * 0.75))
+    thumb_size = (300, int(300 * 0.75))
+
+    @property
+    def url(self):
+        return get_url_path("Superset.slice", slice_id=self.id, standalone="true")
+
+
+class DashboardScreenshot(BaseScreenshot):
+    thumbnail_type = "dashboard"
+    element = "grid-container"
+    window_size = (1600, int(1600 * 0.75))
+    thumb_size = (400, int(400 * 0.75))
+
+    @property
+    def url(self):
+        return get_url_path("Superset.dashboard", dashboard_id=self.id)
+
+
+def _destroy_webdriver(driver):
+    """Destroy a driver"""
+    # This is some very flaky code in selenium. Hence the retries
+    # and catch-all exceptions
+    try:
+        retry_call(driver.close, tries=2)
+    except Exception:
+        pass
+    try:
+        driver.quit()
+    except Exception:
+        pass
+
+
+def get_auth_cookies(user):
+    # Login with the user specified to get the reports
+    with current_app.test_request_context():
+        login_user(user)
+
+        # A mock response object to get the cookie information from
+        response = Response()
+        current_app.session_interface.save_session(current_app, session, response)
+
+    cookies = []
+
+    # Set the cookies in the driver
+    for name, value in response.headers:
+        if name.lower() == "set-cookie":
+            cookie = parse_cookie(value)
+            cookies.append(cookie["session"])
+    return cookies
+
+
+def create_webdriver(user=None, webdriver="chrome", window=None):
+    """Creates a selenium webdriver
+
+    If no user is specified, we use the current request's context"""
+    # Create a webdriver for use in fetching reports
+    if webdriver == "firefox":
+        driver_class = firefox.webdriver.WebDriver
+        options = firefox.options.Options()
+    else:
+        # webdriver == 'chrome':
+        driver_class = chrome.webdriver.WebDriver
+        options = chrome.options.Options()
+        arg = f"--window-size={window[0]},{window[1]}"
+        options.add_argument(arg)
+
+    options.add_argument("--headless")
+
+    # Prepare args for the webdriver init
+    kwargs = dict(options=options)
+    kwargs.update(current_app.config.get("WEBDRIVER_CONFIGURATION"))
+
+    logging.info("Init selenium driver")
+    driver = driver_class(**kwargs)
+
+    # Setting cookies requires doing a request first
+    driver.get(headless_url("/login/"))
+
+    if user:
+        # Set the cookies in the driver
+        for cookie in get_auth_cookies(user):
+            info = dict(name="session", value=cookie)
+            driver.add_cookie(info)
+    elif request.cookies:
+        cookies = request.cookies
+        for k, v in cookies.items():
+            cookie = dict(name=k, value=v)
+            driver.add_cookie(cookie)
+    return driver
+
+
+def get_png_from_url(
+    url, window, element, user, webdriver="chrome", retries=SELENIUM_RETRIES
+):
+    driver = create_webdriver(user, webdriver, window)
+    driver.set_window_size(*window)
+    driver.get(url)
+    img = None
+    logging.debug(f"Sleeping for {SELENIUM_HEADSTART} seconds")
+    time.sleep(SELENIUM_HEADSTART)
+    try:
+        logging.debug(f"Wait for the presence of {element}")
+        element = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CLASS_NAME, element))
+        )
+        logging.debug(f"Wait for .loading to be done")
+        WebDriverWait(driver, 60).until_not(
+            EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))
+        )
+        logging.info("Taking a PNG screenshot")
+        img = element.screenshot_as_png
+    except TimeoutException:
+        logging.error("Selenium timed out")
+    except WebDriverException as e:
+        logging.exception(e)
+        # Some webdrivers do not support screenshots for elements.
+        # In such cases, take a screenshot of the entire page.
+        img = driver.screenshot()  # pylint: disable=no-member
+    finally:
+        _destroy_webdriver(driver)
+    return img

--- a/superset/views/__init__.py
+++ b/superset/views/__init__.py
@@ -23,5 +23,6 @@ from . import annotations  # noqa
 from . import datasource  # noqa
 from . import schedules  # noqa
 from . import tags  # noqa
+from . import thumbnails  # noqa
 from .log import views  # noqa
 from .log import api as log_api  # noqa

--- a/superset/views/thumbnails.py
+++ b/superset/views/thumbnails.py
@@ -1,0 +1,38 @@
+# pylint: disable=C,R,W
+from flask import send_file
+from flask_appbuilder import expose
+from flask_appbuilder.security.decorators import has_access
+
+from superset import app, appbuilder, thumbnail_cache
+from superset.utils.selenium import DashboardScreenshot, SliceScreenshot
+from .base import BaseSupersetView
+
+config = app.config
+NO_IMAGE_SRC = "/static/assets/images/no-image.png"
+
+
+class Thumb(BaseSupersetView):
+    """Base views for thumbnails"""
+
+    @expose("/chart/<slice_id>/<sha>/")
+    @has_access
+    def chart(self, slice_id, sha=None):
+        """Returns an thumbnail for a given chart, uses cache if possible"""
+        # TODO SECURITY
+        screenshot = SliceScreenshot(id=slice_id)
+        # TODO handle no image
+        img = screenshot.get_from_cache(thumbnail_cache)
+        return send_file(img, mimetype="image/png")
+
+    @expose("/dashboard/<dashboard_id>/<sha>/")
+    @has_access
+    def dashboard(self, dashboard_id, sha=None):
+        """Returns an thumbnail for a given dash, uses cache if possible"""
+        # TODO SECURITY
+        screenshot = DashboardScreenshot(id=dashboard_id)
+        img = screenshot.get_from_cache(thumbnail_cache)
+        # TODO handle no image
+        return send_file(img, mimetype="image/png")
+
+
+appbuilder.add_view_no_menu(Thumb)

--- a/tests/email_tests.py
+++ b/tests/email_tests.py
@@ -25,7 +25,7 @@ import unittest
 from unittest import mock
 
 from superset import app
-from superset.utils import core as utils
+from superset.utils.email import send_email_smtp, send_MIME_email
 from .utils import read_fixture
 
 send_email_test = mock.Mock()

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -26,7 +26,8 @@ from superset import db, security_manager
 from superset.dataframe import SupersetDataFrame
 from superset.db_engine_specs import BaseEngineSpec
 from superset.models.sql_lab import Query
-from superset.utils.core import datetime_to_epoch, get_main_database
+from superset.utils.core import get_main_database
+from superset.utils.dates import datetime_to_epoch
 from .base_tests import SupersetTestCase
 
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -29,7 +29,6 @@ from superset import app, db, security_manager
 from superset.exceptions import SupersetException
 from superset.models.core import Database
 from superset.utils.core import (
-    base_json_conv,
     convert_legacy_filters_into_adhoc,
     datetime_f,
     get_or_create_db,
@@ -49,6 +48,7 @@ from superset.utils.core import (
     zlib_compress,
     zlib_decompress_to_string,
 )
+from superset.utils.json import base_json_conv, json_int_dttm_ser, json_iso_dttm_ser
 
 
 def mock_parse_human_datetime(s):


### PR DESCRIPTION
This PR is the backend subset of WiP PR #6601. It includes:

* refactor of the Selenium abstractions used for email schedules,
  generalized to also work with thumbs
* new dependency on PIL, the common way of doing image processing in
  python, we use it to resize selenium screenshots into thumbs
* CLI utilities to compute-thumbnails
* the addition of an extra caching backend for thumbnail, in most cases
  we assume it should point to the same backend as the one used for
  chart JSON caching
* 2 new endpoints to retrieve dashboard and chart thumbs

### CATEGORY

Choose one### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### TODO / extra thoughts
- The security on viewing thumbnails should be the same as viewing the chart/dashboard itself
- We should perf/load test viewing a pageful of thumbnail. Assuming ~50 thumbs are displayed on a card list view, how does the metadata database react? It can represent a fair amount of database lookups depending on the way that perms are setup (if the user is Gamma, and there are lots of dashboards on the system). We should make sure that the worst case is ok.
- Caching for thumbs can be lax (doesn't have to be done daily for instance), but it's different for the image service (say for Slack or email scheduled delivery). Caching for thumb is currently forced on save events (async, and that's the way we'd tell users to get a new fresh thumb), or we could add a feature to force on the endpoint. There's also the CLI. For caching for other purposes, I think that the caching policy for charts should apply for the image the same way as it does for the JSON caching (same logic/policy).
