### PR TITLE
Fix for new Pandas API

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -42,6 +42,7 @@ from markdown import markdown
 import numpy as np
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
+from pandas.tseries.offsets import DateOffset
 import polyline
 import simplejson as json
 
@@ -1398,7 +1399,8 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
         fd = self.form_data
         df = self.process_data(df)
         freq = to_offset(fd.get("freq"))
-        freq.normalize = True
+        freq = DateOffset(normalize=True, **freq.kwds)
+        df.index.name = None
         df[DTTM_ALIAS] = df.index.map(freq.rollback)
         df["ranked"] = df[DTTM_ALIAS].rank(method="dense", ascending=False) - 1
         df.ranked = df.ranked.map(int)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes https://github.com/apache/incubator-superset/issues/7966, where the Time-series Period Pivot visualization is broken because of changes to the Pandas API:

1. `DateOffset` is now immutable, so we can't set it to normalized after it's been created. I fixed this my making a copy and normalizing it during the process.
2. Having an index with the same name as a column now raises an exception. I fixed this by removing the name of the index (since we don't use it).

I'm not very familiar with Pandas, so I'm not sure if this is the right approach.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

I compared visualizations that we have in production at Lyft (running the old code that still works), and the ones created with this PR are identical.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@villebro 