### PR TITLE
[fix] TimeTable timelag error

### DIFF
--- a/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset/assets/src/visualizations/TimeTable/TimeTable.jsx
@@ -165,8 +165,8 @@ class TimeTable extends React.PureComponent {
       // Time lag ratio
       const { timeLag } = column;
       const totalLag = Object.keys(reversedEntries).length;
-      if (timeLag > totalLag) {
-        errorMsg = `The time lag set at ${timeLag} exceeds the length of data at ${reversedEntries.length}. No data available.`;
+      if (timeLag >= totalLag) {
+        errorMsg = `The time lag set at ${timeLag} is too large for the length of data at ${reversedEntries.length}. No data available.`;
       } else {
         v = reversedEntries[timeLag][valueField];
       }


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Off by one error 🙃 

We displayed an error about time lags if the time lag was `>` than the length of the data. It should actually be `>=`.

For example, if the time lag is 7 days and there are 7 data points, there should be an error because there are only 6 days in between the first and last day. However, this error was not caught, so users saw:

`An error occurred while rendering the visualization: TypeError: Cannot read property 'Unknown' of undefined`

Fixed viz to include the `=` case.

### TEST PLAN
Narrow date range to include `n` points. Add a comparison column with a time lag of `n`. Ensure that you get the correct error.

### REVIEWERS
@graceguo-supercat @michellethomas @etr2460 
