### PR TITLE
[dashboard filter scope] force show filter_box as unchecked

### DIFF
--- a/superset/assets/src/dashboard/components/filterscope/FilterScopeSelector.jsx
+++ b/superset/assets/src/dashboard/components/filterscope/FilterScopeSelector.jsx
@@ -86,10 +86,12 @@ export default class FilterScopeSelector extends React.PureComponent {
                 selectedChartId: filterId,
               });
               const expanded = getFilterScopeParentNodes(nodes, 1);
-              // display filter_box chart as checked, but do not show checkbox
-              const chartIdsInFilterScope = getChartIdsInFilterScope({
-                filterScope: dashboardFilters[filterId].scopes[columnName],
-              });
+              // force display filter_box chart as unchecked, but show checkbox as disabled
+              const chartIdsInFilterScope = (
+                getChartIdsInFilterScope({
+                  filterScope: dashboardFilters[filterId].scopes[columnName],
+                }) || []
+              ).filter(id => id !== filterId);
 
               return {
                 ...mapByChartId,

--- a/superset/assets/src/dashboard/util/getRevertedFilterScope.js
+++ b/superset/assets/src/dashboard/util/getRevertedFilterScope.js
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { getChartIdAndColumnFromFilterKey } from './getDashboardFilterKey';
+
 export default function getRevertedFilterScope({
   checked = [],
   filterFields = [],
@@ -29,14 +31,19 @@ export default function getRevertedFilterScope({
     };
   }, {});
 
-  return filterFields.reduce(
-    (map, filterField) => ({
+  return filterFields.reduce((map, filterField) => {
+    const { chartId } = getChartIdAndColumnFromFilterKey(filterField);
+    // force display filter_box chart as unchecked, but show checkbox as disabled
+    const updatedCheckedIds = (
+      checkedChartIdsByFilterField[filterField] || []
+    ).filter(id => id !== chartId);
+
+    return {
       ...map,
       [filterField]: {
         ...filterScopeMap[filterField],
-        checked: checkedChartIdsByFilterField[filterField],
+        checked: updatedCheckedIds,
       },
-    }),
-    {},
-  );
+    };
+  }, {});
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
We do not apply filter on filter_box itself, so in the scope selector modal, the filter_box's checkbox is disabled. But when user clicks on tab or other parent level node's checkbox, react-checkbox-tree framework still set the value for disabled nodes. So sometimes this will cause confusing. For example: in the UI no chart is selected but the root show half-checked:
![image](https://user-images.githubusercontent.com/27990562/68974317-4f521880-07a5-11ea-8c14-3ee2f96fc653.png)

This PR will add an extra logic that enforce filter_box's state is unchecked, but still show as disabled. This is still not **_perfect_**, because when user checked parent's checkbox, they are expected to see all children nodes are also checked. In this case, filter_box's state is still unchecked. 

There is a proposal that to compare all the nodes under the parent, and ignore the filter_box's state. The data structure for all nodes state are in the tree structure. In order to igore the filter_box's state, I need to have a filter_box chartId, then find its parent, and find other siblings in the tree. This computation is not cheap, and will be triggered very frequent.

Given the performance impact is big and UI in-consistency is small, I propose this cheaper solution.


### TEST PLAN
manual test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 @kristw 
