### PR TITLE
Bump sqlparse to 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ simplejson==3.16.0
 six==1.12.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, pathlib2, polyline, prison, pydruid, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
 sqlalchemy-utils==0.34.1
 sqlalchemy==1.3.6
-sqlparse==0.2.4
+sqlparse==0.3.0
 urllib3==1.25.3           # via requests, selenium
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         "simplejson>=3.15.0",
         "sqlalchemy>=1.3.5,<2.0",
         "sqlalchemy-utils>=0.33.2",
-        "sqlparse<0.3",
+        "sqlparse>=0.3.0,<0.4",
         "wtforms-json",
     ],
     extras_require={

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -205,7 +205,7 @@ class ParsedQuery(object):
         if limit.ttype == sqlparse.tokens.Literal.Number.Integer:
             limit.value = new_limit
         elif limit.is_group:
-            limit.value = "{}, {}".format(next(limit.get_identifiers()), new_limit)
+            limit.value = f"{next(limit.get_identifiers())}, {new_limit}"
 
         str_res = ""
         for i in statement.tokens:

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -195,21 +195,19 @@ class ParsedQuery(object):
         if not self._limit:
             return f"{self.stripped()}\nLIMIT {new_limit}"
         limit_pos = None
-        tokens = self._parsed[0].tokens
+        statement = self._parsed[0]
         # Add all items to before_str until there is a limit
-        for pos, item in enumerate(tokens):
+        for pos, item in enumerate(statement.tokens):
             if item.ttype in Keyword and item.value.lower() == "limit":
                 limit_pos = pos
                 break
-        limit = tokens[limit_pos + 2]
+        _, limit = statement.token_next(idx=limit_pos)
         if limit.ttype == sqlparse.tokens.Literal.Number.Integer:
-            tokens[limit_pos + 2].value = new_limit
+            limit.value = new_limit
         elif limit.is_group:
-            tokens[limit_pos + 2].value = "{}, {}".format(
-                next(limit.get_identifiers()), new_limit
-            )
+            limit.value = "{}, {}".format(next(limit.get_identifiers()), new_limit)
 
         str_res = ""
-        for i in tokens:
+        for i in statement.tokens:
             str_res += str(i.value)
         return str_res


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Refactor

### SUMMARY
The function that replaces the query limit assumed that the limit number comes two tokens after the keyword. This was the case for `sqlparse==0.2.4`, but stopped working when bumped to `sqlparse==0.3.0`. This makes the function slightly more robust by using native `sqlparse` functionality to find the next non-whitespace token after the limit keyword. The new code works equally well with `0.2.4`, but I figured it's just as well to bump to the newest version.

### TEST PLAN
- Unit tests.

### REVIEWERS
@john-bodley @betodealmeida 