### PR TITLE
[dashboard] fix duplicated chart fetching when dashboard has default filters

### DIFF
--- a/superset/assets/src/dashboard/components/Dashboard.jsx
+++ b/superset/assets/src/dashboard/components/Dashboard.jsx
@@ -79,7 +79,7 @@ class Dashboard extends React.PureComponent {
 
   constructor(props) {
     super(props);
-    this.appliedFilters = {};
+    this.appliedFilters = props.activeFilters || {};
   }
 
   componentDidMount() {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When dashboard has default filters, I saw duplicated query requests from those charts applicable for the default filters:
![J9xHISyVV0](https://user-images.githubusercontent.com/27990562/70761340-b4941d80-1d01-11ea-9c59-5ca0bf8438ee.gif)

I believe this issue was introduced during building filter indicators or filter scope selector features. The root cause is the initialization value for filter state is wrong, which cause `componentDidUpdate` trigger one extra query when dashboards having default filters.

### TEST PLAN
CI and manual test.


### REVIEWERS
@etr2460 @mistercrunch 