### PR TITLE
Do not delete schema permission on the table deletion

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -303,18 +303,6 @@ class DeleteMixin(object):
                 .all()
             )
 
-            schema_view_menu = None
-            if hasattr(item, "schema_perm"):
-                schema_view_menu = security_manager.find_view_menu(item.schema_perm)
-
-                pvs.extend(
-                    security_manager.get_session.query(
-                        security_manager.permissionview_model
-                    )
-                    .filter_by(view_menu=schema_view_menu)
-                    .all()
-                )
-
             if self.datamodel.delete(item):
                 self.post_delete(item)
 
@@ -323,9 +311,6 @@ class DeleteMixin(object):
 
                 if view_menu:
                     security_manager.get_session.delete(view_menu)
-
-                if schema_view_menu:
-                    security_manager.get_session.delete(schema_view_menu)
 
                 security_manager.get_session.commit()
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix

### SUMMARY
Previously in the code on the table deletion would also delete a relevant schema permission. However there might me other tables existing that share the same schema permission. It causes users loosing access to the tables for the whole schema.

This PR just removes the code that was deleting schema permission on every table delete.
### REVIEWERS
@dpgaspar 
@willbarrett 