### PR TITLE
chore: skip flaky SQL Lab test

### DIFF
--- a/superset/assets/cypress/integration/sqllab/query.js
+++ b/superset/assets/cypress/integration/sqllab/query.js
@@ -58,7 +58,7 @@ export default () => {
         });
     });
 
-    it('successfully saves a query', () => {
+    it.skip('successfully saves a query', () => {
       cy.route('savedqueryviewapi/**').as('getSavedQuery');
       cy.route('superset/tables/**').as('getTables');
 


### PR DESCRIPTION

### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
Tried 2-3 difference approaches to fix the flaky SQL Lab test that has
been biting us for a while. My guess is that the flakiness comes from
brace (the editor). Hoping a future release of brace and/or cypress
may help with this.

But for now, no test is better than a flaky one.

