### PR TITLE
fix urlib opener bug

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -264,7 +264,8 @@ def _get_slice_data(schedule):
         raise URLError(response.getcode())
 
     # TODO: Move to the csv module
-    rows = [r.split(b",") for r in response.content.splitlines()]
+    content = response.read()
+    rows = [r.split(b",") for r in content.splitlines()]
 
     if schedule.delivery_type == EmailDeliveryType.inline:
         data = None
@@ -281,7 +282,7 @@ def _get_slice_data(schedule):
             )
 
     elif schedule.delivery_type == EmailDeliveryType.attachment:
-        data = {__("%(name)s.csv", name=slc.slice_name): response.content}
+        data = {__("%(name)s.csv", name=slc.slice_name): content}
         body = __(
             '<b><a href="%(url)s">Explore in Superset</a></b><p></p>',
             name=slc.slice_name,

--- a/tests/schedules_test.py
+++ b/tests/schedules_test.py
@@ -378,7 +378,7 @@ class SchedulesTestCase(SupersetTestCase):
         mock_open.return_value = response
         mock_urlopen.return_value = response
         mock_urlopen.return_value.getcode.return_value = 200
-        response.content = self.CSV
+        response.read.return_value = self.CSV
 
         schedule = (
             db.session.query(SliceEmailSchedule)
@@ -404,8 +404,7 @@ class SchedulesTestCase(SupersetTestCase):
         mock_open.return_value = response
         mock_urlopen.return_value = response
         mock_urlopen.return_value.getcode.return_value = 200
-        response.content = self.CSV
-
+        response.read.return_value = self.CSV
         schedule = (
             db.session.query(SliceEmailSchedule)
             .filter_by(id=self.slice_schedule)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
`urllib opener` does not have any method called `content` and for getting the content of the response should invoke `read()` method. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #8784 #8286
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
