### PR TITLE
[Config] Disable celery acks late

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -407,7 +407,7 @@ class CeleryConfig(object):
     CELERY_RESULT_BACKEND = "db+sqlite:///celery_results.sqlite"
     CELERYD_LOG_LEVEL = "DEBUG"
     CELERYD_PREFETCH_MULTIPLIER = 1
-    CELERY_ACKS_LATE = True
+    CELERY_ACKS_LATE = False
     CELERY_ANNOTATIONS = {
         "sql_lab.get_sql_results": {"rate_limit": "100/s"},
         "email_reports.send": {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
We should not enable `CELERY_ACKS_LATE` because our tasks are not guaranteed to be idempotent (see here for details: https://docs.celeryproject.org/en/latest/userguide/tasks.html#tasks).

This setting was also causing issues as we'd see a single SQL Lab query fire off duplicate queries to Presto that would then be killed to protect Presto from duplicate queries.

### TEST PLAN
Config was tested and async queries still work as before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley @graceguo-supercat @mistercrunch 