### PR TITLE
[test] fix postgres test failure caused by empty slice.name

### DIFF
--- a/tests/import_export_tests.py
+++ b/tests/import_export_tests.py
@@ -145,8 +145,10 @@ class ImportExportTests(SupersetTestCase):
         self.assertEquals(expected_dash.slug, actual_dash.slug)
         self.assertEquals(expected_dash.dashboard_title, actual_dash.dashboard_title)
         self.assertEquals(len(expected_dash.slices), len(actual_dash.slices))
-        expected_slices = sorted(expected_dash.slices, key=lambda s: s.slice_name or "")
-        actual_slices = sorted(actual_dash.slices, key=lambda s: s.slice_name or "")
+        expected_slices = sorted(
+            expected_dash.slices, key=lambda s: s.slice_name or s.id
+        )
+        actual_slices = sorted(actual_dash.slices, key=lambda s: s.slice_name or s.id)
         for e_slc, a_slc in zip(expected_slices, actual_slices):
             self.assert_slice_equals(e_slc, a_slc)
         if check_position:


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
A postgres test always failed in my new PR. See a sample link here: https://travis-ci.org/apache/incubator-superset/jobs/560192028

I found there is a logic to sort slices by name:
`expected_dash.slices, key=lambda s: s.slice_name or ""`
when multiple slices.name is empty, the order of expected_dash.slices becomes inconsistent. That cause the following test that compares each slice attribute, like viz_type, failed.

### TEST PLAN
ci


### REVIEWERS
@john-bodley @mistercrunch @michellethomas 