### PR TITLE
Only list tables in DB test if API returns them (which it doesn't)

### DIFF
--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -57,15 +57,21 @@
         contentType: "application/json; charset=utf-8"
       }).done(function(data) {
           alert("Seems OK!");
-          if ($('#tables').length == 0)
+          if(Array.isArray(data)){
+            if ($('#tables').length == 0)
             $('body div.container').append('<div id="tables"></div>');
-          div = $('#tables')
-          div.html('Tables:<br>');
-          $.each(data, function(i, d){
-            var id = 'tbl_' + d;
-            div.append('<span id="' + id + '" style="margin: 0px 10px 10px 0px;" class="btn btn-default">' + d + '</span>')
-            $('#' + id).click(function(){window.location = '/tablemodelview/add';})
-          });
+            var div = $('#tables');
+            div.html('Tables:<br>');
+            $.each(data, function(i, d){
+              var id = 'tbl_' + d;
+              div.append('<span id="' + id + '" style="margin: 0px 10px 10px 0px;" class="btn btn-default">' + d + '</span>')
+              $('#' + id).click(function(){window.location = '/tablemodelview/add';})
+            });
+          }
+          else{
+            console.warn('No table list returned by API.');
+          }
+          
       }).fail(function(error) {
           var respJSON = error.responseJSON;
           var errorMsg = error.responseText;

--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -57,21 +57,6 @@
         contentType: "application/json; charset=utf-8"
       }).done(function(data) {
           alert("Seems OK!");
-          if(Array.isArray(data)){
-            if ($('#tables').length == 0)
-            $('body div.container').append('<div id="tables"></div>');
-            var div = $('#tables');
-            div.html('Tables:<br>');
-            $.each(data, function(i, d){
-              var id = 'tbl_' + d;
-              div.append('<span id="' + id + '" style="margin: 0px 10px 10px 0px;" class="btn btn-default">' + d + '</span>')
-              $('#' + id).click(function(){window.location = '/tablemodelview/add';})
-            });
-          }
-          else{
-            console.warn('No table list returned by API.');
-          }
-          
       }).fail(function(error) {
           var respJSON = error.responseJSON;
           var errorMsg = error.responseText;


### PR DESCRIPTION
…ever will)

### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
I noticed that when you use the button to test a DB connection, the API just responds with "OK" and not a list of tables. That may be an issue worth exploring, or maybe it was changed for a good reason. In any case, there was some Javascript that was bugging out in trying to process/display a list of tables from that "OK" so I made this display logic conditional, such that it will only run if an array of tables is indeed returned. I doubt that will ever happen, but at least this PR kills the console error in any case.

### REVIEWERS
@mistercrunch 