### PR TITLE
[SQL Lab] Fix bug when filtering on results that include nulls

### DIFF
--- a/superset/assets/spec/javascripts/components/FilterableTable/FilterableTable_spec.jsx
+++ b/superset/assets/spec/javascripts/components/FilterableTable/FilterableTable_spec.jsx
@@ -26,6 +26,7 @@ describe('FilterableTable', () => {
     data: [
       { a: 'a1', b: 'b1', c: 'c1', d: 0 },
       { a: 'a2', b: 'b2', c: 'c2', d: 100 },
+      { a: null, b: 'b3', c: 'c3', d: 50 },
     ],
     height: 500,
   };
@@ -38,7 +39,7 @@ describe('FilterableTable', () => {
   });
   it('renders a grid with 2 Table rows', () => {
     expect(wrapper.find('.ReactVirtualized__Grid')).toHaveLength(1);
-    expect(wrapper.find('.ReactVirtualized__Table__row')).toHaveLength(2);
+    expect(wrapper.find('.ReactVirtualized__Table__row')).toHaveLength(3);
   });
   it('renders a grid with 2 Grid rows for wide tables', () => {
     const wideTableColumns = MAX_COLUMNS_FOR_TABLE + 1;

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -223,7 +223,7 @@ export default class FilterableTable extends PureComponent {
         const cellValue = row[key];
         if (typeof cellValue === 'string') {
           values.push(cellValue.toLowerCase());
-        } else if (typeof cellValue.toString === 'function') {
+        } else if (cellValue !== null && typeof cellValue.toString === 'function') {
           values.push(cellValue.toString());
         }
       }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a `TypeError: Cannot read property 'toString' of null` when you filter results in SQL Lab and the results set includes null values. Also adds a unit test to confirm the fix.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Test filtering when the results set includes null values. Also run unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @betodealmeida @michellethomas @xtinec 