### PR TITLE
Welcome page title: use app_name instead of 'Superset'

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2962,7 +2962,6 @@ class Superset(BaseSupersetView):
         return self.render_template(
             "superset/basic.html",
             entry="welcome",
-            title="Superset",
             bootstrap_data=json.dumps(payload, default=utils.json_iso_dttm_ser),
         )
 


### PR DESCRIPTION
### CATEGORY

- [x] Enhancement (new features, refinement)

### SUMMARY

The title of the welcome page is a hard coded string (value: "Superset"). When setting the `APP_NAME` to a custom name, we expect to see this name for the page title.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

When changing the `APP_NAME` in `superset/config.py` file:
```diff
 # GLOBALS FOR APP Builder
 # ------------------------------
 # Uncomment to setup Your App name
-APP_NAME = "Superset"
+APP_NAME = "My Custom Name"
```

**Before**: the title of the welcome page is not updated (neither for pages without an explicit title)

![before](https://user-images.githubusercontent.com/5038274/67294039-92420880-f4e5-11e9-8c90-ab02a15a4270.png)

**After**: the title is updated

![after](https://user-images.githubusercontent.com/5038274/67294056-99691680-f4e5-11e9-920a-6be7d8688d8d.png)