### PR TITLE
Better distinction between tables and views, and show CREATE VIEW

### DIFF
--- a/superset/assets/src/SqlLab/components/ShowCreateView.jsx
+++ b/superset/assets/src/SqlLab/components/ShowCreateView.jsx
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Badge } from 'react-bootstrap';
+import AceEditor from 'react-ace';
+import 'brace/mode/sql';
+import 'brace/theme/textmate';
+
+import { t } from '@superset-ui/translation';
+
+import Link from './Link';
+import ModalTrigger from '../../components/ModalTrigger';
+
+const propTypes = {
+  tooltipText: PropTypes.string,
+  title: PropTypes.string,
+  sql: PropTypes.string,
+};
+
+const defaultProps = {
+  tooltipText: t('Show CREATE VIEW statement'),
+  title: t('CREATE VIEW statement'),
+  sql: '',
+};
+
+export default class ShowCreateView extends React.Component {
+  renderModalBody() {
+    return (
+      <div>
+        <AceEditor
+          mode="sql"
+          theme="textmate"
+          style={{ border: '1px solid #CCC' }}
+          minLines={25}
+          maxLines={50}
+          width="100%"
+          editorProps={{ $blockScrolling: true }}
+          value={this.props.sql}
+        />
+      </div>
+    );
+  }
+  render() {
+    return (
+      <ModalTrigger
+        modalTitle={this.props.title}
+        triggerNode={
+          <Link
+            className="fa fa-eye pull-left m-l-2"
+            tooltip={this.props.tooltipText}
+            href="#"
+          />
+        }
+        modalBody={this.renderModalBody()}
+      />
+    );
+  }
+}
+
+ShowCreateView.propTypes = propTypes;
+ShowCreateView.defaultProps = defaultProps;

--- a/superset/assets/src/SqlLab/components/ShowSQL.jsx
+++ b/superset/assets/src/SqlLab/components/ShowSQL.jsx
@@ -27,6 +27,8 @@ import { t } from '@superset-ui/translation';
 import Link from './Link';
 import ModalTrigger from '../../components/ModalTrigger';
 
+registerLanguage('sql', sql);
+
 const propTypes = {
   tooltipText: PropTypes.string,
   title: PropTypes.string,

--- a/superset/assets/src/SqlLab/components/ShowSQL.jsx
+++ b/superset/assets/src/SqlLab/components/ShowSQL.jsx
@@ -35,12 +35,12 @@ const propTypes = {
 };
 
 const defaultProps = {
-  tooltipText: t('Show CREATE VIEW statement'),
-  title: t('CREATE VIEW statement'),
+  tooltipText: t('Show SQL'),
+  title: t('SQL statement'),
   sql: '',
 };
 
-export default class ShowCreateView extends React.Component {
+export default class ShowSQL extends React.Component {
   renderModalBody() {
     return (
       <div>
@@ -74,5 +74,5 @@ export default class ShowCreateView extends React.Component {
   }
 }
 
-ShowCreateView.propTypes = propTypes;
-ShowCreateView.defaultProps = defaultProps;
+ShowSQL.propTypes = propTypes;
+ShowSQL.defaultProps = defaultProps;

--- a/superset/assets/src/SqlLab/components/ShowSQL.jsx
+++ b/superset/assets/src/SqlLab/components/ShowSQL.jsx
@@ -18,10 +18,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Badge } from 'react-bootstrap';
-import AceEditor from 'react-ace';
-import 'brace/mode/sql';
-import 'brace/theme/textmate';
+import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/dist/light';
+import sql from 'react-syntax-highlighter/dist/languages/hljs/sql';
+import github from 'react-syntax-highlighter/dist/styles/hljs/github';
 
 import { t } from '@superset-ui/translation';
 
@@ -40,20 +39,13 @@ const defaultProps = {
   sql: '',
 };
 
-export default class ShowSQL extends React.Component {
+export default class ShowSQL extends React.PureComponent {
   renderModalBody() {
     return (
       <div>
-        <AceEditor
-          mode="sql"
-          theme="textmate"
-          style={{ border: '1px solid #CCC' }}
-          minLines={25}
-          maxLines={50}
-          width="100%"
-          editorProps={{ $blockScrolling: true }}
-          value={this.props.sql}
-        />
+        <SyntaxHighlighter language="sql" style={github}>
+          {this.props.sql}
+        </SyntaxHighlighter>
       </div>
     );
   }

--- a/superset/assets/src/SqlLab/components/TableElement.jsx
+++ b/superset/assets/src/SqlLab/components/TableElement.jsx
@@ -25,7 +25,7 @@ import { t } from '@superset-ui/translation';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import Link from './Link';
 import ColumnElement from './ColumnElement';
-import ShowCreateView from './ShowCreateView';
+import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
 
@@ -173,7 +173,13 @@ class TableElement extends React.PureComponent {
             tooltipText={t('Copy SELECT statement to the clipboard')}
           />
         }
-        {table.view && <ShowCreateView sql={table.view} />}
+        {table.view &&
+          <ShowSQL
+            sql={table.view}
+            tooltipText={t('Show CREATE VIEW statement')}
+            title={t('CREATE VIEW statement')}
+          />
+        }
         <Link
           className="fa fa-times table-remove pull-left m-l-2"
           onClick={this.removeTable}

--- a/superset/assets/src/SqlLab/components/TableElement.jsx
+++ b/superset/assets/src/SqlLab/components/TableElement.jsx
@@ -25,6 +25,7 @@ import { t } from '@superset-ui/translation';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import Link from './Link';
 import ColumnElement from './ColumnElement';
+import ShowCreateView from './ShowCreateView';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
 
@@ -172,6 +173,7 @@ class TableElement extends React.PureComponent {
             tooltipText={t('Copy SELECT statement to the clipboard')}
           />
         }
+        {table.view && <ShowCreateView sql={table.view} />}
         <Link
           className="fa fa-times table-remove pull-left m-l-2"
           onClick={this.removeTable}

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -110,6 +110,7 @@ export default class TableSelector extends React.PureComponent {
         schema: o.schema,
         label: o.label,
         title: o.title,
+        type: o.type,
       }));
       return ({ options });
     });
@@ -140,6 +141,7 @@ export default class TableSelector extends React.PureComponent {
             schema: o.schema,
             label: o.label,
             title: o.title,
+            type: o.type,
           }));
           this.setState(() => ({
             tableLoading: false,
@@ -203,16 +205,32 @@ export default class TableSelector extends React.PureComponent {
         {db.database_name}
       </span>);
   }
-  renderTableOption({ style, option, selectValue }) {
-    console.log(style);
+  renderTableOption({ focusOption, focusedOption, key, option, selectValue, style, valueArray }) {
+    const classNames = ['Select-option'];
+    if (option === focusedOption) {
+      classNames.push('is-focused');
+    }
+    if (valueArray.indexOf(option) >= 0) {
+      classNames.push('is-selected')
+    }
+    console.log(option);
+
     return (
-      <div style={style} key={`table-option-${option.value}`}>
-        <a
-          onClick={() => selectValue(option)}
-        >
-          &nbsp;
+      <div
+        className={classNames.join(' ')}
+        key={key}
+        onClick={() => selectValue(option)}
+        onMouseEnter={() => focusOption(option)}
+        style={style}
+      >
+        <span>
+          <span className="m-r-5">
+            <small className="text-muted">
+              <i className={`fa fa-${option.type === 'view' ? 'eye' : 'table'}`} />
+            </small>
+          </span>
           {option.value}
-        </a>
+        </span>
       </div>
     );
   }

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -227,7 +227,7 @@ export default class TableSelector extends React.PureComponent {
               <i className={`fa fa-${option.type === 'view' ? 'eye' : 'table'}`} />
             </small>
           </span>
-          {option.value}
+          {option.label}
         </span>
       </div>
     );

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -213,8 +213,6 @@ export default class TableSelector extends React.PureComponent {
     if (valueArray.indexOf(option) >= 0) {
       classNames.push('is-selected')
     }
-    console.log(option);
-
     return (
       <div
         className={classNames.join(' ')}
@@ -307,7 +305,7 @@ export default class TableSelector extends React.PureComponent {
         isLoading={this.state.tableLoading}
         ignoreAccents={false}
         placeholder={t('Select table or type table name')}
-        autosize={true}
+        autosize={false}
         onChange={this.changeTable}
         options={options}
         value={this.state.tableName}
@@ -323,6 +321,7 @@ export default class TableSelector extends React.PureComponent {
           onChange={this.changeTable}
           value={this.state.tableName}
           loadOptions={this.getTableNamesBySubStr}
+          optionRenderer={this.renderTableOption}
         />);
     return this.renderSelectRow(
       select,

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -203,6 +203,19 @@ export default class TableSelector extends React.PureComponent {
         {db.database_name}
       </span>);
   }
+  renderTableOption({ style, option, selectValue }) {
+    console.log(style);
+    return (
+      <div style={style} key={`table-option-${option.value}`}>
+        <a
+          onClick={() => selectValue(option)}
+        >
+          &nbsp;
+          {option.value}
+        </a>
+      </div>
+    );
+  }
   renderSelectRow(select, refreshBtn) {
     return (
       <div className="section">
@@ -276,10 +289,11 @@ export default class TableSelector extends React.PureComponent {
         isLoading={this.state.tableLoading}
         ignoreAccents={false}
         placeholder={t('Select table or type table name')}
-        autosize={false}
+        autosize={true}
         onChange={this.changeTable}
         options={options}
         value={this.state.tableName}
+        optionRenderer={this.renderTableOption}
       />) : (
         <Select
           async

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -211,7 +211,7 @@ export default class TableSelector extends React.PureComponent {
       classNames.push('is-focused');
     }
     if (valueArray.indexOf(option) >= 0) {
-      classNames.push('is-selected')
+      classNames.push('is-selected');
     }
     return (
       <div

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -132,7 +132,7 @@ class BaseEngineSpec:
 
     @classmethod
     def get_engine(cls, database, schema=None, source=None):
-        user_name = g.user.username if g.user else None
+        user_name = utils.get_username()
         return database.get_sqla_engine(
             schema=schema, nullpool=True, user_name=user_name, source=source
         )

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -695,10 +695,7 @@ class BaseEngineSpec:
         parsed_query = sql_parse.ParsedQuery(sql)
         statements = parsed_query.get_statements()
 
-        engine = database.get_sqla_engine(
-            schema=schema, nullpool=True, user_name=user_name, source=source
-        )
-
+        engine = cls.get_engine(database, schema=schema, source=source)
         costs = []
         with closing(engine.raw_connection()) as conn:
             with closing(conn.cursor()) as cursor:

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -131,6 +131,13 @@ class BaseEngineSpec:
         return False
 
     @classmethod
+    def get_engine(cls, database, schema=None, source=None):
+        user_name = g.user.username if g.user else None
+        return database.get_sqla_engine(
+            schema=schema, nullpool=True, user_name=user_name, source=source
+        )
+
+    @classmethod
     def get_timestamp_expr(
         cls, col: ColumnClause, pdf: Optional[str], time_grain: Optional[str]
     ) -> TimestampExpression:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -23,7 +23,7 @@ import logging
 import re
 import textwrap
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, cast, Dict, List, Optional, Set, Tuple
 from urllib import parse
 
 import simplejson as json
@@ -910,7 +910,10 @@ class PrestoEngineSpec(BaseEngineSpec):
                 "partitionQuery": pql,
             }
 
-        metadata["view"] = cls.get_create_view(database, schema_name, table_name)
+        # flake8 is not matching `Optional[str]` to `Any` for some reason...
+        metadata["view"] = cast(
+            Any, cls.get_create_view(database, schema_name, table_name)
+        )
 
         return metadata
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -916,20 +916,19 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_create_view(cls, database, schema: str, table: str) -> str:
-        db_engine_spec = database.db_engine_spec
         engine = cls.get_engine(database, schema)
         with closing(engine.raw_connection()) as conn:
             with closing(conn.cursor()) as cursor:
                 sql = f"SHOW CREATE VIEW {schema}.{table}"
-                db_engine_spec.execute(cursor, sql)
+                cls.execute(cursor, sql)
                 try:
                     polled = cursor.poll()
                 except Exception:  # not a VIEW
-                    return False 
+                    return False
                 while polled:
                     time.sleep(0.2)
                     polled = cursor.poll()
-                rows = db_engine_spec.fetch_data(cursor, 1)
+                rows = cls.fetch_data(cursor, 1)
         return rows[0][0]
 
     @classmethod

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -915,7 +915,14 @@ class PrestoEngineSpec(BaseEngineSpec):
         return metadata
 
     @classmethod
-    def get_create_view(cls, database, schema: str, table: str) -> str:
+    def get_create_view(cls, database, schema: str, table: str) -> Optional[str]:
+        """
+        Return a CREATE VIEW statement, or `None` if not a view.
+
+        :param database: Database instance
+        :param schema: Schema name
+        :param table: Table (view) name
+        """
         engine = cls.get_engine(database, schema)
         with closing(engine.raw_connection()) as conn:
             with closing(conn.cursor()) as cursor:
@@ -924,7 +931,7 @@ class PrestoEngineSpec(BaseEngineSpec):
                 try:
                     polled = cursor.poll()
                 except Exception:  # not a VIEW
-                    return False
+                    return None
                 while polled:
                     time.sleep(0.2)
                     polled = cursor.poll()

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -90,10 +90,10 @@ class PrestoEngineSpec(BaseEngineSpec):
         and get_view_names() is not implemented in sqlalchemy_presto.py
         https://github.com/dropbox/PyHive/blob/e25fc8440a0686bbb7a5db5de7cb1a77bdb4167a/pyhive/sqlalchemy_presto.py
         """
-        return [] #'google_click_daily_report_default_presto']
+        return ['google_click_daily_report_default_presto']
 
     @classmethod
-    def _get_table_names(cls, *args, **kwargs):
+    def get_table_names(cls, *args, **kwargs):
         return ['applicant_quality_estimates']
 
     @classmethod

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -90,11 +90,7 @@ class PrestoEngineSpec(BaseEngineSpec):
         and get_view_names() is not implemented in sqlalchemy_presto.py
         https://github.com/dropbox/PyHive/blob/e25fc8440a0686bbb7a5db5de7cb1a77bdb4167a/pyhive/sqlalchemy_presto.py
         """
-        return ['google_click_daily_report_default_presto']
-
-    @classmethod
-    def get_table_names(cls, *args, **kwargs):
-        return ['applicant_quality_estimates']
+        return []
 
     @classmethod
     def _create_column_info(cls, name: str, data_type: str) -> dict:
@@ -919,7 +915,7 @@ class PrestoEngineSpec(BaseEngineSpec):
         return metadata
 
     @classmethod
-    def get_create_view(cls, database, schema, table):
+    def get_create_view(cls, database, schema: str, table: str) -> str:
         db_engine_spec = database.db_engine_spec
         engine = cls.get_engine(database, schema)
         with closing(engine.raw_connection()) as conn:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1556,6 +1556,7 @@ class Superset(BaseSupersetView):
                 "schema": tn.schema,
                 "label": get_datasource_label(tn),
                 "title": get_datasource_label(tn),
+                "type": "table",
             }
             for tn in tables[:max_tables]
         ]
@@ -1566,6 +1567,7 @@ class Superset(BaseSupersetView):
                     "schema": vn.schema,
                     "label": f"[view] {get_datasource_label(vn)}",
                     "title": f"[view] {get_datasource_label(vn)}",
+                    "type": "view",
                 }
                 for vn in views[:max_views]
             ]

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1565,8 +1565,8 @@ class Superset(BaseSupersetView):
                 {
                     "value": vn.table,
                     "schema": vn.schema,
-                    "label": f"[view] {get_datasource_label(vn)}",
-                    "title": f"[view] {get_datasource_label(vn)}",
+                    "label": get_datasource_label(vn),
+                    "title": get_datasource_label(vn),
                     "type": "view",
                 }
                 for vn in views[:max_views]

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -801,6 +801,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         db.get_extra = mock.Mock(return_value={})
         df = pd.DataFrame({"ds": ["01-01-19"], "hour": [1]})
         db.get_df = mock.Mock(return_value=df)
+        PrestoEngineSpec.get_create_view = mock.Mock(return_value=None)
         result = PrestoEngineSpec.extra_table_metadata(db, "test_table", "test_schema")
         self.assertEqual({"ds": "01-01-19", "hour": 1}, result["partitions"]["latest"])
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In SQL Lab, to distinguish between tables and views we prefix the latter with the string `[view]`, which looks ugly. I changed it to display a small icon representing the type — either a table for actual tables, or an eye for views.

Additionally, we don't present any information on views. I added a link to show the actual `CREATE VIEW` statement that defines a given view.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="1698" alt="Screen Shot 2019-09-10 at 1 53 44 PM" src="https://user-images.githubusercontent.com/1534870/64650175-6d7d5000-d3d3-11e9-99b1-99e366ffaf63.png">
<img width="1698" alt="Screen Shot 2019-09-10 at 1 54 03 PM" src="https://user-images.githubusercontent.com/1534870/64650180-70784080-d3d3-11e9-974b-48712a0a1000.png">
<img width="1698" alt="Screen Shot 2019-09-10 at 1 54 09 PM" src="https://user-images.githubusercontent.com/1534870/64650185-72da9a80-d3d3-11e9-8e15-bc1236c40f76.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Currently most DB engine specs seem to return views as tables, due to limitations in the SQL Alchemy driver. Both Presto and SQLlite return no views, bundling the views with the actual tables. I had to mock the response from the engines to generate the screenshots.

I'm planning to write a PR for Presto next, allowing views to be properly displayed. This might require changes upstream (to https://github.com/dropbox/PyHive), though it's possible to work around it in Superset only.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@mistercrunch @khtruong @etr2460 