### PR TITLE
fix saving new sql lab queries

### DIFF
--- a/superset/assets/src/SqlLab/actions/sqlLab.js
+++ b/superset/assets/src/SqlLab/actions/sqlLab.js
@@ -35,6 +35,7 @@ import COMMON_ERR_MESSAGES from '../../utils/errorMessages';
 export const RESET_STATE = 'RESET_STATE';
 export const ADD_QUERY_EDITOR = 'ADD_QUERY_EDITOR';
 export const UPDATE_QUERY_EDITOR = 'UPDATE_QUERY_EDITOR';
+export const QUERY_EDITOR_SAVED = 'QUERY_EDITOR_SAVED';
 export const CLONE_QUERY_TO_NEW_TAB = 'CLONE_QUERY_TO_NEW_TAB';
 export const REMOVE_QUERY_EDITOR = 'REMOVE_QUERY_EDITOR';
 export const MERGE_TABLE = 'MERGE_TABLE';
@@ -129,7 +130,14 @@ export function saveQuery(query) {
       postPayload: convertQueryToServer(query),
       stringify: false,
     })
-      .then(() => dispatch(addSuccessToast(t('Your query was saved'))))
+      .then((result) => {
+        dispatch({
+          type: QUERY_EDITOR_SAVED,
+          query,
+          result: convertQueryToClient(result.json.item),
+        });
+        dispatch(addSuccessToast(t('Your query was saved')));
+      })
       .catch(() => dispatch(addDangerToast(t('Your query could not be saved'))));
 }
 

--- a/superset/assets/src/SqlLab/reducers/sqlLab.js
+++ b/superset/assets/src/SqlLab/reducers/sqlLab.js
@@ -39,6 +39,11 @@ export default function sqlLabReducer(state = {}, action) {
       const newState = Object.assign({}, state, { tabHistory });
       return addToArr(newState, 'queryEditors', action.queryEditor);
     },
+    [actions.QUERY_EDITOR_SAVED]() {
+      const { query, result } = action;
+      const existing = state.queryEditors.find(qe => qe.id === query.id);
+      return alterInArr(state, 'queryEditors', existing, { remoteId: result.remoteId }, 'id');
+    },
     [actions.UPDATE_QUERY_EDITOR]() {
       const id = action.alterations.remoteId;
       const existing = state.queryEditors.find(qe => qe.remoteId === id);

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -156,17 +156,9 @@ class SavedQueryViewApi(SavedQueryView):
         "sql",
         "extra_json",
     ]
-    show_columns = [
-        "id",
-        "label",
-        "db_id",
-        "schema",
-        "description",
-        "sql",
-        "extra_json",
-    ]
-    add_columns = show_columns
+    add_columns = ["label", "db_id", "schema", "description", "sql", "extra_json"]
     edit_columns = add_columns
+    show_columns = add_columns + ["id"]
 
     @has_access_api
     @expose("show/<pk>")


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This fixes an issue introduced in #8298 as reported by @graceguo-supercat. Due to a lack of FAB know-how on my part, the `id` field was required when POSTing a saved query, which prevents any new saved queries from being created.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Tested locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
