### PR TITLE
[sqllab] use celery worker for stop_query

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -414,6 +414,7 @@ class CeleryConfig(object):
     CELERY_ACKS_LATE = False
     CELERY_ANNOTATIONS = {
         "sql_lab.get_sql_results": {"rate_limit": "100/s"},
+        "sql_lab.stop_query": {"rate_limit": "100/s"},
         "email_reports.send": {
             "rate_limit": "1/s",
             "time_limit": 120,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
#8139 introduced retries for `stop_query` because of lock timeout issues.

This turned out to be problematic because users now have to wait a few seconds after clicking "stop_query" before receiving a message that stopping the query failed.

So now, if a celery worker is available, we run stop_query on a celery worker so that users immediately get a response and don't have to wait for the query to stop. Doesn't actually fix the errors, but at least now users won't see them.

### TEST PLAN
Checked whether `stop_query` worked as expected locally. Threw some fake exceptions to make sure retries still worked.

Confirmed that `stop_query` works whether or not a celery worker is available.

### REVIEWERS
@graceguo-supercat @etr2460 
