### PR TITLE
[sqllab] Fix limit parsing bug when using limit-offset comma notation

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -182,7 +182,7 @@ class ParsedQuery(object):
             _, token = statement.token_next(idx=idx)
             if token:
                 if isinstance(token, IdentifierList):
-                    _, token = token.token_next(idx=-1)
+                    token = token.tokens[-1]
                 if token and token.ttype == sqlparse.tokens.Literal.Number.Integer:
                     return int(token.value)
 

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -184,7 +184,7 @@ class ParsedQuery(object):
                 if isinstance(token, IdentifierList):
                     # In case of "LIMIT <offset>, <limit>", find comma and extract
                     # first succeeding non-whitespace token
-                    idx, _ = token.token_next_by(m=(sqlparse.tokens.Punctuation, ','))
+                    idx, _ = token.token_next_by(m=(sqlparse.tokens.Punctuation, ","))
                     _, token = token.token_next(idx=idx)
                 if token and token.ttype == sqlparse.tokens.Literal.Number.Integer:
                     return int(token.value)

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -182,7 +182,10 @@ class ParsedQuery(object):
             _, token = statement.token_next(idx=idx)
             if token:
                 if isinstance(token, IdentifierList):
-                    token = token.tokens[-1]
+                    # In case of "LIMIT <offset>, <limit>", find comma and extract
+                    # first succeeding non-whitespace token
+                    idx, _ = token.token_next_by(m=(sqlparse.tokens.Punctuation, ','))
+                    _, token = token.token_next(idx=idx)
                 if token and token.ttype == sqlparse.tokens.Literal.Number.Integer:
                     return int(token.value)
 

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -175,12 +175,12 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         q2 = "select * from (select * from my_subquery limit 10) where col=1 limit 20"
         q3 = "select * from (select * from my_subquery limit 10);"
         q4 = "select * from (select * from my_subquery limit 10) where col=1 limit 20;"
-        q5 = "select * from mytable limit 10, 20"
+        q5 = "select * from mytable limit 20, 10"
         q6 = "select * from mytable limit 10 offset 20"
         q7 = "select * from mytable limit"
         q8 = "select * from mytable limit 10.0"
         q9 = "select * from mytable limit x"
-        q10 = "select * from mytable limit x, 20"
+        q10 = "select * from mytable limit 20, x"
         q11 = "select * from mytable limit x offset 20"
 
         self.assertEqual(engine_spec_class.get_limit_from_sql(q0), None)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently parsing of limit from query with limit-offset comma notation (`LIMIT <offset>, <limit>`) incorrectly assumes reversed order (`LIMIT <limit>, <offset>`). This fixes the parsing logic and accompanying unit tests.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
- Test in SqlLab
- CI/Unit tests

### REVIEWERS
@john-bodley (I checked git blame and saw that you had worked on this recently)