### PR TITLE
CLI: removed repeated word

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -184,7 +184,7 @@ def refresh_druid(datasource, merge):
 @click.option(
     "--path",
     "-p",
-    help="Path to a single JSON file or path containing multiple JSON files"
+    help="Path to a single JSON file or path containing multiple JSON "
     "files to import (*.json)",
 )
 @click.option(


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
CLI was printing the following before the PR:
```
-p, --path TEXT      Path to a single JSON file or path containing multiple
                     JSON filesfiles to import (*.json)
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
