### PR TITLE
Fix incorrect datasource_name in dashboard export

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -678,7 +678,7 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
                 # add extra params for the import
                 copied_slc.alter_params(
                     remote_id=slc.id,
-                    datasource_name=slc.datasource.name,
+                    datasource_name=slc.datasource.datasource_name,
                     schema=slc.datasource.schema,
                     database_name=slc.datasource.database.name,
                 )


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

The bug was introduced in #7773

It uses filter by `cls.table_name == datasource_name`:
https://github.com/apache/incubator-superset/pull/7773/files#diff-a8dd5ec8d8decda2e3c5571d1ec0cdb6R740

But export puts `slc.datasource.name` into exported json:
https://github.com/apache/incubator-superset/pull/7773/files#diff-ceeb7eee8d573333109e0037299c9711L673

`slc.datasource.name` in case of `SqlaTable` is `"{}.{}".format(self.schema, self.table_name)`

### TEST PLAN

Export any dashboard using UI, delete it and try to import again.

### REVIEWERS

@mistercrunch 