### PR TITLE
[logging] add query id to SQL Lab logs

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -79,9 +79,9 @@ def get_query(query_id, session, retry_count=5):
             query = session.query(Query).filter_by(id=query_id).one()
         except Exception:
             attempt += 1
-            logging.error("Query with id `{}` could not be retrieved".format(query_id))
+            logging.error(f"Query with id `{query_id}` could not be retrieved")
             stats_logger.incr("error_attempting_orm_query_" + str(attempt))
-            logging.error("Sleeping for a sec before retrying...")
+            logging.error(f"Query {query_id}: Sleeping for a sec before retrying...")
             sleep(1)
     if not query:
         stats_logger.incr("error_failed_at_getting_orm_query")
@@ -144,7 +144,7 @@ def get_sql_results(
                 start_time=start_time,
             )
         except Exception as e:
-            logging.exception(e)
+            logging.exception(f"Query {query_id}: {e}")
             stats_logger.incr("error_sqllab_unhandled")
             query = get_query(query_id, session)
             return handle_query_error(str(e), query, session)
@@ -152,6 +152,7 @@ def get_sql_results(
 
 def execute_sql_statement(sql_statement, query, user_name, session, cursor):
     """Executes a single SQL statement"""
+    query_id = query.id
     database = query.database
     db_engine_spec = database.db_engine_spec
     parsed_query = ParsedQuery(sql_statement)
@@ -200,26 +201,30 @@ def execute_sql_statement(sql_statement, query, user_name, session, cursor):
             )
         query.executed_sql = sql
         with stats_timing("sqllab.query.time_executing_query", stats_logger):
-            logging.info("Running query: \n{}".format(sql))
+            logging.info(f"Query {query_id}: Running query: \n{sql}")
             db_engine_spec.execute(cursor, sql, async_=True)
-            logging.info("Handling cursor")
+            logging.info(f"Query {query_id}: Handling cursor")
             db_engine_spec.handle_cursor(cursor, query, session)
 
         with stats_timing("sqllab.query.time_fetching_results", stats_logger):
-            logging.debug("Fetching data for query object: {}".format(query.to_dict()))
+            logging.debug(
+                "Query {}: Fetching data for query object: {}".format(
+                    query_id, query.to_dict()
+                )
+            )
             data = db_engine_spec.fetch_data(cursor, query.limit)
 
     except SoftTimeLimitExceeded as e:
-        logging.exception(e)
+        logging.exception(f"Query {query_id}: {e}")
         raise SqlLabTimeoutException(
             "SQL Lab timeout. This environment's policy is to kill queries "
             "after {} seconds.".format(SQLLAB_TIMEOUT)
         )
     except Exception as e:
-        logging.exception(e)
+        logging.exception(f"Query {query_id}: {e}")
         raise SqlLabException(db_engine_spec.extract_error_message(e))
 
-    logging.debug("Fetching cursor description")
+    logging.debug(f"Query {query_id}: Fetching cursor description")
     cursor_description = cursor.description
     return dataframe.SupersetDataFrame(data, cursor_description, db_engine_spec)
 
@@ -251,11 +256,12 @@ def execute_sql_statements(
     # Breaking down into multiple statements
     parsed_query = ParsedQuery(rendered_query)
     statements = parsed_query.get_statements()
-    logging.info(f"Executing {len(statements)} statement(s)")
+    logging.info(f"Query {query_id}: Executing {len(statements)} statement(s)")
 
-    logging.info("Set query to 'running'")
+    logging.info(f"Query {query_id}: Set query to 'running'")
     query.status = QueryStatus.RUNNING
     query.start_running_time = now_as_float()
+    session.commit()
 
     engine = database.get_sqla_engine(
         schema=query.schema,
@@ -269,16 +275,20 @@ def execute_sql_statements(
         with closing(conn.cursor()) as cursor:
             statement_count = len(statements)
             for i, statement in enumerate(statements):
-                # TODO CHECK IF STOPPED
+                # Check if stopped
+                query = get_query(query_id, session)
+                if query.status == QueryStatus.STOPPED:
+                    return
+
+                # Run statement
                 msg = f"Running statement {i+1} out of {statement_count}"
-                logging.info(msg)
+                logging.info(f"Query {query_id}: {msg}")
                 query.set_extra_json_key("progress", msg)
                 session.commit()
                 try:
                     cdf = execute_sql_statement(
                         statement, query, user_name, session, cursor
                     )
-                    msg = f"Running statement {i+1} out of {statement_count}"
                 except Exception as e:
                     msg = str(e)
                     if statement_count > 1:
@@ -320,7 +330,9 @@ def execute_sql_statements(
 
     if store_results:
         key = str(uuid.uuid4())
-        logging.info(f"Storing results in results backend, key: {key}")
+        logging.info(
+            f"Query {query_id}: Storing results in results backend, key: {key}"
+        )
         with stats_timing("sqllab.query.results_backend_write", stats_logger):
             json_payload = json.dumps(
                 payload, default=json_iso_dttm_ser, ignore_nan=True

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2572,8 +2572,8 @@ class Superset(BaseSupersetView):
             )
         except Exception as e:
             return json_error_response(
-                "Template rendering failed: {}".format(
-                    utils.error_msg_from_exception(e)
+                "Query {}: Template rendering failed: {}".format(
+                    query_id, utils.error_msg_from_exception(e)
                 )
             )
 
@@ -2583,7 +2583,7 @@ class Superset(BaseSupersetView):
 
         # Async request.
         if async_:
-            logging.info("Running query on a Celery worker")
+            logging.info(f"Query {query_id}: Running query on a Celery worker")
             # Ignore the celery future object and the request may time out.
             try:
                 sql_lab.get_sql_results.delay(
@@ -2595,7 +2595,7 @@ class Superset(BaseSupersetView):
                     start_time=now_as_float(),
                 )
             except Exception as e:
-                logging.exception(e)
+                logging.exception(f"Query {query_id}: {e}")
                 msg = _(
                     "Failed to start remote query on a worker. "
                     "Tell your administrator to verify the availability of "
@@ -2637,7 +2637,7 @@ class Superset(BaseSupersetView):
                 encoding=None,
             )
         except Exception as e:
-            logging.exception(e)
+            logging.exception(f"Query {query_id}: {e}")
             return json_error_response("{}".format(e))
         if data.get("status") == QueryStatus.FAILED:
             return json_error_response(payload=data)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation
- [X] Logging

### SUMMARY
It's hard to debug sqllab using logs because (afaik) there is nothing indicating which logs correspond to which queries, so I added `query_id` into relevant logs to help with debugging in the future.

### TEST PLAN
tox passes.

### REVIEWERS
@graceguo-supercat @etr2460 
