### PR TITLE
[SQL Lab] Reduce db load on /queries endpoint

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -59,7 +59,7 @@ from superset.sql_validators import get_validator_by_name
 from superset.utils import core as utils
 from superset.utils import dashboard_import_export
 from superset.utils.dates import now_as_float
-from superset.utils.decorators import etag_cache
+from superset.utils.decorators import etag_cache, logged_in_api
 from .base import (
     api, BaseSupersetView,
     check_ownership,
@@ -2800,14 +2800,11 @@ class Superset(BaseSupersetView):
         security_manager.assert_datasource_permission(datasource)
         return json_success(json.dumps(datasource.data))
 
-    @has_access_api
+    @logged_in_api
     @expose('/queries/<last_updated_ms>')
     def queries(self, last_updated_ms):
         """Get the updated queries."""
         stats_logger.incr('queries')
-        if not g.user.get_id():
-            return json_error_response(
-                'Please login to access the queries.', status=403)
 
         # Unix time, milliseconds.
         last_updated_ms_int = int(float(last_updated_ms)) if last_updated_ms else 0

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -238,7 +238,7 @@ class RolePermissionTests(SupersetTestCase):
         """Preventing the addition of unsecured views without has_access decorator"""
         # These FAB views are secured in their body as opposed to by decorators
         method_whitelist = ('action', 'action_post')
-        # List of redirect & other benign views
+        # List of manually secured, redirect & other benign views
         views_whitelist = [
             ['MyIndexView', 'index'],
             ['UtilView', 'back'],
@@ -247,6 +247,7 @@ class RolePermissionTests(SupersetTestCase):
             ['AuthDBView', 'logout'],
             ['R', 'index'],
             ['Superset', 'log'],
+            ['Superset', 'queries'],
             ['Superset', 'theme'],
             ['Superset', 'welcome'],
             ['SecurityApi', 'login'],

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -119,8 +119,8 @@ class SqlLabTests(SupersetTestCase):
 
         # Not logged in, should error out
         resp = self.client.get('/superset/queries/0')
-        # Redirects to the login page
-        self.assertEquals(403, resp.status_code)
+        # Returns unauthorized
+        self.assertEquals(401, resp.status_code)
 
         # Admin sees queries
         self.login('admin')
@@ -147,8 +147,8 @@ class SqlLabTests(SupersetTestCase):
 
         self.logout()
         resp = self.client.get('/superset/queries/0')
-        # Redirects to the login page
-        self.assertEquals(403, resp.status_code)
+        # Returns unauthorized
+        self.assertEquals(401, resp.status_code)
 
     def test_search_query_on_db_id(self):
         self.run_some_queries()


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

For the past few months, we were seeing errors like this during times of heavy load for superset:
```
sqlalchemy.exc:TimeoutError: QueuePool limit of size 30 overflow 15 reached,
connection timed out, timeout 30 (Background on this error at: http://sqlalche.me/e/3o7r)
```

When digging further, the stack trace revealed that these errors occurred while evaluating the `has_access` and `has_access_api` decorators. These decorators (which were added to every view in https://github.com/apache/incubator-superset/pull/6553) make many selects against superset's database resulting in an extra hundred or so db reads on every request (see issue filed here https://github.com/dpgaspar/Flask-AppBuilder/issues/1039).

The biggest contributor to these reads is the `/queries` API because it's polled every 2 seconds when a user has a query pending/running in SQL Lab. However, this API should be accessable to all logged in users as it simply returns the set of all queries the user owns. Therefore, I've introduced the new `logged_in_api` decorator to more efficiently secure this view.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Gist of SQL logs for `/queries` endpoint before and after this PR: https://gist.github.com/etr2460/96c9ead2fda43aff507602519cc3183e

Chart of queries against the superset database after deploying the fix on Tuesday afternoon:
![Screen Shot 2019-06-21 at 9 51 36 AM](https://user-images.githubusercontent.com/7409244/59938571-36b62000-940a-11e9-8497-67acdd299c27.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- Run all unit tests to ensure the view is still secured.
- Ensure you can hit the queries endpoint from SQL lab when logged in, but curling it without the cookie returns a 401

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley @mistercrunch @michellethomas @dpgaspar 