### PR TITLE
add GeoJSON encoding support to deck.gl Polygon chart

### DIFF
--- a/superset/assets/src/explore/controlPanels/DeckPolygon.js
+++ b/superset/assets/src/explore/controlPanels/DeckPolygon.js
@@ -74,6 +74,11 @@ export default {
     },
     line_type: {
       label: t('Polygon Encoding'),
+      description: t('The encoding format of the polygons. Each row should contain either a valid Polyline string, valid GeoJSON polygon/multipolygon object, or JSON.array(N) of [longitude, latitude] points'),
+      choices: [
+        ['polyline', 'Polyline'],
+        ['json', 'JSON/GeoJSON'],
+      ],
     },
     point_radius_fixed: {
       label: t('Elevation'),

--- a/superset/assets/src/explore/controlPanels/DeckPolygon.js
+++ b/superset/assets/src/explore/controlPanels/DeckPolygon.js
@@ -78,6 +78,7 @@ export default {
       choices: [
         ['polyline', 'Polyline'],
         ['json', 'JSON/GeoJSON'],
+        ['geohash', 'geohash (square)'],
       ],
     },
     point_radius_fixed: {

--- a/superset/assets/src/visualizations/deckgl/layers/Polygon/Polygon.jsx
+++ b/superset/assets/src/visualizations/deckgl/layers/Polygon/Polygon.jsx
@@ -20,14 +20,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { PolygonLayer } from 'deck.gl';
 
 import AnimatableDeckGLContainer from '../../AnimatableDeckGLContainer';
 import Legend from '../../../Legend';
 import TooltipRow from '../../TooltipRow';
 import { getBuckets, getBreakPointColorScaler } from '../../utils';
-
 import { commonLayerProps, fitViewport } from '../common';
 import { getPlaySliderParams } from '../../../../modules/time';
 import sandboxedEval from '../../../../modules/sandbox';
@@ -48,13 +46,13 @@ function flattenPolygons(data) {
       const points = feature.polygon.coordinates;
       switch (polygonType) {
         case POLYGON_TYPES.single:
-            newData.push({ ...feature, polygon: points });
+          newData.push({ ...feature, polygon: points[0] });
           break;
         case POLYGON_TYPES.multi:
-            points.forEach((polygonPoints) => {
-              newData.push({ ...feature, polygon: polygonPoints });
-            });
-            break;
+          points.forEach((polygonPoints) => {
+            newData.push({ ...feature, polygon: polygonPoints[0] });
+          });
+          break;
         default:
       }
     }
@@ -63,7 +61,7 @@ function flattenPolygons(data) {
 }
 
 function getPoints(features) {
-  return flattenPolygons(features).map(d => d.polygon.flat()).flat();
+  return flattenPolygons(features).map(d => d.polygon).flat();
 }
 
 function getElevation(d, colorScaler) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the deck.gl Polygon layer only accepts JSON coordinate arrays, polyline, or geohashes as data inputs. This requires user's to perform substantial pre-processing on their data if their data source stores geometry objects as GeoJSON. 

This PR adds GeoJSON encoding support to the deck.gl polygon chart. It will automatically determine if the user supplied polygon data is a GeoJSON (either single or multi-polygon) or a simple JSON coordinate array. All existing charts using JSON coordinate arrays should be unaffected by this change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/7088252/63461980-d5212a80-c427-11e9-8978-ac77c8f0f112.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Visual inspection

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
