### PR TITLE
[fix] Remedying filter-box w/ invalid metrics

### DIFF
--- a/superset/assets/src/explore/components/controls/FilterBoxItemControl.jsx
+++ b/superset/assets/src/explore/components/controls/FilterBoxItemControl.jsx
@@ -76,10 +76,15 @@ export default class FilterBoxItemControl extends React.Component {
               value={this.state.column}
               name="column"
               clearable={false}
-              options={this.props.datasource.columns.map(col => ({
-                value: col.column_name,
-                label: col.column_name,
-              }))}
+              options={this.props.datasource.columns
+                .filter(col => col !== this.state.column)
+                .map(col => ({
+                  value: col.column_name,
+                  label: col.column_name,
+                }))
+                .concat([
+                  { value: this.state.column, label: this.state.column },
+                ])}
               onChange={v => this.onControlChange('column', v)}
             />
           }
@@ -116,10 +121,15 @@ export default class FilterBoxItemControl extends React.Component {
             <SelectControl
               value={this.state.metric}
               name="column"
-              options={this.props.datasource.metrics.map(m => ({
-                value: m.metric_name,
-                label: m.metric_name,
-              }))}
+              options={this.props.datasource.metrics
+                .filter(metric => metric !== this.state.metric)
+                .map(m => ({
+                  value: m.metric_name,
+                  label: m.metric_name,
+                }))
+                .concat([
+                  { value: this.state.metric, label: this.state.metric },
+                ])}
               onChange={v => this.onControlChange('metric', v)}
             />
           }

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1826,19 +1826,21 @@ class FilterBoxViz(BaseViz):
             col = flt.get("column")
             metric = flt.get("metric")
             df = self.dataframes.get(col)
-            if metric:
-                df = df.sort_values(
-                    utils.get_metric_name(metric), ascending=flt.get("asc")
-                )
-                d[col] = [
-                    {"id": row[0], "text": row[0], "metric": row[1]}
-                    for row in df.itertuples(index=False)
-                ]
-            else:
-                df = df.sort_values(col, ascending=flt.get("asc"))
-                d[col] = [
-                    {"id": row[0], "text": row[0]} for row in df.itertuples(index=False)
-                ]
+            if df is not None:
+                if metric:
+                    df = df.sort_values(
+                        utils.get_metric_name(metric), ascending=flt.get("asc")
+                    )
+                    d[col] = [
+                        {"id": row[0], "text": row[0], "metric": row[1]}
+                        for row in df.itertuples(index=False)
+                    ]
+                else:
+                    df = df.sort_values(col, ascending=flt.get("asc"))
+                    d[col] = [
+                        {"id": row[0], "text": row[0]}
+                        for row in df.itertuples(index=False)
+                    ]
         return d
 
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes an issue where if the filter box referenced an obsolete value it would throw an exception when trying to sort the values (see before and after). Afterwards the error is shown, e.g. `Metric 'count' does not exist' however it is not apparent which filter this applies to as undefined values are filtered out from the set of options. 

The solution is to add any saved values to the default options. Note ideally there would be some frontend validation which would propagate upwards and thus prevent the query from being run in the first place.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before 
<img width="1426" alt="Screen Shot 2019-12-02 at 4 34 11 PM" src="https://user-images.githubusercontent.com/4567245/70006345-9c621880-1521-11ea-8ed6-b40183555ce1.png">

#### After

<img width="1430" alt="Screen Shot 2019-12-02 at 4 07 59 PM" src="https://user-images.githubusercontent.com/4567245/70006261-560cb980-1521-11ea-8d50-4f4fa9005e9e.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @michellethomas @mistercrunch 
