### PR TITLE
[cli] Fix, import datasources exported by UI

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -239,6 +239,8 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):
         ),
     }
 
+    yaml_dict_key = "databases"
+
     edit_form_extra_fields = {
         "cluster_name": QuerySelectField(
             "Cluster",

--- a/superset/utils/dict_import_export.py
+++ b/superset/utils/dict_import_export.py
@@ -73,6 +73,9 @@ def export_to_dict(session, recursive, back_references, include_defaults):
 
 def import_from_dict(session, data, sync=[]):
     """Imports databases and druid clusters from dictionary"""
+    if isinstance(data, list):
+        logging.info("Object is a list, will assume it was exported on the UI")
+        data = {"databases": data}
     if isinstance(data, dict):
         logging.info("Importing %d %s", len(data.get(DATABASES_KEY, [])), DATABASES_KEY)
         for database in data.get(DATABASES_KEY, []):
@@ -85,4 +88,4 @@ def import_from_dict(session, data, sync=[]):
             DruidCluster.import_from_dict(session, datasource, sync=sync)
         session.commit()
     else:
-        logging.info("Supplied object is not a dictionary.")
+        logging.info("Supplied object is not a dictionary")

--- a/superset/utils/dict_import_export.py
+++ b/superset/utils/dict_import_export.py
@@ -73,9 +73,6 @@ def export_to_dict(session, recursive, back_references, include_defaults):
 
 def import_from_dict(session, data, sync=[]):
     """Imports databases and druid clusters from dictionary"""
-    if isinstance(data, list):
-        logging.info("Object is a list, will assume it was exported on the UI")
-        data = {"databases": data}
     if isinstance(data, dict):
         logging.info("Importing %d %s", len(data.get(DATABASES_KEY, [])), DATABASES_KEY)
         for database in data.get(DATABASES_KEY, []):
@@ -88,4 +85,4 @@ def import_from_dict(session, data, sync=[]):
             DruidCluster.import_from_dict(session, datasource, sync=sync)
         session.commit()
     else:
-        logging.error("Supplied object is not a dictionary.")
+        logging.info("Supplied object is not a dictionary.")

--- a/superset/utils/dict_import_export.py
+++ b/superset/utils/dict_import_export.py
@@ -88,4 +88,4 @@ def import_from_dict(session, data, sync=[]):
             DruidCluster.import_from_dict(session, datasource, sync=sync)
         session.commit()
     else:
-        logging.info("Supplied object is not a dictionary")
+        logging.error("Supplied object is not a dictionary.")

--- a/superset/utils/import_datasource.py
+++ b/superset/utils/import_datasource.py
@@ -26,7 +26,7 @@ def import_datasource(
     """Imports the datasource from the object to the database.
 
      Metrics and columns and datasource will be overrided if exists.
-     This function can be used to import/export dashboards between multiple
+     This function can be used to import/export datasources between multiple
      superset instances. Audit metadata isn't copies over.
     """
     make_transient(i_datasource)

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -208,12 +208,20 @@ def validate_json(form, field):
 
 
 class YamlExportMixin(object):
+    yaml_dict_key = None
+    """
+    Override this if you a dict response instead, with a certain key. 
+    Used on DatabaseView for cli compatibility
+    """
+
     @action("yaml_export", __("Export to YAML"), __("Export to YAML?"), "fa-download")
     def yaml_export(self, items):
         if not isinstance(items, list):
             items = [items]
 
         data = [t.export_to_dict() for t in items]
+        if self.yaml_dict_key:
+            data = {self.yaml_dict_key: data}
         return Response(
             yaml.safe_dump(data),
             headers=generate_download_headers("yaml"),

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -19,7 +19,7 @@ import functools
 import logging
 import traceback
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import simplejson as json
 import yaml
@@ -208,7 +208,7 @@ def validate_json(form, field):
 
 
 class YamlExportMixin(object):
-    yaml_dict_key = None
+    yaml_dict_key: Optional[str] = None
     """
     Override this if you a dict response instead, with a certain key. 
     Used on DatabaseView for cli compatibility

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -210,7 +210,7 @@ def validate_json(form, field):
 class YamlExportMixin(object):
     yaml_dict_key: Optional[str] = None
     """
-    Override this if you a dict response instead, with a certain key. 
+    Override this if you want a dict response instead, with a certain key. 
     Used on DatabaseView for cli compatibility
     """
 

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -54,6 +54,8 @@ class DatabaseView(DatabaseMixin, SupersetModelView, DeleteMixin, YamlExportMixi
     edit_template = "superset/models/database/edit.html"
     validators_columns = {"sqlalchemy_uri": [sqlalchemy_uri_form_validator]}
 
+    yaml_dict_key = "databases"
+
     def _delete(self, pk):
         DeleteMixin._delete(self, pk)
 


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Databases/Datasources export on the UI can't be imported by `superset import_datasource` cli.
This fix makes UI yaml export for SQLAlchemy datasources and Druid compatible with the cli.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #8453 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@villebro 