### PR TITLE
Limit payload returned when using SQLLAB_BACKEND_PERSISTENCE

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -169,64 +169,66 @@ class BaseSupersetView(BaseView):
             mimetype="application/json",
         )
 
-    def menu_data(self):
-        menu = appbuilder.menu.get_data()
-        root_path = "#"
-        logo_target_path = ""
-        if not g.user.is_anonymous:
-            try:
-                logo_target_path = (
-                    appbuilder.app.config.get("LOGO_TARGET_PATH")
-                    or f"/profile/{g.user.username}/"
-                )
-            # when user object has no username
-            except NameError as e:
-                logging.exception(e)
 
-            if logo_target_path.startswith("/"):
-                root_path = f"/superset{logo_target_path}"
-            else:
-                root_path = logo_target_path
+def menu_data():
+    menu = appbuilder.menu.get_data()
+    root_path = "#"
+    logo_target_path = ""
+    if not g.user.is_anonymous:
+        try:
+            logo_target_path = (
+                appbuilder.app.config.get("LOGO_TARGET_PATH")
+                or f"/profile/{g.user.username}/"
+            )
+        # when user object has no username
+        except NameError as e:
+            logging.exception(e)
 
-        languages = {}
-        for lang in appbuilder.languages:
-            languages[lang] = {
-                **appbuilder.languages[lang],
-                "url": appbuilder.get_url_for_locale(lang),
-            }
-        return {
-            "menu": menu,
-            "brand": {
-                "path": root_path,
-                "icon": appbuilder.app_icon,
-                "alt": appbuilder.app_name,
-            },
-            "navbar_right": {
-                "bug_report_url": appbuilder.app.config.get("BUG_REPORT_URL"),
-                "documentation_url": appbuilder.app.config.get("DOCUMENTATION_URL"),
-                "languages": languages,
-                "show_language_picker": len(languages.keys()) > 1,
-                "user_is_anonymous": g.user.is_anonymous,
-                "user_info_url": appbuilder.get_url_for_userinfo,
-                "user_logout_url": appbuilder.get_url_for_logout,
-                "user_login_url": appbuilder.get_url_for_login,
-                "locale": session.get("locale", "en"),
-            },
+        if logo_target_path.startswith("/"):
+            root_path = f"/superset{logo_target_path}"
+        else:
+            root_path = logo_target_path
+
+    languages = {}
+    for lang in appbuilder.languages:
+        languages[lang] = {
+            **appbuilder.languages[lang],
+            "url": appbuilder.get_url_for_locale(lang),
         }
+    return {
+        "menu": menu,
+        "brand": {
+            "path": root_path,
+            "icon": appbuilder.app_icon,
+            "alt": appbuilder.app_name,
+        },
+        "navbar_right": {
+            "bug_report_url": appbuilder.app.config.get("BUG_REPORT_URL"),
+            "documentation_url": appbuilder.app.config.get("DOCUMENTATION_URL"),
+            "languages": languages,
+            "show_language_picker": len(languages.keys()) > 1,
+            "user_is_anonymous": g.user.is_anonymous,
+            "user_info_url": appbuilder.get_url_for_userinfo,
+            "user_logout_url": appbuilder.get_url_for_logout,
+            "user_login_url": appbuilder.get_url_for_login,
+            "locale": session.get("locale", "en"),
+        },
+    }
 
-    def common_bootstrap_payload(self):
-        """Common data always sent to the client"""
-        messages = get_flashed_messages(with_categories=True)
-        locale = str(get_locale())
 
-        return {
-            "flash_messages": messages,
-            "conf": {k: conf.get(k) for k in FRONTEND_CONF_KEYS},
-            "locale": locale,
-            "language_pack": get_language_pack(locale),
-            "feature_flags": get_feature_flags(),
-            "menu_data": self.menu_data(),
-        }
+def common_bootstrap_payload():
+    """Common data always sent to the client"""
+    messages = get_flashed_messages(with_categories=True)
+    locale = str(get_locale())
+
+    return {
+        "flash_messages": messages,
+        "conf": {k: conf.get(k) for k in FRONTEND_CONF_KEYS},
+        "locale": locale,
+        "language_pack": get_language_pack(locale),
+        "feature_flags": get_feature_flags(),
+        "menu_data": menu_data(),
+    }
 
 
 class SupersetListWidget(ListWidget):

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -3065,18 +3065,18 @@ class Superset(BaseSupersetView):
         )
 
     @staticmethod
-    def _get_sqllab_payload() -> Dict[str, Any]:
+    def _get_sqllab_payload(user_id: int) -> Dict[str, Any]:
         # send list of tab state ids
         tabs_state = (
             db.session.query(TabState.id, TabState.label)
-            .filter_by(user_id=g.user.get_id())
+            .filter_by(user_id=user_id)
             .all()
         )
         tab_state_ids = [tab_state[0] for tab_state in tabs_state]
         # return first active tab, or fallback to another one if no tab is active
         active_tab = (
             db.session.query(TabState)
-            .filter_by(user_id=g.user.get_id())
+            .filter_by(user_id=user_id)
             .order_by(TabState.active.desc())
             .first()
         )
@@ -3093,10 +3093,9 @@ class Superset(BaseSupersetView):
                 for database in db.session.query(models.Database).all()
             }
             # return all user queries associated with existing SQL editors
-            print(tab_state_ids)
             user_queries = (
                 db.session.query(Query)
-                .filter_by(user_id=g.user.get_id())
+                .filter_by(user_id=user_id)
                 .filter(Query.sql_editor_id.in_(tab_state_ids))
                 .all()
             )
@@ -3118,8 +3117,7 @@ class Superset(BaseSupersetView):
     @expose("/sqllab")
     def sqllab(self):
         """SQL Editor"""
-
-        payload = self._get_sqllab_payload()
+        payload = self._get_sqllab_payload(g.user.get_id())
         bootstrap_data = json.dumps(
             payload, default=utils.pessimistic_json_iso_dttm_ser
         )

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -3094,7 +3094,10 @@ class Superset(BaseSupersetView):
                 for database in db.session.query(models.Database).all()
             }
             user_queries = (
-                db.session.query(Query).filter_by(user_id=g.user.get_id()).all()
+                db.session.query(Query)
+                .filter_by(user_id=g.user.get_id())
+                .filter(Query.client_id.in_(tab_state_ids))
+                .all()
             )
             queries = {
                 query.client_id: {k: v for k, v in query.to_dict().items()}

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -90,6 +90,7 @@ from .base import (
     api,
     BaseSupersetView,
     check_ownership,
+    common_bootstrap_payload,
     CsvResponse,
     data_payload_response,
     DeleteMixin,
@@ -1285,7 +1286,7 @@ class Superset(BaseSupersetView):
             "standalone": standalone,
             "user_id": user_id,
             "forced_height": request.args.get("height"),
-            "common": self.common_bootstrap_payload(),
+            "common": common_bootstrap_payload(),
         }
         table_name = (
             datasource.table_name
@@ -2222,7 +2223,7 @@ class Superset(BaseSupersetView):
             "user_id": g.user.get_id(),
             "dashboard_data": dashboard_data,
             "datasources": {ds.uid: ds.data for ds in datasources},
-            "common": self.common_bootstrap_payload(),
+            "common": common_bootstrap_payload(),
             "editMode": edit_mode,
             "urlParams": url_params,
         }
@@ -3025,7 +3026,7 @@ class Superset(BaseSupersetView):
 
         payload = {
             "user": bootstrap_user_data(g.user),
-            "common": self.common_bootstrap_payload(),
+            "common": common_bootstrap_payload(),
         }
 
         return self.render_template(
@@ -3051,7 +3052,7 @@ class Superset(BaseSupersetView):
 
         payload = {
             "user": bootstrap_user_data(user, include_perms=True),
-            "common": self.common_bootstrap_payload(),
+            "common": common_bootstrap_payload(),
         }
 
         return self.render_template(
@@ -3092,6 +3093,7 @@ class Superset(BaseSupersetView):
                 for database in db.session.query(models.Database).all()
             }
             # return all user queries associated with existing SQL editors
+            print(tab_state_ids)
             user_queries = (
                 db.session.query(Query)
                 .filter_by(user_id=g.user.get_id())
@@ -3105,7 +3107,7 @@ class Superset(BaseSupersetView):
 
         return {
             "defaultDbId": config["SQLLAB_DEFAULT_DBID"],
-            "common": self.common_bootstrap_payload(),
+            "common": common_bootstrap_payload(),
             "tab_state_ids": tabs_state,
             "active_tab": active_tab.to_dict() if active_tab else None,
             "databases": databases,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -45,7 +45,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_appbuilder.security.sqla import models as ab_models
 from flask_babel import gettext as __, lazy_gettext as _
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, Integer, or_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import Session
 from werkzeug.routing import BaseConverter
@@ -3096,7 +3096,7 @@ class Superset(BaseSupersetView):
             user_queries = (
                 db.session.query(Query)
                 .filter_by(user_id=user_id)
-                .filter(Query.sql_editor_id.in_(tab_state_ids))
+                .filter(Query.sql_editor_id.cast(Integer).in_(tab_state_ids))
                 .all()
             )
             queries = {

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -193,6 +193,7 @@ class SupersetTestCase(TestCase):
         raise_on_error=False,
         query_limit=None,
         database_name="examples",
+        sql_editor_id=None,
     ):
         if user_name:
             self.logout()
@@ -207,6 +208,7 @@ class SupersetTestCase(TestCase):
                 select_as_create_as=False,
                 client_id=client_id,
                 queryLimit=query_limit,
+                sql_editor_id=sql_editor_id,
             ),
         )
         if raise_on_error and "error" in resp:

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -983,10 +983,12 @@ class CoreTests(SupersetTestCase):
             data = self.get_resp(url)
             self.assertTrue(html in data)
 
+    @mock.patch.dict(
+        "superset.extensions.feature_flag_manager._feature_flags",
+        {"SQLLAB_BACKEND_PERSISTENCE": True},
+        clear=True,
+    )
     def test_sqllab_backend_persistence_payload(self):
-        sqllab_backend_persistence = app.config.get("SQLLAB_BACKEND_PERSISTENCE")
-        app.config["SQLLAB_BACKEND_PERSISTENCE"] = True
-
         username = "admin"
         self.login(username)
         user_id = security_manager.find_user(username).id
@@ -1027,8 +1029,6 @@ class CoreTests(SupersetTestCase):
         # associated with any tabs
         payload = views.Superset._get_sqllab_payload(user_id=user_id)
         self.assertEqual(len(payload["queries"]), 1)
-
-        app.config["SQLLAB_BACKEND_PERSISTENCE"] = sqllab_backend_persistence
 
 
 if __name__ == "__main__":

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -988,7 +988,7 @@ class CoreTests(SupersetTestCase):
 
         app.config["SQLLAB_BACKEND_PERSISTENCE"] = True
         payload = views.Superset._get_sqllab_payload()
-        self.assertEqual(payload, {})
+        self.assertEqual(payload["queries"], {1, 2})
 
 
 if __name__ == "__main__":

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -983,6 +983,13 @@ class CoreTests(SupersetTestCase):
             data = self.get_resp(url)
             self.assertTrue(html in data)
 
+    def test_sqllab_backend_persistence_payload(self):
+        self.login()
+
+        app.config["SQLLAB_BACKEND_PERSISTENCE"] = True
+        payload = views.Superset._get_sqllab_payload()
+        self.assertEqual(payload, {})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -984,6 +984,9 @@ class CoreTests(SupersetTestCase):
             self.assertTrue(html in data)
 
     def test_sqllab_backend_persistence_payload(self):
+        sqllab_backend_persistence = app.config.get("SQLLAB_BACKEND_PERSISTENCE")
+        app.config["SQLLAB_BACKEND_PERSISTENCE"] = True
+
         self.login("admin")
 
         # create a tab
@@ -1018,12 +1021,12 @@ class CoreTests(SupersetTestCase):
             raise_on_error=True,
         )
 
-        app.config["SQLLAB_BACKEND_PERSISTENCE"] = True
-        payload = views.Superset._get_sqllab_payload(user_id=1)
-
         # we should have only 1 query returned, since the second one is not
         # associated with any tabs
+        payload = views.Superset._get_sqllab_payload(user_id=1)
         self.assertEqual(len(payload["queries"]), 1)
+
+        app.config["SQLLAB_BACKEND_PERSISTENCE"] = sqllab_backend_persistence
 
 
 if __name__ == "__main__":

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -987,7 +987,9 @@ class CoreTests(SupersetTestCase):
         sqllab_backend_persistence = app.config.get("SQLLAB_BACKEND_PERSISTENCE")
         app.config["SQLLAB_BACKEND_PERSISTENCE"] = True
 
-        self.login("admin")
+        username = "admin"
+        self.login(username)
+        user_id = security_manager.find_user(username).id
 
         # create a tab
         data = {
@@ -1009,7 +1011,7 @@ class CoreTests(SupersetTestCase):
         self.run_sql(
             "SELECT name FROM birth_names",
             "client_id_1",
-            user_name="admin",
+            user_name=username,
             raise_on_error=True,
             sql_editor_id=tab_state_id,
         )
@@ -1017,13 +1019,13 @@ class CoreTests(SupersetTestCase):
         self.run_sql(
             "SELECT name FROM birth_names",
             "client_id_2",
-            user_name="admin",
+            user_name=username,
             raise_on_error=True,
         )
 
         # we should have only 1 query returned, since the second one is not
         # associated with any tabs
-        payload = views.Superset._get_sqllab_payload(user_id=1)
+        payload = views.Superset._get_sqllab_payload(user_id=user_id)
         self.assertEqual(len(payload["queries"]), 1)
 
         app.config["SQLLAB_BACKEND_PERSISTENCE"] = sqllab_backend_persistence


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, if `SQLLAB_BACKEND_PERSISTENCE` is enabled we will send the browser a payload with the whole query history of the user. This PR changes the behavior so that only the queries associated with existing query editors are sent.

<!-- ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF -->
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added a unit test. I refactored the `/sqllab/` view to simplify testing.

Also tested on my browser, verified that old queries not associated with a tab are not sent over the wire.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@etr2460 