### PR TITLE
Revert "[sqllab] Fix, API page size limit on database select box"

### DIFF
--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -218,8 +218,7 @@ export default class TableSelector extends React.PureComponent {
           '/api/v1/database/?q=' +
           '(keys:!(none),' +
           'filters:!((col:expose_in_sqllab,opr:eq,value:!t)),' +
-          'order_columns:database_name,order_direction:asc,' +
-          'page:0,page_size:-1)'
+          'order_columns:database_name,order_direction:asc)'
         }
         onChange={this.onDatabaseChange}
         onAsyncError={() => this.props.handleError(t('Error while fetching database list'))}

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -50,8 +50,6 @@ class DatabaseRestApi(DatabaseMixin, ModelRestApi):
         "allows_subquery",
         "backend",
     ]
-    # Removes the local limit for the page size
-    max_page_size = -1
 
 
 appbuilder.add_api(DatabaseRestApi)


### PR DESCRIPTION
Reverts apache/incubator-superset#7987

I think this should be reverted as it results in SQL errors trying to LIMIT -1 when getting the list of databases in sql lab.

By setting page_size to -1, we apply a limit on the query of -1 here in FAB: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/models/sqla/interface.py#L188

@dpgaspar I think the required fix in FAB would be to
return _page, None if _page_size == -1 else _page_size
here: https://github.com/dpgaspar/Flask-AppBuilder/blob/2353b36fb611a6ffe2ca88637d0311a3c5c2a3ec/flask_appbuilder/api/__init__.py#L1518

We might want to also revert the bump to FAB 2.1.8, or we could fix this forward. I leave that up to you

cc @john-bodley @mistercrunch @dpgaspar @michellethomas 