### PR TITLE
Revert "Fix tooltips not visible for NVD3 charts on Firefox (#7822)"

### DIFF
--- a/superset/assets/stylesheets/less/index.less
+++ b/superset/assets/stylesheets/less/index.less
@@ -25,7 +25,11 @@
 @stroke-primary:  @brand-primary;
 
 body {
-  min-height: 100vh;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
Reverts apache/incubator-superset#7929

This broke embedded charts. I tested by creating an `index.html` file with the following code:
```
<iframe width="600" height="400" seamless frameBorder="0" scrolling="no"
  src="http://localhost:5000/superset/explore/?form_data=%7B%22datasource%22%3A%222__table%22%2C%22viz_type%22%3A%22table%22%2C%22slice_id%22%3A157%2C%22url_params%22%3A%7B%7D%2C%22granularity_sqla%22%3A%22year%22%2C%22time_grain_sqla%22%3A%22P1D%22%2C%22time_range%22%3A%222014-01-01+%3A+2014-01-02%22%2C%22groupby%22%3A%5B%22country_name%22%5D%2C%22metrics%22%3A%5B%22sum__SP_POP_TOTL%22%5D%2C%22percent_metrics%22%3A%5B%5D%2C%22timeseries_limit_metric%22%3Anull%2C%22row_limit%22%3A50000%2C%22include_time%22%3Afalse%2C%22order_desc%22%3Atrue%2C%22all_columns%22%3A%5B%5D%2C%22order_by_cols%22%3A%5B%5D%2C%22adhoc_filters%22%3A%5B%5D%2C%22table_timestamp_format%22%3A%22%25Y-%25m-%25d+%25H%3A%25M%3A%25S%22%2C%22page_length%22%3A0%2C%22include_search%22%3Afalse%2C%22table_filter%22%3Afalse%2C%22align_pn%22%3Afalse%2C%22color_pn%22%3Atrue%7D&standalone=true&height=400">
</iframe>
```

Before revert:
<img width="757" alt="Screen Shot 2019-08-30 at 12 30 16 PM" src="https://user-images.githubusercontent.com/7409244/64046917-11d4dc00-cb22-11e9-94f1-9a15f131bb81.png">


After revert:
<img width="712" alt="Screen Shot 2019-08-30 at 12 29 46 PM" src="https://user-images.githubusercontent.com/7409244/64046920-16999000-cb22-11e9-889e-16baa0a762c5.png">

@schoel-bis @graceguo-supercat @mistercrunch 