### PR TITLE
[sip-15] Fixing time range endpoints from dashboards

### DIFF
--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -137,7 +137,9 @@ def get_form_data(slice_id=None, use_slice_data=False):
     update_time_range(form_data)
 
     if app.config["SIP_15_ENABLED"]:
-        form_data["time_range_endpoints"] = get_time_range_endpoints(form_data, slc)
+        form_data["time_range_endpoints"] = get_time_range_endpoints(
+            form_data, slc, slice_id
+        )
 
     return form_data, slc
 
@@ -207,17 +209,23 @@ def apply_display_max_row_limit(
 
 
 def get_time_range_endpoints(
-    form_data: Dict[str, Any], slc: Optional[models.Slice]
+    form_data: Dict[str, Any],
+    slc: Optional[models.Slice] = None,
+    slice_id: Optional[int] = None,
 ) -> Optional[Tuple[TimeRangeEndpoint, TimeRangeEndpoint]]:
     """
     Get the slice aware time range endpoints from the form-data falling back to the SQL
     database specific definition or default if not defined.
 
+    Note under certain circumstances the slice object may not exist, however the slice
+    ID may be defined which serves as a fallback.
+
     When SIP-15 is enabled all slices and will the [start, end) interval. If the grace
     period is defined and has ended all slices will adhere to the [start, end) interval.
 
     :param form_data: The form-data
-    :param slc: The chart
+    :param slc: The slice
+    :param slice_id: The slice ID
     :returns: The time range endpoints tuple
     """
 
@@ -229,14 +237,22 @@ def get_time_range_endpoints(
 
     endpoints = form_data.get("time_range_endpoints")
 
-    if slc and not endpoints:
+    if (slc or slice_id) and not endpoints:
         try:
             _, datasource_type = get_datasource_info(None, None, form_data)
         except SupersetException:
             return None
 
         if datasource_type == "table":
-            endpoints = slc.datasource.database.get_extra().get("time_range_endpoints")
+            if not slc:
+                slc = (
+                    db.session.query(models.Slice).filter_by(id=slice_id).one_or_none()
+                )
+
+            if slc:
+                endpoints = slc.datasource.database.get_extra().get(
+                    "time_range_endpoints"
+                )
 
             if not endpoints:
                 endpoints = app.config["SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS"]

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -886,19 +886,19 @@ class UtilsTestCase(unittest.TestCase):
 
     def test_get_time_range_endpoints(self):
         self.assertEqual(
-            get_time_range_endpoints(form_data={}, slc=None),
+            get_time_range_endpoints(form_data={}),
             (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.EXCLUSIVE),
         )
 
         self.assertEqual(
             get_time_range_endpoints(
-                form_data={"time_range_endpoints": ["inclusive", "inclusive"]}, slc=None
+                form_data={"time_range_endpoints": ["inclusive", "inclusive"]}
             ),
             (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.INCLUSIVE),
         )
 
         self.assertEqual(
-            get_time_range_endpoints(form_data={"datasource": "1_druid"}, slc=None),
+            get_time_range_endpoints(form_data={"datasource": "1_druid"}),
             (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.EXCLUSIVE),
         )
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes an issue where the time range endpoints are incorrect from a dashboard as `slc` is `None` when getting the form data and thus if undefined the time range endpoints were `(inclusive, exclusive)` rather than relying on the default or database override. 

The logic here is to determine whether the form-data represents an existing slice (or a mutation of an existing slice) hence falling back to the `slice_id` if the `slc` is defined.

### TEST PLAN

Tested locally to ensure the the `time_range_endpoints` was correctly defined.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @michellethomas 