### PR TITLE
[setup] Fix, download_url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
     author_email="dev@superset.incubator.apache.org",
     url="https://superset.apache.org/",
     download_url=(
-        "https://dist.apache.org/repos/dist/release/superset/" + version_string
+        "https://www.apache.org/dist/incubator/superset/" + version_string
     ),
     classifiers=[
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -121,9 +121,7 @@ setup(
     author="Apache Software Foundation",
     author_email="dev@superset.incubator.apache.org",
     url="https://superset.apache.org/",
-    download_url=(
-        "https://www.apache.org/dist/incubator/superset/" + version_string
-    ),
+    download_url="https://www.apache.org/dist/incubator/superset/" + version_string,
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Apache download URL may have changed, noticed that the download_url returns 404
(https://dist.apache.org/repos/dist/release/superset/0.34.1)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
