### PR TITLE
[SQL Lab] Add commit to resolve query table lock

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -220,6 +220,7 @@ def execute_sql_statement(sql_statement, query, user_name, session, cursor):
                 security_manager,
             )
         query.executed_sql = sql
+        session.commit()
         with stats_timing("sqllab.query.time_executing_query", stats_logger):
             logging.info(f"Query {query_id}: Running query: \n{sql}")
             db_engine_spec.execute(cursor, sql, async_=True)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
We've been trying to track down database row locking issues when trying to call the `stop_query` endpoint for several months now. After digging into this file, it seems like the session that we create to run sql queries has autoflush enabled. Therefore, we're locking the db on these rows until committing the changes to the query. We don't commit this until after the query finishes, so the row gets locked and we can't set the query to stopped. By committing before running the query, this seems to have resolved the issue for us.

### TEST PLAN
CI + Deployed in our production environment

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @michellethomas @john-bodley @mistercrunch 