### PR TITLE
fix: handle duplicate groupby keys

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -731,6 +731,9 @@ class SqlaTable(Model, BaseDatasource):
         groupby_exprs_sans_timestamp: OrderedDict = OrderedDict()
 
         if groupby:
+            # dedup columns while preserving order
+            groupby = list(dict.fromkeys(groupby))
+
             select_exprs = []
             for s in groupby:
                 if s in cols:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -961,6 +961,10 @@ class BubbleViz(NVD3Viz):
         d["groupby"] = [form_data.get("entity")]
         if form_data.get("series"):
             d["groupby"].append(form_data.get("series"))
+
+        # dedup groupby if it happens to be the same
+        d["groupby"] = list(dict.fromkeys(d["groupby"]))
+
         self.x_metric = form_data.get("x")
         self.y_metric = form_data.get("y")
         self.z_metric = form_data.get("size")


### PR DESCRIPTION
### CATEGORY

Choose one: bugfix

### SUMMARY
In a bubble chart, when picking the same `Series` and `Entity` against postgres, pandas chokes on something related to having a duplicate column name (`SELECT foo, foo FROM bar`)

<img width="1030" alt="Screen Shot 2019-11-25 at 9 55 25 PM" src="https://user-images.githubusercontent.com/487433/69603084-6fb47b00-0fce-11ea-834d-5ba6b142c47c.png">

stacktrace:
```
Traceback (most recent call last):
  File "/Users/maximebeauchemin/code/superset/superset/connectors/sqla/models.py", line 999, in query
    df = self.database.get_df(sql, self.schema, mutator)
  File "/Users/maximebeauchemin/code/superset/superset/models/core.py", line 992, in get_df
    if v.type == numpy.object_ and needs_conversion(df[k]):
  File "/Users/maximebeauchemin/code/superset/superset/models/core.py", line 963, in needs_conversion
    return not df_series.empty and isinstance(df_series[0], (list, dict))
  File "/Users/maximebeauchemin/code/superset/env/lib/python3.6/site-packages/pandas/core/frame.py", line 2927, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/Users/maximebeauchemin/code/superset/env/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 2657, in get_loc
    return self._engine.get_loc(key)
  File "pandas/_libs/index.pyx", line 108, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 127, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 142, in pandas._libs.index.IndexEngine._get_loc_duplicates
TypeError: '<' not supported between instances of 'str' and 'int'

This addresses the issue by preventing dups in selects/groupby altogether
```

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

