### PR TITLE
Simplify and improve `expand_data` in Presto

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
-from collections import deque, defaultdict, OrderedDict
+from collections import defaultdict, deque, OrderedDict
 from datetime import datetime
 from distutils.version import StrictVersion
 import logging
@@ -823,7 +823,7 @@ class PrestoEngineSpec(BaseEngineSpec):
             # the first. every time we change a level in the nested arrays we
             # reinitialize this.
             if level != current_array_level:
-                unnested_rows = defaultdict(int)
+                unnested_rows: Dict[int, int] = defaultdict(int)
                 current_array_level = level
 
             name = column["name"]
@@ -872,7 +872,9 @@ class PrestoEngineSpec(BaseEngineSpec):
                     for value, col in zip(row.get(name) or [], expanded):
                         row[col["name"]] = value
 
-        data = [{k["name"]: row.get(k["name"], "") for k in all_columns} for row in data]
+        data = [
+            {k["name"]: row.get(k["name"], "") for k in all_columns} for row in data
+        ]
 
         return all_columns, data, expanded_columns
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -809,12 +809,13 @@ class PrestoEngineSpec(BaseEngineSpec):
 
         # process each column, unnesting ARRAY types and expanding ROW types into new columns
         to_process = deque((column, 0) for column in columns)
-        all_columns = []
+        all_columns: List[dict] = []
         expanded_columns = []
         current_array_level = None
         while to_process:
             column, level = to_process.popleft()
-            all_columns.append(column)
+            if column["name"] not in [column["name"] for column in all_columns]:
+                all_columns.append(column)
 
             # When unnesting arrays we need to keep track of how many extra rows
             # were added, for each original row. This is necessary when we expand multiple

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -68,7 +68,7 @@ def get_children(column: Dict[str, str]) -> List[Dict[str, str]]:
     if type_ == "ARRAY":
         return [{"name": column["name"], "type": children_type}]
     elif type_ == "ROW":
-        i = 0
+        nameless_columns = 0
         columns = []
         for child in utils.split(children_type, ","):
             parts = list(utils.split(child.strip(), " "))
@@ -76,9 +76,9 @@ def get_children(column: Dict[str, str]) -> List[Dict[str, str]]:
                 name, type_ = parts
                 name = name.strip('"')
             else:
-                name = f"_col{i}"
+                name = f"_col{nameless_columns}"
                 type_ = parts[0]
-                i += 1
+                nameless_columns += 1
             columns.append({"name": f"{column['name']}.{name.lower()}", "type": type_})
         return columns
     else:
@@ -775,7 +775,7 @@ class PrestoEngineSpec(BaseEngineSpec):
                 del array_column_hierarchy[array_column]
 
     @classmethod
-    def _expand_data(
+    def expand_data(
         cls, columns: List[dict], data: List[dict]
     ) -> Tuple[List[dict], List[dict], List[dict]]:
         """

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -32,7 +32,7 @@ import signal
 import smtplib
 from time import struct_time
 import traceback
-from typing import List, NamedTuple, Optional, Tuple, Union
+from typing import Iterator, List, NamedTuple, Optional, Tuple, Union
 from urllib.parse import unquote_plus
 import uuid
 import zlib
@@ -1197,8 +1197,8 @@ def get_stacktrace():
 
 
 def split(
-    s: str, delimiter: str, quote: str = '"', escaped_quote: str = '\\"'
-) -> List[str]:
+    s: str, delimiter: str = " ", quote: str = '"', escaped_quote: str = r"\""
+) -> Iterator[str]:
     """
     A split function that is aware of quotes and parentheses.
 
@@ -1221,7 +1221,7 @@ def split(
         elif c == ")":
             parens -= 1
         elif c == quote:
-            if quotes and s[j - len(escaped_quote) : j] != escaped_quote:
+            if quotes and s[j - len(escaped_quote) + 1 : j + 1] != escaped_quote:
                 quotes = False
             elif not quotes:
                 quotes = True

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1194,3 +1194,35 @@ class DatasourceName(NamedTuple):
 def get_stacktrace():
     if current_app.config.get("SHOW_STACKTRACE"):
         return traceback.format_exc()
+
+
+def split(
+    s: str, delimiter: str, quote: str = '"', escaped_quote: str = '\\"'
+) -> List[str]:
+    """
+    A split function that is aware of quotes and parentheses.
+
+    :param s: string to split
+    :param delimiter: string defining where to split, usually a comma or space
+    :param quote: string, either a single or a double quote
+    :param escaped_quote: string representing an escaped quote
+    :return: list of strings
+    """
+    parens = 0
+    quotes = False
+    i = 0
+    for j, c in enumerate(s):
+        complete = parens == 0 and not quotes
+        if complete and c == delimiter:
+            yield s[i:j]
+            i = j + len(delimiter)
+        elif c == "(":
+            parens += 1
+        elif c == ")":
+            parens -= 1
+        elif c == quote:
+            if quotes and s[j - len(escaped_quote) : j] != escaped_quote:
+                quotes = False
+            elif not quotes:
+                quotes = True
+    yield s[i:]

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -653,18 +653,52 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             cols, data
         )
         expected_cols = [
-            {"name": "row_column", "type": "ROW"},
+            {"name": "__row_id", "type": "BIGINT"},
+            {"name": "row_column", "type": "ROW(NESTED_OBJ VARCHAR)"},
             {"name": "row_column.nested_obj", "type": "VARCHAR"},
-            {"name": "array_column", "type": "ARRAY"},
+            {"name": "array_column", "type": "ARRAY(BIGINT)"},
+            {"name": "array_column", "type": "BIGINT"},
         ]
+
         expected_data = [
-            {"row_column": ["a"], "row_column.nested_obj": "a", "array_column": 1},
-            {"row_column": "", "row_column.nested_obj": "", "array_column": 2},
-            {"row_column": "", "row_column.nested_obj": "", "array_column": 3},
-            {"row_column": ["b"], "row_column.nested_obj": "b", "array_column": 4},
-            {"row_column": "", "row_column.nested_obj": "", "array_column": 5},
-            {"row_column": "", "row_column.nested_obj": "", "array_column": 6},
+            {
+                "__row_id": 0,
+                "array_column": 1,
+                "row_column": ["a"],
+                "row_column.nested_obj": "a",
+            },
+            {
+                "__row_id": "",
+                "array_column": 2,
+                "row_column": "",
+                "row_column.nested_obj": "",
+            },
+            {
+                "__row_id": "",
+                "array_column": 3,
+                "row_column": "",
+                "row_column.nested_obj": "",
+            },
+            {
+                "__row_id": 1,
+                "array_column": 4,
+                "row_column": ["b"],
+                "row_column.nested_obj": "b",
+            },
+            {
+                "__row_id": "",
+                "array_column": 5,
+                "row_column": "",
+                "row_column.nested_obj": "",
+            },
+            {
+                "__row_id": "",
+                "array_column": 6,
+                "row_column": "",
+                "row_column.nested_obj": "",
+            },
         ]
+
         expected_expanded_cols = [{"name": "row_column.nested_obj", "type": "VARCHAR"}]
         self.assertEqual(actual_cols, expected_cols)
         self.assertEqual(actual_data, expected_data)
@@ -677,7 +711,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         cols = [
             {
                 "name": "row_column",
-                "type": "ROW(NESTED_OBJ1 VARCHAR, NESTED_ROW ROW(NESTED_OBJ2 VARCHAR)",
+                "type": "ROW(NESTED_OBJ1 VARCHAR, NESTED_ROW ROW(NESTED_OBJ2 VARCHAR))",
             }
         ]
         data = [{"row_column": ["a1", ["a2"]]}, {"row_column": ["b1", ["b2"]]}]
@@ -685,28 +719,35 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             cols, data
         )
         expected_cols = [
-            {"name": "row_column", "type": "ROW"},
-            {"name": "row_column.nested_obj1", "type": "VARCHAR"},
-            {"name": "row_column.nested_row", "type": "ROW"},
+            {"name": "__row_id", "type": "BIGINT"},
+            {
+                "name": "row_column",
+                "type": "ROW(NESTED_OBJ1 VARCHAR, NESTED_ROW ROW(NESTED_OBJ2 VARCHAR))",
+            },
+            {"name": "row_column.nested_row", "type": "ROW(NESTED_OBJ2 VARCHAR)"},
             {"name": "row_column.nested_row.nested_obj2", "type": "VARCHAR"},
+            {"name": "row_column.nested_obj1", "type": "VARCHAR"},
         ]
         expected_data = [
             {
+                "__row_id": 0,
                 "row_column": ["a1", ["a2"]],
                 "row_column.nested_obj1": "a1",
                 "row_column.nested_row": ["a2"],
                 "row_column.nested_row.nested_obj2": "a2",
             },
             {
+                "__row_id": 1,
                 "row_column": ["b1", ["b2"]],
                 "row_column.nested_obj1": "b1",
                 "row_column.nested_row": ["b2"],
                 "row_column.nested_row.nested_obj2": "b2",
             },
         ]
+
         expected_expanded_cols = [
             {"name": "row_column.nested_obj1", "type": "VARCHAR"},
-            {"name": "row_column.nested_row", "type": "ROW"},
+            {"name": "row_column.nested_row", "type": "ROW(NESTED_OBJ2 VARCHAR)"},
             {"name": "row_column.nested_row.nested_obj2", "type": "VARCHAR"},
         ]
         self.assertEqual(actual_cols, expected_cols)
@@ -732,63 +773,86 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             cols, data
         )
         expected_cols = [
+            {"name": "__row_id", "type": "BIGINT"},
             {"name": "int_column", "type": "BIGINT"},
-            {"name": "array_column", "type": "ARRAY"},
-            {"name": "array_column.nested_array", "type": "ARRAY"},
+            {
+                "name": "array_column",
+                "type": "ARRAY(ROW(NESTED_ARRAY ARRAY(ROW(NESTED_OBJ VARCHAR))))",
+            },
+            {
+                "name": "array_column",
+                "type": "ROW(NESTED_ARRAY ARRAY(ROW(NESTED_OBJ VARCHAR)))",
+            },
+            {
+                "name": "array_column.nested_array",
+                "type": "ARRAY(ROW(NESTED_OBJ VARCHAR))",
+            },
+            {"name": "array_column.nested_array", "type": "ROW(NESTED_OBJ VARCHAR)"},
             {"name": "array_column.nested_array.nested_obj", "type": "VARCHAR"},
         ]
         expected_data = [
             {
-                "int_column": 1,
-                "array_column": [[[["a"], ["b"]]], [[["c"], ["d"]]]],
-                "array_column.nested_array": [["a"], ["b"]],
+                "__row_id": 0,
+                "array_column": [[["a"], ["b"]]],
+                "array_column.nested_array": ["a"],
                 "array_column.nested_array.nested_obj": "a",
+                "int_column": 1,
             },
             {
-                "int_column": "",
+                "__row_id": "",
                 "array_column": "",
-                "array_column.nested_array": "",
+                "array_column.nested_array": ["b"],
                 "array_column.nested_array.nested_obj": "b",
+                "int_column": "",
             },
             {
-                "int_column": "",
-                "array_column": "",
-                "array_column.nested_array": [["c"], ["d"]],
+                "__row_id": "",
+                "array_column": [[["c"], ["d"]]],
+                "array_column.nested_array": ["c"],
                 "array_column.nested_array.nested_obj": "c",
+                "int_column": "",
             },
             {
-                "int_column": "",
+                "__row_id": "",
                 "array_column": "",
-                "array_column.nested_array": "",
+                "array_column.nested_array": ["d"],
                 "array_column.nested_array.nested_obj": "d",
+                "int_column": "",
             },
             {
-                "int_column": 2,
-                "array_column": [[[["e"], ["f"]]], [[["g"], ["h"]]]],
-                "array_column.nested_array": [["e"], ["f"]],
+                "__row_id": 1,
+                "array_column": [[["e"], ["f"]]],
+                "array_column.nested_array": ["e"],
                 "array_column.nested_array.nested_obj": "e",
+                "int_column": 2,
             },
             {
-                "int_column": "",
+                "__row_id": "",
                 "array_column": "",
-                "array_column.nested_array": "",
+                "array_column.nested_array": ["f"],
                 "array_column.nested_array.nested_obj": "f",
+                "int_column": "",
             },
             {
-                "int_column": "",
-                "array_column": "",
-                "array_column.nested_array": [["g"], ["h"]],
+                "__row_id": "",
+                "array_column": [[["g"], ["h"]]],
+                "array_column.nested_array": ["g"],
                 "array_column.nested_array.nested_obj": "g",
+                "int_column": "",
             },
             {
-                "int_column": "",
+                "__row_id": "",
                 "array_column": "",
-                "array_column.nested_array": "",
+                "array_column.nested_array": ["h"],
                 "array_column.nested_array.nested_obj": "h",
+                "int_column": "",
             },
         ]
         expected_expanded_cols = [
-            {"name": "array_column.nested_array", "type": "ARRAY"},
+            {
+                "name": "array_column.nested_array",
+                "type": "ARRAY(ROW(NESTED_OBJ VARCHAR))",
+            },
             {"name": "array_column.nested_array.nested_obj", "type": "VARCHAR"},
         ]
         self.assertEqual(actual_cols, expected_cols)

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -657,7 +657,6 @@ class DbEngineSpecsTestCase(SupersetTestCase):
             {"name": "row_column", "type": "ROW(NESTED_OBJ VARCHAR)"},
             {"name": "row_column.nested_obj", "type": "VARCHAR"},
             {"name": "array_column", "type": "ARRAY(BIGINT)"},
-            {"name": "array_column", "type": "BIGINT"},
         ]
 
         expected_data = [
@@ -780,14 +779,9 @@ class DbEngineSpecsTestCase(SupersetTestCase):
                 "type": "ARRAY(ROW(NESTED_ARRAY ARRAY(ROW(NESTED_OBJ VARCHAR))))",
             },
             {
-                "name": "array_column",
-                "type": "ROW(NESTED_ARRAY ARRAY(ROW(NESTED_OBJ VARCHAR)))",
-            },
-            {
                 "name": "array_column.nested_array",
                 "type": "ARRAY(ROW(NESTED_OBJ VARCHAR))",
             },
-            {"name": "array_column.nested_array", "type": "ROW(NESTED_OBJ VARCHAR)"},
             {"name": "array_column.nested_array.nested_obj", "type": "VARCHAR"},
         ]
         expected_data = [

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -45,6 +45,7 @@ from superset.utils.core import (
     parse_js_uri_path_item,
     parse_past_timedelta,
     setup_cache,
+    split,
     validate_json,
     zlib_compress,
     zlib_decompress,
@@ -832,6 +833,20 @@ class UtilsTestCase(unittest.TestCase):
                 stacktrace = get_stacktrace()
                 assert stacktrace is None
 
+    def test_split(self):
+        self.assertEqual(list(split("a b")), ["a", "b"])
+        self.assertEqual(list(split("a,b", delimiter=",")), ["a", "b"])
+        self.assertEqual(list(split("a,(b,a)", delimiter=",")), ["a", "(b,a)"])
+        self.assertEqual(
+            list(split('a,(b,a),"foo , bar"', delimiter=",")),
+            ["a", "(b,a)", '"foo , bar"'],
+        )
+        self.assertEqual(
+            list(split("a,'b,c'", delimiter=",", quote="'")), ["a", "'b,c'"]
+        )
+        self.assertEqual(list(split('a "b c"')), ["a", '"b c"'])
+        self.assertEqual(list(split(r'a "b \" c"')), ["a", r'"b \" c"'])
+
     def test_get_or_create_db(self):
         get_or_create_db("test_db", "sqlite:///superset.db")
         database = db.session.query(Database).filter_by(database_name="test_db").one()
@@ -850,3 +865,7 @@ class UtilsTestCase(unittest.TestCase):
     def test_get_or_create_db_invalid_uri(self):
         with self.assertRaises(ArgumentError):
             get_or_create_db("test_db", "yoursql:superset.db/()")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -865,7 +865,3 @@ class UtilsTestCase(unittest.TestCase):
     def test_get_or_create_db_invalid_uri(self):
         with self.assertRaises(ArgumentError):
             get_or_create_db("test_db", "yoursql:superset.db/()")
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR simplifies the logic of the `expand_data` method in Presto, while making it more generic. Queries that were failing before, like

```sql
SELECT ARRAY[ROW(100,0,'hello')]
```

are now working.

Some of the methods in `db_engine_specs/presto.py` are no longer used and can be removed; I'll do that in a subsequent PR. I wanted to keep this PR simple and small because it's blocking an important release.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I updated the unit tests, and tested with real data. I'll add more unit tests in the next PR, covering more complex cases.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 