### PR TITLE
Bump FAB to 2.1.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ croniter==0.3.30
 cryptography==2.7
 decorator==4.4.0          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.1.9
+flask-appbuilder==2.1.13
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.7.2
 flask-compress==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,3 +82,4 @@ webencodings==0.5.1       # via bleach
 werkzeug==0.15.5          # via flask, flask-jwt-extended
 wtforms-json==0.3.3
 wtforms==2.2.1            # via flask-wtf, wtforms-json
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,4 +82,3 @@ webencodings==0.5.1       # via bleach
 werkzeug==0.15.5          # via flask, flask-jwt-extended
 wtforms-json==0.3.3
 wtforms==2.2.1            # via flask-wtf, wtforms-json
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ croniter==0.3.30
 cryptography==2.7
 decorator==4.4.0          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.1.13
+flask-appbuilder==2.1.10
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.7.2
 flask-compress==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ croniter==0.3.30
 cryptography==2.7
 decorator==4.4.0          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.1.10
+flask-appbuilder==2.1.13
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.7.2
 flask-compress==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=2.1.9, <2.3.0",
+        "flask-appbuilder>=2.1.13, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=2.1.10, <2.3.0",
+        "flask-appbuilder>=2.1.13, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=2.1.13, <2.3.0",
+        "flask-appbuilder>=2.1.10, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Change log since 2.1.9:

Improvements and Bug fixes on 2.1.13
------------------------------------

- Fix, #1105 Has access query fails on MySQL < 8

Improvements and Bug fixes on 2.1.12
------------------------------------

- Fix, #1104 Preserve custom property return type on ModelRestApi
- Fix, #1096 Bootstrap and Bootswatch bump to 3.4.1
- Fix, #1097 python version restriction on setup > 3.6 < 4
- Fix, #1095 OAuth set fallback when next url in state is empty

Improvements and Bug fixes on 2.1.11
------------------------------------

- Fix, #1092 Has access query fails on MSSQL

Improvements and Bug fixes on 2.1.10
------------------------------------

- Fix, #1079 Make it possible to override register_views when using FAB_ADD_SECURITY_VIEWS

Note: Bootstrap 3.4.1 solves the following security issues:

CVE-2018-14040 - Medium Severity Vulnerability Publish Date: 2018-07-13
CVE-2018-14041 - Medium Severity Vulnerability Publish Date: 2018-07-13
CVE-2018-14042 - Medium Severity Vulnerability Publish Date: 2018-07-13
CVE-2018-20677 - Medium Severity Vulnerability Publish Date: 2019-01-09
CVE-2019-8331 - Medium Severity Vulnerability Publish Date: 2019-02-20

### ADDITIONAL INFORMATION
- [x] Has associated issue: #7739 (Solved by @paulvic on FAB)
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
