### PR TITLE
[WIP] [bugfix] Fix CTEs for engines that don't support LIMIT expression

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -379,11 +379,11 @@ Here's a list of some of the recommended packages.
 +------------------+---------------------------------------+-------------------------------------------------+
 | Google Sheets    | ``pip install gsheetsdb``             | ``gsheets://``                                  |
 +------------------+---------------------------------------+-------------------------------------------------+
-| IBM Db2          | ``pip install ibm_db_sa``             | ``db2+ibm_db://``                               |
+| IBM Db2*         | ``pip install ibm_db_sa``             | ``db2+ibm_db://``                               |
 +------------------+---------------------------------------+-------------------------------------------------+
 | MySQL            | ``pip install mysqlclient``           | ``mysql://``                                    |
 +------------------+---------------------------------------+-------------------------------------------------+
-| Oracle           | ``pip install cx_Oracle``             | ``oracle://``                                   |
+| Oracle*          | ``pip install cx_Oracle``             | ``oracle://``                                   |
 +------------------+---------------------------------------+-------------------------------------------------+
 | PostgreSQL       | ``pip install psycopg2``              | ``postgresql+psycopg2://``                      |
 +------------------+---------------------------------------+-------------------------------------------------+
@@ -393,13 +393,16 @@ Here's a list of some of the recommended packages.
 +------------------+---------------------------------------+-------------------------------------------------+
 | SQLite           |                                       | ``sqlite://``                                   |
 +------------------+---------------------------------------+-------------------------------------------------+
-| SQL Server       | ``pip install pymssql``               | ``mssql://``                                    |
+| SQL Server*      | ``pip install pymssql``               | ``mssql://``                                    |
 +------------------+---------------------------------------+-------------------------------------------------+
-| Teradata         | ``pip install sqlalchemy-teradata``   | ``teradata://``                                 |
+| Teradata*        | ``pip install sqlalchemy-teradata``   | ``teradata://``                                 |
 +------------------+---------------------------------------+-------------------------------------------------+
 | Vertica          | ``pip install                         |  ``vertica+vertica_python://``                  |
 |                  | sqlalchemy-vertica-python``           |                                                 |
 +------------------+---------------------------------------+-------------------------------------------------+
+
+* Databases that don't support ANSI SQL standard LIMIT syntax will not automatically
+limit CTE queries.
 
 Note that many other databases are supported, the main criteria being the
 existence of a functional SqlAlchemy dialect and Python driver. Googling

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -143,7 +143,6 @@ class BaseEngineSpec:
     allows_joins = True
     allows_subqueries = True
     allows_column_aliases = True
-    allows_limit_syntax = True
     force_column_alias_quotes = False
     arraysize = 0
     max_column_name_length = 0

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -54,6 +54,9 @@ class ParsedQuery(object):
     def is_select(self) -> bool:
         return self._parsed[0].get_type() == "SELECT"
 
+    def is_cte(self):
+        return self.stripped().upper().startswith("WITH")
+
     def is_explain(self) -> bool:
         return self.stripped().upper().startswith("EXPLAIN")
 

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -45,6 +45,7 @@ class ParsedQuery(object):
 
     @property
     def tables(self) -> Set[str]:
+        """Get a set of tables referenced by the query."""
         return self._table_names
 
     @property
@@ -54,7 +55,7 @@ class ParsedQuery(object):
     def is_select(self) -> bool:
         return self._parsed[0].get_type() == "SELECT"
 
-    def is_cte(self):
+    def is_cte(self) -> bool:
         return self.stripped().upper().startswith("WITH")
 
     def is_explain(self) -> bool:
@@ -65,10 +66,20 @@ class ParsedQuery(object):
         return self.is_select() or self.is_explain()
 
     def stripped(self) -> str:
+        """
+        Generate a query where all spaces, tabs, line changes and colons have
+        been removed.
+
+        :return: Stripped query
+        """
         return self.sql.strip(" \t\n;")
 
     def get_statements(self) -> List[str]:
-        """Returns a list of SQL statements as strings, stripped"""
+        """
+        Returns a list of SQL statements as strings, stripped.
+
+        :return: List of SQL statements
+        """
         statements = []
         for statement in self._parsed:
             if statement:

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -967,3 +967,12 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         else:
             expected = ["VARCHAR(255)", "VARCHAR(255)", "FLOAT"]
         self.assertEquals(col_names, expected)
+
+    def test_cte_query(self):
+        database = get_example_database()
+        cte_query = "WITH t AS (SELECT 1 a) SELECT * FROM t"
+        limit = 10
+        result_mssql = MssqlEngineSpec.apply_limit_to_sql(cte_query, limit, database)
+        result_mysql = MySQLEngineSpec.apply_limit_to_sql(cte_query, limit, database)
+        self.assertEqual(cte_query, result_mssql)
+        self.assertEqual(cte_query + "\nLIMIT 10", result_mysql)

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -974,5 +974,5 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         limit = 10
         result_mssql = MssqlEngineSpec.apply_limit_to_sql(cte_query, limit, database)
         result_mysql = MySQLEngineSpec.apply_limit_to_sql(cte_query, limit, database)
-        self.assertEqual(cte_query, result_mssql)
-        self.assertEqual(cte_query + "\nLIMIT 10", result_mysql)
+        self.assertEqual(result_mssql, cte_query)
+        self.assertEqual(result_mysql, cte_query + "\nLIMIT 10")


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
In SQL Lab, CTEs were failing for engines that don't support LIMIT expressions. This removes limits for those engines when performing CTEs and adds tests.

### TEST PLAN
- Test CTE on MSSQL and Oracle
- CI

### SCREENSHOTS

SQL Server:
![image](https://user-images.githubusercontent.com/33317356/63445026-5f758880-c440-11e9-9941-a8c0ee0bc897.png)

Oracle:
![image](https://user-images.githubusercontent.com/33317356/63445061-6d2b0e00-c440-11e9-8930-cecbc17b2ac2.png)


### ADDITIONAL INFORMATION
- [x] Has associated issue: Closes #8074
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@abhinavsood @mistercrunch 