### PR TITLE
Allow user to customize query cost estimate

### DIFF
--- a/docs/sqllab.rst
+++ b/docs/sqllab.rst
@@ -128,13 +128,20 @@ can optionally specify a custom formatter. Eg:
 
 .. code-block:: python
 
-	def presto_query_cost_formatter(result):
-        # convert cost to dollars
-		cpu_coefficient = 1e-12
+	def presto_query_cost_formatter(cost_estimate: List[Dict[str, float]]) -> List[Dict[str, str]]:
+        """
+        Format cost estimate returned by Presto.
+
+        :param cost_estimate: JSON estimate from Presto
+        :return: Human readable cost estimate
+        """
+        # Convert cost to dollars based on CPU and network cost. These coefficients are just
+        # examples, they need to be estimated based on your infrastructure.
+		cpu_coefficient = 2e-12
 		network_coefficient = 1e-12
 
 		cost = 0
-		for row in result:
+		for row in cost_estimate:
 			cost += row.get("cpuCost", 0) * cpu_coefficient
 			cost += row.get("networkCost", 0) * network_coefficient
 

--- a/docs/sqllab.rst
+++ b/docs/sqllab.rst
@@ -123,6 +123,29 @@ database configuration:
 Here, "version" should be the version of your Presto cluster. Support for this
 functionality was introduced in Presto 0.319.
 
+You also need to enable the feature flag in your `superset_config.py`, and you
+can optionally specify a custom formatter. Eg:
+
+.. code-block:: python
+
+	def presto_query_cost_formatter(result):
+        # convert cost to dollars
+		cpu_coefficient = 1e-12
+		network_coefficient = 1e-12
+
+		cost = 0
+		for row in result:
+			cost += row.get("cpuCost", 0) * cpu_coefficient
+			cost += row.get("networkCost", 0) * network_coefficient
+
+		return [{"Cost": f"US$ {cost:.2f}"}]
+
+
+	DEFAULT_FEATURE_FLAGS = {
+		"ESTIMATE_QUERY_COST": True,
+		"QUERY_COST_FORMATTERS_BY_ENGINE": {"presto": presto_query_cost_formatter},
+	}
+
 .. _ref_ctas_engine_config:
 
 Create Table As (CTAS)

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -687,7 +687,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         raise Exception("Database does not support cost estimation")
 
     @classmethod
-    def query_cost_formatter(cls, raw_cost: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    def query_cost_formatter(
+        cls, raw_cost: List[Dict[str, Any]]
+    ) -> List[Dict[str, str]]:
         """
         Format cost estimate.
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -674,7 +674,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     @classmethod
     def estimate_statement_cost(
         cls, statement: str, database, cursor, user_name: str
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Any]:
         """
         Generate a SQL query that estimates the cost of a given statement.
 
@@ -682,6 +682,17 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         :param database: Database instance
         :param cursor: Cursor instance
         :param username: Effective username
+        :return: Dictionary with different costs
+        """
+        raise Exception("Database does not support cost estimation")
+
+    @classmethod
+    def query_cost_formatter(cls, raw_cost: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+        """
+        Format cost estimate.
+
+        :param raw_cost: Raw estimate from `estimate_query_cost`
+        :return: Human readable cost estimate
         """
         raise Exception("Database does not support cost estimation")
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -443,14 +443,15 @@ class PrestoEngineSpec(BaseEngineSpec):
     @classmethod
     def estimate_statement_cost(  # pylint: disable=too-many-locals
         cls, statement: str, database, cursor, user_name: str
-    ) -> Dict[str, str]:
+    ) -> Dict[str, float]:
         """
-        Generate a SQL query that estimates the cost of a given statement.
+        Run a SQL query that estimates the cost of a given statement.
 
         :param statement: A single SQL statement
         :param database: Database instance
         :param cursor: Cursor instance
         :param username: Effective username
+        :return: JSON estimate from Presto
         """
         parsed_query = ParsedQuery(statement)
         sql = parsed_query.stripped()
@@ -476,7 +477,16 @@ class PrestoEngineSpec(BaseEngineSpec):
         #     }
         #   }
         result = json.loads(cursor.fetchone()[0])
-        estimate = result["estimate"]
+        return result["estimate"]
+
+    @classmethod
+    def query_cost_formatter(cls, raw_cost: List[Dict[str, float]]) -> List[Dict[str, str]]:
+        """
+        Format cost estimate.
+
+        :param raw_cost: JSON estimate from Presto
+        :return: Human readable cost estimate
+        """
 
         def humanize(value: Any, suffix: str) -> str:
             try:
@@ -493,7 +503,7 @@ class PrestoEngineSpec(BaseEngineSpec):
 
             return f"{value} {prefix}{suffix}"
 
-        cost = {}
+        cost = []
         columns = [
             ("outputRowCount", "Output count", " rows"),
             ("outputSizeInBytes", "Output size", "B"),
@@ -501,9 +511,12 @@ class PrestoEngineSpec(BaseEngineSpec):
             ("maxMemory", "Max memory", "B"),
             ("networkCost", "Network cost", ""),
         ]
-        for key, label, suffix in columns:
-            if key in estimate:
-                cost[label] = humanize(estimate[key], suffix)
+        for row in raw_cost:
+            statement_cost = {}
+            for key, label, suffix in columns:
+                if key in row:
+                    statement_cost[label] = humanize(row[key], suffix).strip()
+            cost.append(statement_cost)
 
         return cost
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -480,7 +480,9 @@ class PrestoEngineSpec(BaseEngineSpec):
         return result["estimate"]
 
     @classmethod
-    def query_cost_formatter(cls, raw_cost: List[Dict[str, float]]) -> List[Dict[str, str]]:
+    def query_cost_formatter(
+        cls, raw_cost: List[Dict[str, float]]
+    ) -> List[Dict[str, str]]:
         """
         Format cost estimate.
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2411,8 +2411,12 @@ class Superset(BaseSupersetView):
             return json_error_response(str(e))
 
         spec = mydb.db_engine_spec
-        query_cost_formatters = get_feature_flags().get("QUERY_COST_FORMATTER", {})
-        query_cost_formatter = query_cost_formatters.get(spec.engine, spec.query_cost_formatter)
+        query_cost_formatters = get_feature_flags().get(
+            "QUERY_COST_FORMATTERS_BY_ENGINE", {}
+        )
+        query_cost_formatter = query_cost_formatters.get(
+            spec.engine, spec.query_cost_formatter
+        )
         cost = query_cost_formatter(cost)
 
         return json_success(json.dumps(cost))

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2410,6 +2410,11 @@ class Superset(BaseSupersetView):
         except Exception as e:
             return json_error_response(str(e))
 
+        spec = mydb.db_engine_spec
+        query_cost_formatters = get_feature_flags().get("QUERY_COST_FORMATTER", {})
+        query_cost_formatter = query_cost_formatters.get(spec.engine, spec.query_cost_formatter)
+        cost = query_cost_formatter(cost)
+
         return json_success(json.dumps(cost))
 
     @expose("/theme/")


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/incubator-superset/pull/8172 introduced the ability to estimate query costs before running them. Currently, this is supported by Presto, and it returns a _relative_ CPU and network cost.

Ideally, we want to show the cost as dollars, time or percentile, instead of showing relative costs. Since the relationship between the relative cost and the actual cost varies from infrastructure to infrastructure, we need to provide users a way of customizing the query cost estimate.

Here's a hypothetical example where we use a coefficient to compute the query cost in dollars based on CPU and network cost:

```python
def presto_query_cost_formatter(result):
    cpu_coefficient = 1e-12
    network_coefficient = 1e-12

    cost = 0
    for row in result:
        cost += row.get("cpuCost", 0) * cpu_coefficient
        cost += row.get("networkCost", 0) * network_coefficient

    return [{"Cost": f"US$ {cost:.2f}"}]


DEFAULT_FEATURE_FLAGS = {
    "ESTIMATE_QUERY_COST": True,
    "QUERY_COST_FORMATTER": {"presto": presto_query_cost_formatter},
}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="1680" alt="Screen Shot 2019-10-29 at 1 36 24 PM" src="https://user-images.githubusercontent.com/1534870/67808096-3fbb9b80-fa53-11e9-8ba4-59ef49c1c348.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 