### PR TITLE
[bugfix] Correctly quote table and schema in select_star

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -478,7 +478,7 @@ class SqlaTable(Model, BaseDatasource):
         # show_cols and latest_partition set to false to avoid
         # the expensive cost of inspecting the DB
         return self.database.select_star(
-            self.name, show_cols=False, latest_partition=False
+            self.table_name, schema=self.schema, show_cols=False, latest_partition=False
         )
 
     def get_col(self, col_name):

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -126,7 +126,7 @@ class DatabaseModelTestCase(SupersetTestCase):
         )
         assert sql.startswith(expected)
 
-    def test_select_star_with_exotic_names(self):
+    def test_select_star_fully_qualified_names(self):
         db = get_example_database()
         schema = "schema.name"
         table_name = "table/name"

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -104,9 +104,9 @@ class DatabaseModelTestCase(SupersetTestCase):
         self.assertNotEquals(example_user, user_name)
 
     def test_select_star(self):
-        main_db = get_example_database()
+        db = get_example_database()
         table_name = "energy_usage"
-        sql = main_db.select_star(table_name, show_cols=False, latest_partition=False)
+        sql = db.select_star(table_name, show_cols=False, latest_partition=False)
         expected = textwrap.dedent(
             f"""\
         SELECT *
@@ -115,7 +115,7 @@ class DatabaseModelTestCase(SupersetTestCase):
         )
         assert sql.startswith(expected)
 
-        sql = main_db.select_star(table_name, show_cols=True, latest_partition=False)
+        sql = db.select_star(table_name, show_cols=True, latest_partition=False)
         expected = textwrap.dedent(
             f"""\
         SELECT source,
@@ -127,10 +127,10 @@ class DatabaseModelTestCase(SupersetTestCase):
         assert sql.startswith(expected)
 
     def test_select_star_with_exotic_names(self):
-        main_db = get_example_database()
+        db = get_example_database()
         schema = "schema.name"
         table_name = "table/name"
-        sql = main_db.select_star(
+        sql = db.select_star(
             table_name, schema=schema, show_cols=False, latest_partition=False
         )
         fully_qualified_names = {
@@ -138,7 +138,7 @@ class DatabaseModelTestCase(SupersetTestCase):
             "mysql": "`schema.name`.`table/name`",
             "postgres": '"schema.name"."table/name"',
         }
-        fully_qualified_name = fully_qualified_names.get(main_db.db_engine_spec.engine)
+        fully_qualified_name = fully_qualified_names.get(db.db_engine_spec.engine)
         if fully_qualified_name:
             expected = textwrap.dedent(
                 f"""\


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When clicking `Explore in SQL Lab` from a chart, datasources with a schema are quoted incorrectly.

### TEST PLAN
Tested locally

### ADDITIONAL INFORMATION
- [x] Has associated issue: Closes #8178
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@squalou @mistercrunch @john-bodley 