### PR TITLE
[fix] Adding space after -- for SQL comments

### DIFF
--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -262,14 +262,14 @@ class SqlaTableModelTestCase(SupersetTestCase):
             extras={},
         )
         sql = tbl.get_query_str(query_obj)
-        self.assertNotIn("--COMMENT", sql)
+        self.assertNotIn("-- COMMENT", sql)
 
         def mutator(*args):
-            return "--COMMENT\n" + args[0]
+            return "-- COMMENT\n" + args[0]
 
         app.config["SQL_QUERY_MUTATOR"] = mutator
         sql = tbl.get_query_str(query_obj)
-        self.assertIn("--COMMENT", sql)
+        self.assertIn("-- COMMENT", sql)
 
         app.config["SQL_QUERY_MUTATOR"] = None
 

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -449,13 +449,13 @@ class SupersetTestCase(unittest.TestCase):
         self.assertEquals({"SalesOrderHeader"}, self.extract_tables(query))
 
     def test_get_query_with_new_limit_comment(self):
-        sql = "SELECT * FROM ab_user --SOME COMMENT"
+        sql = "SELECT * FROM ab_user -- SOME COMMENT"
         parsed = sql_parse.ParsedQuery(sql)
         newsql = parsed.get_query_with_new_limit(1000)
         self.assertEquals(newsql, sql + "\nLIMIT 1000")
 
     def test_get_query_with_new_limit_comment_with_limit(self):
-        sql = "SELECT * FROM ab_user --SOME COMMENT WITH LIMIT 555"
+        sql = "SELECT * FROM ab_user -- SOME COMMENT WITH LIMIT 555"
         parsed = sql_parse.ParsedQuery(sql)
         newsql = parsed.get_query_with_new_limit(1000)
         self.assertEquals(newsql, sql + "\nLIMIT 1000")


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes an issue where for some SQL dialects (MySQL) a SQL comment begins with two dashes `--` and must be followed by at least one whitespace or control character as described [here](https://dev.mysql.com/doc/refman/8.0/en/comments.html). 

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @graceguo-supercat @michellethomas @mistercrunch