### PR TITLE
Fix no data in Presto

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -106,11 +106,13 @@ class SupersetDataFrame(object):
         self.column_names = column_names
 
         if dtype:
+            # put data in a 2D array so we can efficiently access each column;
+            # the reshape ensures the shape is 2D in case data is empty
+            array = np.array(data, dtype="object").reshape(-1, len(column_names))
             # convert each column in data into a Series of the proper dtype; we
             # need to do this because we can not specify a mixed dtype when
             # instantiating the DataFrame, and this allows us to have different
             # dtypes for each column.
-            array = np.array(data, dtype="object")
             data = {
                 column: pd.Series(array[:, i], dtype=dtype[column])
                 for i, column in enumerate(column_names)

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -145,7 +145,7 @@ class SupersetDataFrameTestCase(SupersetTestCase):
         ]
         cdf = SupersetDataFrame(data, cursor_descr, PrestoEngineSpec)
         self.assertEqual(cdf.raw_df.dtypes[0], np.dtype("O"))
-        self.assertEqual(cdf.raw_df.dtypes[1], pd.Int64Dtype)
+        self.assertEqual(cdf.raw_df.dtypes[1], pd.Int64Dtype())
 
     def test_empty_data(self):
         data = []
@@ -155,4 +155,4 @@ class SupersetDataFrameTestCase(SupersetTestCase):
         ]
         cdf = SupersetDataFrame(data, cursor_descr, PrestoEngineSpec)
         self.assertEqual(cdf.raw_df.dtypes[0], np.dtype("O"))
-        self.assertEqual(cdf.raw_df.dtypes[1], pd.Int64Dtype)
+        self.assertEqual(cdf.raw_df.dtypes[1], pd.Int64Dtype())

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import numpy as np
+import pandas as pd
 
 from superset.dataframe import dedup, SupersetDataFrame
 from superset.db_engine_specs import BaseEngineSpec
@@ -135,3 +136,23 @@ class SupersetDataFrameTestCase(SupersetTestCase):
         cursor_descr = [("ds", "timestamp", None, None, None, None, True)]
         cdf = SupersetDataFrame(data, cursor_descr, PrestoEngineSpec)
         self.assertEqual(cdf.raw_df.dtypes[0], np.dtype("<M8[ns]"))
+
+    def test_no_type_coercion(self):
+        data = [("a", 1), ("b", 2)]
+        cursor_descr = [
+            ("one", "varchar", None, None, None, None, True),
+            ("two", "integer", None, None, None, None, True),
+        ]
+        cdf = SupersetDataFrame(data, cursor_descr, PrestoEngineSpec)
+        self.assertEqual(cdf.raw_df.dtypes[0], np.dtype("O"))
+        self.assertEqual(cdf.raw_df.dtypes[1], pd.Int64Dtype)
+
+    def test_empty_data(self):
+        data = []
+        cursor_descr = [
+            ("one", "varchar", None, None, None, None, True),
+            ("two", "integer", None, None, None, None, True),
+        ]
+        cdf = SupersetDataFrame(data, cursor_descr, PrestoEngineSpec)
+        self.assertEqual(cdf.raw_df.dtypes[0], np.dtype("O"))
+        self.assertEqual(cdf.raw_df.dtypes[1], pd.Int64Dtype)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Presto queries that return no data are raising the exception "too many indices for array". This happens because the Numpy array that wraps the data has shape `(0,)`, and when we create the Pandas time series for the dataframe we try to access each column using index `[:,i]`.

I fixed it by reshaping the array to 2D, even if empty. Query now succeeds with "The query returned no data".

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I tested the failing query, and also added a unit test. I also added a unit test for https://github.com/apache/incubator-superset/pull/8253.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 