### PR TITLE
[dashboard] show fewer filter indicators

### DIFF
--- a/superset/assets/src/dashboard/components/FilterIndicatorGroup.jsx
+++ b/superset/assets/src/dashboard/components/FilterIndicatorGroup.jsx
@@ -55,7 +55,7 @@ class FilterIndicatorGroup extends React.PureComponent {
         tooltip={
           <React.Fragment>
             <div className="group-title">
-              {t('%s more filters', indicators.length)}
+              {t('%s filters', indicators.length)}
             </div>
             <ul className="tooltip-group">
               {indicators.map((indicator, index) => (

--- a/superset/assets/src/dashboard/components/FilterIndicatorsContainer.jsx
+++ b/superset/assets/src/dashboard/components/FilterIndicatorsContainer.jsx
@@ -150,30 +150,25 @@ export default class FilterIndicatorsContainer extends React.PureComponent {
     }
 
     const indicators = this.getFilterIndicators();
-    // if total indicators <= 5, show all
-    // else: show top 4 indicators, and show all the rest in group
-    const showExtraIndicatorsInGroup =
-      indicators.length > FILTER_INDICATORS_DISPLAY_LENGTH + 1;
+    // if total indicators <= FILTER_INDICATORS_DISPLAY_LENGTH,
+    // show indicator for each filter field.
+    // else: show single group indicator.
+    const showIndicatorsInGroup =
+      indicators.length > FILTER_INDICATORS_DISPLAY_LENGTH;
 
     return (
       <div className="dashboard-filter-indicators-container">
-        {indicators
-          .filter((indicator, index) => {
-            if (showExtraIndicatorsInGroup) {
-              return index < FILTER_INDICATORS_DISPLAY_LENGTH;
-            }
-            return true;
-          })
-          .map(indicator => (
+        {!showIndicatorsInGroup &&
+          indicators.map(indicator => (
             <FilterIndicator
               key={`${indicator.chartId}_${indicator.name}`}
               indicator={indicator}
               setDirectPathToChild={setDirectPathToChild}
             />
           ))}
-        {showExtraIndicatorsInGroup && (
+        {showIndicatorsInGroup && (
           <FilterIndicatorGroup
-            indicators={indicators.slice(FILTER_INDICATORS_DISPLAY_LENGTH)}
+            indicators={indicators}
             setDirectPathToChild={setDirectPathToChild}
           />
         )}

--- a/superset/assets/src/dashboard/util/constants.js
+++ b/superset/assets/src/dashboard/util/constants.js
@@ -71,7 +71,7 @@ export const BUILDER_PANE_TYPE = {
 };
 
 // filter indicators display length
-export const FILTER_INDICATORS_DISPLAY_LENGTH = 4;
+export const FILTER_INDICATORS_DISPLAY_LENGTH = 3;
 
 // in-component element types: can be added into
 // directPathToChild, used for in dashboard navigation and focus


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

We deployed dashboard filter indicator feature (#7908) to airbnb for about 1 month, and received some feedback for the indicators UI. Some users feel too many colors creates clutter and distraction on dashboards. 

So we proposed a little simplified UI:

- If dashboard has less than 4 filter fields, show colored indicator for each of filter field.
- if dashboard has 4 or more filter fields, only show 1 grouped (black colored) filter indicator.

**Before:**
<img width="848" alt="Screen Shot 2019-10-04 at 11 42 50 AM" src="https://user-images.githubusercontent.com/27990562/66233391-1c920c00-e6a0-11e9-846e-b1bbc073a585.png">

**After:**
<img width="840" alt="Screen Shot 2019-10-04 at 12 26 17 PM" src="https://user-images.githubusercontent.com/27990562/66234329-4f3d0400-e6a2-11e9-8d3c-dbf2dec234a5.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #7908
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@kenchendesign @etr2460 @mistercrunch 
