### PR TITLE
[SQLLab] Fix, database api unlimited page size v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,7 @@ babel==2.7.0              # via flask-babel
 billiard==3.6.0.0         # via celery
 bleach==3.1.0
 celery==4.3.0
-certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-chardet==3.0.4            # via requests
 click==6.7
 colorama==0.4.1
 contextlib2==0.5.5
@@ -23,7 +21,7 @@ croniter==0.3.30
 cryptography==2.7
 decorator==4.4.0          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.1.7
+flask-appbuilder==2.1.8
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.7.2
 flask-compress==1.4.0
@@ -72,16 +70,13 @@ pyyaml==5.1.2
 retry==0.9.2
 selenium==3.141.0
 simplejson==3.16.0
-six==1.12.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, pathlib2, polyline, prison, pydruid, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
+six==1.12.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, pathlib2, polyline, prison, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
 sqlalchemy-utils==0.34.1
 sqlalchemy==1.3.6
 sqlparse==0.3.0
-urllib3==1.25.3           # via requests, selenium
+urllib3==1.25.3           # via selenium
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
 werkzeug==0.15.5          # via flask, flask-jwt-extended
 wtforms-json==0.3.3
 wtforms==2.2.1            # via flask-wtf, wtforms-json
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via jsonschema, markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ croniter==0.3.30
 cryptography==2.7
 decorator==4.4.0          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.1.8
+flask-appbuilder==2.1.9
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.7.2
 flask-compress==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.0.0, <2.0.0",
-        "flask-appbuilder>=2.1.6, <2.3.0",
+        "flask-appbuilder>=2.1.9, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.0.0, <2.0.0",
-        "flask-appbuilder>=2.1.9, <2.3.0",
+        "flask-appbuilder>=2.1.8, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.0.0, <2.0.0",
-        "flask-appbuilder>=2.1.8, <2.3.0",
+        "flask-appbuilder>=2.1.9, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -218,7 +218,7 @@ export default class TableSelector extends React.PureComponent {
           '/api/v1/database/?q=' +
           '(keys:!(none),' +
           'filters:!((col:expose_in_sqllab,opr:eq,value:!t)),' +
-          'order_columns:database_name,order_direction:asc)'
+          'order_columns:database_name,order_direction:asc,page_size:-1)'
         }
         onChange={this.onDatabaseChange}
         onAsyncError={() => this.props.handleError(t('Error while fetching database list'))}

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -218,7 +218,7 @@ export default class TableSelector extends React.PureComponent {
           '/api/v1/database/?q=' +
           '(keys:!(none),' +
           'filters:!((col:expose_in_sqllab,opr:eq,value:!t)),' +
-          'order_columns:database_name,order_direction:asc,page_size:-1)'
+          'order_columns:database_name,order_direction:asc,page:0,page_size:-1)'
         }
         onChange={this.onDatabaseChange}
         onAsyncError={() => this.props.handleError(t('Error while fetching database list'))}

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -50,6 +50,8 @@ class DatabaseRestApi(DatabaseMixin, ModelRestApi):
         "allows_subquery",
         "backend",
     ]
+    # Removes the local limit for the page size
+    max_page_size = -1
 
 
 appbuilder.add_api(DatabaseRestApi)

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from flask import current_app
 from flask_appbuilder import ModelRestApi
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from flask import current_app
 from flask_appbuilder import ModelRestApi
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
@@ -52,6 +53,22 @@ class DatabaseRestApi(DatabaseMixin, ModelRestApi):
     ]
     # Removes the local limit for the page size
     max_page_size = -1
+
+    def _sanitize_page_args(self, page, page_size):
+        _page = page or 0
+        _page_size = page_size or self.page_size
+        max_page_size = self.max_page_size or current_app.config.get(
+            "FAB_API_MAX_PAGE_SIZE"
+        )
+        # Accept special -1 to uncap the page size
+        if max_page_size == -1:
+            if _page_size == -1:
+                return None, None
+            else:
+                return _page, _page_size
+        if _page_size > max_page_size or _page_size < 1:
+            _page_size = max_page_size
+        return _page, _page_size
 
 
 appbuilder.add_api(DatabaseRestApi)

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -54,21 +54,5 @@ class DatabaseRestApi(DatabaseMixin, ModelRestApi):
     # Removes the local limit for the page size
     max_page_size = -1
 
-    def _sanitize_page_args(self, page, page_size):
-        _page = page or 0
-        _page_size = page_size or self.page_size
-        max_page_size = self.max_page_size or current_app.config.get(
-            "FAB_API_MAX_PAGE_SIZE"
-        )
-        # Accept special -1 to uncap the page size
-        if max_page_size == -1:
-            if _page_size == -1:
-                return None, None
-            else:
-                return _page, _page_size
-        if _page_size > max_page_size or _page_size < 1:
-            _page_size = max_page_size
-        return _page, _page_size
-
 
 appbuilder.add_api(DatabaseRestApi)

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -415,11 +415,11 @@ class SqlLabTests(SupersetTestCase):
             "page": 0,
             "page_size": -1,
         }
-        expected_results = ['examples', 'fake_db_100', 'main']
+        expected_results = ["examples", "fake_db_100", "main"]
         url = "api/v1/database/?{}={}".format("q", prison.dumps(arguments))
         data = self.get_json_resp(url)
         for i, expected_result in enumerate(expected_results):
-            self.assertEquals(expected_result, data["result"][i]['database_name'])
+            self.assertEquals(expected_result, data["result"][i]["database_name"])
 
 
 if __name__ == "__main__":

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -20,6 +20,7 @@ import json
 import unittest
 
 from flask_appbuilder.security.sqla import models as ab_models
+import prison
 
 from superset import db, security_manager
 from superset.dataframe import SupersetDataFrame
@@ -402,6 +403,36 @@ class SqlLabTests(SupersetTestCase):
         )
 
         session.commit()
+
+    def test_api_database(self):
+        self.login("admin")
+
+        arguments = {
+            "keys": [],
+            "filters": [{"col": "expose_in_sqllab", "opr": "eq", "value": True}],
+            "order_column": "database_name",
+            "order_direction": "asc",
+            "page": 0,
+            "page_size": -1,
+        }
+        expected_results = [
+            {
+                "allow_csv_upload": False,
+                "allow_ctas": False,
+                "allow_dml": False,
+                "allow_multi_schema_metadata_fetch": False,
+                "allow_run_async": False,
+                "allows_subquery": "True",
+                "backend": "postgresql",
+                "database_name": "main",
+                "expose_in_sqllab": True,
+                "force_ctas_schema": None,
+                "id": 1,
+            }
+        ]
+        url = "api/v1/database/?{}={}".format("q", prison.dumps(arguments))
+        data = self.get_json_resp(url)
+        self.assertEquals(expected_results, data["result"])
 
 
 if __name__ == "__main__":

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -415,24 +415,11 @@ class SqlLabTests(SupersetTestCase):
             "page": 0,
             "page_size": -1,
         }
-        expected_results = [
-            {
-                "allow_csv_upload": False,
-                "allow_ctas": False,
-                "allow_dml": False,
-                "allow_multi_schema_metadata_fetch": False,
-                "allow_run_async": False,
-                "allows_subquery": "True",
-                "backend": "postgresql",
-                "database_name": "main",
-                "expose_in_sqllab": True,
-                "force_ctas_schema": None,
-                "id": 1,
-            }
-        ]
+        expected_results = ['examples', 'fake_db_100', 'main']
         url = "api/v1/database/?{}={}".format("q", prison.dumps(arguments))
         data = self.get_json_resp(url)
-        self.assertEquals(expected_results, data["result"])
+        for i, expected_result in enumerate(expected_results):
+            self.assertEquals(expected_result, data["result"][i]['database_name'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Bumps FAB to 2.1.9, and makes an unlimited request to fetch database connections on SQLLab select box.
Also added a test for this API endpoint using SQLLab request parameters (unlimited, order and filters). The added test failed for FAB 2.1.8 (has expected) and is successful on 2.1.9 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
- [X] Has associated issue: #7996, #7995  
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@etr2460 @mistercrunch  