### PR TITLE
Use python3 for black to support py>=3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: stable
     hooks:
     -   id: black
-        language_version: python3.6
+        language_version: python3
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
I'm currently using Python 3.7 without `python3.6` in my env. Just calling `python3` should be sufficient.

### TEST PLAN
Tested to work with python 3.7.3

### REVIEWERS
@john-bodley 