### PR TITLE
Druid subqueries support

### DIFF
--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -23,7 +23,7 @@ class DruidEngineSpec(BaseEngineSpec):
 
     engine = "druid"
     inner_joins = False
-    allows_subquery = False
+    allows_subquery = True
 
     time_grain_functions = {
         None: "{col}",


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Druid SQL supports subqueries so superset should allow users to explore druid queries.

### AFTER SCREENSHOTS
![Screenshot from 2019-07-12 18-22-56](https://user-images.githubusercontent.com/16355374/61143372-5359eb00-a4d2-11e9-9b9d-b0f1bd7b9fd8.png)
![Screenshot from 2019-07-12 18-24-28](https://user-images.githubusercontent.com/16355374/61143375-55bc4500-a4d2-11e9-9c83-e6e712b6b391.png)


### ADDITIONAL INFORMATION
- [x] Has associated issue: #7849 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

