### PR TITLE
Support timeFormat extraction function for Druid as filter field

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -62,6 +62,7 @@ try:
         MapLookupExtraction,
         RegexExtraction,
         RegisteredLookupExtraction,
+        TimeFormatExtraction,
     )
     from pydruid.utils.filters import Dimension, Filter
     from pydruid.utils.having import Aggregation, Having
@@ -1436,6 +1437,10 @@ class DruidDatasource(Model, BaseDatasource):
                 extraction_fn = RegexExtraction(fn["expr"])
             elif ext_type == "registeredLookup":
                 extraction_fn = RegisteredLookupExtraction(fn.get("lookup"))
+            elif ext_type == "timeFormat":
+                extraction_fn = TimeFormatExtraction(
+                    fn.get("format"), fn.get("locale"), fn.get("timeZone")
+                )
             else:
                 raise Exception(_("Unsupported extraction function: " + ext_type))
         return (col, extraction_fn)

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -29,6 +29,7 @@ try:
         MapLookupExtraction,
         RegexExtraction,
         RegisteredLookupExtraction,
+        TimeFormatExtraction,
     )
     import pydruid.utils.postaggregator as postaggs
 except ImportError:
@@ -135,6 +136,33 @@ class DruidFuncTestCase(unittest.TestCase):
         dim_ext_fn = dimension_spec["extractionFn"]
         self.assertEqual(dim_ext_fn["type"], f.extraction_function.extraction_type)
         self.assertEqual(dim_ext_fn["lookup"], f.extraction_function._lookup)
+
+    @unittest.skipUnless(
+        SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"
+    )
+    def test_get_filters_extraction_fn_time_format(self):
+        filters = [{"col": "dayOfMonth", "val": ["1", "20"], "op": "in"}]
+        dimension_spec = {
+            "type": "extraction",
+            "dimension": "__time",
+            "outputName": "dayOfMonth",
+            "extractionFn": {
+                "type": "timeFormat",
+                "format": "d",
+                "timeZone": "Asia/Kolkata",
+                "locale": "en",
+            },
+        }
+        spec_json = json.dumps(dimension_spec)
+        col = DruidColumn(column_name="dayOfMonth", dimension_spec_json=spec_json)
+        column_dict = {"dayOfMonth": col}
+        f = DruidDatasource.get_filters(filters, [], column_dict)
+        assert isinstance(f.extraction_function, TimeFormatExtraction)
+        dim_ext_fn = dimension_spec["extractionFn"]
+        self.assertEqual(dim_ext_fn["type"], f.extraction_function.extraction_type)
+        self.assertEqual(dim_ext_fn["format"], f.extraction_function._format)
+        self.assertEqual(dim_ext_fn["timeZone"], f.extraction_function._time_zone)
+        self.assertEqual(dim_ext_fn["locale"], f.extraction_function._locale)
 
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The `timeFormat` extraction function works as `group by` field but does not work as `filter` field.
```
{
  "type": "extraction",
  "dimension": "__time",
  "outputName": "dayOfMonth",
  "extractionFn":{
    "type" : "timeFormat",
    "format" : "d",
    "timeZone" : "Asia/Kolkata",
    "locale" : "en"
  }
}
```
If we use this custom column as `filter` field, Superset gives `Unsupported extraction function: timeFormat` error.

### FIX:
I have used existing `TimeFormatExtraction` from `pydruid` to support this. 

### TEST PLAN
- Create custom druid column as mentioned above.
- Use the column as filter in any chart. We have checked this for `Line Chart` and `Big number with Trendline Chart`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
