### PR TITLE
[revert] Partial revert of #7888

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -734,46 +734,43 @@ class SqlaTable(Model, BaseDatasource):
             if not all([flt.get(s) for s in ["col", "op"]]):
                 continue
             col = flt["col"]
-
-            if col not in cols:
-                raise Exception(_("Column '%(column)s' does not exist", column=col))
-
             op = flt["op"]
-            col_obj = cols[col]
-            is_list_target = op in ("in", "not in")
-            eq = self.filter_values_handler(
-                flt.get("val"),
-                target_column_is_numeric=col_obj.is_num,
-                is_list_target=is_list_target,
-            )
-            if op in ("in", "not in"):
-                cond = col_obj.get_sqla_col().in_(eq)
-                if "<NULL>" in eq:
-                    cond = or_(cond, col_obj.get_sqla_col() == None)  # noqa
-                if op == "not in":
-                    cond = ~cond
-                where_clause_and.append(cond)
-            else:
-                if col_obj.is_num:
-                    eq = utils.string_to_num(flt["val"])
-                if op == "==":
-                    where_clause_and.append(col_obj.get_sqla_col() == eq)
-                elif op == "!=":
-                    where_clause_and.append(col_obj.get_sqla_col() != eq)
-                elif op == ">":
-                    where_clause_and.append(col_obj.get_sqla_col() > eq)
-                elif op == "<":
-                    where_clause_and.append(col_obj.get_sqla_col() < eq)
-                elif op == ">=":
-                    where_clause_and.append(col_obj.get_sqla_col() >= eq)
-                elif op == "<=":
-                    where_clause_and.append(col_obj.get_sqla_col() <= eq)
-                elif op == "LIKE":
-                    where_clause_and.append(col_obj.get_sqla_col().like(eq))
-                elif op == "IS NULL":
-                    where_clause_and.append(col_obj.get_sqla_col() == None)  # noqa
-                elif op == "IS NOT NULL":
-                    where_clause_and.append(col_obj.get_sqla_col() != None)  # noqa
+            col_obj = cols.get(col)
+            if col_obj:
+                is_list_target = op in ("in", "not in")
+                eq = self.filter_values_handler(
+                    flt.get("val"),
+                    target_column_is_numeric=col_obj.is_num,
+                    is_list_target=is_list_target,
+                )
+                if op in ("in", "not in"):
+                    cond = col_obj.get_sqla_col().in_(eq)
+                    if "<NULL>" in eq:
+                        cond = or_(cond, col_obj.get_sqla_col() == None)  # noqa
+                    if op == "not in":
+                        cond = ~cond
+                    where_clause_and.append(cond)
+                else:
+                    if col_obj.is_num:
+                        eq = utils.string_to_num(flt["val"])
+                    if op == "==":
+                        where_clause_and.append(col_obj.get_sqla_col() == eq)
+                    elif op == "!=":
+                        where_clause_and.append(col_obj.get_sqla_col() != eq)
+                    elif op == ">":
+                        where_clause_and.append(col_obj.get_sqla_col() > eq)
+                    elif op == "<":
+                        where_clause_and.append(col_obj.get_sqla_col() < eq)
+                    elif op == ">=":
+                        where_clause_and.append(col_obj.get_sqla_col() >= eq)
+                    elif op == "<=":
+                        where_clause_and.append(col_obj.get_sqla_col() <= eq)
+                    elif op == "LIKE":
+                        where_clause_and.append(col_obj.get_sqla_col().like(eq))
+                    elif op == "IS NULL":
+                        where_clause_and.append(col_obj.get_sqla_col() == None)  # noqa
+                    elif op == "IS NOT NULL":
+                        where_clause_and.append(col_obj.get_sqla_col() != None)  # noqa
         if extras:
             where = extras.get("where")
             if where:

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -289,23 +289,3 @@ class SqlaTableModelTestCase(SupersetTestCase):
             tbl.get_query_str(query_obj)
 
         self.assertTrue("Metric 'invalid' does not exist", context.exception)
-
-    def test_query_with_non_existent_filter_columns(self):
-        tbl = self.get_table_by_name("birth_names")
-
-        query_obj = dict(
-            groupby=[],
-            metrics=["count"],
-            filter=[{"col": "invalid", "op": "==", "val": "male"}],
-            is_timeseries=False,
-            columns=["name"],
-            granularity=None,
-            from_dttm=None,
-            to_dttm=None,
-            extras={},
-        )
-
-        with self.assertRaises(Exception) as context:
-            tbl.get_query_str(query_obj)
-
-        self.assertTrue("Column 'invalid' does not exist", context.exception)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This is a partial revert of https://github.com/apache/incubator-superset/pull/7888 where it was discovered that this breaks [filter_values](https://github.com/apache/incubator-superset/blob/4568b2a532069bdd5595c8f79a55d20e6326f9e4/superset/jinja_context.py#L87) logic (which is used within custom SQL views and can reference columns not present in the UI) which simply ignores invalid filters. By raising an exception prematurely one could cause functional charts to break.

Personally I think the long term fix is to rethink the filter logic however this is non-trivial and thus in the interim reverting the logic for raising on invalid filters is being reverted. 


### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @michellethomas @mistercrunch 
cc: @williaster 