### PR TITLE
[Bugfix] Remove prequery properties from query_obj

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -48,8 +48,6 @@ class QueryObject:
         timeseries_limit_metric: Optional[Dict] = None,
         order_desc: bool = True,
         extras: Optional[Dict] = None,
-        prequeries: Optional[List[Dict]] = None,
-        is_prequery: bool = False,
         columns: List[str] = None,
         orderby: List[List] = None,
         relative_start: str = app.config.get("DEFAULT_RELATIVE_START_TIME", "today"),
@@ -78,8 +76,6 @@ class QueryObject:
         self.timeseries_limit = timeseries_limit
         self.timeseries_limit_metric = timeseries_limit_metric
         self.order_desc = order_desc
-        self.prequeries = prequeries if prequeries is not None else []
-        self.is_prequery = is_prequery
         self.extras = extras if extras is not None else {}
         self.columns = columns if columns is not None else []
         self.orderby = orderby if orderby is not None else []
@@ -97,8 +93,6 @@ class QueryObject:
             "timeseries_limit": self.timeseries_limit,
             "timeseries_limit_metric": self.timeseries_limit_metric,
             "order_desc": self.order_desc,
-            "prequeries": self.prequeries,
-            "is_prequery": self.is_prequery,
             "extras": self.extras,
             "columns": self.columns,
             "orderby": self.orderby,

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1120,8 +1120,6 @@ class DruidDatasource(Model, BaseDatasource):
         phase=2,
         client=None,
         order_desc=True,
-        prequeries=None,
-        is_prequery=False,
     ):
         """Runs a query against Druid and returns a dataframe.
         """

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -930,8 +930,6 @@ class SqlaTable(Model, BaseDatasource):
             db_engine_spec = self.database.db_engine_spec
             error_message = db_engine_spec.extract_error_message(e)
 
-        sql += ";"
-
         return QueryResult(
             status=status,
             df=df,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -351,7 +351,7 @@ class SqlaTable(Model, BaseDatasource):
         """
         label_expected = label or sqla_col.name
         db_engine_spec = self.database.db_engine_spec
-        if db_engine_spec.supports_column_aliases:
+        if db_engine_spec.allows_column_aliases:
             label = db_engine_spec.make_label_compatible(label_expected)
             sqla_col = sqla_col.label(label)
         sqla_col._df_label_expected = label_expected
@@ -544,9 +544,8 @@ class SqlaTable(Model, BaseDatasource):
 
     def get_query_str(self, query_obj):
         query_str_ext = self.get_query_str_extended(query_obj)
-        sql = ";\n\n".join(query_str_ext.prequeries)
-        sql += ";\n\n" + query_str_ext.sql
-        return sql
+        all_queries = query_str_ext.prequeries + [query_str_ext.sql]
+        return ";\n\n".join(all_queries)
 
     def get_sqla_table(self):
         tbl = table(self.table_name)
@@ -795,7 +794,7 @@ class SqlaTable(Model, BaseDatasource):
             qry = qry.limit(row_limit)
 
         if is_timeseries and timeseries_limit and groupby and not time_groupby_inline:
-            if self.database.db_engine_spec.inner_joins:
+            if self.database.db_engine_spec.allows_joins:
                 # some sql dialects require for order by expressions
                 # to also be in the select clause -- others, e.g. vertica,
                 # require a unique inner alias

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -117,9 +117,9 @@ class BaseEngineSpec(object):
     time_groupby_inline = False
     limit_method = LimitMethod.FORCE_LIMIT
     time_secondary_columns = False
-    inner_joins = True
-    allows_subquery = True
-    supports_column_aliases = True
+    allows_joins = True
+    allows_subqueries = True
+    allows_column_aliases = True
     force_column_alias_quotes = False
     arraysize = 0
     max_column_name_length = 0

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -22,8 +22,8 @@ class DruidEngineSpec(BaseEngineSpec):
     """Engine spec for Druid.io"""
 
     engine = "druid"
-    inner_joins = False
-    allows_subquery = True
+    allows_joins = False
+    allows_subqueries = True
 
     time_grain_functions = {
         None: "{col}",

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -22,5 +22,5 @@ class GSheetsEngineSpec(SqliteEngineSpec):
     """Engine for Google spreadsheets"""
 
     engine = "gsheets"
-    inner_joins = False
-    allows_subquery = False
+    allows_joins = False
+    allows_subqueries = False

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -24,9 +24,9 @@ from superset.db_engine_specs.base import BaseEngineSpec, TimestampExpression
 
 class PinotEngineSpec(BaseEngineSpec):
     engine = "pinot"
-    allows_subquery = False
-    inner_joins = False
-    supports_column_aliases = False
+    allows_subqueries = False
+    allows_joins = False
+    allows_column_aliases = False
 
     # Pinot does its own conversion below
     time_grain_functions: Dict[Optional[str], str] = {

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -771,7 +771,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
     @property
     def allows_subquery(self):
-        return self.db_engine_spec.allows_subquery
+        return self.db_engine_spec.allows_subqueries
 
     @property
     def data(self):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1350,9 +1350,6 @@ class Superset(BaseSupersetView):
             logging.exception(e)
             return json_error_response(e)
 
-        if query_obj and query_obj["prequeries"]:
-            query_obj["prequeries"].append(query)
-            query = ";\n\n".join(query_obj["prequeries"])
         if query:
             query += ";"
         else:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1350,9 +1350,7 @@ class Superset(BaseSupersetView):
             logging.exception(e)
             return json_error_response(e)
 
-        if query:
-            query += ";"
-        else:
+        if not query:
             query = "No query."
 
         return self.json_response(

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -320,8 +320,6 @@ class BaseViz(object):
             "extras": extras,
             "timeseries_limit_metric": timeseries_limit_metric,
             "order_desc": order_desc,
-            "prequeries": [],
-            "is_prequery": False,
         }
         return d
 
@@ -1798,11 +1796,11 @@ class FilterBoxViz(BaseViz):
         return None
 
     def run_extra_queries(self):
+        qry = super().query_obj()
         filters = self.form_data.get("filter_configs") or []
+        qry["row_limit"] = self.filter_row_limit
         self.dataframes = {}
         for flt in filters:
-            qry = super().query_obj()
-            qry["row_limit"] = self.filter_row_limit
             col = flt.get("column")
             if not col:
                 raise Exception(

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1798,11 +1798,11 @@ class FilterBoxViz(BaseViz):
         return None
 
     def run_extra_queries(self):
-        qry = super().query_obj()
         filters = self.form_data.get("filter_configs") or []
-        qry["row_limit"] = self.filter_row_limit
         self.dataframes = {}
         for flt in filters:
+            qry = super().query_obj()
+            qry["row_limit"] = self.filter_row_limit
             col = flt.get("column")
             if not col:
                 raise Exception(

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -195,11 +195,11 @@ class SqlaTableModelTestCase(SupersetTestCase):
         ds_col.expression = None
         ds_col.python_date_format = None
         spec = self.get_database_by_id(tbl.database_id).db_engine_spec
-        if not spec.allow_joins and inner_join:
+        if not spec.allows_joins and inner_join:
             # if the db does not support inner joins, we cannot force it so
             return None
-        old_inner_join = spec.allow_joins
-        spec.allow_joins = inner_join
+        old_inner_join = spec.allows_joins
+        spec.allows_joins = inner_join
         arbitrary_gby = "state || gender || '_test'"
         arbitrary_metric = dict(
             label="arbitrary", expressionType="SQL", sqlExpression="COUNT(1)"
@@ -224,7 +224,7 @@ class SqlaTableModelTestCase(SupersetTestCase):
             self.assertIn("JOIN", sql.upper())
         else:
             self.assertNotIn("JOIN", sql.upper())
-        spec.allow_joins = old_inner_join
+        spec.allows_joins = old_inner_join
         self.assertIsNotNone(qr.df)
         return qr.df
 

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -195,11 +195,11 @@ class SqlaTableModelTestCase(SupersetTestCase):
         ds_col.expression = None
         ds_col.python_date_format = None
         spec = self.get_database_by_id(tbl.database_id).db_engine_spec
-        if not spec.inner_joins and inner_join:
+        if not spec.allow_joins and inner_join:
             # if the db does not support inner joins, we cannot force it so
             return None
-        old_inner_join = spec.inner_joins
-        spec.inner_joins = inner_join
+        old_inner_join = spec.allow_joins
+        spec.allow_joins = inner_join
         arbitrary_gby = "state || gender || '_test'"
         arbitrary_metric = dict(
             label="arbitrary", expressionType="SQL", sqlExpression="COUNT(1)"
@@ -209,12 +209,10 @@ class SqlaTableModelTestCase(SupersetTestCase):
             metrics=[arbitrary_metric],
             filter=[],
             is_timeseries=is_timeseries,
-            prequeries=[],
             columns=[],
             granularity="ds",
             from_dttm=None,
             to_dttm=None,
-            is_prequery=False,
             extras=dict(time_grain_sqla="P1Y"),
         )
         qr = tbl.query(query_obj)
@@ -226,7 +224,7 @@ class SqlaTableModelTestCase(SupersetTestCase):
             self.assertIn("JOIN", sql.upper())
         else:
             self.assertNotIn("JOIN", sql.upper())
-        spec.inner_joins = old_inner_join
+        spec.allow_joins = old_inner_join
         self.assertIsNotNone(qr.df)
         return qr.df
 
@@ -258,7 +256,6 @@ class SqlaTableModelTestCase(SupersetTestCase):
             granularity=None,
             from_dttm=None,
             to_dttm=None,
-            is_prequery=False,
             extras={},
         )
         sql = tbl.get_query_str(query_obj)
@@ -285,7 +282,6 @@ class SqlaTableModelTestCase(SupersetTestCase):
             granularity=None,
             from_dttm=None,
             to_dttm=None,
-            is_prequery=False,
             extras={},
         )
 
@@ -306,7 +302,6 @@ class SqlaTableModelTestCase(SupersetTestCase):
             granularity=None,
             from_dttm=None,
             to_dttm=None,
-            is_prequery=False,
             extras={},
         )
 

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -52,7 +52,6 @@ class DatabaseModelTestCase(SupersetTestCase):
             "metrics": [],
             "is_timeseries": False,
             "filter": [],
-            "is_prequery": False,
             "extras": {"where": "(user != '{{ cache_key_wrapper('user_2') }}')"},
         }
         extra_cache_keys = table.get_extra_cache_keys(query_obj)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Refactor

### SUMMARY

TL;DR:

There is a bug in how the `prequeries` property of `query_obj` is constructed in `sqla/models.py`, which causes cache misses if there are more than one filter selected in FilterBox. This PR fixes that bug without introducing any (user facing) functional changes.

Long explanation:

When non-join based prequeries were introduced in #4163, the properties `is_prequery` and `prequeries` were introduced into `query_obj`. This was done to be able to produce "Top N" filtering for engines that don't support joins, namely Druid (and later Pinot). However, prequeries are not actually needed in the `query_obj` (and later `cache_dict`), as they are only an intermediary construct that can be deduced from the `query_obj`. Furthermore, prequeries were  added to `query_obj` in `sqla_models.py`, making the calls non-idempotent and non-deterministic. Ideally `query_obj` should never be mutated after it is constructed in `viz.py`, as all the information necessary for the query should already be known at that time. This caused a caching bug in Filterbox, which runs as many queries as there are filters, and erroneously interpreted the previous queries as prequeries, causing bloated `prequeries` properties in the `query_obj`.

 When Pinot support was introduced in #6719, two named tuples (`SqlaQuery` and `QueryStrExtended`) were introduced in `sqla/models.py` to facilitate returning more context for how a query that produces the resulting `DataFrame` were produced. In the current codebase, this is the correct placeholder for prequeries. This PR removes both `is_prequery` and `prequeries` from `query_obj`, and adds `prequeries` into the `SqlaQuery` and `QueryStrExtended` objects, enabling the functionality introduced in #4163.

Functional changes:
- Removed `prequeries` and `is_prequery` from `query_obj`.
- Moved prequery related handling from `query_obj` to `SqlaQuery` and `QueryStrExtended`, ensuring that `query_obj` stays unmutated during processing in `sqla/models.py`.

Other refactoring:
- Renamed property `inner_joins` in `BaseEngineSpec` to `allows_joins` (currently not necessary to distinguish between inner/outer/full joins). Also harmonized other similarly named properties, such as `allows_subqueries` and `allows_column_aliases`.
- Added typing to `SqlaQuery`and `QueryStrExtended`.
- Moved some query formatting from `core.py` to `sqla/models.py`.

### TEST PLAN
- CI
- Tested locally by setting `allows_joins` to both `True` and `False` on `sqlite`
- Verified that no more cache misses occur when running Filterbox with more than one filter.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #7666

### REVIEWERS
@smokemonster99