### PR TITLE
Replace hardcoded default colors with defaults in setupColors.js

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -375,7 +375,7 @@ export const controls = {
     choices: () => sequentialSchemeRegistry
       .values()
       .map(value => [value.id, value.label]),
-    default: 'blue_white_yellow',
+    default: sequentialSchemeRegistry.getDefaultKey(),
     clearable: false,
     description: '',
     renderTrigger: true,
@@ -2066,7 +2066,7 @@ export const controls = {
   color_scheme: {
     type: 'ColorSchemeControl',
     label: t('Color Scheme'),
-    default: 'bnbColors',
+    default: categoricalSchemeRegistry.getDefaultKey(),
     renderTrigger: true,
     choices: () => categoricalSchemeRegistry.keys().map(s => ([s, s])),
     description: t('The color scheme for rendering chart'),

--- a/superset/assets/src/setup/setupColors.js
+++ b/superset/assets/src/setup/setupColors.js
@@ -40,4 +40,5 @@ export default function setupColors() {
       sequentialSchemeRegistry.registerValue(scheme.id, scheme);
     });
   });
+  sequentialSchemeRegistry.setDefaultKey('blue_white_yellow');
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently the default colors for both categorical and sequential schemes are hardcoded in `controls.js`, which means that changing the default values in `setupColors.js` don't have any effect on the default color scheme. This PR changes `controls.js` to use the default scheme as defined in `setupColors.js`, and also sets the default key for `sequentialSchemeRegistry` (previously only hard coded in `controls.js`).

### TEST PLAN
Tested locally by changing the default key in `setupColors.js`, and verifying that the default colors in a test dashboard reflected the change. If needed I can look into adding tests for this.

### REVIEWERS
@etr2460 @mistercrunch @graceguo-supercat 