### PR TITLE
[Explore] Fix annotation layer select box formatting

### DIFF
--- a/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset/assets/src/explore/components/controls/AnnotationLayer.jsx
@@ -41,6 +41,7 @@ import ANNOTATION_TYPES, {
 import PopoverSection from '../../../components/PopoverSection';
 import ControlHeader from '../ControlHeader';
 import { nonEmpty } from '../../validators';
+import './AnnotationLayer.less';
 
 const AUTOMATIC_COLOR = '';
 
@@ -331,6 +332,14 @@ export default class AnnotationLayer extends React.PureComponent {
     this.props.close();
   }
 
+  renderOption(option) {
+    return (
+      <span className="optionWrapper" title={option.label}>
+        {option.label}
+      </span>
+    );
+  }
+
   renderValueConfiguration() {
     const {
       annotationType,
@@ -373,6 +382,7 @@ export default class AnnotationLayer extends React.PureComponent {
           value={value}
           onChange={this.handleValue}
           validationErrors={!value ? ['Mandatory'] : []}
+          optionRenderer={this.renderOption}
         />
       );
     }

--- a/superset/assets/src/explore/components/controls/AnnotationLayer.less
+++ b/superset/assets/src/explore/components/controls/AnnotationLayer.less
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.optionWrapper {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When rendering the annotation selector box, sometimes it was super jank looking because options were very verbose. This truncates the options and provides the full option on hover 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="250" alt="Screen Shot 2019-12-03 at 11 37 07 AM" src="https://user-images.githubusercontent.com/7409244/70083496-552b6480-15c1-11ea-8ede-ad580460a8e9.png">

After:
<img width="255" alt="Screen Shot 2019-12-03 at 12 10 22 PM" src="https://user-images.githubusercontent.com/7409244/70085899-046a3a80-15c6-11ea-8b55-509f2e799477.png">

### TEST PLAN
Make a chart with a really long name, view it in the annotation layer selector, see it truncated appropriately 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @betodealmeida @rusackas 