### PR TITLE
chore: fix version info

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,6 +21,8 @@ include README.md
 recursive-include superset/examples *
 recursive-include superset/migrations *
 
+include superset/assets/package.json
+
 # Whitelist anything that needs to be added to the static bundle
 recursive-exclude superset/static *
 recursive-include superset/static/assets/branding *

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,12 @@ if sys.version_info < (3, 6):
     sys.exit("Sorry, Python < 3.6 is not supported")
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-PACKAGE_DIR = os.path.join(BASE_DIR, "superset", "static", "assets")
-PACKAGE_FILE = os.path.join(PACKAGE_DIR, "package.json")
-with open(PACKAGE_FILE) as package_file:
+
+PACKAGE_JSON = os.path.join(BASE_DIR, "superset", "assets", "package.json")
+with open(PACKAGE_JSON, "r") as package_file:
     version_string = json.load(package_file)["version"]
 
-with io.open("README.md", encoding="utf-8") as f:
+with io.open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 
@@ -50,7 +50,11 @@ print("VERSION: " + version_string)
 print("GIT SHA: " + GIT_SHA)
 print("-==-" * 15)
 
-with open(os.path.join(PACKAGE_DIR, "version_info.json"), "w") as version_file:
+VERSION_INFO_FILE = os.path.join(
+    BASE_DIR, "superset", "static", "assets", "version_info.json"
+)
+
+with open(VERSION_INFO_FILE, "w") as version_file:
     json.dump(version_info, version_file)
 
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -53,7 +53,7 @@ VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
 PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets" "package.json")
 
 
-def _try_json_reafile(filepath):
+def _try_json_readfile(filepath):
     try:
         with open(filepath, "r") as f:
             return json.load(f).get("version")
@@ -66,7 +66,7 @@ def _try_json_reafile(filepath):
 # that we're actually running Superset, we will have already installed, therefore it WILL
 # exist. When unit tests are running, however, it WILL NOT exist, so we fall
 # back to reading package.json
-VERSION_STRING = _try_json_reafile(VERSION_INFO_FILE) or _try_json_reafile(
+VERSION_STRING = _try_json_readfile(VERSION_INFO_FILE) or _try_json_readfile(
     PACKAGE_JSON_FILE
 )
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -50,21 +50,25 @@ else:
 # ---------------------------------------------------------
 PACKAGE_DIR = os.path.join(BASE_DIR, "static", "assets")
 VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
-PACKAGE_JSON_FILE = os.path.join(PACKAGE_DIR, "package.json")
+PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets" "package.json")
 
-#
+
+def _try_json_reafile(filepath):
+    try:
+        with open(filepath, "r") as f:
+            return json.load(f).get("version")
+    except Exception:
+        return None
+
+
 # Depending on the context in which this config is loaded, the version_info.json file
 # may or may not be available, as it is generated on install via setup.py. In the event
 # that we're actually running Superset, we will have already installed, therefore it WILL
 # exist. When unit tests are running, however, it WILL NOT exist, so we fall
 # back to reading package.json
-#
-try:
-    with open(VERSION_INFO_FILE) as version_file:
-        VERSION_STRING = json.load(version_file)["version"]
-except Exception:
-    with open(PACKAGE_JSON_FILE) as version_file:
-        VERSION_STRING = json.load(version_file)["version"]
+VERSION_STRING = _try_json_reafile(VERSION_INFO_FILE) or _try_json_reafile(
+    PACKAGE_JSON_FILE
+)
 
 ROW_LIMIT = 50000
 VIZ_ROW_LIMIT = 10000


### PR DESCRIPTION
Ran into Cypress issues while getting too ambitious in #8157
this is a simplified more targeted version of it

* include package.json (but not under static/)
* use package.json as single source of truth for version info
