### PR TITLE
darker opacity on shadow border for highlighted cards

### DIFF
--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -43,7 +43,7 @@
   &.fade-in {
     border-radius: 4px;
     box-shadow: inset 0 0 0 2px fade(@shadow-highlight, 1),
-      0 0 0 3px fade(@shadow-highlight, @opacity-light);
+      0 0 0 3px fade(@shadow-highlight, @opacity-medium-light);
     transition: box-shadow 1s ease-in-out;
   }
 

--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -42,7 +42,7 @@
 
   &.fade-in {
     border-radius: 4px;
-    box-shadow: inset 0 0 0 2px fade(@shadow-highlight, 1),
+    box-shadow: inset 0 0 0 2px @shadow-highlight,
       0 0 0 3px fade(@shadow-highlight, @opacity-medium-light);
     transition: box-shadow 1s ease-in-out;
   }

--- a/superset/assets/src/dashboard/stylesheets/components/chart.less
+++ b/superset/assets/src/dashboard/stylesheets/components/chart.less
@@ -43,7 +43,7 @@
   &.fade-in {
     border-radius: 4px;
     box-shadow: inset 0 0 0 2px @shadow-highlight,
-      0 0 0 3px fade(@shadow-highlight, @opacity-medium-light);
+      0 0 0 3px fade(@shadow-highlight, @opacity-light);
     transition: box-shadow 1s ease-in-out;
   }
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The border (actually a shadow) on the highlighted viz card got a little lost at the lowest opacity step. This bumps it up a notch for visibility. Fixes #8780 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After screenshot (for @graceguo-supercat to review):
![border2](https://user-images.githubusercontent.com/812905/70467431-075ba400-1a7a-11ea-8a19-af4555c7475f.gif)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat 