### PR TITLE
Add `Duplicate Tab` option

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
+++ b/superset/assets/spec/javascripts/sqllab/TabbedSqlEditors_spec.jsx
@@ -162,6 +162,14 @@ describe('TabbedSqlEditors', () => {
     expect(wrapper.instance().props.actions.addQueryEditor.getCall(0).args[0].title)
         .toContain('Untitled Query');
   });
+  it('should duplicate query editor', () => {
+    wrapper = getWrapper();
+    sinon.stub(wrapper.instance().props.actions, 'cloneQueryToNewTab');
+
+    wrapper.instance().duplicateQueryEditor(queryEditors[0]);
+    expect(wrapper.instance().props.actions.cloneQueryToNewTab.getCall(0).args[0])
+        .toBe(queryEditors[0]);
+  });
   it('should handle select', () => {
     wrapper = getWrapper();
     sinon.spy(wrapper.instance(), 'newQueryEditor');

--- a/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -67,6 +67,7 @@ class TabbedSqlEditors extends React.PureComponent {
     this.renameTab = this.renameTab.bind(this);
     this.toggleLeftBar = this.toggleLeftBar.bind(this);
     this.removeAllOtherQueryEditors = this.removeAllOtherQueryEditors.bind(this);
+    this.duplicateQueryEditor = this.duplicateQueryEditor.bind(this);
   }
   componentDidMount() {
     const query = URI(window.location).search(true);
@@ -182,6 +183,9 @@ class TabbedSqlEditors extends React.PureComponent {
     this.props.queryEditors
       .forEach(qe => qe !== cqe && this.removeQueryEditor(qe));
   }
+  duplicateQueryEditor(qe) {
+    this.props.actions.cloneQueryToNewTab(qe);
+  }
   toggleLeftBar() {
     this.setState({ hideLeftBar: !this.state.hideLeftBar });
   }
@@ -235,6 +239,12 @@ class TabbedSqlEditors extends React.PureComponent {
               <i className="fa fa-times-circle-o" />
             </div>
             {t('Close all other tabs')}
+          </MenuItem>
+          <MenuItem eventKey="5" onClick={() => this.duplicateQueryEditor(qe)}>
+            <div className="icon-container">
+              <i className="fa fa-files-o" />
+            </div>
+            {t('Duplicate tab')}
           </MenuItem>
         </SplitButton>
       );


### PR DESCRIPTION
### CATEGORY
Adds an option to duplicate the current tab's setting/content into a new tab. Useful if you're iterating on a query.

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This adds a `Duplicate Tab` option.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
New option:
![image](https://user-images.githubusercontent.com/20205680/67893556-ac679080-fb4e-11e9-9fdd-cc877c47ce83.png)

![Superset_DuplicateTabs](https://user-images.githubusercontent.com/20205680/67893206-0c116c00-fb4e-11e9-91eb-20f1e99b82cb.gif)

### TEST PLAN
Open a tab, selected the "options" chevron, click on `Duplicate Tab`.
Verify the new tab's settings (database and schema selections) and SQL query match the previous tab's
Verify the title is `Copy of <previous tab title>`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
