### PR TITLE
[querysearch] Improve database query request on select dropdown

### DIFF
--- a/superset/assets/src/SqlLab/components/QuerySearch.jsx
+++ b/superset/assets/src/SqlLab/components/QuerySearch.jsx
@@ -208,7 +208,13 @@ class QuerySearch extends React.PureComponent {
           <div className="col-sm-2">
             <AsyncSelect
               onChange={this.onChange}
-              dataEndpoint="/api/v1/database/?q=(filters:!((col:expose_in_sqllab,opr:eq,value:!t)))"
+              dataEndpoint={
+                '/api/v1/database/?q=' +
+                '(keys:!(none),' +
+                'columns:!(id,database_name),' +
+                'filters:!((col:expose_in_sqllab,opr:eq,value:!t)),' +
+                'order_columns:database_name,order_direction:asc,page:0,page_size:-1)'
+              }
               value={this.state.databaseId}
               mutator={this.dbMutator}
               placeholder={t('Filter by database')}

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -410,7 +410,7 @@ class SqlLabTests(SupersetTestCase):
         self.create_fake_db()
 
         arguments = {
-            "keys": [],
+            "keys": ["none"],
             "filters": [{"col": "expose_in_sqllab", "opr": "eq", "value": True}],
             "order_column": "database_name",
             "order_direction": "asc",


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Improves select databases dropdown on query search by requesting:
- Just the columns we want: id, database_name
- override pagination
- order by database_name 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
