### PR TITLE
[contrib] Add Mapbox API key variable to docker compose file

### DIFF
--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -42,6 +42,10 @@ docker-compose up
 After several minutes for superset initialization to finish, you can open a browser and view [`http://localhost:8088`](http://localhost:8088) 
 to start your journey.
 
+## Map Visualization
+To correctly display map visualizations (deck.gl or Mapbox), it is necessary to provide a valid Mapbox access token. To do this,
+modify the `docker-compose.yml` file to include the `MAPBOX_API_KEY` environment variable in the `superset` service.
+
 ## Developing
 
 While running, the container server will reload on modification of the superset python and javascript source code.

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -43,8 +43,21 @@ After several minutes for superset initialization to finish, you can open a brow
 to start your journey.
 
 ## Map Visualization
-To correctly display map visualizations (deck.gl or Mapbox), it is necessary to provide a valid Mapbox access token. To do this,
-modify the `docker-compose.yml` file to include the `MAPBOX_API_KEY` environment variable in the `superset` service.
+To correctly display map visualizations, it is necessary to provide a valid Mapbox access token.
+If you already have a Mapbox account, you can find all your tokens on your Mapbox tokens page.
+By default, all accounts have a public access token that can be used to access Mapbox's API.
+If you want to learn more about Mapbox access tokens, please refer to Mapbox documentation.
+
+Once you have your Mapbox access token, you should set the `MAPBOX_API_KEY` environment variable as follows:
+```bash
+$> export MAPBOX_API_KEY=<your_access_token>
+```
+The Compose tool will use the environment variable defined in your shell to populate the value inside the Compose file:
+```bash
+superset:
+  environment:
+    MAPBOX_API_KEY: ${MAPBOX_API_KEY}
+```
 
 ## Developing
 

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -42,8 +42,7 @@ services:
       dockerfile: contrib/docker/Dockerfile
     restart: unless-stopped
     environment:
-      # Add Mapxbox access token to correctly display deck.gl visualizations
-      #MAPBOX_API_KEY:
+      MAPBOX_API_KEY: ${MAPBOX_API_KEY}
       POSTGRES_DB: superset
       POSTGRES_USER: superset
       POSTGRES_PASSWORD: superset

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       dockerfile: contrib/docker/Dockerfile
     restart: unless-stopped
     environment:
+      # Add Mapxbox access token to correctly display deck.gl visualizations
+      #MAPBOX_API_KEY:
       POSTGRES_DB: superset
       POSTGRES_USER: superset
       POSTGRES_PASSWORD: superset


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Add the `MAPBOX_API_KEY` environment variable to the `superset` service in the docker-compose file, allowing the user to specify an access token to correctly display deck.gl and Mapbox visualizations. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #7272 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
