### PR TITLE
fix: add default value to log param in sql_json

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2444,7 +2444,7 @@ class Superset(BaseSupersetView):
         rendered_query: str,
         query: Query,
         expand_data: bool,
-        log_params: Dict[str, Any],
+        log_params: Dict[str, Any] = None,
     ) -> str:
         """
             Send SQL JSON query to celery workers
@@ -2495,7 +2495,7 @@ class Superset(BaseSupersetView):
         rendered_query: str,
         query: Query,
         expand_data: bool,
-        log_params: Dict[str, Any],
+        log_params: Dict[str, Any] = None,
     ) -> str:
         """
             Execute SQL query (sql json)
@@ -2541,11 +2541,11 @@ class Superset(BaseSupersetView):
     @event_logger.log_this
     def sql_json(self):
         log_params = {
-            "USER_AGENT": cast(Optional[str], request.headers.get("USER_AGENT"))
+            "user_agent": cast(Optional[str], request.headers.get("USER_AGENT"))
         }
         return self.sql_json_exec(request.json, log_params)
 
-    def sql_json_exec(self, query_params: dict, log_params: dict):
+    def sql_json_exec(self, query_params: dict, log_params: dict = None):
         """Runs arbitrary sql and returns data as json"""
         # Collect Values
         database_id: int = cast(int, query_params.get("database_id"))

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2444,7 +2444,7 @@ class Superset(BaseSupersetView):
         rendered_query: str,
         query: Query,
         expand_data: bool,
-        log_params: Dict[str, Any] = None,
+        log_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
             Send SQL JSON query to celery workers
@@ -2495,7 +2495,7 @@ class Superset(BaseSupersetView):
         rendered_query: str,
         query: Query,
         expand_data: bool,
-        log_params: Dict[str, Any] = None,
+        log_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
             Execute SQL query (sql json)
@@ -2545,7 +2545,7 @@ class Superset(BaseSupersetView):
         }
         return self.sql_json_exec(request.json, log_params)
 
-    def sql_json_exec(self, query_params: dict, log_params: dict = None):
+    def sql_json_exec(self, query_params: dict, log_params: Optional[Dict[str, Any]] = None):
         """Runs arbitrary sql and returns data as json"""
         # Collect Values
         database_id: int = cast(int, query_params.get("database_id"))

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2545,7 +2545,9 @@ class Superset(BaseSupersetView):
         }
         return self.sql_json_exec(request.json, log_params)
 
-    def sql_json_exec(self, query_params: dict, log_params: Optional[Dict[str, Any]] = None):
+    def sql_json_exec(
+        self, query_params: dict, log_params: Optional[Dict[str, Any]] = None
+    ):
         """Runs arbitrary sql and returns data as json"""
         # Collect Values
         database_id: int = cast(int, query_params.get("database_id"))


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
For backwards compatibility, add default values to `log_params` in endpoint `sql_json`

### TEST PLAN
Manually
