### PR TITLE
Add improved typed casting to BigQuery

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -25,6 +25,21 @@ from sqlalchemy import literal_column
 from superset.db_engine_specs.base import BaseEngineSpec
 
 
+pandas_dtype_map = {
+    "STRING": "object",
+    "BOOLEAN": "bool",
+    "INTEGER": "Int64",
+    "FLOAT": "float64",
+    "TIMESTAMP": "datetime64[ns]",
+    "DATETIME": "datetime64[ns]",
+    "DATE": "object",
+    "BYTES": "object",
+    "TIME": "object",
+    "RECORD": "object",
+    "NUMERIC": "object",
+}
+
+
 class BigQueryEngineSpec(BaseEngineSpec):
     """Engine spec for Google's BigQuery
 
@@ -183,3 +198,9 @@ class BigQueryEngineSpec(BaseEngineSpec):
             if key in kwargs:
                 gbq_kwargs[key] = kwargs[key]
         pandas_gbq.to_gbq(df, **gbq_kwargs)
+
+    @classmethod
+    def get_pandas_dtype(cls, cursor_description: List[tuple]) -> Dict[str, str]:
+        return {
+            col[0]: pandas_dtype_map.get(col[1], "object") for col in cursor_description
+        }


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add improved type casting for BigQuery, similar to what https://github.com/apache/incubator-superset/pull/8226 did for Presto. This prevents 64 bit integers from being converted to floats by Pandas, losing precision.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I verified that int64 values are not cast to float, and that precision is maintained. I also tested that all types are cast correctly:

```sql
SELECT
  'string' AS `string`,
  CAST('string' AS BYTES) AS `bytes`,
  100 AS `integer`,
  100.0 AS `float`,
  CAST(1 AS NUMERIC) AS `numeric`,
  CAST(1 AS BOOLEAN) AS `boolean`,
  STRUCT(1) AS `record`,
  TIMESTAMP(DATETIME "2008-12-25 15:30:00", "America/Los_Angeles") AS `timestamp`,
  DATE "2008-12-25" AS `date`,
  TIME "15:30:00" AS `time`,
  DATETIME "2008-12-25 15:30:00" AS `datetime`
```

Generated CSV:

| string | bytes | integer | float | numeric | boolean | record | timestamp | date | time | datetime |
| - | - | - | - | - | - | - | - | - | - | - |
| string | b'string' | 100 | 100.0 | 1.0 | True | "{""_field_1"": 1}" | 2008-12-25 23:30:00+00:00 | 2008-12-25 | 15:30:00 | 2008-12-25 15:30:00 |


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
