### PR TITLE
Fixing #7775 Change docker from jessie to stretch

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 FROM python:3.6-stretch
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.6-jessie
+FROM python:3.6-stretch
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 


### PR DESCRIPTION
apt-get was going into an infinite loop with this error. Upgrading to stretch appears to have fixed it

```
fcntl(11083488, F_SETFD, FD_CLOEXEC)    = -1 EBADF (Bad file descriptor)
getrlimit(RLIMIT_NOFILE, {rlim_cur=1073741816, rlim_max=1073741816}) = 0
```

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
