### PR TITLE
Copy template params when duplicating query

### DIFF
--- a/superset/assets/src/SqlLab/actions/sqlLab.js
+++ b/superset/assets/src/SqlLab/actions/sqlLab.js
@@ -458,6 +458,7 @@ export function cloneQueryToNewTab(query) {
       sql: query.sql,
       queryLimit: sourceQueryEditor.queryLimit,
       maxRow: sourceQueryEditor.maxRow,
+      templateParams: sourceQueryEditor.templateParams,
     };
     return dispatch(addQueryEditor(queryEditor));
   };


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`templateParams` is not being copied when duplicating a query.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 