### PR TITLE
Remove collation info from MSSQL column type

### DIFF
--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -66,3 +66,14 @@ class MssqlEngineSpec(BaseEngineSpec):
             if regex.match(type_):
                 return sqla_type
         return None
+
+    @classmethod
+    def column_datatype_to_string(cls, sqla_column_type, dialect):
+        datatype = super().column_datatype_to_string(sqla_column_type, dialect)
+        # MSSQL returns long overflowing datatype
+        # as in 'VARCHAR(255) COLLATE SQL_LATIN1_GENERAL_CP1_CI_AS'
+        # and we don't need the verbose collation type
+        str_cutoff = " COLLATE "
+        if str_cutoff in datatype:
+            datatype = datatype.split(str_cutoff)[0]
+        return datatype


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
MSSQL columns can have lengthy types due to collations, for example `NVARCHAR(50) COLLATE SQL_LATIN1_GENERAL_CP1_CI_AS`, exceeding the 32 character limit in Superset. This PR copies logic from the MySQL spec which removes the unnecessary collation info.

### TEST PLAN
Test locally

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #7870
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@vitorbellini @syazwan0913