### PR TITLE
[Hive Engine Spec] Fix latest partition logic

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -950,10 +950,10 @@ class PrestoEngineSpec(BaseEngineSpec):
             )
         except Exception:
             # table is not partitioned
-            return False
+            return None
 
         if values is None:
-            return False
+            return None
 
         column_names = {column.get("name") for column in columns or []}
         for col_name, value in zip(col_names, values):
@@ -962,7 +962,7 @@ class PrestoEngineSpec(BaseEngineSpec):
         return query
 
     @classmethod
-    def _latest_partition_from_df(cls, df):
+    def _latest_partition_from_df(cls, df) -> Optional[List[str]]:
         if not df.empty:
             return df.to_records(index=False)[0].item()
         return None


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the Presto db engine spec was changed to support multiple partition columns, it broke Hive because it extends Presto. Table previews and copy select star broke because they wouldn't add partition filters. This PR updates the functions that the Hive spec extends to return and accept the same data types

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- Test copy select statement and ensure it has a partition
- Test table preview
- Test jinja latest partition function

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@michellethomas @villebro @betodealmeida @serenajiang 