### PR TITLE
[fix] Updating Pandas resample logic

### DIFF
--- a/superset/assets/src/explore/controlPanels/sections.jsx
+++ b/superset/assets/src/explore/controlPanels/sections.jsx
@@ -97,7 +97,7 @@ export const NVD3TimeSeries = [
       ['time_compare', 'comparison_type'],
       [<h1 className="section-header">{t('Python Functions')}</h1>],
       [<h2 className="section-header">pandas.resample</h2>],
-      ['resample_how', 'resample_rule', 'resample_fillmethod'],
+      ['resample_rule', 'resample_method'],
     ],
   },
 ];

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -925,26 +925,17 @@ export const controls = {
     freeForm: true,
     label: t('Rule'),
     default: null,
-    choices: formatSelectOptions(['', '1T', '1H', '1D', '7D', '1M', '1AS']),
+    choices: formatSelectOptions(['1T', '1H', '1D', '7D', '1M', '1AS']),
     description: t('Pandas resample rule'),
   },
 
-  resample_how: {
+  resample_method: {
     type: 'SelectControl',
     freeForm: true,
-    label: t('How'),
+    label: t('Method'),
     default: null,
-    choices: formatSelectOptions(['', 'mean', 'sum', 'median']),
-    description: t('Pandas resample how'),
-  },
-
-  resample_fillmethod: {
-    type: 'SelectControl',
-    freeForm: true,
-    label: t('Fill Method'),
-    default: null,
-    choices: formatSelectOptions(['', 'ffill', 'bfill']),
-    description: t('Pandas resample fill method'),
+    choices: formatSelectOptions(['asfreq', 'bfill', 'ffill', 'median', 'mean', 'sum']),
+    description: t('Pandas resample method'),
   },
 
   time_range: {

--- a/superset/migrations/versions/ab8c66efdd01_resample.py
+++ b/superset/migrations/versions/ab8c66efdd01_resample.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""resample
+
+Revision ID: ab8c66efdd01
+Revises: d7c1a0d6f2da
+Create Date: 2019-06-28 13:17:59.517089
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "ab8c66efdd01"
+down_revision = "d7c1a0d6f2da"
+
+import json
+import logging
+
+from alembic import op
+from sqlalchemy import Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).all():
+        try:
+            params = json.loads(slc.params)
+
+            # Note that the resample params could be encoded as empty strings.
+            if "resample_rule" in params:
+                rule = params["resample_rule"]
+
+                # Per the old logic how takes precedence over fill-method. Note that
+                # due to UI options, alongside None, empty strings were viable choices
+                # hence the truthiness checks.
+                if rule:
+                    how = None
+
+                    if "resample_how" in params:
+                        how = params["resample_how"]
+
+                        if how:
+                            params["resample_method"] = how
+
+                    if not how and "fill_method" in params:
+                        fill_method = params["resample_fillmethod"]
+
+                        if fill_method:
+                            params["resample_method"] = fill_method
+
+                    # Ensure that the resample logic is fully defined.
+                    if not "resample_method" in params:
+                        del params["resample_rule"]
+                else:
+                    del params["resample_rule"]
+
+                # Finally remove any erroneous legacy fields.
+                params.pop("resample_fillmethod", None)
+                params.pop("resample_how", None)
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception as e:
+            logging.exception(e)
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).all():
+        try:
+            params = json.loads(slc.params)
+
+            if "resample_method" in params:
+                method = params["resample_method"]
+
+                if method in ["asfreq", "bfill", "ffill"]:
+                    params["resample_fillmethod"] = method
+                else:
+                    params["resample_how"] = method
+
+                del params["resample_method"]
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception as e:
+            logging.exception(e)
+
+    session.commit()
+    session.close()

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1129,14 +1129,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
         if fd.get("granularity") == "all":
             raise Exception(_("Pick a time granularity for your time series"))
 
-        if not aggregate:
-            df = df.pivot_table(
-                index=DTTM_ALIAS,
-                columns=fd.get("groupby"),
-                values=self.metric_labels,
-                dropna=False,
-            )
-        else:
+        if aggregate:
             df = df.pivot_table(
                 index=DTTM_ALIAS,
                 columns=fd.get("groupby"),
@@ -1145,14 +1138,19 @@ class NVD3TimeSeriesViz(NVD3Viz):
                 aggfunc=sum,
                 dropna=False,
             )
+        else:
+            df = df.pivot_table(
+                index=DTTM_ALIAS,
+                columns=fd.get("groupby"),
+                values=self.metric_labels,
+                dropna=False,
+            )
 
-        fm = fd.get("resample_fillmethod")
-        if not fm:
-            fm = None
-        how = fd.get("resample_how")
         rule = fd.get("resample_rule")
-        if how and rule:
-            df = df.resample(rule, how=how, fill_method=fm)
+        method = fd.get("resample_method")
+
+        if rule and method:
+            df = getattr(df.resample(rule), method)()
 
         if self.sort_series:
             dfs = df.sum()


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This  PR updates a number of issues related to the "Advanced Analytics" Pandas resampling logic. Specifically it: 

1. Removes empty UI options.
2. Fixes an issue where `how` needed to be specified with `fill_method` which isn't a requirement for the the `resample` method. This has been resolved by using the the new `resample` method signature. 
3. Updates the Pandas [resample](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.resample.html#pandas.Series.resample) logic for `fill_method` and `how` is deprecated. Note previously both `how` (predominantly down-scaling) and `fill_method` (up-scaling) could be used simultaneously which was somewhat misleading. The new resampling logic simply uses a method many of which can be applied when either down- or up-scaling.

  
### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @michellethomas @mistercrunch 
