### PR TITLE
[WIP] Allow password from environment

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -21,6 +21,7 @@ from copy import copy, deepcopy
 from datetime import datetime
 import json
 import logging
+import os
 import textwrap
 from typing import List
 
@@ -726,6 +727,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     database_name = Column(String(250), unique=True)
     sqlalchemy_uri = Column(String(1024))
     password = Column(EncryptedType(String(1024), config.get("SECRET_KEY")))
+    password_from_environ = Column(Boolean, default=False)
     cache_timeout = Column(Integer)
     select_as_create_table_as = Column(Boolean, default=False)
     expose_in_sqllab = Column(Boolean, default=True)
@@ -1172,6 +1174,8 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             conn.password = custom_password_store(conn)
         else:
             conn.password = self.password
+        if self.password_from_environ:
+            conn.password = conn.password.format(**os.environ)
         return str(conn)
 
     @property

--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -37,6 +37,7 @@
       try{
         data = JSON.stringify({
           uri: $.trim($("#sqlalchemy_uri").val()),
+          password_from_environ: $('#password_from_environ').is(':checked'),
           name: $('#database_name').val(),
           impersonate_user: $('#impersonate_user').is(':checked'),
           extras: JSON.parse($("#extra").val()),

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -18,6 +18,7 @@
 from contextlib import closing
 from datetime import datetime, timedelta
 import logging
+import os
 import re
 from typing import Dict, List  # noqa: F401
 from urllib import parse
@@ -1678,6 +1679,13 @@ class Superset(BaseSupersetView):
         try:
             db_name = request.json.get("name")
             uri = request.json.get("uri")
+            if request.json.get("password_from_environ"):
+                parts = parse.urlsplit(uri)
+                if parts.password:
+                    pwd = parts.password.format(**os.environ)
+                    netloc = f'{parts.username}:{pwd}@{parts.hostname}:{parts.port}'
+                    parts = parts._replace(netloc=netloc)
+                    uri = parse.urlunsplit(parts)
 
             # if the database already exists in the database, only its safe (password-masked) URI
             # would be shown in the UI and would be passed in the form data.

--- a/superset/views/database/__init__.py
+++ b/superset/views/database/__init__.py
@@ -62,6 +62,7 @@ class DatabaseMixin:  # noqa
     add_columns = [
         "database_name",
         "sqlalchemy_uri",
+        "password_from_environ",
         "cache_timeout",
         "expose_in_sqllab",
         "allow_run_async",
@@ -103,6 +104,10 @@ class DatabaseMixin:  # noqa
             "database-urls) "
             "for more information on how to structure your URI.",
             True,
+        ),
+        "password_from_environ": _(
+            "Read password from the environment, using the Python "
+            "format notation (eg, 'user:{PASSWORD}@host')."
         ),
         "expose_in_sqllab": _("Expose this DB in SQL Lab"),
         "allow_run_async": _(


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR allows reading database passwords from the OS environment. For example, a user can specify the SQL Alchemy URL as:

```
hive://username:{HIVE_PASSWORD}@hive.example.com:9407/default?auth=LDAP
```

And `HIVE_PASSWORD` is read from the environment, allowing credentials to be easily rotated.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="884" alt="Screen Shot 2019-08-01 at 4 05 55 PM" src="https://user-images.githubusercontent.com/1534870/62332946-477c9b80-b476-11e9-8cea-f7e2864bc3ee.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [X] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
