### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ if sys.version_info < (3, 6):
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 PACKAGE_DIR = os.path.join(BASE_DIR, "superset", "static", "assets")
-PACKAGE_FILE = os.path.join(PACKAGE_DIR, "package.json")
-with open(PACKAGE_FILE) as package_file:
-    version_string = json.load(package_file)["version"]
+VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
+with open(VERSION_INFO_FILE) as version_info_file:
+    version_string = json.load(version_info_file)["version"]
 
 with io.open("README.md", encoding="utf-8") as f:
     long_description = f.read()


### PR DESCRIPTION
#7985 # CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

After building the NodeJS dependencies and creating an sdist tarball with `python setup.py sdist`, installing this tarball with pip fails because `./superset/assets/package.json` is now omitted from the manifest. I believe this fixes the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS