### PR TITLE
[fix] Adding check for invalid filter columns

### DIFF
--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -272,3 +272,45 @@ class SqlaTableModelTestCase(SupersetTestCase):
         self.assertIn("--COMMENT", sql)
 
         app.config["SQL_QUERY_MUTATOR"] = None
+
+    def test_query_with_non_existent_metrics(self):
+        tbl = self.get_table_by_name("birth_names")
+
+        query_obj = dict(
+            groupby=[],
+            metrics=["invalid"],
+            filter=[],
+            is_timeseries=False,
+            columns=["name"],
+            granularity=None,
+            from_dttm=None,
+            to_dttm=None,
+            is_prequery=False,
+            extras={},
+        )
+
+        with self.assertRaises(Exception) as context:
+            tbl.get_query_str(query_obj)
+
+        self.assertTrue("Metric 'invalid' does not exist", context.exception)
+
+    def test_query_with_non_existent_filter_columns(self):
+        tbl = self.get_table_by_name("birth_names")
+
+        query_obj = dict(
+            groupby=[],
+            metrics=["count"],
+            filter=[{"col": "invalid", "op": "==", "val": "male"}],
+            is_timeseries=False,
+            columns=["name"],
+            granularity=None,
+            from_dttm=None,
+            to_dttm=None,
+            is_prequery=False,
+            extras={},
+        )
+
+        with self.assertRaises(Exception) as context:
+            tbl.get_query_str(query_obj)
+
+        self.assertTrue("Column 'invalid' does not exist", context.exception)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes an issue where if you specified an invalid column (achievable in the URL) in a simple filter, i.e., not custom SQL, then the filter was simply ignored and the the query would execute sans the filter with no clear indication to the user that the filter wasn't being applied. 

This PR applies the same logic as invalid metrics and raises an exception if the column is invalid. Note I added unit tests to cover both the invalid metric and column use cases.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

##### BEFORE 
![Screen Shot 2019-07-17 at 3 32 12 PM](https://user-images.githubusercontent.com/4567245/61416309-1746d180-a8a8-11e9-9c27-24c21d8173b0.png)

##### AFTER 
![Screen Shot 2019-07-17 at 3 29 58 PM](https://user-images.githubusercontent.com/4567245/61416308-1746d180-a8a8-11e9-86ff-67e6dfd7de94.png)



<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @michellethomas @mistercrunch @williaster 