### PR TITLE
feat: emphasis on the database engine error message

### DIFF
--- a/superset/assets/src/components/StackTraceMessage.css
+++ b/superset/assets/src/components/StackTraceMessage.css
@@ -1,0 +1,3 @@
+.stack-trace-container .markdown p {
+  margin: 0;
+}

--- a/superset/assets/src/components/StackTraceMessage.jsx
+++ b/superset/assets/src/components/StackTraceMessage.jsx
@@ -19,7 +19,10 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactMarkdown from 'react-markdown';
 import { Alert, Collapse } from 'react-bootstrap';
+
+import './StackTraceMessage.css';
 
 const propTypes = {
   message: PropTypes.node.isRequired,
@@ -55,7 +58,11 @@ class StackTraceMessage extends React.PureComponent {
             this.setState({ showStackTrace: !this.state.showStackTrace })
           }
         >
-          {this.props.message}
+          <ReactMarkdown
+            className="markdown"
+            source={this.props.message}
+            skipHtml
+          />
           {this.props.link && (
             <a href={this.props.link} target="_blank" rel="noopener noreferrer">
               (Request Access)

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -492,7 +492,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def extract_error_message(cls, e: Exception) -> str:
-        return f"{cls.engine} error: {cls._extract_error_message(e)}"
+        prefix = f"**{cls.engine} error:**".upper()
+        return f"{prefix} {cls._extract_error_message(e)}"
 
     @classmethod
     def _extract_error_message(cls, e: Exception) -> str:


### PR DESCRIPTION
RFC 
when bubbling up error messages surfaced by the datbase, we prefix with
"{engine} error:". In this PR we make the error message capitalized and
bold. To make it bold we introduce the ability to use markdown in error
messages. This also fixes issues where "<html><body>{error_msg}</body><html>"
shows up inside the error message. We've seen Presto and transport layer
generate 50* pages that have html. The react-markdown component here
removes all tags.

<img width="1088" alt="Screen Shot 2019-12-03 at 4 57 17 PM" src="https://user-images.githubusercontent.com/487433/70102772-02b46d00-15ee-11ea-8866-922bdc4c7a48.png">
