### PR TITLE
[sqllab] Fix, #7928 query async not working

### DIFF
--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -217,7 +217,7 @@ export default class TableSelector extends React.PureComponent {
         dataEndpoint={
           '/api/v1/database/?q=' +
           '(keys:!(none),' +
-          'columns:!(id,database_name,backend),' +
+          'columns:!(id,database_name,backend,allow_run_async),' +
           'filters:!((col:expose_in_sqllab,opr:eq,value:!t)),' +
           'order_columns:database_name,order_direction:asc)'
         }

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -217,7 +217,6 @@ export default class TableSelector extends React.PureComponent {
         dataEndpoint={
           '/api/v1/database/?q=' +
           '(keys:!(none),' +
-          'columns:!(id,database_name,backend,allow_run_async,allow_ctas,allow_multi_schema_metadata_fetch),' +
           'filters:!((col:expose_in_sqllab,opr:eq,value:!t)),' +
           'order_columns:database_name,order_direction:asc)'
         }

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -217,7 +217,7 @@ export default class TableSelector extends React.PureComponent {
         dataEndpoint={
           '/api/v1/database/?q=' +
           '(keys:!(none),' +
-          'columns:!(id,database_name,backend,allow_run_async),' +
+          'columns:!(id,database_name,backend,allow_run_async,allow_ctas,allow_multi_schema_metadata_fetch),' +
           'filters:!((col:expose_in_sqllab,opr:eq,value:!t)),' +
           'order_columns:database_name,order_direction:asc)'
         }

--- a/superset/config.py
+++ b/superset/config.py
@@ -647,3 +647,6 @@ try:
         )
 except ImportError:
     pass
+
+SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:postgres@localhost/superset'
+

--- a/superset/config.py
+++ b/superset/config.py
@@ -647,6 +647,3 @@ try:
         )
 except ImportError:
     pass
-
-SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:postgres@localhost/superset'
-


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
New database API call from `TableSelector.jsx` missing required row `allow_run_async`. This prevents running async queries

### TEST PLAN
Run queries sync and async on sqllab.

### ADDITIONAL INFORMATION
- [X] Has associated issue: #7928 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
