### PR TITLE
Add duration formatter for numeric data

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -88,9 +88,8 @@ const D3_FORMAT_OPTIONS = [
   [',.3f', ',.3f (12345.432 => 12,345.432)'],
   ['+,', '+, (12345.432 => +12,345.432)'],
   ['$,.2f', '$,.2f (12345.432 => $12,345.43)'],
-  ['DURATION_MS', 'Duration in ms (66000 => 1m 6s)'],
-  ['DURATION_SEC', 'Duration in sec (66 => 1m 6s)'],
-  ['DURATION_MIN', 'Duration in min (66 => 1h 6 min)'],
+  ['DURATION', 'Duration in ms (66000 => 1m 6s)'],
+  ['DURATION_SUB', 'Duration in ms (100.40008 => 100ms 400µs 80ns)'],
 ];
 
 const ROW_LIMIT_OPTIONS = [10, 50, 100, 250, 500, 1000, 5000, 10000, 50000];

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -88,6 +88,9 @@ const D3_FORMAT_OPTIONS = [
   [',.3f', ',.3f (12345.432 => 12,345.432)'],
   ['+,', '+, (12345.432 => +12,345.432)'],
   ['$,.2f', '$,.2f (12345.432 => $12,345.43)'],
+  ['DURATION_MS', 'Duration in ms (66000 => 1m 6s)'],
+  ['DURATION_SEC', 'Duration in sec (66 => 1m 6s)'],
+  ['DURATION_MIN', 'Duration in min (66 => 1h 6 min)'],
 ];
 
 const ROW_LIMIT_OPTIONS = [10, 50, 100, 250, 500, 1000, 5000, 10000, 50000];

--- a/superset/assets/src/setup/setupFormatters.js
+++ b/superset/assets/src/setup/setupFormatters.js
@@ -55,9 +55,8 @@ export default function setupFormatters() {
     .registerValue('$,0', getNumberFormatter('$,.4f'))
     .registerValue('$,0f', getNumberFormatter('$,.4f'))
     .registerValue('$,.f', getNumberFormatter('$,.4f'))
-    .registerValue('DURATION_MS', createDurationFormatter())
-    .registerValue('DURATION_SEC', createDurationFormatter({ multiplier: 1000 }))
-    .registerValue('DURATION_MIN', createDurationFormatter({ multiplier: 60000 }));
+    .registerValue('DURATION', createDurationFormatter())
+    .registerValue('DURATION_SUB', createDurationFormatter({ formatSubMilliseconds: true }));
 
   getTimeFormatterRegistry()
     .registerValue('smart_date', smartDateFormatter)

--- a/superset/assets/src/setup/setupFormatters.js
+++ b/superset/assets/src/setup/setupFormatters.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { getNumberFormatter, getNumberFormatterRegistry, NumberFormats } from '@superset-ui/number-format';
+import { createDurationFormatter, getNumberFormatter, getNumberFormatterRegistry, NumberFormats } from '@superset-ui/number-format';
 import { getTimeFormatterRegistry, smartDateFormatter, smartDateVerboseFormatter } from '@superset-ui/time-format';
 
 export default function setupFormatters() {
@@ -54,7 +54,10 @@ export default function setupFormatters() {
     .registerValue('.0%f', getNumberFormatter('.1%'))
     .registerValue('$,0', getNumberFormatter('$,.4f'))
     .registerValue('$,0f', getNumberFormatter('$,.4f'))
-    .registerValue('$,.f', getNumberFormatter('$,.4f'));
+    .registerValue('$,.f', getNumberFormatter('$,.4f'))
+    .registerValue('DURATION_MS', createDurationFormatter())
+    .registerValue('DURATION_SEC', createDurationFormatter({ multiplier: 1000 }))
+    .registerValue('DURATION_MIN', createDurationFormatter({ multiplier: 60000 }));
 
   getTimeFormatterRegistry()
     .registerValue('smart_date', smartDateFormatter)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR adds a number formatter based on [pretty-ms](https://www.npmjs.com/package/pretty-ms) for formatting time durations that was added to `superset-ui` in version `0.12.1`(https://github.com/apache-superset/superset-ui/pull/209). The following formatters are available:
- `DURATION`: 66000 => 1m 6s, 66111 => 1m 6.1s (rounded to 1 decimal point)
- `DURATION_SUB`: 66100.40008 => 1m 6s 100ms 400µs 80ns, 100.40008 => 100ms 400µs 80ns
 
### SCREENSHOT
![image](https://user-images.githubusercontent.com/33317356/63862091-b1745c00-c9b4-11e9-9898-612f57b7a45b.png)

### TEST PLAN
Tested locally

### REVIEWERS
@etr2460 @kristw @mistercrunch 