### PR TITLE
moving favicon(s) to config, allowing multiple favicons

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -58,7 +58,7 @@ VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
 PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets", "package.json")
 
 # Multiple favicons can be specified here. The "href" property
-# is mandatory, but "sizes," "type," and "rel" are optional. 
+# is mandatory, but "sizes," "type," and "rel" are optional.
 # For example:
 # {
 #     "href":path/to/image.png",
@@ -66,9 +66,8 @@ PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets", "package.json")
 #     "type": "image/png"
 #     "rel": "icon"
 # },
-FAVICONS = [
-    {"href":"/static/assets/images/favicon.png"},
-]
+FAVICONS = [{"href": "/static/assets/images/favicon.png"}]
+
 
 def _try_json_readversion(filepath):
     try:

--- a/superset/config.py
+++ b/superset/config.py
@@ -57,6 +57,18 @@ PACKAGE_DIR = os.path.join(BASE_DIR, "static", "assets")
 VERSION_INFO_FILE = os.path.join(PACKAGE_DIR, "version_info.json")
 PACKAGE_JSON_FILE = os.path.join(BASE_DIR, "assets", "package.json")
 
+# Multiple favicons can be specified here. The "href" property
+# is mandatory, but "sizes," "type," and "rel" are optional. 
+# For example:
+# {
+#     "href":path/to/image.png",
+#     "sizes": "16x16",
+#     "type": "image/png"
+#     "rel": "icon"
+# },
+FAVICONS = [
+    {"href":"/static/assets/images/favicon.png"},
+]
 
 def _try_json_readversion(filepath):
     try:

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -16,7 +16,11 @@
   specific language governing permissions and limitations
   under the License.
 #}
+
 {% import 'appbuilder/general/lib.html' as lib %}
+
+{% set favicons = appbuilder.app.config['FAVICONS'] %}
+
 <html>
   <head>
     <title>
@@ -30,7 +34,14 @@
     </title>
     {% block head_meta %}{% endblock %}
     {% block head_css %}
-      <link rel="icon" type="image/png" href="/static/assets/images/favicon.png">
+      {% for favicon in favicons %}
+        <link 
+          rel="{{favicon.rel if favicon.rel else "icon"}}"
+          type="{{favicon.type if favicon.type else "image/png"}}" 
+          {% if favicon.sizes %}sizes={{favicon.sizes}}{% endif %} 
+          href="{{favicon.href}}"
+        >
+      {% endfor %}
       <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/flags/flags16.css" />
       <link rel="stylesheet" type="text/css" href="/static/appbuilder/css/font-awesome.min.css">
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR moves the Favicon path to the config file, and restructures the template to allow _multiple_ favicons of different sizes/types to be configured there. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch @graceguo-supercat @dpgaspar 