### PR TITLE
bugfix: Oracle timegrains fail to render when wrapped in outer query

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -78,6 +78,13 @@ class TimestampExpression(ColumnClause):
         super().__init__(expr, **kwargs)
         self.col = col
 
+    @property
+    def _constructor(self):
+        # Needed to ensure that the column label is rendered correctly when
+        # proxied to the outer query.
+        # See https://github.com/sqlalchemy/sqlalchemy/issues/4730
+        return ColumnClause
+
 
 @compiles(TimestampExpression)
 def compile_timegrain_expression(element: TimestampExpression, compiler, **kw):
@@ -123,9 +130,9 @@ class BaseEngineSpec(object):
         cls, col: ColumnClause, pdf: Optional[str], time_grain: Optional[str]
     ) -> TimestampExpression:
         """
-        Construct a TimeExpression to be used in a SQLAlchemy query.
+        Construct a TimestampExpression to be used in a SQLAlchemy query.
 
-        :param col: Target column for the TimeExpression
+        :param col: Target column for the TimestampExpression
         :param pdf: date format (seconds or milliseconds)
         :param time_grain: time grain, e.g. P1Y for 1 year
         :return: TimestampExpression object

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -67,7 +67,7 @@ builtin_time_grains = {
 
 
 class TimestampExpression(ColumnClause):
-    def __init__(self, expr: str, col: Optional[ColumnClause] = None, **kwargs):
+    def __init__(self, expr: str, col: ColumnClause, **kwargs):
         """Sqlalchemy class that can be can be used to render native column elements
         respeting engine-specific quoting rules as part of a string-based expression.
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -67,7 +67,7 @@ builtin_time_grains = {
 
 
 class TimestampExpression(ColumnClause):
-    def __init__(self, expr: str, col: ColumnClause, **kwargs):
+    def __init__(self, expr: str, col: Optional[ColumnClause] = None, **kwargs):
         """Sqlalchemy class that can be can be used to render native column elements
         respeting engine-specific quoting rules as part of a string-based expression.
 


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix

### SUMMARY
This bug is slightly related to #7729 , where Oracle is forced to wrap an additional query around the original query. This causes the SQLAlchemy compiler to create a new column object based on the original `TimestampExpression`, which doesn't receive a column (is only supposed to have the label of the original object), and hence is unable to complete the compilation. This is solved by passing a `ColumnClause` class to the method via the `_constructor` property that creates the outer query proxy column, which solves the problem.

### Before
![image](https://user-images.githubusercontent.com/33317356/60154390-dd763400-97ef-11e9-8a5b-620fe050c8a1.png)

### After
![image](https://user-images.githubusercontent.com/33317356/60154372-d0f1db80-97ef-11e9-88c9-c6b7850b2a5c.png)

### TEST PLAN
Tested locally to work on sqlite (regression testing) and Oracle, with and without time grain.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #7765

### REVIEWERS
@devilzhangzzz
