### PR TITLE
introduce a space in command line option

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -843,7 +843,7 @@ have the same configuration.
 
 * To start a Celery worker to leverage the configuration run: ::
 
-    celery worker --app=superset.tasks.celery_app:app --pool=prefork -Ofair -c 4
+    celery worker --app=superset.tasks.celery_app:app --pool=prefork -O fair -c 4
 
 * To start a job which schedules periodic background jobs, run ::
 


### PR DESCRIPTION
see https://docs.celeryproject.org/en/latest/userguide/optimizing.html
![Bildschirmfoto 2019-10-24 um 10 58 06](https://user-images.githubusercontent.com/2032443/67469989-51fd9a00-f64d-11e9-8d98-5fdb99a4b277.png)

### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
According to the examples in the docs, there need to be a space between `-O` and `fair`. However, this notation still seems to be supported as I found [examples](https://github.com/celery/celery/issues/1933) in the web. Probably still cleaner to stick closely to the celery docs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
