### PR TITLE
fix create-admin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,7 +353,7 @@ pip install -r requirements-dev.txt
 pip install -e .
 
 # Create an admin user in your metadata database
-flask fab create-admin
+superset fab create-admin
 
 # Initialize the database
 superset db upgrade

--- a/RELEASING/from_tarball_entrypoint.sh
+++ b/RELEASING/from_tarball_entrypoint.sh
@@ -21,7 +21,7 @@ echo "[WARNING] this entrypoint creates an admin/admin user"
 echo "[WARNING] it should only be used for lightweight testing/validation"
 
 # Create an admin user (you will be prompted to set username, first and last name before setting a password)
-flask fab create-admin \
+superset fab create-admin \
     --username admin \
     --firstname admin \
     --lastname admin \

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -19,7 +19,7 @@ set -ex
 
 # Create an admin user
 echo "Setting up admin user..."
-flask fab create-admin \
+superset fab create-admin \
               --username admin \
               --firstname Superset \
               --lastname Admin \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -178,7 +178,7 @@ Follow these few simple steps to install Superset.::
 
     # Create an admin user (you will be prompted to set a username, first and last name before setting a password)
     $ export FLASK_APP=superset
-    flask fab create-admin
+    superset fab create-admin
 
     # Load some data to play with
     superset load_examples


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [X] Documentation

### SUMMARY
`flask fab` and `superset fab` are working differently from each other and   `flask fab create-admin` command does not create any admin on the database.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
