### PR TITLE
change log from csv_export to data_export; fix db name in log

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2736,10 +2736,10 @@ class Superset(BaseSupersetView):
             "Content-Disposition"
         ] = f"attachment; filename={query.name}.csv"
         event_info = {
-            "event_type": "csv_export",
+            "event_type": "data_export",
             "client_id": client_id,
             "row_count": len(df.index),
-            "database": query.database,
+            "database": query.database.name,
             "schema": query.schema,
             "sql": query.sql,
         }

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2742,6 +2742,7 @@ class Superset(BaseSupersetView):
             "database": query.database.name,
             "schema": query.schema,
             "sql": query.sql,
+            "exported_format": "csv",
         }
         logging.info(
             f"CSV exported: {repr(event_info)}", extra={"superset_event": event_info}


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The event dict that was logged previously contained the actual database object rather than the database name. Also, the log will now log a "data_export" event rather than a "csv_export" event, so that logging can be consistent for csv or json export.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
