### PR TITLE
fixes error creating a new database due to Malformed JSON error for empty Secure extras field

### DIFF
--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -34,13 +34,14 @@
       });
 
       var data = {};
+      const extra = $("#extra").val();
       const encryptedExtra = $("#encrypted_extra").val();
       try{
         data = JSON.stringify({
           uri: $.trim($("#sqlalchemy_uri").val()),
           name: $('#database_name').val(),
           impersonate_user: $('#impersonate_user').is(':checked'),
-          extras: JSON.parse($("#extra").val()),
+          extras: extra ? JSON.parse(extra) : {},
           encrypted_extra: encryptedExtra ? JSON.parse(encryptedExtra) : {},
         })
       } catch(parse_error){

--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -40,7 +40,7 @@
           name: $('#database_name').val(),
           impersonate_user: $('#impersonate_user').is(':checked'),
           extras: JSON.parse($("#extra").val()),
-          encrypted_extra: JSON.parse($("#encrypted_extra").val()),
+          encrypted_extra: $("#encrypted_extra").val() ? JSON.parse($("#encrypted_extra").val()) : {},
         })
       } catch(parse_error){
         alert("Malformed JSON in the extras field: " + parse_error);

--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -34,13 +34,14 @@
       });
 
       var data = {};
+      const encryptedExtra = $("#encrypted_extra").val();
       try{
         data = JSON.stringify({
           uri: $.trim($("#sqlalchemy_uri").val()),
           name: $('#database_name').val(),
           impersonate_user: $('#impersonate_user').is(':checked'),
           extras: JSON.parse($("#extra").val()),
-          encrypted_extra: $("#encrypted_extra").val() ? JSON.parse($("#encrypted_extra").val()) : {},
+          encrypted_extra: encryptedExtra ? JSON.parse(encryptedExtra) : {},
         })
       } catch(parse_error){
         alert("Malformed JSON in the extras field: " + parse_error);


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix

### SUMMARY
Fixes #8628 and Fixes #8607 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See #8628 for before screenshots.

After screenshots demonstrate I am able to have a blank `Secure extras` field and successfully test a new connection.

![Screen Shot 2019-11-21 at 4 18 19 PM](https://user-images.githubusercontent.com/4043751/69389955-935c8600-0c9b-11ea-8440-48168bae6ed9.png)
![Screen Shot 2019-11-21 at 4 18 05 PM](https://user-images.githubusercontent.com/4043751/69389959-96f00d00-0c9b-11ea-803c-1bd288e34ace.png)


### TEST PLAN

Tested locally in docker.

```
git clone https://github.com/apache/incubator-superset/
cd incubator-superset/contrib/docker
docker-compose run --rm superset ./docker-init.sh
docker-compose up
# then tested adding a new database in UI and was successful
```

Note: I tested an empty `Secure extra` field, as well as explicitly setting `Secure extra` field = `{}` in UI to test case when someone provides valid JSON for `Secure extra` field.

### ADDITIONAL INFORMATION
- [ X] Has associated issue: Fixes #8628 and Fixes #8607 

### REVIEWERS
@dpgaspar 