### PR TITLE
Update query tab's title when saving a new query

### DIFF
--- a/superset/assets/src/SqlLab/reducers/sqlLab.js
+++ b/superset/assets/src/SqlLab/reducers/sqlLab.js
@@ -42,8 +42,8 @@ export default function sqlLabReducer(state = {}, action) {
     [actions.QUERY_EDITOR_SAVED]() {
       const { query, result } = action;
       const existing = state.queryEditors.find(qe => qe.id === query.id);
-      return alterInArr(state, 'queryEditors', existing, { 
-        remoteId: result.remoteId, 
+      return alterInArr(state, 'queryEditors', existing, {
+        remoteId: result.remoteId,
         title: query.title,
       }, 'id');
     },

--- a/superset/assets/src/SqlLab/reducers/sqlLab.js
+++ b/superset/assets/src/SqlLab/reducers/sqlLab.js
@@ -42,7 +42,10 @@ export default function sqlLabReducer(state = {}, action) {
     [actions.QUERY_EDITOR_SAVED]() {
       const { query, result } = action;
       const existing = state.queryEditors.find(qe => qe.id === query.id);
-      return alterInArr(state, 'queryEditors', existing, { remoteId: result.remoteId }, 'id');
+      return alterInArr(state, 'queryEditors', existing, { 
+        remoteId: result.remoteId, 
+        title: query.title,
+      }, 'id');
     },
     [actions.UPDATE_QUERY_EDITOR]() {
       const id = action.alterations.remoteId;


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This change updates the query tab's title when you save a query. This currently happens when you click `Update` in the Save dialog, but not if you click `Save` or `Save New`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Superset_SaveQuery_Before](https://user-images.githubusercontent.com/20205680/67890574-e03fb780-fb48-11e9-91d4-771c22177675.gif)

After:
![Superset_SaveQuery_After](https://user-images.githubusercontent.com/20205680/67890583-e6359880-fb48-11e9-9b0f-e51650c0ae5b.gif)


### TEST PLAN
Tested that tab title is correctly updated both `update` and `save new` scenarios.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat (adding you as potential reviewer as you recently made a fix here)

