### PR TITLE
[SIP-15] Making client time use UTC as the local time

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,7 +24,7 @@ assists people when migrating to a new version.
 ## Next Version
 
 * [8450](https://github.com/apache/incubator-superset/pull/8450): The time ranger picker
-now uses UTC for the tooltips and default placeholder timestamps (san timezone).
+now uses UTC for the tooltips and default placeholder timestamps (sans timezone).
 
 * [8370](https://github.com/apache/incubator-superset/pull/8370): Deprecates
   the `HTTP_HEADERS` variable in favor of `DEFAULT_HTTP_HEADERS` and

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,9 @@ assists people when migrating to a new version.
 
 ## Next Version
 
+* [8450](https://github.com/apache/incubator-superset/pull/8450): The time ranger picker
+now uses UTC for the tooltips and default placeholder timestamps (san timezone).
+
 * [8370](https://github.com/apache/incubator-superset/pull/8370): Deprecates
   the `HTTP_HEADERS` variable in favor of `DEFAULT_HTTP_HEADERS` and
   `OVERRIDE_HTTP_HEADERS`. To retain the same behavior you should use

--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -67,8 +67,15 @@ const COMMON_TIME_FRAMES = [
 const TIME_GRAIN_OPTIONS = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'];
 
 const MOMENT_FORMAT = 'YYYY-MM-DD[T]HH:mm:ss';
-const DEFAULT_SINCE = moment().startOf('day').subtract(7, 'days').format(MOMENT_FORMAT);
-const DEFAULT_UNTIL = moment().startOf('day').format(MOMENT_FORMAT);
+const DEFAULT_SINCE = moment()
+  .utc()
+  .startOf('day')
+  .subtract(7, 'days')
+  .format(MOMENT_FORMAT);
+const DEFAULT_UNTIL = moment()
+  .utc()
+  .startOf('day')
+  .format(MOMENT_FORMAT);
 const SEPARATOR = ' : ';
 const FREEFORM_TOOLTIP = t(
   'Superset supports smart date parsing. Strings like `last sunday` or ' +
@@ -116,8 +123,12 @@ function getStateFromCommonTimeFrame(value) {
     tab: TABS.DEFAULTS,
     type: TYPES.DEFAULTS,
     common: value,
-    since: moment().startOf('day').subtract(1, units).format(MOMENT_FORMAT),
-    until: moment().startOf('day').format(MOMENT_FORMAT),
+    since: moment()
+      .utc()
+      .startOf('day')
+      .subtract(1, units)
+      .format(MOMENT_FORMAT),
+    until: moment().utc().startOf('day').format(MOMENT_FORMAT),
   };
 }
 
@@ -126,13 +137,15 @@ function getStateFromCustomRange(value) {
   let since;
   let until;
   if (rel === RELATIVE_TIME_OPTIONS.LAST) {
-    until = moment().startOf('day').format(MOMENT_FORMAT);
+    until = moment().utc().startOf('day').format(MOMENT_FORMAT);
     since = moment()
+      .utc()
       .startOf('day')
       .subtract(num, grain)
       .format(MOMENT_FORMAT);
   } else {
     until = moment()
+      .utc()
       .startOf('day')
       .add(num, grain)
       .format(MOMENT_FORMAT);

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -951,6 +951,14 @@ export const controls = {
     freeForm: true,
     label: t('Time range'),
     default: t('Last week'),
+    description: t(
+      'The time range for the visualization. All relative times, e.g. "Last month", ' +
+      '"Last 7 days", "now", etc. are evaluated on the server using the server\'s ' +
+      'local time (sans timezone). All tooltips and placeholder times are expressed ' +
+      'in UTC (sans timezone). The timestamps are then evaluated by the database ' +
+      'using the engine\'s local timezone. Note one can explicitly set the timezone ' +
+      'per the ISO 8601 format if specifying either the start and/or end time.',
+    ),
   },
 
   max_bubble_size: {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Whilst playing with the time range picker I discovered that for relative times ("Last Week" etc.) the reference time (either shown in default or via a tooltip) would use the client timezone rather than the server timezone. This was problematic say at 2019-10-24:18:00:00 PDT the UI would reference `2019-10-24 00:00:00` in various tooltips however when the query was executed it would use `2019-10-25 00:00:00`.  

Initially I was unsure whether we should parse the server timezone to the client but it seems in [other places](https://github.com/apache/incubator-superset/blob/bd9a2c15e79f2f337bf3bdfd67603eee8d0e16a9/superset/assets/src/modules/dates.js#L27) there's the assumption that times are expressed in UTC (irrespective of the server timezone). 

Note the time range picker does not explicitly set the timezone by default for absolute dates, i.e., the query will actually run in reference to the timezone of the executing database engine. However one can specify the timezone via the ISO 8601 format. I’m not certain whether Superset should be more opinionated with regards to timezones. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

I added a tooltip to explicitly define where/how times are evaluated. 

<img width="197" alt="Screen Shot 2019-10-26 at 6 17 08 PM" src="https://user-images.githubusercontent.com/4567245/67628066-039ef580-f81d-11e9-8635-82911c3be017.png">

### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/incubator-superset/issues/6360
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @betodealmeida @etr2460 @mistercrunch 
cc: @vylc 