### PR TITLE
[Explore] should not trigger chart render when overlay is on

### DIFF
--- a/superset/assets/spec/javascripts/chart/ChartRenderer_spec.jsx
+++ b/superset/assets/spec/javascripts/chart/ChartRenderer_spec.jsx
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SuperChart } from '@superset-ui/chart';
+
+import ChartRenderer from '../../../src/chart/ChartRenderer';
+
+describe('ChartRenderer', () => {
+  it('should render SuperChart', () => {
+    const wrapper = shallow(<ChartRenderer refreshOverlayVisible={false} />);
+    expect(wrapper.find(SuperChart)).toHaveLength(1);
+  });
+
+  it('should not render SuperChart when refreshOverlayVisible is true', () => {
+    const wrapper = shallow(<ChartRenderer refreshOverlayVisible />);
+    expect(wrapper.find(SuperChart)).toHaveLength(0);
+  });
+});

--- a/superset/assets/src/chart/ChartRenderer.jsx
+++ b/superset/assets/src/chart/ChartRenderer.jsx
@@ -192,10 +192,21 @@ class ChartRenderer extends React.Component {
   }
 
   render() {
-    const { chartAlert, chartStatus, vizType, chartId } = this.props;
+    const {
+      chartAlert,
+      chartStatus,
+      vizType,
+      chartId,
+      refreshOverlayVisible,
+    } = this.props;
 
     // Skip chart rendering
-    if (chartStatus === 'loading' || !!chartAlert || chartStatus === null) {
+    if (
+      refreshOverlayVisible ||
+      chartStatus === 'loading' ||
+      !!chartAlert ||
+      chartStatus === null
+    ) {
       return null;
     }
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
see reproduce steps in: https://github.com/apache/incubator-superset/issues/8708

The root cause is, when user changes viz type, it should trigger a new query first, then chart should get re-rendered. But right now the chart is re-rendered without updated query results. The old query results's data format doesn't matched with new viz, and the JS error is thrown.

### TEST PLAN
CI and manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/incubator-superset/issues/8708
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
