### PR TITLE
Fix bug where lists in queries cannot contain multiple types

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -907,9 +907,7 @@ def merge_extra_filters(form_data: dict):
                         if isinstance(existing_filters[filter_key], list):
                             # Add filters for unequal lists
                             # order doesn't matter
-                            if set(existing_filters[filter_key]) != set(
-                                filtr["val"]
-                            ):
+                            if set(existing_filters[filter_key]) != set(filtr["val"]):
                                 form_data["adhoc_filters"].append(to_adhoc(filtr))
                         else:
                             form_data["adhoc_filters"].append(to_adhoc(filtr))

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -907,7 +907,7 @@ def merge_extra_filters(form_data: dict):
                         if isinstance(existing_filters[filter_key], list):
                             # Add filters for unequal lists
                             # order doesn't matter
-                            if sorted(existing_filters[filter_key]) != sorted(
+                            if set(existing_filters[filter_key]) != set(
                                 filtr["val"]
                             ):
                                 form_data["adhoc_filters"].append(to_adhoc(filtr))

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -301,6 +301,7 @@ class UtilsTestCase(unittest.TestCase):
             "extra_filters": [
                 {"col": "a", "op": "in", "val": "someval"},
                 {"col": "B", "op": "==", "val": ["c1", "c2"]},
+                {"col": "c", "op": "in", "val": ["c1", 1, None]},
             ],
             "adhoc_filters": [
                 {
@@ -316,6 +317,13 @@ class UtilsTestCase(unittest.TestCase):
                     "expressionType": "SIMPLE",
                     "operator": "==",
                     "subject": "B",
+                },
+                {
+                    "clause": "WHERE",
+                    "comparator": ["c1", 1, None],
+                    "expressionType": "SIMPLE",
+                    "operator": "in",
+                    "subject": "c",
                 },
             ],
         }
@@ -334,6 +342,13 @@ class UtilsTestCase(unittest.TestCase):
                     "expressionType": "SIMPLE",
                     "operator": "==",
                     "subject": "B",
+                },
+                {
+                    "clause": "WHERE",
+                    "comparator": ["c1", 1, None],
+                    "expressionType": "SIMPLE",
+                    "operator": "in",
+                    "subject": "c",
                 },
             ]
         }


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Use `set` instead of `sorted` to check equality of lists to allow for lists in queries to contain different types.

### TEST PLAN
Edited `test_merge_extra_filters_ignores_equal_filters` to include a test case for a list containing different types. Passes all tests.

### REVIEWERS
@etr2460 @john-bodley @michellethomas 
