### PR TITLE
Fix Pandas 0.24 DateOffset bug pt. 2

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1398,7 +1398,10 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
         fd = self.form_data
         df = self.process_data(df)
         freq = to_offset(fd.get("freq"))
-        freq = type(freq)(freq.n, normalize=True, **freq.kwds)
+        try:
+            freq = type(freq)(freq.n, normalize=True, **freq.kwds)
+        except ValueError:
+            freq = type(freq)(freq.n, **freq.kwds)
         df.index.name = None
         df[DTTM_ALIAS] = df.index.map(freq.rollback)
         df["ranked"] = df[DTTM_ALIAS].rank(method="dense", ascending=False) - 1

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -42,7 +42,6 @@ from markdown import markdown
 import numpy as np
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
-from pandas.tseries.offsets import DateOffset
 import polyline
 import simplejson as json
 
@@ -1399,7 +1398,7 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
         fd = self.form_data
         df = self.process_data(df)
         freq = to_offset(fd.get("freq"))
-        freq = DateOffset(normalize=True, **freq.kwds)
+        freq = type(freq)(freq.n, normalize=True, **freq.kwds)
         df.index.name = None
         df[DTTM_ALIAS] = df.index.map(freq.rollback)
         df["ranked"] = df[DTTM_ALIAS].rank(method="dense", ascending=False) - 1


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix

### SUMMARY
This should fix the DateOffset bug that was introduced when moving from Pandas `0.23` to `0.24`. Credits for this go to @jbrockmendel, see https://github.com/pandas-dev/pandas/issues/27728

### TEST PLAN
Tested locally

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #7966

### REVIEWERS
@betodealmeida @AndLLA