### PR TITLE
Allow customization of documentation icon and text

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -656,7 +656,7 @@ BUG_REPORT_URL = None
 
 # Send user to a link where they can read more about Superset
 DOCUMENTATION_URL = None
-DOCUMENTATION_TEXT = 'Documentation'
+DOCUMENTATION_TEXT = "Documentation"
 DOCUMENTATION_ICON = None  # Recommended size: 16x16
 
 # What is the Last N days relative in the time selector to:

--- a/superset/config.py
+++ b/superset/config.py
@@ -653,11 +653,11 @@ WEBDRIVER_BASEURL = "http://0.0.0.0:8080/"
 
 # Send user to a link where they can report bugs
 BUG_REPORT_URL = None
+
 # Send user to a link where they can read more about Superset
 DOCUMENTATION_URL = None
-DOCUMENTATION_ICON = None
-DOCUMENTATION_TEXT = None
-DOCUMENTATION_ICON_WIDTH = None
+DOCUMENTATION_TEXT = 'Documentation'
+DOCUMENTATION_ICON = None  # Recommended size: 16x16
 
 # What is the Last N days relative in the time selector to:
 # 'today' means it is midnight (00:00:00) in the local timezone

--- a/superset/config.py
+++ b/superset/config.py
@@ -655,6 +655,9 @@ WEBDRIVER_BASEURL = "http://0.0.0.0:8080/"
 BUG_REPORT_URL = None
 # Send user to a link where they can read more about Superset
 DOCUMENTATION_URL = None
+DOCUMENTATION_ICON = None
+DOCUMENTATION_TEXT = None
+DOCUMENTATION_ICON_WIDTH = None
 
 # What is the Last N days relative in the time selector to:
 # 'today' means it is midnight (00:00:00) in the local timezone

--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -17,8 +17,11 @@
   under the License.
 #}
 
-{% set bug_report_url = appbuilder.app.config['BUG_REPORT_URL'] %}
-{% set documentation_url = appbuilder.app.config['DOCUMENTATION_URL'] %}
+{% set bug_report_url = appbuilder.app.config.get('BUG_REPORT_URL') %}
+{% set documentation_url = appbuilder.app.config.get('DOCUMENTATION_URL') %}
+{% set documentation_icon = appbuilder.app.config.get('DOCUMENTATION_ICON') %}
+{% set documentation_text = appbuilder.app.config.get('DOCUMENTATION_TEXT', 'Documentation') %}
+{% set documentation_icon_width = appbuilder.app.config.get('DOCUMENTATION_ICON_WIDTH', 126) %}
 {% set locale = session['locale'] %}
 {% if not locale %}
     {% set locale = 'en' %}
@@ -41,9 +44,18 @@
   <a
     tabindex="-1"
     href="{{ documentation_url }}"
-    title="Documentation"
+    title="{{ documentation_text }}"
+    target="_blank"
   >
+  {% if documentation_icon %}
+    <img
+      width="{{ documentation_icon_width }}"
+      src="{{ documentation_icon }}"
+      alt="{{ documentation_text }}"
+    />
+  {% else %}
     <i class="fa fa-question"></i>&nbsp;
+  {% endif %}
   </a>
 </li>
 {% endif %}

--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -17,11 +17,10 @@
   under the License.
 #}
 
-{% set bug_report_url = appbuilder.app.config.get('BUG_REPORT_URL') %}
-{% set documentation_url = appbuilder.app.config.get('DOCUMENTATION_URL') %}
-{% set documentation_icon = appbuilder.app.config.get('DOCUMENTATION_ICON') %}
-{% set documentation_text = appbuilder.app.config.get('DOCUMENTATION_TEXT', 'Documentation') %}
-{% set documentation_icon_width = appbuilder.app.config.get('DOCUMENTATION_ICON_WIDTH', 126) %}
+{% set bug_report_url = appbuilder.app.config['BUG_REPORT_URL'] %}
+{% set documentation_url = appbuilder.app.config['DOCUMENTATION_URL'] %}
+{% set documentation_text = appbuilder.app.config['DOCUMENTATION_TEXT'] %}
+{% set documentation_icon = appbuilder.app.config['DOCUMENTATION_ICON'] %}
 {% set locale = session['locale'] %}
 {% if not locale %}
     {% set locale = 'en' %}
@@ -49,7 +48,7 @@
   >
   {% if documentation_icon %}
     <img
-      width="{{ documentation_icon_width }}"
+      width="100%"
       src="{{ documentation_icon }}"
       alt="{{ documentation_text }}"
     />


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This change allows customisation of the documentation link's icon and text. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Example with a custom icon
![image](https://user-images.githubusercontent.com/20205680/68217639-cd3d4500-ff97-11e9-80b6-9742e1e5e322.png)

### TEST PLAN
Validated that the default icon is used when no icon is specified

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
