### PR TITLE
[Feature] Dashboard filter indicators

### DIFF
--- a/superset/assets/spec/javascripts/components/AnchorLink_spec.jsx
+++ b/superset/assets/spec/javascripts/components/AnchorLink_spec.jsx
@@ -28,6 +28,19 @@ describe('AnchorLink', () => {
     anchorLinkId: 'CHART-123',
   };
 
+  beforeEach(() => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        hash: '#' + props.anchorLinkId,
+      },
+    });
+  });
+
+  afterEach(() => {
+    delete global.window.location.value;
+  });
+
   it('should scroll the AnchorLink into view upon mount', () => {
     const callback = sinon.spy();
     const clock = sinon.useFakeTimers();
@@ -35,11 +48,7 @@ describe('AnchorLink', () => {
       scrollIntoView: callback,
     });
 
-    const wrapper = shallow(<AnchorLink {...props} />);
-    wrapper.instance().getLocationHash = () => (props.anchorLinkId);
-    wrapper.update();
-
-    wrapper.instance().componentDidMount();
+    shallow(<AnchorLink {...props} />);
     clock.tick(2000);
     expect(callback.callCount).toEqual(1);
     stub.restore();

--- a/superset/assets/spec/javascripts/dashboard/actions/dashboardState_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/actions/dashboardState_spec.js
@@ -19,17 +19,29 @@
 import sinon from 'sinon';
 import { SupersetClient } from '@superset-ui/connection';
 
-import { saveDashboardRequest } from '../../../../src/dashboard/actions/dashboardState';
+import {
+  removeSliceFromDashboard,
+  saveDashboardRequest,
+} from '../../../../src/dashboard/actions/dashboardState';
+import { REMOVE_FILTER } from '../../../../src/dashboard/actions/dashboardFilters';
 import { UPDATE_COMPONENTS_PARENTS_LIST } from '../../../../src/dashboard/actions/dashboardLayout';
+import {
+  filterId,
+  sliceEntitiesForDashboard as sliceEntities,
+} from '../fixtures/mockSliceEntities';
+import { emptyFilters } from '../fixtures/mockDashboardFilters';
 import mockDashboardData from '../fixtures/mockDashboardData';
 import { DASHBOARD_GRID_ID } from '../../../../src/dashboard/util/constants';
 
 describe('dashboardState actions', () => {
   const mockState = {
     dashboardState: {
+      sliceIds: [filterId],
       hasUnsavedChanges: true,
     },
     dashboardInfo: {},
+    sliceEntities,
+    dashboardFilters: emptyFilters,
     dashboardLayout: {
       past: [],
       present: mockDashboardData.positions,
@@ -96,5 +108,15 @@ describe('dashboardState actions', () => {
         mockParentsList,
       );
     });
+  });
+
+  it('should dispatch removeFilter if a removed slice is a filter_box', () => {
+    const { getState, dispatch } = setup(mockState);
+    const thunk = removeSliceFromDashboard(filterId);
+    thunk(dispatch, getState);
+
+    const removeFilter = dispatch.getCall(0).args[0];
+    removeFilter(dispatch, getState);
+    expect(dispatch.getCall(3).args[0].type).toBe(REMOVE_FILTER);
   });
 });

--- a/superset/assets/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -67,7 +67,7 @@ describe('DashboardBuilder', () => {
     setColorSchemeAndUnsavedChanges() {},
     colorScheme: undefined,
     handleComponentDrop() {},
-    toggleBuilderPane() {},
+    setDirectPathToChild: sinon.spy(),
   };
 
   function setup(overrideProps, useProvider = false, store = mockStore) {
@@ -171,7 +171,7 @@ describe('DashboardBuilder', () => {
     expect(wrapper.find(BuilderComponentPane)).toHaveLength(1);
   });
 
-  it('should change tabs if a top-level Tab is clicked', () => {
+  it('should change redux state if a top-level Tab is clicked', () => {
     const wrapper = setup(
       { dashboardLayout: layoutWithTabs },
       true,
@@ -185,6 +185,6 @@ describe('DashboardBuilder', () => {
       .at(1)
       .simulate('click');
 
-    expect(wrapper.find(TabContainer).prop('activeKey')).toBe(1);
+    expect(props.setDirectPathToChild.callCount).toBe(1);
   });
 });

--- a/superset/assets/spec/javascripts/dashboard/components/FilterIndicatorGroup_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/FilterIndicatorGroup_spec.jsx
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { dashboardFilters } from '../fixtures/mockDashboardFilters';
+import { filterId, column } from '../fixtures/mockSliceEntities';
+import FilterIndicatorGroup from '../../../../src/dashboard/components/FilterIndicatorGroup';
+import FilterBadgeIcon from '../../../../src/components/FilterBadgeIcon';
+
+describe('FilterIndicatorGroup', () => {
+  const mockedProps = {
+    indicators: [
+      {
+        ...dashboardFilters[filterId],
+        colorCode: 'badge-1',
+        name: column,
+        values: ['a', 'b', 'c'],
+      },
+    ],
+    setDirectPathToChild: () => {},
+  };
+
+  function setup(overrideProps) {
+    return shallow(
+      <FilterIndicatorGroup {...mockedProps} {...overrideProps} />,
+    );
+  }
+
+  it('should show indicator group with badge', () => {
+    const wrapper = setup();
+    expect(wrapper.find(FilterBadgeIcon)).toHaveLength(1);
+  });
+});

--- a/superset/assets/spec/javascripts/dashboard/components/FilterIndicatorTooltip_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/FilterIndicatorTooltip_spec.jsx
@@ -16,17 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { sliceId } from './mockChartQueries';
-import { BUILDER_PANE_TYPE } from '../../../../src/dashboard/util/constants';
+import React from 'react';
+import { shallow } from 'enzyme';
 
-export default {
-  sliceIds: [sliceId],
-  expandedSlices: {},
-  editMode: false,
-  builderPaneType: BUILDER_PANE_TYPE.NONE,
-  hasUnsavedChanges: false,
-  maxUndoHistoryExceeded: false,
-  isStarred: true,
-  isPublished: true,
-  css: '',
-};
+import FilterIndicatorTooltip from '../../../../src/dashboard/components/FilterIndicatorTooltip';
+
+describe('FilterIndicatorTooltip', () => {
+  const label = 'region';
+  const mockedProps = {
+    colorCode: 'badge-1',
+    label,
+    values: [],
+    clickIconHandler: jest.fn(),
+  };
+
+  function setup(overrideProps) {
+    return shallow(
+      <FilterIndicatorTooltip {...mockedProps} {...overrideProps} />,
+    );
+  }
+
+  it('should show label', () => {
+    const wrapper = setup();
+    expect(wrapper.find(`[htmlFor="filter-tooltip-${label}"]`)).toHaveLength(1);
+  });
+});

--- a/superset/assets/spec/javascripts/dashboard/components/FilterIndicator_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/FilterIndicator_spec.jsx
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { dashboardFilters } from '../fixtures/mockDashboardFilters';
+import { filterId, column } from '../fixtures/mockSliceEntities';
+import FilterIndicator from '../../../../src/dashboard/components/FilterIndicator';
+import FilterBadgeIcon from '../../../../src/components/FilterBadgeIcon';
+
+describe('FilterIndicator', () => {
+  const mockedProps = {
+    indicator: {
+      ...dashboardFilters[filterId],
+      colorCode: 'badge-1',
+      name: column,
+      label: column,
+      values: ['a', 'b', 'c'],
+    },
+    setDirectPathToChild: jest.fn(),
+  };
+
+  function setup(overrideProps) {
+    return shallow(<FilterIndicator {...mockedProps} {...overrideProps} />);
+  }
+
+  it('should show indicator with badge', () => {
+    const wrapper = setup();
+    expect(wrapper.find(FilterBadgeIcon)).toHaveLength(1);
+  });
+
+  it('should call setDirectPathToChild prop', () => {
+    const wrapper = setup();
+    const badge = wrapper.find('.filter-indicator');
+    expect(badge).toHaveLength(1);
+
+    badge.simulate('click');
+    expect(mockedProps.setDirectPathToChild).toHaveBeenCalledWith(
+      dashboardFilters[filterId].directPathToFilter,
+    );
+  });
+});

--- a/superset/assets/spec/javascripts/dashboard/components/FilterIndicatorsContainer_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/FilterIndicatorsContainer_spec.jsx
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { dashboardFilters } from '../fixtures/mockDashboardFilters';
+import { filterId, column } from '../fixtures/mockSliceEntities';
+import FilterIndicatorsContainer from '../../../../src/dashboard/components/FilterIndicatorsContainer';
+import FilterIndicator from '../../../../src/dashboard/components/FilterIndicator';
+import * as colorMap from '../../../../src/dashboard/util/dashboardFiltersColorMap';
+
+describe('FilterIndicatorsContainer', () => {
+  const chartId = 1;
+  const mockedProps = {
+    dashboardFilters,
+    chartId,
+    chartStatus: 'success',
+    filterImmuneSlices: [],
+    filterImmuneSliceFields: {},
+    setDirectPathToChild: () => {},
+  };
+
+  colorMap.getFilterColorKey = jest.fn(() => 'id_column');
+  colorMap.getFilterColorMap = jest.fn(() => ({
+    id_column: 'badge-1',
+  }));
+
+  function setup(overrideProps) {
+    return shallow(
+      <FilterIndicatorsContainer {...mockedProps} {...overrideProps} />,
+    );
+  }
+
+  it('should not show indicator when chart is loading', () => {
+    const wrapper = setup({ chartStatus: 'loading' });
+    expect(wrapper.find(FilterIndicator)).toHaveLength(0);
+  });
+
+  it('should not show indicator for filter_box itself', () => {
+    const wrapper = setup({ chartId: filterId });
+    expect(wrapper.find(FilterIndicator)).toHaveLength(0);
+  });
+
+  it('should not show indicator when chart is immune', () => {
+    const wrapper = setup({ filterImmuneSlices: [chartId] });
+    expect(wrapper.find(FilterIndicator)).toHaveLength(0);
+  });
+
+  it('should not show indicator when chart field is immune', () => {
+    const wrapper = setup({ filterImmuneSliceFields: { [chartId]: [column] } });
+    expect(wrapper.find(FilterIndicator)).toHaveLength(0);
+  });
+
+  it('should show indicator', () => {
+    const wrapper = setup();
+    expect(wrapper.find(FilterIndicator)).toHaveLength(1);
+  });
+});

--- a/superset/assets/spec/javascripts/dashboard/components/FilterTooltipWrapper_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/FilterTooltipWrapper_spec.jsx
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Overlay, Tooltip } from 'react-bootstrap';
+
+import FilterTooltipWrapper from '../../../../src/dashboard/components/FilterTooltipWrapper';
+import FilterIndicatorTooltip from '../../../../src/dashboard/components/FilterIndicatorTooltip';
+
+describe('FilterTooltipWrapper', () => {
+  const mockedProps = {
+    tooltip: (
+      <FilterIndicatorTooltip
+        label="region"
+        values={['a', 'b', 'c']}
+        clickIconHandler={jest.fn()}
+      />
+    ),
+  };
+
+  function setup() {
+    return shallow(
+      <FilterTooltipWrapper {...mockedProps}>
+        <div className="badge-1" />
+      </FilterTooltipWrapper>,
+    );
+  }
+
+  it('should contain Overlay and Tooltip', () => {
+    const wrapper = setup();
+    expect(wrapper.find(Overlay)).toHaveLength(1);
+    expect(wrapper.find(Tooltip)).toHaveLength(1);
+  });
+
+  it('should show tooltip on hover', () => {
+    const wrapper = setup();
+    wrapper.instance().isHover = true;
+
+    jest.useFakeTimers();
+    wrapper.find('.indicator-container').simulate('mouseover');
+    jest.runAllTimers();
+    expect(wrapper.state('show')).toBe(true);
+  });
+
+  it('should hide tooltip on hover', () => {
+    const wrapper = setup();
+    wrapper.instance().isHover = false;
+
+    jest.useFakeTimers();
+    wrapper.find('.indicator-container').simulate('mouseout');
+    jest.runAllTimers();
+    expect(wrapper.state('show')).toBe(false);
+  });
+});

--- a/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
@@ -52,7 +52,6 @@ describe('Header', () => {
     setEditMode: () => {},
     showBuilderPane: () => {},
     builderPaneType: BUILDER_PANE_TYPE.NONE,
-    toggleBuilderPane: () => {},
     updateCss: () => {},
     hasUnsavedChanges: false,
     maxUndoHistoryExceeded: false,

--- a/superset/assets/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
@@ -25,17 +25,14 @@ import SliceHeader from '../../../../../src/dashboard/components/SliceHeader';
 import ChartContainer from '../../../../../src/chart/ChartContainer';
 
 import mockDatasource from '../../../../fixtures/mockDatasource';
-import {
-  sliceEntitiesForChart as sliceEntities,
-  sliceId,
-} from '../../fixtures/mockSliceEntities';
+import { sliceEntitiesForChart as sliceEntities } from '../../fixtures/mockSliceEntities';
 import chartQueries, {
   sliceId as queryId,
 } from '../../fixtures/mockChartQueries';
 
 describe('Chart', () => {
   const props = {
-    id: sliceId,
+    id: queryId,
     width: 100,
     height: 100,
     updateSliceName() {},
@@ -43,12 +40,12 @@ describe('Chart', () => {
     // from redux
     chart: chartQueries[queryId],
     formData: chartQueries[queryId].formData,
-    datasource: mockDatasource[sliceEntities.slices[sliceId].datasource],
+    datasource: mockDatasource[sliceEntities.slices[queryId].datasource],
     slice: {
-      ...sliceEntities.slices[sliceId],
+      ...sliceEntities.slices[queryId],
       description_markeddown: 'markdown',
     },
-    sliceName: sliceEntities.slices[sliceId].slice_name,
+    sliceName: sliceEntities.slices[queryId].slice_name,
     timeout: 60,
     filters: {},
     refreshChart() {},
@@ -92,10 +89,10 @@ describe('Chart', () => {
     expect(refreshChart.callCount).toBe(1);
   });
 
-  it('should call addFilter when ChartContainer calls addFilter', () => {
-    const addFilter = sinon.spy();
-    const wrapper = setup({ addFilter });
-    wrapper.instance().addFilter();
-    expect(addFilter.callCount).toBe(1);
+  it('should call changeFilter when ChartContainer calls changeFilter', () => {
+    const changeFilter = sinon.spy();
+    const wrapper = setup({ changeFilter });
+    wrapper.instance().changeFilter();
+    expect(changeFilter.callCount).toBe(1);
   });
 });

--- a/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardFilters.js
+++ b/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardFilters.js
@@ -16,17 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { sliceId } from './mockChartQueries';
-import { BUILDER_PANE_TYPE } from '../../../../src/dashboard/util/constants';
+import { filterId } from './mockSliceEntities';
 
-export default {
-  sliceIds: [sliceId],
-  expandedSlices: {},
-  editMode: false,
-  builderPaneType: BUILDER_PANE_TYPE.NONE,
-  hasUnsavedChanges: false,
-  maxUndoHistoryExceeded: false,
-  isStarred: true,
-  isPublished: true,
-  css: '',
+export const emptyFilters = {};
+
+export const dashboardFilters = {
+  [filterId]: {
+    chartId: filterId,
+    componentId: 'CHART-rwDfbGqeEn',
+    directPathToFilter: [
+      'ROOT_ID',
+      'TABS-VPEX_c476g',
+      'TAB-PMJyKM1yB',
+      'TABS-YdylzDMTMQ',
+      'TAB-O9AaU9FT0',
+      'ROW-l6PrlhwSjh',
+      'CHART-rwDfbGqeEn',
+    ],
+    scope: 'ROOT_ID',
+    isDateFilter: false,
+    isInstantFilter: true,
+    columns: {
+      region: ['a', 'b'],
+    },
+    labels: {
+      region: 'region',
+    },
+  },
 };

--- a/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardInfo.js
+++ b/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardInfo.js
@@ -20,8 +20,8 @@ export default {
   id: 1234,
   slug: 'dashboardSlug',
   metadata: {
-    filter_immune_slices: [],
-    filter_immune_slice_fields: {},
+    filterImmuneSlices: [],
+    filterImmuneSliceFields: {},
   },
   userId: 'mock_user_id',
   dash_edit_perm: true,

--- a/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardLayout.js
+++ b/superset/assets/spec/javascripts/dashboard/fixtures/mockDashboardLayout.js
@@ -37,6 +37,7 @@ import {
 import newComponentFactory from '../../../../src/dashboard/util/newComponentFactory';
 
 import { sliceId as chartId } from './mockChartQueries';
+import { filterId } from './mockDashboardFilters';
 
 export const sliceId = chartId;
 
@@ -186,4 +187,23 @@ export const dashboardLayoutWithTabs = {
     },
   },
   future: [],
+};
+
+export const filterComponent = {
+  ...newComponentFactory(CHART_TYPE),
+  id: 'CHART-rwDfbGqeEn',
+  parents: [
+    'ROOT_ID',
+    'TABS-VPEX_c476g',
+    'TAB-PMJyKM1yB',
+    'TABS-YdylzDMTMQ',
+    'TAB-O9AaU9FT0',
+    'ROW-l6PrlhwSjh',
+  ],
+  meta: {
+    chartId: filterId,
+    width: 3,
+    height: 10,
+    chartName: 'Filter',
+  },
 };

--- a/superset/assets/spec/javascripts/dashboard/fixtures/mockSliceEntities.js
+++ b/superset/assets/spec/javascripts/dashboard/fixtures/mockSliceEntities.js
@@ -16,10 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { sliceId as id } from './mockChartQueries';
 import { datasourceId } from '../../../fixtures/mockDatasource';
+import { sliceId } from './mockChartQueries';
 
-export const sliceId = id;
+export const filterId = 127;
+export const column = 'region';
 
 export const sliceEntitiesForChart = {
   slices: {
@@ -49,6 +50,8 @@ export const sliceEntitiesForChart = {
       datasource: datasourceId,
       description: null,
       description_markeddown: '',
+      modified: '23 hours ago',
+      changed_on: 1529453332615,
     },
   },
   isLoading: false,
@@ -58,11 +61,23 @@ export const sliceEntitiesForChart = {
 
 export const sliceEntitiesForDashboard = {
   slices: {
-    127: {
-      slice_id: 127,
+    [filterId]: {
+      slice_id: filterId,
       slice_url: '/superset/explore/?form_data=%7B%22slice_id%22%3A%20127%7D',
       slice_name: 'Region Filter',
-      form_data: {},
+      form_data: {
+        instant_filtering: true,
+        filter_configs: [
+          {
+            asc: true,
+            clearable: true,
+            column,
+            key: 'JknLrSlNL',
+            multiple: true,
+            label: column,
+          },
+        ],
+      },
       edit_url: '/chart/edit/127',
       viz_type: 'filter_box',
       datasource: '2__table',

--- a/superset/assets/spec/javascripts/dashboard/fixtures/mockState.js
+++ b/superset/assets/spec/javascripts/dashboard/fixtures/mockState.js
@@ -19,6 +19,7 @@
 import chartQueries from './mockChartQueries';
 import { dashboardLayout } from './mockDashboardLayout';
 import dashboardInfo from './mockDashboardInfo';
+import { emptyFilters } from './mockDashboardFilters';
 import dashboardState from './mockDashboardState';
 import messageToasts from '../../messageToasts/mockMessageToasts';
 import datasources from '../../../fixtures/mockDatasource';
@@ -29,6 +30,7 @@ export default {
   sliceEntities,
   charts: chartQueries,
   dashboardInfo,
+  dashboardFilters: emptyFilters,
   dashboardState,
   dashboardLayout,
   messageToasts,

--- a/superset/assets/spec/javascripts/dashboard/fixtures/mockStore.js
+++ b/superset/assets/spec/javascripts/dashboard/fixtures/mockStore.js
@@ -35,6 +35,7 @@ export const mockStoreWithTabs = createStore(
   {
     ...mockState,
     dashboardLayout: dashboardLayoutWithTabs,
+    dashboardFilters: {},
   },
   compose(applyMiddleware(thunk)),
 );

--- a/superset/assets/spec/javascripts/dashboard/reducers/dashboardFilters_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/reducers/dashboardFilters_spec.js
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-disable camelcase */
+import {
+  ADD_FILTER,
+  REMOVE_FILTER,
+  CHANGE_FILTER,
+} from '../../../../src/dashboard/actions/dashboardFilters';
+import dashboardFiltersReducer from '../../../../src/dashboard/reducers/dashboardFilters';
+import {
+  emptyFilters,
+  dashboardFilters,
+} from '../fixtures/mockDashboardFilters';
+import {
+  sliceEntitiesForDashboard,
+  filterId,
+  column,
+} from '../fixtures/mockSliceEntities';
+import { filterComponent } from '../fixtures/mockDashboardLayout';
+import { DASHBOARD_ROOT_ID } from '../../../../src/dashboard/util/constants';
+
+describe('dashboardFilters reducer', () => {
+  const form_data = sliceEntitiesForDashboard.slices[filterId].form_data;
+  const component = filterComponent;
+  const directPathToFilter = (component.parents || []).slice();
+  directPathToFilter.push(component.id);
+
+  it('should add a new filter if it does not exist', () => {
+    expect(
+      dashboardFiltersReducer(emptyFilters, {
+        type: ADD_FILTER,
+        chartId: filterId,
+        component,
+        form_data,
+      }),
+    ).toEqual({
+      [filterId]: {
+        chartId: filterId,
+        componentId: component.id,
+        directPathToFilter,
+        scope: DASHBOARD_ROOT_ID,
+        isDateFilter: false,
+        isInstantFilter: !!form_data.instant_filtering,
+        columns: {
+          [column]: undefined,
+        },
+        labels: {
+          [column]: column,
+        },
+      },
+    });
+  });
+
+  it('should overwrite a filter if merge is false', () => {
+    expect(
+      dashboardFiltersReducer(dashboardFilters, {
+        type: CHANGE_FILTER,
+        chartId: filterId,
+        newSelectedValues: {
+          region: ['c'],
+          gender: ['body', 'girl'],
+        },
+        merge: false,
+      }),
+    ).toEqual({
+      [filterId]: {
+        chartId: filterId,
+        componentId: component.id,
+        directPathToFilter,
+        scope: DASHBOARD_ROOT_ID,
+        isDateFilter: false,
+        isInstantFilter: !!form_data.instant_filtering,
+        columns: {
+          region: ['c'],
+          gender: ['body', 'girl'],
+        },
+        labels: {
+          [column]: column,
+        },
+      },
+    });
+  });
+
+  it('should merge a filter if merge is true', () => {
+    expect(
+      dashboardFiltersReducer(dashboardFilters, {
+        type: CHANGE_FILTER,
+        chartId: filterId,
+        newSelectedValues: {
+          region: ['c'],
+          gender: ['body', 'girl'],
+        },
+        merge: true,
+      }),
+    ).toEqual({
+      [filterId]: {
+        chartId: filterId,
+        componentId: component.id,
+        directPathToFilter,
+        scope: DASHBOARD_ROOT_ID,
+        isDateFilter: false,
+        isInstantFilter: !!form_data.instant_filtering,
+        columns: {
+          region: ['a', 'b', 'c'],
+          gender: ['body', 'girl'],
+        },
+        labels: {
+          [column]: column,
+        },
+      },
+    });
+  });
+
+  it('should remove the filter if values are empty', () => {
+    expect(
+      dashboardFiltersReducer(dashboardFilters, {
+        type: REMOVE_FILTER,
+        chartId: filterId,
+      }),
+    ).toEqual({});
+  });
+});

--- a/superset/assets/spec/javascripts/dashboard/reducers/dashboardState_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/reducers/dashboardState_spec.js
@@ -18,7 +18,6 @@
  */
 import {
   ADD_SLICE,
-  CHANGE_FILTER,
   ON_CHANGE,
   ON_SAVE,
   REMOVE_SLICE,
@@ -52,16 +51,7 @@ describe('dashboardState reducer', () => {
         { sliceIds: [1, 2], filters: {} },
         { type: REMOVE_SLICE, sliceId: 2 },
       ),
-    ).toEqual({ sliceIds: [1], refresh: false, filters: {} });
-  });
-
-  it('should reset filters if a removed slice is a filter', () => {
-    expect(
-      dashboardStateReducer(
-        { sliceIds: [1, 2], filters: { 2: {}, 1: {} } },
-        { type: REMOVE_SLICE, sliceId: 2 },
-      ),
-    ).toEqual({ sliceIds: [1], filters: { 1: {} }, refresh: true });
+    ).toEqual({ sliceIds: [1], filters: {} });
   });
 
   it('should toggle fav star', () => {
@@ -139,106 +129,6 @@ describe('dashboardState reducer', () => {
       editMode: false,
       builderPaneType: BUILDER_PANE_TYPE.NONE,
       updatedColorScheme: false,
-    });
-  });
-
-  describe('change filter', () => {
-    it('should add a new filter if it does not exist', () => {
-      expect(
-        dashboardStateReducer(
-          {
-            filters: {},
-            sliceIds: [1],
-          },
-          {
-            type: CHANGE_FILTER,
-            chart: { id: 1, formData: { groupby: 'column' } },
-            col: 'column',
-            vals: ['b', 'a'],
-            refresh: true,
-            merge: true,
-          },
-        ),
-      ).toEqual({
-        filters: { 1: { column: ['b', 'a'] } },
-        refresh: true,
-        sliceIds: [1],
-      });
-    });
-
-    it('should overwrite a filter if merge is false', () => {
-      expect(
-        dashboardStateReducer(
-          {
-            filters: {
-              1: { column: ['z'] },
-            },
-            sliceIds: [1],
-          },
-          {
-            type: CHANGE_FILTER,
-            chart: { id: 1, formData: { groupby: 'column' } },
-            col: 'column',
-            vals: ['b', 'a'],
-            refresh: true,
-            merge: false,
-          },
-        ),
-      ).toEqual({
-        filters: { 1: { column: ['b', 'a'] } },
-        refresh: true,
-        sliceIds: [1],
-      });
-    });
-
-    it('should merge a filter if merge is true', () => {
-      expect(
-        dashboardStateReducer(
-          {
-            filters: {
-              1: { column: ['z'] },
-            },
-            sliceIds: [1],
-          },
-          {
-            type: CHANGE_FILTER,
-            chart: { id: 1, formData: { groupby: 'column' } },
-            col: 'column',
-            vals: ['b', 'a'],
-            refresh: true,
-            merge: true,
-          },
-        ),
-      ).toEqual({
-        filters: { 1: { column: ['z', 'b', 'a'] } },
-        refresh: true,
-        sliceIds: [1],
-      });
-    });
-
-    it('should remove the filter if values are empty', () => {
-      expect(
-        dashboardStateReducer(
-          {
-            filters: {
-              1: { column: ['z'] },
-            },
-            sliceIds: [1],
-          },
-          {
-            type: CHANGE_FILTER,
-            chart: { id: 1, formData: { groupby: 'column' } },
-            col: 'column',
-            vals: [],
-            refresh: true,
-            merge: false,
-          },
-        ),
-      ).toEqual({
-        filters: {},
-        refresh: true,
-        sliceIds: [1],
-      });
     });
   });
 });

--- a/superset/assets/spec/javascripts/dashboard/util/findTabIndexByComponentId_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/findTabIndexByComponentId_spec.js
@@ -49,22 +49,22 @@ describe('findTabIndexByComponentId', () => {
   ];
   const badPath = ['ROOT_ID', 'TABS-MNQQSW-kyd', 'TAB-ABC', 'TABS-Oduxop1L7I'];
 
-  it('should return 0 if no directPathToChild', () => {
+  it('should return -1 if no directPathToChild', () => {
     expect(
       findTabIndexByComponentId({
         currentComponent: topLevelTabsComponent,
         directPathToChild: [],
       }),
-    ).toBe(0);
+    ).toBe(-1);
   });
 
-  it('should return 0 if not found tab id', () => {
+  it('should return -1 if not found tab id', () => {
     expect(
       findTabIndexByComponentId({
         currentComponent: topLevelTabsComponent,
         directPathToChild: badPath,
       }),
-    ).toBe(0);
+    ).toBe(-1);
   });
 
   it('should return children index if matched an id in the path', () => {

--- a/superset/assets/spec/javascripts/dashboard/util/getFormDataWithExtraFilters_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getFormDataWithExtraFilters_spec.js
@@ -34,8 +34,8 @@ describe('getFormDataWithExtraFilters', () => {
       },
     },
     dashboardMetadata: {
-      filter_immune_slices: [],
-      filter_immune_slice_fields: {},
+      filterImmuneSlices: [],
+      filterImmuneSliceFields: {},
     },
     filters: {
       filterId: {
@@ -65,7 +65,7 @@ describe('getFormDataWithExtraFilters', () => {
     const result = getFormDataWithExtraFilters({
       ...mockArgs,
       dashboardMetadata: {
-        filter_immune_slices: [chartId],
+        filterImmuneSlices: [chartId],
       },
     });
     expect(result.extra_filters).toHaveLength(0);
@@ -75,7 +75,7 @@ describe('getFormDataWithExtraFilters', () => {
     const result = getFormDataWithExtraFilters({
       ...mockArgs,
       dashboardMetadata: {
-        filter_immune_slice_fields: {
+        filterImmuneSliceFields: {
           [chartId]: ['region'],
         },
       },

--- a/superset/assets/spec/javascripts/dashboard/util/getLeafComponentIdFromPath_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getLeafComponentIdFromPath_spec.js
@@ -16,17 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { sliceId } from './mockChartQueries';
-import { BUILDER_PANE_TYPE } from '../../../../src/dashboard/util/constants';
+import getLeafComponentIdFromPath from '../../../../src/dashboard/util/getLeafComponentIdFromPath';
+import { filterId } from '../fixtures/mockSliceEntities';
+import { dashboardFilters } from '../fixtures/mockDashboardFilters';
 
-export default {
-  sliceIds: [sliceId],
-  expandedSlices: {},
-  editMode: false,
-  builderPaneType: BUILDER_PANE_TYPE.NONE,
-  hasUnsavedChanges: false,
-  maxUndoHistoryExceeded: false,
-  isStarred: true,
-  isPublished: true,
-  css: '',
-};
+describe('getLeafComponentIdFromPath', () => {
+  const path = dashboardFilters[filterId].directPathToFilter;
+  const leaf = path.slice().pop();
+
+  it('should return component id', () => {
+    expect(getLeafComponentIdFromPath(path)).toBe(leaf);
+  });
+
+  it('should not return label component', () => {
+    const updatedPath = dashboardFilters[filterId].directPathToFilter.concat(
+      'LABEL-test123',
+    );
+    expect(getLeafComponentIdFromPath(updatedPath)).toBe(leaf);
+  });
+});

--- a/superset/assets/src/chart/chartReducer.js
+++ b/superset/assets/src/chart/chartReducer.js
@@ -182,7 +182,7 @@ export default function chartReducer(charts = {}, action) {
   if (action.type in actionHandlers) {
     return {
       ...charts,
-      [action.key]: actionHandlers[action.type](charts[action.key], action),
+      [action.key]: actionHandlers[action.type](charts[action.key]),
     };
   }
 

--- a/superset/assets/src/components/AnchorLink.jsx
+++ b/superset/assets/src/components/AnchorLink.jsx
@@ -22,42 +22,52 @@ import { t } from '@superset-ui/translation';
 
 import URLShortLinkButton from './URLShortLinkButton';
 import getDashboardUrl from '../dashboard/util/getDashboardUrl';
+import getLocationHash from '../dashboard/util/getLocationHash';
 
 const propTypes = {
   anchorLinkId: PropTypes.string.isRequired,
   filters: PropTypes.object,
   showShortLinkButton: PropTypes.bool,
+  inFocus: PropTypes.bool,
   placement: PropTypes.oneOf(['right', 'left', 'top', 'bottom']),
 };
 
 const defaultProps = {
+  inFocus: false,
   showShortLinkButton: false,
   placement: 'right',
   filters: {},
 };
 
-
 class AnchorLink extends React.PureComponent {
 
   componentDidMount() {
-    const hash = this.getLocationHash();
+    const hash = getLocationHash();
     const { anchorLinkId } = this.props;
 
     if (hash && anchorLinkId === hash) {
-      const directLinkComponent = document.getElementById(anchorLinkId);
-      if (directLinkComponent) {
-        setTimeout(() => {
-          directLinkComponent.scrollIntoView({
-            block: 'center',
-            behavior: 'smooth',
-          });
-        }, 1000);
-      }
+      this.scrollToView();
     }
   }
 
-  getLocationHash() {
-    return (window.location.hash || '').substring(1);
+  componentWillReceiveProps(nextProps) {
+    const { inFocus = false } = nextProps;
+    if (inFocus) {
+      this.scrollToView();
+    }
+  }
+
+  scrollToView(delay = 0) {
+    const { anchorLinkId } = this.props;
+    const directLinkComponent = document.getElementById(anchorLinkId);
+    if (directLinkComponent) {
+      setTimeout(() => {
+        directLinkComponent.scrollIntoView({
+          block: 'center',
+          behavior: 'smooth',
+        });
+      }, delay);
+    }
   }
 
   render() {

--- a/superset/assets/src/components/FilterBadgeIcon.css
+++ b/superset/assets/src/components/FilterBadgeIcon.css
@@ -16,17 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
-
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+.filter-badge {
+    width: 20px;
+    height: 20px;
+    background-color: #bababa;
+    border-radius: 2px;
+    z-index: 10;
+}
+.filter-badge:hover {
+    cursor: pointer;
+    background-color: #9e9e9e;
+}

--- a/superset/assets/src/components/FilterBadgeIcon.jsx
+++ b/superset/assets/src/components/FilterBadgeIcon.jsx
@@ -16,17 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
+import React from 'react';
+import PropTypes from 'prop-types';
 
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+import './FilterBadgeIcon.css';
+
+const propTypes = {
+  colorCode: PropTypes.string,
+};
+
+export default function FilterBadgeIcon({ colorCode = '' }) {
+  return (
+    <svg className={`filter-badge ${colorCode}`} width="20" height="20" viewBox="0 0 20 20">
+      <path d="M4 5H16V7H4V5ZM6 9H14V11H6V9ZM12 13H8V15H12V13Z" fill="#fff" />
+    </svg>
+  );
+}
+
+FilterBadgeIcon.propTypes = propTypes;

--- a/superset/assets/src/components/FilterEditIcon.css
+++ b/superset/assets/src/components/FilterEditIcon.css
@@ -16,17 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
-
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+.filter-edit {
+    cursor: pointer;
+}

--- a/superset/assets/src/components/FilterEditIcon.jsx
+++ b/superset/assets/src/components/FilterEditIcon.jsx
@@ -16,17 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
+import React from 'react';
+import PropTypes from 'prop-types';
 
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+import './FilterEditIcon.css';
+
+const propTypes = {
+  clickIconHandler: PropTypes.func,
+};
+
+export default function FilterEditIcon({ clickIconHandler = () => {} }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      onClick={clickIconHandler}
+      className="filter-edit"
+      viewBox="0 0 12 12"
+    >
+      <path d="M11.8049 1.75476C12.0649 2.01472 12.0649 2.43466 11.8049 2.69463L10.5851 3.91446L8.08547 1.4148L9.3053 0.194973C9.56526 -0.064991 9.9852 -0.064991 10.2452 0.194973L11.8049 1.75476ZM0 12V9.50035L7.37231 2.12804L9.87196 4.62769L2.49965 12H0Z" fill="#fff" />
+    </svg>
+  );
+}
+
+FilterEditIcon.propTypes = propTypes;

--- a/superset/assets/src/dashboard/actions/dashboardFilters.js
+++ b/superset/assets/src/dashboard/actions/dashboardFilters.js
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-disable camelcase */
+// util function to make sure filter is a valid slice in current dashboard
+function isValidFilter(getState, chartId) {
+  return getState().dashboardState.sliceIds.includes(chartId);
+}
+
+export const ADD_FILTER = 'ADD_FILTER';
+export function addFilter(chartId, component, form_data) {
+  return (dispatch, getState) => {
+    if (isValidFilter(getState, chartId)) {
+      return dispatch({ type: ADD_FILTER, chartId, component, form_data });
+    }
+    return getState().dashboardFilters;
+  };
+}
+
+export const REMOVE_FILTER = 'REMOVE_FILTER';
+export function removeFilter(chartId) {
+  return (dispatch, getState) => {
+    if (isValidFilter(getState, chartId)) {
+      return dispatch({ type: REMOVE_FILTER, chartId });
+    }
+    return getState().dashboardFilters;
+  };
+}
+
+export const CHANGE_FILTER = 'CHANGE_FILTER';
+export function changeFilter(chartId, newSelectedValues, merge) {
+  return (dispatch, getState) => {
+    if (isValidFilter(getState, chartId)) {
+      return dispatch({
+        type: CHANGE_FILTER,
+        chartId,
+        newSelectedValues,
+        merge,
+      });
+    }
+    return getState().dashboardFilters;
+  };
+}
+
+export const UPDATE_DIRECT_PATH_TO_FILTER = 'UPDATE_DIRECT_PATH_TO_FILTER';
+export function updateDirectPathToFilter(chartId, path) {
+  return (dispatch, getState) => {
+    if (isValidFilter(getState, chartId)) {
+      return dispatch({ type: UPDATE_DIRECT_PATH_TO_FILTER, chartId, path });
+    }
+    return getState().dashboardFilters;
+  };
+}

--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -24,6 +24,11 @@ import { SupersetClient } from '@superset-ui/connection';
 import { addChart, removeChart, refreshChart } from '../../chart/chartAction';
 import { chart as initChart } from '../../chart/chartReducer';
 import { fetchDatasourceMetadata } from '../../dashboard/actions/datasources';
+import {
+  addFilter,
+  removeFilter,
+  updateDirectPathToFilter,
+} from '../../dashboard/actions/dashboardFilters';
 import { applyDefaultFormData } from '../../explore/store';
 import getClientErrorObject from '../../utils/getClientErrorObject';
 import { SAVE_TYPE_OVERWRITE } from '../util/constants';
@@ -37,11 +42,6 @@ import { UPDATE_COMPONENTS_PARENTS_LIST } from '../actions/dashboardLayout';
 export const SET_UNSAVED_CHANGES = 'SET_UNSAVED_CHANGES';
 export function setUnsavedChanges(hasUnsavedChanges) {
   return { type: SET_UNSAVED_CHANGES, payload: { hasUnsavedChanges } };
-}
-
-export const CHANGE_FILTER = 'CHANGE_FILTER';
-export function changeFilter(chart, col, vals, merge = true, refresh = true) {
-  return { type: CHANGE_FILTER, chart, col, vals, merge, refresh };
 }
 
 export const ADD_SLICE = 'ADD_SLICE';
@@ -166,8 +166,18 @@ export function saveDashboardRequestSuccess() {
 export function saveDashboardRequest(data, id, saveType) {
   const path = saveType === SAVE_TYPE_OVERWRITE ? 'save_dash' : 'copy_dash';
 
-  return dispatch => {
+  return (dispatch, getState) => {
     dispatch({ type: UPDATE_COMPONENTS_PARENTS_LIST });
+
+    const { dashboardFilters, dashboardLayout } = getState();
+    const layout = dashboardLayout.present;
+    Object.values(dashboardFilters).forEach(filter => {
+      const { chartId } = filter;
+      const componentId = filter.directPathToFilter.slice().pop();
+      const directPathToFilter = (layout[componentId].parents || []).slice();
+      directPathToFilter.push(componentId);
+      dispatch(updateDirectPathToFilter(chartId, directPathToFilter));
+    });
 
     return SupersetClient.post({
       endpoint: `/superset/${path}/${id}/`,
@@ -257,7 +267,7 @@ export function showBuilderPane(builderPaneType) {
   return { type: SHOW_BUILDER_PANE, builderPaneType };
 }
 
-export function addSliceToDashboard(id) {
+export function addSliceToDashboard(id, component) {
   return (dispatch, getState) => {
     const { sliceEntities } = getState();
     const selectedSlice = sliceEntities.slices[id];
@@ -282,12 +292,23 @@ export function addSliceToDashboard(id) {
     return Promise.all([
       dispatch(addChart(newChart, id)),
       dispatch(fetchDatasourceMetadata(form_data.datasource)),
-    ]).then(() => dispatch(addSlice(selectedSlice)));
+    ]).then(() => {
+      dispatch(addSlice(selectedSlice));
+
+      if (selectedSlice && selectedSlice.viz_type === 'filter_box') {
+        dispatch(addFilter(id, component, selectedSlice.form_data));
+      }
+    });
   };
 }
 
 export function removeSliceFromDashboard(id) {
-  return dispatch => {
+  return (dispatch, getState) => {
+    const sliceEntity = getState().sliceEntities.slices[id];
+    if (sliceEntity && sliceEntity.viz_type === 'filter_box') {
+      dispatch(removeFilter(id));
+    }
+
     dispatch(removeSlice(id));
     dispatch(removeChart(id));
   };
@@ -303,6 +324,11 @@ export function setColorSchemeAndUnsavedChanges(colorScheme) {
     dispatch(setColorScheme(colorScheme));
     dispatch(setUnsavedChanges(true));
   };
+}
+
+export const SET_DIRECT_PATH = 'SET_DIRECT_PATH';
+export function setDirectPathToChild(path) {
+  return { type: SET_DIRECT_PATH, path };
 }
 
 // Undo history ---------------------------------------------------------------

--- a/superset/assets/src/dashboard/components/DashboardGrid.jsx
+++ b/superset/assets/src/dashboard/components/DashboardGrid.jsx
@@ -32,6 +32,7 @@ const propTypes = {
   handleComponentDrop: PropTypes.func.isRequired,
   isComponentVisible: PropTypes.bool.isRequired,
   resizeComponent: PropTypes.func.isRequired,
+  setDirectPathToChild: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
 };
 
@@ -51,6 +52,7 @@ class DashboardGrid extends React.PureComponent {
     this.handleTopDropTargetDrop = this.handleTopDropTargetDrop.bind(this);
     this.getRowGuidePosition = this.getRowGuidePosition.bind(this);
     this.setGridRef = this.setGridRef.bind(this);
+    this.handleChangeTab = this.handleChangeTab.bind(this);
   }
 
   getRowGuidePosition(resizeRef) {
@@ -108,6 +110,10 @@ class DashboardGrid extends React.PureComponent {
     }
   }
 
+  handleChangeTab({ pathToTabIndex }) {
+    this.props.setDirectPathToChild(pathToTabIndex);
+  }
+
   render() {
     const {
       gridComponent,
@@ -160,6 +166,7 @@ class DashboardGrid extends React.PureComponent {
               onResizeStart={this.handleResizeStart}
               onResize={this.handleResize}
               onResizeStop={this.handleResizeStop}
+              onChangeTab={this.handleChangeTab}
             />
           ))}
 

--- a/superset/assets/src/dashboard/components/FilterIndicator.jsx
+++ b/superset/assets/src/dashboard/components/FilterIndicator.jsx
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { t } from '@superset-ui/translation';
+
+import { filterIndicatorPropShape } from '../util/propShapes';
+import FilterBadgeIcon from '../../components/FilterBadgeIcon';
+import FilterIndicatorTooltip from './FilterIndicatorTooltip';
+import FilterTooltipWrapper from './FilterTooltipWrapper';
+
+const propTypes = {
+  indicator: filterIndicatorPropShape.isRequired,
+  setDirectPathToChild: PropTypes.func.isRequired,
+};
+
+class FilterIndicator extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    const { indicator, setDirectPathToChild } = props;
+    const { directPathToFilter } = indicator;
+    this.focusToFilterComponent = setDirectPathToChild.bind(
+      this,
+      directPathToFilter,
+    );
+  }
+
+  render() {
+    const { colorCode, label, values } = this.props.indicator;
+
+    const filterTooltip = (
+      <FilterIndicatorTooltip
+        label={t(label)}
+        values={values}
+        clickIconHandler={this.focusToFilterComponent}
+      />
+    );
+
+    return (
+      <FilterTooltipWrapper tooltip={filterTooltip}>
+        <div
+          className="filter-indicator"
+          onClick={this.focusToFilterComponent}
+          role="none"
+        >
+          <div className={`color-bar ${colorCode}`} />
+          <FilterBadgeIcon />
+        </div>
+      </FilterTooltipWrapper>
+    );
+  }
+}
+
+FilterIndicator.propTypes = propTypes;
+
+export default FilterIndicator;

--- a/superset/assets/src/dashboard/components/FilterIndicatorGroup.jsx
+++ b/superset/assets/src/dashboard/components/FilterIndicatorGroup.jsx
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { t } from '@superset-ui/translation';
+
+import FilterBadgeIcon from '../../components/FilterBadgeIcon';
+import FilterIndicatorTooltip from './FilterIndicatorTooltip';
+import FilterTooltipWrapper from './FilterTooltipWrapper';
+import { filterIndicatorPropShape } from '../util/propShapes';
+
+const propTypes = {
+  indicators: PropTypes.arrayOf(filterIndicatorPropShape).isRequired,
+  setDirectPathToChild: PropTypes.func.isRequired,
+};
+
+class FilterIndicatorGroup extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    const { indicators, setDirectPathToChild } = this.props;
+    this.onClickIcons = indicators.map(indicator =>
+      setDirectPathToChild.bind(this, indicator.directPathToFilter),
+    );
+  }
+
+  render() {
+    const { indicators } = this.props;
+    return (
+      <FilterTooltipWrapper
+        tooltip={
+          <React.Fragment>
+            <div className="group-title">
+              {t('%s more filters', indicators.length)}
+            </div>
+            <ul className="tooltip-group">
+              {indicators.map((indicator, index) => (
+                <li key={`${indicator.chartId}_${indicator.name}`}>
+                  <FilterIndicatorTooltip
+                    clickIconHandler={this.onClickIcons[index]}
+                    label={indicator.label}
+                    values={indicator.values}
+                  />
+                </li>
+              ))}
+            </ul>
+          </React.Fragment>
+        }
+      >
+        <div className="filter-indicator-group">
+          <div className="color-bar badge-group" />
+          <FilterBadgeIcon />
+        </div>
+      </FilterTooltipWrapper>
+    );
+  }
+}
+
+FilterIndicatorGroup.propTypes = propTypes;
+
+export default FilterIndicatorGroup;

--- a/superset/assets/src/dashboard/components/FilterIndicatorTooltip.jsx
+++ b/superset/assets/src/dashboard/components/FilterIndicatorTooltip.jsx
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { t } from '@superset-ui/translation';
+import { isEmpty } from 'lodash';
+
+import FilterEditIcon from '../../components/FilterEditIcon';
+
+const propTypes = {
+  label: PropTypes.string.isRequired,
+  values: PropTypes.array.isRequired,
+  clickIconHandler: PropTypes.func,
+};
+
+const defaultProps = {
+  clickIconHandler: undefined,
+};
+
+export default function FilterIndicatorTooltip({
+  label,
+  values,
+  clickIconHandler,
+}) {
+  const displayValue = isEmpty(values) ? t('Not filtered') : values.join(', ');
+
+  return (
+    <div className="tooltip-item">
+      <div className="filter-content">
+        <label htmlFor={`filter-tooltip-${label}`}>{label}:</label>
+        <span> {displayValue}</span>
+      </div>
+
+      {clickIconHandler && (
+        <FilterEditIcon clickIconHandler={clickIconHandler} />
+      )}
+    </div>
+  );
+}
+
+FilterIndicatorTooltip.propTypes = propTypes;
+FilterIndicatorTooltip.defaultProps = defaultProps;

--- a/superset/assets/src/dashboard/components/FilterIndicatorsContainer.jsx
+++ b/superset/assets/src/dashboard/components/FilterIndicatorsContainer.jsx
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { isEmpty } from 'lodash';
+
+import FilterIndicator from './FilterIndicator';
+import FilterIndicatorGroup from './FilterIndicatorGroup';
+import { FILTER_INDICATORS_DISPLAY_LENGTH } from '../util/constants';
+import {
+  getFilterColorKey,
+  getFilterColorMap,
+} from '../util/dashboardFiltersColorMap';
+
+const propTypes = {
+  // from props
+  dashboardFilters: PropTypes.object.isRequired,
+  chartId: PropTypes.number.isRequired,
+  chartStatus: PropTypes.string,
+
+  // from redux
+  filterImmuneSlices: PropTypes.arrayOf(PropTypes.number).isRequired,
+  filterImmuneSliceFields: PropTypes.object.isRequired,
+  setDirectPathToChild: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  chartStatus: 'loading',
+};
+
+function sortByIndicatorLabel(indicator1, indicator2) {
+  const s1 = (indicator1.label || indicator1.name).toLowerCase();
+  const s2 = (indicator2.label || indicator2.name).toLowerCase();
+  if (s1 < s2) {
+    return -1;
+  } else if (s1 > s2) {
+    return 1;
+  }
+  return 0;
+}
+
+export default class FilterIndicatorsContainer extends React.PureComponent {
+  getFilterIndicators() {
+    const {
+      dashboardFilters,
+      chartId: currentChartId,
+      filterImmuneSlices,
+      filterImmuneSliceFields,
+    } = this.props;
+
+    if (Object.keys(dashboardFilters).length === 0) {
+      return [];
+    }
+
+    const dashboardFiltersColorMap = getFilterColorMap();
+
+    const sortIndicatorsByEmptiness = Object.values(dashboardFilters).reduce(
+      (indicators, dashboardFilter) => {
+        const {
+          chartId,
+          componentId,
+          directPathToFilter,
+          scope,
+          isDateFilter,
+          isInstantFilter,
+          columns,
+          labels,
+        } = dashboardFilter;
+
+        // do not apply filter on filter_box itself
+        // do not apply filter on filterImmuneSlices list
+        if (
+          currentChartId !== chartId &&
+          !filterImmuneSlices.includes(currentChartId)
+        ) {
+          Object.keys(columns).forEach(name => {
+            const colorMapKey = getFilterColorKey(chartId, name);
+            const directPathToLabel = directPathToFilter.slice();
+            directPathToLabel.push(`LABEL-${name}`);
+            const indicator = {
+              chartId,
+              colorCode: dashboardFiltersColorMap[colorMapKey],
+              componentId,
+              directPathToFilter: directPathToLabel,
+              scope,
+              isDateFilter,
+              isInstantFilter,
+              name,
+              label: labels[name] || name,
+              values:
+                isEmpty(columns[name]) ||
+                (isDateFilter && columns[name] === 'No filter')
+                  ? []
+                  : [].concat(columns[name]),
+            };
+
+            // do not apply filter on fields in the filterImmuneSliceFields map
+            if (
+              filterImmuneSliceFields[currentChartId] &&
+              filterImmuneSliceFields[currentChartId].includes(name)
+            ) {
+              return;
+            }
+
+            if (isEmpty(indicator.values)) {
+              indicators[1].push(indicator);
+            } else {
+              indicators[0].push(indicator);
+            }
+          });
+        }
+
+        return indicators;
+      },
+      [[], []],
+    );
+
+    // cypress' electron don't support [].flat():
+    return [
+      ...sortIndicatorsByEmptiness[0].sort(sortByIndicatorLabel),
+      ...sortIndicatorsByEmptiness[1].sort(sortByIndicatorLabel),
+    ];
+  }
+
+  render() {
+    const { chartStatus, setDirectPathToChild } = this.props;
+    if (chartStatus === 'loading') {
+      return null;
+    }
+
+    const indicators = this.getFilterIndicators();
+    // if total indicators <= 5, show all
+    // else: show top 4 indicators, and show all the rest in group
+    const showExtraIndicatorsInGroup =
+      indicators.length > FILTER_INDICATORS_DISPLAY_LENGTH + 1;
+
+    return (
+      <div className="dashboard-filter-indicators-container">
+        {indicators
+          .filter((indicator, index) => {
+            if (showExtraIndicatorsInGroup) {
+              return index < FILTER_INDICATORS_DISPLAY_LENGTH;
+            }
+            return true;
+          })
+          .map(indicator => (
+            <FilterIndicator
+              key={`${indicator.chartId}_${indicator.name}`}
+              indicator={indicator}
+              setDirectPathToChild={setDirectPathToChild}
+            />
+          ))}
+        {showExtraIndicatorsInGroup && (
+          <FilterIndicatorGroup
+            indicators={indicators.slice(FILTER_INDICATORS_DISPLAY_LENGTH)}
+            setDirectPathToChild={setDirectPathToChild}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+FilterIndicatorsContainer.propTypes = propTypes;
+FilterIndicatorsContainer.defaultProps = defaultProps;

--- a/superset/assets/src/dashboard/components/FilterTooltipWrapper.jsx
+++ b/superset/assets/src/dashboard/components/FilterTooltipWrapper.jsx
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Overlay, Tooltip } from 'react-bootstrap';
+
+const propTypes = {
+  tooltip: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+class FilterTooltipWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // internal instance variable to make tooltip show/hide have delay
+    this.isHover = false;
+    this.state = {
+      show: false,
+    };
+
+    this.showTooltip = this.showTooltip.bind(this);
+    this.hideTooltip = this.hideTooltip.bind(this);
+    this.attachRef = target => this.setState({ target });
+  }
+
+  showTooltip() {
+    this.isHover = true;
+
+    setTimeout(() => this.isHover && this.setState({ show: true }), 100);
+  }
+
+  hideTooltip() {
+    this.isHover = false;
+
+    setTimeout(() => !this.isHover && this.setState({ show: false }), 300);
+  }
+
+  render() {
+    const { show, target } = this.state;
+    return (
+      <React.Fragment>
+        <Overlay container={this} target={target} show={show} placement="left">
+          <Tooltip id="filter-indicator-tooltip">
+            <div onMouseOver={this.showTooltip} onMouseOut={this.hideTooltip}>
+              {this.props.tooltip}
+            </div>
+          </Tooltip>
+        </Overlay>
+
+        <div
+          className="indicator-container"
+          onMouseOver={this.showTooltip}
+          onMouseOut={this.hideTooltip}
+          ref={this.attachRef}
+        >
+          {this.props.children}
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+FilterTooltipWrapper.propTypes = propTypes;
+
+export default FilterTooltipWrapper;

--- a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
@@ -40,7 +40,7 @@ const propTypes = {
   isComponentVisible: PropTypes.bool,
 
   // from redux
-  chart: PropTypes.shape(chartPropShape).isRequired,
+  chart: chartPropShape.isRequired,
   formData: PropTypes.object.isRequired,
   datasource: PropTypes.object.isRequired,
   slice: slicePropShape.isRequired,
@@ -50,7 +50,7 @@ const propTypes = {
   refreshChart: PropTypes.func.isRequired,
   logEvent: PropTypes.func.isRequired,
   toggleExpandSlice: PropTypes.func.isRequired,
-  addFilter: PropTypes.func.isRequired,
+  changeFilter: PropTypes.func.isRequired,
   editMode: PropTypes.bool.isRequired,
   isExpanded: PropTypes.bool.isRequired,
   isCached: PropTypes.bool,
@@ -72,6 +72,7 @@ const SHOULD_UPDATE_ON_PROP_CHANGES = Object.keys(propTypes).filter(
   prop => prop !== 'width' && prop !== 'height',
 );
 const OVERFLOWABLE_VIZ_TYPES = new Set(['filter_box']);
+const DEFAULT_HEADER_HEIGHT = 22;
 
 class Chart extends React.Component {
   constructor(props) {
@@ -81,7 +82,7 @@ class Chart extends React.Component {
       height: props.height,
     };
 
-    this.addFilter = this.addFilter.bind(this);
+    this.changeFilter = this.changeFilter.bind(this);
     this.exploreChart = this.exploreChart.bind(this);
     this.exportCSV = this.exportCSV.bind(this);
     this.forceRefresh = this.forceRefresh.bind(this);
@@ -142,7 +143,9 @@ class Chart extends React.Component {
   }
 
   getHeaderHeight() {
-    return (this.headerRef && this.headerRef.offsetHeight) || 30;
+    return (
+      (this.headerRef && this.headerRef.offsetHeight) || DEFAULT_HEADER_HEIGHT
+    );
   }
 
   setDescriptionRef(ref) {
@@ -158,15 +161,12 @@ class Chart extends React.Component {
     this.setState(() => ({ width, height }));
   }
 
-  addFilter(...[col, vals, merge, refresh]) {
+  changeFilter(newSelectedValues = {}) {
     this.props.logEvent(LOG_ACTIONS_CHANGE_DASHBOARD_FILTER, {
       id: this.props.chart.id,
-      column: col,
-      value_count: Array.isArray(vals) ? vals.length : (vals && 1) || 0,
-      merge,
-      refresh,
+      columns: Object.keys(newSelectedValues),
     });
-    this.props.addFilter(this.props.chart, col, vals, merge, refresh);
+    this.props.changeFilter(this.props.chart.id, newSelectedValues);
   }
 
   exploreChart() {
@@ -277,7 +277,7 @@ class Chart extends React.Component {
           <ChartContainer
             width={width}
             height={this.getChartHeight()}
-            addFilter={this.addFilter}
+            addFilter={this.changeFilter}
             annotationData={chart.annotationData}
             chartAlert={chart.chartAlert}
             chartId={id}

--- a/superset/assets/src/dashboard/components/gridComponents/ChartHolder.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/ChartHolder.jsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import FilterIndicators from '../../containers/FilterIndicators';
 import Chart from '../../containers/Chart';
 import AnchorLink from '../../../components/AnchorLink';
 import DeleteComponentButton from '../DeleteComponentButton';
@@ -27,11 +28,13 @@ import HoverMenu from '../menu/HoverMenu';
 import ResizableContainer from '../resizable/ResizableContainer';
 import { componentShape } from '../../util/propShapes';
 import { ROW_TYPE, COLUMN_TYPE } from '../../util/componentTypes';
+
 import {
   GRID_MIN_COLUMN_COUNT,
   GRID_MIN_ROW_UNITS,
   GRID_BASE_UNIT,
   GRID_GUTTER_SIZE,
+  IN_COMPONENT_ELEMENT_TYPES,
 } from '../../util/constants';
 
 const CHART_MARGIN = 32;
@@ -44,6 +47,7 @@ const propTypes = {
   index: PropTypes.number.isRequired,
   depth: PropTypes.number.isRequired,
   editMode: PropTypes.bool.isRequired,
+  directPathToChild: PropTypes.arrayOf(PropTypes.string),
 
   // grid related
   availableColumnCount: PropTypes.number.isRequired,
@@ -58,9 +62,21 @@ const propTypes = {
   handleComponentDrop: PropTypes.func.isRequired,
 };
 
-const defaultProps = {};
+const defaultProps = {
+  directPathToChild: [],
+};
 
 class ChartHolder extends React.Component {
+  static renderInFocusCSS(labelName) {
+    return (
+      <style>
+        {`.inFocus label[for=${labelName}] + .Select .Select-control {
+                    border: 2px solid #00736a;
+           }`}
+      </style>
+    );
+  }
+
   constructor(props) {
     super(props);
     this.state = {
@@ -70,6 +86,27 @@ class ChartHolder extends React.Component {
     this.handleChangeFocus = this.handleChangeFocus.bind(this);
     this.handleDeleteComponent = this.handleDeleteComponent.bind(this);
     this.handleUpdateSliceName = this.handleUpdateSliceName.bind(this);
+  }
+
+  getChartAndLabelComponentIdFromPath() {
+    const { directPathToChild = [] } = this.props;
+    const result = {};
+
+    if (directPathToChild.length > 0) {
+      const currentPath = directPathToChild.slice();
+
+      while (currentPath.length) {
+        const componentId = currentPath.pop();
+        const componentType = componentId.split('-')[0];
+
+        result[componentType.toLowerCase()] = componentId;
+        if (!IN_COMPONENT_ELEMENT_TYPES.includes(componentType)) {
+          break;
+        }
+      }
+    }
+
+    return result;
   }
 
   handleChangeFocus(nextFocus) {
@@ -118,6 +155,12 @@ class ChartHolder extends React.Component {
         ? parentComponent.meta.width || GRID_MIN_COLUMN_COUNT
         : component.meta.width || GRID_MIN_COLUMN_COUNT;
 
+    const {
+      label: labelName,
+      chart: chartComponentId,
+    } = this.getChartAndLabelComponentIdFromPath();
+    const inFocus = chartComponentId === component.id;
+
     return (
       <DragDroppable
         component={component}
@@ -148,9 +191,14 @@ class ChartHolder extends React.Component {
           >
             <div
               ref={dragSourceRef}
-              className="dashboard-component dashboard-component-chart-holder"
+              className={`dashboard-component dashboard-component-chart-holder ${
+                inFocus ? 'inFocus' : ''
+              }`}
             >
-              {!editMode && <AnchorLink anchorLinkId={component.id} />}
+              {!editMode && (
+                <AnchorLink anchorLinkId={component.id} inFocus={inFocus} />
+              )}
+              {inFocus && ChartHolder.renderInFocusCSS(labelName)}
               <Chart
                 componentId={component.id}
                 id={component.meta.chartId}
@@ -166,6 +214,9 @@ class ChartHolder extends React.Component {
                 updateSliceName={this.handleUpdateSliceName}
                 isComponentVisible={isComponentVisible}
               />
+              {!editMode && (
+                <FilterIndicators chartId={component.meta.chartId} />
+              )}
               {editMode && (
                 <HoverMenu position="top">
                   <DeleteComponentButton

--- a/superset/assets/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Tab.jsx
@@ -54,6 +54,7 @@ const propTypes = {
   handleComponentDrop: PropTypes.func.isRequired,
   deleteComponent: PropTypes.func.isRequired,
   updateComponents: PropTypes.func.isRequired,
+  setDirectPathToChild: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -77,10 +78,15 @@ export default class Tab extends React.PureComponent {
     this.handleDeleteComponent = this.handleDeleteComponent.bind(this);
     this.handleDrop = this.handleDrop.bind(this);
     this.handleTopDropTargetDrop = this.handleTopDropTargetDrop.bind(this);
+    this.handleChangeTab = this.handleChangeTab.bind(this);
   }
 
   handleChangeFocus(nextFocus) {
     this.setState(() => ({ isFocused: nextFocus }));
+  }
+
+  handleChangeTab({ pathToTabIndex }) {
+    this.props.setDirectPathToChild(pathToTabIndex);
   }
 
   handleChangeText(nextTabText) {
@@ -171,6 +177,7 @@ export default class Tab extends React.PureComponent {
             onResize={onResize}
             onResizeStop={onResizeStop}
             isComponentVisible={isComponentVisible}
+            onChangeTab={this.handleChangeTab}
           />
         ))}
         {/* Make bottom of tab droppable */}

--- a/superset/assets/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Tabs.jsx
@@ -26,6 +26,8 @@ import DashboardComponent from '../../containers/DashboardComponent';
 import DeleteComponentButton from '../DeleteComponentButton';
 import HoverMenu from '../menu/HoverMenu';
 import findTabIndexByComponentId from '../../util/findTabIndexByComponentId';
+import getDirectPathToTabIndex from '../../util/getDirectPathToTabIndex';
+import getLeafComponentIdFromPath from '../../util/getLeafComponentIdFromPath';
 import { componentShape } from '../../util/propShapes';
 import { NEW_TAB_ID, DASHBOARD_ROOT_ID } from '../../util/constants';
 import { RENDER_TAB, RENDER_TAB_CONTENT } from './Tab';
@@ -58,7 +60,7 @@ const propTypes = {
   // dnd
   createComponent: PropTypes.func.isRequired,
   handleComponentDrop: PropTypes.func.isRequired,
-  onChangeTab: PropTypes.func,
+  onChangeTab: PropTypes.func.isRequired,
   deleteComponent: PropTypes.func.isRequired,
   updateComponents: PropTypes.func.isRequired,
 };
@@ -70,7 +72,6 @@ const defaultProps = {
   availableColumnCount: 0,
   columnWidth: 0,
   directPathToChild: [],
-  onChangeTab() {},
   onResizeStart() {},
   onResize() {},
   onResizeStop() {},
@@ -79,10 +80,13 @@ const defaultProps = {
 class Tabs extends React.PureComponent {
   constructor(props) {
     super(props);
-    const tabIndex = findTabIndexByComponentId({
-      currentComponent: props.component,
-      directPathToChild: props.directPathToChild,
-    });
+    const tabIndex = Math.max(
+      0,
+      findTabIndexByComponentId({
+        currentComponent: props.component,
+        directPathToChild: props.directPathToChild,
+      }),
+    );
 
     this.state = {
       tabIndex,
@@ -98,14 +102,37 @@ class Tabs extends React.PureComponent {
     if (this.state.tabIndex > maxIndex) {
       this.setState(() => ({ tabIndex: maxIndex }));
     }
+
+    if (nextProps.isComponentVisible) {
+      const nextFocusComponent = getLeafComponentIdFromPath(
+        nextProps.directPathToChild,
+      );
+      const currentFocusComponent = getLeafComponentIdFromPath(
+        this.props.directPathToChild,
+      );
+
+      if (nextFocusComponent !== currentFocusComponent) {
+        const nextTabIndex = findTabIndexByComponentId({
+          currentComponent: nextProps.component,
+          directPathToChild: nextProps.directPathToChild,
+        });
+
+        // make sure nextFocusComponent is under this tabs component
+        if (nextTabIndex > -1 && nextTabIndex !== this.state.tabIndex) {
+          this.setState(() => ({ tabIndex: nextTabIndex }));
+        }
+      }
+    }
   }
 
   handleClickTab(tabIndex, ev) {
-    const target = ev.target;
-    // special handler for clicking on anchor link icon (or whitespace nearby):
-    // will show short link popover but do not change tab
-    if (target.classList.contains('short-link-trigger')) {
-      return;
+    if (ev) {
+      const target = ev.target;
+      // special handler for clicking on anchor link icon (or whitespace nearby):
+      // will show short link popover but do not change tab
+      if (target && target.classList.contains('short-link-trigger')) {
+        return;
+      }
     }
 
     const { component, createComponent } = this.props;
@@ -128,8 +155,8 @@ class Tabs extends React.PureComponent {
         index: tabIndex,
       });
 
-      this.setState(() => ({ tabIndex }));
-      this.props.onChangeTab({ tabIndex, tabId: component.children[tabIndex] });
+      const pathToTabIndex = getDirectPathToTabIndex(component, tabIndex);
+      this.props.onChangeTab({ pathToTabIndex });
     }
   }
 

--- a/superset/assets/src/dashboard/containers/Chart.jsx
+++ b/superset/assets/src/dashboard/containers/Chart.jsx
@@ -19,14 +19,13 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import {
-  changeFilter as addFilter,
-  toggleExpandSlice,
-} from '../actions/dashboardState';
+import { toggleExpandSlice } from '../actions/dashboardState';
 import { updateComponents } from '../actions/dashboardLayout';
+import { changeFilter } from '../actions/dashboardFilters';
 import { addDangerToast } from '../../messageToasts/actions';
 import { refreshChart } from '../../chart/chartAction';
 import { logEvent } from '../../logger/actions';
+import { getActiveFilters } from '../util/activeDashboardFilters';
 import getFormDataWithExtraFilters from '../util/charts/getFormDataWithExtraFilters';
 import Chart from '../components/gridComponents/Chart';
 
@@ -44,7 +43,8 @@ function mapStateToProps(
 ) {
   const { id } = ownProps;
   const chart = chartQueries[id] || {};
-  const { filters, colorScheme, colorNamespace } = dashboardState;
+  const { colorScheme, colorNamespace } = dashboardState;
+  const filters = getActiveFilters();
 
   return {
     chart,
@@ -77,7 +77,7 @@ function mapDispatchToProps(dispatch) {
       updateComponents,
       addDangerToast,
       toggleExpandSlice,
-      addFilter,
+      changeFilter,
       refreshChart,
       logEvent,
     },

--- a/superset/assets/src/dashboard/containers/Dashboard.jsx
+++ b/superset/assets/src/dashboard/containers/Dashboard.jsx
@@ -28,6 +28,7 @@ import {
 import { triggerQuery } from '../../chart/chartAction';
 import { logEvent } from '../../logger/actions';
 import getLoadStatsPerTopLevelComponent from '../util/logging/getLoadStatsPerTopLevelComponent';
+import { getActiveFilters } from '../util/activeDashboardFilters';
 
 function mapStateToProps(state) {
   const {
@@ -48,6 +49,11 @@ function mapStateToProps(state) {
     dashboardState,
     charts,
     datasources,
+    // filters prop: All the filter_box's state in this dashboard
+    // When dashboard is first loaded into browser,
+    // its value is from preselect_filters that dashboard owner saved in dashboard's meta data
+    // When user start interacting with dashboard, it will be user picked values from all filter_box
+    filters: getActiveFilters(),
     slices: sliceEntities.slices,
     layout: dashboardLayout.present,
     impressionId,

--- a/superset/assets/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset/assets/src/dashboard/containers/DashboardComponent.jsx
@@ -23,6 +23,7 @@ import { connect } from 'react-redux';
 
 import ComponentLookup from '../components/gridComponents';
 import getDetailedComponentWidth from '../util/getDetailedComponentWidth';
+import { getActiveFilters } from '../util/activeDashboardFilters';
 import { componentShape } from '../util/propShapes';
 import { COLUMN_TYPE, ROW_TYPE } from '../util/componentTypes';
 
@@ -32,7 +33,7 @@ import {
   updateComponents,
   handleComponentDrop,
 } from '../actions/dashboardLayout';
-
+import { setDirectPathToChild } from '../actions/dashboardState';
 import { logEvent } from '../../logger/actions';
 
 const propTypes = {
@@ -62,7 +63,7 @@ function mapStateToProps(
     component,
     parentComponent: dashboardLayout[parentId],
     editMode: dashboardState.editMode,
-    filters: dashboardState.filters,
+    filters: getActiveFilters(),
     directPathToChild: dashboardState.directPathToChild,
   };
 
@@ -91,6 +92,7 @@ function mapDispatchToProps(dispatch) {
       deleteComponent,
       updateComponents,
       handleComponentDrop,
+      setDirectPathToChild,
       logEvent,
     },
     dispatch,

--- a/superset/assets/src/dashboard/containers/DashboardHeader.jsx
+++ b/superset/assets/src/dashboard/containers/DashboardHeader.jsx
@@ -51,8 +51,8 @@ import {
 } from '../../messageToasts/actions';
 
 import { logEvent } from '../../logger/actions';
-
 import { DASHBOARD_HEADER_ID } from '../util/constants';
+import { getActiveFilters } from '../util/activeDashboardFilters';
 
 function mapStateToProps({
   dashboardLayout: undoableLayout,
@@ -65,7 +65,7 @@ function mapStateToProps({
     undoLength: undoableLayout.past.length,
     redoLength: undoableLayout.future.length,
     layout: undoableLayout.present,
-    filters: dashboardState.filters,
+    filters: getActiveFilters(),
     dashboardTitle: (
       (undoableLayout.present[DASHBOARD_HEADER_ID] || {}).meta || {}
     ).text,

--- a/superset/assets/src/dashboard/containers/FilterIndicators.jsx
+++ b/superset/assets/src/dashboard/containers/FilterIndicators.jsx
@@ -16,38 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import DashboardBuilder from '../components/DashboardBuilder';
+import { bindActionCreators } from 'redux';
 
-import {
-  setColorSchemeAndUnsavedChanges,
-  showBuilderPane,
-  setDirectPathToChild,
-} from '../actions/dashboardState';
-import {
-  deleteTopLevelTabs,
-  handleComponentDrop,
-} from '../actions/dashboardLayout';
+import FilterIndicatorsContainer from '../components/FilterIndicatorsContainer';
+import { setDirectPathToChild } from '../actions/dashboardState';
 
-function mapStateToProps({ dashboardLayout: undoableLayout, dashboardState }) {
+function mapStateToProps(
+  { dashboardFilters, dashboardInfo, charts },
+  ownProps,
+) {
+  const chartId = ownProps.chartId;
+  const chartStatus = charts[chartId].chartStatus;
+
   return {
-    dashboardLayout: undoableLayout.present,
-    editMode: dashboardState.editMode,
-    showBuilderPane: dashboardState.showBuilderPane,
-    directPathToChild: dashboardState.directPathToChild,
-    builderPaneType: dashboardState.builderPaneType,
-    colorScheme: dashboardState.colorScheme,
+    dashboardFilters,
+    chartId,
+    chartStatus,
+    filterImmuneSlices: dashboardInfo.metadata.filterImmuneSlices || [],
+    filterImmuneSliceFields:
+      dashboardInfo.metadata.filterImmuneSliceFields || {},
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
-      deleteTopLevelTabs,
-      handleComponentDrop,
-      showBuilderPane,
-      setColorSchemeAndUnsavedChanges,
       setDirectPathToChild,
     },
     dispatch,
@@ -57,4 +51,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(DashboardBuilder);
+)(FilterIndicatorsContainer);

--- a/superset/assets/src/dashboard/reducers/dashboardFilters.js
+++ b/superset/assets/src/dashboard/reducers/dashboardFilters.js
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-disable camelcase */
+import { DASHBOARD_ROOT_ID } from '../util/constants';
+import {
+  ADD_FILTER,
+  REMOVE_FILTER,
+  CHANGE_FILTER,
+  UPDATE_DIRECT_PATH_TO_FILTER,
+} from '../actions/dashboardFilters';
+import { TIME_RANGE } from '../../visualizations/FilterBox/FilterBox';
+import getFilterConfigsFromFormdata from '../util/getFilterConfigsFromFormdata';
+import { buildFilterColorMap } from '../util/dashboardFiltersColorMap';
+import { buildActiveFilters } from '../util/activeDashboardFilters';
+
+export const dashboardFilter = {
+  chartId: 0,
+  componentId: '',
+  directPathToFilter: [],
+  scope: DASHBOARD_ROOT_ID,
+  isDateFilter: false,
+  isInstantFilter: true,
+  columns: {},
+};
+
+export default function dashboardFiltersReducer(dashboardFilters = {}, action) {
+  const actionHandlers = {
+    [ADD_FILTER]() {
+      const { chartId, component, form_data } = action;
+      const { columns, labels } = getFilterConfigsFromFormdata(form_data);
+      const directPathToFilter = component
+        ? (component.parents || []).slice().concat(component.id)
+        : [];
+
+      const newFilter = {
+        ...dashboardFilter,
+        chartId,
+        componentId: component.id,
+        directPathToFilter,
+        columns,
+        labels,
+        isInstantFilter: !!form_data.instant_filtering,
+        isDateFilter: Object.keys(columns).includes(TIME_RANGE),
+      };
+
+      return newFilter;
+    },
+
+    [CHANGE_FILTER](state) {
+      const { newSelectedValues, merge } = action;
+      const updatedColumns = Object.keys(newSelectedValues).reduce(
+        (columns, name) => {
+          // override existed column value, or add new column name
+          if (!merge || !(name in columns)) {
+            return {
+              ...columns,
+              [name]: newSelectedValues[name],
+            };
+          }
+
+          return {
+            ...columns,
+            [name]: [...columns[name], ...newSelectedValues[name]],
+          };
+        },
+        { ...state.columns },
+      );
+
+      return {
+        ...state,
+        columns: updatedColumns,
+      };
+    },
+
+    [UPDATE_DIRECT_PATH_TO_FILTER](state) {
+      const { path } = action;
+      return {
+        ...state,
+        directPathToFilter: path,
+      };
+    },
+  };
+
+  if (action.type === REMOVE_FILTER) {
+    const { chartId } = action;
+    const { [chartId]: deletedFilter, ...updatedFilters } = dashboardFilters;
+    buildActiveFilters(updatedFilters);
+    buildFilterColorMap(updatedFilters);
+
+    return updatedFilters;
+  } else if (action.type in actionHandlers) {
+    const updatedFilters = {
+      ...dashboardFilters,
+      [action.chartId]: actionHandlers[action.type](
+        dashboardFilters[action.chartId],
+      ),
+    };
+    buildActiveFilters(updatedFilters);
+    buildFilterColorMap(updatedFilters);
+
+    return updatedFilters;
+  }
+
+  return dashboardFilters;
+}

--- a/superset/assets/src/dashboard/reducers/dashboardState.js
+++ b/superset/assets/src/dashboard/reducers/dashboardState.js
@@ -19,7 +19,6 @@
 /* eslint-disable camelcase */
 import {
   ADD_SLICE,
-  CHANGE_FILTER,
   ON_CHANGE,
   ON_SAVE,
   REMOVE_SLICE,
@@ -33,6 +32,7 @@ import {
   TOGGLE_PUBLISHED,
   UPDATE_CSS,
   SET_REFRESH_FREQUENCY,
+  SET_DIRECT_PATH,
 } from '../actions/dashboardState';
 import { BUILDER_PANE_TYPE } from '../util/constants';
 
@@ -54,19 +54,9 @@ export default function dashboardStateReducer(state = {}, action) {
       const updatedSliceIds = new Set(state.sliceIds);
       updatedSliceIds.delete(sliceId);
 
-      const key = sliceId;
-      // if this slice is a filter
-      const newFilter = { ...state.filters };
-      let refresh = false;
-      if (state.filters[key]) {
-        delete newFilter[key];
-        refresh = true;
-      }
       return {
         ...state,
         sliceIds: Array.from(updatedSliceIds),
-        filters: newFilter,
-        refresh,
       };
     },
     [TOGGLE_FAVE_STAR]() {
@@ -121,46 +111,6 @@ export default function dashboardStateReducer(state = {}, action) {
         updatedColorScheme: false,
       };
     },
-
-    [CHANGE_FILTER]() {
-      const hasSelectedFilter = state.sliceIds.includes(action.chart.id);
-      if (!hasSelectedFilter) {
-        return state;
-      }
-
-      let filters = state.filters;
-      const { chart, col, vals: nextVals, merge, refresh } = action;
-      const sliceId = chart.id;
-      let newFilter = {};
-      if (!(sliceId in filters)) {
-        // if no filters existed for the slice, set them
-        newFilter = { [col]: nextVals };
-      } else if ((filters[sliceId] && !(col in filters[sliceId])) || !merge) {
-        // If no filters exist for this column, or we are overwriting them
-        newFilter = { ...filters[sliceId], [col]: nextVals };
-      } else if (filters[sliceId][col] instanceof Array) {
-        newFilter[col] = [...filters[sliceId][col], ...nextVals];
-      } else {
-        newFilter[col] = [filters[sliceId][col], ...nextVals];
-      }
-      filters = { ...filters, [sliceId]: newFilter };
-
-      // remove any empty filters so they don't pollute the logs
-      Object.keys(filters).forEach(chartId => {
-        Object.keys(filters[chartId]).forEach(column => {
-          if (
-            !filters[chartId][column] ||
-            filters[chartId][column].length === 0
-          ) {
-            delete filters[chartId][column];
-          }
-        });
-        if (Object.keys(filters[chartId]).length === 0) {
-          delete filters[chartId];
-        }
-      });
-      return { ...state, filters, refresh };
-    },
     [SET_UNSAVED_CHANGES]() {
       const { hasUnsavedChanges } = action.payload;
       return { ...state, hasUnsavedChanges };
@@ -170,6 +120,12 @@ export default function dashboardStateReducer(state = {}, action) {
         ...state,
         refreshFrequency: action.refreshFrequency,
         hasUnsavedChanges: true,
+      };
+    },
+    [SET_DIRECT_PATH]() {
+      return {
+        ...state,
+        directPathToChild: action.path,
       };
     },
   };

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -22,12 +22,11 @@ import shortid from 'shortid';
 import { CategoricalColorNamespace } from '@superset-ui/color';
 
 import { chart } from '../../chart/chartReducer';
+import { dashboardFilter } from './dashboardFilters';
 import { initSliceEntities } from './sliceEntities';
 import { getParam } from '../../modules/utils';
 import { applyDefaultFormData } from '../../explore/store';
-import findFirstParentContainerId from '../util/findFirstParentContainer';
-import getEmptyLayout from '../util/getEmptyLayout';
-import newComponentFactory from '../util/newComponentFactory';
+import { buildActiveFilters } from '../util/activeDashboardFilters';
 import {
   BUILDER_PANE_TYPE,
   DASHBOARD_HEADER_ID,
@@ -39,15 +38,22 @@ import {
   CHART_TYPE,
   ROW_TYPE,
 } from '../util/componentTypes';
+import { buildFilterColorMap } from '../util/dashboardFiltersColorMap';
+import findFirstParentContainerId from '../util/findFirstParentContainer';
+import getEmptyLayout from '../util/getEmptyLayout';
+import getFilterConfigsFromFormdata from '../util/getFilterConfigsFromFormdata';
+import getLocationHash from '../util/getLocationHash';
+import newComponentFactory from '../util/newComponentFactory';
+import { TIME_RANGE } from '../../visualizations/FilterBox/FilterBox';
 
 export default function(bootstrapData) {
   const { user_id, datasources, common, editMode } = bootstrapData;
 
   const dashboard = { ...bootstrapData.dashboard_data };
-  let filters = {};
+  let preselectFilters = {};
   try {
     // allow request parameter overwrite dashboard metadata
-    filters = JSON.parse(
+    preselectFilters = JSON.parse(
       getParam('preselect_filters') || dashboard.metadata.default_filters,
     );
   } catch (e) {
@@ -93,6 +99,7 @@ export default function(bootstrapData) {
   let newSlicesContainerWidth = 0;
 
   const chartQueries = {};
+  const dashboardFilters = {};
   const slices = {};
   const sliceIds = new Set();
   dashboard.slices.forEach(slice => {
@@ -127,21 +134,61 @@ export default function(bootstrapData) {
           newSlicesContainerWidth === 0 ||
           newSlicesContainerWidth + GRID_DEFAULT_CHART_WIDTH > GRID_COLUMN_COUNT
         ) {
-          newSlicesContainer = newComponentFactory(ROW_TYPE);
+          newSlicesContainer = newComponentFactory(
+            ROW_TYPE,
+            (parent.parents || []).slice(),
+          );
           layout[newSlicesContainer.id] = newSlicesContainer;
           parent.children.push(newSlicesContainer.id);
           newSlicesContainerWidth = 0;
         }
 
-        const chartHolder = newComponentFactory(CHART_TYPE, {
-          chartId: slice.slice_id,
-        });
+        const chartHolder = newComponentFactory(
+          CHART_TYPE,
+          {
+            chartId: slice.slice_id,
+          },
+          (newSlicesContainer.parents || []).slice(),
+        );
 
         layout[chartHolder.id] = chartHolder;
         newSlicesContainer.children.push(chartHolder.id);
         chartIdToLayoutId[chartHolder.meta.chartId] = chartHolder.id;
         newSlicesContainerWidth += GRID_DEFAULT_CHART_WIDTH;
       }
+
+      // build DashboardFilters for interactive filter features
+      if (slice.form_data.viz_type === 'filter_box') {
+        const configs = getFilterConfigsFromFormdata(slice.form_data);
+        let columns = configs.columns;
+        const labels = configs.labels;
+        if (preselectFilters[key]) {
+          Object.keys(columns).forEach(col => {
+            if (preselectFilters[key][col]) {
+              columns = {
+                ...columns,
+                [col]: preselectFilters[key][col],
+              };
+            }
+          });
+        }
+
+        const componentId = chartIdToLayoutId[key];
+        const directPathToFilter = (layout[componentId].parents || []).slice();
+        directPathToFilter.push(componentId);
+        dashboardFilters[key] = {
+          ...dashboardFilter,
+          chartId: key,
+          componentId,
+          directPathToFilter,
+          columns,
+          labels,
+          isInstantFilter: !!slice.form_data.instant_filtering,
+          isDateFilter: Object.keys(columns).includes(TIME_RANGE),
+        };
+      }
+      buildActiveFilters(dashboardFilters);
+      buildFilterColorMap(dashboardFilters);
     }
 
     // sync layout names with current slice names in case a slice was edited
@@ -169,7 +216,7 @@ export default function(bootstrapData) {
   };
 
   // find direct link component and path from root
-  const directLinkComponentId = (window.location.hash || '#').substring(1);
+  const directLinkComponentId = getLocationHash();
   let directPathToChild = [];
   if (layout[directLinkComponentId]) {
     directPathToChild = (layout[directLinkComponentId].parents || []).slice();
@@ -185,9 +232,9 @@ export default function(bootstrapData) {
       id: dashboard.id,
       slug: dashboard.slug,
       metadata: {
-        filter_immune_slice_fields:
+        filterImmuneSliceFields:
           dashboard.metadata.filter_immune_slice_fields || {},
-        filter_immune_slices: dashboard.metadata.filter_immune_slices || [],
+        filterImmuneSlices: dashboard.metadata.filter_immune_slices || [],
         timed_refresh_immune_slices:
           dashboard.metadata.timed_refresh_immune_slices,
       },
@@ -202,14 +249,9 @@ export default function(bootstrapData) {
         conf: common.conf,
       },
     },
+    dashboardFilters,
     dashboardState: {
       sliceIds: Array.from(sliceIds),
-      refresh: false,
-      // All the filter_box's state in this dashboard
-      // When dashboard is first loaded into browser,
-      // its value is from preselect_filters that dashboard owner saved in dashboard's meta data
-      // When user start interacting with dashboard, it will be user picked values from all filter_box
-      filters,
       directPathToChild,
       expandedSlices: dashboard.metadata.expanded_slices || {},
       refreshFrequency: dashboard.metadata.refresh_frequency || 0,

--- a/superset/assets/src/dashboard/reducers/index.js
+++ b/superset/assets/src/dashboard/reducers/index.js
@@ -20,6 +20,7 @@ import { combineReducers } from 'redux';
 
 import charts from '../../chart/chartReducer';
 import dashboardState from './dashboardState';
+import dashboardFilters from './dashboardFilters';
 import datasources from './datasources';
 import sliceEntities from './sliceEntities';
 import dashboardLayout from '../reducers/undoableDashboardLayout';
@@ -32,6 +33,7 @@ export default combineReducers({
   charts,
   datasources,
   dashboardInfo,
+  dashboardFilters,
   dashboardState,
   dashboardLayout,
   impressionId,

--- a/superset/assets/src/dashboard/stylesheets/filter-indicator-tooltip.less
+++ b/superset/assets/src/dashboard/stylesheets/filter-indicator-tooltip.less
@@ -16,17 +16,57 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
+#filter-indicator-tooltip {
+  font-size: 15px;
+  text-align: left;
 
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+  > .tooltip-arrow {
+    margin-right: 8px;
+    border-left-color: #484848;
+  }
+
+  > .tooltip-inner {
+    width: 200px;
+    max-width: 200px;
+    border-radius: 4px;
+    margin-right: 8px;
+    padding: 16px 12px;
+    background-color: #484848;
+    text-align: left;
+  }
+}
+
+.tooltip-item {
+  position: relative;
+
+  .filter-content {
+    line-height: 22px;
+    margin-right: 22px;
+    text-align: left;
+
+    label {
+      font-weight: 700;
+      white-space: nowrap;
+    }
+  }
+
+  .filter-edit {
+    position: absolute;
+    top: 4px;
+    right: 0;
+  }
+}
+
+.group-title {
+  margin-bottom: 8px;
+}
+
+.tooltip-group {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    margin-bottom: 8px;
+  }
+}

--- a/superset/assets/src/dashboard/stylesheets/filter-indicator.less
+++ b/superset/assets/src/dashboard/stylesheets/filter-indicator.less
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+.dashboard-filter-indicators-container {
+  position: absolute;
+  right: -20px;
+  top: 40px;
+  width: 20px;
+  height: 125px;
+
+  .indicator-container {
+    position: relative;
+    margin-bottom: 4px;
+  }
+
+  .filter-indicator,
+  .filter-indicator-group {
+    width: 3px;
+    height: 20px;
+    overflow: hidden;
+    display: flex;
+    background-color: #bababa;
+    transition: width 0.3s;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+
+    .color-bar {
+      width: 0px;
+      height: 20px;
+      position: absolute;
+      right: 100%;
+      transition: width 0.3s;
+    }
+
+    .filter-badge {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .filter-indicator-group {
+    box-shadow: rgb(255, 255, 255) -2px 0 0 0, rgb(219, 219, 219) -4px 0 0 0;
+  }
+}
+
+.inFocus .filter-indicator-group {
+  box-shadow: rgba(0, 166, 153, 1) -2px 0 0 0, rgb(255, 255, 255) -4px 0 0 0, rgb(219, 219, 219) -6px 0 0 0;
+}
+
+.dashboard-component-chart-holder:hover,
+.dashboard-filter-indicators-container:hover {
+  .filter-indicator,
+  .filter-indicator-group {
+    width: 20px;
+    background-color: transparent;
+
+    .color-bar {
+      width: 2px;
+
+      &.badge-group {
+        background-color: rgb(72, 72, 72);
+      }
+    }
+
+    .filter-badge {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+
+  .filter-indicator-group {
+    box-shadow: rgb(255, 255, 255) -4px 0 0 0, rgb(219, 219, 219) -6px 0 0 0;
+  }
+}
+
+.inFocus {
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 2px rgba(0, 166, 153, 1), 0 0 0 3px rgba(0, 166, 153, .15);
+}

--- a/superset/assets/src/dashboard/stylesheets/grid.less
+++ b/superset/assets/src/dashboard/stylesheets/grid.less
@@ -18,7 +18,7 @@
  */
 .grid-container {
   position: relative;
-  margin: 24px;
+  margin: 24px 36px 24px;
   /* without this, the grid will not get smaller upon toggling the builder panel on */
   min-width: 0;
   width: 100%;

--- a/superset/assets/src/dashboard/stylesheets/variables.less
+++ b/superset/assets/src/dashboard/stylesheets/variables.less
@@ -36,3 +36,40 @@
 @success: #00BFA5;
 @warning: #FFAB00;
 @danger: @pink;
+
+/* filter indicators */
+/* make sure be consistent with FILTER_COLORS_COUNT in
+   dashboardFiltersColorMap.js
+*/
+@badge-colors:
+  #228be6,
+  #40c057,
+  #fab005,
+  #f76707,
+  #e64980,
+  #15aabf,
+  #7950f2,
+  #fa5252,
+  #74b816,
+  #12b886,
+  #1864ab,
+  #2b8a3e,
+  #e67700,
+  #d9480f,
+  #a61e4d,
+  #0b7285,
+  #5f3dc4,
+  #c92a2a,
+  #5c940d,
+  #087f5b;
+
+@iterations: length(@badge-colors);
+.badge-loop (@i) when (@i > 0) {
+  .filter-badge.badge-@{i},
+  .dashboard-component-chart-holder:hover .color-bar.badge-@{i} {
+    @value:  extract(@badge-colors, @i);
+    background-color: @value;
+  }
+  .badge-loop(@i - 1);
+}
+.badge-loop (@iterations);

--- a/superset/assets/src/dashboard/util/activeDashboardFilters.js
+++ b/superset/assets/src/dashboard/util/activeDashboardFilters.js
@@ -16,34 +16,35 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import DashboardGrid from '../components/DashboardGrid';
+let activeFilters = {};
 
-import {
-  handleComponentDrop,
-  resizeComponent,
-} from '../actions/dashboardLayout';
-import { setDirectPathToChild } from '../actions/dashboardState';
-
-function mapStateToProps({ dashboardState }) {
-  return {
-    editMode: dashboardState.editMode,
-  };
+export function getActiveFilters() {
+  return activeFilters;
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    {
-      handleComponentDrop,
-      resizeComponent,
-      setDirectPathToChild,
+// non-empty filters from dashboardFilters,
+// this function does not take into account: filter immune or filter scope settings
+export function buildActiveFilters(allDashboardFilters = {}) {
+  activeFilters = Object.values(allDashboardFilters).reduce(
+    (result, filter) => {
+      const { chartId, columns } = filter;
+
+      Object.keys(columns).forEach(key => {
+        if (
+          Array.isArray(columns[key])
+            ? columns[key].length
+            : columns[key] !== undefined
+        ) {
+          /* eslint-disable no-param-reassign */
+          result[chartId] = {
+            ...result[chartId],
+            [key]: columns[key],
+          };
+        }
+      });
+
+      return result;
     },
-    dispatch,
+    {},
   );
 }
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DashboardGrid);

--- a/superset/assets/src/dashboard/util/charts/getEffectiveExtraFilters.js
+++ b/superset/assets/src/dashboard/util/charts/getEffectiveExtraFilters.js
@@ -21,7 +21,7 @@ export default function getEffectiveExtraFilters({
   filters,
   sliceId,
 }) {
-  const immuneSlices = dashboardMetadata.filter_immune_slices || [];
+  const immuneSlices = dashboardMetadata.filterImmuneSlices || [];
 
   if (sliceId && immuneSlices.includes(sliceId)) {
     // The slice is immune to dashboard filters
@@ -33,10 +33,10 @@ export default function getEffectiveExtraFilters({
   let immuneToFields = [];
   if (
     sliceId &&
-    dashboardMetadata.filter_immune_slice_fields &&
-    dashboardMetadata.filter_immune_slice_fields[sliceId]
+    dashboardMetadata.filterImmuneSliceFields &&
+    dashboardMetadata.filterImmuneSliceFields[sliceId]
   ) {
-    immuneToFields = dashboardMetadata.filter_immune_slice_fields[sliceId];
+    immuneToFields = dashboardMetadata.filterImmuneSliceFields[sliceId];
   }
 
   Object.keys(filters).forEach(filteringSliceId => {

--- a/superset/assets/src/dashboard/util/constants.js
+++ b/superset/assets/src/dashboard/util/constants.js
@@ -69,3 +69,10 @@ export const BUILDER_PANE_TYPE = {
   ADD_COMPONENTS: 'ADD_COMPONENTS',
   COLORS: 'COLORS',
 };
+
+// filter indicators display length
+export const FILTER_INDICATORS_DISPLAY_LENGTH = 4;
+
+// in-component element types: can be added into
+// directPathToChild, used for in dashboard navigation and focus
+export const IN_COMPONENT_ELEMENT_TYPES = ['LABEL'];

--- a/superset/assets/src/dashboard/util/dashboardFiltersColorMap.js
+++ b/superset/assets/src/dashboard/util/dashboardFiltersColorMap.js
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// should be consistent with @badge-colors .less variable
+const FILTER_COLORS_COUNT = 20;
+
+let filterColorMap = {};
+
+export function getFilterColorKey(chartId, column) {
+  return `${chartId}_${column}`;
+}
+
+export function getFilterColorMap() {
+  return filterColorMap;
+}
+
+export function buildFilterColorMap(allDashboardFilters = {}) {
+  let filterColorIndex = 1;
+  filterColorMap = Object.values(allDashboardFilters).reduce(
+    (colorMap, filter) => {
+      const { chartId, columns } = filter;
+
+      Object.keys(columns)
+        .sort()
+        .forEach(column => {
+          const key = getFilterColorKey(chartId, column);
+          const colorCode = `badge-${filterColorIndex % FILTER_COLORS_COUNT}`;
+          /* eslint-disable no-param-reassign */
+          colorMap[key] = colorCode;
+
+          filterColorIndex += 1;
+        });
+
+      return colorMap;
+    },
+    {},
+  );
+}

--- a/superset/assets/src/dashboard/util/findTabIndexByComponentId.js
+++ b/superset/assets/src/dashboard/util/findTabIndexByComponentId.js
@@ -25,7 +25,7 @@ export default function findTabIndexByComponentId({
     directPathToChild.length === 0 ||
     directPathToChild.indexOf(currentComponent.id) === -1
   ) {
-    return 0;
+    return -1;
   }
 
   const currentComponentIdx = directPathToChild.findIndex(
@@ -37,5 +37,5 @@ export default function findTabIndexByComponentId({
       childId => childId === nextParentId,
     );
   }
-  return 0;
+  return -1;
 }

--- a/superset/assets/src/dashboard/util/getDirectPathToTabIndex.js
+++ b/superset/assets/src/dashboard/util/getDirectPathToTabIndex.js
@@ -16,17 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
+export default function getDirectPathToTabIndex(tabsComponent, tabIndex) {
+  const directPathToFilter = (tabsComponent.parents || []).slice();
+  directPathToFilter.push(tabsComponent.id);
+  directPathToFilter.push(tabsComponent.children[tabIndex]);
 
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+  return directPathToFilter;
+}

--- a/superset/assets/src/dashboard/util/getFilterConfigsFromFormdata.js
+++ b/superset/assets/src/dashboard/util/getFilterConfigsFromFormdata.js
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-disable camelcase */
+import {
+  TIME_RANGE,
+  FILTER_LABELS,
+} from '../../visualizations/FilterBox/FilterBox';
+
+export default function getFilterConfigsFromFormdata(form_data = {}) {
+  const { date_filter, filter_configs = [] } = form_data;
+  let configs = filter_configs.reduce(
+    ({ columns, labels }, config) => {
+      const updatedColumns = {
+        ...columns,
+        [config.column]: config.vals,
+      };
+      const updatedLabels = {
+        ...labels,
+        [config.column]: config.label,
+      };
+
+      return {
+        columns: updatedColumns,
+        labels: updatedLabels,
+      };
+    },
+    { columns: {}, labels: {} },
+  );
+
+  if (date_filter) {
+    const updatedColumns = {
+      ...configs.columns,
+      [TIME_RANGE]: form_data[TIME_RANGE],
+    };
+    const updatedLabels = {
+      ...configs.labels,
+      [TIME_RANGE]: FILTER_LABELS[TIME_RANGE],
+    };
+
+    configs = {
+      ...configs,
+      columns: updatedColumns,
+      labels: updatedLabels,
+    };
+  }
+  return configs;
+}

--- a/superset/assets/src/dashboard/util/getLayoutComponentFromChartId.js
+++ b/superset/assets/src/dashboard/util/getLayoutComponentFromChartId.js
@@ -16,17 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
+/* eslint-disable no-param-reassign */
+import { CHART_TYPE } from './componentTypes';
 
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+export default function getLayoutComponentFromChartId(layout, chartId) {
+  return Object.values(layout).find(
+    currentComponent =>
+      currentComponent &&
+      currentComponent.type === CHART_TYPE &&
+      currentComponent.meta &&
+      currentComponent.meta.chartId === chartId,
+  );
+}

--- a/superset/assets/src/dashboard/util/getLeafComponentIdFromPath.js
+++ b/superset/assets/src/dashboard/util/getLeafComponentIdFromPath.js
@@ -16,17 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
+import { IN_COMPONENT_ELEMENT_TYPES } from './constants';
 
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+export default function getLeafComponentIdFromPath(directPathToChild = []) {
+  if (directPathToChild.length > 0) {
+    const currentPath = directPathToChild.slice();
+
+    while (currentPath.length) {
+      const componentId = currentPath.pop();
+      const componentType = componentId.split('-')[0];
+
+      if (!IN_COMPONENT_ELEMENT_TYPES.includes(componentType)) {
+        return componentId;
+      }
+    }
+  }
+
+  return null;
+}

--- a/superset/assets/src/dashboard/util/getLocationHash.js
+++ b/superset/assets/src/dashboard/util/getLocationHash.js
@@ -16,17 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@import './variables.less';
-
-@import './builder.less';
-@import './builder-sidepane.less';
-@import './buttons.less';
-@import './dashboard.less';
-@import './dnd.less';
-@import './filter-indicator.less';
-@import './filter-indicator-tooltip.less';
-@import './grid.less';
-@import './hover-menu.less';
-@import './popover-menu.less';
-@import './resizable.less';
-@import './components/index.less';
+export default function getLocationHash() {
+  return (window.location.hash || '#').substring(1);
+}

--- a/superset/assets/src/dashboard/util/newComponentFactory.js
+++ b/superset/assets/src/dashboard/util/newComponentFactory.js
@@ -57,11 +57,12 @@ function uuid(type) {
   return `${type}-${shortid.generate()}`;
 }
 
-export default function entityFactory(type, meta) {
+export default function entityFactory(type, meta, parents = []) {
   return {
     type,
     id: uuid(type),
     children: [],
+    parents,
     meta: {
       ...typeToDefaultMetaData[type],
       ...meta,

--- a/superset/assets/src/dashboard/util/propShapes.jsx
+++ b/superset/assets/src/dashboard/util/propShapes.jsx
@@ -66,10 +66,21 @@ export const slicePropShape = PropTypes.shape({
   description_markeddown: PropTypes.string,
 });
 
+export const filterIndicatorPropShape = PropTypes.shape({
+  chartId: PropTypes.number.isRequired,
+  colorCode: PropTypes.string.isRequired,
+  componentId: PropTypes.string.isRequired,
+  directPathToFilter: PropTypes.arrayOf(PropTypes.string).isRequired,
+  isDateFilter: PropTypes.bool.isRequired,
+  isInstantFilter: PropTypes.bool.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  scope: PropTypes.string.isRequired,
+  values: PropTypes.array.isRequired,
+});
+
 export const dashboardStatePropShape = PropTypes.shape({
   sliceIds: PropTypes.arrayOf(PropTypes.number).isRequired,
-  refresh: PropTypes.bool.isRequired,
-  filters: PropTypes.object.isRequired,
   expandedSlices: PropTypes.object,
   editMode: PropTypes.bool,
   isPublished: PropTypes.bool.isRequired,

--- a/superset/assets/src/visualizations/FilterBox/FilterBox.css
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.css
@@ -45,7 +45,7 @@ ul.select2-results div.filter_box{
     border-color: transparent;
 }
 .filter_box {
-    padding: 10px;
+    padding: 10px 0;
     overflow: visible !important;
 }
 .filter_box:hover {
@@ -53,4 +53,18 @@ ul.select2-results div.filter_box{
 }
 .m-b-5 {
     margin-bottom: 5px;
+}
+.filter-container {
+    display: flex;
+}
+.filter-container label {
+    display: flex;
+    font-weight: bold;
+    margin-bottom: 8px;
+}
+.filter-container .filter-badge-container {
+    width: 30px;
+}
+.filter-container .filter-badge-container + div {
+    width: 100%;
 }

--- a/superset/assets/src/visualizations/FilterBox/transformProps.js
+++ b/superset/assets/src/visualizations/FilterBox/transformProps.js
@@ -26,6 +26,7 @@ export default function transformProps(chartProps) {
     rawDatasource,
   } = chartProps;
   const {
+    sliceId,
     dateFilter,
     instantFiltering,
     showDruidTimeGranularity,
@@ -43,6 +44,7 @@ export default function transformProps(chartProps) {
   }));
 
   return {
+    chartId: sliceId,
     datasource: rawDatasource,
     filtersFields,
     filtersChoices: payload.data,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [x] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

1. Show indicator on each chart which filter can apply and what filter values are applied
2. Allow user navigate from chart to any of its applicable filter.

### Implementation

- Refactor `filters` in redux state.

Before this PR, `filters` state is a sub-state in `dashboardstate`:
```
dashboard redux state:

{
    datasources,
    sliceEntities,
    charts,
    dashboardInfo,
    dashboardState: {
      ...
      filters: {
        124: {
           __time_range: 'Last quarter',
        },
        131: {
           gender: ['boy', 'girl'],
        }
      }
      ...
    },
    dashboardLayout,
    messageToasts: [],
    impressionId: shortid.generate(),
}
```
In order to support UI features and in-dashboard navigation functionality, I move **`dashboardFilter`** up to be **root-level state** in redux store, and it will contain more props about filter value and its layout information:
```
dashboard redux state:

{
    datasources,
    sliceEntities,
    charts,
    dashboardInfo,
    dashboardState,
    dashboardFilters: {
      124: {
        chartId: 124,
        componentId: "CHART-CHTxAXRuJW",
        directPathToFilter: [
          'ROOT_ID',
          'TABS-VPEX_c476g',
          'TAB-1bnpXJkoS8',
          'ROW-qc1WPC4bOn',
          'CHART-CHTxAXRuJW'
        ],
        scope: "ROOT_ID",
        isDateFilter: true,
        isInstantFilter: true,
        columns: {
          __time_range(pin): "Last quarter",
        }
      },
      131: {
        ...
      }
    },
    dashboardLayout,
    messageToasts: [],
    impressionId: shortid.generate(),
}
```
Because `filters` prop is used by a lot of components in dashboard, I added a converter utility function [`buildActiveFilters`](https://github.com/apache/incubator-superset/blob/2e92ec9ade844866932a721e6b486fbf8b8df0ef/superset/assets/src/dashboard/util/activeDashboardFilters.js#L19), which converts raw `dashboardFilters` state into old `filters` format so that other components can still use `filters` as before, and won't be affected by this big state change. 

`buildActiveFilters` function will be triggered whenever dashboardFilters state is changed, and the converted results will be cached. All other components in dashboard will call `getActiveFilters` to get the cached filters state, and they don't need to run the converter function again and again.

- Color assignment

In this PR we introduced a new [color palette ](https://github.com/apache/incubator-superset/blob/2e92ec9ade844866932a721e6b486fbf8b8df0ef/superset/assets/src/dashboard/stylesheets/variables.less#L41) for dashboard filters.

Each filter field is assigned a unique colorKey: `chartId_filter_column_name`. This colorKey is used by bother filter badge and filter indicator. Dashboard will pick a color from filter color palette based on colorKey and build a color map.  During render time, each filter and indicators in the chart will lookup color code based on its colorKey. Similar to `buildActiveFilters` function, dashboardFilter state update will trigger re-build color map.

- In-dashboard navigation
![tree1-2](https://user-images.githubusercontent.com/27990562/61979193-0da82280-afa8-11e9-9735-cd5c4435cc1e.jpg)

Suppose A is root, B,C,D are top level tabs, F, G are charts under tabs, H is nested tab, M is chart under nested tab. For example, when user lands on M, how to navigate user to a _filter_ component in another root level tab B?

Dashboard stores layout data in flattened tree structure: each parent node contains ids of its children, and every UI component (chart, header, row, column, tabs, etc) keeps all the parent component ids from root to itself (see #6945):
```
  'CHART-PuHBPak5nl': {
    children: [],
    id: 'CHART-PuHBPak5nl',
    meta: {
      chartId: 146,
      height: 50,
      sliceName: 'Chart B2',
      width: 4
    },
    parents: [
      'ROOT_ID',
      'TABS-nGgMw9Fmmj',
      'TAB-YWfqbvBaqp',
      'TABS-cGWCi1V-mr',
      'TAB-CZxYwmgZZ',
      'ROW-iC9LI5XSxU'
    ],
    type: 'CHART'
  }
```
From this parents list it's very easy to find out to select which root tab or nested tab to a specific filter. `dashboardState` has a `directPathToChild` prop, which is the current state of dashboard, holding a path to one of the chart (or any UI component).  When user clicks on a filter indicator, dashboard will update its `directPathToChild` to be target filter's path. Then dashboard will render the correct list of parent tab/tabs, and display filter chart.

- Filter indicators UI components

  - Container component: `/dashboard/container/FilterIndicators.jsx`
  - `/dashboard/components/FilterIndicatorsContainer.jsx`: indicators organizer for each chart. Usually one chart will be applicable for one or more filters, but user can set dashboard metadata that a chart might be immune to all filters in the dashboard, or some filter fields. We only display indicators for _applicable_ filters. The logic to show/group/hide applicable filters for each chart is here.
   - `/dashboard/components/FilterIndicator.jsx` and `/dashboard/components/FilterIndicatorGroup.jsx`: little colored indicator component for each filter, if chart having > 5 filters, will group them into a group. 
<img width="382" alt="Screen Shot 2019-08-08 at 11 46 05 AM" src="https://user-images.githubusercontent.com/27990562/62729113-249c3b00-b9d2-11e9-89eb-b1d0c7c40d83.png">

  - `/dashboard/components/FilterTooltipWrapper.jsx`: the basic usage of `react-bootstrap Tooltip` components are not enough for our need. We allow user to click on tooltip (especially needed for indicator group) to navigate to actual filter chart. So I added customized wrapper component to trigger/hide `Overlay` with some delay.
  - `/dashboard/components/FilterIndicatorTooltip.jsx`: tooltip component for filter. it shows `column name` and selected values. 
<img width="999" alt="Screen Shot 2019-07-26 at 2 53 04 PM" src="https://user-images.githubusercontent.com/27990562/61983458-47335a80-afb5-11e9-9118-f28961fc1666.png">
If the filter is applicable but not applied, we will show **Not filtered**.
If the filter is not applicable to the chart, we will not show indicator.

### SCREENSHOTS OR ANIMATED GIF
**Page landing**: 

- each filter field is assigned a badge with unique color.


![NXB4w4V9OB](https://user-images.githubusercontent.com/27990562/61613121-44cbac00-ac15-11e9-8eb4-d85c53e29768.gif)


**Interact with filter indicator**

- Hover on chart, you will see filter indicators popping out. The color bar in the filter indicator matched with filter's badge color.
- Hover on filter indicator, it will show filter's name and selected value(s), as filter tooltip.
- We show at most 5 filter indicators for each chart. For charts that having more filters, its indicators will be grouped in the last spot.
- For immune chart, it doesn't have any filter indicator.
- For chart with immune fields, we only show indicators for applicable fields.

![dKRnGt8z0n](https://user-images.githubusercontent.com/27990562/61614771-69298780-ac19-11e9-9cdc-8e713ff70a4e.gif)

**Navigate from chart to filter**

- When user clicks on one of filter indicator, or click on pencil icon in the filter tooltip, page will navigate to the chart, even cross tabs.
- The selected filter chart will be highlighted with green border. 
- If the chart has more than 1 field, the user selected field will be highlighted.


![8KuUojNgUB](https://user-images.githubusercontent.com/27990562/61615403-c70a9f00-ac1a-11e9-8b3e-00073bb02b57.gif)

### TEST PLAN
CI and manual test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@williaster @michellethomas @etr2460 @xtinec @mistercrunch @kenchendesign
@betodealmeida @khtruong 