### PR TITLE
[fix] Force refresh table list broken

### DIFF
--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -183,11 +183,11 @@ export default class TableSelector extends React.PureComponent {
     }
     this.props.onTableChange(tableName, schemaName);
   }
-  changeSchema(schemaOpt) {
+  changeSchema(schemaOpt, force = false) {
     const schema = schemaOpt ? schemaOpt.value : null;
     this.props.onSchemaChange(schema);
     this.setState({ schema }, () => {
-      this.fetchTables();
+      this.fetchTables(force);
       this.onChange();
     });
   }


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In SQL Lab, when you click the reload icon to force refresh the table list, it doesn't.

Clicking the button calls:

```javascript
changeSchema({ value: this.props.schema }, true)
```

The problem is that `changeSchema` does not take the second argument. I fixed it by modifying the signature, and forwarding the argument to `fetchTables` (which takes an argument for force refresh).

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

If you click the icon to "Force refresh the table list", a request similar to this will be issued:

`http://localhost:8081/superset/tables/1/superset/undefined/false/`

Note the last path part, `false`, which maps to `force_refresh`.

With this fix:

`http://localhost:8081/superset/tables/1/VIZ187/undefined/true/`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong @mistercrunch 