### PR TITLE
Upgrade superset-ui/time-format

### DIFF
--- a/superset/assets/package-lock.json
+++ b/superset/assets/package-lock.json
@@ -4425,14 +4425,24 @@
       "integrity": "sha512-eDAuaah+FLFHm3XvHQU7yb0U2xs2wK+DIiZ0E0NKznaItWnBOJT1b8O0lxaelqK5moLDUOkCtl81C2ueD+3c2w=="
     },
     "@superset-ui/time-format": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@superset-ui/time-format/-/time-format-0.12.1.tgz",
-      "integrity": "sha512-Plw2TSZ4vt8YUIruK1tbTHqpQo5HFBuqQpFoBfQCeiVK7Iv9yKuf/GWLjC3t4lPifIy9DyN5OqdpkE5h5++gSA==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@superset-ui/time-format/-/time-format-0.12.4.tgz",
+      "integrity": "sha512-QMBRQbzRw18TAfSRE8ioQ6uUEkg+l5llhWUAN8AgFsWbg/c0Hz87I3SrKodn++gVX9h7/n0kMWw7pHQE+8eXAw==",
       "requires": {
         "@types/d3-time": "^1.0.9",
         "@types/d3-time-format": "^2.1.0",
         "d3-time": "^1.0.10",
-        "d3-time-format": "^2.1.3"
+        "d3-time-format": "^2.2.0"
+      },
+      "dependencies": {
+        "d3-time-format": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.1.tgz",
+          "integrity": "sha512-VA6WqORO1+H1SvSzgl2oT0z3niANh3opa8Cencpen1LFthw/bEX71R/DgjPlWw78J4UHmD0jCPP1W0HpwMkhjg==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/translation": {
@@ -10737,7 +10747,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -82,7 +82,7 @@
     "@superset-ui/plugin-chart-table": "^0.11.4",
     "@superset-ui/preset-chart-xy": "^0.11.0",
     "@superset-ui/query": "^0.12.2",
-    "@superset-ui/time-format": "^0.12.1",
+    "@superset-ui/time-format": "^0.12.4",
     "@superset-ui/translation": "^0.12.0",
     "@types/react-json-tree": "^0.6.11",
     "@vx/responsive": "0.0.172",


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Upgrades so we can use `%q` for quarter in time formatting. See https://github.com/apache-superset/superset-ui/pull/244

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@kristw @graceguo-supercat @john-bodley 