### PR TITLE
[fix] omit datasources with null name or id

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -415,7 +415,9 @@ class SliceModelView(SupersetModelView, DeleteMixin):  # noqa
     def add(self):
         datasources = ConnectorRegistry.get_all_datasources(db.session)
         datasources = [
-            {"value": str(d.id) + "__" + d.type, "label": repr(d)} for d in datasources
+            {"value": str(d.id) + "__" + d.type, "label": repr(d)}
+            for d in datasources
+            if d.id and d.name
         ]
         return self.render_template(
             "superset/add_slice.html",


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Users cannot add charts because there is an error in fetching the representations of the datasources due to null `table_name` or null `id`. Should prevent these fields from being null in the future, but this might require a db migration. For now, a quick fix so that users can add charts again.

### TEST PLAN
`charts/add` looks as expected.

### REVIEWERS
@graceguo-supercat 