### PR TITLE
Truncate data that is expanded

### DIFF
--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -125,6 +125,13 @@ export default class FilterableTable extends PureComponent {
     this.rowClassName = this.rowClassName.bind(this);
     this.sort = this.sort.bind(this);
 
+    // columns that have complex type and were expanded into sub columns
+    this.complexColumns = props.orderedColumnKeys
+      .reduce((obj, key) => ({
+        ...obj,
+        [key]: props.expandedColumns.some(name => name.startsWith(key + '.')),
+      }), {});
+
     this.widthsForColumnsByKey = this.getWidthsForColumns();
     this.totalTableWidth = props.orderedColumnKeys
       .map(key => this.widthsForColumnsByKey[key])
@@ -166,19 +173,17 @@ export default class FilterableTable extends PureComponent {
   }
 
   getCellContent({ cellData, columnKey }) {
-    const complexColumn = this.props.expandedColumns.some(
-      name => name.startsWith(columnKey + '.'),
-    );
     const content = String(cellData);
-    let type;
-    if (content.substring(0, 1) === '[') {
-      type = '[…]';
-    } else if (content.substring(0, 1) === '{') {
-      type = '{…}';
+    const firstCharacter = content.substring(0, 1);
+    let truncated;
+    if (firstCharacter === '[') {
+      truncated = '[…]';
+    } else if (firstCharacter === '{') {
+      truncated = '{…}';
     } else {
-      type = '';
+      truncated = '';
     }
-    return complexColumn ? type : content;
+    return this.complexColumns[columnKey] ? truncated : content;
   }
 
   formatTableData(data) {

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -173,7 +173,7 @@ export default class FilterableTable extends PureComponent {
     let type;
     if (content.substring(0, 1) === '[') {
       type = '[…]';
-    } else if (content.substring(0, 1) === '[') {
+    } else if (content.substring(0, 1) === '{') {
       type = '{…}';
     } else {
       type = '';

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -552,7 +552,7 @@ class PrestoEngineSpec(BaseEngineSpec):
               {'ColumnA': [1, 2], 'ColumnB': [3]},
               {'ColumnA': [11, 22], 'ColumnB': [33]}
           ]
-          all_array_data (intially) = {
+          all_array_data (initially) = {
               0: [{'ColumnA': [1, 2], 'ColumnB': [3}],
               1: [{'ColumnA': [11, 22], 'ColumnB': [33]}]
           }


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When we expand complex columns in SQL Lab, the original data is still presented. This is redundant, and for most rows the values will be partially truncated. Users have complained that this wastes valuable space when previewing wide tables, while at the same bringing very little information.

This PR modifies the results table so that complex columns are presented with `[...]` or `{...}` as the results, instead of the full values (which can be seen in the columns to its left). See the screenshots below:

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="852" alt="Screen Shot 2019-06-25 at 11 27 08 AM" src="https://user-images.githubusercontent.com/1534870/60123416-47cd9c80-973c-11e9-83e8-0ffb7f1a02aa.png">

After:

<img width="509" alt="Screen Shot 2019-06-25 at 11 27 33 AM" src="https://user-images.githubusercontent.com/1534870/60123424-4b612380-973c-11e9-8186-7f8d3af6740c.png">

Note that only **expanded** columns are truncated. The "json" column is not truncated, in this example.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong @etr2460 