### PR TITLE
add schema to webserver address

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -78,7 +78,7 @@ FILTER_SELECT_ROW_LIMIT = 10000
 SUPERSET_WORKERS = 2  # deprecated
 SUPERSET_CELERY_WORKERS = 32  # deprecated
 
-SUPERSET_WEBSERVER_ADDRESS = "0.0.0.0"
+SUPERSET_WEBSERVER_ADDRESS = "http://0.0.0.0"
 SUPERSET_WEBSERVER_PORT = 8088
 
 # This is an important setting, and should be lower than your


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix

### SUMMARY
The only concurrence of this setting is in [cache task](https://github.com/apache/incubator-superset/blob/9fc37ea9f1ff032dea923012613d4e7189ada178/superset/tasks/cache.py#L78) where an URL is built to cache charts and dashboards. This url is [passed into](https://github.com/apache/incubator-superset/blob/9fc37ea9f1ff032dea923012613d4e7189ada178/superset/tasks/cache.py#L284) Python's `urllib.request.urlopen` function which requires a url schema, otherwise you will get this error.

> urllib.error.URLError: <urlopen error unknown url type: 0.0.0.0>