### PR TITLE
Added possibility to translate the phrase 'No results found' in FilterBox

### DIFF
--- a/superset/assets/src/components/OnPasteSelect.jsx
+++ b/superset/assets/src/components/OnPasteSelect.jsx
@@ -94,6 +94,7 @@ OnPasteSelect.propTypes = {
   multi: PropTypes.bool.isRequired,
   value: PropTypes.any,
   isValidNewOption: PropTypes.func,
+  noResultsText: PropTypes.string,
 };
 OnPasteSelect.defaultProps = {
   separator: [',', '\n', '\t'],

--- a/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
@@ -250,6 +250,7 @@ class FilterBox extends React.Component {
         selectComponent={Creatable}
         selectWrap={VirtualizedSelect}
         optionRenderer={VirtualizedRendererWrap(opt => opt.label)}
+        noResultsText={t('No results found')}
       />);
   }
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
I am currently working on a translation of your system to Portuguese. This is one of the enhancements that can be applicable to the core project.
Basically, the changes add the possibility to translate the phrase 'No results found', which we can see when we use FilterBox in a report. When no option is available in select boxes of FilterBox, the phrase is displayed. The current implementation does not translate the phrase even if we add the message to messages.json (message.po) and we select the appropriate application language.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
If we apply this contribution and we modify language messages, eg. Portuguese one, we can see something like this:
![peek1](https://user-images.githubusercontent.com/29867015/60344509-04329700-99b7-11e9-85b5-4947d573aa55.gif)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
