### PR TITLE
Fix tooltips not visible for NVD3 charts on Firefox (#7822)

### DIFF
--- a/superset/assets/stylesheets/less/index.less
+++ b/superset/assets/stylesheets/less/index.less
@@ -25,11 +25,7 @@
 @stroke-primary:  @brand-primary;
 
 body {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

The bug was introduced by #7102

Using `position:absolute` on body gives `document.documentElement` a height of 0 which propagates to `clientHeight` on Firefox. This leads to a wrong calculation of the tooltip position in NVD3.

The solution proposed here is to use `min-height: 100vh` instead of the current technique for stretching the body element to the full window height, thus keeping body and html together.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Access an NVD3 based chart in Firefox and hover with mouse.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #7822
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
