### PR TITLE
Adding error message when there's no partition for a presto table

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -890,6 +890,12 @@ class PrestoEngineSpec(BaseEngineSpec):
         (['ds'], ('2018-01-01',))
         """
         indexes = database.get_indexes(table_name, schema)
+        if not indexes:
+            raise SupersetTemplateException(
+                f"Error getting partition for {schema}.{table_name}. "
+                "Verify that this table has a partition."
+            )
+
         if len(indexes[0]["column_names"]) < 1:
             raise SupersetTemplateException(
                 "The table should have one partitioned field"


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
If someone tries to use `{{ presto.latest_partition('schema.table') }}` but the table doesn't have a partition, it throws a confusing error to the user `Template rendering failed: list index out of range`. This catches the error and throws a clear error message.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Tested query with presto.latest_partition on a table with no partition
Tested query with presto.latest_partition on a table with a partition

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley @serenajiang 