### PR TITLE
[explore view] fix: Inline edit chart title cause unintended overwrite original query parameter

### DIFF
--- a/superset/assets/spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
@@ -23,14 +23,25 @@ import ExploreChartHeader from '../../../../src/explore/components/ExploreChartH
 import ExploreActionButtons from '../../../../src/explore/components/ExploreActionButtons';
 import EditableTitle from '../../../../src/components/EditableTitle';
 
+const stub = jest.fn(() => ({
+  then: () => {},
+}));
 const mockProps = {
-  actions: {},
+  actions: {
+    saveSlice: stub,
+  },
   can_overwrite: true,
   can_download: true,
   isStarred: true,
-  slice: {},
+  slice: {
+    form_data: {
+      viz_type: 'line',
+    },
+  },
   table_name: 'foo',
-  form_data: {},
+  form_data: {
+    viz_type: 'table',
+  },
   timeout: 1000,
   chart: {
     queryResponse: {},
@@ -52,5 +63,15 @@ describe('ExploreChartHeader', () => {
   it('renders', () => {
     expect(wrapper.find(EditableTitle)).toHaveLength(1);
     expect(wrapper.find(ExploreActionButtons)).toHaveLength(1);
+  });
+
+  it('updateChartTitleOrSaveSlice', () => {
+    const newTitle = 'New Chart Title';
+    wrapper.instance().updateChartTitleOrSaveSlice(newTitle);
+    expect(stub.call.length).toEqual(1);
+    expect(stub).toHaveBeenCalledWith(mockProps.slice.form_data, {
+      action: 'overwrite',
+      slice_name: newTitle,
+    });
   });
 });

--- a/superset/assets/spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
@@ -65,12 +65,23 @@ describe('ExploreChartHeader', () => {
     expect(wrapper.find(ExploreActionButtons)).toHaveLength(1);
   });
 
-  it('updateChartTitleOrSaveSlice', () => {
+  it('should updateChartTitleOrSaveSlice for existed slice', () => {
     const newTitle = 'New Chart Title';
     wrapper.instance().updateChartTitleOrSaveSlice(newTitle);
     expect(stub.call.length).toEqual(1);
     expect(stub).toHaveBeenCalledWith(mockProps.slice.form_data, {
       action: 'overwrite',
+      slice_name: newTitle,
+    });
+  });
+
+  it('should updateChartTitleOrSaveSlice for new slice', () => {
+    const newTitle = 'New Chart Title';
+    wrapper.setProps({ slice: undefined });
+    wrapper.instance().updateChartTitleOrSaveSlice(newTitle);
+    expect(stub.call.length).toEqual(1);
+    expect(stub).toHaveBeenCalledWith(mockProps.form_data, {
+      action: 'saveas',
       slice_name: newTitle,
     });
   });

--- a/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -146,7 +146,10 @@ describe('SaveModal', () => {
 
       sinon.stub(defaultProps.actions, 'saveSlice').callsFake(() =>
         Promise.resolve({
-          data: { dashboard: '/mock/', slice: { slice_url: '/mock/' } },
+          data: {
+            dashboard: '/mock_dashboard/',
+            slice: { slice_url: '/mock_slice/' },
+          },
         }),
       );
     });
@@ -189,6 +192,52 @@ describe('SaveModal', () => {
       wrapper.instance().saveOrOverwrite(true);
       const args = defaultProps.actions.saveSlice.getCall(0).args;
       expect(args[1].new_dashboard_name).toBe(newDashboardName);
+    });
+
+    describe('should always reload or redirect', () => {
+      let wrapper;
+      beforeEach(() => {
+        wrapper = getWrapper();
+        sinon.stub(window.location, 'assign');
+      });
+      afterEach(() => {
+        window.location.assign.restore();
+      });
+
+      it('Save & go to dashboard', done => {
+        wrapper.instance().saveOrOverwrite(true);
+        defaultProps.actions.saveSlice().then(() => {
+          expect(window.location.assign.callCount).toEqual(1);
+          expect(window.location.assign.getCall(0).args[0]).toEqual(
+            'http://localhost/mock_dashboard/',
+          );
+          done();
+        });
+      });
+
+      it('saveas new slice', done => {
+        wrapper.setState({ action: 'saveas', newSliceName: 'new slice name' });
+        wrapper.instance().saveOrOverwrite(false);
+        defaultProps.actions.saveSlice().then(() => {
+          expect(window.location.assign.callCount).toEqual(1);
+          expect(window.location.assign.getCall(0).args[0]).toEqual(
+            '/mock_slice/',
+          );
+          done();
+        });
+      });
+
+      it('overwrite original slice', done => {
+        wrapper.setState({ action: 'overwrite' });
+        wrapper.instance().saveOrOverwrite(false);
+        defaultProps.actions.saveSlice().then(() => {
+          expect(window.location.assign.callCount).toEqual(1);
+          expect(window.location.assign.getCall(0).args[0]).toEqual(
+            '/mock_slice/',
+          );
+          done();
+        });
+      });
     });
   });
 

--- a/superset/assets/src/explore/components/ExploreChartHeader.jsx
+++ b/superset/assets/src/explore/components/ExploreChartHeader.jsx
@@ -61,32 +61,36 @@ class ExploreChartHeader extends React.PureComponent {
 
   updateChartTitleOrSaveSlice(newTitle) {
     const isNewSlice = !this.props.slice;
+    const currentFormData = isNewSlice
+      ? this.props.form_data
+      : this.props.slice.form_data;
+
     const params = {
       slice_name: newTitle,
       action: isNewSlice ? 'saveas' : 'overwrite',
     };
     // this.props.slice hold the original slice params stored in slices table
-    this.props.actions
-      .saveSlice(this.props.slice.form_data, params)
-      .then(json => {
-        const { data } = json;
-        if (isNewSlice) {
-          this.props.actions.updateChartId(data.slice.slice_id, 0);
-          this.props.actions.createNewSlice(
-            data.can_add,
-            data.can_download,
-            data.can_overwrite,
-            data.slice,
-            data.form_data,
-          );
-          this.props.addHistory({
-            isReplace: true,
-            title: `[chart] ${data.slice.slice_name}`,
-          });
-        } else {
-          this.props.actions.updateChartTitle(newTitle);
-        }
-      });
+    // when chart is saved or overwritten, the explore view will reload page
+    // to make sure sync with updated query params
+    this.props.actions.saveSlice(currentFormData, params).then(json => {
+      const { data } = json;
+      if (isNewSlice) {
+        this.props.actions.updateChartId(data.slice.slice_id, 0);
+        this.props.actions.createNewSlice(
+          data.can_add,
+          data.can_download,
+          data.can_overwrite,
+          data.slice,
+          data.form_data,
+        );
+        this.props.addHistory({
+          isReplace: true,
+          title: `[chart] ${data.slice.slice_name}`,
+        });
+      } else {
+        this.props.actions.updateChartTitle(newTitle);
+      }
+    });
   }
 
   renderChartTitle() {

--- a/superset/assets/src/explore/components/ExploreChartHeader.jsx
+++ b/superset/assets/src/explore/components/ExploreChartHeader.jsx
@@ -65,25 +65,28 @@ class ExploreChartHeader extends React.PureComponent {
       slice_name: newTitle,
       action: isNewSlice ? 'saveas' : 'overwrite',
     };
-    this.props.actions.saveSlice(this.props.form_data, params).then(json => {
-      const { data } = json;
-      if (isNewSlice) {
-        this.props.actions.updateChartId(data.slice.slice_id, 0);
-        this.props.actions.createNewSlice(
-          data.can_add,
-          data.can_download,
-          data.can_overwrite,
-          data.slice,
-          data.form_data,
-        );
-        this.props.addHistory({
-          isReplace: true,
-          title: `[chart] ${data.slice.slice_name}`,
-        });
-      } else {
-        this.props.actions.updateChartTitle(newTitle);
-      }
-    });
+    // this.props.slice hold the original slice params stored in slices table
+    this.props.actions
+      .saveSlice(this.props.slice.form_data, params)
+      .then(json => {
+        const { data } = json;
+        if (isNewSlice) {
+          this.props.actions.updateChartId(data.slice.slice_id, 0);
+          this.props.actions.createNewSlice(
+            data.can_add,
+            data.can_download,
+            data.can_overwrite,
+            data.slice,
+            data.form_data,
+          );
+          this.props.addHistory({
+            isReplace: true,
+            title: `[chart] ${data.slice.slice_name}`,
+          });
+        } else {
+          this.props.actions.updateChartTitle(newTitle);
+        }
+      });
   }
 
   renderChartTitle() {

--- a/superset/assets/src/explore/components/SaveModal.jsx
+++ b/superset/assets/src/explore/components/SaveModal.jsx
@@ -154,9 +154,9 @@ class SaveModal extends React.Component {
         }
         // Go to new slice url or dashboard url
         if (gotodash) {
-          window.location = supersetURL(data.dashboard);
+          window.location.assign(supersetURL(data.dashboard));
         } else {
-          window.location = data.slice.slice_url;
+          window.location.assign(data.slice.slice_url);
         }
       });
     this.props.onHide();


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
To reproduce this issue:

1. Add a chart to dashboard,
2. Keep edit chart, for example, use left-side controls panel to update query.
3. Now, click chart title and inline edit chart title. Inline editing chart title will not trigger save slice modal.
4. Visit dashboard, you will see the original chart, both title and query are modified.

<img width="889" alt="Screen Shot 2019-12-13 at 10 53 42 AM" src="https://user-images.githubusercontent.com/27990562/70844128-60686680-1df1-11ea-970b-f6ea20b10ea2.png">


**Note**

- Currently, explore view will open Save modal for user to choose to save-as or overwrite chart.
- When user successfully saveas (or overwritten) chart, the explore view page will be reloaded. If user chose to go to dashboard, the page will be redirected. By this way the front-end can always being sync with updated query params in slice table.
- This PR will not change the current behavior. But if in the future we decide to use **async** way of saving chart parameters, we should be aware of that some components will be affected by this change.  So in this PR I added some unit tests to make sure the `reload and redirect` behavior.


Expected behavior:
inline edit chart title should only overwrite chart title, should not change original chart with unsaved query parameters.

### TEST PLAN
CI and manual test


### REVIEWERS
@etr2460 @michellethomas @mistercrunch 