### PR TITLE
[security] [ui] Make security views use superset's list widget

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -19,15 +19,43 @@
 import logging
 from typing import List
 
-from flask import g
+from flask import current_app, g
 from flask_appbuilder.security.sqla import models as ab_models
 from flask_appbuilder.security.sqla.manager import SecurityManager
+from flask_appbuilder.security.views import (
+    PermissionModelView, PermissionViewModelView, RoleModelView, UserModelView)
+from flask_appbuilder.widgets import ListWidget
 from sqlalchemy import or_
 
 from superset import sql_parse
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.exceptions import SupersetSecurityException
 from superset.utils.core import DatasourceName
+
+
+class SupersetSecurityListWidget(ListWidget):
+    """
+        Redeclaring to avoid circular imports
+    """
+    template = 'superset/fab_overrides/list.html'
+
+
+class SupersetRoleListWidget(ListWidget):
+    """
+        Role model view from FAB already uses a custom list widget override
+        So we override the override
+    """
+    template = 'superset/fab_overrides/list_role.html'
+
+    def __init__(self, **kwargs):
+        kwargs['appbuilder'] = current_app.appbuilder
+        super().__init__(**kwargs)
+
+
+UserModelView.list_widget = SupersetSecurityListWidget
+RoleModelView.list_widget = SupersetRoleListWidget
+PermissionViewModelView.list_widget = SupersetSecurityListWidget
+PermissionModelView.list_widget = SupersetSecurityListWidget
 
 
 class SupersetSecurityManager(SecurityManager):

--- a/superset/templates/superset/fab_overrides/list_role.html
+++ b/superset/templates/superset/fab_overrides/list_role.html
@@ -1,0 +1,24 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+#}
+{% extends 'appbuilder/general/widgets/roles/list.html' %}
+
+{% block begin_content scoped %}
+    <div class="table-responsive">
+    <table class="table table-hover">
+{% endblock %}


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Enhancement (new features, refinement)

### SUMMARY
Superset uses a custom `ListWidget` across the board, but FAB's security views are using the default.
This is a simple fix that improves user experience

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (Example for List users)
![Screenshot from 2019-06-18 11-27-57](https://user-images.githubusercontent.com/4025227/59675002-46402980-91bc-11e9-95a5-ef251fec98fa.png)

After (Example for List users)
![Screenshot from 2019-06-18 11-27-08](https://user-images.githubusercontent.com/4025227/59675003-46402980-91bc-11e9-90c4-49a4657a4f6a.png)

### ADDITIONAL INFORMATION
- [X] Changes UI



### REVIEWERS
