### PR TITLE
[SIP-15] Adding grace period

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1356,9 +1356,33 @@ To remedy this rather than having to define the date/time format for every non-I
         }
     }
 
-Additionally to aid with transparency the current endpoint behavior is explicitly called out in the chart time range (post SIP-15 this will be [start, end) for all connectors and databases). One can override the defaults on a per database level via the ``extra``
+**New deployments**
+
+All new Superset deployments should enable SIP-15 via,
+
+.. code-block:: python
+
+    SIP_15_ENABLED = True
+
+**Existing deployments**
+
+Given that it is not apparent whether the chart creator was aware of the time range inconsistencies (and adjusted the endpoints accordingly) changing the behavior of all charts is overly aggressive. Instead SIP-15 proivides a soft transistion allowing producers (chart owners) to see the impact of the proposed change and adjust their charts accordingly.
+
+Prior to enabling SIP-15 existing deployments should communicate to their users the impact of the change and define a grace period end date (exclusive of course) after which all charts will conform to the [start, end) interval, i.e.,
+
+.. code-block:: python
+
+    from dateime import date
+
+    SIP_15_ENABLED = True
+    SIP_15_GRACE_PERIOD_END = date(<YYYY>, <MM>, <DD>)
+
+To aid with transparency the current endpoint behavior is explicitly called out in the chart time range (post SIP-15 this will be [start, end) for all connectors and databases). One can override the defaults on a per database level via the ``extra``
 parameter ::
 
     {
         "time_range_endpoints": ["inclusive", "inclusive"]
     }
+
+
+Note in a future release the interim SIP-15 logic will be removed (including the ``time_grain_endpoints`` form-data field) via a code change and Alembic migration.

--- a/superset/config.py
+++ b/superset/config.py
@@ -28,7 +28,8 @@ import logging
 import os
 import sys
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List
+from datetime import date
+from typing import Any, Callable, Dict, List, Optional
 
 from celery.schedules import crontab
 from dateutil import tz
@@ -698,7 +699,11 @@ SQLALCHEMY_EXAMPLES_URI = None
 # range endpoints adhere to [start, end). For existing deployments admins should provide
 # a dedicated period of time to allow chart producers to update their charts before
 # mass migrating all charts to use the [start, end) interval.
+#
+# Note if no end date for the grace period is specified then the grace period is
+# indefinite.
 SIP_15_ENABLED = False
+SIP_15_GRACE_PERIOD_END: Optional[date] = None  # exclusive
 SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS = ["unknown", "inclusive"]
 SIP_15_TOAST_MESSAGE = 'Action Required: Preview then save your chart using the new time range endpoints <a href="{url}" class="alert-link">here</a>.'
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=C,R,W
 from collections import defaultdict
+from datetime import date
 from typing import Any, Dict, List, Optional, Tuple
 from urllib import parse
 
@@ -212,13 +213,19 @@ def get_time_range_endpoints(
     Get the slice aware time range endpoints from the form-data falling back to the SQL
     database specific definition or default if not defined.
 
-    For SIP-15 all new slices use the [start, end) interval which is consistent with the
-    native Druid connector.
+    When SIP-15 is enabled all slices and will the [start, end) interval. If the grace
+    period is defined and has ended all slices will adhere to the [start, end) interval.
 
     :param form_data: The form-data
     :param slc: The chart
     :returns: The time range endpoints tuple
     """
+
+    if (
+        app.config["SIP_15_GRACE_PERIOD_END"]
+        and date.today() >= app.config["SIP_15_GRACE_PERIOD_END"]
+    ):
+        return (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.EXCLUSIVE)
 
     endpoints = form_data.get("time_range_endpoints")
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -920,3 +920,18 @@ class UtilsTestCase(unittest.TestCase):
         )
 
         self.assertIsNone(get_time_range_endpoints(form_data={}, slc=slc))
+
+        with app.app_context():
+            app.config["SIP_15_GRACE_PERIOD_END"] = date.today() + timedelta(days=1)
+
+            self.assertEqual(
+                get_time_range_endpoints(form_data={"datasource": "1__table"}, slc=slc),
+                (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.INCLUSIVE),
+            )
+
+            app.config["SIP_15_GRACE_PERIOD_END"] = date.today()
+
+            self.assertEqual(
+                get_time_range_endpoints(form_data={"datasource": "1__table"}, slc=slc),
+                (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.EXCLUSIVE),
+            )


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR provides a mechanism to specify a SIP-15 grace period after which all charts will adhere to the `[start, end)` time range interval. This is configurable and provides a mechanism for each installation to handle the transition as they see fit. In the future (circa 6+ months) the interim SIP-15 logic should be removed which will enforce all deployments to use the `[start, end)` time range interval. 

### TEST PLAN

Added new tests and verified the RST formatting. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @betodealmeida @etr2460 @graceguo-supercat @michellethomas @mistercrunch @villebro 