### PR TITLE
[Config] Cache static resources

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,12 @@ assists people when migrating to a new version.
 
 ## Next Version
 
+* [8370](https://github.com/apache/incubator-superset/pull/8370): Deprecates
+  the `HTTP_HEADERS` variable in favor of `DEFAULT_HTTP_HEADERS` and
+  `OVERRIDE_HTTP_HEADERS`. To retain the same behavior you should use
+  `OVERRIDE_HTTP_HEADERS` instead of `HTTP_HEADERS`. `HTTP_HEADERS` will still
+  work but may be removed in a future update.
+
 * We're deprecating the concept of "restricted metric", this feature
   was not fully working anyhow.
 * [8117](https://github.com/apache/incubator-superset/pull/8117): If you are

--- a/superset/config.py
+++ b/superset/config.py
@@ -435,8 +435,14 @@ CELERY_CONFIG = CeleryConfig
 # CELERY_CONFIG = None
 
 # Additional static HTTP headers to be served by your Superset server. Note
-# Flask-Talisman aplies the relevant security HTTP headers.
-HTTP_HEADERS = {}
+# Flask-Talisman applies the relevant security HTTP headers.
+#
+# DEFAULT_HTTP_HEADERS: sets default values for HTTP headers. These may be overridden
+# within the app
+# OVERRIDE_HTTP_HEADERS: sets override values for HTTP headers. These values will
+# override anything set within the app
+DEFAULT_HTTP_HEADERS = {}
+OVERRIDE_HTTP_HEADERS = {}
 
 # The db id here results in selecting this one as a default in SQL Lab
 DEFAULT_DB_ID = None
@@ -664,6 +670,9 @@ TALISMAN_CONFIG = {
 SESSION_COOKIE_HTTPONLY = True  # Prevent cookie from being read by frontend JS?
 SESSION_COOKIE_SECURE = False  # Prevent cookie from being transmitted over non-tls?
 SESSION_COOKIE_SAMESITE = "Lax"  # One of [None, 'Lax', 'Strict']
+
+# Flask configuration variables
+SEND_FILE_MAX_AGE_DEFAULT = 60 * 60 * 24 * 365  # Cache static resources
 
 # URI to database storing the example data, points to
 # SQLALCHEMY_DATABASE_URI by default if set to `None`

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -3125,10 +3125,17 @@ appbuilder.add_separator("Sources")
 
 
 @app.after_request
-def apply_http_headers(response):
+def apply_http_headers(response: Response):
     """Applies the configuration's http headers to all responses"""
-    for k, v in config.get("HTTP_HEADERS").items():
-        response.headers[k] = v
+
+    # HTTP_HEADERS is deprecated, this provides backwards compatibility
+    response.headers.extend(
+        {**config["OVERRIDE_HTTP_HEADERS"], **config.get("HTTP_HEADERS", {})}
+    )
+
+    for k, v in config["DEFAULT_HTTP_HEADERS"].items():
+        if k not in response.headers:
+            response.headers[k] = v
     return response
 
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since static resources have hashed file names, we shouldn't need to even hit the webserver for them. Right now, we're hitting the server and using the etag to cache it, but this should prevent a trip to the server altogether.

It should make superset a bit more stable while deploying because these files won't be found on half the webservers while in the middle of deploying

This change also adds some flexibility to the http header configuration, allowing you to only set headers if they haven't already been set by superset. This means that we can cache static content with the `SEND_FILE_MAX_AGE_DEFAULT` var, but disallow caching on everything else with `DEFAULT_HTTP_HEADERS = {"Cache-Control": "no-cache"}`.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
CI and a test deploy to see new cache control headers set

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch @dpgaspar @john-bodley 