### PR TITLE
DatabaseViewFilter: Permission driven access to database list

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -195,6 +195,18 @@ class DashboardFilter(SupersetFilter):
         )
         return query
 
+class DatabaseViewFilter(SupersetFilter):
+
+    """
+    By default, database list is not permission driven. It shows all
+    databases to all users. This filter allows us to restrict that view.
+    """
+
+    def apply(self, query, func):  # noqa
+        if security_manager.all_datasource_access():
+            return query
+        perms = self.get_view_menus('datasource_access')
+        return query.filter(self.model.perm.in_(perms))
 
 class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
     datamodel = SQLAInterface(models.Database)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -195,6 +195,7 @@ class DashboardFilter(SupersetFilter):
         )
         return query
 
+
 class DatabaseViewFilter(SupersetFilter):
 
     """

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -208,6 +208,7 @@ class DatabaseViewFilter(SupersetFilter):
         perms = self.get_view_menus('datasource_access')
         return query.filter(self.model.perm.in_(perms))
 
+
 class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
     datamodel = SQLAInterface(models.Database)
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
By default, database list is not permission driven. It shows all databases to all users. This filter allows us to restrict that view. After applying this filter, user will only see the databases that the user has datasource_access permission for.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Tested locally by granting/ removing permissions to/from user

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
