### PR TITLE
More intuitive display of negative time deltas (#8274)

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -362,7 +362,7 @@ def format_timedelta(td: timedelta) -> str:
     if td < timedelta(0):
         return "-" + str(abs(td))
     else:
-        # Change this to format positive timedeltas the way you want
+        # Change this to format positive time deltas the way you want
         return str(td)
 
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -360,7 +360,7 @@ def timedelta_f(td: timedelta) -> str:
     '-1 day, 5:06:00'
     """
     if td < timedelta(0):
-        return "-" + timedelta_f(-td)
+        return "-" + str(abs(td))
     else:
         # Change this to format positive timedeltas the way you want
         return str(td)

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -349,14 +349,14 @@ def datetime_f(dttm):
     return "<nobr>{}</nobr>".format(dttm)
 
 
-def timedelta_f(td: timedelta) -> str:
+def format_timedelta(td: timedelta) -> str:
     """
     Ensures negative time deltas are easily interpreted by humans
 
     >>> td = timedelta(0) - timedelta(days=1, hours=5,minutes=6)
     >>> str(td)
     '-2 days, 18:54:00'
-    >>> timedelta_f(td)
+    >>> format_timedelta(td)
     '-1 day, 5:06:00'
     """
     if td < timedelta(0):
@@ -380,7 +380,7 @@ def base_json_conv(obj):
     elif isinstance(obj, uuid.UUID):
         return str(obj)
     elif isinstance(obj, timedelta):
-        return timedelta_f(obj)
+        return format_timedelta(obj)
     elif isinstance(obj, bytes):
         try:
             return obj.decode("utf-8")

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -349,7 +349,7 @@ def datetime_f(dttm):
     return "<nobr>{}</nobr>".format(dttm)
 
 
-def timedelta_f(td):
+def timedelta_f(td: timedelta) -> str:
     """
     Ensures negative time deltas are easily interpreted by humans
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -349,6 +349,23 @@ def datetime_f(dttm):
     return "<nobr>{}</nobr>".format(dttm)
 
 
+def timedelta_f(td):
+    """
+    Ensures negative time deltas are easily interpreted by humans
+
+    >>> td = timedelta(0) - timedelta(days=1, hours=5,minutes=6)
+    >>> str(td)
+    '-2 days, 18:54:00'
+    >>> timedelta_f(td)
+    '-1 day, 5:06:00'
+    """
+    if td < timedelta(0):
+        return "-" + timedelta_f(-td)
+    else:
+        # Change this to format positive timedeltas the way you want
+        return str(td)
+
+
 def base_json_conv(obj):
     if isinstance(obj, memoryview):
         obj = obj.tobytes()
@@ -363,7 +380,7 @@ def base_json_conv(obj):
     elif isinstance(obj, uuid.UUID):
         return str(obj)
     elif isinstance(obj, timedelta):
-        return str(obj)
+        return timedelta_f(obj)
     elif isinstance(obj, bytes):
         try:
             return obj.decode("utf-8")

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -32,6 +32,7 @@ from superset.utils.core import (
     base_json_conv,
     convert_legacy_filters_into_adhoc,
     datetime_f,
+    format_timedelta,
     get_or_create_db,
     get_since_until,
     get_stacktrace,
@@ -46,7 +47,6 @@ from superset.utils.core import (
     parse_past_timedelta,
     setup_cache,
     split,
-    timedelta_f,
     validate_json,
     zlib_compress,
     zlib_decompress,
@@ -537,16 +537,16 @@ class UtilsTestCase(unittest.TestCase):
         [a, b, c] = [int(v) for v in iso]
         self.assertEquals(datetime_f(datetime(a, b, c)), "<nobr>00:00:00</nobr>")
 
-    def test_timedelta_f(self):
-        self.assertEquals(timedelta_f(timedelta(0)), "0:00:00")
-        self.assertEquals(timedelta_f(timedelta(days=1)), "1 day, 0:00:00")
-        self.assertEquals(timedelta_f(timedelta(minutes=-6)), "-0:06:00")
+    def test_format_timedelta(self):
+        self.assertEquals(format_timedelta(timedelta(0)), "0:00:00")
+        self.assertEquals(format_timedelta(timedelta(days=1)), "1 day, 0:00:00")
+        self.assertEquals(format_timedelta(timedelta(minutes=-6)), "-0:06:00")
         self.assertEquals(
-            timedelta_f(timedelta(0) - timedelta(days=1, hours=5, minutes=6)),
+            format_timedelta(timedelta(0) - timedelta(days=1, hours=5, minutes=6)),
             "-1 day, 5:06:00",
         )
         self.assertEquals(
-            timedelta_f(timedelta(0) - timedelta(days=16, hours=4, minutes=3)),
+            format_timedelta(timedelta(0) - timedelta(days=16, hours=4, minutes=3)),
             "-16 days, 4:03:00",
         )
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -46,6 +46,7 @@ from superset.utils.core import (
     parse_past_timedelta,
     setup_cache,
     split,
+    timedelta_f,
     validate_json,
     zlib_compress,
     zlib_decompress,
@@ -120,6 +121,7 @@ class UtilsTestCase(unittest.TestCase):
         assert isinstance(base_json_conv(set([1])), list) is True
         assert isinstance(base_json_conv(Decimal("1.0")), float) is True
         assert isinstance(base_json_conv(uuid.uuid4()), str) is True
+        assert isinstance(base_json_conv(timedelta(0)), str) is True
 
     @patch("superset.utils.core.datetime")
     def test_parse_human_timedelta(self, mock_datetime):
@@ -534,6 +536,19 @@ class UtilsTestCase(unittest.TestCase):
         iso = datetime.now().isoformat()[:10].split("-")
         [a, b, c] = [int(v) for v in iso]
         self.assertEquals(datetime_f(datetime(a, b, c)), "<nobr>00:00:00</nobr>")
+
+    def test_timedelta_f(self):
+        self.assertEquals(timedelta_f(timedelta(0)), '0:00:00')
+        self.assertEquals(timedelta_f(timedelta(days=1)), '1 day, 0:00:00')
+        self.assertEquals(timedelta_f(timedelta(minutes=-6)), '-0:06:00')
+        self.assertEquals(timedelta_f(
+            timedelta(0)-timedelta(days=1, hours=5, minutes=6)),
+            '-1 day, 5:06:00'
+        )
+        self.assertEquals(timedelta_f(
+            timedelta(0)-timedelta(days=16, hours=4, minutes=3)),
+            '-16 days, 4:03:00'
+        )
 
     def test_json_encoded_obj(self):
         obj = {"a": 5, "b": ["a", "g", 5]}

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -538,16 +538,16 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEquals(datetime_f(datetime(a, b, c)), "<nobr>00:00:00</nobr>")
 
     def test_timedelta_f(self):
-        self.assertEquals(timedelta_f(timedelta(0)), '0:00:00')
-        self.assertEquals(timedelta_f(timedelta(days=1)), '1 day, 0:00:00')
-        self.assertEquals(timedelta_f(timedelta(minutes=-6)), '-0:06:00')
-        self.assertEquals(timedelta_f(
-            timedelta(0)-timedelta(days=1, hours=5, minutes=6)),
-            '-1 day, 5:06:00'
+        self.assertEquals(timedelta_f(timedelta(0)), "0:00:00")
+        self.assertEquals(timedelta_f(timedelta(days=1)), "1 day, 0:00:00")
+        self.assertEquals(timedelta_f(timedelta(minutes=-6)), "-0:06:00")
+        self.assertEquals(
+            timedelta_f(timedelta(0) - timedelta(days=1, hours=5, minutes=6)),
+            "-1 day, 5:06:00",
         )
-        self.assertEquals(timedelta_f(
-            timedelta(0)-timedelta(days=16, hours=4, minutes=3)),
-            '-16 days, 4:03:00'
+        self.assertEquals(
+            timedelta_f(timedelta(0) - timedelta(days=16, hours=4, minutes=3)),
+            "-16 days, 4:03:00",
         )
 
     def test_json_encoded_obj(self):


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This pull request changes the way negative time delta's are displayed. The default python display of a negative timedelta is rather unintuitive for a user of a dashboard. For example, -6 minutes is displayed as `'-1 day, 23:54:00`. This basically requires users to make time calculations in their heads to interpret the number correctly. This pull request changes the formatting to  '-0:06:00' at the code level and `-0 days 00:06:00` at the superset UI level to make it easier for users to interpret the time delta. More details on the issue and why this solution was chosen can be found in #8274 .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The data in postgres looks like this:
![data_in_postgres](https://user-images.githubusercontent.com/4882376/65375052-6686f500-dc91-11e9-97b8-097f64ae594c.png)

Before this pull request the data looks like this in superset:
![data_in_superset_table_before](https://user-images.githubusercontent.com/4882376/65375140-6d623780-dc92-11e9-8165-661eb0fd9ea2.png)

Afterwards it looks like this in superset:
![data_in_superset_table_after](https://user-images.githubusercontent.com/4882376/65375109-05135600-dc92-11e9-9e9d-30a195465be9.png)

### TEST PLAN
- The unit test for base_json_conv() has been enhanced to handle timedelta's as well
- A new function has been added in superset.utils.core named `timedelta_f` which is called in base_json_conv() (same module). A new test has been added to test this formatting function.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #8274 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
