### PR TITLE
[sql lab] improve TableElement controls

### DIFF
--- a/superset/assets/src/SqlLab/components/TableElement.jsx
+++ b/superset/assets/src/SqlLab/components/TableElement.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ButtonGroup, Collapse, Well } from 'react-bootstrap';
+import { ButtonGroup, Collapse, Fade, Well } from 'react-bootstrap';
 import shortid from 'shortid';
 import { t } from '@superset-ui/translation';
 
@@ -46,7 +46,12 @@ class TableElement extends React.PureComponent {
     this.state = {
       sortColumns: false,
       expanded: true,
+      hovered: false,
     };
+    this.removeFromStore = this.removeFromStore.bind(this);
+    this.toggleSortColumns = this.toggleSortColumns.bind(this);
+    this.removeTable = this.removeTable.bind(this);
+    this.setHover = this.setHover.bind(this);
   }
 
   popSelectStar() {
@@ -140,13 +145,13 @@ class TableElement extends React.PureComponent {
       );
     }
     return (
-      <ButtonGroup className="ws-el-controls pull-right">
+      <ButtonGroup className="ws-el-controls">
         {keyLink}
         <Link
           className={
             `fa fa-sort-${!this.state.sortColumns ? 'alpha' : 'numeric'}-asc ` +
             'pull-left sort-cols m-l-2'}
-          onClick={this.toggleSortColumns.bind(this)}
+          onClick={this.toggleSortColumns}
           tooltip={
             !this.state.sortColumns ?
             t('Sort columns alphabetically') :
@@ -165,7 +170,7 @@ class TableElement extends React.PureComponent {
         }
         <Link
           className="fa fa-times table-remove pull-left m-l-2"
-          onClick={this.removeTable.bind(this)}
+          onClick={this.removeTable}
           tooltip={t('Remove table preview')}
           href="#"
         />
@@ -179,16 +184,16 @@ class TableElement extends React.PureComponent {
         <div className="pull-left">
           <a
             href="#"
-            className="table-name"
+            className="table-name text-bigger"
             onClick={(e) => { this.toggleTable(e); }}
           >
-            <small className="m-r-5">
-              <i className={`fa fa-${table.expanded ? 'minus' : 'plus'}-square-o`} />
-            </small>
-            <strong>`{table.name}`</strong>
+            <strong>
+              {table.name}
+            </strong>
           </a>
         </div>
         <div className="pull-right">
+          <div>
           {table.isMetadataLoading || table.isExtraMetadataLoading ?
             <Loading
               size={50}
@@ -196,8 +201,19 @@ class TableElement extends React.PureComponent {
               className="margin-zero"
             />
             :
-            this.renderControls()
+            <Fade in={this.state.hovered}>
+              {this.renderControls()}
+            </Fade>
           }
+          <i
+            onClick={(e) => { this.toggleTable(e); }}
+            className={(
+              `text-primary pointer m-l-10 ` +
+              `fa fa-lg ` +
+              `fa-angle-${table.expanded ? 'up' : 'down'}`
+            )}
+          />
+          </div>
         </div>
       </div>
     );
@@ -238,14 +254,22 @@ class TableElement extends React.PureComponent {
     return metadata;
   }
 
+  setHover(hovered) {
+    this.setState({ hovered });
+  }
+
   render() {
     return (
       <Collapse
         in={this.state.expanded}
         timeout={this.props.timeout}
-        onExited={this.removeFromStore.bind(this)}
+        onExited={this.removeFromStore}
       >
-        <div className="TableElement table-schema m-b-10">
+        <div
+          className="TableElement table-schema m-b-10"
+          onMouseEnter={() => this.setHover(true)}
+          onMouseLeave={() => this.setHover(false)}
+        >
           {this.renderHeader()}
           <div>
             {this.renderBody()}

--- a/superset/assets/src/SqlLab/components/TableElement.jsx
+++ b/superset/assets/src/SqlLab/components/TableElement.jsx
@@ -54,6 +54,10 @@ class TableElement extends React.PureComponent {
     this.setHover = this.setHover.bind(this);
   }
 
+  setHover(hovered) {
+    this.setState({ hovered });
+  }
+
   popSelectStar() {
     const qe = {
       id: shortid.generate(),
@@ -193,7 +197,6 @@ class TableElement extends React.PureComponent {
           </a>
         </div>
         <div className="pull-right">
-          <div>
           {table.isMetadataLoading || table.isExtraMetadataLoading ?
             <Loading
               size={50}
@@ -208,12 +211,11 @@ class TableElement extends React.PureComponent {
           <i
             onClick={(e) => { this.toggleTable(e); }}
             className={(
-              `text-primary pointer m-l-10 ` +
-              `fa fa-lg ` +
+              'text-primary pointer m-l-10 ' +
+              'fa fa-lg ' +
               `fa-angle-${table.expanded ? 'up' : 'down'}`
             )}
           />
-          </div>
         </div>
       </div>
     );
@@ -252,10 +254,6 @@ class TableElement extends React.PureComponent {
       </Collapse>
     );
     return metadata;
-  }
-
-  setHover(hovered) {
-    this.setState({ hovered });
   }
 
   render() {

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -583,3 +583,6 @@ tr.reactable-column-header th.reactable-header-sortable {
 td.filtered {
   background-color: lighten(desaturate(@brand-primary, 50%), 50%);
 }
+.text-bigger {
+  font-size: 110%;
+}


### PR DESCRIPTION
Making TableElement (the table metadata shown in left panel in SQL Lab) show
controls only on hover, and use caret instead of plus/minus icons to expand/collapse

### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![2019-07-16 23 43 43](https://user-images.githubusercontent.com/487433/61353246-284dff00-a824-11e9-9ea0-a730ecbb9b81.gif)
