### PR TITLE
Quick fix for Presto queries stuck in infinite loop

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -545,6 +545,10 @@ class PrestoEngineSpec(BaseEngineSpec):
                 unprocessed_array_columns.add(child_array)
             elif child_array and array_column.startswith(child_array):
                 unprocessed_array_columns.add(array_column)
+            else:
+                # array without any data
+                array_columns_to_process.append(array_column)
+                datum[array_column] = []
         return array_columns_to_process, unprocessed_array_columns
 
     @classmethod


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We have seen a few Presto queries with nested types (arrays, structs) that get stuck in an infinite loop. This PR fixes the problem.

@khtruong I tried adding a unit test capturing the regression, but the repro I have returns so many columns that I wasn't able to fully understand the problem and create a minimal repro. I'm planning to merge this to unblock customers, and then work on a test case — maybe you can help me?

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested problematic queries, they all worked.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 