### PR TITLE
Avoid fetch fav dashboard stat not logged in

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
@@ -31,7 +31,7 @@ describe('Header', () => {
   const props = {
     addSuccessToast: () => {},
     addDangerToast: () => {},
-    dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true },
+    dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true, userId: 1 },
     dashboardTitle: 'title',
     charts: {},
     layout: {},
@@ -177,6 +177,42 @@ describe('Header', () => {
     it('should set up undo/redo', () => {
       const wrapper = setup(overrideProps);
       expect(wrapper.find(UndoRedoKeylisteners)).toHaveLength(1);
+    });
+  });
+
+  describe('logged-out-user', () => {
+    const overrideProps = {
+      dashboardInfo: { id: 1, dash_edit_perm: false, dash_save_perm: false, userId: null },
+    };
+
+    it('should render the EditableTitle', () => {
+      const wrapper = setup(overrideProps);
+      expect(wrapper.find(EditableTitle)).toHaveLength(1);
+    });
+
+    it('should render the PublishedStatus', () => {
+      const wrapper = setup(overrideProps);
+      expect(wrapper.find(PublishedStatus)).toHaveLength(1);
+    });
+
+    it('should not render the FaveStar', () => {
+      const wrapper = setup(overrideProps);
+      expect(wrapper.find(FaveStar)).toHaveLength(0);
+    });
+
+    it('should render the HeaderActionsDropdown', () => {
+      const wrapper = setup(overrideProps);
+      expect(wrapper.find(HeaderActionsDropdown)).toHaveLength(1);
+    });
+
+    it('should render one Button', () => {
+      const wrapper = setup(overrideProps);
+      expect(wrapper.find(Button)).toHaveLength(1);
+    });
+
+    it('should not set up undo/redo', () => {
+      const wrapper = setup(overrideProps);
+      expect(wrapper.find(UndoRedoKeylisteners)).toHaveLength(0);
     });
   });
 });

--- a/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
@@ -31,7 +31,12 @@ describe('Header', () => {
   const props = {
     addSuccessToast: () => {},
     addDangerToast: () => {},
-    dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true, userId: 1 },
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      dash_save_perm: true,
+      userId: 1,
+    },
     dashboardTitle: 'title',
     charts: {},
     layout: {},
@@ -72,7 +77,12 @@ describe('Header', () => {
 
   describe('read-only-user', () => {
     const overrideProps = {
-      dashboardInfo: { id: 1, dash_edit_perm: false, dash_save_perm: false, userId: 1 },
+      dashboardInfo: {
+        id: 1,
+        dash_edit_perm: false,
+        dash_save_perm: false,
+        userId: 1,
+      },
     };
 
     it('should render the EditableTitle', () => {
@@ -109,7 +119,12 @@ describe('Header', () => {
   describe('write-user', () => {
     const overrideProps = {
       editMode: false,
-      dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true, userId: 1 },
+      dashboardInfo: {
+        id: 1,
+        dash_edit_perm: true,
+        dash_save_perm: true,
+        userId: 1,
+      },
     };
 
     it('should render the EditableTitle', () => {
@@ -146,7 +161,12 @@ describe('Header', () => {
   describe('write-user-with-edit-mode', () => {
     const overrideProps = {
       editMode: true,
-      dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true, userId: 1 },
+      dashboardInfo: {
+        id: 1,
+        dash_edit_perm: true,
+        dash_save_perm: true,
+        userId: 1,
+      },
     };
 
     it('should render the EditableTitle', () => {
@@ -182,7 +202,12 @@ describe('Header', () => {
 
   describe('logged-out-user', () => {
     const overrideProps = {
-      dashboardInfo: { id: 1, dash_edit_perm: false, dash_save_perm: false, userId: null },
+      dashboardInfo: {
+        id: 1,
+        dash_edit_perm: false,
+        dash_save_perm: false,
+        userId: null,
+      },
     };
 
     it('should render the EditableTitle', () => {

--- a/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
@@ -72,7 +72,7 @@ describe('Header', () => {
 
   describe('read-only-user', () => {
     const overrideProps = {
-      dashboardInfo: { id: 1, dash_edit_perm: false, dash_save_perm: false },
+      dashboardInfo: { id: 1, dash_edit_perm: false, dash_save_perm: false, userId: 1 },
     };
 
     it('should render the EditableTitle', () => {
@@ -109,7 +109,7 @@ describe('Header', () => {
   describe('write-user', () => {
     const overrideProps = {
       editMode: false,
-      dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true },
+      dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true, userId: 1 },
     };
 
     it('should render the EditableTitle', () => {
@@ -146,7 +146,7 @@ describe('Header', () => {
   describe('write-user-with-edit-mode', () => {
     const overrideProps = {
       editMode: true,
-      dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true },
+      dashboardInfo: { id: 1, dash_edit_perm: true, dash_save_perm: true, userId: 1 },
     };
 
     it('should render the EditableTitle', () => {

--- a/superset/assets/src/dashboard/components/Header.jsx
+++ b/superset/assets/src/dashboard/components/Header.jsx
@@ -306,14 +306,16 @@ class Header extends React.PureComponent {
               canSave={userCanSaveAs}
             />
           </span>
-          <span className="favstar">
-            <FaveStar
-              itemId={dashboardInfo.id}
-              fetchFaveStar={this.props.fetchFaveStar}
-              saveFaveStar={this.props.saveFaveStar}
-              isStarred={this.props.isStarred}
-            />
-          </span>
+          {dashboardInfo.userId && (
+            <span className="favstar">
+              <FaveStar
+                itemId={dashboardInfo.id}
+                fetchFaveStar={this.props.fetchFaveStar}
+                saveFaveStar={this.props.saveFaveStar}
+                isStarred={this.props.isStarred}
+              />
+            </span>
+          )}
         </div>
 
         <div className="button-container">


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As explained in #8501, if you allow non logged in users to see dashboards, the favorite status of that dashboard will still be fetched, causing an error toast to appear.
To fix it I check if the userId present on the dashboardInfo prop of the Header component is valid, and only if it is, the span related to the fav-star is rendered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![fav-start-showing](https://user-images.githubusercontent.com/23409890/68392333-7daa7500-0161-11ea-858e-4aebe2f6b71b.png)
![fav-start-not-showing](https://user-images.githubusercontent.com/23409890/68392337-7edba200-0161-11ea-934d-602e95889cc6.png)

<!--- Skip this if not applicable -->

### TEST PLAN
There's already a test that verifies if the fav-start is displayed and works correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #8501
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
