### PR TITLE
[docs] Advise about celery 4.3.0 requirement on redis

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,10 @@ assists people when migrating to a new version.
 
 ## Next Version
 
+* [7848](https://github.com/apache/incubator-superset/pull/7848): If you are 
+running redis with celery, celery bump to 4.3.0 requires redis-py upgrade to
+3.2.0 or later.
+
 * [7667](https://github.com/apache/incubator-superset/pull/7667): a change to
 make all Unix timestamp (which by definition are in UTC) comparisons refer
 to a timestamp in UTC as opposed to local time.


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [X] Documentation

### SUMMARY
UPDATING doc warns about celery version bump to 4.3.0 and new requirement for redis > 3.2.
Follows PR #7848

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
