### PR TITLE
[sql_json] Ensuring the request body is JSON encoded

### DIFF
--- a/superset/assets/cypress/integration/sqllab/query.js
+++ b/superset/assets/cypress/integration/sqllab/query.js
@@ -26,7 +26,7 @@ export default () => {
       cy.server();
       cy.visit('/superset/sqllab');
 
-      cy.route('POST', '/superset/sql_json/**').as('sqlLabQuery');
+      cy.route('POST', '/superset/sql_json/').as('sqlLabQuery');
     });
 
     it('supports entering and running a query', () => {

--- a/superset/assets/spec/javascripts/sqllab/actions/sqlLab_spec.js
+++ b/superset/assets/spec/javascripts/sqllab/actions/sqlLab_spec.js
@@ -114,7 +114,7 @@ describe('async actions', () => {
   });
 
   describe('runQuery', () => {
-    const runQueryEndpoint = 'glob:*/superset/sql_json/*';
+    const runQueryEndpoint = 'glob:*/superset/sql_json/';
     fetchMock.post(runQueryEndpoint, '{ "data": ' + mockBigNumber + ' }');
 
     const makeRequest = () => {

--- a/superset/assets/src/SqlLab/actions/sqlLab.js
+++ b/superset/assets/src/SqlLab/actions/sqlLab.js
@@ -220,9 +220,9 @@ export function runQuery(query) {
     };
 
     return SupersetClient.post({
-      endpoint: `/superset/sql_json/${window.location.search}`,
-      postPayload,
-      stringify: false,
+      endpoint: '/superset/sql_json/',
+      body: JSON.stringify(postPayload),
+      headers: { 'Content-Type': 'application/json' },
       parseMethod: 'text',
     })
       .then(({ text = '{}' }) => {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2675,34 +2675,36 @@ class Superset(BaseSupersetView):
         return json_success(payload)
 
     @has_access_api
-    @expose("/sql_json/", methods=["POST", "GET"])
+    @expose("/sql_json/", methods=["POST"])
     @event_logger.log_this
     def sql_json(self):
         """Runs arbitrary sql and returns and json"""
         # Collect Values
-        database_id: int = int(request.form.get("database_id"))
-        schema: str = request.form.get("schema")
-        sql: str = request.form.get("sql")
+        database_id: int = request.json.get("database_id")
+        schema: str = request.json.get("schema")
+        sql: str = request.json.get("sql")
         try:
-            template_params: dict = json.loads(request.form.get("templateParams", "{}"))
+            template_params: dict = json.loads(
+                request.json.get("templateParams") or "{}"
+            )
         except json.decoder.JSONDecodeError:
             logging.warning(
-                f"Invalid template parameter {request.form.get('templateParams')}"
+                f"Invalid template parameter {request.json.get('templateParams')}"
                 " specified. Defaulting to empty dict"
             )
             template_params = {}
-        limit = int(request.form.get("queryLimit", app.config.get("SQL_MAX_ROW")))
-        async_flag: bool = request.form.get("runAsync") == "true"
+        limit = request.json.get("queryLimit") or app.config.get("SQL_MAX_ROW")
+        async_flag: bool = request.json.get("runAsync")
         if limit < 0:
             logging.warning(
                 f"Invalid limit of {limit} specified. Defaulting to max limit."
             )
             limit = 0
-        select_as_cta: bool = request.form.get("select_as_cta") == "true"
-        tmp_table_name: str = request.form.get("tmp_table_name")
-        client_id: str = request.form.get("client_id") or utils.shortid()[:10]
-        sql_editor_id: str = request.form.get("sql_editor_id")
-        tab_name: str = request.form.get("tab")
+        select_as_cta: bool = request.json.get("select_as_cta")
+        tmp_table_name: str = request.json.get("tmp_table_name")
+        client_id: str = request.json.get("client_id") or utils.shortid()[:10]
+        sql_editor_id: str = request.json.get("sql_editor_id")
+        tab_name: str = request.json.get("tab")
         status: bool = QueryStatus.PENDING if async_flag else QueryStatus.RUNNING
 
         session = db.session()

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -116,19 +116,25 @@ class SupersetTestCase(unittest.TestCase):
         datasource.database.db_engine_spec.mutate_expression_label = lambda x: x
         return datasource
 
-    def get_resp(self, url, data=None, follow_redirects=True, raise_on_error=True):
+    def get_resp(
+        self, url, data=None, follow_redirects=True, raise_on_error=True, json_=None
+    ):
         """Shortcut to get the parsed results while following redirects"""
         if data:
             resp = self.client.post(url, data=data, follow_redirects=follow_redirects)
+        elif json_:
+            resp = self.client.post(url, json=json_, follow_redirects=follow_redirects)
         else:
             resp = self.client.get(url, follow_redirects=follow_redirects)
         if raise_on_error and resp.status_code > 400:
             raise Exception("http request failed with code {}".format(resp.status_code))
         return resp.data.decode("utf-8")
 
-    def get_json_resp(self, url, data=None, follow_redirects=True, raise_on_error=True):
+    def get_json_resp(
+        self, url, data=None, follow_redirects=True, raise_on_error=True, json_=None
+    ):
         """Shortcut to get the parsed results while following redirects"""
-        resp = self.get_resp(url, data, follow_redirects, raise_on_error)
+        resp = self.get_resp(url, data, follow_redirects, raise_on_error, json_)
         return json.loads(resp)
 
     def get_access_requests(self, username, ds_type, ds_id):
@@ -190,7 +196,7 @@ class SupersetTestCase(unittest.TestCase):
         resp = self.get_json_resp(
             "/superset/sql_json/",
             raise_on_error=False,
-            data=dict(
+            json_=dict(
                 database_id=dbid,
                 sql=sql,
                 select_as_create_as=False,

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -114,12 +114,12 @@ class CeleryTestCase(SupersetTestCase):
         )
 
     def run_sql(
-        self, db_id, sql, client_id=None, cta="false", tmp_table="tmp", async_="false"
+        self, db_id, sql, client_id=None, cta=False, tmp_table="tmp", async_=False
     ):
         self.login()
         resp = self.client.post(
             "/superset/sql_json/",
-            data=dict(
+            json=dict(
                 database_id=db_id,
                 sql=sql,
                 runAsync=async_,
@@ -135,7 +135,7 @@ class CeleryTestCase(SupersetTestCase):
         main_db = get_example_database()
         db_id = main_db.id
         sql_dont_exist = "SELECT name FROM table_dont_exist"
-        result1 = self.run_sql(db_id, sql_dont_exist, "1", cta="true")
+        result1 = self.run_sql(db_id, sql_dont_exist, "1", cta=True)
         self.assertTrue("error" in result1)
 
     def test_run_sync_query_cta(self):
@@ -146,9 +146,7 @@ class CeleryTestCase(SupersetTestCase):
         self.drop_table_if_exists(tmp_table_name, main_db)
         name = "James"
         sql_where = f"SELECT name FROM birth_names WHERE name='{name}' LIMIT 1"
-        result = self.run_sql(
-            db_id, sql_where, "2", tmp_table=tmp_table_name, cta="true"
-        )
+        result = self.run_sql(db_id, sql_where, "2", tmp_table=tmp_table_name, cta=True)
         self.assertEqual(QueryStatus.SUCCESS, result["query"]["state"])
         self.assertEqual([], result["data"])
         self.assertEqual([], result["columns"])
@@ -190,7 +188,7 @@ class CeleryTestCase(SupersetTestCase):
 
         sql_where = "SELECT name FROM birth_names WHERE name='James' LIMIT 10"
         result = self.run_sql(
-            db_id, sql_where, "4", async_="true", tmp_table="tmp_async_1", cta="true"
+            db_id, sql_where, "4", async_=True, tmp_table="tmp_async_1", cta=True
         )
         assert result["query"]["state"] in (
             QueryStatus.PENDING,
@@ -224,7 +222,7 @@ class CeleryTestCase(SupersetTestCase):
 
         sql_where = "SELECT name FROM birth_names LIMIT 1"
         result = self.run_sql(
-            db_id, sql_where, "5", async_="true", tmp_table=tmp_table, cta="true"
+            db_id, sql_where, "5", async_=True, tmp_table=tmp_table, cta=True
         )
         assert result["query"]["state"] in (
             QueryStatus.PENDING,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Somewhat of a yak-shaving PR as the intent was to fix an issue where Hive queries failed in SQL Lab if no schema was selected, 

![Screen Shot 2019-09-18 at 3 54 58 PM](https://user-images.githubusercontent.com/4567245/65192859-933ad280-da2d-11e9-9094-45f487dbd7f3.png)

The error is coming from [here](https://github.com/dropbox/PyHive/blob/master/pyhive/hive.py#L205) in PyHive where it seems that the schema (database) is being defined via the `"null"` string as opposed to `None`.

The root cause of this is in the front-end the `SupersetClient` has passing the data as form data (using the `multipart/form-data` Content-Type header) which was then being processed in Flask via [`response.form`](https://flask.palletsprojects.com/en/1.1.x/api/#flask.Request.form). This meant everything was being encoded as strings, i.e., hence why we had logic like,

```
request.form.get("runAsync") == "true"
```

and why `null` was being encoded as `"null"` as opposed to `None`. The fix was to:

1. Ensure that the front-end correctly encodes the body as JSON (and sets the appropriate headers).
2. Use [`response.json`](https://flask.palletsprojects.com/en/1.1.x/api/#flask.Request.json) to correctly process the response.
3. Remove the obsolete `GET` method to `sql_json`. 
4. For testing use the somewhat misnamed `json` argument to Flask's test `client.post(...)` method which is actually a Python dictionary (ironically the `data` argument can be a JSON string) and removes the need to specify the Content-Type header (which is needed for `response.json` otherwise we would need to use `response.get_json(force=True)` which seems a little heavy handed). 
  
### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @serenajiang @williaster 
cc: @mistercrunch @villebro 