### PR TITLE
[SIP-15] Fix time range endpoints decoding

### DIFF
--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -207,35 +207,33 @@ def get_time_range_endpoints(
     form_data: Dict[str, Any], slc: Optional[models.Slice]
 ) -> Optional[Tuple[TimeRangeEndpoint, TimeRangeEndpoint]]:
     """
-    Get the slice aware time range endpoints falling back to the SQL database specific
-    definition or default if not defined.
+    Get the slice aware time range endpoints from the form-data falling back to the SQL
+    database specific definition or default if not defined.
 
     For SIP-15 all new slices use the [start, end) interval which is consistent with the
-    Druid REST API.
+    native Druid connector.
 
     :param form_data: The form-data
     :param slc: The chart
     :returns: The time range endpoints tuple
     """
 
-    time_range_endpoints = form_data.get("time_range_endpoints")
+    endpoints = form_data.get("time_range_endpoints")
 
-    if time_range_endpoints:
-        return time_range_endpoints
+    if slc and not endpoints:
+        try:
+            _, datasource_type = get_datasource_info(None, None, form_data)
+        except SupersetException:
+            return None
 
-    try:
-        _, datasource_type = get_datasource_info(None, None, form_data)
-    except SupersetException:
-        return None
-
-    if datasource_type == "table":
-        if slc:
+        if datasource_type == "table":
             endpoints = slc.datasource.database.get_extra().get("time_range_endpoints")
 
             if not endpoints:
                 endpoints = app.config["SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS"]
 
-            start, end = endpoints
-            return (TimeRangeEndpoint(start), TimeRangeEndpoint(end))
+    if endpoints:
+        start, end = endpoints
+        return (TimeRangeEndpoint(start), TimeRangeEndpoint(end))
 
     return (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.EXCLUSIVE)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Python tuples (which is how the time range endpoints are defined) are encoded as JSON arrays and thus when the  form data is decoded we need to re-encode this as a tuple especially for comparison reasons.

This PR also ensures that the endpoints if present in the JSON form-data are decoded using the enum (as opposed to string) for consistency.   

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Manual testing. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/incubator-superset/issues/6360
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @michellethomas @villbro