### PR TITLE
Small fix for Presto dtype map

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -53,8 +53,8 @@ pandas_dtype_map = {
     "real": "float64",
     "double": "float64",
     "varchar": "object",
-    "timestamp": "datetime64",
-    "date": "datetime64",
+    "timestamp": "datetime64[ns]",
+    "date": "datetime64[ns]",
     "varbinary": "object",
 }
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -129,3 +129,9 @@ class SupersetDataFrameTestCase(SupersetTestCase):
             cdf.raw_df.values.tolist(),
             [[np.nan], [1239162456494753670], [np.nan], [np.nan], [np.nan], [np.nan]],
         )
+
+    def test_pandas_datetime64(self):
+        data = [(None,)]
+        cursor_descr = [("ds", "timestamp", None, None, None, None, True)]
+        cdf = SupersetDataFrame(data, cursor_descr, PrestoEngineSpec)
+        self.assertEqual(cdf.raw_df.dtypes[0], np.dtype("<M8[ns]"))


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Pandas doesn't recognize the `timedelta64` dtype, instead we need to use `timedelta64[ns]`. 

When querying a Presto table I'm getting the error:

> The 'datetime64' dtype has no unit. Please pass in 'datetime64[ns]' instead.

This PR fixes it.

<!--### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF-->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added unit test. Tested with real data, now it works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 