### PR TITLE
Do not autorun query on tab duplicate

### DIFF
--- a/superset/assets/spec/javascripts/sqllab/actions/sqlLab_spec.js
+++ b/superset/assets/spec/javascripts/sqllab/actions/sqlLab_spec.js
@@ -278,7 +278,7 @@ describe('async actions', () => {
           id: 'abcd',
         },
       }];
-      return store.dispatch(actions.cloneQueryToNewTab(query)).then(() => {
+      return store.dispatch(actions.cloneQueryToNewTab(query, true)).then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
     });

--- a/superset/assets/src/SqlLab/actions/sqlLab.js
+++ b/superset/assets/src/SqlLab/actions/sqlLab.js
@@ -445,7 +445,7 @@ export function addQueryEditor(queryEditor) {
   };
 }
 
-export function cloneQueryToNewTab(query) {
+export function cloneQueryToNewTab(query, autorun) {
   return function (dispatch, getState) {
     const state = getState();
     const { queryEditors, tabHistory } = state.sqlLab;
@@ -454,7 +454,7 @@ export function cloneQueryToNewTab(query) {
       title: t('Copy of %s', sourceQueryEditor.title),
       dbId: query.dbId ? query.dbId : null,
       schema: query.schema ? query.schema : null,
-      autorun: true,
+      autorun,
       sql: query.sql,
       queryLimit: sourceQueryEditor.queryLimit,
       maxRow: sourceQueryEditor.maxRow,

--- a/superset/assets/src/SqlLab/components/QueryTable.jsx
+++ b/superset/assets/src/SqlLab/components/QueryTable.jsx
@@ -80,7 +80,7 @@ class QueryTable extends React.PureComponent {
   }
 
   openQueryInNewTab(query) {
-    this.props.actions.cloneQueryToNewTab(query);
+    this.props.actions.cloneQueryToNewTab(query, true);
   }
   openAsyncResults(query, displayLimit) {
     this.props.actions.fetchQueryResults(query, displayLimit);

--- a/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -218,7 +218,7 @@ class TabbedSqlEditors extends React.PureComponent {
       .forEach(qe => qe !== cqe && this.removeQueryEditor(qe));
   }
   duplicateQueryEditor(qe) {
-    this.props.actions.cloneQueryToNewTab(qe);
+    this.props.actions.cloneQueryToNewTab(qe, false);
   }
   toggleLeftBar() {
     this.setState({ hideLeftBar: !this.state.hideLeftBar });


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/incubator-superset/pull/8485 added an option in SQL Lab to duplicate tabs in order to iterate on them. When that happens, we don't want to autorun the query, since the user will probably want to change it before running it.

I left the old behavior of autorunning a query when opening it from the query search, though.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 