### PR TITLE
Disable deprecated druid connector by default

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,10 @@ assists people when migrating to a new version.
 
 ## Next Version
 
+* [8512](https://github.com/apache/incubator-superset/pull/8512): `DRUID_IS_ACTIVE` now
+defaults to False. To enable Druid-API-based functionality, override the
+`DRUID_IS_ACTIVE` configuration variable by setting it to `True` for your deployment.
+
 * [8450](https://github.com/apache/incubator-superset/pull/8450): The time ranger picker
 now uses UTC for the tooltips and default placeholder timestamps (sans timezone).
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -170,9 +170,14 @@ LOGO_TARGET_PATH = None
 # [TimeZone List]
 # See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # other tz can be overridden by providing a local_config
-DRUID_IS_ACTIVE = True
 DRUID_TZ = tz.tzutc()
 DRUID_ANALYSIS_TYPES = ["cardinality"]
+
+# Legacy Druid connector
+# Druid supports a SQL interface in its newer versions.
+# Setting this flag to True enables the deprecated, API-based Druid
+# connector. This feature may be removed at a future date.
+DRUID_IS_ACTIVE = False
 
 # ----------------------------------------------------
 # AUTHENTICATION CONFIG

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -298,9 +298,7 @@ class DruidTests(SupersetTestCase):
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"
     )
-    @unittest.skipUnless(
-        app.config["DRUID_IS_ACTIVE"], "DRUID_IS_ACTIVE is false"
-    )
+    @unittest.skipUnless(app.config["DRUID_IS_ACTIVE"], "DRUID_IS_ACTIVE is false")
     def test_filter_druid_datasource(self):
         CLUSTER_NAME = "new_druid"
         cluster = self.get_or_create(

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 from superset import db, security_manager
+from tests.test_app import app
 
 from .base_tests import SupersetTestCase
 
@@ -296,6 +297,9 @@ class DruidTests(SupersetTestCase):
 
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"
+    )
+    @unittest.skipUnless(
+        app.config["DRUID_IS_ACTIVE"], "DRUID_IS_ACTIVE is false"
     )
     def test_filter_druid_datasource(self):
         CLUSTER_NAME = "new_druid"

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -83,11 +83,8 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_can_all("SqlMetricInlineView", perm_set)
         self.assert_can_all("TableColumnInlineView", perm_set)
         self.assert_can_all("TableModelView", perm_set)
-        self.assert_can_all("DruidDatasourceModelView", perm_set)
-        self.assert_can_all("DruidMetricInlineView", perm_set)
 
         self.assertIn(("all_datasource_access", "all_datasource_access"), perm_set)
-        self.assertIn(("muldelete", "DruidDatasourceModelView"), perm_set)
 
     def assert_cannot_alpha(self, perm_set):
         if app.config["ENABLE_ACCESS_REQUEST"]:
@@ -100,7 +97,6 @@ class RolePermissionTests(SupersetTestCase):
     def assert_can_admin(self, perm_set):
         self.assert_can_read("DatabaseAsync", perm_set)
         self.assert_can_all("DatabaseView", perm_set)
-        self.assert_can_all("DruidClusterModelView", perm_set)
         self.assert_can_all("RoleModelView", perm_set)
         self.assert_can_all("UserDBModelView", perm_set)
 
@@ -178,13 +174,6 @@ class RolePermissionTests(SupersetTestCase):
             security_manager._is_alpha_only(
                 security_manager.find_permission_view_menu(
                     "can_edit", "SqlMetricInlineView"
-                )
-            )
-        )
-        self.assertTrue(
-            security_manager._is_alpha_only(
-                security_manager.find_permission_view_menu(
-                    "can_delete", "DruidMetricInlineView"
                 )
             )
         )

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -55,9 +55,6 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_can_read(view_menu, permissions_set)
         self.assert_can_write(view_menu, permissions_set)
 
-    def assert_cannot_gamma(self, perm_set):
-        self.assert_cannot_write("DruidColumnInlineView", perm_set)
-
     def assert_can_gamma(self, perm_set):
         self.assert_can_read("DatabaseAsync", perm_set)
         self.assert_can_read("TableModelView", perm_set)
@@ -86,7 +83,6 @@ class RolePermissionTests(SupersetTestCase):
         self.assert_can_all("SqlMetricInlineView", perm_set)
         self.assert_can_all("TableColumnInlineView", perm_set)
         self.assert_can_all("TableModelView", perm_set)
-        self.assert_can_all("DruidColumnInlineView", perm_set)
         self.assert_can_all("DruidDatasourceModelView", perm_set)
         self.assert_can_all("DruidMetricInlineView", perm_set)
 
@@ -209,7 +205,6 @@ class RolePermissionTests(SupersetTestCase):
 
     def test_gamma_permissions_basic(self):
         self.assert_can_gamma(get_perm_tuples("Gamma"))
-        self.assert_cannot_gamma(get_perm_tuples("Gamma"))
         self.assert_cannot_alpha(get_perm_tuples("Alpha"))
 
     @unittest.skipUnless(
@@ -234,7 +229,6 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(("can_csv", "Superset"), sql_lab_set)
         self.assertIn(("can_search_queries", "Superset"), sql_lab_set)
 
-        self.assert_cannot_gamma(sql_lab_set)
         self.assert_cannot_alpha(sql_lab_set)
 
     def test_granter_permissions(self):
@@ -242,7 +236,6 @@ class RolePermissionTests(SupersetTestCase):
         self.assertIn(("can_override_role_permissions", "Superset"), granter_set)
         self.assertIn(("can_approve", "Superset"), granter_set)
 
-        self.assert_cannot_gamma(granter_set)
         self.assert_cannot_alpha(granter_set)
 
     def test_gamma_permissions(self):
@@ -273,7 +266,6 @@ class RolePermissionTests(SupersetTestCase):
 
         # check read only perms
         assert_can_read("TableModelView")
-        assert_cannot_write("DruidColumnInlineView")
 
         # make sure that user can create slices and dashboards
         assert_can_all("SliceModelView")


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've been informed by @mistercrunch that the Druid connector is deprecated in favor of the Druid SQLAlchemy engine. After a recent PR ( #8482 ) re-enabled the function of the `DRUID_IS_ACTIVE` flag, I figured I'd follow through and enshrine the deprecation in code by defaulting `DRUID_IS_ACTIVE` to `False`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [X] Removes existing feature or API (only by default, can be re-enabled)

### REVIEWERS
@mistercrunch @dpgaspar @betodealmeida