### PR TITLE
[sqllab] create query slightly earlier

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2609,19 +2609,10 @@ class Superset(BaseSupersetView):
         limit = limit or app.config.get("SQL_MAX_ROW")
 
         session = db.session()
-        mydb = session.query(models.Database).filter_by(id=database_id).first()
+        mydb = session.query(models.Database).filter_by(id=database_id).one_or_none()
 
         if not mydb:
-            json_error_response("Database with id {} is missing.".format(database_id))
-
-        rejected_tables = security_manager.rejected_tables(sql, mydb, schema)
-        if rejected_tables:
-            return json_error_response(
-                security_manager.get_table_access_error_msg(rejected_tables),
-                link=security_manager.get_table_access_link(rejected_tables),
-                status=403,
-            )
-        session.commit()
+            return json_error_response(f"Database with id {database_id} is missing.")
 
         select_as_cta = request.form.get("select_as_cta") == "true"
         tmp_table_name = request.form.get("tmp_table_name")
@@ -2649,6 +2640,16 @@ class Superset(BaseSupersetView):
         if not query_id:
             raise Exception(_("Query record was not created as expected."))
         logging.info("Triggering query_id: {}".format(query_id))
+
+        rejected_tables = security_manager.rejected_tables(sql, mydb, schema)
+        if rejected_tables:
+            query.status = QueryStatus.FAILED
+            session.commit()
+            return json_error_response(
+                security_manager.get_table_access_error_msg(rejected_tables),
+                link=security_manager.get_table_access_link(rejected_tables),
+                status=403,
+            )
 
         try:
             template_processor = get_template_processor(


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Part of the ongoing saga of trying to fix `stop_query` issues.

Flips the order of the rejected tables check and query creation so that queries are created slightly earlier. This might prevent errors like `No row was found for one()` if a user stops the query before it is actually created. 

This also means that if a user doesn't have access to the tables in the query, the query will still be recorded in the queries table with the status `QueryStatus.FAILED`. Previously, these queries were not recorded.

### TEST PLAN
Ran some queries locally to make sure they still worked. Confirmed that queries are now logged to the queries table with the status QueryStatus.FAILED if the user does not have access to a table in the query.

### REVIEWERS
@etr2460 