### PR TITLE
[druid] Fix, pydruid forced dependency

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -167,7 +167,7 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
         base_url = self.get_base_url(self.broker_host, self.broker_port)
         return f"{base_url}/{self.broker_endpoint}"
 
-    def get_pydruid_client(self) -> PyDruid:
+    def get_pydruid_client(self) -> "PyDruid":
         cli = PyDruid(
             self.get_base_url(self.broker_host, self.broker_port), self.broker_endpoint
         )

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -829,7 +829,7 @@ class DruidDatasource(Model, BaseDatasource):
         return granularity
 
     @staticmethod
-    def get_post_agg(mconf: Dict) -> Postaggregator:
+    def get_post_agg(mconf: Dict) -> "Postaggregator":
         """
         For a metric specified as `postagg` returns the
         kind of post aggregation for pydruid.
@@ -1441,7 +1441,7 @@ class DruidDatasource(Model, BaseDatasource):
         return (col, extraction_fn)
 
     @classmethod
-    def get_filters(cls, raw_filters, num_cols, columns_dict) -> Filter:
+    def get_filters(cls, raw_filters, num_cols, columns_dict) -> "Filter":
         """Given Superset filter data structure, returns pydruid Filter(s)"""
         filters = None
         for flt in raw_filters:
@@ -1570,7 +1570,7 @@ class DruidDatasource(Model, BaseDatasource):
 
         return filters
 
-    def _get_having_obj(self, col: str, op: str, eq: str) -> Having:
+    def _get_having_obj(self, col: str, op: str, eq: str) -> "Having":
         cond = None
         if op == "==":
             if col in self.column_names:
@@ -1584,7 +1584,7 @@ class DruidDatasource(Model, BaseDatasource):
 
         return cond
 
-    def get_having_filters(self, raw_filters: List[Dict]) -> Having:
+    def get_having_filters(self, raw_filters: List[Dict]) -> "Having":
         filters = None
         reversed_op_map = {"!=": "==", ">=": "<", "<=": ">"}
 


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Type annotation forces superset to be dependent on `PyDruid` package.

### TEST PLAN
- Create a new python venv and install `pip install -e .`
- Run supeset db upgrade (was failing here)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
