### PR TITLE
Require the SQLAlchemy URI on the database model

### DIFF
--- a/superset/migrations/versions/817e1c9b09d0_add_not_null_to_dbs_sqlalchemy_url.py
+++ b/superset/migrations/versions/817e1c9b09d0_add_not_null_to_dbs_sqlalchemy_url.py
@@ -26,7 +26,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "817e1c9b09d0"
-down_revision = "db4b49eb0782"
+down_revision = "89115a40e8ea"
 
 
 def upgrade():

--- a/superset/migrations/versions/817e1c9b09d0_add_not_null_to_dbs_sqlalchemy_url.py
+++ b/superset/migrations/versions/817e1c9b09d0_add_not_null_to_dbs_sqlalchemy_url.py
@@ -21,22 +21,23 @@ Revises: db4b49eb0782
 Create Date: 2019-12-03 10:24:16.201580
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '817e1c9b09d0'
-down_revision = 'db4b49eb0782'
+revision = "817e1c9b09d0"
+down_revision = "db4b49eb0782"
 
 
 def upgrade():
-    with op.batch_alter_table('dbs') as batch_op:
-        batch_op.alter_column('sqlalchemy_uri',
-                   existing_type=sa.VARCHAR(length=1024),
-                   nullable=False)
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.alter_column(
+            "sqlalchemy_uri", existing_type=sa.VARCHAR(length=1024), nullable=False
+        )
+
 
 def downgrade():
-    with op.batch_alter_table('dbs') as batch_op:
-        batch_op.alter_column('sqlalchemy_uri',
-                   existing_type=sa.VARCHAR(length=1024),
-                   nullable=True)
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.alter_column(
+            "sqlalchemy_uri", existing_type=sa.VARCHAR(length=1024), nullable=True
+        )

--- a/superset/migrations/versions/817e1c9b09d0_add_not_null_to_dbs_sqlalchemy_url.py
+++ b/superset/migrations/versions/817e1c9b09d0_add_not_null_to_dbs_sqlalchemy_url.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_not_null_to_dbs_sqlalchemy_url
+
+Revision ID: 817e1c9b09d0
+Revises: db4b49eb0782
+Create Date: 2019-12-03 10:24:16.201580
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '817e1c9b09d0'
+down_revision = 'db4b49eb0782'
+
+
+def upgrade():
+    with op.batch_alter_table('dbs') as batch_op:
+        batch_op.alter_column('sqlalchemy_uri',
+                   existing_type=sa.VARCHAR(length=1024),
+                   nullable=False)
+
+def downgrade():
+    with op.batch_alter_table('dbs') as batch_op:
+        batch_op.alter_column('sqlalchemy_uri',
+                   existing_type=sa.VARCHAR(length=1024),
+                   nullable=True)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -753,7 +753,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
     verbose_name = Column(String(250), unique=True)
     # short unique name, used in permissions
     database_name = Column(String(250), unique=True, nullable=False)
-    sqlalchemy_uri = Column(String(1024))
+    sqlalchemy_uri = Column(String(1024), nullable=False)
     password = Column(EncryptedType(String(1024), config["SECRET_KEY"]))
     cache_timeout = Column(Integer)
     select_as_create_table_as = Column(Boolean, default=False)

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -226,6 +226,7 @@ class SupersetTestCase(TestCase):
             cls=models.Database,
             criteria={"database_name": database_name},
             session=db.session,
+            sqlalchemy_uri="sqlite://test",
             id=db_id,
             extra=extra,
         )

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -316,7 +316,9 @@ class RolePermissionTests(SupersetTestCase):
 
     def test_set_perm_database(self):
         session = db.session
-        database = Database(database_name="tmp_database", sqlalchemy_uri="sqlite://test")
+        database = Database(
+            database_name="tmp_database", sqlalchemy_uri="sqlite://test"
+        )
         session.add(database)
 
         stored_db = (
@@ -346,7 +348,9 @@ class RolePermissionTests(SupersetTestCase):
 
     def test_set_perm_slice(self):
         session = db.session
-        database = Database(database_name="tmp_database", sqlalchemy_uri="sqlite://test")
+        database = Database(
+            database_name="tmp_database", sqlalchemy_uri="sqlite://test"
+        )
         table = SqlaTable(table_name="tmp_perm_table", database=database)
         session.add(database)
         session.add(table)

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -316,7 +316,7 @@ class RolePermissionTests(SupersetTestCase):
 
     def test_set_perm_database(self):
         session = db.session
-        database = Database(database_name="tmp_database")
+        database = Database(database_name="tmp_database", sqlalchemy_uri="sqlite://test")
         session.add(database)
 
         stored_db = (
@@ -346,7 +346,7 @@ class RolePermissionTests(SupersetTestCase):
 
     def test_set_perm_slice(self):
         session = db.session
-        database = Database(database_name="tmp_database")
+        database = Database(database_name="tmp_database", sqlalchemy_uri="sqlite://test")
         table = SqlaTable(table_name="tmp_perm_table", database=database)
         session.add(database)
         session.add(table)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, attempting to create a database connection without a SQLAlchemy connection string defined will throw a server error (calling `strip` on `NoneType`). After the change, the system will reject empty SQLAlchemy connection strings correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 @betodealmeida @mistercrunch 