### PR TITLE
Add check for calls to cache_key_wrapper

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -18,6 +18,7 @@
 from collections import OrderedDict
 from datetime import datetime
 import logging
+import re
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 from flask import escape, Markup
@@ -1064,9 +1065,31 @@ class SqlaTable(Model, BaseDatasource):
     def default_query(qry):
         return qry.filter_by(is_sqllab_view=False)
 
+    def has_extra_cache_keys(self, query_obj: Dict) -> bool:
+        """
+        Detects the presence of calls to cache_key_wrapper in items in query_obj that can
+        be templated.
+
+        :param query_obj: query object to analyze
+        :return: True if at least one item calls cache_key_wrapper, otherwise False
+        """
+        regex = re.compile(r"\{\{.*cache_key_wrapper\(.*\).*\}\}")
+        templatable_statements: List[str] = []
+        templatable_statements.append(self.sql)
+        extras = query_obj.get("extras", {})
+        templatable_statements.append(extras.get("where", ""))
+        templatable_statements.append(extras.get("having", ""))
+        for statement in templatable_statements:
+            if regex.search(statement):
+                return True
+        return False
+
     def get_extra_cache_keys(self, query_obj: Dict) -> List[Any]:
-        sqla_query = self.get_sqla_query(**query_obj)
-        return sqla_query.extra_cache_keys
+        extra_cache_keys = []
+        if self.has_extra_cache_keys(query_obj):
+            sqla_query = self.get_sqla_query(**query_obj)
+            extra_cache_keys = sqla_query.extra_cache_keys
+        return extra_cache_keys
 
 
 sa.event.listen(SqlaTable, "after_insert", security_manager.set_perm)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1076,6 +1076,7 @@ class SqlaTable(Model, BaseDatasource):
         regex = re.compile(r"\{\{.*cache_key_wrapper\(.*\).*\}\}")
         templatable_statements: List[str] = []
         templatable_statements.append(self.sql)
+        templatable_statements.append(self.fetch_values_predicate)
         extras = query_obj.get("extras", {})
         templatable_statements.append(extras.get("where", ""))
         templatable_statements.append(extras.get("having", ""))

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1090,11 +1090,11 @@ class SqlaTable(Model, BaseDatasource):
         return False
 
     def get_extra_cache_keys(self, query_obj: Dict) -> List[Any]:
-        extra_cache_keys = []
         if self.has_extra_cache_keys(query_obj):
             sqla_query = self.get_sqla_query(**query_obj)
             extra_cache_keys = sqla_query.extra_cache_keys
-        return extra_cache_keys
+            return extra_cache_keys
+        return []
 
 
 sa.event.listen(SqlaTable, "after_insert", security_manager.set_perm)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1075,11 +1075,15 @@ class SqlaTable(Model, BaseDatasource):
         """
         regex = re.compile(r"\{\{.*cache_key_wrapper\(.*\).*\}\}")
         templatable_statements: List[str] = []
-        templatable_statements.append(self.sql)
-        templatable_statements.append(self.fetch_values_predicate)
+        if self.sql:
+            templatable_statements.append(self.sql)
+        if self.fetch_values_predicate:
+            templatable_statements.append(self.fetch_values_predicate)
         extras = query_obj.get("extras", {})
-        templatable_statements.append(extras.get("where", ""))
-        templatable_statements.append(extras.get("having", ""))
+        if "where" in extras:
+            templatable_statements.append(extras["where"])
+        if "having" in extras:
+            templatable_statements.append(extras["having"])
         for statement in templatable_statements:
             if regex.search(statement):
                 return True


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This PR adds a check to see if any component of `query_obj` contains calls to `cache_key_wrapper()`. If not, the query is not compiled if it is already cached.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 