### PR TITLE
Revert "Fixed Histogram visualization bug. "

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1475,22 +1475,18 @@ class HistogramViz(BaseViz):
         numeric_columns = self.form_data.get("all_columns_x")
         if numeric_columns is None:
             raise Exception(_("Must have at least one numeric column specified"))
-        self.columns = [numeric_columns]
-        d["columns"] = [numeric_columns] + self.groupby
+        self.columns = numeric_columns
+        d["columns"] = numeric_columns + self.groupby
         # override groupby entry to avoid aggregation
         d["groupby"] = []
         return d
 
     def labelify(self, keys, column):
-        if isinstance(keys, str) or isinstance(keys, int):
+        if isinstance(keys, str):
             keys = (keys,)
-
         # removing undesirable characters
-        labels = [
-            re.sub(r"\W+", r"_", k) if isinstance(k, str) else str(k) for k in keys
-        ]
-
-        if len(self.columns) > 0 or not self.groupby:
+        labels = [re.sub(r"\W+", r"_", k) for k in keys]
+        if len(self.columns) > 1 or not self.groupby:
             # Only show numeric column in label if there are many
             labels = [column] + labels
         return "__".join(labels)


### PR DESCRIPTION
Reverts apache/incubator-superset#8077

This change introduced a new bug for many more histograms:
```
Traceback (most recent call last):
  File "/Users/erik_ritter/repos/github.com/incubator-superset/superset/viz.py", line 415, in get_df_payload
    df = self.get_df(query_obj)
  File "/Users/erik_ritter/repos/github.com/incubator-superset/superset/viz.py", line 200, in get_df
    self.results = self.datasource.query(query_obj)
  File "/Users/erik_ritter/repos/github.com/incubator-superset/superset/connectors/sqla/models.py", line 913, in query
    query_str_ext = self.get_query_str_extended(query_obj)
  File "/Users/erik_ritter/repos/github.com/incubator-superset/superset/connectors/sqla/models.py", line 545, in get_query_str_extended
    sqlaq = self.get_sqla_query(**query_obj)
  File "/Users/erik_ritter/repos/github.com/incubator-superset/superset/connectors/sqla/models.py", line 691, in get_sqla_query
    if s in cols
TypeError: unhashable type: 'list'
```

Tested:
http://localhost:5000/superset/explore/?form_data=%7B%22datasource%22%3A%223__table%22%2C%22viz_type%22%3A%22histogram%22%2C%22url_params%22%3A%7B%7D%2C%22granularity_sqla%22%3A%22ds%22%2C%22time_grain_sqla%22%3A%22P1D%22%2C%22time_range%22%3A%22No+filter%22%2C%22all_columns_x%22%3A%5B%22sum_boys%22%5D%2C%22adhoc_filters%22%3A%5B%5D%2C%22row_limit%22%3A10000%2C%22groupby%22%3A%5B%22name%22%5D%2C%22color_scheme%22%3A%22bnbColors%22%2C%22label_colors%22%3A%7B%7D%2C%22link_length%22%3A5%2C%22x_axis_label%22%3A%22%22%2C%22y_axis_label%22%3A%22%22%2C%22global_opacity%22%3A1%2C%22normalized%22%3Afalse%7D

This histogram loads with the revert, but throws the error before the revert.

@graceguo-supercat @serenajiang @villebro @kuckjwi0928