### PR TITLE
[fix] Updating parse_human_timedelta typing

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -78,9 +78,7 @@ class QueryObject:
         )
         self.is_timeseries = is_timeseries
         self.time_range = time_range
-        self.time_shift = (
-            utils.parse_human_timedelta(time_shift) if time_shift else None
-        )
+        self.time_shift = utils.parse_human_timedelta(time_shift)
         self.groupby = groupby or []
 
         # Temporal solution for backward compatability issue

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -291,7 +291,7 @@ class DashboardEncoder(json.JSONEncoder):
             return json.JSONEncoder(sort_keys=True).default(self, o)
 
 
-def parse_human_timedelta(s: str) -> timedelta:
+def parse_human_timedelta(s: Optional[str]) -> timedelta:
     """
     Returns ``datetime.datetime`` from natural language time deltas
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -130,6 +130,7 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(parse_human_timedelta("now"), timedelta(0))
         self.assertEqual(parse_human_timedelta("1 year"), timedelta(366))
         self.assertEqual(parse_human_timedelta("-1 year"), timedelta(-365))
+        self.assertEqual(parse_human_timedelta(None), timedelta(0))
 
     @patch("superset.utils.core.datetime")
     def test_parse_past_timedelta(self, mock_datetime):


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes a regression introduced in https://github.com/apache/incubator-superset/pull/8409 as per the typing for `parse_human_timedelta` I was led to believe that `s` needed to be a `str` yet it was being passed a type of `Optional[str]`.  The logic I added in `QueryObject` turned out to be wrong as in fact `s` was of type `Optional[str]` per: https://github.com/apache/incubator-superset/blob/9fc37ea9f1ff032dea923012613d4e7189ada178/superset/utils/core.py#L303


### TEST PLAN

Added additional unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @michellethomas @mistercrunch 
