### PR TITLE
Create new session for tab migration

### DIFF
--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -193,13 +193,14 @@ class TabStateView(BaseSupersetView):
             sql=query_editor.get("sql", "SELECT ..."),
             query_limit=query_editor.get("queryLimit"),
         )
+        session = db.session()
         (
-            db.session.query(TabState)
+            session.query(TabState)
             .filter_by(user_id=g.user.get_id())
             .update({"active": False})
         )
-        db.session.add(tab_state)
-        db.session.commit()
+        session.add(tab_state)
+        session.commit()
         return json_success(json.dumps({"id": tab_state.id}))
 
     @has_access_api
@@ -288,7 +289,8 @@ class TableSchemaView(BaseSupersetView):
         table = json.loads(request.form["table"])
 
         # delete any existing table schema
-        db.session.query(TableSchema).filter(
+        session = db.session()
+        session.query(TableSchema).filter(
             TableSchema.tab_state_id == table["queryEditorId"],
             TableSchema.database_id == table["dbId"],
             TableSchema.schema == table["schema"],
@@ -303,8 +305,8 @@ class TableSchemaView(BaseSupersetView):
             description=json.dumps(table),
             expanded=True,
         )
-        db.session.add(table_schema)
-        db.session.commit()
+        session.add(table_schema)
+        session.commit()
         return json_success(json.dumps({"id": table_schema.id}))
 
     @has_access_api


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Friday we turned on the `SQLLAB_BACKEND_PERSISTENCE` at Lyft, and noticed a deadlock when migrating SQL Lab tabs from `localStorage` to the backend:

```
sqlalchemy.exc.OperationalError: (_mysql_exceptions.OperationalError) (1213, 'Deadlock found when trying to get lock; try restarting transaction')
[SQL: INSERT INTO tab_state (created_on, changed_on, extra_json, user_id, label, active, database_id, `schema`, `sql`, query_limit, latest_query_id, autorun, template_params, created_by_fk, changed_by_fk) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)]
[parameters: (datetime.datetime(2019, 11, 16, 1, 39, 45, 903405), datetime.datetime(2019, 11, 16, 1, 39, 45, 903410), '{}', '1963', 'dim_applicants', 1, 7, None, 'select * from events_annotated.event_ride_requested limit 10', None, None, 0, None, 1963, 1963)]
```

Note that there was no data loss, and the tabs were migrated successfully on a refresh.

I tried to repro this locally, migrating 20 tabs to a MySQL database, but I wasn't able to hit the deadlock. Looking at the code, it seems that we reuse the same session across all requests, so I refactored it to create a new session for each request.

@mistercrunch do you think this would fix the problem? I'm not super familiar with SQL Alchemy, but from what I read this should work.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I wasn't able to repro the original bug, but ran this code to ensure that it still works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@mistercrunch 