### PR TITLE
Bump FAB to 2.1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ croniter==0.3.29
 cryptography==2.4.2
 decorator==4.3.0          # via retry
 defusedxml==0.5.0         # via python3-openid
-flask-appbuilder==2.1.4
+flask-appbuilder==2.1.5
 flask-babel==0.11.1       # via flask-appbuilder
 flask-caching==1.4.0
 flask-compress==1.4.0
@@ -55,7 +55,7 @@ pandas==0.23.4
 parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2
-prison==0.1.0             # via flask-appbuilder
+prison==0.1.2             # via flask-appbuilder
 py==1.7.0                 # via retry
 pycparser==2.19           # via cffi
 pydruid==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         'croniter>=0.3.28',
         'cryptography>=2.4.2',
         'flask>=1.0.0, <2.0.0',
-        'flask-appbuilder>=2.1.4, <2.3.0',
+        'flask-appbuilder>=2.1.5, <2.3.0',
         'flask-caching',
         'flask-compress',
         'flask-talisman',


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [X] Enhancement (new features, refinement)

### SUMMARY
FAB to 2.1.5 brings the following:

New, #1040, #1041 Bump prison to 0.1.2 and remove requests dependency
Fix, #1042 is_item_visible confusing behaviour with base_permissions when perm is still on DB

- [X] Has associated issue: #7643 

### REVIEWERS
