### PR TITLE
[fix] Fixing time controls when switching datasource types

### DIFF
--- a/superset/assets/src/explore/reducers/exploreReducer.js
+++ b/superset/assets/src/explore/reducers/exploreReducer.js
@@ -57,9 +57,8 @@ export default function exploreReducer(state = {}, action) {
         datasource_type: action.datasource.type,
       };
       return {
-        ...state,
+        ...newState,
         form_data: newFormData,
-        datasource: action.datasource,
         controls: getControlsState(newState, newFormData),
       };
     },

--- a/superset/assets/src/explore/reducers/exploreReducer.js
+++ b/superset/assets/src/explore/reducers/exploreReducer.js
@@ -36,9 +36,31 @@ export default function exploreReducer(state = {}, action) {
       };
     },
     [actions.SET_DATASOURCE]() {
-      return {
+      const newFormData = {...state.form_data};
+      if (action.datasource.type != state.datasource.type) {
+        if (action.datasource.type == "table") {
+          newFormData.granularity_sqla = action.datasource.granularity_sqla;
+          newFormData.time_grain_sqla = action.datasource.time_grain_sqla;
+          delete newFormData.druid_time_origin;
+          delete newFormData.granularity;
+        } else {
+          newFormData.druid_time_origin = action.datasource.druid_time_origin;
+          newFormData.granularity = action.datasource.granularity;
+          delete newFormData.granularity_sqla;
+          delete newFormData.time_grain_sqla;
+        }
+      }
+      const newState = {
         ...state,
         datasource: action.datasource,
+        datasource_id: action.datasource.id,
+        datasource_type: action.datasource.type,
+      };
+      return {
+        ...state,
+        form_data: newFormData,
+        datasource: action.datasource,
+        controls: getControlsState(newState, newFormData),
       };
     },
     [actions.FETCH_DATASOURCES_STARTED]() {

--- a/superset/assets/src/explore/reducers/exploreReducer.js
+++ b/superset/assets/src/explore/reducers/exploreReducer.js
@@ -37,8 +37,8 @@ export default function exploreReducer(state = {}, action) {
     },
     [actions.SET_DATASOURCE]() {
       const newFormData = {...state.form_data};
-      if (action.datasource.type != state.datasource.type) {
-        if (action.datasource.type == "table") {
+      if (action.datasource.type !== state.datasource.type) {
+        if (action.datasource.type === "table") {
           newFormData.granularity_sqla = action.datasource.granularity_sqla;
           newFormData.time_grain_sqla = action.datasource.time_grain_sqla;
           delete newFormData.druid_time_origin;

--- a/superset/assets/src/explore/reducers/exploreReducer.js
+++ b/superset/assets/src/explore/reducers/exploreReducer.js
@@ -36,9 +36,9 @@ export default function exploreReducer(state = {}, action) {
       };
     },
     [actions.SET_DATASOURCE]() {
-      const newFormData = {...state.form_data};
+      const newFormData = { ...state.form_data };
       if (action.datasource.type !== state.datasource.type) {
-        if (action.datasource.type === "table") {
+        if (action.datasource.type === 'table') {
           newFormData.granularity_sqla = action.datasource.granularity_sqla;
           newFormData.time_grain_sqla = action.datasource.time_grain_sqla;
           delete newFormData.druid_time_origin;


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR updates the temporal controls when switching datasource types in explorer which were missing as the Druid connector and SQLAlchemy connector have different fields. When we set the datasource upon change we also need to update the controls (indirectly via the form-data) leveraging the state changes.

Thanks @graceguo-supercat for all the help, I would have been completely lost without you. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img width="388" alt="Screen Shot 2019-12-03 at 6 49 18 PM" src="https://user-images.githubusercontent.com/4567245/70108773-ee2ca080-15fe-11ea-93a5-da7019771933.png">

#### After 

<img width="386" alt="Screen Shot 2019-12-03 at 6 58 01 PM" src="https://user-images.githubusercontent.com/4567245/70108757-e3720b80-15fe-11ea-82dd-37fe837e5d70.png">

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @betodealmeida @etr2460 @graceguo-supercat @michellethomas 