### PR TITLE
fix: don't show filter popover on explore view load

### DIFF
--- a/superset/assets/cypress/integration/explore/control.test.js
+++ b/superset/assets/cypress/integration/explore/control.test.js
@@ -168,7 +168,7 @@ describe('AdhocFilters', () => {
         .trigger('mousedown')
         .click();
     });
-
+    cy.get('.adhoc-filter-option').click({ force: true });
     cy.get('#filter-edit-popover').within(() => {
       cy.get('[data-test=adhoc-filter-simple-value]').within(() => {
         cy.get('div.select-input').click({ force: true });
@@ -201,6 +201,7 @@ describe('AdhocFilters', () => {
         .click();
     });
 
+    cy.get('.adhoc-filter-option').click({ force: true });
     cy.get('#filter-edit-popover').within(() => {
       cy.get('#adhoc-filter-edit-tabs-tab-SQL').click();
       cy.get('.ace_content').click();

--- a/superset/assets/src/explore/components/AdhocFilterOption.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterOption.jsx
@@ -45,7 +45,7 @@ export default class AdhocFilterOption extends React.PureComponent {
     this.onPopoverResize = this.onPopoverResize.bind(this);
     this.onOverlayEntered = this.onOverlayEntered.bind(this);
     this.onOverlayExited = this.onOverlayExited.bind(this);
-    this.state = { overlayShown: !this.props.adhocFilter.fromFormData };
+    this.state = { overlayShown: false };
   }
 
   onPopoverResize() {
@@ -90,7 +90,6 @@ export default class AdhocFilterOption extends React.PureComponent {
         overlay={overlay}
         rootClose
         shouldUpdatePosition
-        defaultOverlayShown={!adhocFilter.fromFormData}
         onEntered={this.onOverlayEntered}
         onExited={this.onOverlayExited}
       >

--- a/superset/assets/src/explore/components/AdhocFilterOption.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterOption.jsx
@@ -24,7 +24,6 @@ import AdhocFilterEditPopover from './AdhocFilterEditPopover';
 import AdhocFilter from '../AdhocFilter';
 import columnType from '../propTypes/columnType';
 import adhocMetricType from '../propTypes/adhocMetricType';
-import InfoTooltipWithTrigger from '../../components/InfoTooltipWithTrigger';
 
 const propTypes = {
   adhocFilter: PropTypes.instanceOf(AdhocFilter).isRequired,
@@ -97,15 +96,6 @@ export default class AdhocFilterOption extends React.PureComponent {
         <Label className="adhoc-filter-option">
           <div onMouseDownCapture={this.onMouseDown}>
             <span className="m-r-5 option-label">
-              {adhocFilter.fromFormData &&
-                <>
-                <i className="fa fa-warning" />
-                <InfoTooltipWithTrigger
-                  className="m-r-5 text-warning"
-                  icon="warning"
-                  tooltip="Filter was inherited from dashboard"
-                  label={`filter`}
-                /></>}
               {adhocFilter.getDefaultLabel()}
               <i
                 className={`glyphicon glyphicon-triangle-${

--- a/superset/assets/src/explore/components/AdhocFilterOption.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterOption.jsx
@@ -24,6 +24,7 @@ import AdhocFilterEditPopover from './AdhocFilterEditPopover';
 import AdhocFilter from '../AdhocFilter';
 import columnType from '../propTypes/columnType';
 import adhocMetricType from '../propTypes/adhocMetricType';
+import InfoTooltipWithTrigger from '../../components/InfoTooltipWithTrigger';
 
 const propTypes = {
   adhocFilter: PropTypes.instanceOf(AdhocFilter).isRequired,
@@ -96,6 +97,15 @@ export default class AdhocFilterOption extends React.PureComponent {
         <Label className="adhoc-filter-option">
           <div onMouseDownCapture={this.onMouseDown}>
             <span className="m-r-5 option-label">
+              {adhocFilter.fromFormData &&
+                <>
+                <i className="fa fa-warning" />
+                <InfoTooltipWithTrigger
+                  className="m-r-5 text-warning"
+                  icon="warning"
+                  tooltip="Filter was inherited from dashboard"
+                  label={`filter`}
+                /></>}
               {adhocFilter.getDefaultLabel()}
               <i
                 className={`glyphicon glyphicon-triangle-${

--- a/superset/assets/src/explore/components/AdhocMetricOption.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricOption.jsx
@@ -39,7 +39,7 @@ export default class AdhocMetricOption extends React.PureComponent {
     this.onOverlayEntered = this.onOverlayEntered.bind(this);
     this.onOverlayExited = this.onOverlayExited.bind(this);
     this.onPopoverResize = this.onPopoverResize.bind(this);
-    this.state = { overlayShown: !this.props.adhocMetric.fromFormData };
+    this.state = { overlayShown: false };
   }
 
   onPopoverResize() {
@@ -47,7 +47,7 @@ export default class AdhocMetricOption extends React.PureComponent {
   }
 
   onOverlayEntered() {
-    this.setState({ overlayShown: true });
+    this.setState({ overlayShown: false });
   }
 
   onOverlayExited() {


### PR DESCRIPTION
There's this confusing "feature" that I thought was a bug that shows the
metric popover opened when entering the explore view when the filter
comes from an active dashboard filter, based on the "fromFormData"
attribute of the filter.

The popover is confusing and often shows as misaligned with the actual
element it's supposed to float over when overflowing.

<img width="552" alt="Screen Shot 2019-12-03 at 12 18 49 AM" src="https://user-images.githubusercontent.com/487433/70032553-8294f580-1562-11ea-896e-970ebaf88b49.png">


### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation
