### PR TITLE
[dashboard scoped filter] Reduce calls to expensive safeStringify

### DIFF
--- a/superset/assets/src/dashboard/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/components/Dashboard.jsx
@@ -31,7 +31,7 @@ import {
 } from '../util/propShapes';
 import { LOG_ACTIONS_MOUNT_DASHBOARD } from '../../logger/LogUtils';
 import OmniContainer from '../../components/OmniContainer';
-import { safeStringify } from '../../utils/safeStringify';
+import { areObjectsEqual } from '../../reduxUtils';
 
 import '../stylesheets/index.less';
 
@@ -117,10 +117,7 @@ class Dashboard extends React.PureComponent {
     const appliedFilters = this.appliedFilters;
     const { activeFilters } = this.props;
     // do not apply filter when dashboard in edit mode
-    if (
-      !editMode &&
-      safeStringify(appliedFilters) !== safeStringify(activeFilters)
-    ) {
+    if (!editMode && !areObjectsEqual(appliedFilters, activeFilters)) {
       // refresh charts if a filter was removed, added, or changed
       const currFilterKeys = Object.keys(activeFilters);
       const appliedFilterKeys = Object.keys(appliedFilters);
@@ -134,13 +131,8 @@ class Dashboard extends React.PureComponent {
         } else if (!appliedFilterKeys.includes(filterKey)) {
           // added filter?
           [].push.apply(affectedChartIds, activeFilters[filterKey].scope);
-        } else if (
-          safeStringify(activeFilters[filterKey].values) !==
-            safeStringify(appliedFilters[filterKey].values) ||
-          safeStringify(activeFilters[filterKey].scope) !==
-            safeStringify(appliedFilters[filterKey].scope)
-        ) {
-          // changed filter field value?
+        } else {
+          // changed filter field value or scope?
           const affectedScope = activeFilters[filterKey].scope.concat(
             appliedFilters[filterKey].scope,
           );

--- a/superset/assets/src/dashboard/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/components/Dashboard.jsx
@@ -133,8 +133,8 @@ class Dashboard extends React.PureComponent {
           [].push.apply(affectedChartIds, activeFilters[filterKey].scope);
         } else {
           // changed filter field value or scope?
-          const affectedScope = activeFilters[filterKey].scope.concat(
-            appliedFilters[filterKey].scope,
+          const affectedScope = (activeFilters[filterKey].scope || []).concat(
+            appliedFilters[filterKey].scope || [],
           );
           [].push.apply(affectedChartIds, affectedScope);
         }

--- a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset/assets/src/dashboard/components/gridComponents/Chart.jsx
@@ -30,7 +30,6 @@ import {
   LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART,
   LOG_ACTIONS_FORCE_REFRESH_CHART,
 } from '../../../logger/LogUtils';
-import { safeStringify } from '../../../utils/safeStringify';
 import { isFilterBox } from '../../util/activeDashboardFilters';
 import getFilterValuesByFilterId from '../../util/getFilterValuesByFilterId';
 
@@ -119,9 +118,7 @@ class Chart extends React.Component {
 
       for (let i = 0; i < SHOULD_UPDATE_ON_PROP_CHANGES.length; i += 1) {
         const prop = SHOULD_UPDATE_ON_PROP_CHANGES[i];
-        if (
-          safeStringify(nextProps[prop]) !== safeStringify(this.props[prop])
-        ) {
+        if (nextProps[prop] !== this.props[prop]) {
           return true;
         }
       }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In dashboard scoped filter feature #8590, I introduced a few calls to  `safeStringify`. It cause slower render for large dashboard. So I run profiling, i can see the root causes:
![Screen Shot 2019-11-18 at 4 16 46 PM](https://user-images.githubusercontent.com/27990562/69104983-e7a70200-0a1e-11ea-990d-0ab969121bcd.png)

This PR is remove a few newly introduced `safeStringify`.
Please see code change:
https://github.com/apache/incubator-superset/blame/7d14b71a937f2dffd921b3c58007dfa4e07b7e0a/superset/assets/src/dashboard/components/Dashboard.jsx#L122
and
https://github.com/apache/incubator-superset/blame/7d14b71a937f2dffd921b3c58007dfa4e07b7e0a/superset/assets/src/dashboard/components/gridComponents/Chart.jsx#L123

After this fix:
![Screen Shot 2019-11-18 at 4 05 44 PM](https://user-images.githubusercontent.com/27990562/69105079-1f15ae80-0a1f-11ea-809d-4a71e3511546.png)


### TEST PLAN
manual test


### REVIEWERS
@etr2460 @kristw 