### PR TITLE
Making SECRET_KEY the same in test and default

### DIFF
--- a/tests/superset_test_config.py
+++ b/tests/superset_test_config.py
@@ -40,7 +40,6 @@ def GET_FEATURE_FLAGS_FUNC(ff):
 
 
 TESTING = True
-SECRET_KEY = "thisismyscretkey"
 WTF_CSRF_ENABLED = False
 PUBLIC_ROLE_LIKE_GAMMA = True
 AUTH_ROLE_PUBLIC = "Public"


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
The Flask secret key was different in the default config as compared to the test config. This caused issues when running the "load examples" and then subsequently running unit tests against the same DB in order to repro issues, etc. 

### REVIEWERS
@dpgaspar @john-bodley 
