### PR TITLE
showing version and SHA (subtly) in user menu.

### DIFF
--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -139,6 +139,14 @@ span.title-block {
 }
 div.navbar {
   z-index: 999;
+  .dropdown-menu .fineprint{
+    padding: 10px 20px 0 20px;
+    color: @gray-light;
+    font-size: 1rem;
+    div{
+      white-space: nowrap;
+    }
+  }
 }
 .datasource form div.form-control {
   margin-bottom: 5px !important;

--- a/superset/assets/stylesheets/superset.less
+++ b/superset/assets/stylesheets/superset.less
@@ -134,16 +134,16 @@ span.title-block {
     -moz-transition-delay: 0ms;
     -webkit-transition-delay: 0ms;
 }
-.nvtooltip table td{
+.nvtooltip table td {
     font-size: 11px !important;
 }
 div.navbar {
   z-index: 999;
-  .dropdown-menu .fineprint{
+  .dropdown-menu .fineprint {
     padding: 10px 20px 0 20px;
     color: @gray-light;
     font-size: 1rem;
-    div{
+    div {
       white-space: nowrap;
     }
   }

--- a/superset/config.py
+++ b/superset/config.py
@@ -59,10 +59,17 @@ VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
 PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets" "package.json")
 
 
-def _try_json_readfile(filepath):
+def _try_json_readversion(filepath):
     try:
         with open(filepath, "r") as f:
             return json.load(f).get("version")
+    except Exception:
+        return None
+
+def _try_json_readsha(filepath):
+    try:
+        with open(filepath, "r") as f:
+            return json.load(f).get("GIT_SHA")
     except Exception:
         return None
 
@@ -72,9 +79,12 @@ def _try_json_readfile(filepath):
 # that we're actually running Superset, we will have already installed, therefore it WILL
 # exist. When unit tests are running, however, it WILL NOT exist, so we fall
 # back to reading package.json
-VERSION_STRING = _try_json_readfile(VERSION_INFO_FILE) or _try_json_readfile(
+VERSION_STRING = _try_json_readversion(VERSION_INFO_FILE) or _try_json_readversion(
     PACKAGE_JSON_FILE
 )
+
+VERSION_SHA = _try_json_readsha(VERSION_INFO_FILE)
+
 
 ROW_LIMIT = 50000
 VIZ_ROW_LIMIT = 10000

--- a/superset/config.py
+++ b/superset/config.py
@@ -73,7 +73,6 @@ def _try_json_readsha(filepath):
     except Exception:
         return None
 
-
 # Depending on the context in which this config is loaded, the version_info.json file
 # may or may not be available, as it is generated on install via setup.py. In the event
 # that we're actually running Superset, we will have already installed, therefore it WILL
@@ -84,7 +83,6 @@ VERSION_STRING = _try_json_readversion(VERSION_INFO_FILE) or _try_json_readversi
 )
 
 VERSION_SHA = _try_json_readsha(VERSION_INFO_FILE)
-
 
 ROW_LIMIT = 50000
 VIZ_ROW_LIMIT = 10000

--- a/superset/config.py
+++ b/superset/config.py
@@ -66,12 +66,14 @@ def _try_json_readversion(filepath):
     except Exception:
         return None
 
+
 def _try_json_readsha(filepath):
     try:
         with open(filepath, "r") as f:
             return json.load(f).get("GIT_SHA")
     except Exception:
         return None
+
 
 # Depending on the context in which this config is loaded, the version_info.json file
 # may or may not be available, as it is generated on install via setup.py. In the event

--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -21,6 +21,9 @@
 {% set documentation_url = appbuilder.app.config['DOCUMENTATION_URL'] %}
 {% set documentation_text = appbuilder.app.config['DOCUMENTATION_TEXT'] %}
 {% set documentation_icon = appbuilder.app.config['DOCUMENTATION_ICON'] %}
+{% set version_info = appbuilder.app.config['VERSION_INFO_FILE'] %}
+{% set version_string = appbuilder.app.config['VERSION_STRING'] %}
+
 {% set locale = session['locale'] %}
 {% if not locale %}
     {% set locale = 'en' %}
@@ -105,6 +108,16 @@
         <ul class="dropdown-menu">
             <li><a href="{{appbuilder.get_url_for_userinfo}}"><span class="fa fa-fw fa-user"></span>{{_("Profile")}}</a></li>
             <li><a href="{{appbuilder.get_url_for_logout}}"><span class="fa fa-fw fa-sign-out"></span>{{_("Logout")}}</a></li>
+            {% if version_string or version_sha %}
+              <li class="fineprint">
+                {% if version_string %}
+                  <div>Version {{version_string}}</div>
+                {% endif %}
+                {% if version_sha %}
+                  <div>SHA: {{version_sha}}</div>
+                {% endif %}
+              </li>
+            {% endif %}
         </ul>
     </li>
 {% else %}

--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -21,7 +21,6 @@
 {% set documentation_url = appbuilder.app.config['DOCUMENTATION_URL'] %}
 {% set documentation_text = appbuilder.app.config['DOCUMENTATION_TEXT'] %}
 {% set documentation_icon = appbuilder.app.config['DOCUMENTATION_ICON'] %}
-{% set version_info = appbuilder.app.config['VERSION_INFO_FILE'] %}
 {% set version_string = appbuilder.app.config['VERSION_STRING'] %}
 
 {% set locale = session['locale'] %}

--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -22,6 +22,7 @@
 {% set documentation_text = appbuilder.app.config['DOCUMENTATION_TEXT'] %}
 {% set documentation_icon = appbuilder.app.config['DOCUMENTATION_ICON'] %}
 {% set version_string = appbuilder.app.config['VERSION_STRING'] %}
+{% set version_sha = appbuilder.app.config['VERSION_SHA'] %}
 
 {% set locale = session['locale'] %}
 {% if not locale %}


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Adds version number, and SHA, when available, as fine print at the bottom of the user menu dropdown. This seems less obtrusive than the former version info link/button. I'm open to other locations if there are objections.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/812905/68802919-b6d85e80-0613-11ea-9485-416964de1be7.png)