### PR TITLE
Forward SIGTERM signal to gunicorn

### DIFF
--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -27,7 +27,7 @@ elif [ "$SUPERSET_ENV" = "development" ]; then
     FLASK_ENV=development FLASK_APP=superset:app flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0
 elif [ "$SUPERSET_ENV" = "production" ]; then
     celery worker --app=superset.sql_lab:celery_app --pool=gevent -Ofair &
-    gunicorn --bind  0.0.0.0:8088 \
+    exec gunicorn --bind  0.0.0.0:8088 \
         --workers $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) \
         --timeout 60 \
         --limit-request-line 0 \


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Currently docker entrypoint is a bash script.
`docker stop` command (or restart in kubernetes) sends SIGTERM to the
container but it isn't catched by gunicorn.
So gunicorn can't start graceful shutdown which may lead to killing
user's connection and also adds 10s (default value) delay for stopping
until docker sends SIGKILL.
Using `exec` replaces the shell with the process being opened and
signals are propagated correctly.

Ref: https://docs.docker.com/engine/reference/commandline/stop/
Ref: https://unix.stackexchange.com/questions/146756/forward-sigterm-to-child-in-bash

### TEST PLAN

Run superset in docker container and execute `docker stop` on master it would result in:
1. 10s delay before stopping
2. Exit code 137 (means gunicorn was killed)

Run superset in docker container and execute `docker stop` from this branch it would result in: 
1. Quick exit (~1s)
2. Correct exit code 0

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
