### PR TITLE
Add a new rolling type Cumulative Performance: df = (1.0 + df).cumprod() - 1.0

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1039,7 +1039,7 @@ export const controls = {
     type: 'SelectControl',
     label: t('Rolling'),
     default: 'None',
-    choices: formatSelectOptions(['None', 'mean', 'sum', 'std', 'cumsum']),
+    choices: formatSelectOptions(['None', 'mean', 'sum', 'std', 'cumsum', 'cumperf']),
     description: t('Defines a rolling window function to apply, works along ' +
     'with the [Periods] text box'),
   },

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1186,6 +1186,8 @@ class NVD3TimeSeriesViz(NVD3Viz):
                 df = df.rolling(**kwargs).sum()
         elif rolling_type == "cumsum":
             df = df.cumsum()
+        elif rolling_type == "cumperf":
+            df = (1.0 + df).cumprod() - 1.0
         if min_periods:
             df = df[min_periods:]
 


### PR DESCRIPTION
### CATEGORY
Choose one
- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Add the rolling type Cumulative Performance:
  cumperf =  df = (1.0 + df).cumprod() - 1.0
This is used for example to calculate the performance of an investment portfolio over a period of time.
