### PR TITLE
Fix column type on dbs.encrypted_extra, add instructions for testing migration downgrades

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -768,6 +768,20 @@ https://github.com/apache/incubator-superset/pull/3013
 
     [Example commit](https://github.com/apache/incubator-superset/pull/5745/commits/6220966e2a0a0cf3e6d87925491f8920fe8a3458)
 
+1. Test the migration's `down` method
+
+    ```bash
+    superset db downgrade
+    ```
+
+    The output should look like this:
+
+    ```
+    INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
+    INFO  [alembic.runtime.migration] Will assume transactional DDL.
+    INFO  [alembic.runtime.migration] Running downgrade 40a0a483dd12 -> 1a1d627ebd8e, add_metadata_column_to_annotation_model.py
+    ```
+
 ### Merging DB migrations
 
 When two DB migrations collide, you'll get an error message like this one:

--- a/superset/migrations/versions/c2acd2cf3df2_alter_type_of_dbs_encrypted_extra.py
+++ b/superset/migrations/versions/c2acd2cf3df2_alter_type_of_dbs_encrypted_extra.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""alter type of dbs encrypted_extra
+
+
+Revision ID: c2acd2cf3df2
+Revises: cca2f5d568c8
+Create Date: 2019-11-01 09:18:36.953603
+
+"""
+
+from alembic import op
+
+import sqlalchemy as sa
+
+from sqlalchemy_utils import EncryptedType
+
+# revision identifiers, used by Alembic.
+revision = "c2acd2cf3df2"
+down_revision = "cca2f5d568c8"
+
+
+def upgrade():
+    op.alter_column(
+        "dbs",
+        "encrypted_extra",
+        existing_type=sa.Text(),
+        type_=EncryptedType(sa.Text()),
+        postgresql_using="encrypted_extra::bytea",
+        existing_nullable=True,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "dbs",
+        "encrypted_extra",
+        existing_type=EncryptedType(sa.Text()),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )

--- a/superset/migrations/versions/c2acd2cf3df2_alter_type_of_dbs_encrypted_extra.py
+++ b/superset/migrations/versions/c2acd2cf3df2_alter_type_of_dbs_encrypted_extra.py
@@ -23,10 +23,8 @@ Create Date: 2019-11-01 09:18:36.953603
 
 """
 
-from alembic import op
-
 import sqlalchemy as sa
-
+from alembic import op
 from sqlalchemy_utils import EncryptedType
 
 # revision identifiers, used by Alembic.

--- a/superset/migrations/versions/c2acd2cf3df2_alter_type_of_dbs_encrypted_extra.py
+++ b/superset/migrations/versions/c2acd2cf3df2_alter_type_of_dbs_encrypted_extra.py
@@ -35,14 +35,25 @@ down_revision = "cca2f5d568c8"
 
 
 def upgrade():
-    op.alter_column(
-        "dbs",
-        "encrypted_extra",
-        existing_type=sa.Text(),
-        type_=EncryptedType(sa.Text()),
-        postgresql_using="encrypted_extra::bytea",
-        existing_nullable=True,
-    )
+    try:
+        # Postgres migration
+        op.alter_column(
+            "dbs",
+            "encrypted_extra",
+            existing_type=sa.Text(),
+            type_=EncryptedType(sa.Text()),
+            postgresql_using="encrypted_extra::bytea",
+            existing_nullable=True,
+        )
+    except TypeError:
+        # non-Postgres migration
+        op.alter_column(
+            "dbs",
+            "encrypted_extra",
+            existing_type=sa.Text(),
+            type_=EncryptedType(sa.Text()),
+            existing_nullable=True,
+        )
 
 
 def downgrade():

--- a/superset/migrations/versions/c2acd2cf3df2_alter_type_of_dbs_encrypted_extra.py
+++ b/superset/migrations/versions/c2acd2cf3df2_alter_type_of_dbs_encrypted_extra.py
@@ -35,32 +35,32 @@ down_revision = "cca2f5d568c8"
 
 
 def upgrade():
-    try:
-        # Postgres migration
-        op.alter_column(
-            "dbs",
-            "encrypted_extra",
-            existing_type=sa.Text(),
-            type_=EncryptedType(sa.Text()),
-            postgresql_using="encrypted_extra::bytea",
-            existing_nullable=True,
-        )
-    except TypeError:
-        # non-Postgres migration
-        op.alter_column(
-            "dbs",
-            "encrypted_extra",
-            existing_type=sa.Text(),
-            type_=EncryptedType(sa.Text()),
-            existing_nullable=True,
-        )
+    with op.batch_alter_table("dbs") as batch_op:
+        try:
+            # Postgres migration
+            batch_op.alter_column(
+                "encrypted_extra",
+                existing_type=sa.Text(),
+                type_=EncryptedType(sa.Text()),
+                postgresql_using="encrypted_extra::bytea",
+                existing_nullable=True,
+            )
+        except TypeError:
+            # non-Postgres migration
+            batch_op.alter_column(
+                "dbs",
+                "encrypted_extra",
+                existing_type=sa.Text(),
+                type_=EncryptedType(sa.Text()),
+                existing_nullable=True,
+            )
 
 
 def downgrade():
-    op.alter_column(
-        "dbs",
-        "encrypted_extra",
-        existing_type=EncryptedType(sa.Text()),
-        type_=sa.Text(),
-        existing_nullable=True,
-    )
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.alter_column(
+            "encrypted_extra",
+            existing_type=EncryptedType(sa.Text()),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The new `encrypted_extra` field on the `dbs` table was causing the databases list to become inaccessible when used with Postgres. This was caused by a type misalignment between the database and the model definition. Also add instructions in CONTRIBUTING.md around testing down migrations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [ ] Set up a BigQuery connection according to instructions here: https://github.com/apache/incubator-superset/pull/8462
- [ ] Ensure the databases/list page is still accessible


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [X] Requires DB Migration.
- [X] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@dpgaspar @mistercrunch 