### PR TITLE
Set up a few more pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,24 @@
 # limitations under the License.
 #
 repos:
-  - repo: https://github.com/ambv/black
+-   repo: https://github.com/ambv/black
     rev: stable
     hooks:
-      - id: black
+    -   id: black
         language_version: python3.6
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-docstring-first
+    -   id: check-json
+    -   id: check-added-large-files
+    -   id: check-yaml
+    -   id: debug-statements
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.1
+    hooks:
+    -   id: flake8


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
Following the work on 5c58fd180, I'm setting up a few more commit hooks on top of black, most notably flake8 (!).

We could bring more from https://github.com/pre-commit/pre-commit-hooks/blob/master/.pre-commit-config.yaml