### PR TITLE
Moving towards a whitelist approach for MANIFEST.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 .DS_Store
 .eggs
 .idea
+.mypy_cache
 .python-version
 .tox
 .vscode

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,15 +20,14 @@ graft licenses/
 include README.md
 recursive-include superset/examples *
 recursive-include superset/migrations *
-recursive-include superset/static *
-recursive-exclude superset/static/assets/docs *
-recursive-exclude superset/static/assets/images/viz_thumbnails_large *
-recursive-exclude superset/static/docs *
-recursive-exclude superset/static/spec *
-recursive-exclude superset/static/assets/src *
-recursive-include superset/static/assets/src/visualizations/CountryMap/ *
+
+# Whitelist anything that needs to be added to the static bundle
+recursive-include superset/static/assets/branding *
+recursive-include superset/static/assets/dist *
+recursive-include superset/static/assets/images *
 recursive-exclude superset/static/images/viz_thumbnails_large *
-recursive-exclude superset/static/assets/node_modules *
+recursive-include superset/static/assets/stylesheets *
+
 recursive-include superset/templates *
 recursive-include superset/translations *
 recursive-exclude tests *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ recursive-include superset/examples *
 recursive-include superset/migrations *
 
 # Whitelist anything that needs to be added to the static bundle
+recursive-exclude superset/static *
 recursive-include superset/static/assets/branding *
 recursive-include superset/static/assets/dist *
 recursive-include superset/static/assets/images *

--- a/superset/config.py
+++ b/superset/config.py
@@ -49,8 +49,21 @@ else:
 # ---------------------------------------------------------
 PACKAGE_DIR = os.path.join(BASE_DIR, "static", "assets")
 VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
-with open(VERSION_INFO_FILE) as version_info_file:
-    VERSION_STRING = json.load(version_info_file)["version"]
+PACKAGE_JSON_FILE = os.path.join(PACKAGE_DIR, "package.json")
+
+#
+# Depending on the context in which this config is loaded, the version_info.json file
+# may or may not be available, as it is generated on install via setup.py. In the event
+# that we're actually running Superset, we will have already installed, therefore it WILL
+# exist. When unit tests are running, however, it WILL NOT exist, so we fall
+# back to reading package.json
+#
+try:
+    with open(VERSION_INFO_FILE) as version_file:
+        VERSION_STRING = json.load(version_file)["version"]
+except Exception:
+    with open(PACKAGE_JSON_FILE) as version_file:
+        VERSION_STRING = json.load(version_file)["version"]
 
 ROW_LIMIT = 50000
 VIZ_ROW_LIMIT = 10000

--- a/superset/config.py
+++ b/superset/config.py
@@ -48,9 +48,9 @@ else:
 # Superset specific config
 # ---------------------------------------------------------
 PACKAGE_DIR = os.path.join(BASE_DIR, "static", "assets")
-PACKAGE_FILE = os.path.join(PACKAGE_DIR, "package.json")
-with open(PACKAGE_FILE) as package_file:
-    VERSION_STRING = json.load(package_file)["version"]
+VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
+with open(VERSION_INFO_FILE) as version_info_file:
+    VERSION_STRING = json.load(version_info_file)["version"]
 
 ROW_LIMIT = 50000
 VIZ_ROW_LIMIT = 10000


### PR DESCRIPTION
There's a lot of stuff in `assets` that doesn't need to be shipped and/or served with Superset. The current setup of `MANIFEST.in` starts out by doing an initial `recursive-include` against `static` and then selectively excludes several items. As a result, several files are being left behind, such as terser caches, .rc files, package.json, etc.

Fixes #8107 

### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### REVIEWERS
@mistercrunch 