### PR TITLE
Re-enable DRUID_IS_ACTIVE flag

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -131,8 +131,6 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):
         self.post_update(col)
 
 
-
-
 class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):
     datamodel = SQLAInterface(models.DruidMetric)
 
@@ -183,7 +181,6 @@ class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):
     }
 
     edit_form_extra_fields = add_form_extra_fields
-
 
 
 class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):
@@ -409,7 +406,7 @@ class Druid(BaseSupersetView):
         return self.refresh_datasources(refresh_all=False)
 
 
-if app.config['DRUID_IS_ACTIVE']:
+if app.config["DRUID_IS_ACTIVE"]:
     appbuilder.add_view(
         DruidDatasourceModelView,
         "Druid Datasources",

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -27,7 +27,7 @@ from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __, lazy_gettext as _
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 
-from superset import appbuilder, db, security_manager
+from superset import app, appbuilder, db, security_manager
 from superset.connectors.base.views import DatasourceModelView
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.utils import core as utils
@@ -131,7 +131,6 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):
         self.post_update(col)
 
 
-appbuilder.add_view_no_menu(DruidColumnInlineView)
 
 
 class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):
@@ -185,8 +184,6 @@ class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):
 
     edit_form_extra_fields = add_form_extra_fields
 
-
-appbuilder.add_view_no_menu(DruidMetricInlineView)
 
 
 class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):
@@ -255,17 +252,6 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):
 
     def _delete(self, pk):
         DeleteMixin._delete(self, pk)
-
-
-appbuilder.add_view(
-    DruidClusterModelView,
-    name="Druid Clusters",
-    label=__("Druid Clusters"),
-    icon="fa-cubes",
-    category="Sources",
-    category_label=__("Sources"),
-    category_icon="fa-database",
-)
 
 
 class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):
@@ -378,16 +364,6 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin
         DeleteMixin._delete(self, pk)
 
 
-appbuilder.add_view(
-    DruidDatasourceModelView,
-    "Druid Datasources",
-    label=__("Druid Datasources"),
-    category="Sources",
-    category_label=__("Sources"),
-    icon="fa-cube",
-)
-
-
 class Druid(BaseSupersetView):
     """The base views for Superset!"""
 
@@ -433,26 +409,49 @@ class Druid(BaseSupersetView):
         return self.refresh_datasources(refresh_all=False)
 
 
-appbuilder.add_view_no_menu(Druid)
+if app.config['DRUID_IS_ACTIVE']:
+    appbuilder.add_view(
+        DruidDatasourceModelView,
+        "Druid Datasources",
+        label=__("Druid Datasources"),
+        category="Sources",
+        category_label=__("Sources"),
+        icon="fa-cube",
+    )
 
-appbuilder.add_link(
-    "Scan New Datasources",
-    label=__("Scan New Datasources"),
-    href="/druid/scan_new_datasources/",
-    category="Sources",
-    category_label=__("Sources"),
-    category_icon="fa-database",
-    icon="fa-refresh",
-)
-appbuilder.add_link(
-    "Refresh Druid Metadata",
-    label=__("Refresh Druid Metadata"),
-    href="/druid/refresh_datasources/",
-    category="Sources",
-    category_label=__("Sources"),
-    category_icon="fa-database",
-    icon="fa-cog",
-)
+    appbuilder.add_view(
+        DruidClusterModelView,
+        name="Druid Clusters",
+        label=__("Druid Clusters"),
+        icon="fa-cubes",
+        category="Sources",
+        category_label=__("Sources"),
+        category_icon="fa-database",
+    )
 
+    appbuilder.add_view_no_menu(DruidMetricInlineView)
 
-appbuilder.add_separator("Sources")
+    appbuilder.add_view_no_menu(DruidColumnInlineView)
+
+    appbuilder.add_view_no_menu(Druid)
+
+    appbuilder.add_link(
+        "Scan New Datasources",
+        label=__("Scan New Datasources"),
+        href="/druid/scan_new_datasources/",
+        category="Sources",
+        category_label=__("Sources"),
+        category_icon="fa-database",
+        icon="fa-refresh",
+    )
+    appbuilder.add_link(
+        "Refresh Druid Metadata",
+        label=__("Refresh Druid Metadata"),
+        href="/druid/refresh_datasources/",
+        category="Sources",
+        category_label=__("Sources"),
+        category_icon="fa-database",
+        icon="fa-cog",
+    )
+
+    appbuilder.add_separator("Sources")


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `DRUID_IS_ACTIVE` configuration option was removed from the codebase at some point. Druid's preferred connection method is via the SQL interface, so this change is necessary in order to deprecate the Druid API-based connection methods in Superset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1541" alt="Screen Shot 2019-10-28 at 2 56 07 PM" src="https://user-images.githubusercontent.com/1779034/67721203-37039080-f993-11e9-95e2-69b09de22b4f.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [ ] Boot Superset with the configuration option `DRUID_IS_ACTIVE` set to `True`, ensure Druid options appear in the "Sources" menu.
- [ ] Boot Superset with the configuration option `DRUID_IS_ACTIVE` set to `False`, ensure Druid options are absent from the "Sources" menu.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/incubator-superset/pull/8463 - I decided to split this change out of that PR for clarity and simplicity.
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch @dpgaspar 