### PR TITLE
(Fix ##8288): Select box now searchable by verbose tags

### DIFF
--- a/superset/assets/src/components/OnPasteSelect.jsx
+++ b/superset/assets/src/components/OnPasteSelect.jsx
@@ -64,6 +64,23 @@ export default class OnPasteSelect extends React.Component {
       }
     }
   }
+  customFilter(option, searchText) {
+    // customFilter is passed as a function to react-select library
+    // in the case that there is a column name and verbose name
+    if (!option.column_name) {
+      return false;
+    }
+    if (
+      option.column_name.toLowerCase().includes(searchText.toLowerCase()) ||
+      (!!option.verbose_name &&
+      option.verbose_name.toLowerCase().includes(searchText.toLowerCase()))
+    ) {
+      return true;
+    }
+      return false;
+
+  }
+
   render() {
     const SelectComponent = this.props.selectWrap;
     const refFunc = (ref) => {
@@ -73,11 +90,14 @@ export default class OnPasteSelect extends React.Component {
       this.pasteInput = ref;
     };
     const inputProps = { onPaste: this.onPaste.bind(this) };
+    const customFilter =  this.customFilter.bind(this);
     return (
       <SelectComponent
         {...this.props}
         ref={refFunc}
         inputProps={inputProps}
+        filterOption={!!this.props.options && !!this.props.options[0].column_name && customFilter}
+
       />
     );
   }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Issue documented separately in depth:
https://github.com/apache/incubator-superset/issues/8288

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/41172775/65543235-a3d3c880-dec5-11e9-935f-cc3cbd62bfec.png)

![image](https://user-images.githubusercontent.com/41172775/65543272-b0582100-dec5-11e9-816a-3ad3702bbc48.png)

### TEST PLAN
1. Go to Datasources or Tables, Edit Column, and pick a random column to edit
2. Change 'verbose_name' of the random column to 'willis'
2. Try to search by 'willis' when creating a slice
3. You will find that you can only pull it up by 'id' or whatever the original value was
4. Validate that Filterbox is now searchable by original column name and new column name

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
