### PR TITLE
[fix] Allow dashboard viewer auto refresh dashboard

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/components/HeaderActionsDropdown_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/HeaderActionsDropdown_spec.jsx
@@ -71,9 +71,9 @@ describe('HeaderActionsDropdown', () => {
       expect(wrapper.find(MenuItem)).toHaveLength(1);
     });
 
-    it('should not render the RefreshIntervalModal', () => {
+    it('should render the RefreshIntervalModal', () => {
       const wrapper = setup(overrideProps);
-      expect(wrapper.find(RefreshIntervalModal)).toHaveLength(0);
+      expect(wrapper.find(RefreshIntervalModal)).toHaveLength(1);
     });
 
     it('should render the URLShortLinkModal', () => {
@@ -105,9 +105,9 @@ describe('HeaderActionsDropdown', () => {
       expect(wrapper.find(MenuItem)).toHaveLength(2);
     });
 
-    it('should not render the RefreshIntervalModal', () => {
+    it('should render the RefreshIntervalModal', () => {
       const wrapper = setup(overrideProps);
-      expect(wrapper.find(RefreshIntervalModal)).toHaveLength(0);
+      expect(wrapper.find(RefreshIntervalModal)).toHaveLength(1);
     });
 
     it('should render the URLShortLinkModal', () => {

--- a/superset/assets/spec/javascripts/dashboard/components/RefreshIntervalModal_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/RefreshIntervalModal_spec.jsx
@@ -25,6 +25,8 @@ describe('RefreshIntervalModal', () => {
   const mockedProps = {
     triggerNode: <i className="fa fa-edit" />,
     refreshFrequency: 10,
+    onChange: jest.fn(),
+    editMode: true,
   };
   it('is valid', () => {
     expect(
@@ -38,5 +40,11 @@ describe('RefreshIntervalModal', () => {
   it('should render a interval seconds', () => {
     const wrapper = mount(<RefreshIntervalModal {...mockedProps} />);
     expect(wrapper.prop('refreshFrequency')).toEqual(10);
+  });
+  it('should change refreshFrequency with edit mode', () => {
+    const wrapper = mount(<RefreshIntervalModal {...mockedProps} />);
+    wrapper.instance().handleFrequencyChange({ value: 30 });
+    expect(mockedProps.onChange).toHaveBeenCalled();
+    expect(mockedProps.onChange).toHaveBeenCalledWith(30, mockedProps.editMode);
   });
 });

--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -151,8 +151,8 @@ export function onSave() {
 }
 
 export const SET_REFRESH_FREQUENCY = 'SET_REFRESH_FREQUENCY';
-export function setRefreshFrequency(refreshFrequency) {
-  return { type: SET_REFRESH_FREQUENCY, refreshFrequency };
+export function setRefreshFrequency(refreshFrequency, isPersistent = false) {
+  return { type: SET_REFRESH_FREQUENCY, refreshFrequency, isPersistent };
 }
 
 export function saveDashboardRequestSuccess() {

--- a/superset/assets/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset/assets/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -103,8 +103,8 @@ class HeaderActionsDropdown extends React.PureComponent {
     this.props.updateCss(css);
   }
 
-  changeRefreshInterval(refreshInterval) {
-    this.props.setRefreshFrequency(refreshInterval);
+  changeRefreshInterval(refreshInterval, isPersistent) {
+    this.props.setRefreshFrequency(refreshInterval, isPersistent);
     this.props.startPeriodicRender(refreshInterval * 1000);
   }
 
@@ -177,13 +177,20 @@ class HeaderActionsDropdown extends React.PureComponent {
         <MenuItem onClick={forceRefreshAllCharts} disabled={isLoading}>
           {t('Force refresh dashboard')}
         </MenuItem>
-        {editMode && (
-          <RefreshIntervalModal
-            refreshFrequency={refreshFrequency}
-            onChange={this.changeRefreshInterval}
-            triggerNode={<span>{t('Set auto-refresh interval')}</span>}
-          />
-        )}
+
+        <RefreshIntervalModal
+          refreshFrequency={refreshFrequency}
+          onChange={this.changeRefreshInterval}
+          editMode={editMode}
+          triggerNode={
+            <span>
+              {editMode
+                ? t('Set auto-refresh interval')
+                : t('Auto-refresh dashboard')}
+            </span>
+          }
+        />
+
         {editMode && (
           <MenuItem target="_blank" href={`/dashboard/edit/${dashboardId}`}>
             {t('Edit dashboard metadata')}

--- a/superset/assets/src/dashboard/components/RefreshIntervalModal.jsx
+++ b/superset/assets/src/dashboard/components/RefreshIntervalModal.jsx
@@ -27,6 +27,7 @@ const propTypes = {
   triggerNode: PropTypes.node.isRequired,
   refreshFrequency: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
+  editMode: PropTypes.bool.isRequired,
 };
 
 const options = [
@@ -48,7 +49,17 @@ class RefreshIntervalModal extends React.PureComponent {
     this.state = {
       refreshFrequency: props.refreshFrequency,
     };
+    this.handleFrequencyChange = this.handleFrequencyChange.bind(this);
   }
+
+  handleFrequencyChange(opt) {
+    const value = opt ? opt.value : options[0].value;
+    this.setState({
+      refreshFrequency: value,
+    });
+    this.props.onChange(value, this.props.editMode);
+  }
+
   render() {
     return (
       <ModalTrigger
@@ -61,13 +72,7 @@ class RefreshIntervalModal extends React.PureComponent {
             <Select
               options={options}
               value={this.state.refreshFrequency}
-              onChange={opt => {
-                const value = opt ? opt.value : options[0].value;
-                this.setState({
-                  refreshFrequency: value,
-                });
-                this.props.onChange(value);
-              }}
+              onChange={this.handleFrequencyChange}
             />
           </div>
         }

--- a/superset/assets/src/dashboard/reducers/dashboardState.js
+++ b/superset/assets/src/dashboard/reducers/dashboardState.js
@@ -169,7 +169,7 @@ export default function dashboardStateReducer(state = {}, action) {
       return {
         ...state,
         refreshFrequency: action.refreshFrequency,
-        hasUnsavedChanges: true,
+        hasUnsavedChanges: action.isPersistent,
       };
     },
   };


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
before #7248, dashboard viewers and owners can auto refresh dashboard periodically, but this refresh frequency can not be saved into dashboard metadata. In #7248, dashboard owner can change refresh frequency and save it as part of dashboard metadata, so that next time viewer open dashboard, it will auto-refresh per owner's setting. But in this PR, viewers lost their options to change refresh frequency, even they doesn't want to change owner's setting. There are some cases where dashboard owner didn't set auto refresh, but viewers still want to auto refresh during current visit.

This PR added back this feature:
- dashboard viewers can trigger auto refresh for this visit, but this change won't persist.
- In edit mode, if dashboard owner changes auto refresh frequency, this change will be saved into dashboard metadata.

### AFTER SCREENSHOTS OR ANIMATED GIF
Dashboard viewers will see menu `Auto-refresh dashboard`:
<img width="251" alt="Screen Shot 2019-08-08 at 12 49 59 PM" src="https://user-images.githubusercontent.com/27990562/62735735-b01cc880-b9e0-11e9-9d40-05ee0fabac6a.png">

In edit mode, dashboard owners will see `Set auto-refresh interval`:
<img width="502" alt="Screen Shot 2019-08-08 at 12 50 17 PM" src="https://user-images.githubusercontent.com/27990562/62735751-bd39b780-b9e0-11e9-9cc7-df0bb4042bec.png">


![dwk0K7Y7YK](https://user-images.githubusercontent.com/27990562/62746784-313a8680-ba06-11e9-8dcc-fd33c93108e1.gif)


### TEST PLAN
CI, and manual test.



### REVIEWERS
@betodealmeida @khtruong 
@michellethomas @etr2460 