### PR TITLE
[SQL Lab] Fix unadjustable sql editor height

### DIFF
--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -324,6 +324,7 @@ class SqlEditor extends React.PureComponent {
     );
     return (
       <Split
+        expandToMin
         className="queryPane"
         sizes={[this.state.northPercent, this.state.southPercent]}
         elementStyle={this.elementStyle}

--- a/superset/assets/src/SqlLab/main.less
+++ b/superset/assets/src/SqlLab/main.less
@@ -20,6 +20,7 @@
 @import '../../stylesheets/less/variables.less';
 
 body {
+  min-height: 500px; // Set a min height so the gutter is always visible when resizing
   overflow: hidden;
 }
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
If you made the window really small and adjusted the sql editor height, it would autolock to the minHeight (200px) which was > 100% of the screen size. Then you could never resize it again because the sql editor height would be saved to localstorage.

This PR ensures that the panes are always resized to at least the minHeight (200px) and also sets a min height to the whole page so that you can never make the editor 100% of the page

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![image](https://user-images.githubusercontent.com/7409244/69990137-f64ee800-14f9-11ea-9ca1-b7655e013ffb.png)
After:
![image](https://user-images.githubusercontent.com/7409244/69990561-be947000-14fa-11ea-95c0-984ab9c478e8.png)

### TEST PLAN
Make the window min height, resize the pane, then make the window larger again. See that you can still drag the gutter. Also make sure that when reloading the page you can drag the gutter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @betodealmeida @rusackas 