### PR TITLE
[Bugfix] Response header and response mismatch on explore result from sqllab

### DIFF
--- a/superset/assets/src/SqlLab/actions/sqlLab.js
+++ b/superset/assets/src/SqlLab/actions/sqlLab.js
@@ -530,8 +530,7 @@ export function createDatasource(vizOptions) {
       endpoint: '/superset/sqllab_viz/',
       postPayload: { data: vizOptions },
     })
-      .then(({ json }) => {
-        const data = JSON.parse(json);
+      .then(({ data }) => {
         dispatch(createDatasourceSuccess(data));
 
         return Promise.resolve(data);

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2636,7 +2636,9 @@ class Superset(BaseSupersetView):
         table.columns = cols
         table.metrics = [SqlMetric(metric_name="count", expression="count(*)")]
         db.session.commit()
-        return self.json_response(json.dumps({"table_id": table.id}))
+        return json_success(json.dumps({
+            "table_id": table.id,
+        }))
 
     @has_access
     @expose("/table/<database_id>/<table_name>/<schema>/")

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2636,9 +2636,7 @@ class Superset(BaseSupersetView):
         table.columns = cols
         table.metrics = [SqlMetric(metric_name="count", expression="count(*)")]
         db.session.commit()
-        return json_success(json.dumps({
-            "table_id": table.id,
-        }))
+        return json_success(json.dumps({"table_id": table.id}))
 
     @has_access
     @expose("/table/<database_id>/<table_name>/<schema>/")

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset import db
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.db_engine_specs.druid import DruidEngineSpec
 from superset.utils.core import get_main_database

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -44,7 +44,7 @@ class DatabaseModelTestCase(SupersetTestCase):
 
     def test_cache_key_wrapper(self):
         query = "SELECT '{{ cache_key_wrapper('user_1') }}' as user"
-        table = SqlaTable(sql=query, database=get_main_database(db.session))
+        table = SqlaTable(sql=query, database=get_main_database())
         query_obj = {
             "granularity": None,
             "from_dttm": None,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The  JSON response being passed as string. some of the browser and proxy server ( Knox in particular) will throw you saying response is not a valid JSON.
Also fixes test failure at master

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
```
HTTP/1.0 200 OK
Content-Type: application/json
Content-Length: 20
X-Frame-Options: SAMEORIGIN
Vary: Cookie
Server: Werkzeug/0.14.1 Python/3.6.5
Date: Wed, 17 Jul 2019 09:16:21 GMT
Proxy-Connection: Close

"{\"table_id\": 28}"
```

After
```
HTTP/1.0 200 OK
Content-Type: application/json
Content-Length: 20
X-Frame-Options: SAMEORIGIN
Vary: Cookie
Server: Werkzeug/0.14.1 Python/3.6.5
Date: Wed, 20 Jul 2019 09:26:21 GMT
Proxy-Connection: Close

{\"table_id\": 31}
```
### TEST PLAN
existing test suites should pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch