### PR TITLE
[sip-15] Displaying endpoints for all start/end time ranges

### DIFF
--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -579,9 +579,7 @@ export default class DateFilterControl extends React.Component {
       .map(
         (v, idx, values) =>
           (v.replace('T00:00:00', '') || (idx === 0 ? '-∞' : '∞')) +
-          (endpoints && values.length > 1
-            ? ` (${endpoints[idx]})`
-            : ''),
+          (endpoints && values.length > 1 ? ` (${endpoints[idx]})` : ''),
       )
       .join(SEPARATOR);
     return (

--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -577,7 +577,7 @@ export default class DateFilterControl extends React.Component {
     value = value
       .split(SEPARATOR)
       .map(
-        (v, idx) =>
+        (v, idx, values) =>
           (v.replace('T00:00:00', '') || (idx === 0 ? '-∞' : '∞')) +
           (endpoints && value.includes(SEPARATOR)
             ? ` (${endpoints[idx]})`

--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -579,7 +579,7 @@ export default class DateFilterControl extends React.Component {
       .map(
         (v, idx, values) =>
           (v.replace('T00:00:00', '') || (idx === 0 ? '-∞' : '∞')) +
-          (endpoints && value.includes(SEPARATOR)
+          (endpoints && values.length > 1
             ? ` (${endpoints[idx]})`
             : ''),
       )

--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -576,11 +576,12 @@ export default class DateFilterControl extends React.Component {
     const endpoints = this.props.endpoints;
     value = value
       .split(SEPARATOR)
-      .map((v, idx) =>
-        moment(v).isValid()
-          ? v.replace('T00:00:00', '') +
-            (endpoints ? ` (${endpoints[idx]})` : '')
-          : v || (idx === 0 ? '-∞' : '∞'),
+      .map(
+        (v, idx) =>
+          (v.replace('T00:00:00', '') || (idx === 0 ? '-∞' : '∞')) +
+          (endpoints && value.includes(SEPARATOR)
+            ? ` (${endpoints[idx]})`
+            : ''),
       )
       .join(SEPARATOR);
     return (


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR adds the SIP-15 endpoints to all time ranges which include a start and/or end as not just those containing a timestamp. This helps to provide more transparency. Note the conditional logic has mostly been reverted to what was changed [here](https://github.com/apache/incubator-superset/pull/8398/files).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### AFTER

<img width="310" alt="Screen Shot 2019-12-12 at 3 03 20 PM" src="https://user-images.githubusercontent.com/4567245/70676620-a938f600-1cf1-11ea-91b7-43a2bda467a5.png">
<img width="208" alt="Screen Shot 2019-12-12 at 3 03 31 PM" src="https://user-images.githubusercontent.com/4567245/70676621-a938f600-1cf1-11ea-9c2a-a33b1982f6b8.png">
<img width="327" alt="Screen Shot 2019-12-12 at 3 03 44 PM" src="https://user-images.githubusercontent.com/4567245/70676622-a938f600-1cf1-11ea-8475-53b3ff88ab5c.png">
<img width="116" alt="Screen Shot 2019-12-12 at 3 11 36 PM" src="https://user-images.githubusercontent.com/4567245/70676638-b6ee7b80-1cf1-11ea-88dc-5dbee1e4bb50.png">

### TEST PLAN

CI and manual testing. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @michellethomas 