### PR TITLE
[fix] bug on FixedOrMetricControl component causing issues with deck.gl polygon height + deck.gl scatter radius controls

### DIFF
--- a/superset/assets/spec/javascripts/explore/components/FixedOrMetricControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/FixedOrMetricControl_spec.jsx
@@ -19,7 +19,6 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { OverlayTrigger } from 'react-bootstrap';
 
 import FixedOrMetricControl from
   '../../../../src/explore/components/controls/FixedOrMetricControl';
@@ -27,29 +26,21 @@ import TextControl from
   '../../../../src/explore/components/controls/TextControl';
 import MetricsControl from
   '../../../../src/explore/components/controls/MetricsControl';
-import ControlHeader from '../../../../src/explore/components/ControlHeader';
 
 const defaultProps = {
   value: { },
+  datasource: { },
 };
 
 describe('FixedOrMetricControl', () => {
   let wrapper;
-  let inst;
+
   beforeEach(() => {
     wrapper = shallow(<FixedOrMetricControl {...defaultProps} />);
-    inst = wrapper.instance();
-  });
-
-  it('renders a OverlayTrigger', () => {
-    const controlHeader = wrapper.find(ControlHeader);
-    expect(controlHeader).toHaveLength(1);
-    expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
   });
 
   it('renders a TextControl and a SelectControl', () => {
-    const popOver = shallow(inst.renderPopover());
-    expect(popOver.find(TextControl)).toHaveLength(1);
-    expect(popOver.find(MetricsControl)).toHaveLength(1);
+    expect(wrapper.find(TextControl)).toHaveLength(1);
+    expect(wrapper.find(MetricsControl)).toHaveLength(1);
   });
 });

--- a/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -92,55 +92,55 @@ export default class FixedOrMetricControl extends React.Component {
     return (
       <div>
         <ControlHeader {...this.props} />
-        <Label 
+        <Label
           style={{ cursor: 'pointer' }}
           onClick={this.toggle}
           >
-            {this.state.type === controlTypes.fixed &&
-              <span>{this.state.fixedValue}</span>
-            }
-            {this.state.type === controlTypes.metric &&
-              <span>
-                <span style={{ fontWeight: 'normal' }}>metric: </span>
-                <strong>{this.state.metricValue ? this.state.metricValue.label : null }</strong>
-              </span>
-            }
-          </Label>
-          <Panel
-            className="panel-spreaded" 
-            collapsible
-            expanded={this.state.expanded}>
-            <div 
-              className="well" 
+          {this.state.type === controlTypes.fixed &&
+            <span>{this.state.fixedValue}</span>
+          }
+          {this.state.type === controlTypes.metric &&
+            <span>
+              <span style={{ fontWeight: 'normal' }}>metric: </span>
+              <strong>{this.state.metricValue ? this.state.metricValue.label : null }</strong>
+            </span>
+          }
+        </Label>
+        <Panel
+          className="panel-spreaded" 
+          collapsible
+          expanded={this.state.expanded}>
+          <div 
+            className="well"
+          >
+            <PopoverSection
+              title="Fixed"
+              isSelected={type === controlTypes.fixed}
+              onSelect={() => { this.setType(controlTypes.fixed); }}
             >
-              <PopoverSection
-                title="Fixed"
-                isSelected={type === controlTypes.fixed}
-                onSelect={() => { this.setType(controlTypes.fixed); }}
-              >
-                <TextControl
-                  isFloat
-                  onChange={this.setFixedValue}
-                  onFocus={() => { this.setType(controlTypes.fixed); }}
-                  value={this.state.fixedValue}
-                />
-              </PopoverSection>
-              <PopoverSection
-                title="Based on a metric"
-                isSelected={type === controlTypes.metric}
-                onSelect={() => { this.setType(controlTypes.metric); }}
-              >
-                <MetricsControl
-                  name="metric"
-                  columns={this.props.datasource.columns}
-                  multi={false}
-                  onFocus={() => { this.setType(controlTypes.metric); }}
-                  onChange={this.setMetric}
-                  value={this.state.metricValue}
-                />
-              </PopoverSection>
-            </div>
-          </Panel>
+              <TextControl
+                isFloat
+                onChange={this.setFixedValue}
+                onFocus={() => { this.setType(controlTypes.fixed); }}
+                value={this.state.fixedValue}
+              />
+            </PopoverSection>
+            <PopoverSection
+              title="Based on a metric"
+              isSelected={type === controlTypes.metric}
+              onSelect={() => { this.setType(controlTypes.metric); }}
+            >
+              <MetricsControl
+                name="metric"
+                columns={this.props.datasource.columns}
+                multi={false}
+                onFocus={() => { this.setType(controlTypes.metric); }}
+                onChange={this.setMetric}
+                value={this.state.metricValue}
+              />
+            </PopoverSection>
+          </div>
+        </Panel>
       </div>
     );
   }

--- a/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -102,7 +102,7 @@ export default class FixedOrMetricControl extends React.Component {
           >
             <MetricsControl
               name="metric"
-              datasource={this.state.datasource}
+              columns={this.props.datasource.columns}
               multi={false}
               onFocus={() => { this.setType(controlTypes.metric); }}
               onChange={this.setMetric}

--- a/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -89,6 +89,7 @@ export default class FixedOrMetricControl extends React.Component {
   render() {
     const value = this.props.value || this.props.default;
     const type = value.type || controlTypes.fixed;
+    const columns = this.props.datasource ? this.props.datasource.columns : null;
     return (
       <div>
         <ControlHeader {...this.props} />
@@ -133,7 +134,7 @@ export default class FixedOrMetricControl extends React.Component {
             >
               <MetricsControl
                 name="metric"
-                columns={this.props.datasource.columns}
+                columns={columns}
                 multi={false}
                 onFocus={() => { this.setType(controlTypes.metric); }}
                 onChange={this.setMetric}

--- a/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label, Popover, OverlayTrigger } from 'react-bootstrap';
+import { Label, Popover, OverlayTrigger, Panel } from 'react-bootstrap';
 
 import TextControl from './TextControl';
 import MetricsControl from './MetricsControl';
@@ -53,6 +53,7 @@ export default class FixedOrMetricControl extends React.Component {
     this.setType = this.setType.bind(this);
     this.setFixedValue = this.setFixedValue.bind(this);
     this.setMetric = this.setMetric.bind(this);
+    this.toggle = this.toggle.bind(this);
     const type = (props.value ? props.value.type : props.default.type) || controlTypes.fixed;
     const value = (props.value ? props.value.value : props.default.value) || '100';
     this.state = {
@@ -77,55 +78,24 @@ export default class FixedOrMetricControl extends React.Component {
   setMetric(metricValue) {
     this.setState({ metricValue }, this.onChange);
   }
-  renderPopover() {
+
+  toggle() {
+    const expanded = !this.state.expanded;
+    this.setState({
+      expanded
+    })
+  }
+
+  render() {
     const value = this.props.value || this.props.default;
     const type = value.type || controlTypes.fixed;
     return (
-      <Popover id="filter-popover">
-        <div style={{ width: '240px' }}>
-          <PopoverSection
-            title="Fixed"
-            isSelected={type === controlTypes.fixed}
-            onSelect={() => { this.setType(controlTypes.fixed); }}
-          >
-            <TextControl
-              isFloat
-              onChange={this.setFixedValue}
-              onFocus={() => { this.setType(controlTypes.fixed); }}
-              value={this.state.fixedValue}
-            />
-          </PopoverSection>
-          <PopoverSection
-            title="Based on a metric"
-            isSelected={type === controlTypes.metric}
-            onSelect={() => { this.setType(controlTypes.metric); }}
-          >
-            <MetricsControl
-              name="metric"
-              columns={this.props.datasource.columns}
-              multi={false}
-              onFocus={() => { this.setType(controlTypes.metric); }}
-              onChange={this.setMetric}
-              value={this.state.metricValue}
-            />
-          </PopoverSection>
-        </div>
-      </Popover>
-    );
-  }
-  render() {
-    return (
       <div>
         <ControlHeader {...this.props} />
-        <OverlayTrigger
-          container={document.body}
-          trigger="click"
-          rootClose
-          ref="trigger"
-          placement="right"
-          overlay={this.renderPopover()}
-        >
-          <Label style={{ cursor: 'pointer' }}>
+        <Label 
+          style={{ cursor: 'pointer' }}
+          onClick={this.toggle}
+          >
             {this.state.type === controlTypes.fixed &&
               <span>{this.state.fixedValue}</span>
             }
@@ -136,7 +106,41 @@ export default class FixedOrMetricControl extends React.Component {
               </span>
             }
           </Label>
-        </OverlayTrigger>
+          <Panel
+            className="panel-spreaded" 
+            collapsible
+            expanded={this.state.expanded}>
+            <div 
+              className="well" 
+            >
+              <PopoverSection
+                title="Fixed"
+                isSelected={type === controlTypes.fixed}
+                onSelect={() => { this.setType(controlTypes.fixed); }}
+              >
+                <TextControl
+                  isFloat
+                  onChange={this.setFixedValue}
+                  onFocus={() => { this.setType(controlTypes.fixed); }}
+                  value={this.state.fixedValue}
+                />
+              </PopoverSection>
+              <PopoverSection
+                title="Based on a metric"
+                isSelected={type === controlTypes.metric}
+                onSelect={() => { this.setType(controlTypes.metric); }}
+              >
+                <MetricsControl
+                  name="metric"
+                  columns={this.props.datasource.columns}
+                  multi={false}
+                  onFocus={() => { this.setType(controlTypes.metric); }}
+                  onChange={this.setMetric}
+                  value={this.state.metricValue}
+                />
+              </PopoverSection>
+            </div>
+          </Panel>
       </div>
     );
   }

--- a/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label, Popover, OverlayTrigger, Panel } from 'react-bootstrap';
+import { Label, Panel } from 'react-bootstrap';
 
 import TextControl from './TextControl';
 import MetricsControl from './MetricsControl';
@@ -82,8 +82,8 @@ export default class FixedOrMetricControl extends React.Component {
   toggle() {
     const expanded = !this.state.expanded;
     this.setState({
-      expanded
-    })
+      expanded,
+    });
   }
 
   render() {
@@ -95,7 +95,7 @@ export default class FixedOrMetricControl extends React.Component {
         <Label
           style={{ cursor: 'pointer' }}
           onClick={this.toggle}
-          >
+        >
           {this.state.type === controlTypes.fixed &&
             <span>{this.state.fixedValue}</span>
           }
@@ -107,10 +107,11 @@ export default class FixedOrMetricControl extends React.Component {
           }
         </Label>
         <Panel
-          className="panel-spreaded" 
+          className="panel-spreaded"
           collapsible
-          expanded={this.state.expanded}>
-          <div 
+          expanded={this.state.expanded}
+        >
+          <div
             className="well"
           >
             <PopoverSection

--- a/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset/assets/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -86,7 +86,7 @@ export default class FixedOrMetricControl extends React.Component {
           <PopoverSection
             title="Fixed"
             isSelected={type === controlTypes.fixed}
-            onSelect={() => { this.onChange(controlTypes.fixed); }}
+            onSelect={() => { this.setType(controlTypes.fixed); }}
           >
             <TextControl
               isFloat
@@ -98,7 +98,7 @@ export default class FixedOrMetricControl extends React.Component {
           <PopoverSection
             title="Based on a metric"
             isSelected={type === controlTypes.metric}
-            onSelect={() => { this.onChange(controlTypes.metric); }}
+            onSelect={() => { this.setType(controlTypes.metric); }}
           >
             <MetricsControl
               name="metric"
@@ -132,7 +132,7 @@ export default class FixedOrMetricControl extends React.Component {
             {this.state.type === controlTypes.metric &&
               <span>
                 <span style={{ fontWeight: 'normal' }}>metric: </span>
-                <strong>{this.state.metricValue}</strong>
+                <strong>{this.state.metricValue ? this.state.metricValue.label : null }</strong>
               </span>
             }
           </Label>

--- a/superset/assets/src/explore/components/controls/MetricsControl.jsx
+++ b/superset/assets/src/explore/components/controls/MetricsControl.jsx
@@ -245,7 +245,7 @@ export default class MetricsControl extends React.PureComponent {
     const options = [
       ...columns,
       ...aggregates,
-      ...savedMetrics,
+      ...(savedMetrics ? savedMetrics : []),
     ];
 
     return options.reduce((results, option) => {

--- a/superset/assets/src/explore/components/controls/MetricsControl.jsx
+++ b/superset/assets/src/explore/components/controls/MetricsControl.jsx
@@ -245,7 +245,7 @@ export default class MetricsControl extends React.PureComponent {
     const options = [
       ...columns,
       ...aggregates,
-      ...(savedMetrics ? savedMetrics : []),
+      ...(savedMetrics || []),
     ];
 
     return options.reduce((results, option) => {

--- a/superset/assets/src/explore/main.css
+++ b/superset/assets/src/explore/main.css
@@ -259,3 +259,14 @@ h2.section-header {
   padding-bottom: 5px;
 }
 
+.panel-spreaded, 
+.panel-spreaded .panel-body {
+  padding: 0;
+  margin: 0;
+}
+
+.panel-spreaded .well {
+  margin-top: 8px;
+  margin-bottom: 0;
+  padding: 8px;
+}

--- a/superset/assets/src/visualizations/deckgl/layers/Scatter/Scatter.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Scatter/Scatter.jsx
@@ -36,7 +36,7 @@ function setTooltipContent(formData) {
         o.object.cat_color && <TooltipRow label={`${t('Category')}: `} value={`${o.object.cat_color}`} />
       }
       {
-        o.object.metric && <TooltipRow label={`${formData.point_radius_fixed.value}: `} value={`${o.object.metric}`} />
+        o.object.metric && <TooltipRow label={`${formData.point_radius_fixed.value.label}: `} value={`${o.object.metric}`} />
       }
     </div>
   );

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2425,7 +2425,7 @@ class DeckPolygon(DeckPathViz):
         fd = self.form_data
         elevation = fd["point_radius_fixed"]["value"]
         type_ = fd["point_radius_fixed"]["type"]
-        d["elevation"] = d.get(elevation) if type_ == "metric" else elevation
+        d["elevation"] = d.get(elevation["label"]) if type_ == "metric" else elevation
         return d
 
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes bugs causing FixedOrMetricControl to not render and then associated bugs in deck.gl polygon and deck.gl scatter causing map control functionality to break on input.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Slightly changed the UI of FixedOrMetricControl so it expands downward instead of as a pop-up as this was creating a double pop-up menu when Metric control was selected. See below for new UI:

![fixedormetric](https://user-images.githubusercontent.com/7088252/61883810-17a72400-aec9-11e9-988b-82fcb5fc694b.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Visual inspection
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
