### PR TITLE
Reuse SVG node

### DIFF
--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -37,12 +37,6 @@ import CopyToClipboard from '../CopyToClipboard';
 import ModalTrigger from '../ModalTrigger';
 import TooltipWrapper from '../TooltipWrapper';
 
-const svg = createSVGNode({ container: document.body });
-
-function getTextWidth(text, font = '12px Roboto') {
-  return getTextDimension({ text, style: { font }, existingSVGNode: svg }).width;
-}
-
 function safeJsonObjectParse(data) {
   // First perform a cheap proxy to avoid calling JSON.parse on data that is clearly not a
   // JSON object or array
@@ -152,6 +146,10 @@ export default class FilterableTable extends PureComponent {
   getWidthsForColumns() {
     const PADDING = 40; // accounts for cell padding and width of sorting icon
     const widthsByColumnKey = {};
+
+    // create SVG element to compute width of each cell
+    const svg = createSVGNode({ container: document.body, style: { font: '12px Roboto' } });
+    const getTextWidth = text => getTextDimension({ text, existingSVGNode: svg }).width;
     this.props.orderedColumnKeys.forEach((key) => {
       const colWidths = this.list
         .map(d => getTextWidth(d[key]) + PADDING) // get width for each value for a key
@@ -159,6 +157,8 @@ export default class FilterableTable extends PureComponent {
       // set max width as value for key
       widthsByColumnKey[key] = Math.max(...colWidths);
     });
+    document.body.removeChild(svg);
+
     return widthsByColumnKey;
   }
 

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -29,7 +29,7 @@ import {
   SortIndicator,
   Table,
 } from 'react-virtualized';
-import { getTextDimension } from '@superset-ui/dimension';
+import { createSVGNode, getTextDimension } from '@superset-ui/dimension';
 import { t } from '@superset-ui/translation';
 
 import Button from '../Button';
@@ -37,8 +37,10 @@ import CopyToClipboard from '../CopyToClipboard';
 import ModalTrigger from '../ModalTrigger';
 import TooltipWrapper from '../TooltipWrapper';
 
+const svg = createSVGNode({ container: document.body });
+
 function getTextWidth(text, font = '12px Roboto') {
-  return getTextDimension({ text, style: { font } }).width;
+  return getTextDimension({ text, style: { font }, existingSVGNode: svg }).width;
 }
 
 function safeJsonObjectParse(data) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR changes the `FiltertableTable` component to reuse an `svg` component when computing the width of each cell in the table. This leads to improvements of ~10x on large tables (see https://github.com/apache-superset/superset-ui/pull/173)/

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Benchmarked with a wide table:

1. Without reusing the svg node: 4315ms
2. Reusing the svg node: 2167ms
3. Reusing the svg node and the textNode (this PR and https://github.com/apache-superset/superset-ui/pull/173): 481ms

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@etr2460 