### PR TITLE
Pass url parameters from dashboard to charts

### DIFF
--- a/superset/assets/cypress/integration/dashboard/index.test.js
+++ b/superset/assets/cypress/integration/dashboard/index.test.js
@@ -23,6 +23,7 @@ import DashboardFilterTest from './filter';
 import DashboardLoadTest from './load';
 import DashboardSaveTest from './save';
 import DashboardTabsTest from './tabs';
+import DashboardUrlParamsTest from './url_params';
 
 describe('Dashboard', () => {
   DashboardControlsTest();
@@ -32,4 +33,5 @@ describe('Dashboard', () => {
   DashboardLoadTest();
   DashboardSaveTest();
   DashboardTabsTest();
+  DashboardUrlParamsTest();
 });

--- a/superset/assets/cypress/integration/dashboard/url_params.js
+++ b/superset/assets/cypress/integration/dashboard/url_params.js
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
+
+export default () => describe('dashboard url params', () => {
+  let sliceIds = [];
+
+  beforeEach(() => {
+    cy.server();
+    cy.login();
+
+    cy.visit(WORLD_HEALTH_DASHBOARD + '?param1=123&param2=abc');
+
+    cy.get('#app').then((data) => {
+      const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
+      const dashboard = bootstrapData.dashboard_data;
+      sliceIds = dashboard.slices.map(slice => (slice.slice_id));
+    });
+  });
+
+  it('should apply url params to slice requests', () => {
+    const aliases = [];
+    sliceIds
+      .forEach((id) => {
+        const alias = `getJson_${id}`;
+        aliases.push(`@${alias}`);
+        cy.route('POST', `/superset/explore_json/?form_data={"slice_id":${id}}`).as(alias);
+      });
+
+    cy.wait(aliases).then((requests) => {
+      requests.forEach((xhr) => {
+        const requestFormData = xhr.request.body;
+        const requestParams = JSON.parse(requestFormData.get('form_data'));
+        expect(requestParams.url_params)
+          .deep.eq({ param1: '123', param2: 'abc' });
+      });
+    });
+  });
+});

--- a/superset/assets/cypress/integration/dashboard/url_params.js
+++ b/superset/assets/cypress/integration/dashboard/url_params.js
@@ -19,13 +19,14 @@
 import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
 
 export default () => describe('dashboard url params', () => {
+  const urlParams = { param1: '123', param2: 'abc' };
   let sliceIds = [];
 
   beforeEach(() => {
     cy.server();
     cy.login();
 
-    cy.visit(WORLD_HEALTH_DASHBOARD + '?param1=123&param2=abc');
+    cy.visit(WORLD_HEALTH_DASHBOARD, { qs: urlParams });
 
     cy.get('#app').then((data) => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
@@ -48,7 +49,7 @@ export default () => describe('dashboard url params', () => {
         const requestFormData = xhr.request.body;
         const requestParams = JSON.parse(requestFormData.get('form_data'));
         expect(requestParams.url_params)
-          .deep.eq({ param1: '123', param2: 'abc' });
+          .deep.eq(urlParams);
       });
     });
   });

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -19,7 +19,7 @@
     "lint-fix": "eslint --fix --ignore-path=.eslintignore --ext .js,.jsx . && tslint -c tslint.json --fix ./{src,spec}/**/*.ts{,x}",
     "cypress": "cypress",
     "cypress-debug": "cypress open --config watchForFileChanges=true",
-    "install-cypress": "npm install cypress@3.4.1"
+    "install-cypress": "npm install cypress@3.6.1"
   },
   "repository": {
     "type": "git",

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -105,12 +105,18 @@ export default function(bootstrapData) {
   dashboard.slices.forEach(slice => {
     const key = slice.slice_id;
     if (['separator', 'markup'].indexOf(slice.form_data.viz_type) === -1) {
-      slice.form_data.url_params = {...slice.form_data.url_params || {}, ...urlParams};
+      const form_data = {
+        ...slice.form_data,
+        url_params: {
+          ...slice.form_data.url_params,
+          ...urlParams,
+        },
+      };
       chartQueries[key] = {
         ...chart,
         id: key,
-        form_data: slice.form_data,
-        formData: applyDefaultFormData(slice.form_data),
+        form_data,
+        formData: applyDefaultFormData(form_data),
       };
 
       slices[key] = {

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -47,7 +47,7 @@ import newComponentFactory from '../util/newComponentFactory';
 import { TIME_RANGE } from '../../visualizations/FilterBox/FilterBox';
 
 export default function(bootstrapData) {
-  const { user_id, datasources, common, editMode } = bootstrapData;
+  const { user_id, datasources, common, editMode, urlParams } = bootstrapData;
 
   const dashboard = { ...bootstrapData.dashboard_data };
   let preselectFilters = {};
@@ -105,6 +105,7 @@ export default function(bootstrapData) {
   dashboard.slices.forEach(slice => {
     const key = slice.slice_id;
     if (['separator', 'markup'].indexOf(slice.form_data.viz_type) === -1) {
+      slice.form_data.url_params = {...slice.form_data.url_params || {}, ...urlParams};
       chartQueries[key] = {
         ...chart,
         id: key,

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -56,6 +56,9 @@ def url_param(param: str, default: Optional[str] = None) -> Optional[Any]:
     parameters in the explore view as well as from the dashboard, and
     it should carry through to your queries.
 
+    Default values for URL parameters can be defined in chart metdata by
+    adding the key-value pair `url_params: {'foo': 'bar'}`
+
     :param param: the parameter to lookup
     :param default: the value to return in the absence of the parameter
     """

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -35,7 +35,7 @@ from email.mime.text import MIMEText
 from email.utils import formatdate
 from enum import Enum
 from time import struct_time
-from typing import Iterator, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple, Union
 from urllib.parse import unquote_plus
 
 import bleach
@@ -933,8 +933,16 @@ def merge_extra_filters(form_data: dict):
         del form_data["extra_filters"]
 
 
-def merge_request_params(form_data: dict, params: dict):
-    url_params = {}
+def merge_request_params(form_data: Dict[str, Any], params: Dict[str, Any]) -> None:
+    """
+    Merge request parameters to the key `url_params` in form_data. Only updates
+    or appends parameters to `form_data` that are defined in `params; pre-existing
+    parameters not defined in params are left unchanged.
+
+    :param form_data: object to be updated
+    :param params: request parameters received via query string
+    """
+    url_params = form_data.get("url_params", {})
     for key, value in params.items():
         if key in ("form_data", "r"):
             continue

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1269,3 +1269,13 @@ class TimeRangeEndpoint(str, Enum):
     EXCLUSIVE = "exclusive"
     INCLUSIVE = "inclusive"
     UNKNOWN = "unknown"
+
+
+class ReservedUrlParameters(Enum):
+    """
+    Reserved URL parameters that are used internally by Superset. These will not be
+    passed to chart queries, as they control the behavior of the UI.
+    """
+
+    STANDALONE = "standalone"
+    EDIT_MODE = "edit"

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2192,6 +2192,11 @@ class Superset(BaseSupersetView):
                 "slice_can_edit": slice_can_edit,
             }
         )
+        url_params = {
+            key: value
+            for key, value in request.args.items()
+            if key not in ("edit", "standalone")
+        }
 
         bootstrap_data = {
             "user_id": g.user.get_id(),
@@ -2199,6 +2204,7 @@ class Superset(BaseSupersetView):
             "datasources": {ds.uid: ds.data for ds in datasources},
             "common": self.common_bootstrap_payload(),
             "editMode": edit_mode,
+            "urlParams": url_params,
         }
 
         if request.args.get("json") == "true":

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -521,13 +521,27 @@ class UtilsTestCase(unittest.TestCase):
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
 
-    def test_merge_request_params(self):
+    def test_merge_request_params_when_url_params_undefined(self):
         form_data = {"since": "2000", "until": "now"}
         url_params = {"form_data": form_data, "dashboard_ids": "(1,2,3,4,5)"}
         merge_request_params(form_data, url_params)
         self.assertIn("url_params", form_data.keys())
         self.assertIn("dashboard_ids", form_data["url_params"])
         self.assertNotIn("form_data", form_data.keys())
+
+    def test_merge_request_params_when_url_params_predefined(self):
+        form_data = {
+            "since": "2000",
+            "until": "now",
+            "url_params": {"abc": "123", "dashboard_ids": "(1,2,3)"},
+        }
+        url_params = {"form_data": form_data, "dashboard_ids": "(1,2,3,4,5)"}
+        merge_request_params(form_data, url_params)
+        self.assertIn("url_params", form_data.keys())
+        self.assertIn("abc", form_data["url_params"])
+        self.assertEquals(
+            url_params["dashboard_ids"], form_data["url_params"]["dashboard_ids"]
+        )
 
     def test_datetime_f(self):
         self.assertEqual(


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
Currently URL parameters are correctly handled in explore mode. However, current functionality is limited/broken in the following ways:
- Any default values for `url_params` specified in charts are erased if the chart is opened via the Charts page.
- query parameters passed to dashboards are not forwarded to chart requests, making them unusable in dashboards.

This PR does the following:
- Default values for query parameters are left unchanged when opening a chart via the Charts page.
- URL parameters passed to a dashboard are updated to the chart defaults prior to rendering.
- Add note about setting default values for `url_params`.
- Add cypress test to ensure params are passed through from the dashboard to chart requests.
- Add python test to ensure that url params are appended to pre-defined params.

### SCREENSHOTS
Datasource query:
![image](https://user-images.githubusercontent.com/33317356/69005658-f661bc00-092d-11ea-9fa6-a56df7c65bf3.png)

Chart metadata with default values for `url_params`:
![image](https://user-images.githubusercontent.com/33317356/69005628-a5ea5e80-092d-11ea-879c-bc47354652f7.png)

Dashboard with url parameter (note `name2` falling back to default value):
![image](https://user-images.githubusercontent.com/33317356/69005735-ee564c00-092e-11ea-8046-84170ebb2fed.png)


### TEST PLAN
- Tested locally
- CI
- Ensured that new tests fail when run on master branch

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #6708 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@senturkayhan @rsdpyenugula @mistercrunch @graceguo-supercat @etr2460 