### PR TITLE
Update sql validator status

### DIFF
--- a/superset/sql_validators/presto_db.py
+++ b/superset/sql_validators/presto_db.py
@@ -90,6 +90,11 @@ class PrestoDBSQLValidator(BaseSQLValidator):
             # invalid error, and restructure that error as an annotation we can
             # return up.
 
+            # If the first element in the DatabaseError is not a dictionary, but
+            # is a string, return that message. 
+            if db_error.args and isinstance(db_error.args[0], str):
+                raise PrestoSQLValidationError(db_error.args[0]) from db_error
+
             # Confirm the first element in the DatabaseError constructor is a
             # dictionary with error information. This is currently provided by
             # the pyhive client, but may break if their interface changes when
@@ -107,9 +112,14 @@ class PrestoDBSQLValidator(BaseSQLValidator):
                     "The pyhive presto client did not report an error message"
                 ) from db_error
             if "errorLocation" not in error_args:
-                raise PrestoSQLValidationError(
-                    "The pyhive presto client did not report an error location"
-                ) from db_error
+                # If we have a message but no error location, return the message and
+                # set the location as the beginning.
+                return SQLValidationAnnotation(
+                    message=error_args["message"] + "\n(Error location unknown)",
+                    line_number=1,
+                    start_column=1,
+                    end_column=1,
+                )
 
             # Pylint is confused about the type of error_args, despite the hints
             # and checks above.

--- a/superset/sql_validators/presto_db.py
+++ b/superset/sql_validators/presto_db.py
@@ -91,7 +91,7 @@ class PrestoDBSQLValidator(BaseSQLValidator):
             # return up.
 
             # If the first element in the DatabaseError is not a dictionary, but
-            # is a string, return that message. 
+            # is a string, return that message.
             if db_error.args and isinstance(db_error.args[0], str):
                 raise PrestoSQLValidationError(db_error.args[0]) from db_error
 
@@ -112,17 +112,19 @@ class PrestoDBSQLValidator(BaseSQLValidator):
                     "The pyhive presto client did not report an error message"
                 ) from db_error
             if "errorLocation" not in error_args:
+                # Pylint is confused about the type of error_args, despite the hints
+                # and checks above.
+                # pylint: disable=invalid-sequence-index
+                message = error_args["message"] + "\n(Error location unknown)"
                 # If we have a message but no error location, return the message and
                 # set the location as the beginning.
                 return SQLValidationAnnotation(
-                    message=error_args["message"] + "\n(Error location unknown)",
+                    message=message,
                     line_number=1,
                     start_column=1,
                     end_column=1,
                 )
 
-            # Pylint is confused about the type of error_args, despite the hints
-            # and checks above.
             # pylint: disable=invalid-sequence-index
             message = error_args["message"]
             err_loc = error_args["errorLocation"]

--- a/superset/sql_validators/presto_db.py
+++ b/superset/sql_validators/presto_db.py
@@ -119,10 +119,7 @@ class PrestoDBSQLValidator(BaseSQLValidator):
                 # If we have a message but no error location, return the message and
                 # set the location as the beginning.
                 return SQLValidationAnnotation(
-                    message=message,
-                    line_number=1,
-                    start_column=1,
-                    end_column=1,
+                    message=message, line_number=1, start_column=1, end_column=1
                 )
 
             # pylint: disable=invalid-sequence-index

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2638,11 +2638,11 @@ class Superset(BaseSupersetView):
         except Exception as e:
             logging.exception(e)
             msg = _(
-                f"{validator.name} was unable to check your query.\nPlease "
-                "make sure that any services it depends on are available\n"
+                f"{validator.name} was unable to check your query.\n"
+                "Please recheck your query.\n"
                 f"Exception: {e}"
             )
-            return json_error_response(f"{msg}")
+            return json_error_response(f"{msg}", status=400)
 
     def _sql_json_async(
         self, session: Session, rendered_query: str, query: Query, expand_data: bool

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2642,7 +2642,11 @@ class Superset(BaseSupersetView):
                 "Please recheck your query.\n"
                 f"Exception: {e}"
             )
-            return json_error_response(f"{msg}", status=400)
+            # Return as a 400 if the database error message says we got a 4xx error
+            if re.search(r"([\W]|^)4\d{2}([\W]|$)", str(e)):
+                return json_error_response(f"{msg}", status=400)
+            else:
+                return json_error_response(f"{msg}")
 
     def _sql_json_async(
         self, session: Session, rendered_query: str, query: Query, expand_data: bool


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The Presto SQL validator does not always return a message and error location. Sometimes we only get a message. If it is an explicit message from the validator, return it and set its error location as the beginning of the string. Otherwise, return it as a general error as a 400 if the message explicitly says it is a 4xx error.

### TEST PLAN
Tested manually

### REVIEWERS
@betodealmeida @DiggidyDave 