### PR TITLE
Fix sync failed when datasource is schema-less

### DIFF
--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -261,10 +261,11 @@ export class DatasourceEditor extends React.PureComponent {
   }
   syncMetadata() {
     const { datasource } = this.state;
+    // Handle carefully when the schema is empty
     const endpoint = (
       `/datasource/external_metadata/${datasource.type}/${datasource.id}/` +
       `?db_id=${datasource.database.id}` +
-      `&schema=${datasource.schema}` +
+      `&schema=${datasource.schema || ''}` +
       `&table_name=${datasource.datasource_name}`
     );
     this.setState({ metadataLoading: true });


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When the datasource does not have a schema, the request arguments will assemble the URL contains string 'null'.
this will cause the server side do not find the columns of the datasource.

