### PR TITLE
Fixing default Dockerfile entrypoint

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,8 +20,13 @@ set -eo pipefail
 if [ "${#}" -ne 0 ]; then
     exec "${@}"
 else
-    gunicorn --bind  "0.0.0.0:${SUPERSET_PORT}" \
+    gunicorn \
+        --bind  "0.0.0.0:${SUPERSET_PORT}" \
+        --access-logfile '-' \
+        --error-logfile '-' \
         --workers 1 \
+        --worker-class gthread \
+        --threads 20 \
         --timeout 60 \
         --limit-request-line 0 \
         --limit-request-field_size 0 \


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Fixing default Dockerfile entrypoint. Gunicorn needed a few tweaks.

* Adds gthread option
* Sets thread count
* Sets up error/access logs to go to stdout

### REVIEWERS
@dpgaspar 