### PR TITLE
[examples] Fix, sf population polygons div by zero error

### DIFF
--- a/superset/examples/sf_population_polygons.py
+++ b/superset/examples/sf_population_polygons.py
@@ -17,7 +17,7 @@
 import json
 
 import pandas as pd
-from sqlalchemy import BigInteger, Text
+from sqlalchemy import BigInteger, Float, Text
 
 from superset import db
 from superset.utils import core as utils
@@ -43,7 +43,7 @@ def load_sf_population_polygons(only_metadata=False, force=False):
                 "zipcode": BigInteger,
                 "population": BigInteger,
                 "contour": Text,
-                "area": BigInteger,
+                "area": Float,
             },
             index=False,
         )


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Chart SF population polygons causes a division by zero error, this is caused by the conversion of the float type `area` field for zipcode 94104.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot from 2019-09-10 06-13-55](https://user-images.githubusercontent.com/4025227/64585869-418daa80-d392-11e9-9866-c667a4016511.png)

After:
![Screenshot from 2019-09-10 06-11-19](https://user-images.githubusercontent.com/4025227/64585784-f378a700-d391-11e9-90fc-36a83d6a91ab.png)


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
