### PR TITLE
[fix] cluster_name = cluster_name, not cluster_id

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1612,7 +1612,7 @@ class DruidDatasource(Model, BaseDatasource):
     ) -> List["DruidDatasource"]:
         return (
             session.query(cls)
-            .filter_by(cluster_name=database.id)
+            .filter_by(cluster_name=database.database_name)
             .filter_by(datasource_name=datasource_name)
             .all()
         )

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -339,7 +339,7 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin
         with db.session.no_autoflush:
             query = db.session.query(models.DruidDatasource).filter(
                 models.DruidDatasource.datasource_name == datasource.datasource_name,
-                models.DruidDatasource.cluster_name == datasource.cluster.id,
+                models.DruidDatasource.cluster_name == datasource.cluster.cluster_name,
             )
             if db.session.query(query.exists()).scalar():
                 raise Exception(get_datasource_exist_error_msg(datasource.full_name))


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Found these 3-year-old bugs while looking into some other stuff. I'm guessing this may have happened because of some copy paste errors. It probably isn't too important since they haven't been caught, but it's pretty irksome to look at, so here we go.

### TEST PLAN
Passes `tox`.

### REVIEWERS
@john-bodley 
