### PR TITLE
[bugfix] Make orderby native sqla construct

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -794,6 +794,8 @@ class SqlaTable(Model, BaseDatasource):
             direction = asc if ascending else desc
             if utils.is_adhoc_metric(col):
                 col = self.adhoc_metric_to_sqla(col, cols)
+            elif col in cols:
+                col = cols[col].get_sqla_col()
             qry = qry.order_by(direction(col))
 
         if row_limit:


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently the orderby element is passed as a string when constructing the `Selectable` in `sqla/models.py`. This gets automatically replaced by the corresponding native `ColumnClause` if a column with the same name exists in the `SELECT` columns. However, if the orderable column is not present in the `SELECT`, an exception is thrown. This PR makes the orderable column a native SqlAlchemy construct, avoiding the need for including the orderable in the select columns.

### TEST PLAN
Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Closes #8177
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@squalou @john-bodley @mistercrunch 