### PR TITLE
Revert "[init] Setting up cache before registering blueprints"

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -105,10 +105,6 @@ def get_manifest():
 
 #################################################################
 
-# Setup the cache prior to registering the blueprints.
-cache = setup_cache(app, conf.get("CACHE_CONFIG"))
-tables_cache = setup_cache(app, conf.get("TABLE_NAMES_CACHE_CONFIG"))
-
 for bp in conf.get("BLUEPRINTS"):
     try:
         print("Registering blueprint: '{}'".format(bp.name))
@@ -137,6 +133,9 @@ if conf.get("WTF_CSRF_ENABLED"):
         csrf.exempt(ex)
 
 pessimistic_connection_handling(db.engine)
+
+cache = setup_cache(app, conf.get("CACHE_CONFIG"))
+tables_cache = setup_cache(app, conf.get("TABLE_NAMES_CACHE_CONFIG"))
 
 migrate = Migrate(app, db, directory=APP_DIR + "/migrations")
 


### PR DESCRIPTION
Reverts apache/incubator-superset#7992

Note this will not work given the way the caches are configured and that the blueprint registration is occurring in the same file as the cache instantiation. 
