### PR TITLE
[viz] Adding get_df typing

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -31,6 +31,7 @@ import logging
 import math
 import pickle as pkl
 import re
+from typing import Any, Dict, List, Optional
 import uuid
 
 from dateutil import relativedelta as rdelta
@@ -77,7 +78,7 @@ class BaseViz(object):
 
     """All visualizations derive this base class"""
 
-    viz_type = None
+    viz_type: Optional[str] = None
     verbose_name = "Base Viz"
     credits = ""
     is_timeseries = False
@@ -181,7 +182,9 @@ class BaseViz(object):
         df = self.get_df(query_obj)
         return df.to_dict(orient="records")
 
-    def get_df(self, query_obj=None):
+    def get_df(
+        self, query_obj: Optional[Dict[str, Any]] = None
+    ) -> Optional[pd.DataFrame]:
         """Returns a pandas dataframe based on the query object"""
         if not query_obj:
             query_obj = self.query_obj()
@@ -722,7 +725,9 @@ class MarkupViz(BaseViz):
     def query_obj(self):
         return None
 
-    def get_df(self, query_obj=None):
+    def get_df(
+        self, query_obj: Optional[Dict[str, Any]] = None
+    ) -> Optional[pd.DataFrame]:
         return None
 
     def get_data(self, df):
@@ -855,7 +860,7 @@ class NVD3Viz(BaseViz):
     """Base class for all nvd3 vizs"""
 
     credits = '<a href="http://nvd3.org/">NVD3.org</a>'
-    viz_type = None
+    viz_type: Optional[str] = None
     verbose_name = "Base NVD3 Viz"
     is_timeseries = False
 
@@ -1846,7 +1851,7 @@ class IFrameViz(BaseViz):
     def query_obj(self):
         return None
 
-    def get_df(self, query_obj=None):
+    def get_df(self, query_obj: Dict[str, Any] = None) -> Optional[pd.DataFrame]:
         return None
 
     def get_data(self, df):
@@ -2105,7 +2110,7 @@ class BaseDeckGLViz(BaseViz):
 
     is_timeseries = False
     credits = '<a href="https://uber.github.io/deck.gl/">deck.gl</a>'
-    spatial_control_keys = []
+    spatial_control_keys: List[str] = []
 
     def get_metrics(self):
         self.metric = self.form_data.get("size")


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

I came across a bug in `viz.py` where [`get_csv`](https://github.com/apache/incubator-superset/blob/8cd8ec16d5017076b639a76514069cc276f930ad/superset/viz.py#L489) which uses logic like, 

```
def get_csv(self):
    df = self.get_df()
    include_index = not isinstance(df.index, pd.RangeIndex)
    ...
```

i.e., it assumes that `df` is of type `pd.DataFrame` whereas it can optionally be `None`. Going forward I'm not sure what the correct logic should be but I've added basic type hints to the `get_df(...)` method to inform developers that it can be either a `pd.DataFrame` or `None`. Note this PR does not fix the bug.

Note my preference would be for `get_df(...)` to only return a `pd.DataFrame`, that way we wouldn't need to write logic like `if df is None` in numerous places. One question is if `df` is `None` should the return value from `get_csv()` be `None` or should it be a serialized empty `pd.DataFrame`?

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @mistercrunch @villebro 