### PR TITLE
Adds the ability to replace/extend caching backend

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -521,6 +521,24 @@ into your global default defined in ``CACHE_CONFIG``.
         'CACHE_REDIS_URL': 'redis://localhost:6379/0',
     }
 
+It is also possible to pass a custom cache initialization function in the
+config to handle additional caching use cases. The function must return an
+object that is compatible with the `Flask-Cache <https://pythonhosted.org/Flask-Cache/>` API.
+
+.. code-block:: python
+
+    from custom_caching import CustomCache
+
+    def init_cache(app):
+        """Takes an app instance and returns a custom cache backend"""
+        config = {
+            'CACHE_DEFAULT_TIMEOUT': 60 * 60 * 24, # 1 day default (in secs)
+            'CACHE_KEY_PREFIX': 'superset_results',
+        }
+        return CustomCache(app, config)
+
+    CACHE_CONFIG = init_cache
+
 Superset has a Celery task that will periodically warm up the cache based on
 different strategies. To use it, add the following to the `CELERYBEAT_SCHEDULE`
 section in `config.py`:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -523,7 +523,7 @@ into your global default defined in ``CACHE_CONFIG``.
 
 It is also possible to pass a custom cache initialization function in the
 config to handle additional caching use cases. The function must return an
-object that is compatible with the `Flask-Cache <https://pythonhosted.org/Flask-Cache/>` API.
+object that is compatible with the `Flask-Cache <https://pythonhosted.org/Flask-Cache/>`_ API.
 
 .. code-block:: python
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -776,7 +776,7 @@ def setup_cache(app: Flask, cache_config) -> Optional[Cache]:
     """Setup the flask-cache on a flask app"""
     if cache_config:
         if isinstance(cache_config, dict):
-            if cache_config.get('CACHE_TYPE') != 'null':
+            if cache_config.get("CACHE_TYPE") != "null":
                 return Cache(app, config=cache_config)
         else:
             # Accepts a custom cache initialization function,

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -774,8 +774,14 @@ def choicify(values):
 
 def setup_cache(app: Flask, cache_config) -> Optional[Cache]:
     """Setup the flask-cache on a flask app"""
-    if cache_config and cache_config.get("CACHE_TYPE") != "null":
-        return Cache(app, config=cache_config)
+    if cache_config:
+        if isinstance(cache_config, dict):
+            if cache_config.get('CACHE_TYPE') != 'null':
+                return Cache(app, config=cache_config)
+        else:
+            # Accepts a custom cache initialization function,
+            # returning an object compatible with Flask-Caching API
+            return cache_config(app)
 
     return None
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -22,6 +22,9 @@ import uuid
 
 import numpy
 
+from flask import Flask
+from flask_caching import Cache
+
 from superset.exceptions import SupersetException
 from superset.utils.core import (
     base_json_conv,
@@ -37,6 +40,7 @@ from superset.utils.core import (
     parse_human_timedelta,
     parse_js_uri_path_item,
     parse_past_timedelta,
+    setup_cache,
     validate_json,
     zlib_compress,
     zlib_decompress_to_string,
@@ -763,3 +767,33 @@ class UtilsTestCase(unittest.TestCase):
     def test_parse_js_uri_path_items_item_optional(self):
         self.assertIsNone(parse_js_uri_path_item(None))
         self.assertIsNotNone(parse_js_uri_path_item("item"))
+
+    def test_setup_cache_no_config(self):
+        app = Flask(__name__)
+        cache_config = None
+        self.assertIsNone(setup_cache(app, cache_config))
+
+    def test_setup_cache_null_config(self):
+        app = Flask(__name__)
+        cache_config = {
+            'CACHE_TYPE': 'null',
+        }
+        self.assertIsNone(setup_cache(app, cache_config))
+
+    def test_setup_cache_standard_config(self):
+        app = Flask(__name__)
+        cache_config = {
+            'CACHE_TYPE': 'redis',
+            'CACHE_DEFAULT_TIMEOUT': 60,
+            'CACHE_KEY_PREFIX': 'superset_results',
+            'CACHE_REDIS_URL': 'redis://localhost:6379/0',
+        }
+        assert isinstance(setup_cache(app, cache_config), Cache) is True
+
+    def test_setup_cache_custom_function(self):
+        app = Flask(__name__)
+        CustomCache = type('CustomCache', (object,), {"__init__": lambda *args: None})
+        def init_cache(app):
+            return CustomCache(app, {})
+
+        assert isinstance(setup_cache(app, init_cache), CustomCache) is True

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -20,10 +20,9 @@ import unittest
 from unittest.mock import patch
 import uuid
 
-import numpy
-
 from flask import Flask
 from flask_caching import Cache
+import numpy
 
 from superset.exceptions import SupersetException
 from superset.utils.core import (
@@ -793,6 +792,7 @@ class UtilsTestCase(unittest.TestCase):
     def test_setup_cache_custom_function(self):
         app = Flask(__name__)
         CustomCache = type('CustomCache', (object,), {"__init__": lambda *args: None})
+
         def init_cache(app):
             return CustomCache(app, {})
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -774,24 +774,22 @@ class UtilsTestCase(unittest.TestCase):
 
     def test_setup_cache_null_config(self):
         app = Flask(__name__)
-        cache_config = {
-            'CACHE_TYPE': 'null',
-        }
+        cache_config = {"CACHE_TYPE": "null"}
         self.assertIsNone(setup_cache(app, cache_config))
 
     def test_setup_cache_standard_config(self):
         app = Flask(__name__)
         cache_config = {
-            'CACHE_TYPE': 'redis',
-            'CACHE_DEFAULT_TIMEOUT': 60,
-            'CACHE_KEY_PREFIX': 'superset_results',
-            'CACHE_REDIS_URL': 'redis://localhost:6379/0',
+            "CACHE_TYPE": "redis",
+            "CACHE_DEFAULT_TIMEOUT": 60,
+            "CACHE_KEY_PREFIX": "superset_results",
+            "CACHE_REDIS_URL": "redis://localhost:6379/0",
         }
         assert isinstance(setup_cache(app, cache_config), Cache) is True
 
     def test_setup_cache_custom_function(self):
         app = Flask(__name__)
-        CustomCache = type('CustomCache', (object,), {"__init__": lambda *args: None})
+        CustomCache = type("CustomCache", (object,), {"__init__": lambda *args: None})
 
         def init_cache(app):
             return CustomCache(app, {})


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Adds the ability to replace or extend the caching backend in Superset by passing a function via the `CACHE_CONFIG` configuration option. The initialization function should return a custom caching module instance that is compatible with the Flask-Caching API.

This extension of functionality allows additional processing to be performed in the cache lifecycle to accommodate additional use cases, such as (de)serialization or encryption.

### TEST PLAN

1. Configure Superset with no `CACHE_CONFIG` value, ensure proper operation
2. Configure Superset with standard `dict` `CACHE_CONFIG` value, ensure proper operation
3. Configure Superset with custom init function `CACHE_CONFIG` value (see included documentation), ensure proper operation

### ADDITIONAL INFORMATION
- [X] Has associated issue: https://github.com/apache/incubator-superset/issues/7855
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
