### PR TITLE
Add convert_dttm method to SnowflakeEngineSpec

### DIFF
--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import datetime
+from typing import Optional
 from urllib import parse
 
 from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
@@ -61,3 +63,14 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
     @classmethod
     def epoch_ms_to_dttm(cls) -> str:
         return "DATEADD(MS, {col}, '1970-01-01')"
+
+    @classmethod
+    def convert_dttm(cls, target_type: str, dttm: datetime) -> Optional[str]:
+        tt = target_type.upper()
+        if tt == "DATE":
+            return f"TO_DATE('{dttm.date().isoformat()}')"
+        if tt == "DATETIME":
+            return f"""CAST('{dttm.isoformat(timespec="microseconds")}' AS DATETIME)"""
+        if tt == "TIMESTAMP":
+            return f"""TO_TIMESTAMP('{dttm.isoformat(timespec="microseconds")}')"""
+        return None

--- a/tests/db_engine_specs/snowflake_tests.py
+++ b/tests/db_engine_specs/snowflake_tests.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from sqlalchemy import column
+
+from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
+from tests.db_engine_specs.base_tests import DbEngineSpecTestCase
+
+
+class SnowflakeTestCase(DbEngineSpecTestCase):
+    def test_convert_dttm(self):
+        dttm = self.get_dttm()
+
+        self.assertEqual(
+            SnowflakeEngineSpec.convert_dttm("DATE", dttm), "TO_DATE('2019-01-02')"
+        )
+
+        self.assertEqual(
+            SnowflakeEngineSpec.convert_dttm("DATETIME", dttm),
+            "CAST('2019-01-02T03:04:05.678900' AS DATETIME)",
+        )
+
+        self.assertEqual(
+            SnowflakeEngineSpec.convert_dttm("TIMESTAMP", dttm),
+            "TO_TIMESTAMP('2019-01-02T03:04:05.678900')",
+        )


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
With the introduction of SIP-15, temporal handling can be improved by making sure dates and datetimes are cast to their respective native SQL types. This adds correct handling of `DATE`, `DATETIME` and `TIMESTAMP` to the Snowflake spec along with tests.

While the UI seems to imply that `DATETIME` and `TIMESTAMP` are truncated to millisecond precision, it is my understanding that they are in fact stored at nanosecond precision, hence `timespec=microsecond` like other engines with micro-/nanosecond precision.

### TEST PLAN
CI + executing test expressions in Snowflake UI:
![image](https://user-images.githubusercontent.com/33317356/68737256-93012280-05eb-11ea-8ed5-60438441c49f.png)

### REVIEWERS
@john-bodley 