### PR TITLE
Pass full response to `query_cost_formatter`

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -445,7 +445,7 @@ class PrestoEngineSpec(BaseEngineSpec):
     @classmethod
     def estimate_statement_cost(  # pylint: disable=too-many-locals
         cls, statement: str, database, cursor, user_name: str
-    ) -> Dict[str, float]:
+    ) -> Dict[str, Any]:
         """
         Run a SQL query that estimates the cost of a given statement.
 
@@ -453,7 +453,7 @@ class PrestoEngineSpec(BaseEngineSpec):
         :param database: Database instance
         :param cursor: Cursor instance
         :param username: Effective username
-        :return: JSON estimate from Presto
+        :return: JSON response from Presto
         """
         parsed_query = ParsedQuery(statement)
         sql = parsed_query.stripped()
@@ -479,11 +479,11 @@ class PrestoEngineSpec(BaseEngineSpec):
         #     }
         #   }
         result = json.loads(cursor.fetchone()[0])
-        return result["estimate"]
+        return result
 
     @classmethod
     def query_cost_formatter(
-        cls, raw_cost: List[Dict[str, float]]
+        cls, raw_cost: List[Dict[str, Any]]
     ) -> List[Dict[str, str]]:
         """
         Format cost estimate.
@@ -516,10 +516,11 @@ class PrestoEngineSpec(BaseEngineSpec):
             ("networkCost", "Network cost", ""),
         ]
         for row in raw_cost:
+            estimate: Dict[str, float] = row.get("estimate", {})
             statement_cost = {}
             for key, label, suffix in columns:
-                if key in row:
-                    statement_cost[label] = humanize(row[key], suffix).strip()
+                if key in estimate:
+                    statement_cost[label] = humanize(estimate[key], suffix).strip()
             cost.append(statement_cost)
 
         return cost

--- a/tests/db_engine_specs/presto_tests.py
+++ b/tests/db_engine_specs/presto_tests.py
@@ -19,9 +19,9 @@ from unittest import mock, skipUnless
 import pandas as pd
 from sqlalchemy.engine.result import RowProxy
 from sqlalchemy.sql import select
-from tests.db_engine_specs.base_tests import DbEngineSpecTestCase
 
 from superset.db_engine_specs.presto import PrestoEngineSpec
+from tests.db_engine_specs.base_tests import DbEngineSpecTestCase
 
 
 class PrestoTests(DbEngineSpecTestCase):


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When estimating the cost of queries using Presto we currently pass only the actual estimate to `query_cost_formatter`. I modified it so it passes the full response from Presto, which allows us to log which table(s) and partition(s) are being queried.

Basically, instead of returning `response["estimate"]` this PR makes it return `response`, and the formatter will extract the estimate. Custom formatters defined in `superset_config.py` will have access to the full response, including `inputTableColumnInfos`.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added unit test for `query_cost_formatter`, and tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong @DiggidyDave 