### PR TITLE
Allow resizing width of SQL Lab left bar / editor

### DIFF
--- a/superset/assets/package-lock.json
+++ b/superset/assets/package-lock.json
@@ -2605,6 +2605,13 @@
       "requires": {
         "@babel/runtime": "^7.1.2",
         "whatwg-fetch": "^3.0.0"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+        }
       }
     },
     "@superset-ui/core": {

--- a/superset/assets/spec/javascripts/sqllab/SqlEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/SqlEditor_spec.jsx
@@ -21,8 +21,8 @@ import { shallow } from 'enzyme';
 
 import { defaultQueryEditor, initialState, queries, table } from './fixtures';
 import {
-  SQL_EDITOR_GUTTER_HEIGHT,
-  SQL_EDITOR_GUTTER_MARGIN,
+  SQL_EDITOR_VERTICAL_GUTTER_HEIGHT,
+  SQL_EDITOR_VERTICAL_GUTTER_MARGIN,
   SQL_TOOLBAR_HEIGHT,
 } from '../../../src/SqlLab/constants';
 import AceEditorWrapper from '../../../src/SqlLab/components/AceEditorWrapper';
@@ -73,8 +73,8 @@ describe('SqlEditor', () => {
     const totalSize = parseFloat(wrapper.find(AceEditorWrapper).props().height)
       + wrapper.find(SouthPane).props().height
       + SQL_TOOLBAR_HEIGHT
-      + (SQL_EDITOR_GUTTER_MARGIN * 2)
-      + SQL_EDITOR_GUTTER_HEIGHT;
+      + (SQL_EDITOR_VERTICAL_GUTTER_MARGIN * 2)
+      + SQL_EDITOR_VERTICAL_GUTTER_HEIGHT;
     expect(totalSize).toEqual(MOCKED_SQL_EDITOR_HEIGHT);
   });
   it('does not overflow the editor window after resizing', () => {
@@ -83,8 +83,8 @@ describe('SqlEditor', () => {
     const totalSize = parseFloat(wrapper.find(AceEditorWrapper).props().height)
       + wrapper.find(SouthPane).props().height
       + SQL_TOOLBAR_HEIGHT
-      + (SQL_EDITOR_GUTTER_MARGIN * 2)
-      + SQL_EDITOR_GUTTER_HEIGHT;
+      + (SQL_EDITOR_VERTICAL_GUTTER_MARGIN * 2)
+      + SQL_EDITOR_VERTICAL_GUTTER_HEIGHT;
     expect(totalSize).toEqual(450);
   });
   it('render a LimitControl with default limit', () => {

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -46,9 +46,10 @@ import SqlEditorLeftBar from './SqlEditorLeftBar';
 import AceEditorWrapper from './AceEditorWrapper';
 import {
   STATE_BSSTYLE_MAP,
-  SQL_EDITOR_GUTTER_HEIGHT,
-  SQL_EDITOR_GUTTER_MARGIN,
+  SQL_EDITOR_VERTICAL_GUTTER_HEIGHT,
+  SQL_EDITOR_VERTICAL_GUTTER_MARGIN,
   SQL_TOOLBAR_HEIGHT,
+  SQL_EDITOR_HORIZONTAL_GUTTER_WIDTH,
 } from '../constants';
 import RunQueryActionButton from './RunQueryActionButton';
 import { FeatureFlag, isFeatureEnabled } from '../../featureFlags';
@@ -56,8 +57,11 @@ import { FeatureFlag, isFeatureEnabled } from '../../featureFlags';
 const SQL_EDITOR_PADDING = 10;
 const INITIAL_NORTH_PERCENT = 30;
 const INITIAL_SOUTH_PERCENT = 70;
+const INITIAL_WEST_PERCENT = 20;
+const INITIAL_EAST_PERCENT = 80;
 const VALIDATION_DEBOUNCE_MS = 600;
 const WINDOW_RESIZE_THROTTLE_MS = 100;
+const SQL_EDITOR_MIN_SIZE = 300;
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -103,6 +107,7 @@ class SqlEditor extends React.PureComponent {
     this.onSqlChanged = this.onSqlChanged.bind(this);
     this.setQueryEditorSql = this.setQueryEditorSql.bind(this);
     this.queryPane = this.queryPane.bind(this);
+    this.leftBar = this.leftBar.bind(this);
     this.getAceEditorAndSouthPaneHeights = this.getAceEditorAndSouthPaneHeights.bind(this);
     this.getSqlEditorHeight = this.getSqlEditorHeight.bind(this);
     this.requestValidation = debounce(
@@ -164,10 +169,10 @@ class SqlEditor extends React.PureComponent {
   getAceEditorAndSouthPaneHeights(height, northPercent, southPercent) {
     return {
       aceEditorHeight: height * northPercent / 100
-        - (SQL_EDITOR_GUTTER_HEIGHT / 2 + SQL_EDITOR_GUTTER_MARGIN)
+        - (SQL_EDITOR_VERTICAL_GUTTER_HEIGHT / 2 + SQL_EDITOR_VERTICAL_GUTTER_MARGIN)
         - SQL_TOOLBAR_HEIGHT,
       southPaneHeight: height * southPercent / 100
-        - (SQL_EDITOR_GUTTER_HEIGHT / 2 + SQL_EDITOR_GUTTER_MARGIN),
+        - (SQL_EDITOR_VERTICAL_GUTTER_HEIGHT / 2 + SQL_EDITOR_VERTICAL_GUTTER_MARGIN),
     };
   }
   getHotkeyConfig() {
@@ -215,7 +220,7 @@ class SqlEditor extends React.PureComponent {
   }
   elementStyle(dimension, elementSize, gutterSize) {
     return {
-      [dimension]: `calc(${elementSize}% - ${gutterSize + SQL_EDITOR_GUTTER_MARGIN}px)`,
+      [dimension]: `calc(${elementSize}% - ${gutterSize + SQL_EDITOR_VERTICAL_GUTTER_MARGIN}px)`,
     };
   }
   requestValidation() {
@@ -287,7 +292,7 @@ class SqlEditor extends React.PureComponent {
         elementStyle={this.elementStyle}
         minSize={200}
         direction="vertical"
-        gutterSize={SQL_EDITOR_GUTTER_HEIGHT}
+        gutterSize={SQL_EDITOR_VERTICAL_GUTTER_HEIGHT}
         onDragStart={this.onResizeStart}
         onDragEnd={this.onResizeEnd}
       >
@@ -453,30 +458,33 @@ class SqlEditor extends React.PureComponent {
       </div>
     );
   }
+  leftBar() {
+    return (
+      <CSSTransition
+        classNames="schemaPane"
+        in={!this.props.hideLeftBar}
+        timeout={300}
+      >
+        <SqlEditorLeftBar
+          database={this.props.database}
+          queryEditor={this.props.queryEditor}
+          tables={this.props.tables}
+          actions={this.props.actions}
+        />
+      </CSSTransition>
+    );
+  }
   render() {
     return (
       <Split
         ref={this.sqlEditorRef}
-        className="SqlEditor"
-        sizes={[20, 80]}
+        className={this.props.hideLeftBar ? 'SqlEditor-expanded' : 'SqlEditor'}
+        sizes={[INITIAL_WEST_PERCENT, INITIAL_EAST_PERCENT]}
         direction="horizontal"
-        minSize={300}
-        gutterSize={2}
+        minSize={SQL_EDITOR_MIN_SIZE}
+        gutterSize={SQL_EDITOR_HORIZONTAL_GUTTER_WIDTH}
       >
-        {/* <CSSTransition
-          classNames="schemaPane"
-          in={!this.props.hideLeftBar}
-          timeout={300}
-        > */}
-          <div className="schemaPane">
-            <SqlEditorLeftBar
-              database={this.props.database}
-              queryEditor={this.props.queryEditor}
-              tables={this.props.tables}
-              actions={this.props.actions}
-            />
-          </div>
-        {/* </CSSTransition> */}
+        {this.leftBar()}
         {this.queryPane()}
       </Split>
     );

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -483,6 +483,7 @@ class SqlEditor extends React.PureComponent {
         direction="horizontal"
         minSize={SQL_EDITOR_MIN_SIZE}
         gutterSize={SQL_EDITOR_HORIZONTAL_GUTTER_WIDTH}
+        snapOffset={0}
       >
         {this.leftBar()}
         {this.queryPane()}

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -455,12 +455,19 @@ class SqlEditor extends React.PureComponent {
   }
   render() {
     return (
-      <div ref={this.sqlEditorRef} className="SqlEditor">
-        <CSSTransition
+      <Split
+        ref={this.sqlEditorRef}
+        className="SqlEditor"
+        sizes={[20, 80]}
+        direction="horizontal"
+        minSize={300}
+        gutterSize={2}
+      >
+        {/* <CSSTransition
           classNames="schemaPane"
           in={!this.props.hideLeftBar}
           timeout={300}
-        >
+        > */}
           <div className="schemaPane">
             <SqlEditorLeftBar
               database={this.props.database}
@@ -469,9 +476,9 @@ class SqlEditor extends React.PureComponent {
               actions={this.props.actions}
             />
           </div>
-        </CSSTransition>
+        {/* </CSSTransition> */}
         {this.queryPane()}
-      </div>
+      </Split>
     );
   }
 }

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -321,6 +321,22 @@ class SqlEditor extends React.PureComponent {
       </Split>
     );
   }
+  leftBar() {
+    return (
+      <CSSTransition
+        classNames="schemaPane"
+        in={!this.props.hideLeftBar}
+        timeout={300}
+      >
+        <SqlEditorLeftBar
+          database={this.props.database}
+          queryEditor={this.props.queryEditor}
+          tables={this.props.tables}
+          actions={this.props.actions}
+        />
+      </CSSTransition>
+    );
+  }
   renderEditorBottomBar(hotkeys) {
     let ctasControls;
     if (this.props.database && this.props.database.allow_ctas) {
@@ -456,22 +472,6 @@ class SqlEditor extends React.PureComponent {
           }
         </div>
       </div>
-    );
-  }
-  leftBar() {
-    return (
-      <CSSTransition
-        classNames="schemaPane"
-        in={!this.props.hideLeftBar}
-        timeout={300}
-      >
-        <SqlEditorLeftBar
-          database={this.props.database}
-          queryEditor={this.props.queryEditor}
-          tables={this.props.tables}
-          actions={this.props.actions}
-        />
-      </CSSTransition>
     );
   }
   render() {

--- a/superset/assets/src/SqlLab/constants.js
+++ b/superset/assets/src/SqlLab/constants.js
@@ -45,9 +45,10 @@ export const TIME_OPTIONS = [
 ];
 
 // SqlEditor layout constants
-export const SQL_EDITOR_GUTTER_HEIGHT = 5;
-export const SQL_EDITOR_GUTTER_MARGIN = 3;
+export const SQL_EDITOR_VERTICAL_GUTTER_HEIGHT = 5;
+export const SQL_EDITOR_VERTICAL_GUTTER_MARGIN = 3;
 export const SQL_TOOLBAR_HEIGHT = 51;
+export const SQL_EDITOR_HORIZONTAL_GUTTER_WIDTH = 5;
 
 // kilobyte storage
 export const KB_STORAGE = 1024;

--- a/superset/assets/src/SqlLab/main.less
+++ b/superset/assets/src/SqlLab/main.less
@@ -229,7 +229,7 @@ div.Workspace {
     }
 }
 
-.SqlEditor {
+.SqlEditor, .SqlEditor-expanded {
     display: flex;
     flex-direction: row;
     height: 100%;
@@ -241,13 +241,11 @@ div.Workspace {
     }
 
     .schemaPane {
-        flex: 0 0 300px;
         transition: transform .3s ease-in-out;
     }
 
     .queryPane {
         flex: 1 1 auto;
-        padding-left: 10px;
     }
 
     .schemaPane-enter-done, .schemaPane-exit {
@@ -275,12 +273,15 @@ div.Workspace {
 }
 
 .SqlEditor .gutter-horizontal {
-    background-color: #ccc;
-    // border-left: 1px solid #ccc;
-    // border-right: 1px solid #ccc;
-    // height: 3%;
-    // margin: 47% 3px;
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+    height: 40px;
     cursor: col-resize;
+    margin-right: 10px;
+}
+
+.SqlEditor-expanded .gutter-horizontal {
+    display: none;
 }
 
 .queryPane .gutter-vertical {

--- a/superset/assets/src/SqlLab/main.less
+++ b/superset/assets/src/SqlLab/main.less
@@ -242,7 +242,6 @@ div.Workspace {
 
     .schemaPane {
         flex: 0 0 300px;
-        max-width: 300px;
         transition: transform .3s ease-in-out;
     }
 
@@ -273,18 +272,25 @@ div.Workspace {
     .schemaPane-exit-done + .queryPane {
         margin-left: 0;
     }
-
-    .gutter {
-        border-top: 1px solid #ccc;
-        border-bottom: 1px solid #ccc;
-        width: 3%;
-        margin: 3px 47%;
-    }
-
-    .gutter.gutter-vertical {
-        cursor: row-resize;
-    }
 }
+
+.SqlEditor .gutter-horizontal {
+    background-color: #ccc;
+    // border-left: 1px solid #ccc;
+    // border-right: 1px solid #ccc;
+    // height: 3%;
+    // margin: 47% 3px;
+    cursor: col-resize;
+}
+
+.queryPane .gutter-vertical {
+    border-top: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
+    width: 3%;
+    margin: 3px 47%;
+    cursor: row-resize;
+}
+
 
 .SqlEditorLeftBar {
     height: 100%;


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds a gutter for resizing the width of SQL Lab left bar and editor. Currently, the setting is not persisted, since in the cases we observed the use was more circumstantial.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

![sqllab_resize_width](https://user-images.githubusercontent.com/1534870/63601911-34dc1a80-c57b-11e9-93bf-7e4da404bd92.gif)

Note that the gutter is not vertically centered, which I found more intuitive. I can move it to the center.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

See video above.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@etr2460 @graceguo-supercat 