### PR TITLE
fix SQLLab missing autocommit when use CTAS

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -198,6 +198,7 @@ def execute_sql_statement(sql_statement, query, user_name, session, cursor):
         with stats_timing("sqllab.query.time_executing_query", stats_logger):
             logging.info("Running query: \n{}".format(sql))
             db_engine_spec.execute(cursor, sql, async_=True)
+            cursor.connection.commit()
             logging.info("Handling cursor")
             db_engine_spec.handle_cursor(cursor, query, session)
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Some Python db dialects turn off autocommit by default, such as psycopg2-binary. When using CTAS, if there is no explicit commit(), then this operation will be unsuccessful.

We did not use SQLAlchemy ORM when executing CTAS, so we need to execute connection.commit() at the dbapi2.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
