### PR TITLE
[dashboard scoped filters] Add all time related options to filters initialization

### DIFF
--- a/superset/assets/src/dashboard/util/activeDashboardFilters.js
+++ b/superset/assets/src/dashboard/util/activeDashboardFilters.js
@@ -24,6 +24,7 @@ import {
   getDashboardFilterKey,
 } from './getDashboardFilterKey';
 import { CHART_TYPE } from '../util/componentTypes';
+import { DASHBOARD_FILTER_SCOPE_GLOBAL } from '../reducers/dashboardFilters';
 
 let allFilterBoxChartIds = [];
 let activeFilters = {};
@@ -61,7 +62,9 @@ export function getAppliedFilterValues(chartId) {
   return appliedFilterValuesByChart[chartId];
 }
 
-export function getChartIdsInFilterScope({ filterScope }) {
+export function getChartIdsInFilterScope({
+  filterScope = DASHBOARD_FILTER_SCOPE_GLOBAL,
+}) {
   function traverse(chartIds = [], component = {}, immuneChartIds = []) {
     if (!component) {
       return;

--- a/superset/assets/src/dashboard/util/getFilterConfigsFromFormdata.js
+++ b/superset/assets/src/dashboard/util/getFilterConfigsFromFormdata.js
@@ -18,12 +18,20 @@
  */
 /* eslint-disable camelcase */
 import {
+  TIME_FILTER_MAP,
   TIME_RANGE,
   FILTER_LABELS,
 } from '../../visualizations/FilterBox/FilterBox';
 
 export default function getFilterConfigsFromFormdata(form_data = {}) {
-  const { date_filter, filter_configs = [] } = form_data;
+  const {
+    date_filter,
+    filter_configs = [],
+    show_druid_time_granularity,
+    show_druid_time_origin,
+    show_sqla_time_column,
+    show_sqla_time_granularity,
+  } = form_data;
   let configs = filter_configs.reduce(
     ({ columns, labels }, config) => {
       const updatedColumns = {
@@ -44,14 +52,42 @@ export default function getFilterConfigsFromFormdata(form_data = {}) {
   );
 
   if (date_filter) {
-    const updatedColumns = {
+    let updatedColumns = {
       ...configs.columns,
-      [TIME_RANGE]: form_data[TIME_RANGE],
+      [TIME_FILTER_MAP.time_range]: form_data.time_range,
     };
     const updatedLabels = {
       ...configs.labels,
-      [TIME_RANGE]: FILTER_LABELS[TIME_RANGE],
+      [TIME_FILTER_MAP.time_range]: FILTER_LABELS[TIME_RANGE],
     };
+
+    if (show_sqla_time_column) {
+      updatedColumns = {
+        ...updatedColumns,
+        [TIME_FILTER_MAP.time_grain_sqla]: form_data.time_grain_sqla,
+      };
+    }
+
+    if (show_sqla_time_granularity) {
+      updatedColumns = {
+        ...updatedColumns,
+        [TIME_FILTER_MAP.granularity_sqla]: form_data.granularity_sqla,
+      };
+    }
+
+    if (show_druid_time_granularity) {
+      updatedColumns = {
+        ...updatedColumns,
+        [TIME_FILTER_MAP.granularity]: form_data.granularity,
+      };
+    }
+
+    if (show_druid_time_origin) {
+      updatedColumns = {
+        ...updatedColumns,
+        [TIME_FILTER_MAP.druid_time_origin]: form_data.druid_time_origin,
+      };
+    }
 
     configs = {
       ...configs,

--- a/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
@@ -36,7 +36,7 @@ import FilterBadgeIcon from '../../components/FilterBadgeIcon';
 import './FilterBox.less';
 
 // maps control names to their key in extra_filters
-const TIME_FILTER_MAP = {
+export const TIME_FILTER_MAP = {
   time_range: '__time_range',
   granularity_sqla: '__time_col',
   time_grain_sqla: '__time_grain',
@@ -44,7 +44,8 @@ const TIME_FILTER_MAP = {
   granularity: '__granularity',
 };
 
-export const TIME_RANGE = '__time_range';
+// a shortcut to a map key, used by many components
+export const TIME_RANGE = TIME_FILTER_MAP.time_range;
 export const FILTER_LABELS = {
   [TIME_RANGE]: 'Time range',
 };


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Time filter has a few checkbox options: 

- Show SQL Granularity Dropdown 
- Show SQL Time Column
- Show Druid Granularity Dropdown
- Show Druid Time Origin
<img width="381" alt="Screen Shot 2019-11-22 at 4 50 32 PM" src="https://user-images.githubusercontent.com/27990562/69469900-41be0500-0d48-11ea-959b-7965f263ac59.png">

In #8590 it is not handled in the scoped filters settings. so when user change one option from dashboard, it will throw js errors:
<img width="337" alt="Screen Shot 2019-11-22 at 4 44 32 PM" src="https://user-images.githubusercontent.com/27990562/69469748-5fd73580-0d47-11ea-9f60-229ec1c49427.png">


User also reported a bug that if they set a value for **_Time Granularity_** field, it is not get pre-populated into filter box.


These 2 issues have same root cause: We need to map and initialize those options during dashboard initialization.

### TEST PLAN
manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 @michellethomas 