### PR TITLE
[Datasource Editor] A few small UI changes in modal to prevent accidental edits

### DIFF
--- a/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -22,10 +22,12 @@ import { shallow } from 'enzyme';
 import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
+import Select from 'react-virtualized-select';
 
 import DatasourceEditor from '../../../src/datasource/DatasourceEditor';
 import Field from '../../../src/CRUD/Field';
 import mockDatasource from '../../fixtures/mockDatasource';
+import TableSelector from '../../../src/components/TableSelector';
 
 const props = {
   datasource: mockDatasource['7__table'],
@@ -91,7 +93,30 @@ describe('DatasourceEditor', () => {
   });
 
   it('renders isSqla fields', () => {
+    wrapper.setState({ activeTabKey: 1 });
     expect(wrapper.state('isSqla')).toBe(true);
     expect(wrapper.find(Field).find({ fieldKey: 'fetch_values_predicate' }).exists()).toBe(true);
+  });
+
+  it('disable table selector', () => {
+    wrapper.setState({ activeTabKey: 1 });
+    expect(inst.props.canChangePhysicalTable).toBe(false);
+    const tableSelector = wrapper.find(Field).find({ fieldKey: 'tableSelector' });
+    const selectComponent = tableSelector.dive()
+      .find(TableSelector).dive()
+      .find(Select)
+      .first();
+    expect(selectComponent.props().disabled).toEqual(true);
+  });
+
+  it('enable table selector', () => {
+    wrapper.setProps({ canChangePhysicalTable: true });
+    wrapper.setState({ activeTabKey: 1 });
+    const tableSelector = wrapper.find(Field).find({ fieldKey: 'tableSelector' });
+    const selectComponent = tableSelector.dive()
+      .find(TableSelector).dive()
+      .find(Select)
+      .first();
+    expect(selectComponent.props().disabled).toEqual(false);
   });
 });

--- a/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -93,13 +93,13 @@ describe('DatasourceEditor', () => {
   });
 
   it('renders isSqla fields', () => {
-    wrapper.setState({ activeTabKey: 1 });
+    wrapper.setState({ activeTabKey: 4 });
     expect(wrapper.state('isSqla')).toBe(true);
     expect(wrapper.find(Field).find({ fieldKey: 'fetch_values_predicate' }).exists()).toBe(true);
   });
 
   it('disable table selector', () => {
-    wrapper.setState({ activeTabKey: 1 });
+    wrapper.setState({ activeTabKey: 4 });
     expect(inst.props.canChangePhysicalTable).toBe(false);
     const tableSelector = wrapper.find(Field).find({ fieldKey: 'tableSelector' });
     const selectComponent = tableSelector.dive()
@@ -111,7 +111,7 @@ describe('DatasourceEditor', () => {
 
   it('enable table selector', () => {
     wrapper.setProps({ canChangePhysicalTable: true });
-    wrapper.setState({ activeTabKey: 1 });
+    wrapper.setState({ activeTabKey: 4 });
     const tableSelector = wrapper.find(Field).find({ fieldKey: 'tableSelector' });
     const selectComponent = tableSelector.dive()
       .find(TableSelector).dive()

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -43,6 +43,7 @@ const propTypes = {
   onChange: PropTypes.func,
   clearable: PropTypes.bool,
   handleError: PropTypes.func.isRequired,
+  forceDisableTableSelector: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -56,6 +57,7 @@ const defaultProps = {
   tableNameSticky: true,
   sqlLabMode: true,
   clearable: true,
+  forceDisableTableSelector: false,
 };
 
 export default class TableSelector extends React.PureComponent {
@@ -241,6 +243,7 @@ export default class TableSelector extends React.PureComponent {
     );
   }
   renderDatabaseSelect() {
+    const { forceDisableTableSelector } = this.props;
     return this.renderSelectRow(
       <AsyncSelect
         dataEndpoint={
@@ -264,9 +267,11 @@ export default class TableSelector extends React.PureComponent {
         mutator={this.dbMutator}
         placeholder={t('Select a database')}
         autoSelect
+        disabled={forceDisableTableSelector}
       />);
   }
   renderSchema() {
+    const { forceDisableTableSelector } = this.props;
     return this.renderSelectRow(
       <Select
         name="select-schema"
@@ -281,6 +286,7 @@ export default class TableSelector extends React.PureComponent {
         isLoading={this.state.schemaLoading}
         autosize={false}
         onChange={this.changeSchema}
+        disabled={forceDisableTableSelector}
       />,
       <RefreshLabel
         onClick={() => this.onDatabaseChange({ id: this.props.dbId }, true)}
@@ -289,6 +295,7 @@ export default class TableSelector extends React.PureComponent {
     );
   }
   renderTable() {
+    const { forceDisableTableSelector } = this.props;
     let tableSelectPlaceholder;
     let tableSelectDisabled = false;
     if (this.props.database && this.props.database.allow_multi_schema_metadata_fetch) {
@@ -305,6 +312,7 @@ export default class TableSelector extends React.PureComponent {
         isLoading={this.state.tableLoading}
         ignoreAccents={false}
         placeholder={t('Select table or type table name')}
+        disabled={forceDisableTableSelector}
         autosize={false}
         onChange={this.changeTable}
         options={options}
@@ -316,7 +324,7 @@ export default class TableSelector extends React.PureComponent {
           name="async-select-table"
           ref="selectTable"
           placeholder={tableSelectPlaceholder}
-          disabled={tableSelectDisabled}
+          disabled={forceDisableTableSelector || tableSelectDisabled}
           autosize={false}
           onChange={this.changeTable}
           value={this.state.tableName}

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -213,7 +213,7 @@ export class DatasourceEditor extends React.PureComponent {
       databaseColumns: props.datasource.columns.filter(col => !col.expression),
       calculatedColumns: props.datasource.columns.filter(col => !!col.expression),
       metadataLoading: false,
-      activeTabKey: 4,
+      activeTabKey: 1,
     };
 
     this.onChange = this.onChange.bind(this);
@@ -410,6 +410,7 @@ export class DatasourceEditor extends React.PureComponent {
 
   renderAdvancedFieldset() {
     const datasource = this.state.datasource;
+    const { canChangePhysicalTable } = this.props;
     return (
       <Fieldset title={t('Advanced')} item={datasource} onChange={this.onDatasourceChange}>
         { this.state.isSqla &&
@@ -420,7 +421,7 @@ export class DatasourceEditor extends React.PureComponent {
               'When specifying SQL, the datasource acts as a view. ' +
               'Superset will use this statement as a subquery while grouping and filtering ' +
               'on the generated parent queries.')}
-            control={<TextAreaControl language="sql" offerEditInModal={false} />}
+            control={<TextAreaControl language="sql" offerEditInModal={false} readOnly={!canChangePhysicalTable} />}
           />
         }
         { this.state.isDruid &&
@@ -578,25 +579,11 @@ export class DatasourceEditor extends React.PureComponent {
           onSelect={this.handleTabSelect}
           defaultActiveKey={activeTabKey}
         >
-          <Tab eventKey={1} title={t('Settings')}>
-            {activeTabKey === 1 &&
-              <div>
-                <div className="change-warning well">
-                  <span>Be careful</span>. Changes to these settings can break all charts,
-                  including <span>charts owned by other people</span>.
-                </div>
-                <Col md={6}>
-                  <FormContainer>
-                    {this.renderSettingsFieldset()}
-                  </FormContainer>
-                </Col>
-                <Col md={6}>
-                  <FormContainer>
-                    {this.renderAdvancedFieldset()}
-                  </FormContainer>
-                </Col>
-              </div>
-            }
+          <Tab
+            title={<CollectionTabTitle collection={datasource.metrics} title={t('Metrics')} />}
+            eventKey={1}
+          >
+            {activeTabKey === 1 && this.renderMetricCollection()}
           </Tab>
           <Tab
             title={
@@ -649,11 +636,25 @@ export class DatasourceEditor extends React.PureComponent {
               />
             }
           </Tab>
-          <Tab
-            title={<CollectionTabTitle collection={datasource.metrics} title={t('Metrics')} />}
-            eventKey={4}
-          >
-            {activeTabKey === 4 && this.renderMetricCollection()}
+          <Tab eventKey={4} title={t('Settings')}>
+            {activeTabKey === 4 &&
+            <div>
+              <div className="change-warning well">
+                <span className="bold">{t('Be careful.')} </span>
+                {t('Changing these settings will affect all charts using this datasource, including charts owned by other people.')}
+              </div>
+              <Col md={6}>
+                <FormContainer>
+                  {this.renderSettingsFieldset()}
+                </FormContainer>
+              </Col>
+              <Col md={6}>
+                <FormContainer>
+                  {this.renderAdvancedFieldset()}
+                </FormContainer>
+              </Col>
+            </div>
+            }
           </Tab>
         </Tabs>
       </div>

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -194,9 +194,11 @@ const propTypes = {
   onChange: PropTypes.func,
   addSuccessToast: PropTypes.func.isRequired,
   addDangerToast: PropTypes.func.isRequired,
+  canChangePhysicalTable: PropTypes.bool,
 };
 
 const defaultProps = {
+  canChangePhysicalTable: false,
   onChange: () => {},
 };
 
@@ -211,7 +213,7 @@ export class DatasourceEditor extends React.PureComponent {
       databaseColumns: props.datasource.columns.filter(col => !col.expression),
       calculatedColumns: props.datasource.columns.filter(col => !!col.expression),
       metadataLoading: false,
-      activeTabKey: 1,
+      activeTabKey: 4,
     };
 
     this.onChange = this.onChange.bind(this);
@@ -332,6 +334,7 @@ export class DatasourceEditor extends React.PureComponent {
 
   renderSettingsFieldset() {
     const datasource = this.state.datasource;
+    const { canChangePhysicalTable } = this.props;
     return (
       <Fieldset title={t('Basic')} item={datasource} onChange={this.onDatasourceChange}>
         {this.state.isSqla &&
@@ -349,6 +352,7 @@ export class DatasourceEditor extends React.PureComponent {
                 sqlLabMode={false}
                 clearable={false}
                 handleError={this.props.addDangerToast}
+                forceDisableTableSelector={!canChangePhysicalTable}
               />}
             descr={t(
               'The pointer to a physical table. Keep in mind that the chart is ' +
@@ -565,18 +569,22 @@ export class DatasourceEditor extends React.PureComponent {
   }
 
   render() {
-    const datasource = this.state.datasource;
+    const { datasource, activeTabKey } = this.state;
     return (
       <div className="Datasource">
         {this.renderErrors()}
         <Tabs
           id="table-tabs"
           onSelect={this.handleTabSelect}
-          defaultActiveKey={1}
+          defaultActiveKey={activeTabKey}
         >
           <Tab eventKey={1} title={t('Settings')}>
-            {this.state.activeTabKey === 1 &&
+            {activeTabKey === 1 &&
               <div>
+                <div className="change-warning well">
+                  <span>Be careful</span>. Changes to these settings can break all charts,
+                  including <span>charts owned by other people</span>.
+                </div>
                 <Col md={6}>
                   <FormContainer>
                     {this.renderSettingsFieldset()}
@@ -596,7 +604,7 @@ export class DatasourceEditor extends React.PureComponent {
             }
             eventKey={2}
           >
-            {this.state.activeTabKey === 2 &&
+            {activeTabKey === 2 &&
               <div>
                 <ColumnCollectionTable
                   columns={this.state.databaseColumns}
@@ -623,7 +631,7 @@ export class DatasourceEditor extends React.PureComponent {
               />}
             eventKey={3}
           >
-            {this.state.activeTabKey === 3 &&
+            {activeTabKey === 3 &&
               <ColumnCollectionTable
                 columns={this.state.calculatedColumns}
                 onChange={calculatedColumns => this.setColumns({ calculatedColumns })}
@@ -645,7 +653,7 @@ export class DatasourceEditor extends React.PureComponent {
             title={<CollectionTabTitle collection={datasource.metrics} title={t('Metrics')} />}
             eventKey={4}
           >
-            {this.state.activeTabKey === 4 && this.renderMetricCollection()}
+            {activeTabKey === 4 && this.renderMetricCollection()}
           </Tab>
         </Tabs>
       </div>

--- a/superset/assets/src/datasource/DatasourceModal.jsx
+++ b/superset/assets/src/datasource/DatasourceModal.jsx
@@ -35,6 +35,7 @@ const propTypes = {
   onHide: PropTypes.func,
   onDatasourceSave: PropTypes.func,
   addSuccessToast: PropTypes.func.isRequired,
+  canChangePhysicalTable: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -42,6 +43,7 @@ const defaultProps = {
   onHide: () => {},
   onDatasourceSave: () => {},
   show: false,
+  canChangePhysicalTable: false,
 };
 
 class DatasourceModal extends React.PureComponent {
@@ -149,6 +151,7 @@ class DatasourceModal extends React.PureComponent {
             <DatasourceEditor
               datasource={this.props.datasource}
               onChange={this.onDatasourceChange}
+              canChangePhysicalTable={this.props.canChangePhysicalTable}
             />}
         </Modal.Body>
         <Modal.Footer>

--- a/superset/assets/src/datasource/main.css
+++ b/superset/assets/src/datasource/main.css
@@ -20,3 +20,12 @@
     height: 600px;
     overflow: auto;
 }
+
+.Datasource .change-warning {
+    margin: 16px 10px 0;
+    color: #FE4A49;
+}
+
+.Datasource .change-warning span {
+    font-weight: bold;
+}

--- a/superset/assets/src/datasource/main.css
+++ b/superset/assets/src/datasource/main.css
@@ -26,6 +26,6 @@
     color: #FE4A49;
 }
 
-.Datasource .change-warning span {
+.Datasource .change-warning .bold {
     font-weight: bold;
 }

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -42,12 +42,14 @@ const propTypes = {
   value: PropTypes.string,
   datasource: PropTypes.object.isRequired,
   onDatasourceSave: PropTypes.func,
+  canChangePhysicalTable: PropTypes.bool,
 };
 
 const defaultProps = {
   onChange: () => {},
   onDatasourceSave: () => {},
   value: null,
+  canChangePhysicalTable: false,
 };
 
 class DatasourceControl extends React.PureComponent {
@@ -116,23 +118,16 @@ class DatasourceControl extends React.PureComponent {
 
   render() {
     const { menuExpanded, showChangeDatasourceModal, showEditDatasourceModal } = this.state;
-    const { datasource, onChange, onDatasourceSave, value } = this.props;
+    const { datasource, onChange, onDatasourceSave, value, canChangePhysicalTable } = this.props;
     return (
       <div>
         <ControlHeader {...this.props} />
         <div className="btn-group label-dropdown">
-          <OverlayTrigger
-            placement="right"
-            overlay={
-              <Tooltip id={'error-tooltip'}>{t('Click to edit the datasource')}</Tooltip>
-            }
-          >
-            <div className="btn-group">
-              <Label onClick={this.toggleEditDatasourceModal} className="label-btn-label">
-                {datasource.name}
-              </Label>
-            </div>
-          </OverlayTrigger>
+          <div className="btn-group">
+            <Label>
+              {datasource.name}
+            </Label>
+          </div>
           <DropdownButton
             noCaret
             title={
@@ -145,9 +140,9 @@ class DatasourceControl extends React.PureComponent {
           >
             <MenuItem
               eventKey="3"
-              onClick={this.toggleEditDatasourceModal}
+              onClick={this.toggleChangeDatasourceModal}
             >
-              {t('Edit Datasource')}
+              {t('Change Datasource')}
             </MenuItem>
             {datasource.type === 'table' &&
               <MenuItem
@@ -160,9 +155,9 @@ class DatasourceControl extends React.PureComponent {
               </MenuItem>}
             <MenuItem
               eventKey="3"
-              onClick={this.toggleChangeDatasourceModal}
+              onClick={this.toggleEditDatasourceModal}
             >
-              {t('Change Datasource')}
+              {t('Edit Datasource')}
             </MenuItem>
           </DropdownButton>
           <OverlayTrigger
@@ -187,6 +182,7 @@ class DatasourceControl extends React.PureComponent {
           show={showEditDatasourceModal}
           onDatasourceSave={onDatasourceSave}
           onHide={this.toggleEditDatasourceModal}
+          canChangePhysicalTable={canChangePhysicalTable}
         />
         <ChangeDatasourceModal
           onDatasourceSave={onDatasourceSave}

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -123,11 +123,18 @@ class DatasourceControl extends React.PureComponent {
       <div>
         <ControlHeader {...this.props} />
         <div className="btn-group label-dropdown">
-          <div className="btn-group">
-            <Label>
-              {datasource.name}
-            </Label>
-          </div>
+          <OverlayTrigger
+            placement="right"
+            overlay={
+              <Tooltip id={'error-tooltip'}>{t('Click to change the datasource')}</Tooltip>
+            }
+          >
+            <div className="btn-group">
+              <Label onClick={this.toggleChangeDatasourceModal} className="label-btn-label">
+                {datasource.name}
+              </Label>
+            </div>
+          </OverlayTrigger>
           <DropdownButton
             noCaret
             title={

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -235,6 +235,7 @@ export const controls = {
     mapStateToProps: (state, control, actions) => ({
       datasource: state.datasource,
       onDatasourceSave: actions ? actions.setDatasource : () => {},
+      canChangePhysicalTable: state.can_overwrite_datasource,
     }),
   },
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1221,10 +1221,14 @@ class Superset(BaseSupersetView):
             )
 
         standalone = request.args.get("standalone") == "true"
+        user_roles = [role.name.lower() for role in get_user_roles()]
+        is_admin_role = "admin" in user_roles
         bootstrap_data = {
             "can_add": slice_add_perm,
             "can_download": slice_download_perm,
             "can_overwrite": slice_overwrite_perm,
+            "can_overwrite_datasource": is_admin_role
+            or datasource.created_by_fk == user_id,
             "datasource": datasource.data,
             "form_data": form_data,
             "datasource_id": datasource_id,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In airbnb there are a few users reported that they accidentally edit datasources, but their original ideal is just change datasource. But it caused other charts that used the datasource became invalid.
 
1. Don't open the Datasource Editor modal on clicking the data source name. Several people have accidentally edited the datasource when they really mean to change (swap) datasources. Now will show change datasources modal:  
![image-2019-10-15-11-38-57-049](https://user-images.githubusercontent.com/27990562/67609912-24dfe300-f744-11e9-9d3e-47b99f1c9f22.png)

2. Change the order of options in the drop-down menu so that "Change datasource" is the first option (instead of Edit Datasource). Similar reasoning to the above; we want to prioritize Change Datasource over Edit Datasource.

**Before:**
![image-2019-10-15-11-40-17-893](https://user-images.githubusercontent.com/27990562/67609985-9a4bb380-f744-11e9-9b10-09d97c4b0c30.png)

**After:**
<img width="439" alt="Screen Shot 2019-10-25 at 4 18 11 PM" src="https://user-images.githubusercontent.com/27990562/67609958-6a041500-f744-11e9-97eb-82d85f5ac9cc.png">

3. Land the user on the Metrics tab when they get to the Edit Datasource modal (instead of Settings). Adding Metrics is likely the most common reason people would want to edit the datasource from the Explore view. It makes it easier for people to do the most frequent action, and moves people away from the Settings which is the most risky and the least frequent use case.

4. Make the table name for a datasource only editable by **_admin role_** or _**creator**_ of the datasource
![Screen_Shot_2019-10-28_at_12_13_51_PM](https://user-images.githubusercontent.com/27990562/67710128-9a35f880-f97c-11e9-97b7-04371cb2c76a.jpg)


5. Add a warning to the Settings tab (that is always there) that communicates that changes to this could break all charts, not just your own, so be careful. e.g. "Be careful. Changes to these settings can break all charts, including charts owned by other people."



### TEST PLAN
CI and manual tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@michellethomas @etr2460 @mistercrunch 