### PR TITLE
[migration] add unique constraint on dashboard_slices table

### DIFF
--- a/superset/migrations/versions/190188938582_adding_unique_constraint_on_dashboard_slices_tbl.py
+++ b/superset/migrations/versions/190188938582_adding_unique_constraint_on_dashboard_slices_tbl.py
@@ -1,0 +1,100 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Remove duplicated entries in dashboard_slices table and add unique constraint
+
+Revision ID: 190188938582
+Revises: d6ffdf31bdd4
+Create Date: 2019-07-15 12:00:32.267507
+
+"""
+import logging
+
+from alembic import op
+from sqlalchemy import and_, Column, ForeignKey, Integer, Table
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+# revision identifiers, used by Alembic.
+revision = "190188938582"
+down_revision = "d6ffdf31bdd4"
+
+Base = declarative_base()
+
+
+class DashboardSlices(Base):
+    __tablename__ = "dashboard_slices"
+    id = Column(Integer, primary_key=True)
+    dashboard_id = Column(Integer, ForeignKey("dashboards.id"))
+    slice_id = Column(Integer, ForeignKey("slices.id"))
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    # find dup records in dashboard_slices tbl
+    dup_records = (
+        session.query(
+            DashboardSlices.dashboard_id,
+            DashboardSlices.slice_id,
+            db.func.count(DashboardSlices.id),
+        )
+        .group_by(DashboardSlices.dashboard_id, DashboardSlices.slice_id)
+        .having(db.func.count(DashboardSlices.id) > 1)
+        .all()
+    )
+
+    # remove dup entries
+    for record in dup_records:
+        print(
+            "remove duplicates from dashboard {} slice {}".format(
+                record.dashboard_id, record.slice_id
+            )
+        )
+
+        ids = [
+            item.id
+            for item in session.query(DashboardSlices.id)
+            .filter(
+                and_(
+                    DashboardSlices.slice_id == record.slice_id,
+                    DashboardSlices.dashboard_id == record.dashboard_id,
+                )
+            )
+            .offset(1)
+        ]
+        session.query(DashboardSlices).filter(DashboardSlices.id.in_(ids)).delete(
+            synchronize_session=False
+        )
+
+    # add unique constraint
+    try:
+        with op.batch_alter_table("dashboard_slices") as batch_op:
+            batch_op.create_unique_constraint(
+                "uq_dashboard_slice", ["dashboard_id", "slice_id"]
+            )
+    except Exception as e:
+        logging.exception(e)
+
+
+def downgrade():
+    try:
+        with op.batch_alter_table("dashboard_slices") as batch_op:
+            batch_op.drop_constraint("uq_dashboard_slice", type_="unique")
+    except Exception as e:
+        logging.exception(e)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -395,6 +395,7 @@ dashboard_slices = Table(
     Column("id", Integer, primary_key=True),
     Column("dashboard_id", Integer, ForeignKey("dashboards.id")),
     Column("slice_id", Integer, ForeignKey("slices.id")),
+    UniqueConstraint("dashboard_id", "slice_id"),
 )
 
 dashboard_user = Table(


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Superset didn't have unique constraint on dashboard_sliced table. In dashboard front-end code and when saving dashboard data to db, we added logic to prevent same slice id added into dashboard, but still found some duplicated entries in the dashboard_slices table. 

When user tried to remove the duplicated slice_id from dashboard, they will see following error, and they cannot remove that duplicated slice:
![Screen Shot 2018-11-20 at 1 19 54 PM (5)](https://user-images.githubusercontent.com/27990562/61324852-3837f580-a7c8-11e9-8c8b-2ee4b388a91f.png)


**Solution:**
1. remove duplicated entries in many-to-many relation tbl dashboard_slices
2. add unique constraint
3. update the dashboard_slices model to include the uniqueness constraint 


### TEST PLAN
run following query from database, should get 0 row:
```
SELECT dashboard_id, slice_id, count(*)
from dashboard_slices
group by dashboard_id, slice_id
having count(*) > 1
```


```
mysql> SHOW CREATE TABLE dashboard_slices;

| dashboard_slices | CREATE TABLE `dashboard_slices` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `dashboard_id` int(11) DEFAULT NULL,
  `slice_id` int(11) DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `uq_dashboard_slice` (`dashboard_id`,`slice_id`),
  KEY `dashboard_id` (`dashboard_id`),
  KEY `slice_id` (`slice_id`),
  CONSTRAINT `dashboard_slices_ibfk_1` FOREIGN KEY (`dashboard_id`) REFERENCES `dashboards` (`id`),
  CONSTRAINT `dashboard_slices_ibfk_2` FOREIGN KEY (`slice_id`) REFERENCES `slices` (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=180250 DEFAULT CHARSET=latin1 |
```


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch @john-bodley @michellethomas @etr2460 