### PR TITLE
[filter_box] dashboard should carry defaultValue in filter_box

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/util/getFilterConfigsFromFormdata_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getFilterConfigsFromFormdata_spec.js
@@ -20,6 +20,16 @@ import getFilterConfigsFromFormdata from '../../../../src/dashboard/util/getFilt
 
 describe('getFilterConfigsFromFormdata', () => {
   const testFormdata = {
+    filter_configs: [
+      {
+        asc: true,
+        clearable: true,
+        column: 'state',
+        defaultValue: 'CA',
+        key: 'fvwncPjUf',
+        multiple: true,
+      },
+    ],
     date_filter: true,
     granularity_sqla: '__time',
     time_grain_sqla: 'P1M',
@@ -43,6 +53,16 @@ describe('getFilterConfigsFromFormdata', () => {
     });
     expect(result.columns).toMatchObject({
       __time_col: testFormdata.granularity_sqla,
+    });
+  });
+
+  it('should use default value from form_data', () => {
+    const result = getFilterConfigsFromFormdata({
+      ...testFormdata,
+      show_sqla_time_column: true,
+    });
+    expect(result.columns).toMatchObject({
+      state: 'CA',
     });
   });
 });

--- a/superset/assets/src/dashboard/util/getFilterConfigsFromFormdata.js
+++ b/superset/assets/src/dashboard/util/getFilterConfigsFromFormdata.js
@@ -33,7 +33,7 @@ export default function getFilterConfigsFromFormdata(form_data = {}) {
     ({ columns, labels }, config) => {
       const updatedColumns = {
         ...columns,
-        [config.column]: config.vals,
+        [config.column]: config.vals || config.defaultValue,
       };
       const updatedLabels = {
         ...labels,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When user created a filter_box, they can set defaultValue for a field. 

Currently this defaultValue seems not carried to dashboard. So when user added a filter box with defaultValue to dashboard, they saw filter has pre-selected value, but dashboard didn't apply it.

We should carry defaultValue, and apply defaultValue to charts in dashboard. And when user add dashboard level **default filter** values, this filter_box defaultValue should be overwritten.

### TEST PLAN
Ci and manual test


### REVIEWERS
@etr2460 @michellethomas @mistercrunch 