### PR TITLE
Local config no longer fails to import silently

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -648,5 +648,5 @@ elif importlib.util.find_spec("superset_config"):
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:
-        logging.exception("Failed to import local superset_config")
+        logging.exception("Found but failed to import local superset_config")
         raise

--- a/superset/config.py
+++ b/superset/config.py
@@ -635,20 +635,18 @@ if CONFIG_PATH_ENV_VAR in os.environ:
             if key.isupper():
                 setattr(module, key, getattr(override_conf, key))
 
-        print("Loaded your LOCAL configuration at [{}]".format(cfg_path))
+        print(f"Loaded your LOCAL configuration at [{cfg_path}]")
     except Exception:
         logging.exception(
-            "Failed to import config for {}={}".format(CONFIG_PATH_ENV_VAR, cfg_path)
+            f"Failed to import config for {CONFIG_PATH_ENV_VAR}={cfg_path}"
         )
         raise
 elif importlib.util.find_spec("superset_config"):
     try:
         from superset_config import *  # noqa
-        import superset_config
+        import superset_config  # noqa
 
-        print(
-            "Loaded your LOCAL configuration at [{}]".format(superset_config.__file__)
-        )
+        print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:
-        logging.exception("Failed to import local superset_confg")
+        logging.exception("Failed to import local superset_config")
         raise

--- a/superset/config.py
+++ b/superset/config.py
@@ -643,8 +643,8 @@ if CONFIG_PATH_ENV_VAR in os.environ:
         raise
 elif importlib.util.find_spec("superset_config"):
     try:
-        from superset_config import *  # noqa
-        import superset_config  # noqa
+        from superset_config import *  # noqa pylint: disable=import-error
+        import superset_config  # noqa pylint: disable=import-error
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/config.py
+++ b/superset/config.py
@@ -23,7 +23,9 @@ at the end of this file.
 """
 from collections import OrderedDict
 import imp
+import importlib.util
 import json
+import logging
 import os
 import sys
 
@@ -622,29 +624,31 @@ TALISMAN_CONFIG = {
 # SQLALCHEMY_DATABASE_URI by default if set to `None`
 SQLALCHEMY_EXAMPLES_URI = None
 
-try:
-    if CONFIG_PATH_ENV_VAR in os.environ:
-        # Explicitly import config module that is not in pythonpath; useful
-        # for case where app is being executed via pex.
-        print(
-            "Loaded your LOCAL configuration at [{}]".format(
-                os.environ[CONFIG_PATH_ENV_VAR]
-            )
-        )
+if CONFIG_PATH_ENV_VAR in os.environ:
+    # Explicitly import config module that is not necessarily in pythonpath; useful
+    # for case where app is being executed via pex.
+    try:
+        cfg_path = os.environ[CONFIG_PATH_ENV_VAR]
         module = sys.modules[__name__]
-        override_conf = imp.load_source(
-            "superset_config", os.environ[CONFIG_PATH_ENV_VAR]
-        )
+        override_conf = imp.load_source("superset_config", cfg_path)
         for key in dir(override_conf):
             if key.isupper():
                 setattr(module, key, getattr(override_conf, key))
 
-    else:
+        print("Loaded your LOCAL configuration at [{}]".format(cfg_path))
+    except Exception:
+        logging.exception(
+            "Failed to import config for {}={}".format(CONFIG_PATH_ENV_VAR, cfg_path)
+        )
+        raise
+elif importlib.util.find_spec("superset_config"):
+    try:
         from superset_config import *  # noqa
         import superset_config
 
         print(
             "Loaded your LOCAL configuration at [{}]".format(superset_config.__file__)
         )
-except ImportError:
-    pass
+    except Exception:
+        logging.exception("Failed to import local superset_confg")
+        raise


### PR DESCRIPTION
### CATEGORY

Choose one

- [] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Previously, local superset_config or configured (via env) file could fail to import and superset would swallow the error and continue to run.  Now, if user has provided a path or a superset_config.py and it fails to import, the exception will be clearly logged and re-raised causing superset to stop immediately.

### TEST PLAN
Manually tested with both forms of config (env and superset_config), with and without various errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@betodealmeida @mistercrunch @john-bodley 