### PR TITLE
fix(hive-date-trunc): update time grain functions to use appropriate functions of hive instead of date_trunc function

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -947,6 +947,20 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     engine = 'hive'
 
+     time_grain_functions = {
+        None: '{col}',
+        'PT1S': "from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd HH:mm:ss')",
+        'PT1M': "from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd HH:mm')",
+        'PT1H': "from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd HH')",
+        'P1D': "from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd')",
+        'P1W': "date_sub(next_day(from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd'), 'MON'), 7)",
+        'P1M': "from_unixtime(unix_timestamp({col}), 'yyyy-MM')",
+        'P0.25Y': "add_months(trunc(from_unixtime(unix_timestamp({col})), 'MM'), -(month(from_unixtime(unix_timestamp({col})))-1)%3)",
+        'P1Y': "from_unixtime(unix_timestamp({col}), 'yyyy')",
+        '1969-12-28T00:00:00Z/P1W':
+            "date_sub(next_day(from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd'), 'SUN'), 7)",
+    }
+
     # Scoping regex at class level to avoid recompiling
     # 17/02/07 19:36:38 INFO ql.Driver: Total jobs = 5
     jobs_stats_r = re.compile(


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
As hive does not support `date_trunc` function, update time grain to use hive supported functions

