### PR TITLE
chore: fix flaky SQL Lab test with .focus().blur()

### DIFF
--- a/superset/assets/cypress/integration/sqllab/query.js
+++ b/superset/assets/cypress/integration/sqllab/query.js
@@ -37,9 +37,10 @@ export default () => {
       cy.get('#brace-editor textarea')
         .clear({ force: true })
         .type(
-        `{selectall}{backspace}SELECT ds, gender, name, num FROM main.birth_names LIMIT ${rowLimit}`,
-        { force: true },
-      );
+          `{selectall}{backspace}SELECT ds, gender, name, num FROM main.birth_names LIMIT ${rowLimit}`,
+          { force: true },
+        )
+        .focus().blur(); // focus + blur required to update the store
       cy.get('#js-sql-toolbar button')
         .eq(0)
         .click();
@@ -72,8 +73,7 @@ export default () => {
       cy.get('#brace-editor textarea')
         .clear({ force: true })
         .type(`{selectall}{backspace}${query}`, { force: true })
-        .focus() // focus => blur is required for updating the query that is to be saved
-        .blur();
+        .focus().blur(); // focus + blur required to update the store
 
       // ctrl + r also runs query
       cy.get('#brace-editor textarea').type('{ctrl}r', { force: true });
@@ -93,8 +93,9 @@ export default () => {
       cy.get('.modal-sm input')
         .clear({ force: true })
         .type(`{selectall}{backspace}${savedQueryTitle}`, {
-        force: true,
-      });
+          force: true,
+        })
+        .focus().blur(); // focus + blur required to update the store
 
       cy.get('.modal-sm .modal-body button')
         .eq(0) // save

--- a/superset/assets/cypress/integration/sqllab/query.js
+++ b/superset/assets/cypress/integration/sqllab/query.js
@@ -40,7 +40,8 @@ export default () => {
           `{selectall}{backspace}SELECT ds, gender, name, num FROM main.birth_names LIMIT ${rowLimit}`,
           { force: true },
         )
-        .focus().blur(); // focus + blur required to update the store
+        .focus()
+        .blur(); // focus + blur required to update the store
       cy.get('#js-sql-toolbar button')
         .eq(0)
         .click();
@@ -73,7 +74,8 @@ export default () => {
       cy.get('#brace-editor textarea')
         .clear({ force: true })
         .type(`{selectall}{backspace}${query}`, { force: true })
-        .focus().blur(); // focus + blur required to update the store
+        .focus()
+        .blur(); // focus + blur required to update the store
 
       // ctrl + r also runs query
       cy.get('#brace-editor textarea').type('{ctrl}r', { force: true });
@@ -95,7 +97,8 @@ export default () => {
         .type(`{selectall}{backspace}${savedQueryTitle}`, {
           force: true,
         })
-        .focus().blur(); // focus + blur required to update the store
+        .focus()
+        .blur(); // focus + blur required to update the store
 
       cy.get('.modal-sm .modal-body button')
         .eq(0) // save


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
Second attempt at fixing the flaky cypress SQL Lab test. My intuition is that `.focus().blur()` is needed to insure that the store gets updated. With redux getting save to local storage onChange, it takes some millisecs to save that payload, so we prevent updating the store as it makes typing SQL laggy, and only commit to the store on blur.

Guessing there's a timing issue where blur may not occur in time, so trying to be explicit about it. For reference, other tests were doing this more explicitly before, so extending the approach to all tests touching Ace editor.

🤞 🤞 🤞 

@dpgaspar 