### PR TITLE
[SECURITY] Bump pyarrow to 0.15.1 due to CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ pathlib2==2.3.4
 polyline==1.4.0
 prison==0.1.2             # via flask-appbuilder
 py==1.8.0                 # via retry
-pyarrow==0.14.1
+pyarrow==0.15.1
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via flask-appbuilder, flask-jwt-extended
 pyrsistent==0.15.4        # via jsonschema

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         "python-dateutil",
         "python-dotenv",
         "python-geohash",
-        "pyarrow>=0.14.1, <0.15.0",
+        "pyarrow>=0.15.1, <0.16.0",
         "pyyaml>=5.1",
         "retry>=0.9.2",
         "selenium>=3.141.0",


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Updating PyArrow to latest version due to CVE: https://snyk.io/vuln/SNYK-PYTHON-PYARROW-483024

Note that the `RESULTS_BACKEND_USE_MSGPACK` config has been defaulted to `False` in https://github.com/apache/incubator-superset/pull/8060, but the intention is to re-enable this once https://github.com/apache/incubator-superset/issues/8225 is resolved.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
