### PR TITLE
fixed the bleeding dashboard chart issue

### DIFF
--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -23,6 +23,7 @@
   background-color: white;
   position: relative;
   padding: 16px;
+  overflow: auto;
 
   .missing-chart-container {
     display: flex;

--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -136,13 +136,3 @@
 .time-filter-tabs > .nav-tabs > li > a {
   padding: 4px;
 }
-
-// hrozion edge case
-.superset-legacy-chart-horizon {
-  overflow-y: scroll;
-  height: 95%;
-}
-
-.superset-legacy-chart-horizon, .horizon-row, span.title {
-  position: relative;
-}

--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -23,7 +23,7 @@
   background-color: white;
   position: relative;
   padding: 16px;
-  overflow: auto;
+  overflow: hidden;
 
   .missing-chart-container {
     display: flex;
@@ -40,10 +40,6 @@
       height: 40%;
     }
   }
-}
-
-.dashboard-chart {
-  overflow: hidden;
 }
 
 .dashboard-chart.dashboard-chart--overflowable {

--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -42,6 +42,10 @@
   }
 }
 
+.dashboard-chart {	
+  overflow: hidden;	
+}
+
 .dashboard-chart.dashboard-chart--overflowable {
   overflow: visible;
 }

--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -136,3 +136,13 @@
 .time-filter-tabs > .nav-tabs > li > a {
   padding: 4px;
 }
+
+// hrozion edge case
+.superset-legacy-chart-horizon {
+  overflow-y: scroll;
+  height: 95%;
+}
+
+.superset-legacy-chart-horizon, .horizon-row, span.title {
+  position: relative;
+}

--- a/superset/assets/src/dashboard/stylesheets/dashboard.less
+++ b/superset/assets/src/dashboard/stylesheets/dashboard.less
@@ -241,3 +241,11 @@ i.danger {
 i.warning {
   color: orange;
 }
+// .superset-legacy-chart-horizon {
+//   overflow-y: scroll;
+//   height: 95%;
+//   .horizon-row,
+//   .span.title {
+//     position: relative;
+//   }
+// }

--- a/superset/assets/src/dashboard/stylesheets/dashboard.less
+++ b/superset/assets/src/dashboard/stylesheets/dashboard.less
@@ -241,11 +241,3 @@ i.danger {
 i.warning {
   color: orange;
 }
-// .superset-legacy-chart-horizon {
-//   overflow-y: scroll;
-//   height: 95%;
-//   .horizon-row,
-//   .span.title {
-//     position: relative;
-//   }
-// }

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -586,3 +586,12 @@ td.filtered {
 .text-bigger {
   font-size: 110%;
 }
+// hrozion edge case
+.superset-legacy-chart-horizon {
+  overflow-y: scroll;
+  height: 95%;
+  .horizon-row,
+  .span.title {
+    position: relative;
+  }
+}


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
User mentioned Horizon chart was bleeding. I verified that it was and added simple fix. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="1134" alt="Screen Shot 2019-08-12 at 1 27 23 PM" src="https://user-images.githubusercontent.com/2353608/62897991-49ade800-bd09-11e9-9a7a-44690066b1b7.png">

After:

*Dashboard*

![dash-horizon-gif](https://user-images.githubusercontent.com/2353608/63323380-7b5f1a00-c2da-11e9-88f5-11dd3d240477.gif)

*Explore Chart*

![explore-gif](https://user-images.githubusercontent.com/2353608/63321252-00473500-c2d5-11e9-83ab-b80cbd406c84.gif)


### TEST PLAN
Do we test CSS? I can add if we do, but I did not see that in the project. (honestly didn't look hard)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #7953 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API



### REVIEWERS
@mistercrunch 