### PR TITLE
[fix] Chart specific time controls

### DIFF
--- a/superset/assets/src/explore/controlPanels/Area.js
+++ b/superset/assets/src/explore/controlPanels/Area.js
@@ -63,4 +63,12 @@ export default {
       renderTrigger: false,
     },
   },
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/Bar.js
+++ b/superset/assets/src/explore/controlPanels/Bar.js
@@ -62,4 +62,12 @@ export default {
       default: 'smart_date',
     },
   },
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/BigNumber.js
+++ b/superset/assets/src/explore/controlPanels/BigNumber.js
@@ -52,4 +52,12 @@ export default {
       label: t('Big Number Font Size'),
     },
   },
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/Compare.js
+++ b/superset/assets/src/explore/controlPanels/Compare.js
@@ -56,4 +56,12 @@ export default {
       default: 'smart_date',
     },
   },
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/Iframe.js
+++ b/superset/assets/src/explore/controlPanels/Iframe.js
@@ -25,4 +25,12 @@ export default {
       controlSetRows: [['url']],
     },
   ],
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/Line.js
+++ b/superset/assets/src/explore/controlPanels/Line.js
@@ -64,4 +64,12 @@ export default {
       default: 50000,
     },
   },
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/Markup.js
+++ b/superset/assets/src/explore/controlPanels/Markup.js
@@ -26,4 +26,12 @@ export default {
       controlSetRows: [['markup_type'], ['code']],
     },
   ],
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/Separator.js
+++ b/superset/assets/src/explore/controlPanels/Separator.js
@@ -35,4 +35,12 @@ export default {
         '---------------',
     },
   },
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/TimePivot.js
+++ b/superset/assets/src/explore/controlPanels/TimePivot.js
@@ -62,4 +62,12 @@ export default {
       clearable: false,
     },
   },
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/TimeTable.js
+++ b/superset/assets/src/explore/controlPanels/TimeTable.js
@@ -44,4 +44,12 @@ export default {
       ),
     },
   },
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+    },
+  },
 };

--- a/superset/assets/src/explore/controlPanels/sections.jsx
+++ b/superset/assets/src/explore/controlPanels/sections.jsx
@@ -23,7 +23,7 @@ export const druidTimeSeries = {
   label: t('Time'),
   expanded: true,
   description: t('Time related form attributes'),
-  controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+  controlSetRows: [['time_range']],
 };
 
 export const datasourceAndVizType = {
@@ -45,7 +45,7 @@ export const sqlaTimeSeries = {
   label: t('Time'),
   description: t('Time related form attributes'),
   expanded: true,
-  controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+  controlSetRows: [['granularity_sqla'], ['time_range']],
 };
 
 export const filters = {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR ensures that only the relevant time widgets are included depending on the chart type. Previously the granularity logic was shown even if the chart type did not support granularity, i.e., non-timeseries charts. 

This provides a number of benefits including: 

1. Improved UX: It's not apparent to the user that these controls have no impact on the chart.
2. Improved performance: The controls serve as inputs to the cache and thus the cache is invalidated when these erroneous options are changed. 
3. Cleaner form-data: The impetus for this change stemmed from a project migrating charts from Druid NoSQL to SQL where there isn't a 1:1 mapping for the time parameters. The erroneous values could deem a chart is non-migratable even though in theory is was.

Additionally this PR also removes the time controls for chart types which don't support time filtering, i.e., iFrame, Markup, etc.

Note erroneous form-data fields are removed on load in explorer but will persist in database until the slice is re-saved.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before 

![Screen Shot 2019-11-26 at 6 26 46 PM](https://user-images.githubusercontent.com/4567245/69688249-5bc65300-107a-11ea-94a3-3e8faaadf730.png)

#### After

![Screen Shot 2019-11-26 at 6 24 49 PM](https://user-images.githubusercontent.com/4567245/69688200-376a7680-107a-11ea-9fe8-4bb33514860d.png)

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- [x] Has associated issue: Fixes #2750
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @michellethomas @mistercrunch @willbarrett @villebro 