### PR TITLE
Encode feature flags to JSON pessimistically

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2962,7 +2962,9 @@ class Superset(BaseSupersetView):
         return self.render_template(
             "superset/basic.html",
             entry="welcome",
-            bootstrap_data=json.dumps(payload, default=utils.json_iso_dttm_ser),
+            bootstrap_data=json.dumps(
+                payload, default=utils.pessimistic_json_iso_dttm_ser
+            ),
         )
 
     @has_access
@@ -3001,7 +3003,7 @@ class Superset(BaseSupersetView):
         return self.render_template(
             "superset/basic.html",
             entry="sqllab",
-            bootstrap_data=json.dumps(d, default=utils.json_iso_dttm_ser),
+            bootstrap_data=json.dumps(d, default=utils.pessimistic_json_iso_dttm_ser),
         )
 
     @api

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for Superset"""
+import cgi
 import imp
 import json
 import unittest
@@ -28,7 +29,7 @@ from superset.connectors.druid.models import DruidCluster, DruidDatasource
 from superset.connectors.sqla.models import SqlaTable
 from superset.models import core as models
 from superset.models.core import Database
-from superset.utils.core import get_example_database
+from superset.utils.core import get_example_database, pessimistic_json_iso_dttm_ser
 
 BASE_DIR = app.config["BASE_DIR"]
 

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for Superset"""
-import cgi
 import imp
 import json
 import unittest
@@ -29,7 +28,7 @@ from superset.connectors.druid.models import DruidCluster, DruidDatasource
 from superset.connectors.sqla.models import SqlaTable
 from superset.models import core as models
 from superset.models.core import Database
-from superset.utils.core import get_example_database, pessimistic_json_iso_dttm_ser
+from superset.utils.core import get_example_database
 
 BASE_DIR = app.config["BASE_DIR"]
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/incubator-superset/pull/8470 introduced a feature flag that is a function, for customizing the query cost estimate provided by different backend engines (currently supported only in Presto). The presence of a function in the feature flags breaks the JSON serialization of the payload, when sending it to the frontend.

I fixed it by using the pessimistic JSON encoder, which fallbacks to a string representation of the object when the serialization fails.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I hit the error when deploying a custom feature flag, not sure why it wasn't triggered in https://github.com/apache/incubator-superset/pull/8470. Fixed it and verified it now works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 