### PR TITLE
handle nulls in bar chart series/breakdown

### DIFF
--- a/superset/assets/spec/javascripts/utils/common_spec.jsx
+++ b/superset/assets/spec/javascripts/utils/common_spec.jsx
@@ -19,7 +19,7 @@
 import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
-  NULLSTRING,
+  NULL_STRING,
 } from '../../../src/utils/common';
 
 describe('utils/common', () => {
@@ -31,8 +31,8 @@ describe('utils/common', () => {
       });
       expect(optionFromValue(true)).toEqual({ value: true, label: '<true>' });
       expect(optionFromValue(null)).toEqual({
-        value: NULLSTRING,
-        label: NULLSTRING,
+        value: NULL_STRING,
+        label: NULL_STRING,
       });
       expect(optionFromValue('')).toEqual({
         value: '',

--- a/superset/assets/spec/javascripts/utils/common_spec.jsx
+++ b/superset/assets/spec/javascripts/utils/common_spec.jsx
@@ -19,6 +19,7 @@
 import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
+  NULLSTRING,
 } from '../../../src/utils/common';
 
 describe('utils/common', () => {
@@ -30,8 +31,8 @@ describe('utils/common', () => {
       });
       expect(optionFromValue(true)).toEqual({ value: true, label: '<true>' });
       expect(optionFromValue(null)).toEqual({
-        value: '<NULL>',
-        label: '<NULL>',
+        value: NULLSTRING,
+        label: NULLSTRING,
       });
       expect(optionFromValue('')).toEqual({
         value: '',

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -19,6 +19,8 @@
 import { SupersetClient } from '@superset-ui/connection';
 import getClientErrorObject from './getClientErrorObject';
 
+export const NULLSTRING = '<NULL>';
+
 export function getParamFromQuery(query, param) {
   const vars = query.split('&');
   for (let i = 0; i < vars.length; i += 1) {
@@ -78,7 +80,7 @@ export function supersetURL(rootUrl, getParams = {}) {
 
 export function optionLabel(opt) {
   if (opt === null) {
-    return '<NULL>';
+    return NULLSTRING;
   } else if (opt === '') {
     return '<empty string>';
   } else if (opt === true) {
@@ -93,7 +95,7 @@ export function optionLabel(opt) {
 
 export function optionValue(opt) {
   if (opt === null) {
-    return '<NULL>';
+    return NULLSTRING;
   }
   return opt;
 }

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -19,7 +19,7 @@
 import { SupersetClient } from '@superset-ui/connection';
 import getClientErrorObject from './getClientErrorObject';
 
-export const NULLSTRING = '<NULL>';
+export const NULL_STRING = '<NULL>';
 
 export function getParamFromQuery(query, param) {
   const vars = query.split('&');
@@ -80,7 +80,7 @@ export function supersetURL(rootUrl, getParams = {}) {
 
 export function optionLabel(opt) {
   if (opt === null) {
-    return NULLSTRING;
+    return NULL_STRING;
   } else if (opt === '') {
     return '<empty string>';
   } else if (opt === true) {
@@ -95,7 +95,7 @@ export function optionLabel(opt) {
 
 export function optionValue(opt) {
   if (opt === null) {
-    return NULLSTRING;
+    return NULL_STRING;
   }
   return opt;
 }

--- a/superset/assets/src/utils/common.js
+++ b/superset/assets/src/utils/common.js
@@ -19,6 +19,8 @@
 import { SupersetClient } from '@superset-ui/connection';
 import getClientErrorObject from './getClientErrorObject';
 
+// ATTENTION: If you change any constants, make sure to also change constants.py
+
 export const NULL_STRING = '<NULL>';
 
 export function getParamFromQuery(query, param) {

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -23,6 +23,7 @@ from sqlalchemy import and_, Boolean, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import foreign, Query, relationship
 
+from superset.constants import NULLSTRING
 from superset.models.core import Slice
 from superset.models.helpers import AuditMixinNullable, ImportMixin, QueryResult
 from superset.utils import core as utils
@@ -219,7 +220,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
                     # For backwards compatibility and edge cases
                     # where a column data type might have changed
                     v = utils.string_to_num(v)
-                if v == "<NULL>":
+                if v == NULLSTRING:
                     return None
                 elif v == "<empty string>":
                     return ""

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -23,7 +23,7 @@ from sqlalchemy import and_, Boolean, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import foreign, Query, relationship
 
-from superset.constants import NULLSTRING
+from superset.constants import NULL_STRING
 from superset.models.core import Slice
 from superset.models.helpers import AuditMixinNullable, ImportMixin, QueryResult
 from superset.utils import core as utils
@@ -220,7 +220,7 @@ class BaseDatasource(AuditMixinNullable, ImportMixin):
                     # For backwards compatibility and edge cases
                     # where a column data type might have changed
                     v = utils.string_to_num(v)
-                if v == NULLSTRING:
+                if v == NULL_STRING:
                     return None
                 elif v == "<empty string>":
                     return ""

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -50,7 +50,7 @@ from sqlalchemy_utils import EncryptedType
 
 from superset import conf, db, security_manager
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
-from superset.constants import NULLSTRING
+from superset.constants import NULL_STRING
 from superset.exceptions import SupersetException
 from superset.models.core import Database
 from superset.models.helpers import AuditMixinNullable, ImportMixin, QueryResult
@@ -1364,7 +1364,7 @@ class DruidDatasource(Model, BaseDatasource):
         Here we replace None with <NULL> and make the whole series a
         str instead of an object.
         """
-        df[groupby_cols] = df[groupby_cols].fillna(NULLSTRING).astype("unicode")
+        df[groupby_cols] = df[groupby_cols].fillna(NULL_STRING).astype("unicode")
         return df
 
     def query(self, query_obj: Dict) -> QueryResult:

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -50,6 +50,7 @@ from sqlalchemy_utils import EncryptedType
 
 from superset import conf, db, security_manager
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
+from superset.constants import NULLSTRING
 from superset.exceptions import SupersetException
 from superset.models.core import Database
 from superset.models.helpers import AuditMixinNullable, ImportMixin, QueryResult
@@ -1363,7 +1364,7 @@ class DruidDatasource(Model, BaseDatasource):
         Here we replace None with <NULL> and make the whole series a
         str instead of an object.
         """
-        df[groupby_cols] = df[groupby_cols].fillna("<NULL>").astype("unicode")
+        df[groupby_cols] = df[groupby_cols].fillna(NULLSTRING).astype("unicode")
         return df
 
     def query(self, query_obj: Dict) -> QueryResult:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -51,7 +51,7 @@ from sqlalchemy.sql.expression import Label, Select, TextAsFrom
 
 from superset import app, db, security_manager
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
-from superset.constants import NULLSTRING
+from superset.constants import NULL_STRING
 from superset.db_engine_specs.base import TimestampExpression
 from superset.exceptions import DatabaseNotFound
 from superset.jinja_context import get_template_processor
@@ -809,7 +809,7 @@ class SqlaTable(Model, BaseDatasource):
                 )
                 if op in ("in", "not in"):
                     cond = col_obj.get_sqla_col().in_(eq)
-                    if NULLSTRING in eq:
+                    if NULL_STRING in eq:
                         cond = or_(cond, col_obj.get_sqla_col() == None)
                     if op == "not in":
                         cond = ~cond

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -51,6 +51,7 @@ from sqlalchemy.sql.expression import Label, Select, TextAsFrom
 
 from superset import app, db, security_manager
 from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
+from superset.constants import NULLSTRING
 from superset.db_engine_specs.base import TimestampExpression
 from superset.exceptions import DatabaseNotFound
 from superset.jinja_context import get_template_processor
@@ -808,7 +809,7 @@ class SqlaTable(Model, BaseDatasource):
                 )
                 if op in ("in", "not in"):
                     cond = col_obj.get_sqla_col().in_(eq)
-                    if "<NULL>" in eq:
+                    if NULLSTRING in eq:
                         cond = or_(cond, col_obj.get_sqla_col() == None)
                     if op == "not in":
                         cond = ~cond

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# string to use when None values *need* to be converted to/from strings
+NULLSTRING = "<NULL>"

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -16,4 +16,4 @@
 # under the License.
 
 # string to use when None values *need* to be converted to/from strings
-NULLSTRING = "<NULL>"
+NULL_STRING = "<NULL>"

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -15,5 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# ATTENTION: If you change any constants, make sure to also change utils/common.js
+
 # string to use when None values *need* to be converted to/from strings
 NULL_STRING = "<NULL>"

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -47,7 +47,7 @@ from markdown import markdown
 from pandas.tseries.frequencies import to_offset
 
 from superset import app, cache, get_css_manifest_files
-from superset.constants import NULLSTRING
+from superset.constants import NULL_STRING
 from superset.exceptions import NullValueException, SpatialException
 from superset.utils import core as utils
 from superset.utils.core import (
@@ -1547,9 +1547,9 @@ class DistributionBarViz(DistributionPieViz):
         columns = fd.get("columns") or []
 
         # pandas will throw away nulls when grouping/pivoting,
-        # so we substitute NULLSTRING for any nulls in the necessary columns
+        # so we substitute NULL_STRING for any nulls in the necessary columns
         filled_cols = self.groupby + columns
-        df[filled_cols] = df[filled_cols].fillna(value=NULLSTRING)
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         row = df.groupby(self.groupby).sum()[metrics[0]].copy()
         row.sort_values(ascending=False, inplace=True)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -47,6 +47,7 @@ from markdown import markdown
 from pandas.tseries.frequencies import to_offset
 
 from superset import app, cache, get_css_manifest_files
+from superset.constants import NULLSTRING
 from superset.exceptions import NullValueException, SpatialException
 from superset.utils import core as utils
 from superset.utils.core import (
@@ -1543,10 +1544,15 @@ class DistributionBarViz(DistributionPieViz):
     def get_data(self, df):
         fd = self.form_data
         metrics = self.metric_labels
+        columns = fd.get("columns") or []
+
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULLSTRING for any nulls in the necessary columns
+        filled_cols = self.groupby + columns
+        df[filled_cols] = df[filled_cols].fillna(value=NULLSTRING)
 
         row = df.groupby(self.groupby).sum()[metrics[0]].copy()
         row.sort_values(ascending=False, inplace=True)
-        columns = fd.get("columns") or []
         pt = df.pivot_table(index=self.groupby, columns=columns, values=metrics)
         if fd.get("contribution"):
             pt = pt.T

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 import uuid
 from datetime import datetime
+from math import nan
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -23,6 +24,7 @@ import pandas as pd
 
 import superset.viz as viz
 from superset import app
+from superset.constants import NULL_STRING
 from superset.exceptions import SpatialException
 from superset.utils.core import DTTM_ALIAS
 
@@ -396,6 +398,88 @@ class TableVizTestCase(SupersetTestCase):
         test_viz = viz.TableViz(datasource, form_data)
         with self.assertRaises(Exception):
             test_viz.should_be_timeseries()
+
+
+class DistBarVizTestCase(SupersetTestCase):
+
+    def test_groupby_nulls(self):
+        form_data = {
+            'metrics': ['votes'],
+            'adhoc_filters': [],
+            'groupby': ['toppings'],
+            'columns': [],
+        }
+        datasource = self.get_datasource_mock()
+        df = pd.DataFrame({
+            'toppings': ['cheese', 'pepperoni', 'anchovies', None],
+            'votes': [3, 5, 1, 2],
+        })
+        test_viz = viz.DistributionBarViz(datasource, form_data)
+        data = test_viz.get_data(df)[0]
+        self.assertEqual('votes', data['key'])
+        expected_values = [
+            {'x': 'pepperoni', 'y': 5},
+            {'x': 'cheese', 'y': 3},
+            {'x': NULL_STRING, 'y': 2},
+            {'x': 'anchovies', 'y': 1},
+        ]
+        self.assertEqual(expected_values, data['values'])
+
+    def test_groupby_nans(self):
+        form_data = {
+            'metrics': ['count'],
+            'adhoc_filters': [],
+            'groupby': ['beds'],
+            'columns': [],
+        }
+        datasource = self.get_datasource_mock()
+        df = pd.DataFrame({
+            'beds': [0, 1, nan, 2],
+            'count': [30, 42, 3, 29],
+        })
+        test_viz = viz.DistributionBarViz(datasource, form_data)
+        data = test_viz.get_data(df)[0]
+        self.assertEqual('count', data['key'])
+        expected_values = [
+            {'x': '1.0', 'y': 42},
+            {'x': '0.0', 'y': 30},
+            {'x': '2.0', 'y': 29},
+            {'x': NULL_STRING, 'y': 3},
+        ]
+        self.assertEqual(expected_values, data['values'])
+
+    def test_column_nulls(self):
+        form_data = {
+            'metrics': ['votes'],
+            'adhoc_filters': [],
+            'groupby': ['toppings'],
+            'columns': ['role'],
+        }
+        datasource = self.get_datasource_mock()
+        df = pd.DataFrame({
+            'toppings': ['cheese', 'pepperoni', 'cheese', 'pepperoni'],
+            'role': ['engineer', 'engineer', None, None],
+            'votes': [3, 5, 1, 2],
+        })
+        test_viz = viz.DistributionBarViz(datasource, form_data)
+        data = test_viz.get_data(df)
+        expected = [
+            {
+                'key': NULL_STRING,
+                'values': [
+                    {'x': 'pepperoni', 'y': 2},
+                    {'x': 'cheese', 'y': 1},
+                ],
+            },
+            {
+                'key': 'engineer',
+                'values': [
+                    {'x': 'pepperoni', 'y': 5},
+                    {'x': 'cheese', 'y': 3},
+                ],
+            },
+        ]
+        self.assertEqual(expected, data)
 
 
 class PairedTTestTestCase(SupersetTestCase):

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -401,82 +401,76 @@ class TableVizTestCase(SupersetTestCase):
 
 
 class DistBarVizTestCase(SupersetTestCase):
-
     def test_groupby_nulls(self):
         form_data = {
-            'metrics': ['votes'],
-            'adhoc_filters': [],
-            'groupby': ['toppings'],
-            'columns': [],
+            "metrics": ["votes"],
+            "adhoc_filters": [],
+            "groupby": ["toppings"],
+            "columns": [],
         }
         datasource = self.get_datasource_mock()
-        df = pd.DataFrame({
-            'toppings': ['cheese', 'pepperoni', 'anchovies', None],
-            'votes': [3, 5, 1, 2],
-        })
+        df = pd.DataFrame(
+            {
+                "toppings": ["cheese", "pepperoni", "anchovies", None],
+                "votes": [3, 5, 1, 2],
+            }
+        )
         test_viz = viz.DistributionBarViz(datasource, form_data)
         data = test_viz.get_data(df)[0]
-        self.assertEqual('votes', data['key'])
+        self.assertEqual("votes", data["key"])
         expected_values = [
-            {'x': 'pepperoni', 'y': 5},
-            {'x': 'cheese', 'y': 3},
-            {'x': NULL_STRING, 'y': 2},
-            {'x': 'anchovies', 'y': 1},
+            {"x": "pepperoni", "y": 5},
+            {"x": "cheese", "y": 3},
+            {"x": NULL_STRING, "y": 2},
+            {"x": "anchovies", "y": 1},
         ]
-        self.assertEqual(expected_values, data['values'])
+        self.assertEqual(expected_values, data["values"])
 
     def test_groupby_nans(self):
         form_data = {
-            'metrics': ['count'],
-            'adhoc_filters': [],
-            'groupby': ['beds'],
-            'columns': [],
+            "metrics": ["count"],
+            "adhoc_filters": [],
+            "groupby": ["beds"],
+            "columns": [],
         }
         datasource = self.get_datasource_mock()
-        df = pd.DataFrame({
-            'beds': [0, 1, nan, 2],
-            'count': [30, 42, 3, 29],
-        })
+        df = pd.DataFrame({"beds": [0, 1, nan, 2], "count": [30, 42, 3, 29]})
         test_viz = viz.DistributionBarViz(datasource, form_data)
         data = test_viz.get_data(df)[0]
-        self.assertEqual('count', data['key'])
+        self.assertEqual("count", data["key"])
         expected_values = [
-            {'x': '1.0', 'y': 42},
-            {'x': '0.0', 'y': 30},
-            {'x': '2.0', 'y': 29},
-            {'x': NULL_STRING, 'y': 3},
+            {"x": "1.0", "y": 42},
+            {"x": "0.0", "y": 30},
+            {"x": "2.0", "y": 29},
+            {"x": NULL_STRING, "y": 3},
         ]
-        self.assertEqual(expected_values, data['values'])
+        self.assertEqual(expected_values, data["values"])
 
     def test_column_nulls(self):
         form_data = {
-            'metrics': ['votes'],
-            'adhoc_filters': [],
-            'groupby': ['toppings'],
-            'columns': ['role'],
+            "metrics": ["votes"],
+            "adhoc_filters": [],
+            "groupby": ["toppings"],
+            "columns": ["role"],
         }
         datasource = self.get_datasource_mock()
-        df = pd.DataFrame({
-            'toppings': ['cheese', 'pepperoni', 'cheese', 'pepperoni'],
-            'role': ['engineer', 'engineer', None, None],
-            'votes': [3, 5, 1, 2],
-        })
+        df = pd.DataFrame(
+            {
+                "toppings": ["cheese", "pepperoni", "cheese", "pepperoni"],
+                "role": ["engineer", "engineer", None, None],
+                "votes": [3, 5, 1, 2],
+            }
+        )
         test_viz = viz.DistributionBarViz(datasource, form_data)
         data = test_viz.get_data(df)
         expected = [
             {
-                'key': NULL_STRING,
-                'values': [
-                    {'x': 'pepperoni', 'y': 2},
-                    {'x': 'cheese', 'y': 1},
-                ],
+                "key": NULL_STRING,
+                "values": [{"x": "pepperoni", "y": 2}, {"x": "cheese", "y": 1}],
             },
             {
-                'key': 'engineer',
-                'values': [
-                    {'x': 'pepperoni', 'y': 5},
-                    {'x': 'cheese', 'y': 3},
-                ],
+                "key": "engineer",
+                "values": [{"x": "pepperoni", "y": 5}, {"x": "cheese", "y": 3}],
             },
         ]
         self.assertEqual(expected, data)


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

pandas removes `None` values when doing a groupby or a pivot, so we have to substitute a value for `None`s beforehand to allow null values in the bar chart's series or breakdown. There is already a string `"<NULL>"` being used to indicate nulls in a few places, so I used that and centralized it in a new `constants.py` file.

Fixes #8672 

### BEFORE/AFTER SCREENSHOTS
<!--- Skip this if not applicable -->

Before:

<img width="1065" alt="Screen Shot 2019-12-02 at 5 18 33 PM" src="https://user-images.githubusercontent.com/1858430/70012230-b3583900-1528-11ea-8119-e8f9472bde8e.png">

After:

<img width="1064" alt="Screen Shot 2019-12-02 at 5 18 03 PM" src="https://user-images.githubusercontent.com/1858430/70012232-b521fc80-1528-11ea-8cf0-5edd4858bc6f.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

`<NULL>`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
