### PR TITLE
[SQL Lab] Add hard time limit fallback for async queries

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -40,6 +40,7 @@ from superset.utils.decorators import stats_timing
 config = app.config
 stats_logger = config.get("STATS_LOGGER")
 SQLLAB_TIMEOUT = config.get("SQLLAB_ASYNC_TIME_LIMIT_SEC", 600)
+SQLLAB_HARD_TIMEOUT = SQLLAB_TIMEOUT + 60
 log_query = config.get("QUERY_LOGGER")
 
 
@@ -114,7 +115,10 @@ def session_scope(nullpool):
 
 
 @celery_app.task(
-    name="sql_lab.get_sql_results", bind=True, soft_time_limit=SQLLAB_TIMEOUT
+    name="sql_lab.get_sql_results",
+    bind=True,
+    time_limit=SQLLAB_HARD_TIMEOUT,
+    soft_time_limit=SQLLAB_TIMEOUT,
 )
 def get_sql_results(
     ctask,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
According to https://github.com/celery/celery/issues/1958 celery only implements `time_limit` for the gevent pool. This PR adds a hard time limit 60 seconds after the soft one to clean up any tasks that the soft time limit isn't implemented for (or where the soft time exception is handled in such a way that never returns)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Pass CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@michellethomas @john-bodley @mistercrunch @betodealmeida 