### PR TITLE
Fix error control label Metrics validator

### DIFF
--- a/superset/assets/src/explore/App.jsx
+++ b/superset/assets/src/explore/App.jsx
@@ -44,6 +44,9 @@ const bootstrapData = JSON.parse(
 );
 initFeatureFlags(bootstrapData.common.feature_flags);
 const initState = getInitialState(bootstrapData);
+if (!initState.explore.form_data.viz_type) {
+  initState.explore.form_data.viz_type = 'table';
+}
 
 const store = createStore(
   rootReducer,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The error Control labeled "Metrics" cannot be empty should not appear on the first time goes to chart screen by pressing table name.
Fixes #7916 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #7916 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
