### PR TITLE
Bump FAB to 2.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ croniter==0.3.30
 cryptography==2.7
 decorator==4.4.0          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.2.0
+flask-appbuilder==2.2.1
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.7.2
 flask-compress==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=2.2.0, <2.3.0",
+        "flask-appbuilder>=2.2.1, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Change log since 2.2.0:

 - Fix, [api] OpenAPI method and config exclusions (#1211)
 - Fix, [mvc] default page size out of sync with jinja macro (#1209)
 - New, [api] Support for json encoded content on URI parameter (#1205)
 - Fix, [api] Re-allow filtering by booleans (default generated list) (#1204)
 - Fix, [api] [menu] openapi spec (#1203)
 - New, [api] Exclude route methods from ModelRestApi (#1202)
 - Fix, [api] Don't crash on invalid filters (#1200)
 - Fix, authentication error when using oracle (#1193)
 - Fix, [api] openapi spec for the info endpoint (#1197)
 - Fix, New, Show widget template: Add some basic blocks (#1158)
 - New, State reason for LDAP login failure (#1164)
 - Fix, [docs] Get list result (#1196)
 - Fix, [examples] Update views.py (#1165)
 - Fix, create filters even when search_columns is empty (#1173)
 - Fix, jwt refresh endpoint should return new access_token (#1187)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
