### PR TITLE
Show Presto views as views, not tables

### DIFF
--- a/superset/assets/src/components/TableSelector.css
+++ b/superset/assets/src/components/TableSelector.css
@@ -36,3 +36,6 @@
   border-bottom: 1px solid #f2f2f2;
   margin: 15px 0;
 }
+.TableLabel {
+  white-space: nowrap;
+}

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -221,7 +221,7 @@ export default class TableSelector extends React.PureComponent {
         onMouseEnter={() => focusOption(option)}
         style={style}
       >
-        <span>
+        <span className="TableLabel">
           <span className="m-r-5">
             <small className="text-muted">
               <i className={`fa fa-${option.type === 'view' ? 'eye' : 'table'}`} />

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -20,7 +20,7 @@ from datetime import datetime
 import hashlib
 import os
 import re
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING, Union
 
 from flask import g
 from flask_babel import lazy_gettext as _
@@ -38,8 +38,11 @@ import sqlparse
 from werkzeug.utils import secure_filename
 
 from superset import app, db, sql_parse
-from superset.models.core import Database
 from superset.utils import core as utils
+
+if TYPE_CHECKING:
+    # prevent circular imports
+    from superset.models.core import Database
 
 
 class TimeGrain(NamedTuple):
@@ -540,7 +543,7 @@ class BaseEngineSpec:
 
     @classmethod
     def get_table_names(
-        cls, database: Database, inspector: Inspector, schema: Optional[str]
+        cls, database: "Database", inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         """
         Get all tables from schema
@@ -556,7 +559,7 @@ class BaseEngineSpec:
 
     @classmethod
     def get_view_names(
-        cls, database: Database, inspector: Inspector, schema: Optional[str]
+        cls, database: "Database", inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         """
         Get all views from schema

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -538,7 +538,9 @@ class BaseEngineSpec:
         return sorted(inspector.get_schema_names())
 
     @classmethod
-    def get_table_names(cls, inspector: Inspector, schema: Optional[str]) -> List[str]:
+    def get_table_names(
+        cls, database, inspector: Inspector, schema: Optional[str]
+    ) -> List[str]:
         """
         Get all tables from schema
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -38,6 +38,7 @@ import sqlparse
 from werkzeug.utils import secure_filename
 
 from superset import app, db, sql_parse
+from superset.models.core import Database
 from superset.utils import core as utils
 
 
@@ -539,7 +540,7 @@ class BaseEngineSpec:
 
     @classmethod
     def get_table_names(
-        cls, database, inspector: Inspector, schema: Optional[str]
+        cls, database: Database, inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         """
         Get all tables from schema
@@ -555,7 +556,7 @@ class BaseEngineSpec:
 
     @classmethod
     def get_view_names(
-        cls, database, inspector: Inspector, schema: Optional[str]
+        cls, database: Database, inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         """
         Get all views from schema

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -552,7 +552,9 @@ class BaseEngineSpec:
         return sorted(tables)
 
     @classmethod
-    def get_view_names(cls, inspector: Inspector, schema: Optional[str]) -> List[str]:
+    def get_view_names(
+        cls, database, inspector: Inspector, schema: Optional[str]
+    ) -> List[str]:
         """
         Get all views from schema
 

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Tuple
 from sqlalchemy.dialects.postgresql.base import PGInspector
 
 from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
+from superset.models.core import Database
 
 
 class PostgresBaseEngineSpec(BaseEngineSpec):
@@ -64,7 +65,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
 
     @classmethod
     def get_table_names(
-        cls, database, inspector: PGInspector, schema: Optional[str]
+        cls, database: Database, inspector: PGInspector, schema: Optional[str]
     ) -> List[str]:
         """Need to consider foreign tables for PostgreSQL"""
         tables = inspector.get_table_names(schema)

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -64,7 +64,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
 
     @classmethod
     def get_table_names(
-        cls, inspector: PGInspector, schema: Optional[str]
+        cls, database, inspector: PGInspector, schema: Optional[str]
     ) -> List[str]:
         """Need to consider foreign tables for PostgreSQL"""
         tables = inspector.get_table_names(schema)

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -16,12 +16,15 @@
 # under the License.
 # pylint: disable=C,R,W
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, TYPE_CHECKING
 
 from sqlalchemy.dialects.postgresql.base import PGInspector
 
 from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
-from superset.models.core import Database
+
+if TYPE_CHECKING:
+    # prevent circular imports
+    from superset.models.core import Database
 
 
 class PostgresBaseEngineSpec(BaseEngineSpec):
@@ -65,7 +68,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
 
     @classmethod
     def get_table_names(
-        cls, database: Database, inspector: PGInspector, schema: Optional[str]
+        cls, database: "Database", inspector: PGInspector, schema: Optional[str]
     ) -> List[str]:
         """Need to consider foreign tables for PostgreSQL"""
         tables = inspector.get_table_names(schema)

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -128,18 +128,46 @@ class PrestoEngineSpec(BaseEngineSpec):
         return version is not None and StrictVersion(version) >= StrictVersion("0.319")
 
     @classmethod
-    def get_view_names(cls, inspector: Inspector, schema: Optional[str]) -> List[str]:
+    def get_table_names(
+        cls, database, inspector: Inspector, schema: Optional[str]
+    ) -> List[str]:
+        tables = super().get_table_names(inspector, schema)
+
+        if not is_feature_enabled("PRESTO_SPLIT_VIEWS_FROM_TABLES"):
+            return tables
+
+        views = set(cls.get_view_names(database, inspector, schema))
+        actual_tables = set(tables) - views
+        return list(actual_tables)
+
+    @classmethod
+    def get_view_names(
+        cls, database, inspector: Inspector, schema: Optional[str]
+    ) -> List[str]:
         """Returns an empty list
 
         get_table_names() function returns all table names and view names,
         and get_view_names() is not implemented in sqlalchemy_presto.py
         https://github.com/dropbox/PyHive/blob/e25fc8440a0686bbb7a5db5de7cb1a77bdb4167a/pyhive/sqlalchemy_presto.py
         """
-        
-        if not is_feature_enabled("PRESTO_SPLIT_VIEWS_FROM_TALBES"):
+
+        if not is_feature_enabled("PRESTO_SPLIT_VIEWS_FROM_TABLES"):
             return []
 
+        if schema:
+            sql = "SELECT table_name FROM information_schema.views WHERE schema_name=%(schema)s"
+            params = {"schema": schema}
+        else:
+            sql = "SELECT table_name FROM information_schema.views"
+            params = {}
 
+        engine = cls.get_engine(database, schema=schema)
+        with closing(engine.raw_connection()) as conn:
+            with closing(conn.cursor()) as cursor:
+                cursor.execute(sql, params)
+                results = cursor.fetchall()
+
+        return [row["table_name"] for row in results]
 
     @classmethod
     def _create_column_info(cls, name: str, data_type: str) -> dict:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -135,7 +135,11 @@ class PrestoEngineSpec(BaseEngineSpec):
         and get_view_names() is not implemented in sqlalchemy_presto.py
         https://github.com/dropbox/PyHive/blob/e25fc8440a0686bbb7a5db5de7cb1a77bdb4167a/pyhive/sqlalchemy_presto.py
         """
-        return []
+        
+        if not is_feature_enabled("PRESTO_SPLIT_VIEWS_FROM_TALBES"):
+            return []
+
+
 
     @classmethod
     def _create_column_info(cls, name: str, data_type: str) -> dict:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -131,8 +131,7 @@ class PrestoEngineSpec(BaseEngineSpec):
     def get_table_names(
         cls, database, inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
-        tables = super().get_table_names(inspector, schema)
-
+        tables = super().get_table_names(database, inspector, schema)
         if not is_feature_enabled("PRESTO_SPLIT_VIEWS_FROM_TABLES"):
             return tables
 
@@ -150,12 +149,11 @@ class PrestoEngineSpec(BaseEngineSpec):
         and get_view_names() is not implemented in sqlalchemy_presto.py
         https://github.com/dropbox/PyHive/blob/e25fc8440a0686bbb7a5db5de7cb1a77bdb4167a/pyhive/sqlalchemy_presto.py
         """
-
         if not is_feature_enabled("PRESTO_SPLIT_VIEWS_FROM_TABLES"):
             return []
 
         if schema:
-            sql = "SELECT table_name FROM information_schema.views WHERE schema_name=%(schema)s"
+            sql = "SELECT table_name FROM information_schema.views WHERE table_schema=%(schema)s"
             params = {"schema": schema}
         else:
             sql = "SELECT table_name FROM information_schema.views"
@@ -167,7 +165,7 @@ class PrestoEngineSpec(BaseEngineSpec):
                 cursor.execute(sql, params)
                 results = cursor.fetchall()
 
-        return [row["table_name"] for row in results]
+        return [row[0] for row in results]
 
     @classmethod
     def _create_column_info(cls, name: str, data_type: str) -> dict:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -23,7 +23,7 @@ import logging
 import re
 import textwrap
 import time
-from typing import Any, cast, Dict, List, Optional, Set, Tuple
+from typing import Any, cast, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 from urllib import parse
 
 import simplejson as json
@@ -36,10 +36,13 @@ from sqlalchemy.sql.expression import ColumnClause, Select
 from superset import app, is_feature_enabled, security_manager
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.exceptions import SupersetTemplateException
-from superset.models.core import Database
 from superset.models.sql_types.presto_sql_types import type_map as presto_type_map
 from superset.sql_parse import ParsedQuery
 from superset.utils import core as utils
+
+if TYPE_CHECKING:
+    # prevent circular imports
+    from superset.models.core import Database
 
 QueryStatus = utils.QueryStatus
 config = app.config
@@ -130,7 +133,7 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_table_names(
-        cls, database: Database, inspector: Inspector, schema: Optional[str]
+        cls, database: "Database", inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         tables = super().get_table_names(database, inspector, schema)
         if not is_feature_enabled("PRESTO_SPLIT_VIEWS_FROM_TABLES"):
@@ -142,7 +145,7 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_view_names(
-        cls, database: Database, inspector: Inspector, schema: Optional[str]
+        cls, database: "Database", inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         """Returns an empty list
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -36,6 +36,7 @@ from sqlalchemy.sql.expression import ColumnClause, Select
 from superset import app, is_feature_enabled, security_manager
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.exceptions import SupersetTemplateException
+from superset.models.core import Database
 from superset.models.sql_types.presto_sql_types import type_map as presto_type_map
 from superset.sql_parse import ParsedQuery
 from superset.utils import core as utils
@@ -129,7 +130,7 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_table_names(
-        cls, database, inspector: Inspector, schema: Optional[str]
+        cls, database: Database, inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         tables = super().get_table_names(database, inspector, schema)
         if not is_feature_enabled("PRESTO_SPLIT_VIEWS_FROM_TABLES"):
@@ -141,7 +142,7 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_view_names(
-        cls, database, inspector: Inspector, schema: Optional[str]
+        cls, database: Database, inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         """Returns an empty list
 

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -21,6 +21,7 @@ from typing import List
 from sqlalchemy.engine.reflection import Inspector
 
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.models.core import Database
 from superset.utils import core as utils
 
 
@@ -79,6 +80,8 @@ class SqliteEngineSpec(BaseEngineSpec):
         return "'{}'".format(iso)
 
     @classmethod
-    def get_table_names(cls, database, inspector: Inspector, schema: str) -> List[str]:
+    def get_table_names(
+        cls, database: Database, inspector: Inspector, schema: str
+    ) -> List[str]:
         """Need to disregard the schema for Sqlite"""
         return sorted(inspector.get_table_names())

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -79,6 +79,6 @@ class SqliteEngineSpec(BaseEngineSpec):
         return "'{}'".format(iso)
 
     @classmethod
-    def get_table_names(cls, inspector: Inspector, schema: str) -> List[str]:
+    def get_table_names(cls, database, inspector: Inspector, schema: str) -> List[str]:
         """Need to disregard the schema for Sqlite"""
         return sorted(inspector.get_table_names())

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -16,13 +16,16 @@
 # under the License.
 # pylint: disable=C,R,W
 from datetime import datetime
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from sqlalchemy.engine.reflection import Inspector
 
 from superset.db_engine_specs.base import BaseEngineSpec
-from superset.models.core import Database
 from superset.utils import core as utils
+
+if TYPE_CHECKING:
+    # prevent circular imports
+    from superset.models.core import Database
 
 
 class SqliteEngineSpec(BaseEngineSpec):
@@ -81,7 +84,7 @@ class SqliteEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_table_names(
-        cls, database: Database, inspector: Inspector, schema: str
+        cls, database: "Database", inspector: Inspector, schema: str
     ) -> List[str]:
         """Need to disregard the schema for Sqlite"""
         return sorted(inspector.get_table_names())

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1063,7 +1063,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         """
         try:
             tables = self.db_engine_spec.get_table_names(
-                inspector=self.inspector, schema=schema
+                database=self, inspector=self.inspector, schema=schema
             )
             return [
                 utils.DatasourceName(table=table, schema=schema) for table in tables
@@ -1097,7 +1097,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         """
         try:
             views = self.db_engine_spec.get_view_names(
-                inspector=self.inspector, schema=schema
+                database=self, inspector=self.inspector, schema=schema
             )
             return [utils.DatasourceName(table=view, schema=schema) for view in views]
         except Exception as e:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1572,6 +1572,7 @@ class Superset(BaseSupersetView):
                 for vn in views[:max_views]
             ]
         )
+        table_options.sort(key=lambda value: value["label"])
         payload = {"tableLength": len(tables) + len(views), "options": table_options}
         return json_success(json.dumps(payload))
 

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -342,7 +342,9 @@ class DbEngineSpecsTestCase(SupersetTestCase):
                 self.assertSetEqual(defined_grains, intersection, engine)
 
     def test_presto_get_view_names_return_empty_list(self):
-        self.assertEquals([], PrestoEngineSpec.get_view_names(mock.ANY, mock.ANY))
+        self.assertEquals(
+            [], PrestoEngineSpec.get_view_names(mock.ANY, mock.ANY, mock.ANY)
+        )
 
     def verify_presto_column(self, column, expected_results):
         inspector = mock.Mock()
@@ -877,7 +879,9 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         self.assertEqual("SELECT  \nWHERE ds = '01-01-19' AND hour = 1", query_result)
 
     def test_hive_get_view_names_return_empty_list(self):
-        self.assertEquals([], HiveEngineSpec.get_view_names(mock.ANY, mock.ANY))
+        self.assertEquals(
+            [], HiveEngineSpec.get_view_names(mock.ANY, mock.ANY, mock.ANY)
+        )
 
     def test_bigquery_sqla_column_label(self):
         label = BigQueryEngineSpec.make_label_compatible(column("Col").name)
@@ -952,7 +956,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         ie. when try_remove_schema_from_table_name == True. """
         base_result_expected = ["table", "table_2"]
         base_result = BaseEngineSpec.get_table_names(
-            schema="schema", inspector=inspector
+            database=mock.ANY, schema="schema", inspector=inspector
         )
         self.assertListEqual(base_result_expected, base_result)
 
@@ -960,7 +964,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         ie. when try_remove_schema_from_table_name == False. """
         pg_result_expected = ["schema.table", "table_2", "table_3"]
         pg_result = PostgresEngineSpec.get_table_names(
-            schema="schema", inspector=inspector
+            database=mock.ANY, schema="schema", inspector=inspector
         )
         self.assertListEqual(pg_result_expected, pg_result)
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, Presto displays views as tables, since the statement `SHOW TABLES` shows both views and tables, and there's no `SHOW VIEWS`.

One workaround to get the list of views is to query the `information_schema` schema:

```sql
SELECT table_name FROM information_schema_views WHERE table_schema='default';
```

This returns the actual list of views, but it's slow. On our Presto cluster it takes approximately 90 seconds to get all the views across all schemas. Fortunately, the API that exposes the views is cached, so this shouldn't be too bad.

I added a new feature flag, `PRESTO_SPLIT_VIEWS_FROM_TABLES` (open for better name suggestions), that when enabled will show views differently than tables in SQL Lab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Now views are properly marked as such in Presto:

<img width="286" alt="Screen Shot 2019-09-17 at 5 37 27 PM" src="https://user-images.githubusercontent.com/1534870/65093650-e51e2280-d971-11e9-8eec-9d1442fcf1ee.png">


<!-- ### TEST PLAN -->
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong @etr2460 