### PR TITLE
Version number and SHA added to user menu

### DIFF
--- a/superset/assets/spec/javascripts/components/Menu_spec.jsx
+++ b/superset/assets/spec/javascripts/components/Menu_spec.jsx
@@ -156,7 +156,7 @@ describe('Menu', () => {
     };
 
     const versionedWrapper = mount(<Menu {...props} />);
-    
+
     expect(versionedWrapper.find('.version-info div')).toHaveLength(2);
   });
 });

--- a/superset/assets/spec/javascripts/components/Menu_spec.jsx
+++ b/superset/assets/spec/javascripts/components/Menu_spec.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { Nav } from 'react-bootstrap';
 
 import Menu from '../../../src/components/Menu/Menu';
@@ -136,5 +136,27 @@ describe('Menu', () => {
     });
     expect(loggedOutWrapper.find('i.fa-sign-in')).toHaveLength(1);
     expect(loggedOutWrapper.find('i.fa-user')).toHaveLength(0);
+  });
+
+  it('renders version number and SHA', () => {
+    const overrideProps = {
+      data: {
+        ...defaultProps.data,
+        navbar_right: {
+          ...defaultProps.data.navbar_right,
+          version_string: 'A1',
+          version_sha: 'X',
+        },
+      },
+    };
+
+    const props = {
+      ...defaultProps,
+      ...overrideProps,
+    };
+
+    const versionedWrapper = mount(<Menu {...props} />);
+    
+    expect(versionedWrapper.find('.version-info div')).toHaveLength(2);
   });
 });

--- a/superset/assets/src/components/Menu/Menu.jsx
+++ b/superset/assets/src/components/Menu/Menu.jsx
@@ -36,6 +36,8 @@ const propTypes = {
     }).isRequired,
     navbar_right: PropTypes.shape({
       bug_report_url: PropTypes.string,
+      version_string: PropTypes.string,
+      version_sha: PropTypes.string,
       documentation_url: PropTypes.string,
       languages: PropTypes.object,
       show_language_picker: PropTypes.bool.isRequired,
@@ -91,6 +93,8 @@ export default function Menu({
             <UserMenu
               userInfoUrl={navbarRight.user_info_url}
               userLogoutUrl={navbarRight.user_logout_url}
+              versionString={navbarRight.version_string}
+              versionSha={navbarRight.version_sha}
             />
           )}
           {navbarRight.user_is_anonymous && (

--- a/superset/assets/src/components/Menu/Menu.less
+++ b/superset/assets/src/components/Menu/Menu.less
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+@import '../../../stylesheets/less/variables.less';
 
 #main-menu {
   .navbar .caret {
@@ -24,6 +25,14 @@
     &:before {
       position: relative;
       top: -2px;
+    }
+  }
+  .version-info {
+    padding: 5px 20px;
+    color: @gray-heading;
+    font-size: @font-size-xs;
+    div {
+      white-space: nowrap;
     }
   }
 }

--- a/superset/assets/src/components/Menu/UserMenu.jsx
+++ b/superset/assets/src/components/Menu/UserMenu.jsx
@@ -24,9 +24,11 @@ import { t } from '@superset-ui/translation';
 const propTypes = {
   userInfoUrl: PropTypes.string.isRequired,
   userLogoutUrl: PropTypes.string.isRequired,
+  versionString: PropTypes.string,
+  versionSha: PropTypes.string,
 };
 
-export default function UserMenu({ userInfoUrl, userLogoutUrl }) {
+export default function UserMenu({ userInfoUrl, userLogoutUrl, versionString, versionSha }) {
   return (
     <NavDropdown
       id="user-menu-dropwn"
@@ -44,6 +46,16 @@ export default function UserMenu({ userInfoUrl, userLogoutUrl }) {
         <span className="fa fa-fw fa-sign-out" />
         {t('Logout')}
       </MenuItem>
+      {(versionString || versionSha) && (
+        <li className="version-info">
+          {versionString && (
+              <div>Version: {versionString}</div>
+          )}
+          {versionSha && (
+              <div>SHA: {versionSha}</div>
+          )}
+        </li>
+      )}
     </NavDropdown>
   );
 }

--- a/superset/assets/src/components/Menu/UserMenu.jsx
+++ b/superset/assets/src/components/Menu/UserMenu.jsx
@@ -28,7 +28,12 @@ const propTypes = {
   versionSha: PropTypes.string,
 };
 
-export default function UserMenu({ userInfoUrl, userLogoutUrl, versionString, versionSha }) {
+export default function UserMenu({
+  userInfoUrl,
+  userLogoutUrl,
+  versionString,
+  versionSha,
+}) {
   return (
     <NavDropdown
       id="user-menu-dropwn"
@@ -48,12 +53,8 @@ export default function UserMenu({ userInfoUrl, userLogoutUrl, versionString, ve
       </MenuItem>
       {(versionString || versionSha) && (
         <li className="version-info">
-          {versionString && (
-              <div>Version: {versionString}</div>
-          )}
-          {versionSha && (
-              <div>SHA: {versionSha}</div>
-          )}
+          {versionString && <div>Version: {versionString}</div>}
+          {versionSha && <div>SHA: {versionSha}</div>}
         </li>
       )}
     </NavDropdown>

--- a/superset/config.py
+++ b/superset/config.py
@@ -55,8 +55,7 @@ else:
 # ---------------------------------------------------------
 PACKAGE_DIR = os.path.join(BASE_DIR, "static", "assets")
 VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
-PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets" "package.json")
-
+PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets", "package.json")
 
 def _try_json_readversion(filepath):
     try:
@@ -69,7 +68,7 @@ def _try_json_readversion(filepath):
 def _try_json_readsha(filepath, length):  # pylint: disable=unused-argument
     try:
         with open(filepath, "r") as f:
-            return json.load(f).get("GIT_SHA")
+            return json.load(f).get("GIT_SHA")[:length]
     except Exception:  # pylint: disable=broad-except
         return None
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -57,6 +57,7 @@ PACKAGE_DIR = os.path.join(BASE_DIR, "static", "assets")
 VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
 PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets", "package.json")
 
+
 def _try_json_readversion(filepath):
     try:
         with open(filepath, "r") as f:

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -208,6 +208,8 @@ def menu_data():
         "navbar_right": {
             "bug_report_url": appbuilder.app.config.get("BUG_REPORT_URL"),
             "documentation_url": appbuilder.app.config.get("DOCUMENTATION_URL"),
+            "version_string": appbuilder.app.config.get("VERSION_STRING"),
+            "version_sha": appbuilder.app.config.get("VERSION_SHA"),
             "languages": languages,
             "show_language_picker": len(languages.keys()) > 1,
             "user_is_anonymous": g.user.is_anonymous,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A previous PR added version number and SHA (when avaialable) to the user menu in the top right. The Menu was then refactored to React (yay!) and this feature was lost (doh!). This PR restores it, but in the new menu construct. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Pulls from version_info.json:
![image](https://user-images.githubusercontent.com/812905/70967136-483f5400-204a-11ea-9c2c-7f729d42d7b1.png)

Or from package.json (no SHA)
![image](https://user-images.githubusercontent.com/812905/70967171-6311c880-204a-11ea-9f96-33ac52a6e244.png)

The length of the SHA is configurable in config.py, for those that like a longer SHA.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Unit test added :)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@nytai @robdiciuccio 