### PR TITLE
Removing upgrade of pip from Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ COPY ./requirements.txt ./docker/requirements-extra.txt ./setup.py ./MANIFEST.in
 COPY superset /app/superset
 
 RUN cd /app \
-        && pip install --upgrade setuptools pip \
         && pip install -r requirements.txt -r requirements-extra.txt \
         && pip install -e .
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
We're seeing some issues with the pip upgrade, which isn't really necessary when it comes to building a Dockerfile. Removing it for now...

### REVIEWERS
@dpgaspar 