### PR TITLE
Fix: There was an issue fetching the favorite status of this dashboard (#6824)

### DIFF
--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -64,7 +64,7 @@ export const FETCH_FAVE_STAR = 'FETCH_FAVE_STAR';
 export function fetchFaveStar(id) {
   return function fetchFaveStarThunk(dispatch) {
     return SupersetClient.get({
-      endpoint: `${FAVESTAR_BASE_URL}/${id}/count`,
+      endpoint: `${FAVESTAR_BASE_URL}/${id}/count/`,
     })
       .then(({ json }) => {
         if (json.count > 0) dispatch(toggleFaveStar(true));


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Issue: When Superset is running behind a reverse proxy and the dashboard page is requested with HTTPS protocol, the frontend can't retrieve the favorite status of the dashboard and, instead, displays the following toast message: 'There was an issue fetching the favorite status of this dashboard.'

Cause: While the API exposes the /favestar/Dashboard/{id}/count/ endpoint, the frontend executes an API call to /favestar/Dashboard/{id}/count, which leads to a redirect to an endpoint with HTTP protocol

Fix: Call the correct endpoint

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #6824
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
