### PR TITLE
[docs] Add explicit support for python 3.7

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ Getting Started
 Superset has deprecated support for Python ``2.*`` and supports
 only ``~=3.6`` to take advantage of the newer Python features and reduce
 the burden of supporting previous versions. We run our test suite
-against ``3.6``, but running on ``3.7`` **should** work as well.
+against ``3.6``, but ``3.7`` is fully supported as well.
 
 Cloud-native!
 -------------

--- a/setup.py
+++ b/setup.py
@@ -124,5 +124,8 @@ setup(
     download_url=(
         "https://dist.apache.org/repos/dist/release/superset/" + version_string
     ),
-    classifiers=["Programming Language :: Python :: 3.6"],
+    classifiers=[
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
 )


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [x] Documentation

### SUMMARY
Currently the PyPI package only officially supports `3.6`, and the documentation specifies that "running on `3.7` **should** work". As I've now been running `3.7` exclusively in dev for at least 6 months without any trouble, committing to officially supporting `3.7` should be safe.

### REVIEWERS
@john-bodley @mistercrunch 