### PR TITLE
Updating pip with default timeout

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -47,8 +47,8 @@ COPY requirements.txt .
 COPY requirements-dev.txt .
 COPY contrib/docker/requirements-extra.txt .
 
-RUN pip install --upgrade setuptools pip \
-    && pip install -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt \
+RUN pip --default-timeout=1000 install --upgrade setuptools pip \
+    && pip --default-timeout=1000 install -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt \
     && rm -rf /root/.cache/pip
 
 COPY --chown=superset:superset superset superset

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -47,8 +47,8 @@ COPY requirements.txt .
 COPY requirements-dev.txt .
 COPY contrib/docker/requirements-extra.txt .
 
-RUN pip --default-timeout=1000 install --upgrade setuptools pip \
-    && pip --default-timeout=1000 install -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt \
+RUN pip --default-timeout=120 install --upgrade setuptools pip \
+    && pip --default-timeout=120 install -r requirements.txt -r requirements-dev.txt -r requirements-extra.txt \
     && rm -rf /root/.cache/pip
 
 COPY --chown=superset:superset superset superset


### PR DESCRIPTION
Most of the time, the pip default site is realiable but we do see timeouts pops out when network is busy or temporary unavaliable .

The default value was 15 and that's way too short. So adding --default-time and set it to 1000 should be long enough to mitigate

### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
