### PR TITLE
Fix SQL editor tooltip to not cut off long column names

### DIFF
--- a/superset/assets/src/SqlLab/main.less
+++ b/superset/assets/src/SqlLab/main.less
@@ -388,6 +388,7 @@ a.Link {
 }
 .tooltip-inner {
     max-width: 500px;
+    word-wrap: break-word;
 }
 .SouthPane {
     width: 100%;


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Updated the tooltip for column names on the SQL editor to not cut off long column names that extend pass the max-width. Added css property for word-wrap to break.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
A screenshot of what the tooltip looks like currently: 
![image](https://user-images.githubusercontent.com/51972312/60298922-666c9880-98e0-11e9-9644-84c234d70a33.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Open SQL editor, find a table with a long column name (~100 characters), and ensure that the tooltip that appears when the mouse hovers over is multi-lined and the entire name is visible. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@khtruong @betodealmeida @DiggidyDave 