### PR TITLE
fix: multi deck.gl chart re-rendering layers on tooltip hover

### DIFF
--- a/superset/assets/src/visualizations/deckgl/Multi/Multi.jsx
+++ b/superset/assets/src/visualizations/deckgl/Multi/Multi.jsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { SupersetClient } from '@superset-ui/connection';
 
@@ -53,7 +54,10 @@ class DeckMulti extends React.PureComponent {
 
   componentWillReceiveProps(nextProps) {
     const { formData, payload } = nextProps;
-    this.loadLayers(formData, payload);
+    const hasChanges = !_.isEqual(this.props.formData.deck_slices, nextProps.formData.deck_slices);
+    if (hasChanges) {
+      this.loadLayers(formData, payload);
+    }
   }
 
   onViewportChange(viewport) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a bug where multi deck.gl charts were re-rendering on every interaction with component map layers (i.e. tooltip hover)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
visual inspection

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
