### PR TITLE
Fix error when templateParams is undefined

### DIFF
--- a/superset/assets/src/SqlLab/actions/sqlLab.js
+++ b/superset/assets/src/SqlLab/actions/sqlLab.js
@@ -186,7 +186,7 @@ export function estimateQueryCost(query) {
     dispatch({ type: COST_ESTIMATE_STARTED, query }),
     SupersetClient.post({
       endpoint,
-      postPayload: { sql, templateParams: JSON.parse(templateParams) },
+      postPayload: { sql, templateParams: JSON.parse(templateParams || '{}') },
     })
       .then(({ json }) => dispatch({ type: COST_ESTIMATE_RETURNED, query, json }))
       .catch(response =>


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The query cost estimation breaks when `templateParams` is undefined. This bug is fixed by https://github.com/apache/incubator-superset/pull/8580, but I thought it would be better to be safe here and fallback to an empty object.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 