### PR TITLE
[fix] Updating bound filters for PyDruid 0.5.7

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ pip-tools==3.7.0
 pre-commit==1.17.0
 psycopg2-binary==2.7.5
 pycodestyle==2.5.0
-pydruid==0.5.6
+pydruid==0.5.7
 pyhive==0.6.1
 pylint==1.9.2
 redis==3.2.1

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -63,7 +63,7 @@ try:
         RegexExtraction,
         RegisteredLookupExtraction,
     )
-    from pydruid.utils.filters import Dimension, Filter
+    from pydruid.utils.filters import Bound, Dimension, Filter
     from pydruid.utils.having import Aggregation, Having
     from pydruid.utils.postaggregator import (
         Const,
@@ -1515,48 +1515,44 @@ class DruidDatasource(Model, BaseDatasource):
             # For the ops below, could have used pydruid's Bound,
             # but it doesn't support extraction functions
             elif op == ">=":
-                cond = Filter(
-                    type="bound",
+                cond = Bound(
                     extraction_function=extraction_fn,
                     dimension=col,
                     lowerStrict=False,
                     upperStrict=False,
                     lower=eq,
                     upper=None,
-                    alphaNumeric=is_numeric_col,
+                    ordering=cls._get_ordering(is_numeric_col),
                 )
             elif op == "<=":
-                cond = Filter(
-                    type="bound",
+                cond = Bound(
                     extraction_function=extraction_fn,
                     dimension=col,
                     lowerStrict=False,
                     upperStrict=False,
                     lower=None,
                     upper=eq,
-                    alphaNumeric=is_numeric_col,
+                    ordering=cls._get_ordering(is_numeric_col),
                 )
             elif op == ">":
-                cond = Filter(
-                    type="bound",
+                cond = Bound(
                     extraction_function=extraction_fn,
                     lowerStrict=True,
                     upperStrict=False,
                     dimension=col,
                     lower=eq,
                     upper=None,
-                    alphaNumeric=is_numeric_col,
+                    ordering=cls._get_ordering(is_numeric_col),
                 )
             elif op == "<":
-                cond = Filter(
-                    type="bound",
+                cond = Bound(
                     extraction_function=extraction_fn,
                     upperStrict=True,
                     lowerStrict=False,
                     dimension=col,
                     lower=None,
                     upper=eq,
-                    alphaNumeric=is_numeric_col,
+                    ordering=cls._get_ordering(is_numeric_col),
                 )
             elif op == "IS NULL":
                 cond = Filter(dimension=col, value="")
@@ -1569,6 +1565,10 @@ class DruidDatasource(Model, BaseDatasource):
                 filters = cond
 
         return filters
+
+    @staticmethod
+    def _get_ordering(is_numeric_col: bool) -> str:
+        return "numeric" if is_numeric_col else "lexicographic"
 
     def _get_having_obj(self, col: str, op: str, eq: str) -> "Having":
         cond = None

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -209,7 +209,7 @@ class DruidFuncTestCase(SupersetTestCase):
         self.assertFalse(res.filter["filter"]["lowerStrict"])
         self.assertEqual("A", res.filter["filter"]["dimension"])
         self.assertEqual("h", res.filter["filter"]["lower"])
-        self.assertFalse(res.filter["filter"]["alphaNumeric"])
+        self.assertEqual("lexicographic", res.filter["filter"]["ordering"])
         filtr["op"] = ">"
         res = DruidDatasource.get_filters([filtr], [], column_dict)
         self.assertTrue(res.filter["filter"]["lowerStrict"])
@@ -220,6 +220,9 @@ class DruidFuncTestCase(SupersetTestCase):
         filtr["op"] = "<"
         res = DruidDatasource.get_filters([filtr], [], column_dict)
         self.assertTrue(res.filter["filter"]["upperStrict"])
+        filtr["val"] = 1
+        res = DruidDatasource.get_filters([filtr], ["A"], column_dict)
+        self.assertEqual("numeric", res.filter["filter"]["ordering"])
 
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("pydruid"), "pydruid not installed"


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

PyDruid 0.5.7 introduced logic [here](https://github.com/druid-io/pydruid/pull/170) which updated the bound filter to use the latest Druid API spec (which was introduced quite some time ago in 0.9.2). This PR updates the Druid filters to use the `Bound` class which handles the ordering logic. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @graceguo-supercat @mistercrunch 