### PR TITLE
[Profile] Fix 5xx when user not found

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -3172,7 +3172,7 @@ class Superset(BaseSupersetView):
             return self.dashboard(str(welcome_dashboard_id))
 
         payload = {
-            "user": bootstrap_user_data(),
+            "user": bootstrap_user_data(g.user),
             "common": self.common_bootstrap_payload(),
         }
 
@@ -3190,8 +3190,14 @@ class Superset(BaseSupersetView):
         if not username and g.user:
             username = g.user.username
 
+        user = (
+            db.session.query(ab_models.User).filter_by(username=username).one_or_none()
+        )
+        if not user:
+            abort(404, description=f"User: {username} does not exist.")
+
         payload = {
-            "user": bootstrap_user_data(username, include_perms=True),
+            "user": bootstrap_user_data(user, include_perms=True),
             "common": self.common_bootstrap_payload(),
         }
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -19,8 +19,7 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 from urllib import parse
 
-from flask import g, request
-from flask_appbuilder.security.sqla import models as ab_models
+from flask import request
 import simplejson as json
 
 from superset import app, db, viz
@@ -36,12 +35,7 @@ if not app.config.get("ENABLE_JAVASCRIPT_CONTROLS"):
     FORM_DATA_KEY_BLACKLIST = ["js_tooltip", "js_onclick_href", "js_data_mutator"]
 
 
-def bootstrap_user_data(username=None, include_perms=False):
-    if not username:
-        username = g.user.username
-
-    user = db.session.query(ab_models.User).filter_by(username=username).one()
-
+def bootstrap_user_data(user, include_perms=False):
     payload = {
         "username": user.username,
         "firstName": user.first_name,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When trying to view a user's profile that doesn't exist, we'd return a 5xx. This should be a 404 instead.

Still todo: a more user friendly 404 page

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="829" alt="Screen Shot 2019-07-12 at 11 18 06 AM" src="https://user-images.githubusercontent.com/7409244/61149781-ce9dab80-a496-11e9-8f7f-4f6b9f76df3e.png">

After:
<img width="758" alt="Screen Shot 2019-07-12 at 11 18 16 AM" src="https://user-images.githubusercontent.com/7409244/61149790-d2c9c900-a496-11e9-87c9-349e958acf01.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
See 404 page at: http://localhost:5000/superset/profile/sddsgdsg/
See profile page at: http://localhost:5000/superset/profile/admin/

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley @michellethomas 