### PR TITLE
docs: remove Gitter link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Installation & Configuration
 Resources
 -------------
 * [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
-* [Gitter (live chat) Channel](https://gitter.im/airbnb/superset)
 * [Docker image](https://hub.docker.com/r/amancevice/superset/) (community contributed)
 * [Slides from Strata (March 2016)](https://drive.google.com/open?id=0B5PVE0gzO81oOVJkdF9aNkJMSmM)
 * [Stackoverflow tag](https://stackoverflow.com/questions/tagged/apache-superset)


### PR DESCRIPTION
Let's always use Slack instead