### PR TITLE
[dashboard] fix chart showing loading icon when slice's immune fields is changed

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/components/Dashboard_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/Dashboard_spec.jsx
@@ -66,6 +66,24 @@ describe('Dashboard', () => {
   });
 
   describe('refreshExcept', () => {
+    const overrideDashboardState = {
+      ...dashboardState,
+      filters: {
+        1: { region: [] },
+        2: { country_name: ['USA'] },
+        3: { region: [], country_name: ['USA'] },
+      },
+      refresh: true,
+    };
+
+    const overrideDashboardInfo = {
+      ...dashboardInfo,
+      metadata: {
+        ...dashboardInfo.metadata,
+        filter_immune_slice_fields: { [chartQueries[chartId].id]: ['region'] },
+      },
+    };
+
     const overrideCharts = {
       ...chartQueries,
       1001: {
@@ -107,6 +125,32 @@ describe('Dashboard', () => {
       wrapper.instance().refreshExcept();
       spy.restore();
       expect(spy.callCount).toBe(0);
+    });
+
+    it('should not call triggerQuery for filter_immune_slice_fields', () => {
+      const wrapper = setup({
+        dashboardState: overrideDashboardState,
+        dashboardInfo: overrideDashboardInfo,
+      });
+      const spy = sinon.spy(props.actions, 'triggerQuery');
+      wrapper.instance().refreshExcept('1');
+      expect(spy.callCount).toBe(0);
+      spy.restore();
+    });
+
+    it('should call triggerQuery if filter has more filter-able fields', () => {
+      const wrapper = setup({
+        dashboardState: overrideDashboardState,
+        dashboardInfo: overrideDashboardInfo,
+      });
+      const spy = sinon.spy(props.actions, 'triggerQuery');
+
+      // if filter have additional fields besides immune ones,
+      // should apply filter.
+      wrapper.instance().refreshExcept('3');
+      expect(spy.callCount).toBe(1);
+
+      spy.restore();
     });
   });
 

--- a/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardInfo.js
+++ b/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardInfo.js
@@ -19,7 +19,10 @@
 export default {
   id: 1234,
   slug: 'dashboardSlug',
-  metadata: {},
+  metadata: {
+    filter_immune_slices: [],
+    filter_immune_slice_fields: {},
+  },
   userId: 'mock_user_id',
   dash_edit_perm: true,
   dash_save_perm: true,

--- a/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardState.js
+++ b/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardState.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { id as sliceId } from './mockChartQueries';
+import { sliceId } from './mockChartQueries';
 import { BUILDER_PANE_TYPE } from '../../../../src/dashboard/util/constants';
 
 export default {

--- a/superset/assets/src/chart/Chart.jsx
+++ b/superset/assets/src/chart/Chart.jsx
@@ -22,7 +22,6 @@ import { Alert } from 'react-bootstrap';
 
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { Logger, LOG_ACTIONS_RENDER_CHART_CONTAINER } from '../logger/LogUtils';
-import { safeStringify } from '../utils/safeStringify';
 import Loading from '../components/Loading';
 import RefreshChartOverlay from '../components/RefreshChartOverlay';
 import StackTraceMessage from '../components/StackTraceMessage';
@@ -82,10 +81,8 @@ class Chart extends React.PureComponent {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.triggerQuery &&
-      safeStringify(prevProps.formData) !== safeStringify(this.props.formData)
-    ) {
+  componentDidUpdate() {
+    if (this.props.triggerQuery) {
       this.runQuery();
     }
   }

--- a/superset/assets/src/dashboard/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/components/Dashboard.jsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/* eslint-disable camelcase */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { t } from '@superset-ui/translation';
@@ -143,11 +144,32 @@ class Dashboard extends React.PureComponent {
   }
 
   refreshExcept(filterKey) {
-    const immune = this.props.dashboardInfo.metadata.filter_immune_slices || [];
+    const { filters } = this.props.dashboardState || {};
+    const currentFilteredNames =
+      filterKey && filters[filterKey] ? Object.keys(filters[filterKey]) : [];
+    const filter_immune_slices = this.props.dashboardInfo.metadata
+      .filter_immune_slices;
+    const filter_immune_slice_fields = this.props.dashboardInfo.metadata
+      .filter_immune_slice_fields;
 
     this.getAllCharts().forEach(chart => {
-      // filterKey is a string, immune array contains numbers
-      if (String(chart.id) !== filterKey && immune.indexOf(chart.id) === -1) {
+      // filterKey is a string, filter_immune_slices array contains numbers
+      if (
+        String(chart.id) === filterKey ||
+        filter_immune_slices.includes(chart.id)
+      ) {
+        return;
+      }
+
+      const filter_immune_slice_fields_names =
+        filter_immune_slice_fields[chart.id] || [];
+      // has filter-able field names
+      if (
+        currentFilteredNames.length === 0 ||
+        currentFilteredNames.some(
+          name => !filter_immune_slice_fields_names.includes(name),
+        )
+      ) {
         this.props.actions.triggerQuery(true, chart.id);
       }
     });

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -186,8 +186,8 @@ export default function(bootstrapData) {
       slug: dashboard.slug,
       metadata: {
         filter_immune_slice_fields:
-          dashboard.metadata.filter_immune_slice_fields,
-        filter_immune_slices: dashboard.metadata.filter_immune_slices,
+          dashboard.metadata.filter_immune_slice_fields || {},
+        filter_immune_slices: dashboard.metadata.filter_immune_slices || [],
         timed_refresh_immune_slices:
           dashboard.metadata.timed_refresh_immune_slices,
       },


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When filter is changed, chart shows a loading icon, but not fetching data.

In Dashboard component, the logic to trigger chart refresh has problem. It only checks if whole chart is immune, but not check if chart immune to curtain fields in a applied filter. 
After chart is triggered to refresh, its state changed from success to loading, so we show loading icon for the chart. But the effective filter for the chart is not changed (because filter is not applicable). At the result, chart didn't send new query, but since the chart did not change state any more, the chart's loading status will not disappear.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**before**:
![Pk8afppq1w](https://user-images.githubusercontent.com/27990562/61488044-1ec7b280-a95c-11e9-9529-bc8d575ba082.gif)

**after**: should not show loading icon, and no fetching api call
![ZChCuSsdWA](https://user-images.githubusercontent.com/27990562/61488425-0a37ea00-a95d-11e9-989d-4128f84c90d7.gif)


### TEST PLAN
Added new unit test for this case.

### REVIEWERS
@williaster @michellethomas @mistercrunch @etr2460 