### PR TITLE
[SQL Lab] Re-add erroneously removed css

### DIFF
--- a/superset/assets/src/SqlLab/main.less
+++ b/superset/assets/src/SqlLab/main.less
@@ -262,6 +262,42 @@ div.Workspace {
     flex: 1 1 auto;
     padding-left: 10px;
   }
+
+  .schemaPane-enter-done,
+  .schemaPane-exit {
+    transform: translateX(0);
+  }
+
+  .schemaPane-exit-active {
+    transform: translateX(-120%);
+  }
+
+  .schemaPane-enter-active {
+    transform: translateX(0);
+    max-width: 300px;
+  }
+
+  .schemaPane-enter,
+  .schemaPane-exit-done {
+    max-width: 0;
+    transform: translateX(-120%);
+    overflow: hidden;
+  }
+
+  .schemaPane-exit-done + .queryPane {
+    margin-left: 0;
+  }
+
+  .gutter {
+    border-top: 1px solid @gray-light;
+    border-bottom: 1px solid @gray-light;
+    width: 3%;
+    margin: 3px 47%;
+  }
+
+  .gutter.gutter-vertical {
+    cursor: row-resize;
+  }
 }
 
 .SqlEditorLeftBar {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
https://github.com/apache/incubator-superset/pull/8563 removed some assumed dead css, but it's actually still being used to style the gripper for resizing the sql editor and closing the side pane. This PR readds it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![image](https://user-images.githubusercontent.com/7409244/69978837-f7741b00-14e1-11ea-94f7-81ff483ed7a7.png)

After:
![image](https://user-images.githubusercontent.com/7409244/69978794-e88d6880-14e1-11ea-94ab-19b109974a65.png)

### TEST PLAN
ensure you can resize the sql editor and open and close the side pane

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@rusackas @graceguo-supercat @nytai 