### PR TITLE
 fix: onSave datasource raises React error

### DIFF
--- a/superset/assets/spec/javascripts/explore/components/MetricsControl_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/MetricsControl_spec.jsx
@@ -368,5 +368,12 @@ describe('MetricsControl', () => {
       wrapper.setProps({ ...props, columns: [] });
       expect(onChange.calledOnce).toEqual(false);
     });
+    it('Does not fail if no columns or savedMetrics are passed', () => {
+      const { wrapper } = setup({
+        savedMetrics: null,
+        columns: null,
+      });
+      expect(wrapper.exists('.metrics-select')).toEqual(true);
+    });
   });
 });

--- a/superset/assets/src/explore/components/controls/MetricsControl.jsx
+++ b/superset/assets/src/explore/components/controls/MetricsControl.jsx
@@ -64,7 +64,7 @@ function isDictionaryForAdhocMetric(value) {
 
 function columnsContainAllMetrics(value, nextProps) {
   const columnNames = new Set(
-    [...nextProps.columns, ...nextProps.savedMetrics]
+    [...(nextProps.columns || []), ...(nextProps.savedMetrics || [])]
     // eslint-disable-next-line camelcase
       .map(({ column_name, metric_name }) => (column_name || metric_name)),
   );
@@ -245,7 +245,7 @@ export default class MetricsControl extends React.PureComponent {
       Object.keys(AGGREGATES).map(aggregate => ({ aggregate_name: aggregate })) :
       [];
     const options = [
-      ...columns,
+      ...(columns || []),
       ...aggregates,
       ...(savedMetrics || []),
     ];

--- a/superset/assets/src/explore/components/controls/MetricsControl.jsx
+++ b/superset/assets/src/explore/components/controls/MetricsControl.jsx
@@ -54,6 +54,8 @@ const propTypes = {
 const defaultProps = {
   onChange: () => {},
   clearable: true,
+  savedMetrics: [],
+  columns: [],
 };
 
 function isDictionaryForAdhocMetric(value) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When saving a datasource in the explore view, React throws up



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="651" alt="Screen Shot 2019-08-14 at 2 36 23 PM" src="https://user-images.githubusercontent.com/487433/63065975-fa101d80-bebc-11e9-86cd-4cfae4a58a45.png">

### TEST PLAN
Wrote a unit test to make sure React doesn't fail when props are null
