### PR TITLE
[cypress] Disable chromeWebSecurity globally

### DIFF
--- a/superset/assets/cypress.json
+++ b/superset/assets/cypress.json
@@ -1,10 +1,11 @@
 {
   "baseUrl": "http://localhost:8081",
-  "videoUploadOnPasses": false,
-  "video": false,
+  "chromeWebSecurity": false,
+  "defaultCommandTimeout": 10000,
   "ignoreTestFiles": ["**/!(*.test.js)"],
   "projectId": "fbf96q",
-  "defaultCommandTimeout": 10000,
+  "video": false,
+  "videoUploadOnPasses": false,
   "viewportWidth": 1280,
   "viewportHeight": 800
 }

--- a/superset/assets/cypress/integration/dashboard/save.js
+++ b/superset/assets/cypress/integration/dashboard/save.js
@@ -20,8 +20,6 @@ import readResponseBlob from '../../utils/readResponseBlob';
 import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
 
 export default () => describe('save', () => {
-  Cypress.config('chromeWebSecurity', false);
-
   let dashboardId;
   let boxplotChartId;
 


### PR DESCRIPTION
### CATEGORY
Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
This PR is trying to resolve the same issue in #7552. In the old PR we disable chromeWebSecurity in single test file, but recently we saw a few build failure caused by this same root cause. So this PR will set disable chromeWebSecurity globally (and see if this can fix the flaky tests).

### TEST PLAN
ci.


### REVIEWERS
@mistercrunch 