### PR TITLE
fix: #8711 CSS loads late and app flickers

### DIFF
--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -207,7 +207,7 @@ const config = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
+              sourceMap: isDevMode,
             },
           },
         ],
@@ -220,13 +220,13 @@ const config = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
+              sourceMap: isDevMode,
             },
           },
           {
             loader: 'less-loader',
             options: {
-              sourceMap: true,
+              sourceMap: isDevMode,
             },
           },
         ],


### PR DESCRIPTION
see #8711 for details,

Decided to disable source maps in production, which fixes the flickering in-production only. The issue is still observed in dev.

@rusackas 