### PR TITLE
[dashboard] Fix, prevent delete and update on dashes not owned

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -155,6 +155,26 @@ def handle_api_exception(f):
     return functools.update_wrapper(wraps, f)
 
 
+def api_exists_owned(f):
+    """
+    A Decorator that checks if an object exists and is owned by the current user
+    """
+
+    def wraps(self, pk):  # pylint: disable=invalid-name
+        item = self.datamodel.get(
+            pk, self._base_filters  # pylint: disable=protected-access
+        )
+        if not item:
+            return self.response_404()
+        try:
+            check_ownership(item)
+        except SupersetSecurityException as e:
+            return self.response(403, message=str(e))
+        return f(self, item)
+
+    return functools.update_wrapper(wraps, f)
+
+
 def get_datasource_exist_error_msg(full_name):
     return __("Datasource %(name)s already exists", name=full_name)
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -155,7 +155,7 @@ def handle_api_exception(f):
     return functools.update_wrapper(wraps, f)
 
 
-def api_exists_owned(f):
+def check_ownership_and_item_exists(f):
     """
     A Decorator that checks if an object exists and is owned by the current user
     """

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -42,8 +42,8 @@ def check_owner(f):
 
     def wraps(self, model_id):
         item = self.datamodel.get(
-            model_id, self._base_filters
-        )  # pylint: disable=protected-access
+            model_id, self._base_filters  # pylint: disable=protected-access
+        )
         if not item:
             return self.response_404()
         try:

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -29,7 +29,7 @@ from superset.exceptions import SupersetException
 from superset.models.dashboard import Dashboard
 from superset.utils import core as utils
 from superset.views.base import (
-    api_exists_owned,
+    check_ownership_and_item_exists,
     BaseSupersetModelRestApi,
     BaseSupersetSchema,
 )
@@ -213,7 +213,7 @@ class DashboardRestApi(DashboardMixin, BaseSupersetModelRestApi):
 
     @expose("/<pk>", methods=["PUT"])
     @protect()
-    @api_exists_owned
+    @check_ownership_and_item_exists
     @safe
     def put(self, item):  # pylint: disable=arguments-differ
         """Changes a dashboard
@@ -320,7 +320,7 @@ class DashboardRestApi(DashboardMixin, BaseSupersetModelRestApi):
 
     @expose("/<pk>", methods=["DELETE"])
     @protect()
-    @api_exists_owned
+    @check_ownership_and_item_exists
     @safe
     def delete(self, item):  # pylint: disable=arguments-differ
         """Delete Dashboard

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -29,9 +29,9 @@ from superset.exceptions import SupersetException
 from superset.models.dashboard import Dashboard
 from superset.utils import core as utils
 from superset.views.base import (
-    check_ownership_and_item_exists,
     BaseSupersetModelRestApi,
     BaseSupersetSchema,
+    check_ownership_and_item_exists,
 )
 
 from .mixin import DashboardMixin

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -41,7 +41,9 @@ def check_owner(f):
     """
 
     def wraps(self, model_id):
-        item = self.datamodel.get(model_id, self._base_filters)  # pylint: disable=protected-access
+        item = self.datamodel.get(
+            model_id, self._base_filters
+        )  # pylint: disable=protected-access
         if not item:
             return self.response_404()
         try:

--- a/superset/views/dashboard/mixin.py
+++ b/superset/views/dashboard/mixin.py
@@ -16,6 +16,7 @@
 # under the License.
 from flask_babel import lazy_gettext as _
 
+from ..base import check_ownership
 from .filters import DashboardFilter
 
 
@@ -80,3 +81,6 @@ class DashboardMixin:  # pylint: disable=too-few-public-methods
         "json_metadata": _("JSON Metadata"),
         "table_names": _("Underlying Tables"),
     }
+
+    def pre_delete(self, item):  # pylint: disable=no-self-use
+        check_ownership(item)

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -84,9 +84,6 @@ class DashboardModelView(
         check_ownership(item)
         self.pre_add(item)
 
-    def pre_delete(self, item):  # pylint: disable=no-self-use
-        check_ownership(item)
-
 
 class Dashboard(BaseSupersetView):
     """The base views for Superset!"""

--- a/tests/dashboard_api_tests.py
+++ b/tests/dashboard_api_tests.py
@@ -126,7 +126,7 @@ class DashboardApiTests(SupersetTestCase):
         self.login(username="alpha2", password="password")
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.delete(uri)
-        self.assertEqual(rv.status_code, 500)
+        self.assertEqual(rv.status_code, 403)
         db.session.delete(dashboard)
         db.session.delete(user_alpha1)
         db.session.delete(user_alpha2)

--- a/tests/dashboard_api_tests.py
+++ b/tests/dashboard_api_tests.py
@@ -23,6 +23,7 @@ from flask_appbuilder.security.sqla import models as ab_models
 
 from superset import db, security_manager
 from superset.models import core as models
+from superset.models.slice import Slice
 
 from .base_tests import SupersetTestCase
 
@@ -36,12 +37,14 @@ class DashboardApiTests(SupersetTestCase):
         dashboard_title: str,
         slug: str,
         owners: List[int],
+        slices: List[Slice] = None,
         position_json: str = "",
         css: str = "",
         json_metadata: str = "",
         published: bool = False,
     ) -> models.Dashboard:
         obj_owners = list()
+        slices = slices or []
         for owner in owners:
             user = db.session.query(security_manager.user_model).get(owner)
             obj_owners.append(user)
@@ -52,6 +55,7 @@ class DashboardApiTests(SupersetTestCase):
             position_json=position_json,
             css=css,
             json_metadata=json_metadata,
+            slices=slices,
             published=published,
         )
         db.session.add(dashboard)
@@ -113,11 +117,16 @@ class DashboardApiTests(SupersetTestCase):
         user_alpha2 = self.create_user(
             "alpha2", "password", "Alpha", email="alpha2@superset.org"
         )
-        dashboard = self.insert_dashboard("title", "slug1", [user_alpha1.id])
+        existing_slice = (
+            db.session.query(Slice).filter_by(slice_name="Girl Name Cloud").first()
+        )
+        dashboard = self.insert_dashboard(
+            "title", "slug1", [user_alpha1.id], slices=[existing_slice], published=True
+        )
         self.login(username="alpha2", password="password")
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.delete(uri)
-        self.assertEqual(rv.status_code, 404)
+        self.assertEqual(rv.status_code, 500)
         db.session.delete(dashboard)
         db.session.delete(user_alpha1)
         db.session.delete(user_alpha2)
@@ -333,7 +342,7 @@ class DashboardApiTests(SupersetTestCase):
 
     def test_update_dashboard_not_owned(self):
         """
-            Dashboard API: Test update dashboard not owner
+            Dashboard API: Test update dashboard not owned
         """
         user_alpha1 = self.create_user(
             "alpha1", "password", "Alpha", email="alpha1@superset.org"
@@ -341,12 +350,17 @@ class DashboardApiTests(SupersetTestCase):
         user_alpha2 = self.create_user(
             "alpha2", "password", "Alpha", email="alpha2@superset.org"
         )
-        dashboard = self.insert_dashboard("title", "slug1", [user_alpha1.id])
+        existing_slice = (
+            db.session.query(Slice).filter_by(slice_name="Girl Name Cloud").first()
+        )
+        dashboard = self.insert_dashboard(
+            "title", "slug1", [user_alpha1.id], slices=[existing_slice], published=True
+        )
         self.login(username="alpha2", password="password")
         dashboard_data = {"dashboard_title": "title1_changed", "slug": "slug1 changed"}
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.put(uri, json=dashboard_data)
-        self.assertEqual(rv.status_code, 404)
+        self.assertEqual(rv.status_code, 403)
         db.session.delete(dashboard)
         db.session.delete(user_alpha1)
         db.session.delete(user_alpha2)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
New dashboard API was not correctly preventing user's from updating dashboards they do not own. If a dashboard has slices and is published the user can `list` or `show` but should not be able to update it or delete

### TEST PLAN
Fixed tests to correctly prevent updates and deletes on this context 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
