### PR TITLE
Bump FAB to 2.1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,7 @@ babel==2.7.0              # via flask-babel
 billiard==3.6.0.0         # via celery
 bleach==3.1.0
 celery==4.3.0
-certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-chardet==3.0.4            # via requests
 click==6.7
 colorama==0.4.1
 contextlib2==0.5.5
@@ -23,7 +21,7 @@ croniter==0.3.30
 cryptography==2.7
 decorator==4.4.0          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.1.7
+flask-appbuilder==2.1.8
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.7.2
 flask-compress==1.4.0
@@ -72,16 +70,13 @@ pyyaml==5.1.2
 retry==0.9.2
 selenium==3.141.0
 simplejson==3.16.0
-six==1.12.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, pathlib2, polyline, prison, pydruid, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
+six==1.12.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, pathlib2, polyline, prison, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
 sqlalchemy-utils==0.34.1
 sqlalchemy==1.3.6
 sqlparse==0.2.4
-urllib3==1.25.3           # via requests, selenium
+urllib3==1.25.3           # via selenium
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
 werkzeug==0.15.5          # via flask, flask-jwt-extended
 wtforms-json==0.3.3
 wtforms==2.2.1            # via flask-wtf, wtforms-json
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via jsonschema, markdown

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.0.0, <2.0.0",
-        "flask-appbuilder>=2.1.6, <2.3.0",
+        "flask-appbuilder>=2.1.8, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
FAB 2.1.8 brings the following fixes:

- Fix, #1077 API Info not translating labels and description
- Fix, #1069 API label_columns for get item returning labels for list columns
- Fix, #1072 API max_page_size class property override for FAB_API_MAX_SIZE

Will be important to use `max_page_size` on `ModelRestApi` to unlimit the API page size on the scope of a resource/class. Old FAB API did not limit the results by default.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
