### PR TITLE
Set disableErrorBoundary in SuperChart to fix chart error handling

### DIFF
--- a/superset/assets/src/chart/ChartRenderer.jsx
+++ b/superset/assets/src/chart/ChartRenderer.jsx
@@ -191,6 +191,7 @@ class ChartRenderer extends React.Component {
       <React.Fragment>
         {this.renderTooltip()}
         <SuperChart
+          disableErrorBoundary
           id={`chart-id-${chartId}`}
           className={`${snakeCase(vizType)}`}
           chartType={vizType}


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
There's a bug where if you get a chart error, fix the controls, and hit "Run Query", the chart doesn't update and get rid of the error. I noticed this on the Time Series Table, if I switch from a line chart to time series table and try to add an item, a chart error appears before I update that control correctly, after it's fixed and I "run query" the chart does not update (the same error appears). 

This fixes the issue with error handling, but we should have another PR that more gracefully handles the time series table errors.

### TEST PLAN
Open a line chart, change visualization type to time series table
Add an item under "Time Series Columns"
See error in chart
Correctly fill in column configuration info in Time Series Column
Run Query (chart should show up correctly)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @kristw @etr2460 