### PR TITLE
[dashboard] Modal for editing dashboard properties & metadata

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
+++ b/superset/assets/spec/javascripts/dashboard/components/Header_spec.jsx
@@ -63,6 +63,8 @@ describe('Header', () => {
     redoLength: 0,
     setMaxUndoHistoryExceeded: () => {},
     maxUndoHistoryToast: () => {},
+    dashboardInfoChanged: () => {},
+    dashboardTitleChanged: () => {},
   };
 
   function setup(overrideProps) {

--- a/superset/assets/src/dashboard/actions/dashboardInfo.js
+++ b/superset/assets/src/dashboard/actions/dashboardInfo.js
@@ -16,27 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { combineReducers } from 'redux';
 
-import charts from '../../chart/chartReducer';
-import dashboardInfo from './dashboardInfo';
-import dashboardState from './dashboardState';
-import dashboardFilters from './dashboardFilters';
-import datasources from './datasources';
-import sliceEntities from './sliceEntities';
-import dashboardLayout from '../reducers/undoableDashboardLayout';
-import messageToasts from '../../messageToasts/reducers';
+export const DASHBOARD_INFO_UPDATED = 'DASHBOARD_INFO_UPDATED';
 
-const impressionId = (state = '') => state;
-
-export default combineReducers({
-  charts,
-  datasources,
-  dashboardInfo,
-  dashboardFilters,
-  dashboardState,
-  dashboardLayout,
-  impressionId,
-  messageToasts,
-  sliceEntities,
-});
+// updates partially changed dashboard info
+export function dashboardInfoChanged(newInfo) {
+  return { type: DASHBOARD_INFO_UPDATED, newInfo };
+}

--- a/superset/assets/src/dashboard/actions/dashboardLayout.js
+++ b/superset/assets/src/dashboard/actions/dashboardLayout.js
@@ -88,6 +88,16 @@ export function updateDashboardTitle(text) {
   };
 }
 
+export const DASHBOARD_TITLE_CHANGED = 'DASHBOARD_TITLE_CHANGED';
+
+// call this one when it's not an undo-able action
+export function dashboardTitleChanged(text) {
+  return {
+    type: DASHBOARD_TITLE_CHANGED,
+    text,
+  };
+}
+
 export const DELETE_COMPONENT = 'DELETE_COMPONENT';
 export const deleteComponent = setUnsavedChangesAfterAction((id, parentId) => ({
   type: DELETE_COMPONENT,

--- a/superset/assets/src/dashboard/actions/dashboardLayout.js
+++ b/superset/assets/src/dashboard/actions/dashboardLayout.js
@@ -213,8 +213,10 @@ export function handleComponentDrop(dropResult) {
     } else if (
       destination &&
       source &&
-      !// ensure it has moved
-      (destination.id === source.id && destination.index === source.index)
+      !(
+        // ensure it has moved
+        (destination.id === source.id && destination.index === source.index)
+      )
     ) {
       dispatch(moveComponent(dropResult));
     }

--- a/superset/assets/src/dashboard/actions/dashboardLayout.js
+++ b/superset/assets/src/dashboard/actions/dashboardLayout.js
@@ -213,10 +213,8 @@ export function handleComponentDrop(dropResult) {
     } else if (
       destination &&
       source &&
-      !(
-        // ensure it has moved
-        (destination.id === source.id && destination.index === source.index)
-      )
+      !// ensure it has moved
+      (destination.id === source.id && destination.index === source.index)
     ) {
       dispatch(moveComponent(dropResult));
     }

--- a/superset/assets/src/dashboard/components/Header.jsx
+++ b/superset/assets/src/dashboard/components/Header.jsx
@@ -44,6 +44,7 @@ import {
   LOG_ACTIONS_FORCE_REFRESH_DASHBOARD,
   LOG_ACTIONS_TOGGLE_EDIT_DASHBOARD,
 } from '../../logger/LogUtils';
+import PropertiesModal from './PropertiesModal';
 
 const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,
@@ -103,6 +104,7 @@ class Header extends React.PureComponent {
     this.state = {
       didNotifyMaxUndoHistoryToast: false,
       emphasizeUndo: false,
+      showingPropertiesModal: false,
     };
 
     this.handleChangeText = this.handleChangeText.bind(this);
@@ -116,6 +118,8 @@ class Header extends React.PureComponent {
     this.forceRefresh = this.forceRefresh.bind(this);
     this.startPeriodicRender = this.startPeriodicRender.bind(this);
     this.overwriteDashboard = this.overwriteDashboard.bind(this);
+    this.showPropertiesModal = this.showPropertiesModal.bind(this);
+    this.hidePropertiesModal = this.hidePropertiesModal.bind(this);
   }
 
   componentDidMount() {
@@ -254,6 +258,14 @@ class Header extends React.PureComponent {
 
       this.props.onSave(data, dashboardInfo.id, SAVE_TYPE_OVERWRITE);
     }
+  }
+
+  showPropertiesModal() {
+    this.setState({ showingPropertiesModal: true });
+  }
+
+  hidePropertiesModal() {
+    this.setState({ showingPropertiesModal: false });
   }
 
   render() {
@@ -405,6 +417,15 @@ class Header extends React.PureComponent {
             </Button>
           )}
 
+          {this.state.showingPropertiesModal && (
+            <PropertiesModal
+              dashboardTitle={dashboardTitle}
+              dashboardInfo={dashboardInfo}
+              show={this.state.showingPropertiesModal}
+              onHide={this.hidePropertiesModal}
+            />
+          )}
+
           <HeaderActionsDropdown
             addSuccessToast={this.props.addSuccessToast}
             addDangerToast={this.props.addDangerToast}
@@ -427,6 +448,7 @@ class Header extends React.PureComponent {
             userCanEdit={userCanEdit}
             userCanSave={userCanSaveAs}
             isLoading={isLoading}
+            showPropertiesModal={this.showPropertiesModal}
           />
         </div>
       </div>

--- a/superset/assets/src/dashboard/components/Header.jsx
+++ b/superset/assets/src/dashboard/components/Header.jsx
@@ -87,6 +87,8 @@ const propTypes = {
   maxUndoHistoryToast: PropTypes.func.isRequired,
   refreshFrequency: PropTypes.number.isRequired,
   setRefreshFrequency: PropTypes.func.isRequired,
+  dashboardInfoChanged: PropTypes.func.isRequired,
+  dashboardTitleChanged: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -423,6 +425,18 @@ class Header extends React.PureComponent {
               dashboardInfo={dashboardInfo}
               show={this.state.showingPropertiesModal}
               onHide={this.hidePropertiesModal}
+              onDashboardSave={updates => {
+                this.props.dashboardInfoChanged({
+                  slug: updates.slug,
+                  metadata: JSON.parse(updates.jsonMetadata),
+                });
+                this.props.dashboardTitleChanged(updates.title);
+                history.pushState(
+                  { event: 'dashboard_properties_changed' },
+                  '',
+                  `/superset/dashboard/${updates.slug}/`,
+                );
+              }}
             />
           )}
 

--- a/superset/assets/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset/assets/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -30,6 +30,7 @@ import { SAVE_TYPE_NEWDASHBOARD } from '../util/constants';
 import URLShortLinkModal from '../../components/URLShortLinkModal';
 import getDashboardUrl from '../util/getDashboardUrl';
 import { getActiveFilters } from '../util/activeDashboardFilters';
+import ModalTrigger from 'src/components/ModalTrigger';
 
 const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,
@@ -53,6 +54,7 @@ const propTypes = {
   layout: PropTypes.object.isRequired,
   expandedSlices: PropTypes.object.isRequired,
   onSave: PropTypes.func.isRequired,
+  showPropertiesModal: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -190,8 +192,8 @@ class HeaderActionsDropdown extends React.PureComponent {
         />
 
         {editMode && (
-          <MenuItem target="_blank" href={`/dashboard/edit/${dashboardId}`}>
-            {t('Edit dashboard metadata')}
+          <MenuItem onClick={this.props.showPropertiesModal}>
+            {t('Edit dashboard properties')}
           </MenuItem>
         )}
 

--- a/superset/assets/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset/assets/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -30,7 +30,6 @@ import { SAVE_TYPE_NEWDASHBOARD } from '../util/constants';
 import URLShortLinkModal from '../../components/URLShortLinkModal';
 import getDashboardUrl from '../util/getDashboardUrl';
 import { getActiveFilters } from '../util/activeDashboardFilters';
-import ModalTrigger from 'src/components/ModalTrigger';
 
 const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,

--- a/superset/assets/src/dashboard/components/PropertiesModal.jsx
+++ b/superset/assets/src/dashboard/components/PropertiesModal.jsx
@@ -165,7 +165,7 @@ class PropertiesModal extends React.PureComponent {
           <Modal.Body>
             <Row>
               <Col md={12}>
-                <h3>Basic Information</h3>
+                <h3>{t('Basic Information')}</h3>
               </Col>
             </Row>
             <Row>
@@ -191,12 +191,13 @@ class PropertiesModal extends React.PureComponent {
                   bsSize="sm"
                   value={values.slug}
                   onChange={this.onChange}
+                  placeholder={t('A readable URL for your dashboard')}
                 />
               </Col>
             </Row>
             <Row>
               <Col md={6}>
-                <h3>Access</h3>
+                <h3>{t('Access')}</h3>
                 <label className="control-label" htmlFor="owners">
                   {t('Owners')}
                 </label>
@@ -227,7 +228,7 @@ class PropertiesModal extends React.PureComponent {
                       }`}
                       style={{ minWidth: '1em' }}
                     />
-                    Advanced
+                    {t('Advanced')}
                   </button>
                 </h3>
                 {isAdvancedOpen && (

--- a/superset/assets/src/dashboard/components/PropertiesModal.jsx
+++ b/superset/assets/src/dashboard/components/PropertiesModal.jsx
@@ -1,0 +1,225 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Button, Modal, FormControl } from 'react-bootstrap';
+import Dialog from 'react-bootstrap-dialog';
+import Select from 'react-select';
+import { t } from '@superset-ui/translation';
+import { SupersetClient } from '@superset-ui/connection';
+
+import getClientErrorObject from '../../utils/getClientErrorObject';
+import withToasts from '../../messageToasts/enhancers/withToasts';
+
+
+const propTypes = {
+  dashboardTitle: PropTypes.string,
+  dashboardInfo: PropTypes.object,
+  owners: PropTypes.arrayOf(PropTypes.object),
+  show: PropTypes.bool.isRequired,
+  onHide: PropTypes.func,
+  onDashboardSave: PropTypes.func,
+  addSuccessToast: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  dashboardInfo: {},
+  dashboardTitle: '[dashboard name]',
+  onHide: () => {},
+  onDashboardSave: () => {},
+  show: false,
+};
+
+class PropertiesModal extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      errors: [],
+      values: {
+        dashboardTitle: this.props.dashboardTitle,
+        slug: this.props.dashboardInfo.slug,
+        owners: this.props.owners || [],
+      },
+      userOptions: null,
+    };
+    console.log(props);
+    this.onChange = this.onChange.bind(this);
+    this.onOwnersChange = this.onOwnersChange.bind(this);
+    this.save = this.save.bind(this);
+    this.setDialogRef = this.setDialogRef.bind(this);
+  }
+
+  componentDidMount() {
+    SupersetClient.get({ endpoint: `/users/api/read` })
+    .then(response => {
+      const options = response.json.result.map((user, i) => ({
+        // ids are in a separate `pks` array in the results... need api v2
+        value: response.json.pks[i],
+        label: user.first_name + ' ' + user.last_name,
+      }))
+      this.setState({
+        userOptions: options,
+      });
+    })
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.dashboardInfo !== prevProps.dashboardInfo) {
+      this.setState({
+        values: {
+          dashboard_title: this.props.dashboardInfo.title,
+          slug: this.props.dashboardInfo.slug,
+          owners: this.props.dashboardInfo.owners,
+        },
+      });
+    }
+  }
+
+  onOwnersChange(value) {
+    console.log(value);
+    this.setState((state) => ({
+      values: {
+        ...state.values,
+        owners: value,
+      }
+    }));
+  }
+
+  onChange(e) {
+    const { name, value } = e.target;
+    this.setState((state) => ({
+      values: {
+        ...state.values,
+        [name]: value,
+      },
+    }));
+  }
+
+  save(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    console.log('saving!')
+    const owners = this.state.values.owners.map(o => o.value);
+    SupersetClient.put({
+      endpoint: `/dashboard/api/update/${this.props.dashboardInfo.id}`,
+      postPayload: {
+        ...this.state.values,
+        owners,
+      },
+    })
+      .then(({ json }) => {
+        this.props.addSuccessToast(t('The dashboard has been saved'));
+        this.props.onDashboardSave(json);
+        this.props.onHide();
+      })
+      .catch(response =>
+        console.log(response) ||
+        getClientErrorObject(response).then(({ error, statusText }) => {
+          this.dialog.show({
+            title: 'Error',
+            bsSize: 'medium',
+            bsStyle: 'danger',
+            actions: [
+              Dialog.DefaultAction('Ok', () => {}, 'btn-danger'),
+            ],
+            body: error || statusText || t('An error has occurred'),
+          });
+        }),
+      );
+  }
+
+  setDialogRef(ref) {
+    this.dialog = ref;
+  }
+
+  render() {
+    const { userOptions, values } = this.state;
+    console.log(values)
+    return (
+      <Modal
+        show={this.props.show}
+        onHide={this.props.onHide}
+        bsSize="lg"
+      >
+        <form onSubmit={this.save}>
+          <Modal.Header closeButton>
+            <Modal.Title>
+              <div>
+                <span className="float-left">
+                  {t('Dashboard Properties')}
+                </span>
+              </div>
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div>
+              <FormControl
+                name="dashboard_title"
+                type="text"
+                bsSize="sm"
+                value={values.dashboard_title}
+                placeholder={t('Title')}
+                onChange={this.onChange}
+              />
+              <FormControl
+                name="slug"
+                type="text"
+                bsSize="sm"
+                value={values.slug}
+                placeholder={t('URL Slug')}
+                onChange={this.onChange}
+              />
+              {userOptions && (
+                <Select
+                  name="owners"
+                  placeholder="Owners"
+                  multi
+                  isLoading={!userOptions}
+                  value={values.owners}
+                  options={userOptions || []}
+                  onChange={this.onOwnersChange}
+                />
+              )}
+
+            </div>
+          </Modal.Body>
+          <Modal.Footer>
+            <span className="float-right">
+              <Button
+                type="submit"
+                bsSize="sm"
+                bsStyle="primary"
+                className="m-r-5"
+                disabled={this.state.errors.length > 0}
+              >
+                {t('Save')}
+              </Button>
+              <Button type="button" bsSize="sm" onClick={this.props.onHide}>{t('Cancel')}</Button>
+              <Dialog ref={this.setDialogRef} />
+            </span>
+          </Modal.Footer>
+        </form>
+      </Modal>);
+  }
+}
+
+PropertiesModal.propTypes = propTypes;
+PropertiesModal.defaultProps = defaultProps;
+
+export default withToasts(PropertiesModal);

--- a/superset/assets/src/dashboard/components/PropertiesModal.jsx
+++ b/superset/assets/src/dashboard/components/PropertiesModal.jsx
@@ -191,32 +191,41 @@ class PropertiesModal extends React.PureComponent {
                   bsSize="sm"
                   value={values.slug}
                   onChange={this.onChange}
-                  placeholder={t('A readable URL for your dashboard')}
                 />
+                <p className="help-block">
+                  {t('A readable URL for your dashboard')}
+                </p>
               </Col>
             </Row>
             <Row>
               <Col md={6}>
-                <h3>{t('Access')}</h3>
+                <h3 style={{ marginTop: '1em' }}>{t('Access')}</h3>
                 <label className="control-label" htmlFor="owners">
                   {t('Owners')}
                 </label>
                 {userOptions && (
-                  <Select
-                    name="owners"
-                    multi
-                    isLoading={!userOptions}
-                    value={values.owners}
-                    options={userOptions || []}
-                    onChange={this.onOwnersChange}
-                    disabled={!isOwnersLoaded}
-                  />
+                  <>
+                    <Select
+                      name="owners"
+                      multi
+                      isLoading={!userOptions}
+                      value={values.owners}
+                      options={userOptions || []}
+                      onChange={this.onOwnersChange}
+                      disabled={!isOwnersLoaded}
+                    />
+                    <p className="help-block">
+                      {t(
+                        'Owners is a list of users who can alter the dashboard.',
+                      )}
+                    </p>
+                  </>
                 )}
               </Col>
             </Row>
             <Row>
               <Col md={12}>
-                <h3>
+                <h3 style={{ marginTop: '1em' }}>
                   <button
                     type="button"
                     className="text-button"
@@ -245,6 +254,11 @@ class PropertiesModal extends React.PureComponent {
                       value={values.json_metadata}
                       onChange={this.onChange}
                     />
+                    <p className="help-block">
+                      {t(
+                        'This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter specific parameters.',
+                      )}
+                    </p>
                   </>
                 )}
               </Col>

--- a/superset/assets/src/dashboard/containers/DashboardHeader.jsx
+++ b/superset/assets/src/dashboard/containers/DashboardHeader.jsx
@@ -22,6 +22,8 @@ import { connect } from 'react-redux';
 import DashboardHeader from '../components/Header';
 import isDashboardLoading from '../util/isDashboardLoading';
 
+import { dashboardInfoChanged } from '../actions/dashboardInfo';
+
 import {
   setEditMode,
   showBuilderPane,
@@ -42,6 +44,7 @@ import {
   undoLayoutAction,
   redoLayoutAction,
   updateDashboardTitle,
+  dashboardTitleChanged,
 } from '../actions/dashboardLayout';
 
 import {
@@ -107,6 +110,8 @@ function mapDispatchToProps(dispatch) {
       maxUndoHistoryToast,
       logEvent,
       setRefreshFrequency,
+      dashboardInfoChanged,
+      dashboardTitleChanged,
     },
     dispatch,
   );

--- a/superset/assets/src/dashboard/reducers/dashboardInfo.js
+++ b/superset/assets/src/dashboard/reducers/dashboardInfo.js
@@ -16,27 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { combineReducers } from 'redux';
 
-import charts from '../../chart/chartReducer';
-import dashboardInfo from './dashboardInfo';
-import dashboardState from './dashboardState';
-import dashboardFilters from './dashboardFilters';
-import datasources from './datasources';
-import sliceEntities from './sliceEntities';
-import dashboardLayout from '../reducers/undoableDashboardLayout';
-import messageToasts from '../../messageToasts/reducers';
+import { DASHBOARD_INFO_UPDATED } from '../actions/dashboardInfo';
 
-const impressionId = (state = '') => state;
-
-export default combineReducers({
-  charts,
-  datasources,
-  dashboardInfo,
-  dashboardFilters,
-  dashboardState,
-  dashboardLayout,
-  impressionId,
-  messageToasts,
-  sliceEntities,
-});
+export default function dashboardStateReducer(state = {}, action) {
+  switch (action.type) {
+    case DASHBOARD_INFO_UPDATED:
+      return {
+        ...state,
+        ...action.newInfo,
+      };
+    default:
+      return state;
+  }
+}

--- a/superset/assets/src/dashboard/reducers/dashboardLayout.js
+++ b/superset/assets/src/dashboard/reducers/dashboardLayout.js
@@ -277,8 +277,6 @@ const actionHandlers = {
   },
 
   [DASHBOARD_TITLE_CHANGED](state, action) {
-    console.log('dashboard title changed reducer whaaaaat');
-    console.log(state);
     return {
       ...state,
       [DASHBOARD_HEADER_ID]: {

--- a/superset/assets/src/dashboard/reducers/dashboardLayout.js
+++ b/superset/assets/src/dashboard/reducers/dashboardLayout.js
@@ -20,6 +20,7 @@ import {
   DASHBOARD_ROOT_ID,
   DASHBOARD_GRID_ID,
   NEW_COMPONENTS_SOURCE_ID,
+  DASHBOARD_HEADER_ID,
 } from '../util/constants';
 import componentIsResizable from '../util/componentIsResizable';
 import findParentId from '../util/findParentId';
@@ -39,6 +40,7 @@ import {
   MOVE_COMPONENT,
   CREATE_TOP_LEVEL_TABS,
   DELETE_TOP_LEVEL_TABS,
+  DASHBOARD_TITLE_CHANGED,
 } from '../actions/dashboardLayout';
 
 const actionHandlers = {
@@ -271,6 +273,21 @@ const actionHandlers = {
 
     return {
       ...nextState,
+    };
+  },
+
+  [DASHBOARD_TITLE_CHANGED](state, action) {
+    console.log('dashboard title changed reducer whaaaaat');
+    console.log(state);
+    return {
+      ...state,
+      [DASHBOARD_HEADER_ID]: {
+        ...state[DASHBOARD_HEADER_ID],
+        meta: {
+          ...state[DASHBOARD_HEADER_ID].meta,
+          text: action.text,
+        },
+      },
     };
   },
 };

--- a/superset/assets/src/dashboard/stylesheets/buttons.less
+++ b/superset/assets/src/dashboard/stylesheets/buttons.less
@@ -41,3 +41,14 @@
   padding-left: 8px;
   font-size: @font-size-m;
 }
+
+.text-button {
+  outline: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  background: none;
+  text-decoration: none;
+  font-size: inherit;
+  font-weight: inherit;
+}


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a new modal to the dashboard react app, which allows updating dashboard properties that are currently only updatable from the CRUD editor. This will enable phasing out the CRUD views in favor of a slick new UI.

When the form is submitted, the url also gets updated to reflect any new slug.

Could use some feedback on how I accomplished the dashboard title update, I had to add some new redux flows that work around the undo functionality so that it doesn't trigger a "save" button.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="912" alt="Screen Shot 2019-12-19 at 5 54 24 PM" src="https://user-images.githubusercontent.com/1858430/71223408-c0935880-2288-11ea-82f8-fe7bc2bc6e22.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Need to write some tests still, but I want to open this up to feedback.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
Not entirely sure. @graceguo-supercat seems active in this area? 