### PR TITLE
[fix] reduce content in sql lab localStorage

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/fixtures.js
+++ b/superset/assets/spec/javascripts/sqllab/fixtures.js
@@ -179,6 +179,13 @@ export const defaultQueryEditor = {
   selectedText: null,
   sql: 'SELECT *\nFROM\nWHERE',
   title: 'Untitled Query',
+  schemaOptions: [
+    {
+      value: 'main',
+      label: 'main',
+      title: 'main',
+    },
+  ],
 };
 export const queries = [
   {

--- a/superset/assets/spec/javascripts/sqllab/utils/emptyQueryResults_spec.js
+++ b/superset/assets/spec/javascripts/sqllab/utils/emptyQueryResults_spec.js
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import emptyQueryResults from '../../../../src/SqlLab/utils/emptyQueryResults';
+import { emptyQueryResults, clearQueryEditors } from '../../../../src/SqlLab/utils/reduxStateToLocalStorageHelper';
 import { LOCALSTORAGE_MAX_QUERY_AGE_MS } from '../../../../src/SqlLab/constants';
-import { queries } from '../fixtures';
+import { queries, defaultQueryEditor } from '../fixtures';
 
-describe('emptyQueryResults', () => {
+describe('reduxStateToLocalStorageHelper', () => {
   const queriesObj = {};
   beforeEach(() => {
     queries.forEach((q) => {
@@ -38,5 +38,13 @@ describe('emptyQueryResults', () => {
     const emptiedQuery = emptyQueryResults(queriesObj);
     expect(emptiedQuery[id].startDttm).toBe(startDttm);
     expect(emptiedQuery[id].results).toEqual({});
+  });
+
+  it('should only return selected keys for query editor', () => {
+    const queryEditors = [defaultQueryEditor];
+    expect(Object.keys(queryEditors[0])).toContain('schemaOptions');
+
+    const clearedQueryEditors = clearQueryEditors(queryEditors);
+    expect(Object.keys(clearedQueryEditors)[0]).not.toContain('schemaOptions');
   });
 });

--- a/superset/assets/src/SqlLab/App.jsx
+++ b/superset/assets/src/SqlLab/App.jsx
@@ -27,7 +27,7 @@ import getInitialState from './reducers/getInitialState';
 import rootReducer from './reducers/index';
 import { initEnhancer } from '../reduxUtils';
 import App from './components/App';
-import emptyQueryResults from './utils/emptyQueryResults';
+import { emptyQueryResults, clearQueryEditors } from './utils/reduxStateToLocalStorageHelper';
 import { BYTES_PER_CHAR, KB_STORAGE } from './constants';
 import setupApp from '../setup/setupApp';
 
@@ -57,6 +57,8 @@ const sqlLabPersistStateConfig = {
           subset[path] = {
             ...state[path],
             queries: emptyQueryResults(state[path].queries),
+            queryEditors: clearQueryEditors(state[path].queryEditors),
+            tables: [],
           };
         }
       });

--- a/superset/assets/src/SqlLab/utils/reduxStateToLocalStorageHelper.js
+++ b/superset/assets/src/SqlLab/utils/reduxStateToLocalStorageHelper.js
@@ -18,7 +18,19 @@
  */
 import { LOCALSTORAGE_MAX_QUERY_AGE_MS } from '../constants';
 
-export default function emptyQueryResults(queries) {
+const PERSISTENT_QUERY_EDITOR_KEYS = new Set([
+  'autorun',
+  'dbId',
+  'id',
+  'latestQueryId',
+  'queryLimit',
+  'selectedText',
+  'sql',
+  'templateParams',
+  'title',
+]);
+
+export function emptyQueryResults(queries) {
   return Object.keys(queries)
     .reduce((accu, key) => {
       const { startDttm, results } = queries[key];
@@ -34,4 +46,17 @@ export default function emptyQueryResults(queries) {
       };
       return updatedQueries;
     }, {});
+}
+
+export function clearQueryEditors(queryEditors) {
+  return queryEditors
+    .map(editor =>
+    // only return selected keys
+    Object.keys(editor)
+      .filter(key => PERSISTENT_QUERY_EDITOR_KEYS.has(key))
+      .reduce((accumulator, key) => ({
+        ...accumulator,
+        [key]: editor[key],
+      }), {}),
+    );
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
recent new features increase the size of content in sql lab dropdown list (like tables etc). If we store everything in redux store into localStorage, it's very easy reach localStorage upper limit.

Solution:
remove tables/table options from localStorage.

### TEST PLAN
Added unit test for this update.


### REVIEWERS
@etr2460 @mistercrunch @michellethomas 