### PR TITLE
[test] Fix test data remove slice_name

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1974,7 +1974,8 @@ class Superset(BaseSupersetView):
             ):
                 slice_id = value.get("meta").get("chartId")
                 slice_ids.append(slice_id)
-                slice_id_to_name[slice_id] = value.get("meta").get("sliceName")
+                if "sliceName" in value.get("meta"):
+                    slice_id_to_name[slice_id] = value.get("meta").get("sliceName")
 
         session = db.session()
         Slice = models.Slice  # noqa
@@ -1983,12 +1984,14 @@ class Superset(BaseSupersetView):
         dashboard.slices = current_slices
 
         # update slice names. this assumes user has permissions to update the slice
+        # we allow user set slice name be empty string
         for slc in dashboard.slices:
-            new_name = slice_id_to_name[slc.id]
-            if slc.slice_name != new_name:
-                slc.slice_name = new_name
-                session.merge(slc)
-                session.flush()
+            if slc.id in slice_id_to_name:
+                new_name = slice_id_to_name[slc.id]
+                if slc.slice_name != new_name:
+                    slc.slice_name = new_name
+                    session.merge(slc)
+                    session.flush()
 
         # remove leading and trailing white spaces in the dumped json
         dashboard.position_json = json.dumps(


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When user save dashboard, we allow user do not user original slice_name saved in Slice table, and have a copy of slice name which is only used by a dashboard. We also allow user to set this dashboard's slice name be empty.

in front-end code i think we copy slice_name into layout data and send with save_dash API. But in unit tests we didn't set slicename attribute in the mock layout data, and cause after /save_dash/ api call in unit test, sample slices created for unit tests lost their slice_name. So that some unit tests that rely on slice_name uniqueness became flacky.

**Solution**
I fixed the logic in save_dash. It will only reset slice_name when has explicit attribute in layout.

### TEST PLAN
CI


### REVIEWERS
@john-bodley @mistercrunch 