### PR TITLE
Adding explicit Flask session cookie options to default config

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -655,6 +655,16 @@ TALISMAN_CONFIG = {
     "force_https_permanent": False,
 }
 
+#
+# Flask session cookie options
+#
+# See https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options
+# for details
+#
+SESSION_COOKIE_HTTPONLY=True  # Prevent cookie from being read by frontend JS?
+SESSION_COOKIE_SECURE=False  # Prevent cookie from being transmitted over non-tls?
+SESSION_COOKIE_SAMESITE='Lax'  # One of [None, 'Lax', 'Strict']
+
 # URI to database storing the example data, points to
 # SQLALCHEMY_DATABASE_URI by default if set to `None`
 SQLALCHEMY_EXAMPLES_URI = None

--- a/superset/config.py
+++ b/superset/config.py
@@ -661,9 +661,9 @@ TALISMAN_CONFIG = {
 # See https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options
 # for details
 #
-SESSION_COOKIE_HTTPONLY=True  # Prevent cookie from being read by frontend JS?
-SESSION_COOKIE_SECURE=False  # Prevent cookie from being transmitted over non-tls?
-SESSION_COOKIE_SAMESITE='Lax'  # One of [None, 'Lax', 'Strict']
+SESSION_COOKIE_HTTPONLY = True  # Prevent cookie from being read by frontend JS?
+SESSION_COOKIE_SECURE = False  # Prevent cookie from being transmitted over non-tls?
+SESSION_COOKIE_SAMESITE = "Lax"  # One of [None, 'Lax', 'Strict']
 
 # URI to database storing the example data, points to
 # SQLALCHEMY_DATABASE_URI by default if set to `None`


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This will enforce a SameSite policy of `Lax` for session cookies served up by Superset.
(https://www.owasp.org/index.php/SameSite)
The SameSite cookie attribute attempts to solve many of the issues associated with cross origin attacks as they relate to cookies with a single option.

In this PR, I'm basically surfacing the underlying Flask options which control these options and am providing a sensible set of defaults.

### REVIEWERS
@mistercrunch @dpgaspar 