### PR TITLE
bump legacy-preset-chart-nvd3 to 0.11.5

### DIFF
--- a/superset/assets/package-lock.json
+++ b/superset/assets/package-lock.json
@@ -3948,11 +3948,11 @@
       }
     },
     "@superset-ui/legacy-preset-chart-nvd3": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-nvd3/-/legacy-preset-chart-nvd3-0.11.4.tgz",
-      "integrity": "sha512-oNRWGIGApyH/55IhD8E6rGoyhswU2cs9aPI6zmqVwfEDKmqMonjDlY06YRRh2e3o9AOM1o3VGRiDutJBqOUzaQ==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-nvd3/-/legacy-preset-chart-nvd3-0.11.5.tgz",
+      "integrity": "sha512-OgcivObF02xOOgThOB4iMykjp1Q2WudFAf2H94+TPGlX4vx3opcXInvtxju44bx70ywhtlgp3oYxt1nusE/taQ==",
       "requires": {
-        "@data-ui/xy-chart": "^0.0.81",
+        "@data-ui/xy-chart": "^0.0.82",
         "d3": "^3.5.17",
         "d3-tip": "^0.9.1",
         "dompurify": "^2.0.6",
@@ -3966,11 +3966,11 @@
       },
       "dependencies": {
         "@data-ui/shared": {
-          "version": "0.0.81",
-          "resolved": "https://registry.npmjs.org/@data-ui/shared/-/shared-0.0.81.tgz",
-          "integrity": "sha512-kARqb5FIKk5JLqFUwQQccrJdZccPMoWyJ9N1PGvZ+KT+SbTvby/NiodnnpH3UljrDnoAfNggEnI6z9YJI0yF7w==",
+          "version": "0.0.82",
+          "resolved": "https://registry.npmjs.org/@data-ui/shared/-/shared-0.0.82.tgz",
+          "integrity": "sha512-Orh1Be8Mwgjr5Q42AH9BOLZ6wV3C/gEbzsRYqkGOaCtWTYJOTmAxlmnlvZe5CAyo7QDXQHiV2Xvk90FQcQ/NYQ==",
           "requires": {
-            "@data-ui/theme": "^0.0.81",
+            "@data-ui/theme": "^0.0.82",
             "@vx/event": "^0.0.165",
             "@vx/group": "^0.0.165",
             "@vx/shape": "^0.0.168",
@@ -3996,17 +3996,17 @@
           }
         },
         "@data-ui/theme": {
-          "version": "0.0.81",
-          "resolved": "https://registry.npmjs.org/@data-ui/theme/-/theme-0.0.81.tgz",
-          "integrity": "sha512-Qo0TRf75acWZfsDDDTotQnXum28ECXft1ax9YXKZyRhkb9DiNBI7I1E3Ip/e9VKg1hoH2KnT20PNIKiE7kdhKQ=="
+          "version": "0.0.82",
+          "resolved": "https://registry.npmjs.org/@data-ui/theme/-/theme-0.0.82.tgz",
+          "integrity": "sha512-h7lE+jRmkIfKhePvfbpHy+2TcfxTVcffxqV4LubcdzAT7pue/mR90T9NBXwidMSGs2eo2fBl2QJGNICDFT7miA=="
         },
         "@data-ui/xy-chart": {
-          "version": "0.0.81",
-          "resolved": "https://registry.npmjs.org/@data-ui/xy-chart/-/xy-chart-0.0.81.tgz",
-          "integrity": "sha512-/rJJ+xQ7ISEkObYGGPAOkRGu1m3zQ3QgmaQI9CgeYoJO/So9yqZe2D1ttCYTxtEFQdvTVA1Vxz3VjNiGJffzyA==",
+          "version": "0.0.82",
+          "resolved": "https://registry.npmjs.org/@data-ui/xy-chart/-/xy-chart-0.0.82.tgz",
+          "integrity": "sha512-pzxXv38UfOIMznqO5+iaxLV8+Wra8Rw5MpKnJdOtVdkB2LSgvfRyRyvDF72FsIYIMUmrOIy7XaiEVOsoTZRa9Q==",
           "requires": {
-            "@data-ui/shared": "^0.0.81",
-            "@data-ui/theme": "^0.0.81",
+            "@data-ui/shared": "^0.0.82",
+            "@data-ui/theme": "^0.0.82",
             "@vx/axis": "^0.0.175",
             "@vx/curve": "^0.0.165",
             "@vx/event": "^0.0.165",
@@ -10747,7 +10747,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -77,7 +77,7 @@
     "@superset-ui/legacy-plugin-chart-world-map": "^0.11.0",
     "@superset-ui/legacy-preset-chart-big-number": "^0.11.0",
     "@superset-ui/legacy-preset-chart-deckgl": "^0.1.0",
-    "@superset-ui/legacy-preset-chart-nvd3": "^0.11.4",
+    "@superset-ui/legacy-preset-chart-nvd3": "^0.11.5",
     "@superset-ui/number-format": "^0.12.1",
     "@superset-ui/plugin-chart-table": "^0.11.4",
     "@superset-ui/preset-chart-xy": "^0.11.0",


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bumps package to include fix for multi-line chart. 

relevant pr: https://github.com/apache-superset/superset-ui-plugins/pull/247

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="524" alt="Screen Shot 2019-11-13 at 9 40 55 AM" src="https://user-images.githubusercontent.com/10255196/68789310-0dd13a00-05fa-11ea-9122-5e3797597c7e.png">
<img width="530" alt="Screen Shot 2019-11-13 at 9 41 04 AM" src="https://user-images.githubusercontent.com/10255196/68789319-11fd5780-05fa-11ea-8f3e-f134259d825f.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- multi line chart in examples doesn't render before package upgrade.
- multi line chart in examples renders after package upgrade. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
