### PR TITLE
[Explore view] Fix extra data fetch when user clicks Run Query

### DIFF
--- a/superset/assets/src/explore/components/ExploreViewContainer.jsx
+++ b/superset/assets/src/explore/components/ExploreViewContainer.jsx
@@ -131,8 +131,6 @@ class ExploreViewContainer extends React.Component {
 
   /* eslint no-unused-vars: 0 */
   componentDidUpdate(prevProps, prevState) {
-    this.triggerQueryIfNeeded();
-
     const changedControlKeys = this.findChangedControlKeys(prevProps.controls, this.props.controls);
     if (this.hasDisplayControlChanged(changedControlKeys, this.props.controls)) {
       this.addHistory({});
@@ -211,17 +209,6 @@ class ExploreViewContainer extends React.Component {
     return changedControlKeys.some(
       key => !currentControls[key].renderTrigger && !currentControls[key].dontRefreshOnChange,
     );
-  }
-
-  triggerQueryIfNeeded() {
-    if (this.props.chart.triggerQuery && !this.hasErrors()) {
-      this.props.actions.postChartFormData(
-        this.props.form_data,
-        false,
-        this.props.timeout,
-        this.props.chart.id,
-      );
-    }
   }
 
   addHistory({ isReplace = false, title }) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In explore view, when user change controls and run query again, data fetch are triggered twice. see the animated gif below. 

I believe this issue was introduced since #7233. Before that, dashboard will trigger new queries for all charts in dashboard when filter is updated, even for those charts are under nested tabs and not visible. 

In #7233, we only updated query parameters when filter is updated, but delayed the trigger for new query until chart becomes visible. Instead of call `postChartFormData` to trigger data fetching API,  I added a `componentDidupdate` method for chart component, and use react component state change and triggerQuery flag to trigger the data fetch.

Currently explore view container component it also has componentDidUpdate, it will call data fetching API on parent component updated. Together with chart's componentDidupdate change, that's the reason data fetching is called twice.

Solution:
Do not need to call `postChartFormData` from exploreview container component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**
 
![Il9FmAes6u](https://user-images.githubusercontent.com/27990562/63303904-11bd1c80-c296-11e9-809c-14f9a059f8fb.gif)


**After**
![disyNsnsY6](https://user-images.githubusercontent.com/27990562/63303799-c0ad2880-c295-11e9-9563-f4f087e059da.gif)



### TEST PLAN
CI and manual test


### REVIEWERS
@etr2460 @michellethomas