### PR TITLE
[feature flag] Enforce csrf protection on explore_json endpoint

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -667,7 +667,7 @@ DOMAIN SHARDING
 
 Chrome allows up to 6 open connections per domain at a time. When there are more
 than 6 slices in dashboard, a lot of time fetch requests are queued up and wait for
-next available socket. PR (`#5039 <https://github.com/apache/incubator-superset/pull/5039>`) adds domain sharding to Superset,
+next available socket. `PR 5039 <https://github.com/apache/incubator-superset/pull/5039>`_ adds domain sharding to Superset,
 and this feature will be enabled by configuration only (by default Superset
 doesn't allow cross-domain request).
 
@@ -1161,3 +1161,25 @@ Then we can add this two lines to ``superset_config.py``:
 
   from custom_sso_security_manager import CustomSsoSecurityManager
   CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager
+
+Feature Flags
+---------------------------
+
+Because of a wide variety of users, Superset has some features that are not enabled by default. For example, some users have stronger security restrictions, while some others may not. So Superset allow users to enable or disable some features by config. For feature owners, you can add optional functionalities in Superset, but will be only affected by a subset of users.
+
+You can enable or disable features with flag from ``superset_config.py``:
+
+.. code-block:: python
+
+     DEFAULT_FEATURE_FLAGS = {
+         'CLIENT_CACHE': False,
+         'ENABLE_EXPLORE_JSON_CSRF_PROTECTION': False
+     }
+
+Here is a list of flags and descriptions:
+
+* ENABLE_EXPLORE_JSON_CSRF_PROTECTION
+
+  * For some security concerns, you may need to enforce CSRF protection on all query request to explore_json endpoint. In Superset, we use `flask-csrf <https://sjl.bitbucket.io/flask-csrf/>`_ add csrf protection for all POST requests, but this protection doesn't apply to GET method.
+
+  * When ENABLE_EXPLORE_JSON_CSRF_PROTECTION is set to true, your users cannot make GET request to explore_json. The default value for this feature False (current behavior), explore_json accepts both GET and POST request. See `PR 7935 <https://github.com/apache/incubator-superset/pull/7935>`_ for more details.

--- a/superset/config.py
+++ b/superset/config.py
@@ -204,7 +204,8 @@ LANGUAGES = {
 # will result in combined feature flags of { 'FOO': True, 'BAR': True, 'BAZ': True }
 DEFAULT_FEATURE_FLAGS = {
     # Experimental feature introducing a client (browser) cache
-    "CLIENT_CACHE": False
+    "CLIENT_CACHE": False,
+    "ENABLE_EXPLORE_JSON_CSRF_PROTECTION": False,
 }
 
 # A function that receives a dict of all feature flags

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -32,6 +32,7 @@ from flask_babel import gettext as __
 from flask_babel import lazy_gettext as _
 from flask_wtf.form import FlaskForm
 import simplejson as json
+from werkzeug.exceptions import HTTPException
 from wtforms.fields.core import Field, UnboundField
 import yaml
 
@@ -133,6 +134,13 @@ def handle_api_exception(f):
                 utils.error_msg_from_exception(e),
                 stacktrace=utils.get_stacktrace(),
                 status=e.status,
+            )
+        except HTTPException as e:
+            logging.exception(e)
+            return json_error_response(
+                utils.error_msg_from_exception(e),
+                stacktrace=traceback.format_exc(),
+                status=e.code,
             )
         except Exception as e:
             logging.exception(e)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This PR is to resume the work in #7449. For some security concerns, we need to enforce CSRF protection on query request to `explore_json` endpoint.  

So I want to add a new feature flag: `ENABLE_EXPLORE_JSON_CSRF_PROTECTION`. When `ENABLE_EXPLORE_JSON_CSRF_PROTECTION` is set to true, user cannot make GET request to `explore_json`. 

The default value for this feature `False` (current behavior), explore_json accepts both GET and POST request.

### TEST PLAN
send GET request to `explore_json`, you will get `405 Method Not Allowed` exception.


### REVIEWERS
@DiggidyDave @betodealmeida   @john-bodley @mistercrunch 