### PR TITLE
Math.max(...array) considered harmful

### DIFF
--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -176,7 +176,7 @@ export default class FilterableTable extends PureComponent {
       widthsByColumnKey[key] = colWidths.slice(
         index * (this.list.size + 1),
         (index + 1) * (this.list.size + 1),
-      ).reduce(([a, b]) => Math.max(a, b)) + PADDING;
+      ).reduce((a, b) => Math.max(a, b)) + PADDING;
     });
 
     return widthsByColumnKey;

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -170,10 +170,13 @@ export default class FilterableTable extends PureComponent {
     ).map(dimension => dimension.width);
 
     this.props.orderedColumnKeys.forEach((key, index) => {
-      widthsByColumnKey[key] = Math.max(...colWidths.slice(
+      // we can't use Math.max(...colWidths.slice(...)) here since the number
+      // of elements might be bigger than the number of allowed arguments in a
+      // Javascript function
+      widthsByColumnKey[key] = colWidths.slice(
         index * (this.list.size + 1),
         (index + 1) * (this.list.size + 1),
-      )) + PADDING;
+      ).reduce(([a, b]) => Math.max(a, b)) + PADDING;
     });
 
     return widthsByColumnKey;


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In `<FilterableTable>` we're computing the maximum value of an array using this code snippet:

```javascript
max_value = Math.max(...some_array);
```

The problem is that if `some_array` is big this will trigger the error `RangeError: Maximum call stack size exceeded`, since the number of arguments passed to the function `Math.max` is too big.

I fixed it by using `reduce` instead.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested with a query that was failing, it now works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 