### PR TITLE
[fix][sqllab] nullable booleans in dataframe

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -26,7 +26,7 @@ from superset.db_engine_specs.base import BaseEngineSpec
 
 pandas_dtype_map = {
     "STRING": "object",
-    "BOOLEAN": "object",
+    "BOOLEAN": "object",  # to support nullable bool
     "INTEGER": "Int64",
     "FLOAT": "float64",
     "TIMESTAMP": "datetime64[ns]",

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -26,7 +26,7 @@ from superset.db_engine_specs.base import BaseEngineSpec
 
 pandas_dtype_map = {
     "STRING": "object",
-    "BOOLEAN": "bool",
+    "BOOLEAN": "object",
     "INTEGER": "Int64",
     "FLOAT": "float64",
     "TIMESTAMP": "datetime64[ns]",

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -48,7 +48,7 @@ config = app.config
 
 # map between Presto types and Pandas
 pandas_dtype_map = {
-    "boolean": "object",
+    "boolean": "object",  # to support nullable bool
     "tinyint": "Int64",  # note: capital "I" means nullable int
     "smallint": "Int64",
     "integer": "Int64",

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -48,7 +48,7 @@ config = app.config
 
 # map between Presto types and Pandas
 pandas_dtype_map = {
-    "boolean": "bool",
+    "boolean": "object",
     "tinyint": "Int64",  # note: capital "I" means nullable int
     "smallint": "Int64",
     "integer": "Int64",


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

The pandas `"bool"` dtype is not nullable, so null booleans were incorrectly displayed as `false` in sqllab.

e.g. `SELECT true UNION ALL (SELECT null);` -> 
![image](https://user-images.githubusercontent.com/14146019/70832306-a39ee700-1da9-11ea-97e3-66db8d5156a5.png)

Mapping boolean to object type to support boolean + null.

### TEST PLAN
Ran the above query locally and confirmed it showed `null` instead of `false`.

### REVIEWERS
@etr2460 @graceguo-supercat 