### PR TITLE
[SQL Lab] Fix TableSelector perf for large option sets

### DIFF
--- a/superset/assets/spec/javascripts/components/TableSelector_spec.jsx
+++ b/superset/assets/spec/javascripts/components/TableSelector_spec.jsx
@@ -145,7 +145,6 @@ describe('TableSelector', () => {
     it('should clear table options', () => {
       inst.fetchTables(true);
       expect(wrapper.state().tableOptions).toEqual([]);
-      expect(wrapper.state().filterOptions).toBeNull();
     });
 
     it('should fetch table options', () => {

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-virtualized-select';
-import createFilterOptions from 'react-select-fast-filter-options';
 import { ControlLabel, Label } from 'react-bootstrap';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
@@ -70,7 +69,6 @@ export default class TableSelector extends React.PureComponent {
       dbId: props.dbId,
       schema: props.schema,
       tableName: props.tableName,
-      filterOptions: null,
     };
     this.changeSchema = this.changeSchema.bind(this);
     this.changeTable = this.changeTable.bind(this);
@@ -144,7 +142,6 @@ export default class TableSelector extends React.PureComponent {
             title: o.title,
           }));
           this.setState(() => ({
-            filterOptions: createFilterOptions({ options }),
             tableLoading: false,
             tableOptions: options,
           }));
@@ -155,7 +152,7 @@ export default class TableSelector extends React.PureComponent {
           this.props.handleError(t('Error while fetching table list'));
         });
     }
-     this.setState(() => ({ tableLoading: false, tableOptions: [], filterOptions: null }));
+     this.setState(() => ({ tableLoading: false, tableOptions: [] }));
     return Promise.resolve();
   }
   fetchSchemas(dbId, force) {
@@ -277,10 +274,10 @@ export default class TableSelector extends React.PureComponent {
         name="select-table"
         ref="selectTable"
         isLoading={this.state.tableLoading}
+        ignoreAccents={false}
         placeholder={t('Select table or type table name')}
         autosize={false}
         onChange={this.changeTable}
-        filterOptions={this.state.filterOptions}
         options={options}
         value={this.state.tableName}
       />) : (


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
If you have a large number of tables with a single schema (we have 28k in one of ours), it would take about 10 seconds to load the table selector. This was due to generating the search index, tokenizing, and doing other search-y related things. It turns out that getting rid of the indexing and adding `ignoreAccents={false}` (the same thing as https://github.com/apache/incubator-superset/pull/7791) improves the loading speed (down to under half a second) without hurting the search speed.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- ensure searching for tables in sql lab still works
- see that it's faster!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @michellethomas @khtruong @mistercrunch 