### PR TITLE
refactor: prepare control panel configs for separation into plugins

### DIFF
--- a/superset/assets/src/explore/controlPanels/PairedTtest.js
+++ b/superset/assets/src/explore/controlPanels/PairedTtest.js
@@ -27,9 +27,33 @@ export default {
       label: t('Paired t-test'),
       expanded: false,
       controlSetRows: [
-        ['significance_level'],
-        ['pvalue_precision'],
-        ['liftvalue_precision'],
+        [{
+          name: 'significance_level',
+          config: {
+            type: 'TextControl',
+            label: t('Significance Level'),
+            default: 0.05,
+            description: t('Threshold alpha level for determining significance'),
+          },
+        }],
+        [{
+          name: 'pvalue_precision',
+          config: {
+            type: 'TextControl',
+            label: t('p-value precision'),
+            default: 6,
+            description: t('Number of decimal places with which to display p-values'),
+          },
+        }],
+        [{
+          name: 'liftvalue_precision',
+          config: {
+            type: 'TextControl',
+            label: t('Lift percent precision'),
+            default: 4,
+            description: t('Number of decimal places with which to display lift values'),
+          },
+        }],
       ],
     },
   ],

--- a/superset/assets/src/explore/controlPanels/PairedTtest.js
+++ b/superset/assets/src/explore/controlPanels/PairedTtest.js
@@ -17,12 +17,22 @@
  * under the License.
  */
 import { t } from '@superset-ui/translation';
-import { NVD3TimeSeries } from './sections';
 
 export default {
   requiresTime: true,
   controlPanelSections: [
-    NVD3TimeSeries[0],
+    {
+      label: t('Query'),
+      expanded: true,
+      controlSetRows: [
+        ['metrics'],
+        ['adhoc_filters'],
+        ['groupby'],
+        ['limit', 'timeseries_limit_metric'],
+        ['order_desc', 'contribution'],
+        ['row_limit', null],
+      ],
+    },
     {
       label: t('Paired t-test'),
       expanded: false,

--- a/superset/assets/src/explore/controlPanels/WordCloud.js
+++ b/superset/assets/src/explore/controlPanels/WordCloud.js
@@ -35,8 +35,43 @@ export default {
       label: t('Options'),
       expanded: true,
       controlSetRows: [
-        ['size_from', 'size_to'],
-        ['rotation'],
+        [{
+          name: 'size_from',
+          config: {
+            type: 'TextControl',
+            isInt: true,
+            label: t('Minimum Font Size'),
+            renderTrigger: true,
+            default: 10,
+            description: t('Font size for the smallest value in the list'),
+          },
+        }, {
+          name: 'size_to',
+          config: {
+            type: 'TextControl',
+            isInt: true,
+            label: t('Maximum Font Size'),
+            renderTrigger: true,
+            default: 70,
+            description: t('Font size for the biggest value in the list'),
+          },
+        }],
+        [{
+          name: 'rotation',
+          config: {
+            type: 'SelectControl',
+            label: t('Word Rotation'),
+            choices: [
+              ['random', 'random'],
+              ['flat', 'flat'],
+              ['square', 'square'],
+            ],
+            renderTrigger: true,
+            default: 'square',
+            clearable: false,
+            description: t('Rotation to apply to words in the cloud'),
+          },
+        }],
         ['color_scheme', 'label_colors'],
       ],
     },
@@ -48,12 +83,6 @@ export default {
     },
     row_limit: {
       default: 100,
-    },
-    size_from: {
-      default: 10,
-    },
-    size_to: {
-      default: 70,
     },
   },
 };

--- a/superset/assets/src/explore/controlPanels/WorldMap.js
+++ b/superset/assets/src/explore/controlPanels/WorldMap.js
@@ -25,7 +25,22 @@ export default {
       expanded: true,
       controlSetRows: [
         ['entity'],
-        ['country_fieldtype'],
+        [{
+          name: 'country_fieldtype',
+          config: {
+            type: 'SelectControl',
+            label: t('Country Field Type'),
+            default: 'cca2',
+            choices: [
+              ['name', 'Full name'],
+              ['cioc', 'code International Olympic Committee (cioc)'],
+              ['cca2', 'code ISO 3166-1 alpha-2 (cca2)'],
+              ['cca3', 'code ISO 3166-1 alpha-3 (cca3)'],
+            ],
+            description: t('The country code standard that Superset should expect ' +
+              'to find in the [country] column'),
+          },
+        }],
         ['metric'],
         ['adhoc_filters'],
         ['row_limit'],
@@ -34,7 +49,16 @@ export default {
     {
       label: t('Bubbles'),
       controlSetRows: [
-        ['show_bubbles'],
+        [{
+          name: 'show_bubbles',
+          config: {
+            type: 'CheckboxControl',
+            label: t('Show Bubbles'),
+            default: false,
+            renderTrigger: true,
+            description: t('Whether to display bubbles on top of countries'),
+          },
+        }],
         ['secondary_metric'],
         ['max_bubble_size'],
       ],

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -591,19 +591,6 @@ export const controls = {
     ].map(s => [s, s]),
     description: t('The name of the country that Superset should display'),
   },
-  country_fieldtype: {
-    type: 'SelectControl',
-    label: t('Country Field Type'),
-    default: 'cca2',
-    choices: [
-      ['name', 'Full name'],
-      ['cioc', 'code International Olympic Committee (cioc)'],
-      ['cca2', 'code ISO 3166-1 alpha-2 (cca2)'],
-      ['cca3', 'code ISO 3166-1 alpha-3 (cca3)'],
-    ],
-    description: t('The country code standard that Superset should expect ' +
-    'to find in the [country] column'),
-  },
 
   freq: {
     type: 'SelectControl',
@@ -1311,16 +1298,6 @@ export const controls = {
     description: t('Pick your favorite markup language'),
   },
 
-  rotation: {
-    type: 'SelectControl',
-    label: t('Word Rotation'),
-    choices: formatSelectOptions(['random', 'flat', 'square']),
-    renderTrigger: true,
-    default: 'square',
-    clearable: false,
-    description: t('Rotation to apply to words in the cloud'),
-  },
-
   line_interpolation: {
     type: 'SelectControl',
     label: t('Line Style'),
@@ -1394,24 +1371,6 @@ export const controls = {
       'p95',
       'p99',
     ]),
-  },
-
-  size_from: {
-    type: 'TextControl',
-    isInt: true,
-    label: t('Minimum Font Size'),
-    renderTrigger: true,
-    default: '20',
-    description: t('Font size for the smallest value in the list'),
-  },
-
-  size_to: {
-    type: 'TextControl',
-    isInt: true,
-    label: t('Maximum Font Size'),
-    renderTrigger: true,
-    default: '150',
-    description: t('Font size for the biggest value in the list'),
   },
 
   header_font_size: {
@@ -1582,14 +1541,6 @@ export const controls = {
     renderTrigger: true,
     default: true,
     description: t('Whether to color +/- values'),
-  },
-
-  show_bubbles: {
-    type: 'CheckboxControl',
-    label: t('Show Bubbles'),
-    default: false,
-    renderTrigger: true,
-    description: t('Whether to display bubbles on top of countries'),
   },
 
   show_legend: {

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2114,27 +2114,6 @@ export const controls = {
     }),
   },
 
-  significance_level: {
-    type: 'TextControl',
-    label: t('Significance Level'),
-    default: 0.05,
-    description: t('Threshold alpha level for determining significance'),
-  },
-
-  pvalue_precision: {
-    type: 'TextControl',
-    label: t('p-value precision'),
-    default: 6,
-    description: t('Number of decimal places with which to display p-values'),
-  },
-
-  liftvalue_precision: {
-    type: 'TextControl',
-    label: t('Lift percent precision'),
-    default: 4,
-    description: t('Number of decimal places with which to display lift values'),
-  },
-
   column_collection: {
     type: 'CollectionControl',
     label: t('Time Series Columns'),


### PR DESCRIPTION
### CATEGORY

Choose one
- [X] Refactor

### SUMMARY

This PR is the beginning of work to move controls from `controls.jsx` (> 2,000 lines of code) into per-viztype control panels. The goal is to prepare control panel configs for separation into plugins. 

Note: Depends on #8221 

#### Migration instructions 
* The controls that are used only once or twice should be moved immediately, e.g. `rotation`, `show_bubbles`. (See attached table below.) This would cut the size of `controls.jsx` more than half already.
* We could leave the controls that are commonly used in `controls.jsx` for the first pass.
* If there are `controlOverrides` in the control panel config, manually override the control config and remove the override config from `controlOverrides` (see `size_from` and `size_to`).
* Try to avoid import as the control panel config file should be quite standalone
* Not sure what to do with validators yet. Ideas are welcome.

#### Control usage statistics

Control name | No. of charts using it
-------------| ----
adhoc_filters| 45
row_limit| 33
groupby| 21
color_scheme| 20
label_colors| 20
metric| 16
metrics| 16
y_axis_format| 14
limit| 12
mapbox_style| 10
show_legend| 10
bottom_margin| 10
viewport| 9
timeseries_limit_metric| 9
order_desc| 9
contribution| 9
x_axis_label| 9
filter_nulls| 8
color_picker| 8
js_columns| 8
js_data_mutator| 8
js_tooltip| 8
js_onclick_href| 8
x_ticks_layout| 8
x_axis_format| 8
autozoom| 7
x_axis_showminmax| 7
y_axis_label| 7
y_axis_bounds| 6
y_log_scale| 6
rolling_type| 6
rolling_periods| 6
min_periods| 6
time_compare| 6
comparison_type| 6
resample_rule| 6
resample_method| 6
annotation_layers| 6
left_margin| 6
number_format| 6
linear_color_scheme| 5
line_interpolation| 5
rich_tooltip| 5
y_axis_showminmax| 5
extruded| 4
spatial| 4
size| 4
entity| 4
all_columns_x| 4
legend_position| 3
legend_format| 3
grid_size| 3
show_brush| 3
show_controls| 3
series| 3
columns| 3
secondary_metric| 3
dimension| 2
fill_color_picker| 2
stroke_color_picker| 2
filled| 2
stroked| 2
line_column| 2
line_type| 2
line_width| 2
reverse_long_lat| 2
point_radius_fixed| 2
multiplier| 2
table_filter| 2
show_bar_value| 2
bar_stacked| 2
reduce_x_ticks| 2
header_font_size| 2
subheader_font_size| 2
max_bubble_size| 2
show_values| 2
y_axis_2_format| 2
all_columns| 2
link_length| 2
all_columns_y| 2
normalized| 2
global_opacity| 2
url| 2
show_markers| 2
pandas_aggfunc| 2
markup_type| 2
code| 2
date_time_format| 2
start_spatial| 1
end_spatial| 1
target_color_picker| 1
stroke_width| 1
geojson| 1
point_radius_scale| 1
js_agg_function| 1
deck_slices| 1
opacity| 1
num_buckets| 1
break_points| 1
toggle_polygons| 1
point_unit| 1
min_radius| 1
max_radius| 1
stacked_style| 1
compare_lag| 1
compare_suffix| 1
show_trend_line| 1
start_y_axis_at_zero| 1
subheader| 1
whisker_options| 1
x| 1
y| 1
x_log_scale| 1
ranges| 1
range_labels| 1
markers| 1
marker_labels| 1
marker_lines| 1
marker_line_labels| 1
domain_granularity| 1
subdomain_granularity| 1
cell_size| 1
cell_padding| 1
cell_radius| 1
steps| 1
x_axis_time_format| 1
show_metric_name| 1
select_country| 1
order_bars| 1
metric_2| 1
order_by_entity| 1
min_leaf_node_event_count| 1
filter_configs| 1
date_filter| 1
instant_filtering| 1
show_sqla_time_granularity| 1
show_sqla_time_column| 1
show_druid_time_granularity| 1
show_druid_time_origin| 1
charge| 1
xscale_interval| 1
yscale_interval| 1
canvas_image_rendering| 1
normalize_across| 1
show_perc| 1
sort_x_axis| 1
sort_y_axis| 1
series_height| 1
horizon_color_scale| 1
send_time_range| 1
prefix_metric_with_slice_name| 1
line_charts| 1
line_charts_2| 1
clustering_radius| 1
point_radius| 1
point_radius_unit| 1
mapbox_label| 1
render_while_dragging| 1
mapbox_color| 1
viewport_longitude| 1
viewport_latitude| 1
viewport_zoom| 1
show_datatable| 1
include_series| 1
time_series_option| 1
partition_limit| 1
partition_threshold| 1
log_scale| 1
equal_date_size| 1
pie_label_type| 1
donut| 1
show_labels| 1
labels_outside| 1
pivot_margins| 1
combine_metric| 1
transpose_pivot| 1
percent_metrics| 1
include_time| 1
order_by_cols| 1
table_timestamp_format| 1
page_length| 1
include_search| 1
align_pn| 1
color_pn| 1
freq| 1
column_collection| 1
treemap_ratio| 1
size_from| 1
size_to| 1
rotation| 1
country_fieldtype| 1
show_bubbles| 1

### TEST PLAN
Tested locally + CI

### REVIEWERS
@mistercrunch 