### PR TITLE
[Dashboard] Hide slice titles when they're empty

### DIFF
--- a/superset/assets/src/components/EditableTitle.jsx
+++ b/superset/assets/src/components/EditableTitle.jsx
@@ -84,6 +84,8 @@ export default class EditableTitle extends React.PureComponent {
   }
 
   handleBlur() {
+    const title = this.state.title.trim();
+
     if (!this.props.canEdit) {
       return;
     }
@@ -92,7 +94,7 @@ export default class EditableTitle extends React.PureComponent {
       isEditing: false,
     });
 
-    if (!this.state.title.length) {
+    if (!title.length) {
       this.setState({
         title: this.state.lastTitle,
       });
@@ -100,14 +102,14 @@ export default class EditableTitle extends React.PureComponent {
       return;
     }
 
-    if (this.state.lastTitle !== this.state.title) {
+    if (this.state.lastTitle !== title) {
       this.setState({
-        lastTitle: this.state.title,
+        lastTitle: title,
       });
     }
 
-    if (this.props.title !== this.state.title) {
-      this.props.onSaveTitle(this.state.title);
+    if (this.props.title !== title) {
+      this.props.onSaveTitle(title);
     }
   }
 

--- a/superset/assets/src/dashboard/components/SliceHeader.jsx
+++ b/superset/assets/src/dashboard/components/SliceHeader.jsx
@@ -109,6 +109,7 @@ class SliceHeader extends React.PureComponent {
                 : '')
             }
             canEdit={editMode}
+            emptyText=""
             onSaveTitle={updateSliceName}
             showTooltip={false}
           />


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
After https://github.com/apache/incubator-superset/pull/7084 slices can no longer have whitespace as a name. This means that there's no way to remove the title from a slice in a dashboard. This PR removes the `<empty>` text from a slice when viewing it in a dashboard.

This also prevents you from saving a slice with whitespace as a title.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Screen Shot 2019-08-09 at 10 20 41 AM](https://user-images.githubusercontent.com/7409244/62797099-aef6a480-ba8f-11e9-9349-c4051bf71033.png)

After:
![Screen Shot 2019-08-09 at 10 20 23 AM](https://user-images.githubusercontent.com/7409244/62797108-b28a2b80-ba8f-11e9-828d-759382ae21e6.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
View slices with and without titles in dashboards. See titles when not set to NULL, but see no titles when the slice doesn't have one

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @john-bodley @kristw 