### PR TITLE
slightly decouple sql_json, queries, and results http endpoints from …

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -645,13 +645,13 @@ def pessimistic_connection_handling(some_engine):
 class QueryStatus:
     """Enum-type class for query statuses"""
 
-    STOPPED = "stopped"
-    FAILED = "failed"
-    PENDING = "pending"
-    RUNNING = "running"
-    SCHEDULED = "scheduled"
-    SUCCESS = "success"
-    TIMED_OUT = "timed_out"
+    STOPPED: str = "stopped"
+    FAILED: str = "failed"
+    PENDING: str = "pending"
+    RUNNING: str = "running"
+    SCHEDULED: str = "scheduled"
+    SUCCESS: str = "success"
+    TIMED_OUT: str = "timed_out"
 
 
 def notify_user_about_perm_udate(granter, user, role, datasource, tpl_name, config):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2530,7 +2530,9 @@ class Superset(BaseSupersetView):
             )
 
         payload = utils.zlib_decompress(blob, decode=not results_backend_use_msgpack)
-        obj: dict = _deserialize_results_payload(payload, query, results_backend_use_msgpack)
+        obj: dict = _deserialize_results_payload(
+            payload, query, cast(bool, results_backend_use_msgpack)
+        )
 
         if "rows" in request.args:
             try:
@@ -2737,7 +2739,7 @@ class Superset(BaseSupersetView):
             template_params: dict = json.loads(
                 query_params.get("templateParams") or "{}"
             )
-        except json.decoder.JSONDecodeError:
+        except json.JSONDecodeError:
             logging.warning(
                 f"Invalid template parameter {query_params.get('templateParams')}"
                 " specified. Defaulting to empty dict"
@@ -2752,7 +2754,9 @@ class Superset(BaseSupersetView):
             limit = 0
         select_as_cta: bool = cast(bool, query_params.get("select_as_cta"))
         tmp_table_name: str = cast(str, query_params.get("tmp_table_name"))
-        client_id: str = cast(str, query_params.get("client_id") or utils.shortid()[:10])
+        client_id: str = cast(
+            str, query_params.get("client_id") or utils.shortid()[:10]
+        )
         sql_editor_id: str = cast(str, query_params.get("sql_editor_id"))
         tab_name: str = cast(str, query_params.get("tab"))
         status: str = QueryStatus.PENDING if async_flag else QueryStatus.RUNNING
@@ -2823,9 +2827,11 @@ class Superset(BaseSupersetView):
 
         # Flag for whether or not to expand data
         # (feature that will expand Presto row objects and arrays)
-        expand_data: bool = cast(bool, is_feature_enabled(
-            "PRESTO_EXPAND_DATA"
-        ) and query_params.get("expand_data"))
+        expand_data: bool = cast(
+            bool,
+            is_feature_enabled("PRESTO_EXPAND_DATA")
+            and query_params.get("expand_data"),
+        )
 
         # Async request.
         if async_flag:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -20,7 +20,7 @@ import re
 from contextlib import closing
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import List, Optional, Union
+from typing import cast, List, Optional, Union
 from urllib import parse
 
 import backoff
@@ -2530,7 +2530,7 @@ class Superset(BaseSupersetView):
             )
 
         payload = utils.zlib_decompress(blob, decode=not results_backend_use_msgpack)
-        obj = _deserialize_results_payload(payload, query, results_backend_use_msgpack)
+        obj: dict = _deserialize_results_payload(payload, query, results_backend_use_msgpack)
 
         if "rows" in request.args:
             try:
@@ -2730,9 +2730,9 @@ class Superset(BaseSupersetView):
     def sql_json_exec(self, query_params: dict):
         """Runs arbitrary sql and returns data as json"""
         # Collect Values
-        database_id: int = query_params.get("database_id")
-        schema: str = query_params.get("schema")
-        sql: str = query_params.get("sql")
+        database_id: int = cast(int, query_params.get("database_id"))
+        schema: str = cast(str, query_params.get("schema"))
+        sql: str = cast(str, query_params.get("sql"))
         try:
             template_params: dict = json.loads(
                 query_params.get("templateParams") or "{}"
@@ -2744,18 +2744,18 @@ class Superset(BaseSupersetView):
             )
             template_params = {}
         limit: int = query_params.get("queryLimit") or app.config["SQL_MAX_ROW"]
-        async_flag: bool = query_params.get("runAsync")
+        async_flag: bool = cast(bool, query_params.get("runAsync"))
         if limit < 0:
             logging.warning(
                 f"Invalid limit of {limit} specified. Defaulting to max limit."
             )
             limit = 0
-        select_as_cta: bool = query_params.get("select_as_cta")
-        tmp_table_name: str = query_params.get("tmp_table_name")
-        client_id: str = query_params.get("client_id") or utils.shortid()[:10]
-        sql_editor_id: str = query_params.get("sql_editor_id")
-        tab_name: str = query_params.get("tab")
-        status: bool = QueryStatus.PENDING if async_flag else QueryStatus.RUNNING
+        select_as_cta: bool = cast(bool, query_params.get("select_as_cta"))
+        tmp_table_name: str = cast(str, query_params.get("tmp_table_name"))
+        client_id: str = cast(str, query_params.get("client_id") or utils.shortid()[:10])
+        sql_editor_id: str = cast(str, query_params.get("sql_editor_id"))
+        tab_name: str = cast(str, query_params.get("tab"))
+        status: str = QueryStatus.PENDING if async_flag else QueryStatus.RUNNING
 
         session = db.session()
         mydb = session.query(models.Database).filter_by(id=database_id).one_or_none()
@@ -2823,9 +2823,9 @@ class Superset(BaseSupersetView):
 
         # Flag for whether or not to expand data
         # (feature that will expand Presto row objects and arrays)
-        expand_data: bool = is_feature_enabled(
+        expand_data: bool = cast(bool, is_feature_enabled(
             "PRESTO_EXPAND_DATA"
-        ) and query_params.get("expand_data")
+        ) and query_params.get("expand_data"))
 
         # Async request.
         if async_flag:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2725,8 +2725,7 @@ class Superset(BaseSupersetView):
     @expose("/sql_json/", methods=["POST"])
     @event_logger.log_this
     def sql_json(self):
-        query_params = request.json
-        return self.sql_json_exec(query_params)
+        return self.sql_json_exec(request.json)
 
     def sql_json_exec(self, query_params: dict):
         """Runs arbitrary sql and returns data as json"""

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2728,7 +2728,7 @@ class Superset(BaseSupersetView):
         query_params = request.json
         return self.sql_json_exec(query_params)
 
-    def sql_json_exec(self, ):
+    def sql_json_exec(self, query_params):
         """Runs arbitrary sql and returns data as json"""
         # Collect Values
         database_id: int = query_params.get("database_id")
@@ -2913,7 +2913,7 @@ class Superset(BaseSupersetView):
     def queries(self, last_updated_ms):
         return self.queries_exec(last_updated_ms)
 
-    def queries_exec(self, last_updated_us)
+    def queries_exec(self, last_updated_us):
         """Get the updated queries."""
         stats_logger.incr("queries")
         if not g.user.get_id():


### PR DESCRIPTION

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [X] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Some of the views and view logic (http request handlers, template rendering, response construction, etc) is hyper-coupled to the business logic. In our case, we need to setup alternate endpoints with different internal auth, routes, etc to use the `sql_json`, `queries`, and `results` endpoints from `views.core.Superset`.  I think these should be more thoroughly decoupled (ie, views just doing view stuff, and calling into a completely separate library for business logic) but that is a lot more than I can chew off right now, so this tiny change is simply breaking those three http request handlers off so we other functions can call into the business logic from different endpoints.

Choose one##** BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
