### PR TITLE
Bump pandas to 0.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ marshmallow-enum==1.4.1   # via flask-appbuilder
 marshmallow-sqlalchemy==0.16.2  # via flask-appbuilder
 marshmallow==2.19.2       # via flask-appbuilder, marshmallow-enum, marshmallow-sqlalchemy
 numpy==1.15.2             # via pandas
-pandas==0.23.4
+pandas==0.24.2
 parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "idna",
         "isodate",
         "markdown>=3.0",
-        "pandas>=0.18.0, <0.24.0",  # `pandas`>=0.24.0 changes datetimelike API
+        "pandas>=0.24.2, <0.25.0",
         "parsedatetime",
         "pathlib2",
         "polyline",

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -27,7 +27,7 @@ import logging
 
 import numpy as np
 import pandas as pd
-from pandas.core.common import _maybe_box_datetimelike
+from pandas.core.common import maybe_box_datetimelike
 from pandas.core.dtypes.dtypes import ExtensionDtype
 
 from superset.utils.core import JS_MAX_INTEGER
@@ -109,7 +109,7 @@ class SupersetDataFrame(object):
         # work around for https://github.com/pandas-dev/pandas/issues/18372
         data = [
             dict(
-                (k, _maybe_box_datetimelike(v))
+                (k, maybe_box_datetimelike(v))
                 for k, v in zip(self.df.columns, np.atleast_1d(row))
             )
             for row in self.df.values


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Enhancement (new features, refinement)

### SUMMARY

PR #6837 intended to add support for 0.24, but was later closed. As Pandas `0.24` branch has already been out since Jan 2019, now on `0.24.2`, it makes sense to bump the version to avoid getting stuck on an old version.

### TEST PLAN
Tested locally to work + CI
