### PR TITLE
[datasource editor] Only one click target for edit action

### DIFF
--- a/superset/assets/src/explore/components/controls/DatasourceControl.css
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.css
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#datasource_menu {
+    border-radius: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
+#datasource_menu .caret {
+    position: relative;
+    padding-right: 8px;
+    margin-left: 4px;
+    color: #fff;
+    top: -8px;
+}
+
+#datasource_menu + ul {
+    margin-top: 26px;
+}

--- a/superset/assets/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset/assets/src/explore/components/controls/DatasourceControl.jsx
@@ -36,6 +36,8 @@ import ColumnOption from '../../../components/ColumnOption';
 import MetricOption from '../../../components/MetricOption';
 import DatasourceModal from '../../../datasource/DatasourceModal';
 import ChangeDatasourceModal from '../../../datasource/ChangeDatasourceModal';
+import TooltipWrapper from '../../../components/TooltipWrapper';
+import './DatasourceControl.css';
 
 const propTypes = {
   onChange: PropTypes.func,
@@ -115,56 +117,45 @@ class DatasourceControl extends React.PureComponent {
   }
 
   render() {
-    const { menuExpanded, showChangeDatasourceModal, showEditDatasourceModal } = this.state;
+    const { showChangeDatasourceModal, showEditDatasourceModal } = this.state;
     const { datasource, onChange, onDatasourceSave, value } = this.props;
     return (
       <div>
         <ControlHeader {...this.props} />
         <div className="btn-group label-dropdown">
-          <OverlayTrigger
-            placement="right"
-            overlay={
-              <Tooltip id={'error-tooltip'}>{t('Click to change the datasource')}</Tooltip>
-            }
+          <TooltipWrapper
+            label="change-datasource"
+            tooltip={t('Click to change the datasource')}
           >
-            <div className="btn-group">
-              <Label onClick={this.toggleChangeDatasourceModal} className="label-btn-label">
-                {datasource.name}
-              </Label>
-            </div>
-          </OverlayTrigger>
-          <DropdownButton
-            noCaret
-            title={
-              <span>
-                <i className={`float-right expander fa fa-angle-${menuExpanded ? 'up' : 'down'}`} />
-              </span>}
-            className="label label-btn m-r-5"
-            bsSize="sm"
-            id="datasource_menu"
-          >
-            <MenuItem
-              eventKey="3"
-              onClick={this.toggleChangeDatasourceModal}
+            <DropdownButton
+              title={datasource.name}
+              className="label label-default label-btn m-r-5"
+              bsSize="sm"
+              id="datasource_menu"
             >
-              {t('Change Datasource')}
-            </MenuItem>
-            {datasource.type === 'table' &&
               <MenuItem
                 eventKey="3"
-                href={`/superset/sqllab?datasourceKey=${value}`}
-                target="_blank"
-                rel="noopener noreferrer"
+                onClick={this.toggleChangeDatasourceModal}
               >
-                {t('Explore in SQL Lab')}
-              </MenuItem>}
-            <MenuItem
-              eventKey="3"
-              onClick={this.toggleEditDatasourceModal}
-            >
-              {t('Edit Datasource')}
-            </MenuItem>
-          </DropdownButton>
+                {t('Change Datasource')}
+              </MenuItem>
+              {datasource.type === 'table' &&
+                <MenuItem
+                  eventKey="3"
+                  href={`/superset/sqllab?datasourceKey=${value}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t('Explore in SQL Lab')}
+                </MenuItem>}
+              <MenuItem
+                eventKey="3"
+                onClick={this.toggleEditDatasourceModal}
+              >
+                {t('Edit Datasource')}
+              </MenuItem>
+            </DropdownButton>
+          </TooltipWrapper>
           <OverlayTrigger
             placement="right"
             overlay={


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Some of our users didn't know how to find all options for edit datasource, since they didn't realize the **_datasource name_** and **_caret_** are different label buttons.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
<img width="457" alt="Screen Shot 2019-11-01 at 3 16 35 PM" src="https://user-images.githubusercontent.com/27990562/68059688-9f67b000-fcba-11e9-9be3-c282ac6ab9da.png">

**After:**
<img width="1002" alt="Screen Shot 2019-11-01 at 3 41 24 PM" src="https://user-images.githubusercontent.com/27990562/68060584-34b87380-fcbe-11e9-9f8c-2fb848e3a691.png">




### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@michellethomas @etr2460 @john-bodley