### PR TITLE
[SIP-15] Fix ISO 8601 datetime matching/labeling in the DateFilterControl 

### DIFF
--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -83,7 +83,6 @@ const FREEFORM_TOOLTIP = t(
 );
 
 const DATE_FILTER_POPOVER_STYLE = { width: '250px' };
-const ISO_8601_REGEX_MATCH = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/;
 
 const propTypes = {
   animation: PropTypes.bool,
@@ -514,7 +513,7 @@ export default class DateFilterControl extends React.Component {
     value = value
       .split(SEPARATOR)
       .map((v, idx) =>
-        ISO_8601_REGEX_MATCH.test(v)
+        moment(v).isValid()
           ? v.replace('T00:00:00', '') + (endpoints ? ` (${endpoints[idx]})` : '')
           : v || (idx === 0 ? '-∞' : '∞'),
       )


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR  replaces the ISO 8601 regex for the `DateFilterControl` with `moment`'s parsing as it's viable for one to simply defined a date (or similar). 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE 

![Screen Shot 2019-11-01 at 11 46 35 AM](https://user-images.githubusercontent.com/4567245/68048336-8ef50c80-fc9d-11e9-9a2d-6e852c0a292d.png)

#### AFTER

![Screen Shot 2019-11-01 at 11 45 44 AM](https://user-images.githubusercontent.com/4567245/68048346-987e7480-fc9d-11e9-8aa3-b2d570dd5735.png)

### TEST PLAN

Manually tested. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat 