### PR TITLE
[talisman] Enforcing HTTP for status checks

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -222,9 +222,11 @@ def is_feature_enabled(feature):
 if conf.get("ENABLE_FLASK_COMPRESS"):
     Compress(app)
 
+
+talisman = Talisman()
+
 if app.config["TALISMAN_ENABLED"]:
-    talisman_config = app.config.get("TALISMAN_CONFIG")
-    Talisman(app, **talisman_config)
+    talisman.init_app(app, **app.config["TALISMAN_CONFIG"])
 
 # Hook that provides administrators a handle on the Flask APP
 # after initialization

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -62,6 +62,7 @@ from superset import (
     results_backend_use_msgpack,
     security_manager,
     sql_lab,
+    talisman,
     viz,
 )
 from superset.connectors.connector_registry import ConnectorRegistry
@@ -629,16 +630,19 @@ class DashboardAddView(DashboardModelView):  # noqa
 appbuilder.add_view_no_menu(DashboardAddView)
 
 
+@talisman(force_https=False)
 @app.route("/health")
 def health():
     return "OK"
 
 
+@talisman(force_https=False)
 @app.route("/healthcheck")
 def healthcheck():
     return "OK"
 
 
+@talisman(force_https=False)
 @app.route("/ping")
 def ping():
     return "OK"


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

The `/health` and `/ping` checks probably should use HTTP when Flask-Talisman is enabled. 

### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @mistercrunch 