### PR TITLE
Add toast presenter to Welcome app

### DIFF
--- a/superset/assets/src/welcome/App.jsx
+++ b/superset/assets/src/welcome/App.jsx
@@ -28,6 +28,7 @@ import { initEnhancer } from '../reduxUtils';
 import setupApp from '../setup/setupApp';
 import Welcome from './Welcome';
 import Menu from '../components/Menu/Menu';
+import ToastPresenter from '../messageToasts/containers/ToastPresenter';
 
 setupApp();
 
@@ -51,6 +52,7 @@ const App = () => (
       <Switch>
         <Route path="/superset/welcome">
           <Welcome user={user} />
+          <ToastPresenter />
         </Route>
       </Switch>
     </Router>

--- a/superset/assets/src/welcome/DashboardTable.jsx
+++ b/superset/assets/src/welcome/DashboardTable.jsx
@@ -47,10 +47,16 @@ class DashboardTable extends React.PureComponent {
       .then(({ json }) => {
         this.setState({ dashboards: json.result });
       })
-      .catch(() => {
-        this.props.addDangerToast(
-          t('An error occurred while fethching Dashboards'),
-        );
+      .catch(response => {
+        if (response.status === 401) {
+          this.props.addDangerToast(
+            t("You don't have the necessary permissions to load dashboards. Please contact your administrator."),
+          );
+        } else {
+          this.props.addDangerToast(
+            t('An error occurred while fetching Dashboards'),
+          );
+        }
       });
   }
 

--- a/superset/assets/src/welcome/DashboardTable.jsx
+++ b/superset/assets/src/welcome/DashboardTable.jsx
@@ -50,7 +50,9 @@ class DashboardTable extends React.PureComponent {
       .catch(response => {
         if (response.status === 401) {
           this.props.addDangerToast(
-            t("You don't have the necessary permissions to load dashboards. Please contact your administrator."),
+            t(
+              "You don't have the necessary permissions to load dashboards. Please contact your administrator.",
+            ),
           );
         } else {
           this.props.addDangerToast(


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The toast presenter is missing from the welcome app, so toasts are never displayed. I noticed this while investigating another problem.

I also improved the error message when the dashboard endpoint returns a 401.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Now:

![Screen Shot 2019-12-17 at 11 31 57 AM](https://user-images.githubusercontent.com/1534870/71027824-e0782000-20c0-11ea-98bc-2d32f1d0d0fb.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@khtruong @nytai 