### PR TITLE
[Datasource Editor] A few small UI changes in modal to prevent accidental edits

### DIFF
--- a/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset/assets/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -91,6 +91,7 @@ describe('DatasourceEditor', () => {
   });
 
   it('renders isSqla fields', () => {
+    wrapper.setState({ activeTabKey: 4 });
     expect(wrapper.state('isSqla')).toBe(true);
     expect(wrapper.find(Field).find({ fieldKey: 'fetch_values_predicate' }).exists()).toBe(true);
   });

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -565,30 +565,20 @@ export class DatasourceEditor extends React.PureComponent {
   }
 
   render() {
-    const datasource = this.state.datasource;
+    const { datasource, activeTabKey } = this.state;
     return (
       <div className="Datasource">
         {this.renderErrors()}
         <Tabs
           id="table-tabs"
           onSelect={this.handleTabSelect}
-          defaultActiveKey={1}
+          defaultActiveKey={activeTabKey}
         >
-          <Tab eventKey={1} title={t('Settings')}>
-            {this.state.activeTabKey === 1 &&
-              <div>
-                <Col md={6}>
-                  <FormContainer>
-                    {this.renderSettingsFieldset()}
-                  </FormContainer>
-                </Col>
-                <Col md={6}>
-                  <FormContainer>
-                    {this.renderAdvancedFieldset()}
-                  </FormContainer>
-                </Col>
-              </div>
-            }
+          <Tab
+            title={<CollectionTabTitle collection={datasource.metrics} title={t('Metrics')} />}
+            eventKey={1}
+          >
+            {activeTabKey === 1 && this.renderMetricCollection()}
           </Tab>
           <Tab
             title={
@@ -596,7 +586,7 @@ export class DatasourceEditor extends React.PureComponent {
             }
             eventKey={2}
           >
-            {this.state.activeTabKey === 2 &&
+            {activeTabKey === 2 &&
               <div>
                 <ColumnCollectionTable
                   columns={this.state.databaseColumns}
@@ -623,7 +613,7 @@ export class DatasourceEditor extends React.PureComponent {
               />}
             eventKey={3}
           >
-            {this.state.activeTabKey === 3 &&
+            {activeTabKey === 3 &&
               <ColumnCollectionTable
                 columns={this.state.calculatedColumns}
                 onChange={calculatedColumns => this.setColumns({ calculatedColumns })}
@@ -641,11 +631,25 @@ export class DatasourceEditor extends React.PureComponent {
               />
             }
           </Tab>
-          <Tab
-            title={<CollectionTabTitle collection={datasource.metrics} title={t('Metrics')} />}
-            eventKey={4}
-          >
-            {this.state.activeTabKey === 4 && this.renderMetricCollection()}
+          <Tab eventKey={4} title={t('Settings')}>
+            {activeTabKey === 4 &&
+            <div>
+              <div className="change-warning well">
+                <span className="bold">{t('Be careful.')} </span>
+                {t('Changing these settings will affect all charts using this datasource, including charts owned by other people.')}
+              </div>
+              <Col md={6}>
+                <FormContainer>
+                  {this.renderSettingsFieldset()}
+                </FormContainer>
+              </Col>
+              <Col md={6}>
+                <FormContainer>
+                  {this.renderAdvancedFieldset()}
+                </FormContainer>
+              </Col>
+            </div>
+            }
           </Tab>
         </Tabs>
       </div>

--- a/superset/assets/src/datasource/main.css
+++ b/superset/assets/src/datasource/main.css
@@ -20,3 +20,12 @@
     height: 600px;
     overflow: auto;
 }
+
+.Datasource .change-warning {
+    margin: 16px 10px 0;
+    color: #FE4A49;
+}
+
+.Datasource .change-warning .bold {
+    font-weight: bold;
+}

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -124,11 +124,11 @@ class DatasourceControl extends React.PureComponent {
           <OverlayTrigger
             placement="right"
             overlay={
-              <Tooltip id={'error-tooltip'}>{t('Click to edit the datasource')}</Tooltip>
+              <Tooltip id={'error-tooltip'}>{t('Click to change the datasource')}</Tooltip>
             }
           >
             <div className="btn-group">
-              <Label onClick={this.toggleEditDatasourceModal} className="label-btn-label">
+              <Label onClick={this.toggleChangeDatasourceModal} className="label-btn-label">
                 {datasource.name}
               </Label>
             </div>
@@ -145,9 +145,9 @@ class DatasourceControl extends React.PureComponent {
           >
             <MenuItem
               eventKey="3"
-              onClick={this.toggleEditDatasourceModal}
+              onClick={this.toggleChangeDatasourceModal}
             >
-              {t('Edit Datasource')}
+              {t('Change Datasource')}
             </MenuItem>
             {datasource.type === 'table' &&
               <MenuItem
@@ -160,9 +160,9 @@ class DatasourceControl extends React.PureComponent {
               </MenuItem>}
             <MenuItem
               eventKey="3"
-              onClick={this.toggleChangeDatasourceModal}
+              onClick={this.toggleEditDatasourceModal}
             >
-              {t('Change Datasource')}
+              {t('Edit Datasource')}
             </MenuItem>
           </DropdownButton>
           <OverlayTrigger


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In airbnb there are a few users reported that they accidentally edit datasources, but their original ideal is just change datasource. But it caused other charts that used the datasource became invalid.
 
1. Don't open the Datasource Editor modal on clicking the data source name. Several people have accidentally edited the datasource when they really mean to change (swap) datasources. Now will show change datasources modal:  
<img width="463" alt="Screen Shot 2019-10-29 at 3 10 57 PM" src="https://user-images.githubusercontent.com/27990562/67813255-56b3bb00-fa5e-11e9-9ae8-0aef6390ad32.png">




2. Change the order of options in the drop-down menu so that "Change datasource" is the first option (instead of Edit Datasource). Similar reasoning to the above; we want to prioritize Change Datasource over Edit Datasource.

**Before:**
![image-2019-10-15-11-40-17-893](https://user-images.githubusercontent.com/27990562/67609985-9a4bb380-f744-11e9-9b10-09d97c4b0c30.png)

**After:**
<img width="439" alt="Screen Shot 2019-10-25 at 4 18 11 PM" src="https://user-images.githubusercontent.com/27990562/67609958-6a041500-f744-11e9-97eb-82d85f5ac9cc.png">

3. Land the user on the Metrics tab when they get to the Edit Datasource modal (instead of Settings). Adding Metrics is likely the most common reason people would want to edit the datasource from the Explore view. It makes it easier for people to do the most frequent action, and moves people away from the Settings which is the most risky and the least frequent use case.

4. Add a warning to the Settings tab (that is always there) that communicates that changes to this could break all charts, not just your own, so be careful. e.g. "Be careful. Changes to these settings can break all charts, including charts owned by other people."
<img width="903" alt="Screen Shot 2019-10-29 at 3 09 22 PM" src="https://user-images.githubusercontent.com/27990562/67813177-1c4a1e00-fa5e-11e9-95fb-c27e3eddc5ff.png">


### TEST PLAN
CI and manual tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@michellethomas @etr2460 @mistercrunch 