### PR TITLE
Add "Year to Date" to the Time Range control options

### DIFF
--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -62,6 +62,7 @@ const COMMON_TIME_FRAMES = [
   'Last month',
   'Last quarter',
   'Last year',
+  'Year to Date',
   'No filter',
 ];
 const TIME_GRAIN_OPTIONS = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'];
@@ -111,6 +112,16 @@ function getStateFromSeparator(value) {
 }
 
 function getStateFromCommonTimeFrame(value) {
+  if (value === "Year to Date") {
+    return {
+      tab: TABS.DEFAULTS,
+      type: TYPES.DEFAULTS,
+      common: value,
+      since: moment().startOf('day').dayOfYear(1).format(MOMENT_FORMAT),
+      until: moment().startOf('day').format(MOMENT_FORMAT),
+    };
+  }
+
   const units = value.split(' ')[1] + 's';
   return {
     tab: TABS.DEFAULTS,

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1067,6 +1067,10 @@ def get_since_until(
             relative_start - relativedelta(years=1),  # noqa: T400
             relative_end,
         ),
+        "Year to Date": (
+            relative_start - relativedelta(yearday=1),
+            relative_end,
+        ),
     }
 
     if time_range:


### PR DESCRIPTION
### CATEGORY

Choose one:
- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Introduces the "Year to Date" time frame, to be used to select the current calendar year (i.e. from Jan 1st to today).
