### PR TITLE
[init] Setting up cache before registering blueprints

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -105,6 +105,7 @@ def get_manifest():
 
 #################################################################
 
+# Setup the cache prior to registering the blueprints.
 cache = setup_cache(app, conf.get("CACHE_CONFIG"))
 tables_cache = setup_cache(app, conf.get("TABLE_NAMES_CACHE_CONFIG"))
 

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -105,6 +105,9 @@ def get_manifest():
 
 #################################################################
 
+cache = setup_cache(app, conf.get("CACHE_CONFIG"))
+tables_cache = setup_cache(app, conf.get("TABLE_NAMES_CACHE_CONFIG"))
+
 for bp in conf.get("BLUEPRINTS"):
     try:
         print("Registering blueprint: '{}'".format(bp.name))
@@ -133,9 +136,6 @@ if conf.get("WTF_CSRF_ENABLED"):
         csrf.exempt(ex)
 
 pessimistic_connection_handling(db.engine)
-
-cache = setup_cache(app, conf.get("CACHE_CONFIG"))
-tables_cache = setup_cache(app, conf.get("TABLE_NAMES_CACHE_CONFIG"))
 
 migrate = Migrate(app, db, directory=APP_DIR + "/migrations")
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Having all the registration logic in `superset/__init__.py` results in some complex cyclical logic (not I really like the model that the [cookiecutter-flask](https://github.com/cookiecutter-flask/cookiecutter-flask/blob/master/%7B%7Bcookiecutter.app_name%7D%7D/%7B%7Bcookiecutter.app_name%7D%7D/app.py) package uses where the cache etc. are registered as extensions and available prior to the instantiation of the app) though this may be a limitation of using Flask-AppBuilder. 

It't not apparent what order we should register certain logic but we've run into an issue using Blueprints where we wanted to reference the cache which need to be defined prior to the registration of the blueprints. 

### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @michellethomas @mistercrunch 