### PR TITLE
Import `filter_immune_slice_fields` when importing dashboards

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -586,6 +586,7 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         slices = copy(dashboard_to_import.slices)
         old_to_new_slc_id_dict = {}
         new_filter_immune_slices = []
+        new_filter_immune_slice_fields = {}
         new_timed_refresh_immune_slices = []
         new_expanded_slices = {}
         i_params_dict = dashboard_to_import.params_dict
@@ -611,6 +612,13 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
                 and old_slc_id_str in i_params_dict["filter_immune_slices"]
             ):
                 new_filter_immune_slices.append(new_slc_id_str)
+            if (
+                "filter_immune_slice_fields" in i_params_dict
+                and old_slc_id_str in i_params_dict["filter_immune_slice_fields"]
+            ):
+                new_filter_immune_slice_fields[new_slc_id_str] = i_params_dict[
+                    "filter_immune_slice_fields"
+                ][old_slc_id_str]
             if (
                 "timed_refresh_immune_slices" in i_params_dict
                 and old_slc_id_str in i_params_dict["timed_refresh_immune_slices"]
@@ -646,6 +654,10 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         if new_filter_immune_slices:
             dashboard_to_import.alter_params(
                 filter_immune_slices=new_filter_immune_slices
+            )
+        if new_filter_immune_slice_fields:
+            dashboard_to_import.alter_params(
+                filter_immune_slice_fields=new_filter_immune_slice_fields
             )
         if new_timed_refresh_immune_slices:
             dashboard_to_import.alter_params(


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When we import a dashboard we currently ignore `filter_immune_slice_fields`. I added logic to import the field as well.

This PR fixes https://github.com/apache/incubator-superset/issues/8489.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Exported dashboard with the following JSON metadata:

```json
{
  "filter_immune_slices": [324, 65, 92],
  "expanded_slices": {},
  "filter_immune_slice_fields": {
    "177": ["country_name", "__time_range"],
    "32": ["__time_range"]
  },
  "timed_refresh_immune_slices": [324]
}
```

Imported it, and verified that the new dashboard has `filter_immune_slice_fields`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/incubator-superset/issues/8489
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
