### PR TITLE
Make pydruid truly optional

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -168,9 +168,6 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
         return f"{base_url}/{self.broker_endpoint}"
 
     try:
-        # This will actually return a PyDruid type, but using that
-        # type declaration here will cause Superset to crash when
-        # the pydruid library is not installed.
         def get_pydruid_client(self) -> PyDruid:
             cli = PyDruid(
                 self.get_base_url(self.broker_host, self.broker_port),

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -168,6 +168,7 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
         return f"{base_url}/{self.broker_endpoint}"
 
     try:
+
         def get_pydruid_client(self) -> PyDruid:
             cli = PyDruid(
                 self.get_base_url(self.broker_host, self.broker_port),

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -27,7 +27,7 @@ from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __, lazy_gettext as _
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 
-from superset import appbuilder, db, security_manager
+from superset import app, appbuilder, db, security_manager
 from superset.connectors.base.views import DatasourceModelView
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.utils import core as utils
@@ -257,15 +257,16 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):
         DeleteMixin._delete(self, pk)
 
 
-appbuilder.add_view(
-    DruidClusterModelView,
-    name="Druid Clusters",
-    label=__("Druid Clusters"),
-    icon="fa-cubes",
-    category="Sources",
-    category_label=__("Sources"),
-    category_icon="fa-database",
-)
+if app.config["DRUID_IS_ACTIVE"]:
+    appbuilder.add_view(
+        DruidClusterModelView,
+        name="Druid Clusters",
+        label=__("Druid Clusters"),
+        icon="fa-cubes",
+        category="Sources",
+        category_label=__("Sources"),
+        category_icon="fa-database",
+    )
 
 
 class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):
@@ -378,14 +379,15 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin
         DeleteMixin._delete(self, pk)
 
 
-appbuilder.add_view(
-    DruidDatasourceModelView,
-    "Druid Datasources",
-    label=__("Druid Datasources"),
-    category="Sources",
-    category_label=__("Sources"),
-    icon="fa-cube",
-)
+if app.config["DRUID_IS_ACTIVE"]:
+    appbuilder.add_view(
+        DruidDatasourceModelView,
+        "Druid Datasources",
+        label=__("Druid Datasources"),
+        category="Sources",
+        category_label=__("Sources"),
+        icon="fa-cube",
+    )
 
 
 class Druid(BaseSupersetView):
@@ -433,26 +435,26 @@ class Druid(BaseSupersetView):
         return self.refresh_datasources(refresh_all=False)
 
 
-appbuilder.add_view_no_menu(Druid)
+if app.config["DRUID_IS_ACTIVE"]:
+    appbuilder.add_view_no_menu(Druid)
 
-appbuilder.add_link(
-    "Scan New Datasources",
-    label=__("Scan New Datasources"),
-    href="/druid/scan_new_datasources/",
-    category="Sources",
-    category_label=__("Sources"),
-    category_icon="fa-database",
-    icon="fa-refresh",
-)
-appbuilder.add_link(
-    "Refresh Druid Metadata",
-    label=__("Refresh Druid Metadata"),
-    href="/druid/refresh_datasources/",
-    category="Sources",
-    category_label=__("Sources"),
-    category_icon="fa-database",
-    icon="fa-cog",
-)
+    appbuilder.add_link(
+        "Scan New Datasources",
+        label=__("Scan New Datasources"),
+        href="/druid/scan_new_datasources/",
+        category="Sources",
+        category_label=__("Sources"),
+        category_icon="fa-database",
+        icon="fa-refresh",
+    )
+    appbuilder.add_link(
+        "Refresh Druid Metadata",
+        label=__("Refresh Druid Metadata"),
+        href="/druid/refresh_datasources/",
+        category="Sources",
+        category_label=__("Sources"),
+        category_icon="fa-database",
+        icon="fa-cog",
+    )
 
-
-appbuilder.add_separator("Sources")
+    appbuilder.add_separator("Sources")


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Somewhere along the line, type definitions were added to the `superset/connectors/druid/models.py` file that would cause NameErrors when the `pydruid` package was not installed. This PR wraps the appropriate function definitions in `try/except` statements to allow the system to boot without `pydruid` installed. Additionally, somewhere along the line the `DRUID_IS_ACTIVE` option was disabled, though it remains defaulted to `True` in `config.py`. I have re-enabled the configuration so that users may disable the (I believe depricated?) menu items.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
"Sources" menu with `config['DRUID_IS_ACTIVE'] = False`:
<img width="1541" alt="Screen Shot 2019-10-28 at 2 56 07 PM" src="https://user-images.githubusercontent.com/1779034/67721203-37039080-f993-11e9-95e2-69b09de22b4f.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [ ] Uninstall pydruid from your environment and ensure Superset still boots
- [ ] Set the configuration `DRUID_IS_ACTIVE = False` and ensure the Druid-related menu items disappear

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: Fixes #8425
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@EvaSDK @mistercrunch @dpgaspar 