### PR TITLE
[ci] Deprecate flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,20 @@
 #
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.3b0
     hooks:
     -   id: black
         language_version: python3
+
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.3
+    hooks:
+    -   id: seed-isort-config
+
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    -   id: isort
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
@@ -30,8 +40,3 @@ repos:
     -   id: check-added-large-files
     -   id: check-yaml
     -   id: debug-statements
-
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.1
-    hooks:
-    -   id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,10 @@ jobs:
       env: TOXENV=black
     - language: python
       python: 3.6
-      env: TOXENV=flake8
+      env: TOXENV=isort
+    - language: python
+      python: 3.6
+      env: TOXENV=mypy
     - language: python
       python: 3.6
       env: TOXENV=py36-sqlite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -479,6 +479,24 @@ The Python code is auto-formatted using [Black](https://github.com/python/black)
 is configured as a pre-commit hook. There are also numerous [editor integrations](https://black.readthedocs.io/en/stable/editor_integration.html).
 
 
+## Conventions
+
+### Python
+
+Parameters in the `config.py` (which are accessible via the Flask app.config dictionary) are assummed to always be defined and thus should be accessed directly via,
+
+```python
+blueprints = app.config["BLUEPRINTS"]
+```
+
+rather than,
+
+```python
+blueprints = app.config.get("BLUEPRINTS")
+```
+
+or similar as the later will cause typing issues. The former is of type `List[Callable]` whereas the later is of type `Optional[List[Callable]]`.
+
 ## Testing
 
 ### Python Testing

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,11 +16,9 @@
 #
 black==19.3b0
 coverage==4.5.3
-flake8-import-order==0.18.1
-flake8-mypy==17.8.0
-flake8==3.7.7
 flask-cors==3.0.7
 ipdb==0.12
+isort==4.3.21
 mypy==0.670
 nose==1.3.7
 pip-tools==3.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,15 @@ detailed-errors = 1
 with-coverage = 1
 nocapture = 1
 cover-package = superset
+
+[isort]
+combine_as_imports = true
+include_trailing_comma = true
+line_length = 88
+known_first_party = superset
+known_third_party =alembic,backoff,bleach,celery,click,colorama,contextlib2,croniter,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,psycopg2,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
+multi_line_output = 3
+order_by_type = false
+
+[mypy]
+ignore_missing_imports = true

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -16,17 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
-from datetime import datetime
 import logging
+from datetime import datetime
 from subprocess import Popen
 from sys import stdout
 
 import click
+import yaml
 from colorama import Fore, Style
 from flask import g
 from flask_appbuilder import Model
 from pathlib2 import Path
-import yaml
 
 from superset import app, appbuilder, db, examples, security_manager
 from superset.common.tags import add_favorites, add_owners, add_types

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -15,21 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
-from datetime import datetime, timedelta
 import logging
 import pickle as pkl
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
 
-from superset import app, cache
-from superset import db
+from superset import app, cache, db
 from superset.connectors.base.models import BaseDatasource
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.stats_logger import BaseStatsLogger
 from superset.utils import core as utils
 from superset.utils.core import DTTM_ALIAS
+
 from .query_object import QueryObject
 
 config = app.config
@@ -59,8 +59,10 @@ class QueryContext:
         force: bool = False,
         custom_cache_timeout: Optional[int] = None,
     ) -> None:
-        self.datasource = ConnectorRegistry.get_datasource(
-            datasource.get("type"), int(datasource.get("id")), db.session  # noqa: T400
+        self.datasource = ConnectorRegistry.get_datasource(  # type: ignore
+            datasource.get("type"),  # type: ignore
+            int(datasource.get("id")),  # type: ignore
+            db.session,
         )
         self.queries = list(map(lambda query_obj: QueryObject(**query_obj), queries))
 

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -15,15 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=R
-from datetime import datetime, timedelta
 import hashlib
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
 
 import simplejson as json
 
 from superset import app
 from superset.utils import core as utils
-
 
 # TODO: Type Metrics dictionary with TypedDict when it becomes a vanilla python type
 # https://github.com/python/mypy/issues/5288
@@ -39,7 +38,7 @@ class QueryObject:
     from_dttm: datetime
     to_dttm: datetime
     is_timeseries: bool
-    time_shift: timedelta
+    time_shift: Optional[timedelta]
     groupby: List[str]
     metrics: List[Union[Dict, str]]
     row_limit: int
@@ -61,7 +60,7 @@ class QueryObject:
         time_shift: Optional[str] = None,
         is_timeseries: bool = False,
         timeseries_limit: int = 0,
-        row_limit: int = app.config.get("ROW_LIMIT"),
+        row_limit: int = app.config["ROW_LIMIT"],
         timeseries_limit_metric: Optional[Dict] = None,
         order_desc: bool = True,
         extras: Optional[Dict] = None,
@@ -79,13 +78,15 @@ class QueryObject:
         )
         self.is_timeseries = is_timeseries
         self.time_range = time_range
-        self.time_shift = utils.parse_human_timedelta(time_shift)
+        self.time_shift = (
+            utils.parse_human_timedelta(time_shift) if time_shift else None
+        )
         self.groupby = groupby or []
 
         # Temporal solution for backward compatability issue
         # due the new format of non-ad-hoc metric.
         self.metrics = [
-            metric if "expressionType" in metric else metric["label"]  # noqa: T484
+            metric if "expressionType" in metric else metric["label"]  # type: ignore
             for metric in metrics
         ]
         self.row_limit = row_limit

--- a/superset/config.py
+++ b/superset/config.py
@@ -21,13 +21,14 @@ All configuration in this file can be overridden by providing a superset_config
 in your PYTHONPATH as there is a ``from superset_config import *``
 at the end of this file.
 """
-from collections import OrderedDict
 import imp
 import importlib.util
 import json
 import logging
 import os
 import sys
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List
 
 from celery.schedules import crontab
 from dateutil import tz
@@ -93,7 +94,7 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 # ---------------------------------------------------------
 
 # Your App secret key
-SECRET_KEY = "\2\1thisismyscretkey\1\2\e\y\y\h"  # noqa
+SECRET_KEY = "\2\1thisismyscretkey\1\2\e\y\y\h"
 
 # The SQLAlchemy connection string.
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(DATA_DIR, "superset.db")
@@ -262,12 +263,12 @@ IMG_UPLOAD_URL = "/static/uploads/"
 # IMG_SIZE = (300, 200, True)
 
 CACHE_DEFAULT_TIMEOUT = 60 * 60 * 24
-CACHE_CONFIG = {"CACHE_TYPE": "null"}
+CACHE_CONFIG: Dict[str, Any] = {"CACHE_TYPE": "null"}
 TABLE_NAMES_CACHE_CONFIG = {"CACHE_TYPE": "null"}
 
 # CORS Options
 ENABLE_CORS = False
-CORS_OPTIONS = {}
+CORS_OPTIONS: Dict[Any, Any] = {}
 
 # Chrome allows up to 6 open connections per domain at a time. When there are more
 # than 6 slices in dashboard, a lot of time fetch requests are queued up and wait for
@@ -292,13 +293,13 @@ CSV_EXPORT = {"encoding": "utf-8"}
 # time grains in superset/db_engine_specs.builtin_time_grains).
 # For example: to disable 1 second time grain:
 # TIME_GRAIN_BLACKLIST = ['PT1S']
-TIME_GRAIN_BLACKLIST = []
+TIME_GRAIN_BLACKLIST: List[str] = []
 
 # Additional time grains to be supported using similar definitions as in
 # superset/db_engine_specs.builtin_time_grains.
 # For example: To add a new 2 second time grain:
 # TIME_GRAIN_ADDONS = {'PT2S': '2 second'}
-TIME_GRAIN_ADDONS = {}
+TIME_GRAIN_ADDONS: Dict[str, str] = {}
 
 # Implementation of additional time grains per engine.
 # For example: To implement 2 second time grain on clickhouse engine:
@@ -307,7 +308,7 @@ TIME_GRAIN_ADDONS = {}
 #         'PT2S': 'toDateTime(intDiv(toUInt32(toDateTime({col})), 2)*2)'
 #     }
 # }
-TIME_GRAIN_ADDON_FUNCTIONS = {}
+TIME_GRAIN_ADDON_FUNCTIONS: Dict[str, Dict[str, str]] = {}
 
 # ---------------------------------------------------
 # List of viz_types not allowed in your environment
@@ -315,13 +316,13 @@ TIME_GRAIN_ADDON_FUNCTIONS = {}
 #  VIZ_TYPE_BLACKLIST = ['pivot_table', 'treemap']
 # ---------------------------------------------------
 
-VIZ_TYPE_BLACKLIST = []
+VIZ_TYPE_BLACKLIST: List[str] = []
 
 # ---------------------------------------------------
 # List of data sources not to be refreshed in druid cluster
 # ---------------------------------------------------
 
-DRUID_DATA_SOURCE_BLACKLIST = []
+DRUID_DATA_SOURCE_BLACKLIST: List[str] = []
 
 # --------------------------------------------------
 # Modules, datasources and middleware to be registered
@@ -332,8 +333,8 @@ DEFAULT_MODULE_DS_MAP = OrderedDict(
         ("superset.connectors.druid.models", ["DruidDatasource"]),
     ]
 )
-ADDITIONAL_MODULE_DS_MAP = {}
-ADDITIONAL_MIDDLEWARE = []
+ADDITIONAL_MODULE_DS_MAP: Dict[str, List[str]] = {}
+ADDITIONAL_MIDDLEWARE: List[Callable] = []
 
 # 1) https://docs.python-guide.org/writing/logging/
 # 2) https://docs.python.org/2/library/logging.config.html
@@ -441,8 +442,8 @@ CELERY_CONFIG = CeleryConfig
 # within the app
 # OVERRIDE_HTTP_HEADERS: sets override values for HTTP headers. These values will
 # override anything set within the app
-DEFAULT_HTTP_HEADERS = {}
-OVERRIDE_HTTP_HEADERS = {}
+DEFAULT_HTTP_HEADERS: Dict[str, Any] = {}
+OVERRIDE_HTTP_HEADERS: Dict[str, Any] = {}
 
 # The db id here results in selecting this one as a default in SQL Lab
 DEFAULT_DB_ID = None
@@ -492,7 +493,7 @@ UPLOADED_CSV_HIVE_NAMESPACE = None
 # SQL Lab. The existing context gets updated with this dictionary,
 # meaning values for existing keys get overwritten by the content of this
 # dictionary.
-JINJA_CONTEXT_ADDONS = {}
+JINJA_CONTEXT_ADDONS: Dict[str, Callable] = {}
 
 # Roles that are controlled by the API / Superset and should not be changes
 # by humans.
@@ -521,7 +522,7 @@ SMTP_PASSWORD = "superset"
 SMTP_MAIL_FROM = "superset@superset.com"
 
 if not CACHE_DEFAULT_TIMEOUT:
-    CACHE_DEFAULT_TIMEOUT = CACHE_CONFIG.get("CACHE_DEFAULT_TIMEOUT")
+    CACHE_DEFAULT_TIMEOUT = CACHE_CONFIG.get("CACHE_DEFAULT_TIMEOUT")  # type: ignore
 
 # Whether to bump the logging level to ERROR on the flask_appbuilder package
 # Set to False if/when debugging FAB related issues like
@@ -541,12 +542,12 @@ PERMISSION_INSTRUCTIONS_LINK = ""
 
 # Integrate external Blueprints to the app by passing them to your
 # configuration. These blueprints will get integrated in the app
-BLUEPRINTS = []
+BLUEPRINTS: List[Callable] = []
 
 # Provide a callable that receives a tracking_url and returns another
 # URL. This is used to translate internal Hadoop job tracker URL
 # into a proxied one
-TRACKING_URL_TRANSFORMER = lambda x: x  # noqa: E731
+TRACKING_URL_TRANSFORMER = lambda x: x
 
 # Interval between consecutive polls when using Hive Engine
 HIVE_POLL_INTERVAL = 5
@@ -629,7 +630,7 @@ EMAIL_REPORTS_WEBDRIVER = "firefox"
 WEBDRIVER_WINDOW = {"dashboard": (1600, 2000), "slice": (3000, 1200)}
 
 # Any config options to be passed as-is to the webdriver
-WEBDRIVER_CONFIGURATION = {}
+WEBDRIVER_CONFIGURATION: Dict[Any, Any] = {}
 
 # The base URL to query for accessing the user interface
 WEBDRIVER_BASEURL = "http://0.0.0.0:8080/"
@@ -697,8 +698,8 @@ if CONFIG_PATH_ENV_VAR in os.environ:
         raise
 elif importlib.util.find_spec("superset_config"):
     try:
-        from superset_config import *  # noqa pylint: disable=import-error
-        import superset_config  # noqa pylint: disable=import-error
+        from superset_config import *  # pylint: disable=import-error
+        import superset_config  # pylint: disable=import-error
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -16,7 +16,7 @@
 # under the License.
 # pylint: disable=C,R,W
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 from flask_appbuilder.security.sqla.models import User
 from sqlalchemy import and_, Boolean, Column, Integer, String, Text
@@ -35,15 +35,17 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
     # ---------------------------------------------------------------
     # class attributes to define when deriving BaseDatasource
     # ---------------------------------------------------------------
-    __tablename__ = None  # {connector_name}_datasource
-    type = None  # datasoure type, str to be defined when deriving this class
-    baselink = None  # url portion pointing to ModelView endpoint
-    column_class = None  # link to derivative of BaseColumn
-    metric_class = None  # link to derivative of BaseMetric
+    __tablename__: Optional[str] = None  # {connector_name}_datasource
+    type: Optional[  # datasoure type, str to be defined when deriving this class
+        str
+    ] = None
+    baselink: Optional[str] = None  # url portion pointing to ModelView endpoint
+    column_class: Optional[Type] = None  # link to derivative of BaseColumn
+    metric_class: Optional[Type] = None  # link to derivative of BaseMetric
     owner_class = None
 
     # Used to do code highlighting when displaying the query in the UI
-    query_language = None
+    query_language: Optional[str] = None
 
     name = None  # can be a Column or a property pointing to one
 
@@ -341,7 +343,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
 class BaseColumn(AuditMixinNullable, ImportMixin):
     """Interface for column"""
 
-    __tablename__ = None  # {connector_name}_column
+    __tablename__: Optional[str] = None  # {connector_name}_column
 
     id = Column(Integer, primary_key=True)
     column_name = Column(String(255), nullable=False)
@@ -411,7 +413,7 @@ class BaseMetric(AuditMixinNullable, ImportMixin):
 
     """Interface for Metrics"""
 
-    __tablename__ = None  # {connector_name}_metric
+    __tablename__: Optional[str] = None  # {connector_name}_metric
 
     id = Column(Integer, primary_key=True)
     metric_name = Column(String(255), nullable=False)

--- a/superset/connectors/druid/__init__.py
+++ b/superset/connectors/druid/__init__.py
@@ -14,5 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from . import models  # noqa
-from . import views  # noqa
+from . import models, views

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -15,17 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
-from datetime import datetime
 import json
 import logging
+from datetime import datetime
 
 from flask import flash, Markup, redirect
 from flask_appbuilder import CompactCRUDMixin, expose
 from flask_appbuilder.fieldwidgets import Select2Widget
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
-from flask_babel import gettext as __
-from flask_babel import lazy_gettext as _
+from flask_babel import gettext as __, lazy_gettext as _
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 
 from superset import appbuilder, db, security_manager
@@ -42,10 +41,11 @@ from superset.views.base import (
     validate_json,
     YamlExportMixin,
 )
+
 from . import models
 
 
-class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
+class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):
     datamodel = SQLAInterface(models.DruidColumn)
 
     list_title = _("Columns")
@@ -134,7 +134,7 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
 appbuilder.add_view_no_menu(DruidColumnInlineView)
 
 
-class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
+class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):
     datamodel = SQLAInterface(models.DruidMetric)
 
     list_title = _("Metrics")
@@ -189,7 +189,7 @@ class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
 appbuilder.add_view_no_menu(DruidMetricInlineView)
 
 
-class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
+class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):
     datamodel = SQLAInterface(models.DruidCluster)
 
     list_title = _("Druid Clusters")
@@ -268,9 +268,7 @@ appbuilder.add_view(
 )
 
 
-class DruidDatasourceModelView(
-    DatasourceModelView, DeleteMixin, YamlExportMixin
-):  # noqa
+class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):
     datamodel = SQLAInterface(models.DruidDatasource)
 
     list_title = _("Druid Datasources")

--- a/superset/connectors/sqla/__init__.py
+++ b/superset/connectors/sqla/__init__.py
@@ -14,5 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from . import models  # noqa
-from . import views  # noqa
+from . import models, views

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -25,8 +25,7 @@ from flask_appbuilder.actions import action
 from flask_appbuilder.fieldwidgets import Select2Widget
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
-from flask_babel import gettext as __
-from flask_babel import lazy_gettext as _
+from flask_babel import gettext as __, lazy_gettext as _
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms.validators import Regexp
 
@@ -41,12 +40,13 @@ from superset.views.base import (
     SupersetModelView,
     YamlExportMixin,
 )
+
 from . import models
 
 logger = logging.getLogger(__name__)
 
 
-class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
+class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):
     datamodel = SQLAInterface(models.TableColumn)
 
     list_title = _("Columns")
@@ -162,7 +162,7 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
 appbuilder.add_view_no_menu(TableColumnInlineView)
 
 
-class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
+class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):
     datamodel = SQLAInterface(models.SqlMetric)
 
     list_title = _("Metrics")
@@ -224,7 +224,7 @@ class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):  # noqa
 appbuilder.add_view_no_menu(SqlMetricInlineView)
 
 
-class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
+class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):
     datamodel = SQLAInterface(models.SqlaTable)
 
     list_title = _("Tables")

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -22,8 +22,8 @@ TODO(bkyryliuk): add support for the conventions like: *_dim or dim_*
 TODO(bkyryliuk): recognize integer encoded enums.
 
 """
-from datetime import date, datetime
 import logging
+from datetime import date, datetime
 
 import numpy as np
 import pandas as pd

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -28,10 +28,10 @@ at all. The classes here will use a common interface to specify all this.
 
 The general idea is to use static classes and an inheritance scheme.
 """
-from importlib import import_module
 import inspect
-from pathlib import Path
 import pkgutil
+from importlib import import_module
+from pathlib import Path
 from typing import Dict, Type
 
 from superset.db_engine_specs.base import BaseEngineSpec

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -15,16 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=unused-argument
-from contextlib import closing
-from datetime import datetime
 import hashlib
 import os
 import re
+from contextlib import closing
+from datetime import datetime
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING, Union
 
+import pandas as pd
+import sqlparse
 from flask import g
 from flask_babel import lazy_gettext as _
-import pandas as pd
 from sqlalchemy import column, DateTime, select
 from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.base import Engine
@@ -34,7 +35,6 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import quoted_name, text
 from sqlalchemy.sql.expression import ColumnClause, ColumnElement, Select, TextAsFrom
 from sqlalchemy.types import TypeEngine
-import sqlparse
 from werkzeug.utils import secure_filename
 
 from superset import app, db, sql_parse
@@ -339,7 +339,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return sql
 
     @classmethod
-    def get_limit_from_sql(cls, sql: str) -> int:
+    def get_limit_from_sql(cls, sql: str) -> Optional[int]:
         """
         Extract limit from SQL query
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime
 import hashlib
 import re
+from datetime import datetime
 from typing import Any, Dict, List, Tuple
 
 import pandas as pd
@@ -68,7 +68,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
     def fetch_data(cls, cursor, limit: int) -> List[Tuple]:
         data = super(BigQueryEngineSpec, cls).fetch_data(cursor, limit)
         if data and type(data[0]).__name__ == "Row":
-            data = [r.values() for r in data]
+            data = [r.values() for r in data]  # type: ignore
         return data
 
     @staticmethod

--- a/superset/db_engine_specs/exasol.py
+++ b/superset/db_engine_specs/exasol.py
@@ -44,5 +44,5 @@ class ExasolEngineSpec(BaseEngineSpec):
         data = super().fetch_data(cursor, limit)
         # Lists of `pyodbc.Row` need to be unpacked further
         if data and type(data[0]).__name__ == "Row":
-            data = [[value for value in row] for row in data]
+            data = [tuple(row) for row in data]
         return data

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime
 import logging
 import os
 import re
 import time
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 from urllib import parse
 
@@ -415,7 +415,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         return configuration
 
     @staticmethod
-    def execute(
+    def execute(  # type: ignore
         cursor, query: str, async_: bool = False
     ):  # pylint: disable=arguments-differ
         kwargs = {"async": async_}

--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime
 import re
+from datetime import datetime
 from typing import List, Optional, Tuple
 
 from sqlalchemy.engine.interfaces import Dialect
@@ -26,7 +26,6 @@ from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 
 class MssqlEngineSpec(BaseEngineSpec):
     engine = "mssql"
-    epoch_to_dttm = "dateadd(S, {col}, '1970-01-01')"
     limit_method = LimitMethod.WRAP_SQL
     max_column_name_length = 128
 
@@ -47,6 +46,10 @@ class MssqlEngineSpec(BaseEngineSpec):
     }
 
     @classmethod
+    def epoch_to_dttm(cls):
+        return "dateadd(S, {col}, '1970-01-01')"
+
+    @classmethod
     def convert_dttm(cls, target_type: str, dttm: datetime) -> str:
         return "CONVERT(DATETIME, '{}', 126)".format(dttm.isoformat())
 
@@ -54,7 +57,7 @@ class MssqlEngineSpec(BaseEngineSpec):
     def fetch_data(cls, cursor, limit: int) -> List[Tuple]:
         data = super().fetch_data(cursor, limit)
         if data and type(data[0]).__name__ == "Row":
-            data = [[elem for elem in r] for r in data]
+            data = [tuple(row) for row in data]
         return data
 
     column_types = [

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -14,14 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from collections import defaultdict, deque
-from contextlib import closing
-from datetime import datetime
-from distutils.version import StrictVersion
 import logging
 import re
 import textwrap
 import time
+from collections import defaultdict, deque
+from contextlib import closing
+from datetime import datetime
+from distutils.version import StrictVersion
 from typing import Any, cast, Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib import parse
 
@@ -787,14 +787,14 @@ class PrestoEngineSpec(BaseEngineSpec):
         limit_clause = "LIMIT {}".format(limit) if limit else ""
         order_by_clause = ""
         if order_by:
-            l = []  # noqa: E741
+            l = []
             for field, desc in order_by:
                 l.append(field + " DESC" if desc else "")
             order_by_clause = "ORDER BY " + ", ".join(l)
 
         where_clause = ""
         if filters:
-            l = []  # noqa: E741
+            l = []
             for field, value in filters.items():
                 l.append(f"{field} = '{value}'")
             where_clause = "WHERE " + " AND ".join(l)
@@ -824,7 +824,7 @@ class PrestoEngineSpec(BaseEngineSpec):
     def where_latest_partition(  # pylint: disable=too-many-arguments
         cls,
         table_name: str,
-        schema: str,
+        schema: Optional[str],
         database,
         query: Select,
         columns: Optional[List] = None,
@@ -856,7 +856,7 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     def latest_partition(
-        cls, table_name: str, schema: str, database, show_first: bool = False
+        cls, table_name: str, schema: Optional[str], database, show_first: bool = False
     ):
         """Returns col name and the latest (max) partition value for a table
 

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import List, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 from sqlalchemy.engine.reflection import Inspector
 
@@ -83,7 +83,7 @@ class SqliteEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_table_names(
-        cls, database: "Database", inspector: Inspector, schema: str
+        cls, database: "Database", inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
         """Need to disregard the schema for Sqlite"""
         return sorted(inspector.get_table_names())

--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -27,8 +27,8 @@ def fetch_logs(self, max_rows=1024, orientation=None):
     .. note::
         This is not a part of DB-API.
     """
-    from pyhive import hive  # noqa
-    from TCLIService import ttypes  # noqa
+    from pyhive import hive
+    from TCLIService import ttypes
     from thrift import Thrift  # pylint: disable=import-error
 
     orientation = orientation or ttypes.TFetchOrientation.FETCH_NEXT

--- a/superset/examples/__init__.py
+++ b/superset/examples/__init__.py
@@ -14,20 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from .bart_lines import load_bart_lines  # noqa
-from .birth_names import load_birth_names  # noqa
-from .country_map import load_country_map_data  # noqa
-from .css_templates import load_css_templates  # noqa
-from .deck import load_deck_dash  # noqa
-from .energy import load_energy  # noqa
-from .flights import load_flights  # noqa
-from .long_lat import load_long_lat_data  # noqa
-from .misc_dashboard import load_misc_dashboard  # noqa
-from .multi_line import load_multi_line  # noqa
-from .multiformat_time_series import load_multiformat_time_series  # noqa
-from .paris import load_paris_iris_geojson  # noqa
-from .random_time_series import load_random_time_series_data  # noqa
-from .sf_population_polygons import load_sf_population_polygons  # noqa
-from .tabbed_dashboard import load_tabbed_dashboard  # noqa
-from .unicode_test_data import load_unicode_test_data  # noqa
-from .world_bank import load_world_bank_health_n_pop  # noqa
+from .bart_lines import load_bart_lines
+from .birth_names import load_birth_names
+from .country_map import load_country_map_data
+from .css_templates import load_css_templates
+from .deck import load_deck_dash
+from .energy import load_energy
+from .flights import load_flights
+from .long_lat import load_long_lat_data
+from .misc_dashboard import load_misc_dashboard
+from .multi_line import load_multi_line
+from .multiformat_time_series import load_multiformat_time_series
+from .paris import load_paris_iris_geojson
+from .random_time_series import load_random_time_series_data
+from .sf_population_polygons import load_sf_population_polygons
+from .tabbed_dashboard import load_tabbed_dashboard
+from .unicode_test_data import load_unicode_test_data
+from .world_bank import load_world_bank_health_n_pop

--- a/superset/examples/bart_lines.py
+++ b/superset/examples/bart_lines.py
@@ -22,6 +22,7 @@ from sqlalchemy import String, Text
 
 from superset import db
 from superset.utils.core import get_example_database
+
 from .helpers import get_example_data, TBL
 
 

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -24,6 +24,7 @@ from sqlalchemy.sql import column
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlMetric, TableColumn
 from superset.utils.core import get_example_database
+
 from .helpers import (
     config,
     Dash,

--- a/superset/examples/countries.py
+++ b/superset/examples/countries.py
@@ -15,7 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains data related to countries and is used for geo mapping"""
-countries = [
+from typing import Any, Dict, List
+
+countries: List[Dict[str, Any]] = [
     {
         "name": "Angola",
         "area": 1246700,
@@ -2488,7 +2490,7 @@ countries = [
     },
 ]
 
-all_lookups = {}
+all_lookups: Dict[str, Dict[str, Dict[str, Any]]] = {}
 lookups = ["cioc", "cca2", "cca3", "name"]
 for lookup in lookups:
     all_lookups[lookup] = {}

--- a/superset/examples/country_map.py
+++ b/superset/examples/country_map.py
@@ -23,6 +23,7 @@ from sqlalchemy.sql import column
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
 from superset.utils import core as utils
+
 from .helpers import (
     get_example_data,
     get_slice_json,

--- a/superset/examples/deck.py
+++ b/superset/examples/deck.py
@@ -18,6 +18,7 @@
 import json
 
 from superset import db
+
 from .helpers import Dash, get_slice_json, merge_slice, Slice, TBL, update_slice_ids
 
 COLOR_RED = {"r": 205, "g": 0, "b": 3, "a": 0.82}

--- a/superset/examples/energy.py
+++ b/superset/examples/energy.py
@@ -25,6 +25,7 @@ from sqlalchemy.sql import column
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
 from superset.utils import core as utils
+
 from .helpers import get_example_data, merge_slice, misc_dash_slices, Slice, TBL
 
 

--- a/superset/examples/flights.py
+++ b/superset/examples/flights.py
@@ -19,6 +19,7 @@ from sqlalchemy import DateTime
 
 from superset import db
 from superset.utils import core as utils
+
 from .helpers import get_example_data, TBL
 
 

--- a/superset/examples/helpers.py
+++ b/superset/examples/helpers.py
@@ -16,11 +16,12 @@
 # under the License.
 """Loads datasets, dashboards and slices in a new superset instance"""
 # pylint: disable=C,R,W
-from io import BytesIO
 import json
 import os
-from urllib import request
 import zlib
+from io import BytesIO
+from typing import Set
+from urllib import request
 
 from superset import app, db
 from superset.connectors.connector_registry import ConnectorRegistry
@@ -37,9 +38,9 @@ TBL = ConnectorRegistry.sources["table"]
 
 config = app.config
 
-EXAMPLES_FOLDER = os.path.join(config.get("BASE_DIR"), "examples")
+EXAMPLES_FOLDER = os.path.join(config["BASE_DIR"], "examples")
 
-misc_dash_slices = set()  # slices assembled in a 'Misc Chart' dashboard
+misc_dash_slices: Set[str] = set()  # slices assembled in a 'Misc Chart' dashboard
 
 
 def update_slice_ids(layout_dict, slices):

--- a/superset/examples/long_lat.py
+++ b/superset/examples/long_lat.py
@@ -23,6 +23,7 @@ from sqlalchemy import DateTime, Float, String
 
 from superset import db
 from superset.utils import core as utils
+
 from .helpers import (
     get_example_data,
     get_slice_json,

--- a/superset/examples/misc_dashboard.py
+++ b/superset/examples/misc_dashboard.py
@@ -17,8 +17,8 @@
 import json
 import textwrap
 
-
 from superset import db
+
 from .helpers import Dash, misc_dash_slices, Slice, update_slice_ids
 
 DASH_SLUG = "misc_charts"

--- a/superset/examples/multi_line.py
+++ b/superset/examples/multi_line.py
@@ -17,6 +17,7 @@
 import json
 
 from superset import db
+
 from .birth_names import load_birth_names
 from .helpers import merge_slice, misc_dash_slices, Slice
 from .world_bank import load_world_bank_health_n_pop

--- a/superset/examples/multiformat_time_series.py
+++ b/superset/examples/multiformat_time_series.py
@@ -20,6 +20,7 @@ from sqlalchemy import BigInteger, Date, DateTime, String
 
 from superset import db
 from superset.utils.core import get_example_database
+
 from .helpers import (
     config,
     get_example_data,

--- a/superset/examples/paris.py
+++ b/superset/examples/paris.py
@@ -21,6 +21,7 @@ from sqlalchemy import String, Text
 
 from superset import db
 from superset.utils import core as utils
+
 from .helpers import get_example_data, TBL
 
 

--- a/superset/examples/random_time_series.py
+++ b/superset/examples/random_time_series.py
@@ -20,6 +20,7 @@ from sqlalchemy import DateTime
 
 from superset import db
 from superset.utils import core as utils
+
 from .helpers import config, get_example_data, get_slice_json, merge_slice, Slice, TBL
 
 

--- a/superset/examples/sf_population_polygons.py
+++ b/superset/examples/sf_population_polygons.py
@@ -21,6 +21,7 @@ from sqlalchemy import BigInteger, Float, Text
 
 from superset import db
 from superset.utils import core as utils
+
 from .helpers import get_example_data, TBL
 
 

--- a/superset/examples/tabbed_dashboard.py
+++ b/superset/examples/tabbed_dashboard.py
@@ -20,6 +20,7 @@ import json
 import textwrap
 
 from superset import db
+
 from .helpers import Dash, Slice, update_slice_ids
 
 

--- a/superset/examples/unicode_test_data.py
+++ b/superset/examples/unicode_test_data.py
@@ -23,6 +23,7 @@ from sqlalchemy import Date, Float, String
 
 from superset import db
 from superset.utils import core as utils
+
 from .helpers import (
     config,
     Dash,

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -27,6 +27,7 @@ from sqlalchemy.sql import column
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
 from superset.utils import core as utils
+
 from .helpers import (
     config,
     Dash,

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -16,13 +16,13 @@
 # under the License.
 # pylint: disable=C,R,W
 """Defines the templating context for SQL Lab"""
-from datetime import datetime, timedelta
 import inspect
 import json
 import random
 import time
-from typing import Any, List, Optional, Tuple
 import uuid
+from datetime import datetime, timedelta
+from typing import Any, List, Optional, Tuple
 
 from dateutil.relativedelta import relativedelta
 from flask import g, request

--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -19,6 +19,7 @@ import logging
 from logging.config import fileConfig
 
 from alembic import context
+from flask import current_app
 from flask_appbuilder import Base
 from sqlalchemy import engine_from_config, pool
 
@@ -31,10 +32,6 @@ config = context.config
 fileConfig(config.config_file_name)
 logger = logging.getLogger("alembic.env")
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-from flask import current_app
 
 config.set_main_option(
     "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")

--- a/superset/migrations/versions/0b1f1ab473c0_add_extra_column_to_query.py
+++ b/superset/migrations/versions/0b1f1ab473c0_add_extra_column_to_query.py
@@ -21,8 +21,8 @@ Revises: 55e910a74826
 Create Date: 2018-11-05 08:42:56.181012
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "0b1f1ab473c0"

--- a/superset/migrations/versions/0c5070e96b57_add_user_attributes_table.py
+++ b/superset/migrations/versions/0c5070e96b57_add_user_attributes_table.py
@@ -26,8 +26,8 @@ Create Date: 2018-08-06 14:38:18.965248
 revision = "0c5070e96b57"
 down_revision = "7fcdcde0761c"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/11c737c17cc6_deprecate_restricted_metrics.py
+++ b/superset/migrations/versions/11c737c17cc6_deprecate_restricted_metrics.py
@@ -21,9 +21,8 @@ Revises: def97f26fdfb
 Create Date: 2019-09-08 21:50:58.200229
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "11c737c17cc6"

--- a/superset/migrations/versions/1226819ee0e3_fix_wrong_constraint_on_table_columns.py
+++ b/superset/migrations/versions/1226819ee0e3_fix_wrong_constraint_on_table_columns.py
@@ -21,10 +21,12 @@ Revises: 956a063c52b3
 Create Date: 2016-05-27 15:03:32.980343
 
 """
+import logging
+
 from alembic import op
+
 from superset import db
 from superset.utils.core import generic_find_constraint_name
-import logging
 
 # revision identifiers, used by Alembic.
 revision = "1226819ee0e3"

--- a/superset/migrations/versions/1296d28ec131_druid_exports.py
+++ b/superset/migrations/versions/1296d28ec131_druid_exports.py
@@ -26,8 +26,8 @@ Create Date: 2016-12-06 17:40:40.389652
 revision = "1296d28ec131"
 down_revision = "6414e83d82b7"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/12d55656cbca_is_featured.py
+++ b/superset/migrations/versions/12d55656cbca_is_featured.py
@@ -26,8 +26,8 @@ Create Date: 2015-12-14 13:37:17.374852
 revision = "12d55656cbca"
 down_revision = "55179c7f25c7"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/130915240929_is_sqllab_viz_flow.py
+++ b/superset/migrations/versions/130915240929_is_sqllab_viz_flow.py
@@ -21,8 +21,8 @@ Revises: f231d82b9b26
 Create Date: 2018-04-03 08:19:34.098789
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db

--- a/superset/migrations/versions/18dc26817ad2_.py
+++ b/superset/migrations/versions/18dc26817ad2_.py
@@ -26,8 +26,8 @@ Create Date: 2019-01-18 14:56:26.307684
 revision = "18dc26817ad2"
 down_revision = ("8b70aa3d0f87", "a33a03f16c4a")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/18e88e1cc004_making_audit_nullable.py
+++ b/superset/migrations/versions/18e88e1cc004_making_audit_nullable.py
@@ -21,8 +21,8 @@ Revises: 430039611635
 Create Date: 2016-03-13 21:30:24.833107
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "18e88e1cc004"

--- a/superset/migrations/versions/19a814813610_adding_metric_warning_text.py
+++ b/superset/migrations/versions/19a814813610_adding_metric_warning_text.py
@@ -26,8 +26,8 @@ Create Date: 2017-09-15 15:09:40.495345
 revision = "19a814813610"
 down_revision = "ca69c70ec99b"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/1a1d627ebd8e_position_json.py
+++ b/superset/migrations/versions/1a1d627ebd8e_position_json.py
@@ -23,8 +23,8 @@ Create Date: 2018-08-13 11:30:07.101702
 """
 
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from superset.utils.core import MediumText
 

--- a/superset/migrations/versions/1a48a5411020_adding_slug_to_dash.py
+++ b/superset/migrations/versions/1a48a5411020_adding_slug_to_dash.py
@@ -26,8 +26,8 @@ Create Date: 2015-12-04 09:42:16.973264
 revision = "1a48a5411020"
 down_revision = "289ce07647b"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/1d2ddd543133_log_dt.py
+++ b/superset/migrations/versions/1d2ddd543133_log_dt.py
@@ -25,8 +25,8 @@ Create Date: 2016-03-25 14:35:44.642576
 revision = "1d2ddd543133"
 down_revision = "d2424a248d63"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/1d9e835a84f9_.py
+++ b/superset/migrations/versions/1d9e835a84f9_.py
@@ -21,8 +21,8 @@ Revises: 3dda56f1c4c6
 Create Date: 2018-07-16 18:04:07.764659
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.sql import expression
 
 # revision identifiers, used by Alembic.

--- a/superset/migrations/versions/1e2841a4128_.py
+++ b/superset/migrations/versions/1e2841a4128_.py
@@ -26,8 +26,8 @@ Create Date: 2015-10-05 22:11:00.537054
 revision = "1e2841a4128"
 down_revision = "5a7bad26f2a7"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/258b5280a45e_form_strip_leading_and_trailing_whitespace.py
+++ b/superset/migrations/versions/258b5280a45e_form_strip_leading_and_trailing_whitespace.py
@@ -22,9 +22,10 @@ Create Date: 2019-09-19 13:40:25.293907
 
 """
 import re
+
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 from superset.utils.core import MediumText

--- a/superset/migrations/versions/2591d77e9831_user_id.py
+++ b/superset/migrations/versions/2591d77e9831_user_id.py
@@ -26,8 +26,8 @@ Create Date: 2015-12-15 17:02:45.128709
 revision = "2591d77e9831"
 down_revision = "12d55656cbca"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/27ae655e4247_make_creator_owners.py
+++ b/superset/migrations/versions/27ae655e4247_make_creator_owners.py
@@ -27,12 +27,13 @@ revision = "27ae655e4247"
 down_revision = "d8bc074f7aad"
 
 from alembic import op
-from superset import db
-from sqlalchemy.ext.declarative import declarative_base
-from flask_appbuilder.models.mixins import AuditMixin
-from sqlalchemy.orm import relationship
 from flask_appbuilder import Model
-from sqlalchemy import Column, Integer, ForeignKey, Table
+from flask_appbuilder.models.mixins import AuditMixin
+from sqlalchemy import Column, ForeignKey, Integer, Table
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+
+from superset import db
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/289ce07647b_add_encrypted_password_field.py
+++ b/superset/migrations/versions/289ce07647b_add_encrypted_password_field.py
@@ -22,8 +22,8 @@ Create Date: 2015-11-21 11:18:00.650587
 
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy_utils import EncryptedType
 
 # revision identifiers, used by Alembic.

--- a/superset/migrations/versions/2929af7925ed_tz_offsets_in_data_sources.py
+++ b/superset/migrations/versions/2929af7925ed_tz_offsets_in_data_sources.py
@@ -26,8 +26,8 @@ Create Date: 2015-10-19 20:54:00.565633
 revision = "2929af7925ed"
 down_revision = "1e2841a4128"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/2fcdcb35e487_saved_queries.py
+++ b/superset/migrations/versions/2fcdcb35e487_saved_queries.py
@@ -21,8 +21,8 @@ Revises: a6c18f869a4e
 Create Date: 2017-03-29 15:04:35.734190
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "2fcdcb35e487"

--- a/superset/migrations/versions/30bb17c0dc76_.py
+++ b/superset/migrations/versions/30bb17c0dc76_.py
@@ -28,8 +28,8 @@ down_revision = "f231d82b9b26"
 
 from datetime import date
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/315b3f4da9b0_adding_log_model.py
+++ b/superset/migrations/versions/315b3f4da9b0_adding_log_model.py
@@ -26,8 +26,8 @@ Create Date: 2015-12-04 11:16:58.226984
 revision = "315b3f4da9b0"
 down_revision = "1a48a5411020"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/33d996bcc382_update_slice_model.py
+++ b/superset/migrations/versions/33d996bcc382_update_slice_model.py
@@ -14,12 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from alembic import op
-import sqlalchemy as sa
-from superset import db
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String
-
 """update slice model
 
 Revision ID: 33d996bcc382
@@ -27,6 +21,12 @@ Revises: 41f6a59a61f2
 Create Date: 2016-09-07 23:50:59.366779
 
 """
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
 
 # revision identifiers, used by Alembic.
 revision = "33d996bcc382"

--- a/superset/migrations/versions/3b626e2a6783_sync_db_with_models.py
+++ b/superset/migrations/versions/3b626e2a6783_sync_db_with_models.py
@@ -24,12 +24,14 @@ Revises: 5e4a03ef0bf0
 Create Date: 2016-09-22 10:21:33.618976
 
 """
+import logging
+
+import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import mysql
+
 from superset import db
 from superset.utils.core import generic_find_constraint_name
-import logging
-import sqlalchemy as sa
-from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = "3b626e2a6783"

--- a/superset/migrations/versions/3c3ffe173e4f_add_sql_string_to_table.py
+++ b/superset/migrations/versions/3c3ffe173e4f_add_sql_string_to_table.py
@@ -26,8 +26,8 @@ Create Date: 2016-08-18 14:06:28.784699
 revision = "3c3ffe173e4f"
 down_revision = "ad82a75afd82"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/3dda56f1c4c6_migrate_num_period_compare_and_period_.py
+++ b/superset/migrations/versions/3dda56f1c4c6_migrate_num_period_compare_and_period_.py
@@ -27,10 +27,10 @@ Create Date: 2018-07-05 15:19:14.609299
 import datetime
 import json
 
-from alembic import op
 import isodate
-from sqlalchemy.ext.declarative import declarative_base
+from alembic import op
 from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 from superset.utils.core import parse_human_timedelta

--- a/superset/migrations/versions/3e1b21cd94a4_change_owner_to_m2m_relation_on_.py
+++ b/superset/migrations/versions/3e1b21cd94a4_change_owner_to_m2m_relation_on_.py
@@ -22,15 +22,15 @@ Create Date: 2018-12-15 12:34:47.228756
 
 """
 
+import sqlalchemy as sa
+from alembic import op
+
 # revision identifiers, used by Alembic.
 from superset import db
 from superset.utils.core import generic_find_fk_constraint_name
 
 revision = "3e1b21cd94a4"
 down_revision = "6c7537a6004a"
-
-from alembic import op
-import sqlalchemy as sa
 
 
 sqlatable_user = sa.Table(

--- a/superset/migrations/versions/41f6a59a61f2_database_options_for_sql_lab.py
+++ b/superset/migrations/versions/41f6a59a61f2_database_options_for_sql_lab.py
@@ -21,8 +21,8 @@ Revises: 3c3ffe173e4f
 Create Date: 2016-08-31 10:26:37.969107
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "41f6a59a61f2"

--- a/superset/migrations/versions/430039611635_log_more.py
+++ b/superset/migrations/versions/430039611635_log_more.py
@@ -21,8 +21,8 @@ Revises: d827694c7555
 Create Date: 2016-02-10 08:47:28.950891
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "430039611635"

--- a/superset/migrations/versions/43df8de3a5f4_dash_json.py
+++ b/superset/migrations/versions/43df8de3a5f4_dash_json.py
@@ -26,8 +26,8 @@ Create Date: 2016-01-18 23:43:16.073483
 revision = "43df8de3a5f4"
 down_revision = "7dbf98566af7"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/4451805bbaa1_remove_double_percents.py
+++ b/superset/migrations/versions/4451805bbaa1_remove_double_percents.py
@@ -27,10 +27,11 @@ revision = "4451805bbaa1"
 down_revision = "bddc498dd179"
 
 
-from alembic import op
 import json
-from sqlalchemy.ext.declarative import declarative_base
+
+from alembic import op
 from sqlalchemy import Column, create_engine, ForeignKey, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/4500485bde7d_allow_run_sync_async.py
+++ b/superset/migrations/versions/4500485bde7d_allow_run_sync_async.py
@@ -26,8 +26,8 @@ Create Date: 2016-09-12 23:33:14.789632
 revision = "4500485bde7d"
 down_revision = "41f6a59a61f2"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/45e7da7cfeba_.py
+++ b/superset/migrations/versions/45e7da7cfeba_.py
@@ -26,8 +26,8 @@ Create Date: 2019-02-16 17:44:44.493427
 revision = "45e7da7cfeba"
 down_revision = ("e553e78e90c5", "c82ee8a39623")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/46ba6aaaac97_.py
+++ b/superset/migrations/versions/46ba6aaaac97_.py
@@ -26,8 +26,8 @@ Create Date: 2018-07-23 11:20:54.929246
 revision = "46ba6aaaac97"
 down_revision = ("705732c70154", "e3970889f38e")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/46f444d8b9b7_remove_coordinator_from_druid_cluster_.py
+++ b/superset/migrations/versions/46f444d8b9b7_remove_coordinator_from_druid_cluster_.py
@@ -21,8 +21,8 @@ Revises: 4ce8df208545
 Create Date: 2018-11-26 00:01:04.781119
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "46f444d8b9b7"

--- a/superset/migrations/versions/472d2f73dfd4_.py
+++ b/superset/migrations/versions/472d2f73dfd4_.py
@@ -26,8 +26,8 @@ Create Date: 2017-09-21 18:37:30.844196
 revision = "472d2f73dfd4"
 down_revision = ("19a814813610", "a9c47e2c1547")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/4736ec66ce19_.py
+++ b/superset/migrations/versions/4736ec66ce19_.py
@@ -24,8 +24,8 @@ Create Date: 2017-10-03 14:37:01.376578
 
 import logging
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from superset.utils.core import (
     generic_find_fk_constraint_name,

--- a/superset/migrations/versions/4e6a06bad7a8_init.py
+++ b/superset/migrations/versions/4e6a06bad7a8_init.py
@@ -26,8 +26,8 @@ Create Date: 2015-09-21 17:30:38.442998
 revision = "4e6a06bad7a8"
 down_revision = None
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/4fa88fe24e94_owners_many_to_many.py
+++ b/superset/migrations/versions/4fa88fe24e94_owners_many_to_many.py
@@ -25,8 +25,8 @@ Create Date: 2016-04-15 17:58:33.842012
 revision = "4fa88fe24e94"
 down_revision = "b4456560d4f3"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/525c854f0005_log_this_plus.py
+++ b/superset/migrations/versions/525c854f0005_log_this_plus.py
@@ -26,8 +26,8 @@ Create Date: 2016-12-13 16:19:02.239322
 revision = "525c854f0005"
 down_revision = "e46f2d27a08e"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/55179c7f25c7_sqla_descr.py
+++ b/superset/migrations/versions/55179c7f25c7_sqla_descr.py
@@ -26,8 +26,8 @@ Create Date: 2015-12-13 08:38:43.704145
 revision = "55179c7f25c7"
 down_revision = "315b3f4da9b0"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/55e910a74826_add_metadata_column_to_annotation_model_.py
+++ b/superset/migrations/versions/55e910a74826_add_metadata_column_to_annotation_model_.py
@@ -26,8 +26,8 @@ Create Date: 2018-08-29 14:35:20.407743
 revision = "55e910a74826"
 down_revision = "1a1d627ebd8e"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/5a7bad26f2a7_.py
+++ b/superset/migrations/versions/5a7bad26f2a7_.py
@@ -26,8 +26,8 @@ Create Date: 2015-10-05 10:32:15.850753
 revision = "5a7bad26f2a7"
 down_revision = "4e6a06bad7a8"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/5ccf602336a0_.py
+++ b/superset/migrations/versions/5ccf602336a0_.py
@@ -25,8 +25,8 @@ Create Date: 2018-04-12 16:00:47.639218
 revision = "5ccf602336a0"
 down_revision = ("130915240929", "c9495751e314")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
+++ b/superset/migrations/versions/5e4a03ef0bf0_add_request_access_model.py
@@ -21,8 +21,8 @@ Revises: 41f6a59a61f2
 Create Date: 2016-09-09 17:39:57.846309
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "5e4a03ef0bf0"

--- a/superset/migrations/versions/6414e83d82b7_.py
+++ b/superset/migrations/versions/6414e83d82b7_.py
@@ -25,8 +25,8 @@ Create Date: 2016-12-19 09:57:05.814013
 revision = "6414e83d82b7"
 down_revision = ("525c854f0005", "f1f2d4af5b90")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/65903709c321_allow_dml.py
+++ b/superset/migrations/versions/65903709c321_allow_dml.py
@@ -24,12 +24,12 @@ Create Date: 2016-09-15 08:48:27.284752
 
 import logging
 
+import sqlalchemy as sa
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = "65903709c321"
 down_revision = "4500485bde7d"
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/superset/migrations/versions/67a6ac9b727b_update_spatial_params.py
+++ b/superset/migrations/versions/67a6ac9b727b_update_spatial_params.py
@@ -24,8 +24,8 @@ Create Date: 2017-12-08 08:19:21.148775
 import json
 
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/6c7537a6004a_models_for_email_reports.py
+++ b/superset/migrations/versions/6c7537a6004a_models_for_email_reports.py
@@ -26,8 +26,8 @@ Create Date: 2018-05-15 20:28:51.977572
 revision = "6c7537a6004a"
 down_revision = "a61b40f9f57f"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/705732c70154_.py
+++ b/superset/migrations/versions/705732c70154_.py
@@ -25,8 +25,8 @@ Create Date: 2018-07-22 21:51:19.235558
 revision = "705732c70154"
 down_revision = ("4451805bbaa1", "1d9e835a84f9")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/732f1c06bcbf_add_fetch_values_predicate.py
+++ b/superset/migrations/versions/732f1c06bcbf_add_fetch_values_predicate.py
@@ -26,8 +26,8 @@ Create Date: 2017-03-03 09:15:56.800930
 revision = "732f1c06bcbf"
 down_revision = "d6db5a5cdb5d"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/7467e77870e4_remove_aggs.py
+++ b/superset/migrations/versions/7467e77870e4_remove_aggs.py
@@ -21,8 +21,8 @@ Revises: c829ff0b37d0
 Create Date: 2018-07-22 08:50:01.078218
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "7467e77870e4"

--- a/superset/migrations/versions/763d4b211ec9_fixing_audit_fk.py
+++ b/superset/migrations/versions/763d4b211ec9_fixing_audit_fk.py
@@ -26,8 +26,8 @@ Create Date: 2016-03-24 14:13:44.817723
 revision = "763d4b211ec9"
 down_revision = "d2424a248d63"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/7dbf98566af7_slice_description.py
+++ b/superset/migrations/versions/7dbf98566af7_slice_description.py
@@ -26,8 +26,8 @@ Create Date: 2016-01-17 22:00:23.640788
 revision = "7dbf98566af7"
 down_revision = "8e80a26a31db"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/7e3ddad2a00b_results_key_to_query.py
+++ b/superset/migrations/versions/7e3ddad2a00b_results_key_to_query.py
@@ -26,8 +26,8 @@ Create Date: 2016-10-14 11:17:54.995156
 revision = "7e3ddad2a00b"
 down_revision = "b46fa1b0b39e"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/7fcdcde0761c_.py
+++ b/superset/migrations/versions/7fcdcde0761c_.py
@@ -26,8 +26,8 @@ Create Date: 2018-08-01 11:47:02.233971
 import json
 import re
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db

--- a/superset/migrations/versions/80a67c5192fa_single_pie_chart_metric.py
+++ b/superset/migrations/versions/80a67c5192fa_single_pie_chart_metric.py
@@ -30,11 +30,10 @@ down_revision = "afb7730f6a9c"
 import json
 
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
-
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/80aa3f04bc82_add_parent_ids_in_dashboard_layout.py
+++ b/superset/migrations/versions/80aa3f04bc82_add_parent_ids_in_dashboard_layout.py
@@ -24,12 +24,11 @@ Create Date: 2019-04-09 16:27:03.392872
 import json
 import logging
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import Column, Integer, Text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from alembic import op
-import sqlalchemy as sa
 
 from superset import db
 

--- a/superset/migrations/versions/836c0bf75904_cache_timeouts.py
+++ b/superset/migrations/versions/836c0bf75904_cache_timeouts.py
@@ -25,8 +25,8 @@ Create Date: 2016-03-17 08:40:03.186534
 revision = "836c0bf75904"
 down_revision = "18e88e1cc004"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/867bf4f117f9_adding_extra_field_to_database_model.py
+++ b/superset/migrations/versions/867bf4f117f9_adding_extra_field_to_database_model.py
@@ -25,8 +25,8 @@ Create Date: 2016-04-03 15:23:20.280841
 revision = "867bf4f117f9"
 down_revision = "fee7b758c130"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/8b70aa3d0f87_.py
+++ b/superset/migrations/versions/8b70aa3d0f87_.py
@@ -26,8 +26,8 @@ Create Date: 2019-01-17 08:31:55.781032
 revision = "8b70aa3d0f87"
 down_revision = ("fbd55e0f83eb", "fb13d49b72f9")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/8e80a26a31db_.py
+++ b/superset/migrations/versions/8e80a26a31db_.py
@@ -25,8 +25,8 @@ Create Date: 2016-01-13 20:24:45.256437
 revision = "8e80a26a31db"
 down_revision = "2591d77e9831"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/937d04c16b64_update_datasources.py
+++ b/superset/migrations/versions/937d04c16b64_update_datasources.py
@@ -26,8 +26,8 @@ Create Date: 2018-07-20 16:08:10.195843
 revision = "937d04c16b64"
 down_revision = "d94d33dbe938"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/956a063c52b3_adjusting_key_length.py
+++ b/superset/migrations/versions/956a063c52b3_adjusting_key_length.py
@@ -21,8 +21,8 @@ Revises: f0fbf6129e13
 Create Date: 2016-05-11 17:28:32.407340
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "956a063c52b3"

--- a/superset/migrations/versions/960c69cb1f5b_.py
+++ b/superset/migrations/versions/960c69cb1f5b_.py
@@ -26,8 +26,8 @@ Create Date: 2016-06-16 14:15:19.573183
 revision = "960c69cb1f5b"
 down_revision = "27ae655e4247"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/979c03af3341_.py
+++ b/superset/migrations/versions/979c03af3341_.py
@@ -26,8 +26,8 @@ Create Date: 2017-03-21 15:41:34.383808
 revision = "979c03af3341"
 down_revision = ("db527d8c4c78", "ea033256294a")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/a2d606a761d9_adding_favstar_model.py
+++ b/superset/migrations/versions/a2d606a761d9_adding_favstar_model.py
@@ -26,8 +26,8 @@ Create Date: 2016-03-13 09:56:58.329512
 revision = "a2d606a761d9"
 down_revision = "18e88e1cc004"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/a33a03f16c4a_add_extra_column_to_savedquery.py
+++ b/superset/migrations/versions/a33a03f16c4a_add_extra_column_to_savedquery.py
@@ -41,8 +41,8 @@ Create Date: 2019-01-14 16:00:26.344439
 revision = "a33a03f16c4a"
 down_revision = "fb13d49b72f9"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/a61b40f9f57f_remove_allow_run_sync.py
+++ b/superset/migrations/versions/a61b40f9f57f_remove_allow_run_sync.py
@@ -21,8 +21,8 @@ Revises: 46f444d8b9b7
 Create Date: 2018-11-27 11:53:17.512627
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a61b40f9f57f"

--- a/superset/migrations/versions/a65458420354_add_result_backend_time_logging.py
+++ b/superset/migrations/versions/a65458420354_add_result_backend_time_logging.py
@@ -21,8 +21,8 @@ Revises: 2fcdcb35e487
 Create Date: 2017-04-25 10:00:58.053120
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a65458420354"

--- a/superset/migrations/versions/a6c18f869a4e_query_start_running_time.py
+++ b/superset/migrations/versions/a6c18f869a4e_query_start_running_time.py
@@ -21,8 +21,8 @@ Revises: 979c03af3341
 Create Date: 2017-03-28 11:28:41.387182
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a6c18f869a4e"

--- a/superset/migrations/versions/a99f2f7c195a_rewriting_url_from_shortner_with_new_.py
+++ b/superset/migrations/versions/a99f2f7c195a_rewriting_url_from_shortner_with_new_.py
@@ -26,12 +26,14 @@ Create Date: 2017-02-08 14:16:34.948793
 revision = "a99f2f7c195a"
 down_revision = "db0c65b146bd"
 
-from alembic import op
 import json
-import sqlalchemy as sa
-from superset import db
-from sqlalchemy.ext.declarative import declarative_base
 from urllib import parse
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/a9c47e2c1547_add_impersonate_user_to_dbs.py
+++ b/superset/migrations/versions/a9c47e2c1547_add_impersonate_user_to_dbs.py
@@ -25,8 +25,8 @@ Create Date: 2017-08-31 17:35:58.230723
 revision = "a9c47e2c1547"
 down_revision = "ca69c70ec99b"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/ab3d66c4246e_add_cache_timeout_to_druid_cluster.py
+++ b/superset/migrations/versions/ab3d66c4246e_add_cache_timeout_to_druid_cluster.py
@@ -26,8 +26,8 @@ Create Date: 2016-09-30 18:01:30.579760
 revision = "ab3d66c4246e"
 down_revision = "eca4694defa7"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/ad4d656d92bc_add_avg_metric.py
+++ b/superset/migrations/versions/ad4d656d92bc_add_avg_metric.py
@@ -26,8 +26,8 @@ Create Date: 2016-10-25 10:16:39.871078
 revision = "ad4d656d92bc"
 down_revision = "7e3ddad2a00b"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/ad82a75afd82_add_query_model.py
+++ b/superset/migrations/versions/ad82a75afd82_add_query_model.py
@@ -26,8 +26,8 @@ Create Date: 2016-07-25 17:48:12.771103
 revision = "ad82a75afd82"
 down_revision = "f162a1dea4c4"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/afb7730f6a9c_remove_empty_filters.py
+++ b/superset/migrations/versions/afb7730f6a9c_remove_empty_filters.py
@@ -26,10 +26,11 @@ Create Date: 2018-06-07 09:52:54.535961
 revision = "afb7730f6a9c"
 down_revision = "c5756bec8b47"
 
-from alembic import op
 import json
-from sqlalchemy.ext.declarative import declarative_base
+
+from alembic import op
 from sqlalchemy import Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/afc69274c25a_alter_sql_column_data_type_in_query_mysql_table.py
+++ b/superset/migrations/versions/afc69274c25a_alter_sql_column_data_type_in_query_mysql_table.py
@@ -22,10 +22,10 @@ Revises: e9df189e5c7e
 Create Date: 2019-05-06 14:30:26.181449
 
 """
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.databases import mysql
 from sqlalchemy.dialects.mysql.base import MySQLDialect
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "afc69274c25a"

--- a/superset/migrations/versions/b318dfe5fb6c_adding_verbose_name_to_druid_column.py
+++ b/superset/migrations/versions/b318dfe5fb6c_adding_verbose_name_to_druid_column.py
@@ -26,8 +26,8 @@ Create Date: 2017-03-08 11:48:10.835741
 revision = "b318dfe5fb6c"
 down_revision = "d6db5a5cdb5d"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/b46fa1b0b39e_add_params_to_tables.py
+++ b/superset/migrations/versions/b46fa1b0b39e_add_params_to_tables.py
@@ -26,9 +26,10 @@ Create Date: 2016-10-05 11:30:31.748238
 revision = "b46fa1b0b39e"
 down_revision = "ef8843b41dac"
 
-from alembic import op
 import logging
+
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/b4a38aa87893_deprecate_database_expression.py
+++ b/superset/migrations/versions/b4a38aa87893_deprecate_database_expression.py
@@ -26,8 +26,8 @@ Create Date: 2019-06-05 11:35:16.222519
 revision = "b4a38aa87893"
 down_revision = "ab8c66efdd01"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/b6fa807eac07_make_names_non_nullable.py
+++ b/superset/migrations/versions/b6fa807eac07_make_names_non_nullable.py
@@ -21,8 +21,8 @@ Revises: 1495eb914ad3
 Create Date: 2019-10-02 00:29:16.679272
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from superset.utils.core import generic_find_fk_constraint_name
 

--- a/superset/migrations/versions/bb51420eaf83_add_schema_to_table_model.py
+++ b/superset/migrations/versions/bb51420eaf83_add_schema_to_table_model.py
@@ -26,8 +26,8 @@ Create Date: 2016-04-11 22:41:06.185955
 revision = "bb51420eaf83"
 down_revision = "867bf4f117f9"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/bcf3126872fc_add_keyvalue.py
+++ b/superset/migrations/versions/bcf3126872fc_add_keyvalue.py
@@ -26,8 +26,8 @@ Create Date: 2017-01-10 11:47:56.306938
 revision = "bcf3126872fc"
 down_revision = "f18570e03440"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/bddc498dd179_adhoc_filters.py
+++ b/superset/migrations/versions/bddc498dd179_adhoc_filters.py
@@ -27,20 +27,19 @@ revision = "bddc498dd179"
 down_revision = "80a67c5192fa"
 
 
-from collections import defaultdict
 import json
 import uuid
+from collections import defaultdict
 
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 from superset.utils.core import (
     convert_legacy_filters_into_adhoc,
     split_adhoc_filters_into_base_filters,
 )
-
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/bebcf3fed1fe_convert_dashboard_v1_positions.py
+++ b/superset/migrations/versions/bebcf3fed1fe_convert_dashboard_v1_positions.py
@@ -24,10 +24,10 @@ Create Date: 2018-07-22 11:59:07.025119
 
 # revision identifiers, used by Alembic.
 import collections
-from functools import reduce
 import json
 import sys
 import uuid
+from functools import reduce
 
 from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, String, Table, Text

--- a/superset/migrations/versions/c3a8f8611885_materializing_permission.py
+++ b/superset/migrations/versions/c3a8f8611885_materializing_permission.py
@@ -21,8 +21,8 @@ Revises: 4fa88fe24e94
 Create Date: 2016-04-25 08:54:04.303859
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 

--- a/superset/migrations/versions/c5756bec8b47_time_grain_sqla.py
+++ b/superset/migrations/versions/c5756bec8b47_time_grain_sqla.py
@@ -26,10 +26,11 @@ Create Date: 2018-06-04 11:12:59.878742
 revision = "c5756bec8b47"
 down_revision = "e502db2af7be"
 
-from alembic import op
 import json
-from sqlalchemy.ext.declarative import declarative_base
+
+from alembic import op
 from sqlalchemy import Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/c611f2b591b8_dim_spec.py
+++ b/superset/migrations/versions/c611f2b591b8_dim_spec.py
@@ -26,8 +26,8 @@ Create Date: 2016-11-02 17:36:04.970448
 revision = "c611f2b591b8"
 down_revision = "ad4d656d92bc"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/c617da68de7d_form_nullable.py
+++ b/superset/migrations/versions/c617da68de7d_form_nullable.py
@@ -27,8 +27,8 @@ revision = "c617da68de7d"
 down_revision = "18dc26817ad2"
 
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 from superset.utils.core import MediumText

--- a/superset/migrations/versions/c829ff0b37d0_.py
+++ b/superset/migrations/versions/c829ff0b37d0_.py
@@ -26,8 +26,8 @@ Create Date: 2018-07-22 08:49:48.936117
 revision = "c829ff0b37d0"
 down_revision = ("4451805bbaa1", "1d9e835a84f9")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/c82ee8a39623_add_implicit_tags.py
+++ b/superset/migrations/versions/c82ee8a39623_add_implicit_tags.py
@@ -27,12 +27,11 @@ revision = "c82ee8a39623"
 down_revision = "c617da68de7d"
 
 from alembic import op
-from sqlalchemy import Column, Enum, Integer, ForeignKey, String
+from sqlalchemy import Column, Enum, ForeignKey, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 
 from superset.models.helpers import AuditMixinNullable
 from superset.models.tags import ObjectTypes, TagTypes
-
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/c9495751e314_.py
+++ b/superset/migrations/versions/c9495751e314_.py
@@ -25,8 +25,8 @@ Create Date: 2018-04-10 20:46:57.890773
 revision = "c9495751e314"
 down_revision = ("30bb17c0dc76", "bf706ae5eb46")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/ca69c70ec99b_tracking_url.py
+++ b/superset/migrations/versions/ca69c70ec99b_tracking_url.py
@@ -26,8 +26,8 @@ Create Date: 2017-07-26 20:09:52.606416
 revision = "ca69c70ec99b"
 down_revision = "a65458420354"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import mysql
 
 

--- a/superset/migrations/versions/cefabc8f7d38_increase_size_of_name_column_in_ab_view_.py
+++ b/superset/migrations/versions/cefabc8f7d38_increase_size_of_name_column_in_ab_view_.py
@@ -26,8 +26,8 @@ Create Date: 2018-12-13 15:38:36.772750
 revision = "cefabc8f7d38"
 down_revision = "6c7537a6004a"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/d39b1e37131d_.py
+++ b/superset/migrations/versions/d39b1e37131d_.py
@@ -26,8 +26,8 @@ Create Date: 2017-09-19 15:09:14.292633
 revision = "d39b1e37131d"
 down_revision = ("a9c47e2c1547", "ddd6ebdd853b")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/d6db5a5cdb5d_.py
+++ b/superset/migrations/versions/d6db5a5cdb5d_.py
@@ -25,8 +25,8 @@ Create Date: 2017-02-10 17:58:20.149960
 revision = "d6db5a5cdb5d"
 down_revision = ("a99f2f7c195a", "bcf3126872fc")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/d6ffdf31bdd4_add_published_column_to_dashboards.py
+++ b/superset/migrations/versions/d6ffdf31bdd4_add_published_column_to_dashboards.py
@@ -26,8 +26,8 @@ Create Date: 2018-03-30 14:00:44.929483
 revision = "d6ffdf31bdd4"
 down_revision = "b4a38aa87893"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/d7c1a0d6f2da_remove_limit_used_from_query_model.py
+++ b/superset/migrations/versions/d7c1a0d6f2da_remove_limit_used_from_query_model.py
@@ -26,8 +26,8 @@ Create Date: 2019-06-04 10:12:36.675369
 revision = "d7c1a0d6f2da"
 down_revision = "afc69274c25a"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/d827694c7555_css_templates.py
+++ b/superset/migrations/versions/d827694c7555_css_templates.py
@@ -26,8 +26,8 @@ Create Date: 2016-02-03 17:41:10.944019
 revision = "d827694c7555"
 down_revision = "43df8de3a5f4"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/d8bc074f7aad_add_new_field_is_restricted_to_.py
+++ b/superset/migrations/versions/d8bc074f7aad_add_new_field_is_restricted_to_.py
@@ -26,11 +26,12 @@ Create Date: 2016-06-07 12:33:25.756640
 revision = "d8bc074f7aad"
 down_revision = "1226819ee0e3"
 
-from alembic import op
 import sqlalchemy as sa
-from superset import db
+from alembic import op
+from sqlalchemy import Boolean, Column, Integer
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, Boolean
+
+from superset import db
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/d94d33dbe938_form_strip.py
+++ b/superset/migrations/versions/d94d33dbe938_form_strip.py
@@ -27,8 +27,8 @@ revision = "d94d33dbe938"
 down_revision = "80aa3f04bc82"
 
 from alembic import op
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 from superset.utils.core import MediumText

--- a/superset/migrations/versions/db0c65b146bd_update_slice_model_json.py
+++ b/superset/migrations/versions/db0c65b146bd_update_slice_model_json.py
@@ -26,10 +26,11 @@ Create Date: 2017-01-24 12:31:06.541746
 revision = "db0c65b146bd"
 down_revision = "f18570e03440"
 
-from alembic import op
 import json
-from sqlalchemy.ext.declarative import declarative_base
+
+from alembic import op
 from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/db527d8c4c78_add_db_verbose_name.py
+++ b/superset/migrations/versions/db527d8c4c78_add_db_verbose_name.py
@@ -26,9 +26,10 @@ Create Date: 2017-03-16 18:10:57.193035
 revision = "db527d8c4c78"
 down_revision = "b318dfe5fb6c"
 
-from alembic import op
 import logging
+
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/ddd6ebdd853b_annotations.py
+++ b/superset/migrations/versions/ddd6ebdd853b_annotations.py
@@ -21,8 +21,8 @@ Revises: ca69c70ec99b
 Create Date: 2017-09-13 16:36:39.144489
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "ddd6ebdd853b"

--- a/superset/migrations/versions/e3970889f38e_.py
+++ b/superset/migrations/versions/e3970889f38e_.py
@@ -26,8 +26,8 @@ Create Date: 2018-07-22 09:32:36.986561
 revision = "e3970889f38e"
 down_revision = ("4451805bbaa1", "1d9e835a84f9")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/e46f2d27a08e_materialize_perms.py
+++ b/superset/migrations/versions/e46f2d27a08e_materialize_perms.py
@@ -25,8 +25,8 @@ Create Date: 2016-11-14 15:23:32.594898
 revision = "e46f2d27a08e"
 down_revision = "c611f2b591b8"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/e502db2af7be_add_template_params_to_tables.py
+++ b/superset/migrations/versions/e502db2af7be_add_template_params_to_tables.py
@@ -26,8 +26,8 @@ Create Date: 2018-05-09 23:45:14.296283
 revision = "e502db2af7be"
 down_revision = "5ccf602336a0"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/e553e78e90c5_add_druid_auth_py_py.py
+++ b/superset/migrations/versions/e553e78e90c5_add_druid_auth_py_py.py
@@ -26,8 +26,8 @@ Create Date: 2019-02-01 16:07:04.268023
 revision = "e553e78e90c5"
 down_revision = "18dc26817ad2"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy_utils import EncryptedType
 
 

--- a/superset/migrations/versions/e68c4473c581_allow_multi_schema_metadata_fetch.py
+++ b/superset/migrations/versions/e68c4473c581_allow_multi_schema_metadata_fetch.py
@@ -21,8 +21,8 @@ Revises: e866bd2d4976
 Create Date: 2018-03-06 12:24:30.896293
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "e68c4473c581"

--- a/superset/migrations/versions/e866bd2d4976_smaller_grid.py
+++ b/superset/migrations/versions/e866bd2d4976_smaller_grid.py
@@ -21,10 +21,10 @@ Create Date: 2018-02-13 08:07:40.766277
 """
 import json
 
-from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+from alembic import op
 from flask_appbuilder.models.mixins import AuditMixin
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
 

--- a/superset/migrations/versions/ea033256294a_.py
+++ b/superset/migrations/versions/ea033256294a_.py
@@ -26,8 +26,8 @@ Create Date: 2017-03-16 14:55:59.431283
 revision = "ea033256294a"
 down_revision = ("732f1c06bcbf", "b318dfe5fb6c")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/eca4694defa7_sqllab_setting_defaults.py
+++ b/superset/migrations/versions/eca4694defa7_sqllab_setting_defaults.py
@@ -22,9 +22,10 @@ Create Date: 2016-09-22 11:31:50.543820
 
 """
 from alembic import op
-from superset import db
+from sqlalchemy import Boolean, Column, Integer
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, Boolean
+
+from superset import db
 
 # revision identifiers, used by Alembic.
 revision = "eca4694defa7"

--- a/superset/migrations/versions/f0fbf6129e13_adding_verbose_name_to_tablecolumn.py
+++ b/superset/migrations/versions/f0fbf6129e13_adding_verbose_name_to_tablecolumn.py
@@ -26,8 +26,8 @@ Create Date: 2016-05-01 12:21:18.331191
 revision = "f0fbf6129e13"
 down_revision = "c3a8f8611885"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/f162a1dea4c4_d3format_by_metric.py
+++ b/superset/migrations/versions/f162a1dea4c4_d3format_by_metric.py
@@ -26,8 +26,8 @@ Create Date: 2016-07-06 22:04:28.685100
 revision = "f162a1dea4c4"
 down_revision = "960c69cb1f5b"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/f1f2d4af5b90_.py
+++ b/superset/migrations/versions/f1f2d4af5b90_.py
@@ -26,8 +26,8 @@ Create Date: 2016-11-23 10:27:18.517919
 revision = "f1f2d4af5b90"
 down_revision = "e46f2d27a08e"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/f231d82b9b26_.py
+++ b/superset/migrations/versions/f231d82b9b26_.py
@@ -21,8 +21,8 @@ Revises: e68c4473c581
 Create Date: 2018-03-20 19:47:54.991259
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from superset.utils.core import generic_find_uq_constraint_name
 

--- a/superset/migrations/versions/f959a6652acd_.py
+++ b/superset/migrations/versions/f959a6652acd_.py
@@ -26,8 +26,8 @@ Create Date: 2017-09-24 20:18:35.791707
 revision = "f959a6652acd"
 down_revision = ("472d2f73dfd4", "d39b1e37131d")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/fbd55e0f83eb_.py
+++ b/superset/migrations/versions/fbd55e0f83eb_.py
@@ -26,8 +26,8 @@ Create Date: 2018-12-22 17:26:16.113317
 revision = "fbd55e0f83eb"
 down_revision = ("7467e77870e4", "de021a1ca60d")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/migrations/versions/fc480c87706c_.py
+++ b/superset/migrations/versions/fc480c87706c_.py
@@ -26,8 +26,8 @@ Create Date: 2018-07-22 11:50:54.174443
 revision = "fc480c87706c"
 down_revision = ("4451805bbaa1", "1d9e835a84f9")
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/superset/models/__init__.py
+++ b/superset/models/__init__.py
@@ -14,7 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from . import core  # noqa
-from . import sql_lab  # noqa
-from . import user_attributes  # noqa
-from . import schedules  # noqa
+from . import core, schedules, sql_lab, user_attributes

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -16,21 +16,23 @@
 # under the License.
 # pylint: disable=C,R,W
 """A collection of ORM sqlalchemy models for Superset"""
-from contextlib import closing
-from copy import copy, deepcopy
-from datetime import datetime
 import json
 import logging
 import textwrap
+from contextlib import closing
+from copy import copy, deepcopy
+from datetime import datetime
 from typing import List
+from urllib import parse
 
+import numpy
+import pandas as pd
+import sqlalchemy as sqla
+import sqlparse
 from flask import escape, g, Markup, request
 from flask_appbuilder import Model
 from flask_appbuilder.models.decorators import renders
 from flask_appbuilder.security.sqla.models import User
-import numpy
-import pandas as pd
-import sqlalchemy as sqla
 from sqlalchemy import (
     Boolean,
     Column,
@@ -50,7 +52,6 @@ from sqlalchemy.orm.session import make_transient
 from sqlalchemy.pool import NullPool
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy_utils import EncryptedType
-import sqlparse
 
 from superset import app, db, db_engine_specs, is_feature_enabled, security_manager
 from superset.connectors.connector_registry import ConnectorRegistry
@@ -60,7 +61,6 @@ from superset.models.tags import ChartUpdater, DashboardUpdater, FavStarUpdater
 from superset.models.user_attributes import UserAttribute
 from superset.utils import cache as cache_util, core as utils
 from superset.viz import viz_types
-from urllib import parse  # noqa
 
 config = app.config
 custom_password_store = config.get("SQLALCHEMY_CUSTOM_PASSWORD_STORE")
@@ -71,7 +71,7 @@ metadata = Model.metadata  # pylint: disable=no-member
 PASSWORD_MASK = "X" * 10
 
 
-def set_related_perm(mapper, connection, target):  # noqa
+def set_related_perm(mapper, connection, target):
     src_class = target.cls_model
     id_ = target.datasource_id
     if id_:
@@ -167,14 +167,14 @@ class Slice(Model, AuditMixinNullable, ImportMixin):
     perm = Column(String(1000))
     owners = relationship(security_manager.user_model, secondary=slice_user)
 
-    export_fields = (
+    export_fields = [
         "slice_name",
         "datasource_type",
         "datasource_name",
         "viz_type",
         "params",
         "cache_timeout",
-    )
+    ]
 
     def __repr__(self):
         return self.slice_name or str(self.id)
@@ -424,14 +424,14 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
     owners = relationship(security_manager.user_model, secondary=dashboard_user)
     published = Column(Boolean, default=False)
 
-    export_fields = (
+    export_fields = [
         "dashboard_title",
         "position_json",
         "json_metadata",
         "description",
         "css",
         "slug",
-    )
+    ]
 
     def __repr__(self):
         return self.dashboard_title or str(self.id)
@@ -750,7 +750,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     )
     perm = Column(String(1000))
     impersonate_user = Column(Boolean, default=False)
-    export_fields = (
+    export_fields = [
         "database_name",
         "sqlalchemy_uri",
         "cache_timeout",
@@ -759,7 +759,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         "allow_ctas",
         "allow_csv_upload",
         "extra",
-    )
+    ]
     export_children = ["tables"]
 
     def __repr__(self):

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -16,20 +16,21 @@
 # under the License.
 # pylint: disable=C,R,W
 """a collection of model-related helper classes and functions"""
-from datetime import datetime
 import json
 import logging
 import re
+from datetime import datetime
+from typing import List, Optional
 
+import humanize
+import sqlalchemy as sa
+import yaml
 from flask import escape, g, Markup
 from flask_appbuilder.models.decorators import renders
 from flask_appbuilder.models.mixins import AuditMixin
-import humanize
-import sqlalchemy as sa
 from sqlalchemy import and_, or_, UniqueConstraint
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm.exc import MultipleResultsFound
-import yaml
 
 from superset.utils.core import QueryStatus
 
@@ -44,15 +45,15 @@ def json_to_dict(json_str):
 
 
 class ImportMixin(object):
-    export_parent = None
+    export_parent: Optional[str] = None
     # The name of the attribute
     # with the SQL Alchemy back reference
 
-    export_children = []
+    export_children: List[str] = []
     # List of (str) names of attributes
     # with the SQL Alchemy forward references
 
-    export_fields = []
+    export_fields: List[str] = []
     # The names of the attributes
     # that are available for import and export
 
@@ -300,7 +301,7 @@ class AuditMixinNullable(AuditMixin):
     )
 
     @declared_attr
-    def created_by_fk(self):  # noqa
+    def created_by_fk(self):
         return sa.Column(
             sa.Integer,
             sa.ForeignKey("ab_user.id"),
@@ -309,7 +310,7 @@ class AuditMixinNullable(AuditMixin):
         )
 
     @declared_attr
-    def changed_by_fk(self):  # noqa
+    def changed_by_fk(self):
         return sa.Column(
             sa.Integer,
             sa.ForeignKey("ab_user.id"),
@@ -330,7 +331,7 @@ class AuditMixinNullable(AuditMixin):
         return ""
 
     @renders("created_by")
-    def creator(self):  # noqa
+    def creator(self):
         return self._user_link(self.created_by)
 
     @property
@@ -354,7 +355,7 @@ class QueryResult(object):
 
     """Object returned by the query interface"""
 
-    def __init__(  # noqa
+    def __init__(
         self, df, query, duration, status=QueryStatus.SUCCESS, error_message=None
     ):
         self.df = df

--- a/superset/models/schedules.py
+++ b/superset/models/schedules.py
@@ -27,7 +27,6 @@ from sqlalchemy.orm import relationship
 from superset import security_manager
 from superset.models.helpers import AuditMixinNullable, ImportMixin
 
-
 metadata = Model.metadata  # pylint: disable=no-member
 
 

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -16,12 +16,12 @@
 # under the License.
 # pylint: disable=C,R,W
 """A collection of ORM sqlalchemy models for SQL Lab"""
-from datetime import datetime
 import re
+from datetime import datetime
 
+import sqlalchemy as sqla
 from flask import Markup
 from flask_appbuilder import Model
-import sqlalchemy as sqla
 from sqlalchemy import (
     Boolean,
     Column,

--- a/superset/models/sql_types/presto_sql_types.py
+++ b/superset/models/sql_types/presto_sql_types.py
@@ -19,7 +19,6 @@ from sqlalchemy import types
 from sqlalchemy.sql.sqltypes import Integer
 from sqlalchemy.sql.type_api import TypeEngine
 
-
 # _compiler_dispatch is defined to help with type compilation
 
 

--- a/superset/models/tags.py
+++ b/superset/models/tags.py
@@ -15,12 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W,no-init
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import enum
+from typing import Optional
 
 from flask_appbuilder import Model
 from sqlalchemy import Column, Enum, ForeignKey, Integer, String
@@ -28,7 +26,6 @@ from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.orm.exc import NoResultFound
 
 from superset.models.helpers import AuditMixinNullable
-
 
 Session = sessionmaker(autoflush=False)
 
@@ -109,7 +106,7 @@ def get_object_type(class_name):
 
 class ObjectUpdater(object):
 
-    object_type = None
+    object_type: Optional[str] = None
 
     @classmethod
     def get_owners_ids(cls, target):

--- a/superset/security.py
+++ b/superset/security.py
@@ -37,13 +37,13 @@ from sqlalchemy.orm.mapper import Mapper
 from superset import sql_parse
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.exceptions import SupersetSecurityException
+from superset.utils.core import DatasourceName
 
 if TYPE_CHECKING:
     from superset.common.query_context import QueryContext
-    from superset.models.core import Database, BaseDatasource
+    from superset.connectors.base.models import BaseDatasource
+    from superset.models.core import Database
     from superset.viz import BaseViz
-
-from superset.utils.core import DatasourceName  # noqa: E402
 
 
 class SupersetSecurityListWidget(ListWidget):
@@ -333,9 +333,9 @@ class SupersetSecurityManager(SecurityManager):
 
         table_name_pieces = table_in_query.split(".")
         if len(table_name_pieces) == 3:
-            return tuple(table_name_pieces[1:])  # noqa: T484
+            return tuple(table_name_pieces[1:])  # type: ignore
         elif len(table_name_pieces) == 2:
-            return tuple(table_name_pieces)  # noqa: T484
+            return tuple(table_name_pieces)  # type: ignore
         return (schema, table_name_pieces[0])
 
     def _datasource_access_by_fullname(
@@ -546,8 +546,8 @@ class SupersetSecurityManager(SecurityManager):
         sesh = self.get_session
         pvms = sesh.query(ab_models.PermissionView).filter(
             or_(
-                ab_models.PermissionView.permission == None,  # noqa
-                ab_models.PermissionView.view_menu == None,  # noqa
+                ab_models.PermissionView.permission == None,
+                ab_models.PermissionView.view_menu == None,
             )
         )
         deleted_count = pvms.delete()

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -15,21 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
+import logging
+import uuid
 from contextlib import closing
 from datetime import datetime
-import logging
 from sys import getsizeof
 from typing import Optional, Tuple, Union
-import uuid
 
 import backoff
-from celery.exceptions import SoftTimeLimitExceeded
-from contextlib2 import contextmanager
-from flask_babel import lazy_gettext as _
 import msgpack
 import pyarrow as pa
 import simplejson as json
 import sqlalchemy
+from celery.exceptions import SoftTimeLimitExceeded
+from contextlib2 import contextmanager
+from flask_babel import lazy_gettext as _
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 

--- a/superset/sql_validators/__init__.py
+++ b/superset/sql_validators/__init__.py
@@ -14,12 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional
+from typing import Optional, Type
 
-from . import base  # noqa
-from . import presto_db  # noqa
-from .base import SQLValidationAnnotation  # noqa
+from . import base, presto_db
+from .base import SQLValidationAnnotation
 
 
-def get_validator_by_name(name: str) -> Optional[base.BaseSQLValidator]:
+def get_validator_by_name(name: str) -> Optional[Type[base.BaseSQLValidator]]:
     return {"PrestoDBSQLValidator": presto_db.PrestoDBSQLValidator}.get(name)

--- a/superset/sql_validators/presto_db.py
+++ b/superset/sql_validators/presto_db.py
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from contextlib import closing
 import logging
 import time
+from contextlib import closing
 from typing import Any, Dict, List, Optional
 
 from flask import g

--- a/superset/tasks/__init__.py
+++ b/superset/tasks/__init__.py
@@ -15,5 +15,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from . import schedules  # noqa
-from . import cache  # noqa
+from . import cache, schedules

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -30,7 +30,6 @@ from superset.models.tags import Tag, TaggedObject
 from superset.tasks.celery_app import app as celery_app
 from superset.utils.core import parse_human_datetime
 
-
 logger = get_task_logger(__name__)
 logger.setLevel(logging.INFO)
 

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -18,15 +18,16 @@
 
 """Utility functions used across Superset"""
 
+import logging
+import time
+import urllib.request
 from collections import namedtuple
 from datetime import datetime, timedelta
 from email.utils import make_msgid, parseaddr
-import logging
-import time
 from urllib.error import URLError
-import urllib.request
 
 import croniter
+import simplejson as json
 from dateutil.tz import tzlocal
 from flask import render_template, Response, session, url_for
 from flask_babel import gettext as __
@@ -34,8 +35,7 @@ from flask_login import login_user
 from retry.api import retry_call
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver import chrome, firefox
-import simplejson as json
-from werkzeug.utils import parse_cookie
+from werkzeug.http import parse_cookie
 
 # Superset framework imports
 from superset import app, db, security_manager

--- a/superset/translations/utils.py
+++ b/superset/translations/utils.py
@@ -17,9 +17,10 @@
 # pylint: disable=C,R,W
 import json
 import os
+from typing import Any, Dict
 
 # Global caching for JSON language packs
-ALL_LANGUAGE_PACKS = {"en": {}}
+ALL_LANGUAGE_PACKS: Dict[str, Dict[Any, Any]] = {"en": {}}
 
 DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -16,13 +16,7 @@
 # under the License.
 # pylint: disable=C,R,W
 """Utility functions used across Superset"""
-from datetime import date, datetime, time, timedelta
 import decimal
-from email.mime.application import MIMEApplication
-from email.mime.image import MIMEImage
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
-from email.utils import formatdate
 import errno
 import functools
 import json
@@ -30,32 +24,32 @@ import logging
 import os
 import signal
 import smtplib
-from time import struct_time
 import traceback
-from typing import Iterator, List, NamedTuple, Optional, Tuple, Union
-from urllib.parse import unquote_plus
 import uuid
 import zlib
+from datetime import date, datetime, time, timedelta
+from email.mime.application import MIMEApplication
+from email.mime.image import MIMEImage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formatdate
+from time import struct_time
+from typing import Iterator, List, NamedTuple, Optional, Tuple, Union
+from urllib.parse import unquote_plus
 
 import bleach
 import celery
-from dateutil.parser import parse
-from dateutil.relativedelta import relativedelta
-from flask import current_app, flash, Flask, g, Markup, render_template
-from flask_appbuilder.security.sqla.models import User
-from flask_babel import gettext as __
-from flask_babel import lazy_gettext as _
-from flask_caching import Cache
 import markdown as md
 import numpy
 import pandas as pd
 import parsedatetime
-
-try:
-    from pydruid.utils.having import Having
-except ImportError:
-    pass
 import sqlalchemy as sa
+from dateutil.parser import parse
+from dateutil.relativedelta import relativedelta
+from flask import current_app, flash, Flask, g, Markup, render_template
+from flask_appbuilder.security.sqla.models import User
+from flask_babel import gettext as __, lazy_gettext as _
+from flask_caching import Cache
 from sqlalchemy import event, exc, select, Text
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.sql.type_api import Variant
@@ -63,6 +57,11 @@ from sqlalchemy.types import TEXT, TypeDecorator
 
 from superset.exceptions import SupersetException, SupersetTimeoutException
 from superset.utils.dates import datetime_to_epoch, EPOCH
+
+try:
+    from pydruid.utils.having import Having
+except ImportError:
+    pass
 
 
 logging.getLogger("MARKDOWN").setLevel(logging.INFO)
@@ -105,7 +104,7 @@ def flasher(msg, severity=None):
             logging.info(msg)
 
 
-class _memoized:  # noqa
+class _memoized:
     """Decorator that caches a function's return value each time it is called
 
     If called later with the same arguments, the cached value is returned, and
@@ -1048,23 +1047,23 @@ def get_since_until(
     relative_end = parse_human_datetime(relative_end if relative_end else "today")
     common_time_frames = {
         "Last day": (
-            relative_start - relativedelta(days=1),  # noqa: T400
+            relative_start - relativedelta(days=1),  # type: ignore
             relative_end,
         ),
         "Last week": (
-            relative_start - relativedelta(weeks=1),  # noqa: T400
+            relative_start - relativedelta(weeks=1),  # type: ignore
             relative_end,
         ),
         "Last month": (
-            relative_start - relativedelta(months=1),  # noqa: T400
+            relative_start - relativedelta(months=1),  # type: ignore
             relative_end,
         ),
         "Last quarter": (
-            relative_start - relativedelta(months=3),  # noqa: T400
+            relative_start - relativedelta(months=3),  # type: ignore
             relative_end,
         ),
         "Last year": (
-            relative_start - relativedelta(years=1),  # noqa: T400
+            relative_start - relativedelta(years=1),  # type: ignore
             relative_end,
         ),
     }
@@ -1083,13 +1082,15 @@ def get_since_until(
         else:
             rel, num, grain = time_range.split()
             if rel == "Last":
-                since = relative_start - relativedelta(  # noqa: T400
+                since = relative_start - relativedelta(  # type: ignore
                     **{grain: int(num)}
                 )
                 until = relative_end
             else:  # rel == 'Next'
                 since = relative_start
-                until = relative_end + relativedelta(**{grain: int(num)})  # noqa: T400
+                until = relative_end + relativedelta(  # type: ignore
+                    **{grain: int(num)}
+                )
     else:
         since = since or ""
         if since:
@@ -1099,13 +1100,13 @@ def get_since_until(
 
     if time_shift:
         time_delta = parse_past_timedelta(time_shift)
-        since = since if since is None else (since - time_delta)  # noqa: T400
-        until = until if until is None else (until - time_delta)  # noqa: T400
+        since = since if since is None else (since - time_delta)  # type: ignore
+        until = until if until is None else (until - time_delta)  # type: ignore
 
     if since and until and since > until:
         raise ValueError(_("From date cannot be larger than to date"))
 
-    return since, until  # noqa: T400
+    return since, until  # type: ignore
 
 
 def add_ago_to_since(since: str) -> str:

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -14,16 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
 from datetime import datetime, timedelta
 from functools import wraps
-import logging
 
 from contextlib2 import contextmanager
 from flask import request
 
 from superset import app, cache
 from superset.utils.dates import now_as_float
-
 
 # If a user sets `max_age` to 0, for long the browser should cache the
 # resource? Flask-Caching will cache forever, but for the HTTP header we need

--- a/superset/utils/dict_import_export.py
+++ b/superset/utils/dict_import_export.py
@@ -20,7 +20,6 @@ import logging
 from superset.connectors.druid.models import DruidCluster
 from superset.models.core import Database
 
-
 DATABASES_KEY = "databases"
 DRUID_CLUSTERS_KEY = "druid_clusters"
 

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
-from abc import ABC, abstractmethod
-from datetime import datetime
 import functools
 import inspect
 import json
 import logging
 import textwrap
+from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any, cast, Type
 
 from flask import current_app, g, request

--- a/superset/utils/logging_configurator.py
+++ b/superset/utils/logging_configurator.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# noqa: T484
 import abc
 import logging
 from logging.handlers import TimedRotatingFileHandler
@@ -50,16 +49,14 @@ class DefaultLoggingConfigurator(LoggingConfigurator):
             )  # pylint: disable=no-member
             superset_logger.setLevel(logging.INFO)  # pylint: disable=no-member
 
-        logging.getLogger("pyhive.presto").setLevel(logging.INFO)  # noqa: T484
+        logging.getLogger("pyhive.presto").setLevel(logging.INFO)
 
-        logging.basicConfig(format=app_config.get("LOG_FORMAT"))  # noqa: T484
-        logging.getLogger().setLevel(app_config.get("LOG_LEVEL"))  # noqa: T484
+        logging.basicConfig(format=app_config["LOG_FORMAT"])
+        logging.getLogger().setLevel(app_config["LOG_LEVEL"])
 
         if app_config.get("ENABLE_TIME_ROTATE"):
-            logging.getLogger().setLevel(  # noqa: T484
-                app_config.get("TIME_ROTATE_LOG_LEVEL")
-            )
-            handler = TimedRotatingFileHandler(  # noqa: T484
+            logging.getLogger().setLevel(app_config["TIME_ROTATE_LOG_LEVEL"])
+            handler = TimedRotatingFileHandler(  # type: ignore
                 app_config.get("FILENAME"),
                 when=app_config.get("ROLLOVER"),
                 interval=app_config.get("INTERVAL"),

--- a/superset/views/__init__.py
+++ b/superset/views/__init__.py
@@ -14,14 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from . import base  # noqa
-from . import api  # noqa
-from . import core  # noqa
-from . import sql_lab  # noqa
-from . import dashboard  # noqa
-from . import annotations  # noqa
-from . import datasource  # noqa
-from . import schedules  # noqa
-from . import tags  # noqa
-from .log import views  # noqa
-from .log import api as log_api  # noqa
+from . import (
+    annotations,
+    api,
+    base,
+    core,
+    dashboard,
+    datasource,
+    schedules,
+    sql_lab,
+    tags,
+)
+from .log import api as log_api, views

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -16,12 +16,12 @@
 # under the License.
 # pylint: disable=C,R,W
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_babel import gettext as __
-from flask_babel import lazy_gettext as _
+from flask_babel import gettext as __, lazy_gettext as _
 from wtforms.validators import StopValidation
 
 from superset import appbuilder
 from superset.models.annotations import Annotation, AnnotationLayer
+
 from .base import DeleteMixin, SupersetModelView
 
 
@@ -43,7 +43,7 @@ class StartEndDttmValidator(object):
             )
 
 
-class AnnotationModelView(SupersetModelView, DeleteMixin):  # noqa
+class AnnotationModelView(SupersetModelView, DeleteMixin):
     datamodel = SQLAInterface(Annotation)
 
     list_title = _("List Annotation")

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -15,16 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=R
+import simplejson as json
 from flask import request
 from flask_appbuilder import expose
 from flask_appbuilder.security.decorators import has_access_api
-import simplejson as json
 
+import superset.models.core as models
 from superset import appbuilder, db, event_logger, security_manager
 from superset.common.query_context import QueryContext
 from superset.legacy import update_time_range
-import superset.models.core as models
 from superset.utils import core as utils
+
 from .base import api, BaseSupersetView, handle_api_exception
 
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -15,26 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
-from datetime import datetime
 import functools
 import logging
 import traceback
+from datetime import datetime
 from typing import Any, Dict
 
+import simplejson as json
+import yaml
 from flask import abort, flash, g, get_flashed_messages, redirect, Response
 from flask_appbuilder import BaseView, ModelView
 from flask_appbuilder.actions import action
 from flask_appbuilder.forms import DynamicForm
 from flask_appbuilder.models.sqla.filters import BaseFilter
 from flask_appbuilder.widgets import ListWidget
-from flask_babel import get_locale
-from flask_babel import gettext as __
-from flask_babel import lazy_gettext as _
+from flask_babel import get_locale, gettext as __, lazy_gettext as _
 from flask_wtf.form import FlaskForm
-import simplejson as json
 from werkzeug.exceptions import HTTPException
 from wtforms.fields.core import Field, UnboundField
-import yaml
 
 from superset import conf, db, get_feature_flags, security_manager
 from superset.exceptions import SupersetException, SupersetSecurityException
@@ -200,7 +198,7 @@ class ListWidgetWithCheckboxes(ListWidget):
     template = "superset/fab_overrides/list_with_checkboxes.html"
 
 
-def validate_json(form, field):  # noqa
+def validate_json(form, field):
     try:
         json.loads(field.data)
     except Exception as e:
@@ -335,7 +333,7 @@ class SupersetFilter(BaseFilter):
 
 
 class DatasourceFilter(SupersetFilter):
-    def apply(self, query, func):  # noqa
+    def apply(self, query, func):
         if security_manager.all_datasource_access():
             return query
         perms = self.get_view_menus("datasource_access")
@@ -348,7 +346,7 @@ class CsvResponse(Response):
     Override Response to take into account csv encoding from config.py
     """
 
-    charset = conf.get("CSV_EXPORT").get("encoding", "utf-8")
+    charset = conf["CSV_EXPORT"].get("encoding", "utf-8")
 
 
 def check_ownership(obj, raise_if_false=True):

--- a/superset/views/dashboard.py
+++ b/superset/views/dashboard.py
@@ -21,6 +21,7 @@ from flask_appbuilder.security.decorators import has_access
 
 from superset import appbuilder, db
 from superset.models import core as models
+
 from .base import BaseSupersetView
 
 

--- a/superset/views/database/__init__.py
+++ b/superset/views/database/__init__.py
@@ -50,14 +50,14 @@ def sqlalchemy_uri_validator(
 
 
 class DatabaseFilter(SupersetFilter):
-    def apply(self, query, func):  # noqa
+    def apply(self, query, func):
         if security_manager.all_database_access():
             return query
         perms = self.get_view_menus("database_access")
         return query.filter(self.model.perm.in_(perms))
 
 
-class DatabaseMixin:  # noqa
+class DatabaseMixin:
     list_title = _("Databases")
     show_title = _("Show Database")
     add_title = _("Add Database")

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -17,8 +17,9 @@
 from flask_appbuilder import ModelRestApi
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
-from superset import appbuilder
 import superset.models.core as models
+from superset import appbuilder
+
 from . import DatabaseFilter, DatabaseMixin, sqlalchemy_uri_validator
 
 

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -33,7 +33,7 @@ config = app.config
 
 class CsvToDatabaseForm(DynamicForm):
     # pylint: disable=E0211
-    def csv_allowed_dbs():
+    def csv_allowed_dbs():  # type: ignore
         csv_allowed_dbs = []
         csv_enabled_dbs = (
             db.session.query(models.Database).filter_by(allow_csv_upload=True).all()

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -21,21 +21,20 @@ from flask import flash, redirect
 from flask_appbuilder import SimpleFormView
 from flask_appbuilder.forms import DynamicForm
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_babel import gettext as __
-from flask_babel import lazy_gettext as _
+from flask_babel import gettext as __, lazy_gettext as _
 from sqlalchemy.exc import IntegrityError
 from werkzeug.utils import secure_filename
 from wtforms.fields import StringField
 from wtforms.validators import ValidationError
 
+import superset.models.core as models
 from superset import app, appbuilder, security_manager
 from superset.connectors.sqla.models import SqlaTable
-import superset.models.core as models
 from superset.utils import core as utils
 from superset.views.base import DeleteMixin, SupersetModelView, YamlExportMixin
+
 from . import DatabaseMixin, sqlalchemy_uri_validator
 from .forms import CsvToDatabaseForm
-
 
 config = app.config
 stats_logger = config.get("STATS_LOGGER")
@@ -48,9 +47,7 @@ def sqlalchemy_uri_form_validator(form: DynamicForm, field: StringField) -> None
     sqlalchemy_uri_validator(field.data, exception=ValidationError)
 
 
-class DatabaseView(
-    DatabaseMixin, SupersetModelView, DeleteMixin, YamlExportMixin
-):  # noqa
+class DatabaseView(DatabaseMixin, SupersetModelView, DeleteMixin, YamlExportMixin):
     datamodel = SQLAInterface(models.Database)
 
     add_template = "superset/models/database/add.html"

--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -24,6 +24,7 @@ from flask_appbuilder.security.decorators import has_access_api
 from superset import appbuilder, db
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.models.core import Database
+
 from .base import BaseSupersetView, json_error_response
 
 

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -17,8 +17,9 @@
 from flask_appbuilder import ModelRestApi
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
-from superset import app, appbuilder
 import superset.models.core as models
+from superset import app, appbuilder
+
 from . import LogMixin
 
 

--- a/superset/views/log/views.py
+++ b/superset/views/log/views.py
@@ -18,9 +18,10 @@
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import gettext as __
 
-from superset import app, appbuilder
 import superset.models.core as models
+from superset import app, appbuilder
 from superset.views.base import SupersetModelView
+
 from . import LogMixin
 
 

--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -15,17 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
-
 import enum
+from typing import Optional, Type
 
+import simplejson as json
 from croniter import croniter
 from flask import flash, g
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
-from flask_babel import gettext as __
-from flask_babel import lazy_gettext as _
-import simplejson as json
+from flask_babel import gettext as __, lazy_gettext as _
 from wtforms import BooleanField, StringField
 
 from superset import app, appbuilder, db, security_manager
@@ -39,13 +38,14 @@ from superset.models.schedules import (
 from superset.tasks.schedules import schedule_email_report
 from superset.utils.core import get_email_address_list, json_iso_dttm_ser
 from superset.views.core import json_success
+
 from .base import DeleteMixin, SupersetModelView
 
 
 class EmailScheduleView(SupersetModelView, DeleteMixin):
     _extra_data = {"test_email": False, "test_email_recipients": None}
-    schedule_type = None
-    schedule_type_model = None
+    schedule_type: Optional[Type] = None
+    schedule_type_model: Optional[Type] = None
 
     page_size = 20
 
@@ -150,7 +150,7 @@ class EmailScheduleView(SupersetModelView, DeleteMixin):
 
 
 class DashboardEmailScheduleView(EmailScheduleView):
-    schedule_type = ScheduleType.dashboard.name
+    schedule_type = ScheduleType.dashboard.value
     schedule_type_model = Dashboard
 
     add_title = _("Schedule Email Reports for Dashboards")
@@ -209,7 +209,7 @@ class DashboardEmailScheduleView(EmailScheduleView):
 
 
 class SliceEmailScheduleView(EmailScheduleView):
-    schedule_type = ScheduleType.slice.name
+    schedule_type = ScheduleType.slice.value
     schedule_type_model = Slice
     add_title = _("Schedule Email Reports for Charts")
     edit_title = add_title

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -17,18 +17,18 @@
 # pylint: disable=C,R,W
 from typing import Callable
 
+import simplejson as json
 from flask import g, redirect
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
-from flask_babel import gettext as __
-from flask_babel import lazy_gettext as _
+from flask_babel import gettext as __, lazy_gettext as _
 from flask_sqlalchemy import BaseQuery
-import simplejson as json
 
 from superset import appbuilder, get_feature_flags, security_manager
 from superset.models.sql_lab import Query, SavedQuery
 from superset.utils import core as utils
+
 from .base import BaseSupersetView, DeleteMixin, SupersetFilter, SupersetModelView
 
 

--- a/superset/views/tags.py
+++ b/superset/views/tags.py
@@ -15,16 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=C,R,W
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
+import simplejson as json
 from flask import request, Response
 from flask_appbuilder import expose
 from flask_appbuilder.security.decorators import has_access_api
 from jinja2.sandbox import SandboxedEnvironment
-import simplejson as json
 from sqlalchemy import and_, func
 from werkzeug.routing import BaseConverter
 
@@ -33,6 +30,7 @@ from superset.jinja_context import current_user_id, current_username
 from superset.models.core import Dashboard, Slice
 from superset.models.sql_lab import SavedQuery
 from superset.models.tags import ObjectTypes, Tag, TaggedObject, TagTypes
+
 from .base import BaseSupersetView, json_success
 
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -19,16 +19,15 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 from urllib import parse
 
-from flask import request
 import simplejson as json
+from flask import request
 
+import superset.models.core as models
 from superset import app, db, viz
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.exceptions import SupersetException
 from superset.legacy import update_time_range
-import superset.models.core as models
 from superset.utils.core import QueryStatus
-
 
 FORM_DATA_KEY_BLACKLIST: List[str] = []
 if not app.config.get("ENABLE_JAVASCRIPT_CONTROLS"):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -20,31 +20,31 @@
 These objects represent the backend of all the visualizations that
 Superset can render.
 """
-from collections import defaultdict, OrderedDict
 import copy
-from datetime import datetime, timedelta
-from functools import reduce
 import hashlib
 import inspect
-from itertools import product
 import logging
 import math
 import pickle as pkl
 import re
-from typing import Any, Dict, List, Optional
 import uuid
+from collections import defaultdict, OrderedDict
+from datetime import datetime, timedelta
+from functools import reduce
+from itertools import product
+from typing import Any, Dict, List, Optional
 
+import geohash
+import numpy as np
+import pandas as pd
+import polyline
+import simplejson as json
 from dateutil import relativedelta as rdelta
 from flask import request
 from flask_babel import lazy_gettext as _
-import geohash
 from geopy.point import Point
 from markdown import markdown
-import numpy as np
-import pandas as pd
 from pandas.tseries.frequencies import to_offset
-import polyline
-import simplejson as json
 
 from superset import app, cache, get_css_manifest_files
 from superset.exceptions import NullValueException, SpatialException
@@ -55,7 +55,6 @@ from superset.utils.core import (
     merge_extra_filters,
     to_adhoc,
 )
-
 
 config = app.config
 stats_logger = config.get("STATS_LOGGER")
@@ -686,7 +685,7 @@ class PivotTableViz(BaseViz):
 
         # Ensure that Pandas's sum function mimics that of SQL.
         if aggfunc == "sum":
-            aggfunc = lambda x: x.sum(min_count=1)  # noqa: E731
+            aggfunc = lambda x: x.sum(min_count=1)
 
         groupby = self.form_data.get("groupby")
         columns = self.form_data.get("columns")
@@ -1525,7 +1524,7 @@ class DistributionBarViz(DistributionPieViz):
     is_timeseries = False
 
     def query_obj(self):
-        d = super().query_obj()  # noqa
+        d = super().query_obj()
         fd = self.form_data
         if len(d["groupby"]) < len(fd.get("groupby") or []) + len(
             fd.get("columns") or []
@@ -2771,6 +2770,6 @@ viz_types = {
     if (
         inspect.isclass(o)
         and issubclass(o, BaseViz)
-        and o.viz_type not in config.get("VIZ_TYPE_BLACKLIST")
+        and o.viz_type not in config["VIZ_TYPE_BLACKLIST"]
     )
 }

--- a/tests/access_tests.py
+++ b/tests/access_tests.py
@@ -24,6 +24,7 @@ from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.druid.models import DruidDatasource
 from superset.connectors.sqla.models import SqlaTable
 from superset.models import core as models
+
 from .base_tests import SupersetTestCase
 
 ROLE_TABLES_PERM_DATA = {

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -20,8 +20,8 @@ import json
 import unittest
 from unittest.mock import Mock, patch
 
-from flask_appbuilder.security.sqla import models as ab_models
 import pandas as pd
+from flask_appbuilder.security.sqla import models as ab_models
 
 from superset import app, db, is_feature_enabled, security_manager
 from superset.connectors.druid.models import DruidCluster, DruidDatasource

--- a/tests/cache_tests.py
+++ b/tests/cache_tests.py
@@ -19,6 +19,7 @@ import json
 
 from superset import cache, db
 from superset.utils.core import QueryStatus
+
 from .base_tests import SupersetTestCase
 
 

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -29,8 +29,8 @@ from superset.models.helpers import QueryStatus
 from superset.models.sql_lab import Query
 from superset.sql_parse import ParsedQuery
 from superset.utils.core import get_example_database
-from .base_tests import SupersetTestCase
 
+from .base_tests import SupersetTestCase
 
 BASE_DIR = app.config.get("BASE_DIR")
 CELERY_SLEEP_TIME = 5

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -41,6 +41,7 @@ from superset.models.sql_lab import Query
 from superset.utils import core as utils
 from superset.views import core as views
 from superset.views.database.views import DatabaseView
+
 from .base_tests import SupersetTestCase
 from .fixtures.pyodbcRow import Row
 

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -24,6 +24,7 @@ from sqlalchemy import func
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.models import core as models
+
 from .base_tests import SupersetTestCase
 
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -20,6 +20,7 @@ import pandas as pd
 from superset.dataframe import dedup, SupersetDataFrame
 from superset.db_engine_specs import BaseEngineSpec
 from superset.db_engine_specs.presto import PrestoEngineSpec
+
 from .base_tests import SupersetTestCase
 
 

--- a/tests/db_engine_specs_test.py
+++ b/tests/db_engine_specs_test.py
@@ -38,6 +38,7 @@ from superset.db_engine_specs.presto import PrestoEngineSpec
 from superset.db_engine_specs.sqlite import SqliteEngineSpec
 from superset.models.core import Database
 from superset.utils.core import get_example_database
+
 from .base_tests import SupersetTestCase
 
 
@@ -764,7 +765,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         result = str(expr.compile(dialect=postgresql.dialect()))
         self.assertEqual(
             result,
-            "DATE_TRUNC('year', (timestamp 'epoch' + lower_case * interval '1 second'))",  # noqa ignore: E50
+            "DATE_TRUNC('year', (timestamp 'epoch' + lower_case * interval '1 second'))",
         )
 
     def test_pg_time_expression_mixed_case_column_1y_grain(self):
@@ -792,7 +793,7 @@ class DbEngineSpecsTestCase(SupersetTestCase):
         self.assertEqual(
             result,
             'DATETIMECONVERT(tstamp, "1:SECONDS:EPOCH", "1:SECONDS:EPOCH", "1:MONTHS")',
-        )  # noqa
+        )
 
     def test_column_datatype_to_string(self):
         example_db = get_example_database()

--- a/tests/dict_import_export_tests.py
+++ b/tests/dict_import_export_tests.py
@@ -24,6 +24,7 @@ from superset import db
 from superset.connectors.druid.models import DruidColumn, DruidDatasource, DruidMetric
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.utils.core import get_example_database
+
 from .base_tests import SupersetTestCase
 
 DBREF = "dict_import__export_test"

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -18,6 +18,12 @@ import json
 import unittest
 from unittest.mock import Mock
 
+import superset.connectors.druid.models as models
+from superset.connectors.druid.models import DruidColumn, DruidDatasource, DruidMetric
+from superset.exceptions import SupersetException
+
+from .base_tests import SupersetTestCase
+
 try:
     from pydruid.utils.dimensions import (
         MapLookupExtraction,
@@ -27,11 +33,6 @@ try:
     import pydruid.utils.postaggregator as postaggs
 except ImportError:
     pass
-
-import superset.connectors.druid.models as models
-from superset.connectors.druid.models import DruidColumn, DruidDatasource, DruidMetric
-from superset.exceptions import SupersetException
-from .base_tests import SupersetTestCase
 
 
 def mock_metric(metric_name, is_postagg=False):

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -15,12 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for Superset"""
-from datetime import datetime
 import json
 import unittest
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 from superset import db, security_manager
+
+from .base_tests import SupersetTestCase
 
 try:
     from superset.connectors.druid.models import (
@@ -31,7 +33,6 @@ try:
     )
 except ImportError:
     pass
-from .base_tests import SupersetTestCase
 
 
 class PickableMock(Mock):
@@ -94,7 +95,7 @@ GB_RESULT_SET = [
     },
 ]
 
-DruidCluster.get_druid_version = lambda _: "0.9.1"
+DruidCluster.get_druid_version = lambda _: "0.9.1"  # type: ignore
 
 
 class DruidTests(SupersetTestCase):

--- a/tests/email_tests.py
+++ b/tests/email_tests.py
@@ -16,16 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for email service in Superset"""
-from email.mime.application import MIMEApplication
-from email.mime.image import MIMEImage
-from email.mime.multipart import MIMEMultipart
 import logging
 import tempfile
 import unittest
+from email.mime.application import MIMEApplication
+from email.mime.image import MIMEImage
+from email.mime.multipart import MIMEMultipart
 from unittest import mock
 
 from superset import app
 from superset.utils import core as utils
+
 from .utils import read_fixture
 
 send_email_test = mock.Mock()

--- a/tests/import_export_tests.py
+++ b/tests/import_export_tests.py
@@ -26,6 +26,7 @@ from superset.connectors.druid.models import DruidColumn, DruidDatasource, Druid
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.models import core as models
 from superset.utils import core as utils
+
 from .base_tests import SupersetTestCase
 
 
@@ -251,7 +252,7 @@ class ImportExportTests(SupersetTestCase):
         self.login("admin")
         birth_dash = self.get_dash_by_slug("births")
         world_health_dash = self.get_dash_by_slug("world_health")
-        export_dash_url = "/dashboard/export_dashboards_form?id={}&id={}&action=go".format(  # noqa ignore: E50
+        export_dash_url = "/dashboard/export_dashboards_form?id={}&id={}&action=go".format(
             birth_dash.id, world_health_dash.id
         )
         resp = self.client.get(export_dash_url)

--- a/tests/load_examples_test.py
+++ b/tests/load_examples_test.py
@@ -16,6 +16,7 @@
 # under the License.
 from superset import examples
 from superset.cli import load_test_users_run
+
 from .base_tests import SupersetTestCase
 
 

--- a/tests/macro_tests.py
+++ b/tests/macro_tests.py
@@ -16,8 +16,7 @@
 # under the License.
 from flask import json
 
-from superset import app
-from superset import jinja_context
+from superset import app, jinja_context
 from tests.base_tests import SupersetTestCase
 
 

--- a/tests/migration_tests.py
+++ b/tests/migration_tests.py
@@ -20,6 +20,7 @@ from superset.migrations.versions.fb13d49b72f9_better_filters import (
     Slice,
     upgrade_slice,
 )
+
 from .base_tests import SupersetTestCase
 
 

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -23,6 +23,7 @@ from sqlalchemy.engine.url import make_url
 from superset import app
 from superset.models.core import Database
 from superset.utils.core import get_example_database, QueryStatus
+
 from .base_tests import SupersetTestCase
 
 

--- a/tests/schedules_test.py
+++ b/tests/schedules_test.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime, timedelta
 import unittest
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch, PropertyMock
 
 from flask_babel import gettext as __
@@ -35,6 +35,7 @@ from superset.tasks.schedules import (
     deliver_slice,
     next_schedules,
 )
+
 from .utils import read_fixture
 
 

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch
 
 from superset import app, appbuilder, security_manager, viz
 from superset.exceptions import SupersetSecurityException
+
 from .base_tests import SupersetTestCase
 
 

--- a/tests/sql_validator_tests.py
+++ b/tests/sql_validator_tests.py
@@ -27,6 +27,7 @@ from superset.sql_validators.presto_db import (
     PrestoDBSQLValidator,
     PrestoSQLValidationError,
 )
+
 from .base_tests import SupersetTestCase
 
 PRESTO_TEST_FEATURE_FLAGS = {
@@ -119,7 +120,7 @@ class PrestoValidatorTests(SupersetTestCase):
 
     def setUp(self):
         self.validator = PrestoDBSQLValidator
-        self.database = MagicMock()  # noqa
+        self.database = MagicMock()
         self.database_engine = self.database.get_sqla_engine.return_value
         self.database_conn = self.database_engine.raw_connection.return_value
         self.database_cursor = self.database_conn.cursor.return_value

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -17,6 +17,7 @@
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.db_engine_specs.druid import DruidEngineSpec
 from superset.utils.core import get_example_database
+
 from .base_tests import SupersetTestCase
 
 

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for Sql Lab"""
-from datetime import datetime, timedelta
 import json
+from datetime import datetime, timedelta
 
 import prison
 
@@ -25,6 +25,7 @@ from superset.dataframe import SupersetDataFrame
 from superset.db_engine_specs import BaseEngineSpec
 from superset.models.sql_lab import Query
 from superset.utils.core import datetime_to_epoch, get_example_database
+
 from .base_tests import SupersetTestCase
 
 QUERY_1 = "SELECT * FROM birth_names LIMIT 1"

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -26,8 +26,8 @@ from superset.tasks.cache import (
     get_form_data,
     TopNDashboardsStrategy,
 )
-from .base_tests import SupersetTestCase
 
+from .base_tests import SupersetTestCase
 
 URL_PREFIX = "0.0.0.0:8081"
 

--- a/tests/superset_test_config.py
+++ b/tests/superset_test_config.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# flake8: noqa
 from copy import copy
-from superset.config import *
+
+from superset.config import *  # type: ignore
 
 AUTH_USER_REGISTRATION_ROLE = "alpha"
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(DATA_DIR, "unittests.db")
@@ -26,7 +26,7 @@ SUPERSET_WEBSERVER_PORT = 8081
 # Allowing SQLALCHEMY_DATABASE_URI to be defined as an env var for
 # continuous integration
 if "SUPERSET__SQLALCHEMY_DATABASE_URI" in os.environ:
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SUPERSET__SQLALCHEMY_DATABASE_URI")
+    SQLALCHEMY_DATABASE_URI = os.environ["SUPERSET__SQLALCHEMY_DATABASE_URI"]
 
 SQL_SELECT_AS_CTA = True
 SQL_MAX_ROW = 666

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -14,15 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import unittest
+import uuid
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-import unittest
 from unittest.mock import patch
-import uuid
 
+import numpy
 from flask import Flask
 from flask_caching import Cache
-import numpy
 from sqlalchemy.exc import ArgumentError
 
 from superset import app, db, security_manager

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -14,17 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import uuid
 from datetime import datetime
 from unittest.mock import Mock, patch
-import uuid
 
 import numpy as np
 import pandas as pd
 
+import superset.viz as viz
 from superset import app
 from superset.exceptions import SpatialException
 from superset.utils.core import DTTM_ALIAS
-import superset.viz as viz
+
 from .base_tests import SupersetTestCase
 from .utils import load_fixture
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,26 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-[flake8]
-accept-encodings = utf-8
-application-import-names =
-    superset
-    tests
-commands =
-    flake8 setup.py superset tests
-exclude =
-    superset/assets
-    superset/data
-    superset/migrations
-ignore =
-    E203
-    E501
-    I202
-    W503
-    W605
-import-order-style = google
-max-line-length = 88
-
 [testenv]
 commands =
     {toxinidir}/superset/bin/superset db upgrade
@@ -104,9 +84,15 @@ commands =
     npm run lint
 deps =
 
-[testenv:flake8]
+[testenv:fossa]
 commands =
-    flake8 setup.py superset tests
+    {toxinidir}/scripts/fossa.sh
+deps =
+passenv = *
+
+[testenv:isort]
+commands =
+    isort --check-only --recursive setup.py superset tests
 deps =
     -rrequirements-dev.txt
 
@@ -124,11 +110,11 @@ whitelist_externals =
     {toxinidir}/scripts/check_license.sh
 deps =
 
-[testenv:fossa]
+[testenv:mypy]
 commands =
-    {toxinidir}/scripts/fossa.sh
-passenv = *
+    mypy setup.py superset tests
 deps =
+    -rrequirements-dev.txt
 
 [testenv:py36-mysql]
 deps =
@@ -157,8 +143,9 @@ envlist =
     cypress-explore
     cypress-sqllab
     eslint
-    flake8
+    isort
     javascript
+    mypy
     pylint
     license-check
 skipsdist = true


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR deprecates `flake8` (where we were using `flake8-import-order` and `flake8-mypy`)  in favor of using `isort` and `mypy` directly. Note `pylint` (which we use though in many cases have warnings disabled) can be viewed as a superset `flake8`.

The reasons for the changes are:

1. We've noticed in other repos that `flake8-mypy` has missed some issues that `mypy` discovers (fixed in this PR) and ignores some of the `mypy` settings.
2. We were using `flake8` mostly for checking import order and typing now that we're using `black`. Note that `isort` both checks and formats. 

Also we were using `flake8` for some other checks but simply ignoring these via `# noqa` which lacked specificity, i.e., reading the code it's not apparent what we're ignoring. Ideally we should be upping our `pylint` game as these checks would be caught by `pylint`. Currently many files have `pylint` warnings ignored and we have disabled a number of checks in the `.pylintrc` file per [here](https://github.com/apache/incubator-superset/blob/master/.pylintrc#L84). In the future we enforce `pylint` for all errors and warning and enable most (if not all) checks.  

There are a few cases where I used `# type: ignore` as I ended up going down a rabbit hole when trying to resolve types. I think in the future we should try to re-enable these checks. 

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @betodealmeida @etr2460 @michellethomas @mistercrunch @villebro 