### PR TITLE
Set owner when creating SQL Lab view

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2294,6 +2294,7 @@ class Superset(BaseSupersetView):
         table = db.session.query(SqlaTable).filter_by(table_name=table_name).first()
         if not table:
             table = SqlaTable(table_name=table_name)
+        table.owners = [g.user]
         table.database_id = data.get("dbId")
         table.schema = data.get("schema")
         table.template_params = data.get("templateParams")

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2293,8 +2293,7 @@ class Superset(BaseSupersetView):
         table_name = data.get("datasourceName")
         table = db.session.query(SqlaTable).filter_by(table_name=table_name).first()
         if not table:
-            table = SqlaTable(table_name=table_name)
-        table.owners = [g.user]
+            table = SqlaTable(table_name=table_name, owners=[g.user])
         table.database_id = data.get("dbId")
         table.schema = data.get("schema")
         table.template_params = data.get("templateParams")

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 import prison
 
 from superset import db, security_manager
+from superset.connectors.sqla.models import SqlaTable
 from superset.dataframe import SupersetDataFrame
 from superset.db_engine_specs import BaseEngineSpec
 from superset.models.sql_lab import Query
@@ -289,6 +290,7 @@ class SqlLabTests(SupersetTestCase):
         self.assertEqual(len(cols), len(cdf.columns))
 
     def test_sqllab_viz(self):
+        self.login("admin")
         examples_dbid = get_example_database().id
         payload = {
             "chartType": "dist_bar",
@@ -318,6 +320,11 @@ class SqlLabTests(SupersetTestCase):
         data = {"data": json.dumps(payload)}
         resp = self.get_json_resp("/superset/sqllab_viz/", data=data)
         self.assertIn("table_id", resp)
+
+        # ensure owner is set correctly
+        table_id = resp["table_id"]
+        table = db.session.query(SqlaTable).filter_by(id=table_id).one()
+        self.assertEqual([owner.username for owner in table.owners], ["admin"])
 
     def test_sql_limit(self):
         self.login("admin")


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, when we create a SQL Lab view (by clicking "Visualize" in SQL Lab), we don't assign the user as the owner of the view.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested and SQL Lab view now belongs to the user who created it.

Added unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong @etr2460 