### PR TITLE
fix: default missing values to zero on area chart

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1086,7 +1086,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
     verbose_name = _("Time Series - Line Chart")
     sort_series = False
     is_timeseries = True
-    pivot_fill_value = None
+    pivot_fill_value: Optional[int] = None
 
     def to_series(self, df, classed="", title_suffix=""):
         cols = []

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1158,7 +1158,10 @@ class NVD3TimeSeriesViz(NVD3Viz):
             )
         else:
             df = df.pivot_table(
-                index=DTTM_ALIAS, columns=fd.get("groupby"), values=self.metric_labels
+                index=DTTM_ALIAS,
+                columns=fd.get("groupby"),
+                values=self.metric_labels,
+                fill_value=0,
             )
 
         rule = fd.get("resample_rule")

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1086,6 +1086,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
     verbose_name = _("Time Series - Line Chart")
     sort_series = False
     is_timeseries = True
+    pivot_fill_value = None
 
     def to_series(self, df, classed="", title_suffix=""):
         cols = []
@@ -1161,7 +1162,7 @@ class NVD3TimeSeriesViz(NVD3Viz):
                 index=DTTM_ALIAS,
                 columns=fd.get("groupby"),
                 values=self.metric_labels,
-                fill_value=0,
+                fill_value=self.pivot_fill_value,
             )
 
         rule = fd.get("resample_rule")
@@ -1447,6 +1448,7 @@ class NVD3TimeSeriesStackedViz(NVD3TimeSeriesViz):
     viz_type = "area"
     verbose_name = _("Time Series - Stacked")
     sort_series = True
+    pivot_fill_value = 0
 
 
 class DistributionPieViz(NVD3Viz):


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Area chart currently fails to render properly if there are missing groupby values in the time series. This PR makes it possible to specify NULL handling behavior per NVD3 chart, and defaults values to zero for the Area chart. Note: other charts are left unchanged, as defaulting to zero is most likely *not* expected behavior for all charts (at least line charts).

### BEFORE
<img width="780" alt="Screenshot 2019-11-27 at 18 21 59" src="https://user-images.githubusercontent.com/33317356/69741686-2be38200-1144-11ea-8131-2646ae9bf4c6.png">

### AFTER
<img width="778" alt="Screenshot 2019-11-27 at 18 21 18" src="https://user-images.githubusercontent.com/33317356/69741705-3140cc80-1144-11ea-8806-e7135f32a42f.png">

### TEST PLAN
Visual inspection.

### ADDITIONAL INFORMATION
- [x] Has associated issue: closes #8671
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 