### PR TITLE
[sqllab] Make sure null schema is `None` and not `"null"`

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2600,7 +2600,9 @@ class Superset(BaseSupersetView):
         async_ = request.form.get("runAsync") == "true"
         sql = request.form.get("sql")
         database_id = request.form.get("database_id")
-        schema = request.form.get("schema") or None
+        schema = (
+            request.form.get("schema") != "null" and request.form.get("schema") or None
+        )
         template_params = json.loads(request.form.get("templateParams") or "{}")
         limit = int(request.form.get("queryLimit", 0))
         if limit < 0:


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
A null schema in the request form is interpreted as the string `"null"` rather than actual `null`, resulting in `/sql_json/` returning a response containing "null". This causes problems. These problems can be better explained by @john-bodley.

Just a one line change to make sure `"null"` is translated into Python `None`.

### TEST PLAN
Ran query locally that previously returned a `"null"` schema. Confirmed it is now `null`.

### REVIEWERS
@john-bodley @graceguo-supercat 