### PR TITLE
Event logger config takes instance instead of class

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -738,9 +738,9 @@ Example of a simple JSON to Stdout class::
                 print(json.dumps(log))
 
 
-Then on Superset's config reference the class you want to use::
+Then on Superset's config pass an instance of the logger type you want to use.
 
-    EVENT_LOGGER = JSONStdOutEventLogger
+    EVENT_LOGGER = JSONStdOutEventLogger()
 
 
 Upgrading

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -17,6 +17,7 @@
 # pylint: disable=C,R,W
 """Package's main module!"""
 from copy import deepcopy
+import inspect
 import json
 import logging
 from logging.handlers import TimedRotatingFileHandler
@@ -36,7 +37,7 @@ from superset import config
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.security import SupersetSecurityManager
 from superset.utils.core import pessimistic_connection_handling, setup_cache
-from superset.utils.log import DBEventLogger
+from superset.utils.log import DBEventLogger, get_event_logger_from_cfg_value
 
 wtforms_json.init()
 
@@ -220,8 +221,7 @@ _feature_flags = app.config.get("DEFAULT_FEATURE_FLAGS") or {}
 _feature_flags.update(app.config.get("FEATURE_FLAGS") or {})
 
 # Event Logger
-event_logger = app.config.get("EVENT_LOGGER", DBEventLogger)()
-
+event_logger = get_event_logger_from_cfg_value(app.config.get("EVENT_LOGGER", DBEventLogger()))
 
 def get_feature_flags():
     GET_FEATURE_FLAGS_FUNC = app.config.get("GET_FEATURE_FLAGS_FUNC")

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -17,7 +17,6 @@
 # pylint: disable=C,R,W
 """Package's main module!"""
 from copy import deepcopy
-import inspect
 import json
 import logging
 from logging.handlers import TimedRotatingFileHandler

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -221,7 +221,10 @@ _feature_flags = app.config.get("DEFAULT_FEATURE_FLAGS") or {}
 _feature_flags.update(app.config.get("FEATURE_FLAGS") or {})
 
 # Event Logger
-event_logger = get_event_logger_from_cfg_value(app.config.get("EVENT_LOGGER", DBEventLogger()))
+event_logger = get_event_logger_from_cfg_value(
+    app.config.get("EVENT_LOGGER", DBEventLogger())
+)
+
 
 def get_feature_flags():
     GET_FEATURE_FLAGS_FUNC = app.config.get("GET_FEATURE_FLAGS_FUNC")

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -99,7 +99,7 @@ def get_event_logger_from_cfg_value(cfg_value: object) -> AbstractEventLogger:
     :return: if cfg_value is a class type, will return a new instance created using a
     default con
     """
-    result: Any = None
+    result: Any = cfg_value
     if inspect.isclass(cfg_value):
         logging.getLogger().warning(
             """
@@ -112,8 +112,6 @@ def get_event_logger_from_cfg_value(cfg_value: object) -> AbstractEventLogger:
 
         event_logger_type = cast(Type, cfg_value)
         result = event_logger_type()
-    else:
-        result = cast(AbstractEventLogger, cfg_value)
 
     # Verify that we have a valid logger impl
     if not isinstance(result, AbstractEventLogger):

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -21,6 +21,7 @@ import functools
 import inspect
 import json
 import logging
+import textwrap
 from typing import Any, cast, Type
 
 from flask import current_app, g, request
@@ -101,13 +102,15 @@ def get_event_logger_from_cfg_value(cfg_value: object) -> AbstractEventLogger:
     """
     result: Any = cfg_value
     if inspect.isclass(cfg_value):
-        logging.getLogger().warning(
-            """
-            In superset private config, EVENT_LOGGER has been assigned a class object. In order to
-            accomodate pre-configured instances without a default constructor, assignment of a class
-            is deprecated and may no longer work at some point in the future. Please assign an object
-            instance of a type that implements superset.utils.log.AbstractEventLogger.
-            """
+        logging.warning(
+            textwrap.dedent(
+                """
+                In superset private config, EVENT_LOGGER has been assigned a class object. In order to
+                accomodate pre-configured instances without a default constructor, assignment of a class
+                is deprecated and may no longer work at some point in the future. Please assign an object
+                instance of a type that implements superset.utils.log.AbstractEventLogger.
+                """
+            )
         )
 
         event_logger_type = cast(Type, cfg_value)
@@ -116,10 +119,10 @@ def get_event_logger_from_cfg_value(cfg_value: object) -> AbstractEventLogger:
     # Verify that we have a valid logger impl
     if not isinstance(result, AbstractEventLogger):
         raise TypeError(
-            "EVENT_LOGGER must be configured with a concrete instance ofsuperset.utils.log.AbstractEventLogger."
+            "EVENT_LOGGER must be configured with a concrete instance of superset.utils.log.AbstractEventLogger."
         )
 
-    logging.info("Configured event logger of type {}".format(type(result)))
+    logging.info(f"Configured event logger of type {type(result)}")
     return cast(AbstractEventLogger, result)
 
 

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -84,8 +84,9 @@ class AbstractEventLogger(ABC):
     def stats_logger(self):
         return current_app.config.get("STATS_LOGGER")
 
+
 def get_event_logger_from_cfg_value(cfg_value: object) -> AbstractEventLogger:
-    '''
+    """
     This function implements the deprecation of assignment of class objects to EVENT_LOGGER
     configuration, and validates type of configured loggers.
 
@@ -96,8 +97,8 @@ def get_event_logger_from_cfg_value(cfg_value: object) -> AbstractEventLogger:
     :param cfg_value: The configured EVENT_LOGGER value to be validated
     :return: if cfg_value is a class type, will return a new instance created using a
     default con
-    '''
-    result : AbstractEventLogger = cfg_value 
+    """
+    result: AbstractEventLogger = cfg_value
     if inspect.isclass(cfg_value):
         logging.getLogger().warning(
             """
@@ -105,12 +106,15 @@ def get_event_logger_from_cfg_value(cfg_value: object) -> AbstractEventLogger:
             accomodate pre-configured instances without a default constructor, assignment of a class
             is deprecated and may no longer work at some point in the future. Please assign an object 
             instance of a type that implements superset.utils.log.AbstractEventLogger.
-            """.format(type(cfg_value)))
+            """
+        )
         result = cfg_value()
 
     # Verify that we have a valid logger impl
     if not isinstance(result, AbstractEventLogger):
-        raise TypeError('EVENT_LOGGER must be configured with a concrete instance ofsuperset.utils.log.AbstractEventLogger.')
+        raise TypeError(
+            "EVENT_LOGGER must be configured with a concrete instance ofsuperset.utils.log.AbstractEventLogger."
+        )
 
     logging.info("Configured event logger of type {}".format(type(result)))
     return result

--- a/tests/event_logger_tests.py
+++ b/tests/event_logger_tests.py
@@ -1,11 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 import logging
 import unittest
 
-from superset.utils.log import AbstractEventLogger, DBEventLogger, get_event_logger_from_cfg_value
+from superset.utils.log import (
+    AbstractEventLogger,
+    DBEventLogger,
+    get_event_logger_from_cfg_value,
+)
 
 
 class TestEventLogger(unittest.TestCase):
-
     def test_returns_configured_object_if_correct(self):
         # test that assignment of concrete AbstractBaseClass impl returns unmodified object
         obj = DBEventLogger()
@@ -17,7 +36,7 @@ class TestEventLogger(unittest.TestCase):
         res = None
 
         # print warning if a class is assigned to EVENT_LOGGER
-        with self.assertLogs(level='WARNING') as l:
+        with self.assertLogs(level="WARNING") as l:
             res = get_event_logger_from_cfg_value(DBEventLogger)
 
         # class is instantiated and returned

--- a/tests/event_logger_tests.py
+++ b/tests/event_logger_tests.py
@@ -1,0 +1,29 @@
+import logging
+import unittest
+
+from superset.utils.log import AbstractEventLogger, DBEventLogger, get_event_logger_from_cfg_value
+
+
+class TestEventLogger(unittest.TestCase):
+
+    def test_returns_configured_object_if_correct(self):
+        # test that assignment of concrete AbstractBaseClass impl returns unmodified object
+        obj = DBEventLogger()
+        res = get_event_logger_from_cfg_value(obj)
+        self.assertTrue(obj is res)
+
+    def test_event_logger_config_class_deprecation(self):
+        # test that assignment of a class object to EVENT_LOGGER is correctly deprecated
+        res = None
+
+        # print warning if a class is assigned to EVENT_LOGGER
+        with self.assertLogs(level='WARNING') as l:
+            res = get_event_logger_from_cfg_value(DBEventLogger)
+
+        # class is instantiated and returned
+        self.assertIsInstance(res, DBEventLogger)
+
+    def test_raises_typerror_if_not_abc_impl(self):
+        # test that assignment of non AbstractEventLogger derived type raises TypeError
+        with self.assertRaises(TypeError) as f:
+            get_event_logger_from_cfg_value(logging.getLogger())

--- a/tests/event_logger_tests.py
+++ b/tests/event_logger_tests.py
@@ -17,10 +17,7 @@
 import logging
 import unittest
 
-from superset.utils.log import (
-    DBEventLogger,
-    get_event_logger_from_cfg_value,
-)
+from superset.utils.log import DBEventLogger, get_event_logger_from_cfg_value
 
 
 class TestEventLogger(unittest.TestCase):

--- a/tests/event_logger_tests.py
+++ b/tests/event_logger_tests.py
@@ -18,7 +18,6 @@ import logging
 import unittest
 
 from superset.utils.log import (
-    AbstractEventLogger,
     DBEventLogger,
     get_event_logger_from_cfg_value,
 )
@@ -36,7 +35,7 @@ class TestEventLogger(unittest.TestCase):
         res = None
 
         # print warning if a class is assigned to EVENT_LOGGER
-        with self.assertLogs(level="WARNING") as l:
+        with self.assertLogs(level="WARNING"):
             res = get_event_logger_from_cfg_value(DBEventLogger)
 
         # class is instantiated and returned
@@ -44,5 +43,5 @@ class TestEventLogger(unittest.TestCase):
 
     def test_raises_typerror_if_not_abc_impl(self):
         # test that assignment of non AbstractEventLogger derived type raises TypeError
-        with self.assertRaises(TypeError) as f:
+        with self.assertRaises(TypeError):
             get_event_logger_from_cfg_value(logging.getLogger())


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [X] Refactor
- [X] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Deprecate EVENT_LOGGER assignment of class type in favor of instance. Deprecation is handled gracefully and only outputs a WARNING log message at config load time.  We have a need to configure an impl of AbstractEventLogger which is instantiated/pre-configured with some proprietary dependencies.

This change is a small refactor on top of the nice change #7705 @dpgaspar made a few weeks ago.

### TEST PLAN
Unit tests added, and tested manually.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: 7705

### REVIEWERS
@dpgaspar @john-bodley @graceguo-supercat @mistercrunch 