### PR TITLE
Autocomplete in the table browser in SQL lab is broken

### DIFF
--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -131,9 +131,9 @@ export default class TableSelector extends React.PureComponent {
        return SupersetClient.get({ endpoint })
         .then(({ json }) => {
           const filterOptions = createFilterOptions({
-              options: json.options.map(o => ({
-                value: o.value.table,
-                label: o.label,
+            options: json.options.map(o => ({
+              value: o.value.table,
+              label: o.label,
             })),
           });
           this.setState(() => ({

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -130,7 +130,12 @@ export default class TableSelector extends React.PureComponent {
           `${encodeURIComponent(schema)}/${encodeURIComponent(substr)}/${forceRefresh}/`);
        return SupersetClient.get({ endpoint })
         .then(({ json }) => {
-          const filterOptions = createFilterOptions({ options: json.options });
+          const filterOptions = createFilterOptions({
+              options: json.options.map(o => ({
+                value: o.value.table,
+                label: o.label,
+            })),
+          });
           this.setState(() => ({
             filterOptions,
             tableLoading: false,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The autocomplete in the table browser in SQL lab does not work. We use the createFilterOptions API from the react-select-fast-filter-options library for autocomplete. The API expects a list of option objects where its properties **value** and **label** are strings. The bug is that we were passing objects to the property **value**, which caused the algorithm to not work properly. Now we explicitly pass strings to the API.

### TEST PLAN
Manually verified

### REVIEWERS
@betodealmeida @DiggidyDave @xtinec 