### PR TITLE
docs: reflect the pypi move from superset to apache-superset

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -176,7 +176,7 @@ Superset installation and initialization
 Follow these few simple steps to install Superset.::
 
     # Install superset
-    pip install superset
+    pip install apache-superset
 
     # Initialize the database
     superset db upgrade
@@ -748,7 +748,7 @@ Upgrading
 
 Upgrading should be as straightforward as running::
 
-    pip install superset --upgrade
+    pip install apache-superset --upgrade
     superset db upgrade
     superset init
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
Moved on pypi.org from https://pypi.org/project/superset/ to https://pypi.org/project/apache-superset/
I also tried to upload a fake new version to `superset` with a readme that says something about the move. idk how to unvalidate prior releases on the previous namespace...