### PR TITLE
[fix] Time range endpoint encoding

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1153,10 +1153,10 @@ class Superset(BaseSupersetView):
             and (
                 not form_data.get("time_range_endpoints")
                 or form_data["time_range_endpoints"]
-                != (
+                != [
                     utils.TimeRangeEndpoint.INCLUSIVE,
                     utils.TimeRangeEndpoint.EXCLUSIVE,
-                )
+                ]
             )
         ):
             url = Href("/superset/explore/")(
@@ -1164,10 +1164,10 @@ class Superset(BaseSupersetView):
                     "form_data": json.dumps(
                         {
                             "slice_id": slc.id,
-                            "time_range_endpoints": (
+                            "time_range_endpoints": [
                                 utils.TimeRangeEndpoint.INCLUSIVE.value,
                                 utils.TimeRangeEndpoint.EXCLUSIVE.value,
-                            ),
+                            ],
                         }
                     )
                 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Tuples are encoded in JSON as arrays and thus the comparison needs to use an array (Python list) as well. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI and manual testing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 