### PR TITLE
[SIP-15] Adding database level python-date-format

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -954,8 +954,8 @@ cache store when upgrading an existing environment.
   entire setup. If not, background jobs can get scheduled multiple times
   resulting in weird behaviors like duplicate delivery of reports,
   higher than expected load / traffic etc.
-  
-* SQL Lab will only run your queries asynchronously if you enable 
+
+* SQL Lab will only run your queries asynchronously if you enable
   "Asynchronous Query Execution" in your database settings.
 
 
@@ -1306,7 +1306,17 @@ SIP-15
 
 `SIP-15 <https://github.com/apache/incubator-superset/issues/6360>`_ aims to ensure that time intervals are handled in a consistent and transparent manner for both the Druid and SQLAlchemy connectors.
 
-Prior to SIP-15 SQLAlchemy used inclusive endpoints however these may behave like exclusive depending on the time column (refer to the SIP for details) and thus the endpoint behavior could be unknown. To aid with transparency the current endpoint behavior is explicitly called out in the chart time range (post SIP-15 this will be [start, end) for all connectors and databases). One can override the defaults on a per database level via the ``extra``
+Prior to SIP-15 SQLAlchemy used inclusive endpoints however these may behave like exclusive for string columns (due to lexicographical ordering) if no formatting was defined and the column formatting did not conform to an ISO 8601 date-time (refer to the SIP for details).
+
+To remedy this rather than having to define the date/time format for every non-IS0 8601 date-time column, once can define a default column mapping on a per database level via the ``extra`` parameter ::
+
+    {
+        "python_date_format_by_column_name": {
+            "ds": "%Y-%m-%d"
+        }
+    }
+
+Additionally to aid with transparency the current endpoint behavior is explicitly called out in the chart time range (post SIP-15 this will be [start, end) for all connectors and databases). One can override the defaults on a per database level via the ``extra``
 parameter ::
 
     {

--- a/superset/assets/src/datasource/DatasourceEditor.jsx
+++ b/superset/assets/src/datasource/DatasourceEditor.jsx
@@ -113,7 +113,9 @@ function ColumnCollectionTable({
                       you will need to define an expression and type for
                       transforming the string into a date or timestamp. Note
                       currently time zones are not supported. If time is stored
-                      in epoch format, put \`epoch_s\` or \`epoch_ms\`.`)}
+                      in epoch format, put \`epoch_s\` or \`epoch_ms\`. If no pattern
+                      is specified we fall back to using the optional defaults on a per
+                      database/column name level via the extra parameter.`)}
                 </div>
               }
               control={<TextControl />}

--- a/superset/config.py
+++ b/superset/config.py
@@ -679,7 +679,10 @@ SEND_FILE_MAX_AGE_DEFAULT = 60 * 60 * 24 * 365  # Cache static resources
 # SQLALCHEMY_DATABASE_URI by default if set to `None`
 SQLALCHEMY_EXAMPLES_URI = None
 
-# Note currently SIP-15 feature is WIP and should not be enabled.
+# SIP-15 should be enabled for all new Superset deployments which ensures that the time
+# range endpoints adhere to [start, end). For existing deployments admins should provide
+# a dedicated period of time to allow chart producers to update their charts before
+# mass migrating all charts to use the [start, end) interval.
 SIP_15_ENABLED = False
 SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS = ["unknown", "inclusive"]
 SIP_15_TOAST_MESSAGE = 'Action Required: Preview then save your chart using the new time range endpoints <a href="{url}" class="alert-link">here</a>.'

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -112,6 +112,9 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):
                 "define an expression and type for transforming the string into a "
                 "date or timestamp. Note currently time zones are not supported. "
                 "If time is stored in epoch format, put `epoch_s` or `epoch_ms`."
+                "If no pattern is specified we fall back to using the optional "
+                "defaults on a per database/column name level via the extra parameter."
+                ""
             ),
             True,
         ),


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR addresses the [SIP-15](https://github.com/apache/incubator-superset/issues/6360) issue where for string column types the start endpoint may behave like `(start` rather than `[start` due to lexicographical ordering if the RHS is not encoded to mimic the formatting of the LHS. 

For example at Airbnb we have over 20,000 tables in Superset which have a `ds` column (datestamp) which adheres to the `YYYY-MM-DD` ISO 8601 format however no python-date-format is specified for these columns and thus the filter endpoints behave like, 

```
> SELECT
    '2018-01-01' >= '2018-01-01 00:00:00',
    '2018-01-01' <= '2018-01-02 00:00:00'
FALSE TRUE
```

i.e., `(start` rather than `[start`. This problem could be remedied by setting the python-date-format for every table but that seems overkill and doesn't ensure newly added tables will define the formatting. This PR creates a default column/python-date-format mapping on a per engine basis where one can specify a fallback (default) format if not specified. 

Note https://github.com/apache/incubator-superset/pull/8464 switched the order of evaluation for obtaining the `datetime` SQL literal ensuring known per engine data types conversions, i.e., `DATE`, `TIMESTAMP`, etc. are applied prior to any python-date-format. This helps to ensure that the mapping isn't heavy handed, i.e., applying the format in an unnecessary or problematic manner. 
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="199" alt="Screen Shot 2019-10-29 at 11 45 32 PM" src="https://user-images.githubusercontent.com/4567245/67837195-bd12fa80-faab-11e9-9dbb-168d9383e2b3.png">
<img width="1133" alt="Screen Shot 2019-10-29 at 11 46 04 PM" src="https://user-images.githubusercontent.com/4567245/67837196-bd12fa80-faab-11e9-84fd-7b0fc86fd317.png">

##### Before

<img width="897" alt="Screen Shot 2019-10-30 at 12 11 06 AM" src="https://user-images.githubusercontent.com/4567245/67837176-ad93b180-faab-11e9-8e1c-70b89746b197.png">

##### After

<img width="900" alt="Screen Shot 2019-10-30 at 12 10 54 AM" src="https://user-images.githubusercontent.com/4567245/67837175-ad93b180-faab-11e9-84a6-d065fb363038.png">



### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/pull/8464
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @betodealmeida @etr2460 @michellethomas @mistercrunch @villebro @willbarrett
