### PR TITLE
[dashboard] Fix URLShortLinkButton position after click anchor link

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
@@ -131,6 +131,17 @@ describe('Tabs', () => {
     expect(onChangeTab.callCount).toBe(1);
   });
 
+  it('should not call onChangeTab when anchor link is clicked', () => {
+    const onChangeTab = sinon.spy();
+    const wrapper = setup({ editMode: true, onChangeTab });
+    wrapper
+      .find('.dashboard-component-tabs .nav-tabs a .short-link-trigger')
+      .at(1) // will not call if it is already selected
+      .simulate('click');
+
+    expect(onChangeTab.callCount).toBe(0);
+  });
+
   it('should render a HoverMenu in editMode', () => {
     let wrapper = setup();
     expect(wrapper.find(HoverMenu)).toHaveLength(0);

--- a/superset/assets/src/components/AnchorLink.jsx
+++ b/superset/assets/src/components/AnchorLink.jsx
@@ -38,11 +38,6 @@ const defaultProps = {
 
 
 class AnchorLink extends React.PureComponent {
-  constructor(props) {
-    super(props);
-
-    this.handleClickAnchorLink = this.handleClickAnchorLink.bind(this);
-  }
 
   componentDidMount() {
     const hash = this.getLocationHash();
@@ -65,17 +60,12 @@ class AnchorLink extends React.PureComponent {
     return (window.location.hash || '').substring(1);
   }
 
-  handleClickAnchorLink(ev) {
-    ev.stopPropagation();
-  }
-
   render() {
     const { anchorLinkId, filters, showShortLinkButton, placement } = this.props;
     return (
       <span
         className="anchor-link-container"
         id={anchorLinkId}
-        onClick={this.handleClickAnchorLink}
       >
         {showShortLinkButton &&
         <URLShortLinkButton

--- a/superset/assets/src/components/URLShortLinkButton.jsx
+++ b/superset/assets/src/components/URLShortLinkButton.jsx
@@ -78,8 +78,8 @@ class URLShortLinkButton extends React.Component {
         onEnter={this.getCopyUrl}
         overlay={this.renderPopover()}
       >
-        <span className="btn btn-default btn-sm" data-test="short-link-button">
-          <i className="fa fa-link" />&nbsp;
+        <span className="short-link-trigger btn btn-default btn-sm" data-test="short-link-button">
+          <i className="short-link-trigger fa fa-link" />&nbsp;
         </span>
       </OverlayTrigger>
     );

--- a/superset/assets/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Tabs.jsx
@@ -100,7 +100,14 @@ class Tabs extends React.PureComponent {
     }
   }
 
-  handleClickTab(tabIndex) {
+  handleClickTab(tabIndex, ev) {
+    const target = ev.target;
+    // special handler for clicking on anchor link icon (or whitespace nearby):
+    // will show short link popover but do not change tab
+    if (target.classList.contains('short-link-trigger')) {
+      return;
+    }
+
     const { component, createComponent } = this.props;
 
     if (tabIndex === NEW_TAB_INDEX) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
in #7640 I added a change that prevent click event bubble up, so that clicking on anchor link will not trigger tab switch. But i just found this introduced a bug: if you click on tab's anchor link at the bottom of long dashboard, URLShortLinkButton can not re-position since there is no click event triggered, so it cause URLShortLinkButton show up in wired position.

**Solution**
Fix the click event handling in higher parent component. In click handler for `Tabs` component, I added logic to check event's target. It will switch tab when the event's target is not anchor link component.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**:
![uBYLbwFAm8](https://user-images.githubusercontent.com/27990562/60545505-1c185c80-9cd0-11e9-8e9d-f06f819d17ec.gif)

**After**:
![ItOaYcp735](https://user-images.githubusercontent.com/27990562/60545545-2cc8d280-9cd0-11e9-9217-1efe8cc56436.gif)

### TEST PLAN
CI and manual test.

### REVIEWERS
@etr2460 @williaster @michellethomas 