### PR TITLE
[Jinja] Make Presto template functions backwards compatible

### DIFF
--- a/docs/sqllab.rst
+++ b/docs/sqllab.rst
@@ -56,7 +56,7 @@ Templating with Jinja
 
     SELECT *
     FROM some_table
-    WHERE partition_key = '{{ presto.latest_partition('some_table') }}'
+    WHERE partition_key = '{{ presto.first_latest_partition('some_table') }}'
 
 Templating unleashes the power and capabilities of a
 programming language within your SQL code.

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -240,7 +240,25 @@ class PrestoTemplateProcessor(BaseTemplateProcessor):
             schema, table_name = table_name.split(".")
         return table_name, schema
 
-    def latest_partition(self, table_name: str):
+    def first_latest_partition(self, table_name: str) -> str:
+        """
+        Gets the first value in the array of all latest partitions
+
+        :param table_name: table name in the format `schema.table`
+        :return: the first (or only) value in the latest partition array
+        :raises IndexError: If no partition exists
+        """
+
+        return self.latest_partitions(table_name)[0]
+
+    def latest_partitions(self, table_name: str) -> List[str]:
+        """
+        Gets the array of all latest partitions
+
+        :param table_name: table name in the format `schema.table`
+        :return: the latest partition array
+        """
+
         table_name, schema = self._schema_table(table_name, self.schema)
         return self.database.db_engine_spec.latest_partition(
             table_name, schema, self.database
@@ -251,6 +269,8 @@ class PrestoTemplateProcessor(BaseTemplateProcessor):
         return self.database.db_engine_spec.latest_sub_partition(
             table_name=table_name, schema=schema, database=self.database, **kwargs
         )
+
+    latest_partition = first_latest_partition
 
 
 class HiveTemplateProcessor(PrestoTemplateProcessor):


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/apache/incubator-superset/pull/7782 changed the behavior of the `presto.latest_partition` Jinja template function to return an array instead of a string, breaking all sql metrics/slices that used it. This PR makes the `latest_partition` function behave the same as prior to this change, introduces a new function `presto.latest_partitions` that can be used with this new behavior, and provides documentation for the change in code.

It might be worth renaming these functions if we were ever to do a breaking release of superset, but i don't see that happening any time soon.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Tested locally, CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@michellethomas @john-bodley @betodealmeida @DiggidyDave @xtinec