### PR TITLE
[sqllab] Fix, API page size limit on database select box

### DIFF
--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -218,7 +218,8 @@ export default class TableSelector extends React.PureComponent {
           '/api/v1/database/?q=' +
           '(keys:!(none),' +
           'filters:!((col:expose_in_sqllab,opr:eq,value:!t)),' +
-          'order_columns:database_name,order_direction:asc)'
+          'order_columns:database_name,order_direction:asc,' +
+          'page:0,page_size:-1)'
         }
         onChange={this.onDatabaseChange}
         onAsyncError={() => this.props.handleError(t('Error while fetching database list'))}

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -50,6 +50,8 @@ class DatabaseRestApi(DatabaseMixin, ModelRestApi):
         "allows_subquery",
         "backend",
     ]
+    # Removes the local limit for the page size
+    max_page_size = -1
 
 
 appbuilder.add_api(DatabaseRestApi)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Only merge this PR after FAB version is >= 2.1.8.

New API has a limited `page_size` set globally by `FAB_API_MAX_PAGE_SIZE` or by `max_page_size` class attribute. Default `page_size` is 20. 
This PR removes the cap on page size making unlimited, used on SQLLab database select box 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
