### PR TITLE
Fix pypi link and replace gitter badge with slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Superset
 [![Build Status](https://travis-ci.org/apache/incubator-superset.svg?branch=master)](https://travis-ci.org/apache/incubator-superset)
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
 [![Coverage Status](https://codecov.io/github/apache/incubator-superset/coverage.svg?branch=master)](https://codecov.io/github/apache/incubator-superset)
-[![PyPI](https://img.shields.io/pypi/pyversions/superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/superset)
-[![Join the chat at https://gitter.im/airbnb/superset](https://badges.gitter.im/apache/incubator-superset.svg)](https://gitter.im/airbnb/superset?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![PyPI](https://img.shields.io/pypi/pyversions/apache-superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache-superset)
+[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://apache-superset.slack.com)
 [![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.incubator.apache.org)
 [![dependencies Status](https://david-dm.org/apache/incubator-superset/status.svg?path=superset/assets)](https://david-dm.org/apache/incubator-superset?path=superset/assets)
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
The badge indicating supported python versions was referencing the old package `superset`, not `apache-superset`. Also, as discussion has moved from gitter to slack, the gitter badge should be replaced with one referencing the slack workspace. Not sure about the color (just picked one that I found on google and modified accordingly).

### SCREENSHOT
![image](https://user-images.githubusercontent.com/33317356/65971826-811b5400-e471-11e9-8e12-c9bed55d9122.png)

### TEST PLAN
Clicked both updated badges and verified visually that the new badges work.
