### PR TITLE
Change column to longtext

### DIFF
--- a/superset/assets/src/SqlLab/actions/sqlLab.js
+++ b/superset/assets/src/SqlLab/actions/sqlLab.js
@@ -603,32 +603,34 @@ export function loadQueryEditor(queryEditor) {
 }
 
 export function setTables(tableSchemas) {
-  const tables = tableSchemas.map(tableSchema => {
-    const {
-      columns,
-      selectStar,
-      primaryKey,
-      foreignKeys,
-      indexes,
-      dataPreviewQueryId,
-    } = tableSchema.description;
-    return {
-      dbId: tableSchema.database_id,
-      queryEditorId: tableSchema.tab_state_id.toString(),
-      schema: tableSchema.schema,
-      name: tableSchema.table,
-      expanded: tableSchema.expanded,
-      id: tableSchema.id,
-      dataPreviewQueryId,
-      columns,
-      selectStar,
-      primaryKey,
-      foreignKeys,
-      indexes,
-      isMetadataLoading: false,
-      isExtraMetadataLoading: false,
-    };
-  });
+  const tables = tableSchemas
+    .filter(tableSchema => tableSchema.description !== null)
+    .map(tableSchema => {
+      const {
+        columns,
+        selectStar,
+        primaryKey,
+        foreignKeys,
+        indexes,
+        dataPreviewQueryId,
+      } = tableSchema.description;
+      return {
+        dbId: tableSchema.database_id,
+        queryEditorId: tableSchema.tab_state_id.toString(),
+        schema: tableSchema.schema,
+        name: tableSchema.table,
+        expanded: tableSchema.expanded,
+        id: tableSchema.id,
+        dataPreviewQueryId,
+        columns,
+        selectStar,
+        primaryKey,
+        foreignKeys,
+        indexes,
+        isMetadataLoading: false,
+        isExtraMetadataLoading: false,
+      };
+    });
   return { type: SET_TABLES, tables };
 }
 

--- a/superset/assets/src/SqlLab/reducers/getInitialState.js
+++ b/superset/assets/src/SqlLab/reducers/getInitialState.js
@@ -95,33 +95,35 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
 
   const tables = [];
   if (activeTab) {
-    activeTab.table_schemas.forEach(tableSchema => {
-      const {
-        columns,
-        selectStar,
-        primaryKey,
-        foreignKeys,
-        indexes,
-        dataPreviewQueryId,
-      } = tableSchema.description;
-      const table = {
-        dbId: tableSchema.database_id,
-        queryEditorId: tableSchema.tab_state_id.toString(),
-        schema: tableSchema.schema,
-        name: tableSchema.table,
-        expanded: tableSchema.expanded,
-        id: tableSchema.id,
-        isMetadataLoading: false,
-        isExtraMetadataLoading: false,
-        dataPreviewQueryId,
-        columns,
-        selectStar,
-        primaryKey,
-        foreignKeys,
-        indexes,
-      };
-      tables.push(table);
-    });
+    activeTab.table_schemas
+      .filter(tableSchema => tableSchema.description !== null)
+      .forEach(tableSchema => {
+        const {
+          columns,
+          selectStar,
+          primaryKey,
+          foreignKeys,
+          indexes,
+          dataPreviewQueryId,
+        } = tableSchema.description;
+        const table = {
+          dbId: tableSchema.database_id,
+          queryEditorId: tableSchema.tab_state_id.toString(),
+          schema: tableSchema.schema,
+          name: tableSchema.table,
+          expanded: tableSchema.expanded,
+          id: tableSchema.id,
+          isMetadataLoading: false,
+          isExtraMetadataLoading: false,
+          dataPreviewQueryId,
+          columns,
+          selectStar,
+          primaryKey,
+          foreignKeys,
+          indexes,
+        };
+        tables.push(table);
+      });
   }
 
   const { databases, queries } = restBootstrapData;

--- a/superset/migrations/versions/89115a40e8ea_change_table_schema_description_to_long_.py
+++ b/superset/migrations/versions/89115a40e8ea_change_table_schema_description_to_long_.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Change table schema description to long text
+
+Revision ID: 89115a40e8ea
+Revises: db4b49eb0782
+Create Date: 2019-12-03 13:50:24.746867
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "89115a40e8ea"
+down_revision = "db4b49eb0782"
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.databases import mysql
+from sqlalchemy.dialects.mysql.base import MySQLDialect
+
+
+def upgrade():
+    bind = op.get_bind()
+    if isinstance(bind.dialect, MySQLDialect):
+        with op.batch_alter_table("table_schema") as batch_op:
+            batch_op.alter_column(
+                "description", existing_type=sa.Text, type_=mysql.LONGTEXT
+            )
+
+
+def downgrade():
+    bind = op.get_bind()
+    if isinstance(bind.dialect, MySQLDialect):
+        with op.batch_alter_table("table_schema") as batch_op:
+            batch_op.alter_column(
+                "description", existing_type=mysql.LONGTEXT, type_=sa.Text
+            )

--- a/superset/migrations/versions/89115a40e8ea_change_table_schema_description_to_long_.py
+++ b/superset/migrations/versions/89115a40e8ea_change_table_schema_description_to_long_.py
@@ -17,14 +17,14 @@
 """Change table schema description to long text
 
 Revision ID: 89115a40e8ea
-Revises: db4b49eb0782
+Revises: 5afa9079866a
 Create Date: 2019-12-03 13:50:24.746867
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "89115a40e8ea"
-down_revision = "db4b49eb0782"
+down_revision = "5afa9079866a"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -259,13 +259,18 @@ class TableSchema(Model, AuditMixinNullable, ExtraJSONMixin):
     expanded = Column(Boolean, default=False)
 
     def to_dict(self):
+        try:
+            description = json.loads(self.description)
+        except json.JSONDecodeError:
+            description = None
+
         return {
             "id": self.id,
             "tab_state_id": self.tab_state_id,
             "database_id": self.database_id,
             "schema": self.schema,
             "table": self.table,
-            "description": json.loads(self.description),
+            "description": description,
             "expanded": self.expanded,
         }
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The column `description` in the table `table_schema` currently has type text, being limited to 65535 characters in MySQL. Since the column is used to store JSON, and the values can be quite large, any JSON with more than 65535 that is stored will be truncated, becoming invalid.

I added a migration script to change the type to long text in MySQL. I also wrapped the decoding of the column in a try/except block to prevent locking users out of SQL Lab in case the JSON is malformed (though it shouldn't happen again after this fix). I also added code to the frontend to handle the description being null; in that case the table is not show in SQL Lab, since we don't have the required information.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested migration, and tested that if the JSON is invalid SQL Lab works, although not showing the metadata for the table (as expected).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [X] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong 