### PR TITLE
Refine release instructions

### DIFF
--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -53,8 +53,9 @@ need to be done at every release.
 Now let's craft a source release
 ```bash
     # Assuming these commands are executed from the root of the repo
-    # Setting a VERSION var will be useful
-    export VERSION=0.31.0rc18
+    export REPO_DIR=$(pwd)
+    # Set VERSION to the release being prepared (rc1 for first vote on version)
+    export VERSION=0.34.1rc1
     export RELEASE=apache-superset-incubating-${VERSION}
     export RELEASE_TARBALL=${RELEASE}-source.tar.gz
 
@@ -69,7 +70,7 @@ Now let's craft a source release
         -o ~/svn/superset_dev/${VERSION}/${RELEASE_TARBALL}
 
     cd ~/svn/superset_dev/${VERSION}/
-    scripts/sign.sh ${RELEASE}-source.tar.gz
+    ${REPO_DIR}/scripts/sign.sh ${RELEASE}-source.tar.gz
 ```
 
 ## Shipping to SVN

--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -80,7 +80,7 @@ Now let's ship this RC into svn's dev folder
 ```bash
     cd ~/svn/superset_dev/
     svn add ${VERSION}
-    svn commit
+    svn commit -m "${VERSION}"
 ```
 
 Now you're ready to start the VOTE thread.
@@ -97,7 +97,7 @@ folder.
     cp -r ~/svn/superset_dev/${VERSION}/ ~/svn/superset/${VERSION}/
     cd ~/svn/superset/
     svn add ${VERSION}
-    svn commit
+    svn commit -m "${VERSION}"
 ```
 
 Now you can announce the release on the mailing list, make sure to use the


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
The release instructions had an erroneous reference to the `sign.sh` script.

### TEST PLAN
Built `0.34.1rc1` with this instruction.

### REVIEWERS
@mistercrunch @michellethomas 