### PR TITLE
Move Darwin-specific JS libs to optional

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -186,7 +186,6 @@
     "fetch-mock": "^7.0.0-alpha.6",
     "file-loader": "^1.1.11",
     "fork-ts-checker-webpack-plugin": "^0.4.9",
-    "fsevents": "^2.0.7",
     "ignore-styles": "^5.0.1",
     "imports-loader": "^0.7.1",
     "jest": "^24.8.0",
@@ -217,5 +216,8 @@
     "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.14",
     "webpack-sources": "^1.1.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.0.7"
   }
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
fsevents is Darwin (OSX) specific library/wrapper. Build fails on non-darwin (e.g. linux) environments. Moved fsevents to optional dependencies which can be skipped with `--no-optional`, issuing a warning instead of error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
