### PR TITLE
[dashboard] Deprecate superset published API

### DIFF
--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -110,9 +110,12 @@ export function togglePublished(isPublished) {
 
 export function savePublished(id, isPublished) {
   return function savePublishedThunk(dispatch) {
-    return SupersetClient.post({
-      endpoint: `/superset/dashboard/${id}/published/`,
-      postPayload: { published: isPublished },
+    return SupersetClient.put({
+      endpoint: `/api/v1/dashboard/${id}`,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        published: isPublished
+      })
     })
       .then(() => {
         const nowPublished = isPublished ? 'published' : 'hidden';

--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -114,8 +114,8 @@ export function savePublished(id, isPublished) {
       endpoint: `/api/v1/dashboard/${id}`,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        published: isPublished
-      })
+        published: isPublished,
+      }),
     })
       .then(() => {
         const nowPublished = isPublished ? 'published' : 'hidden';

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1901,6 +1901,9 @@ class Superset(BaseSupersetView):
     @expose("/dashboard/<dashboard_id>/published/", methods=("GET", "POST"))
     def publish(self, dashboard_id):
         """Gets and toggles published status on dashboards"""
+        logging.warning(
+            "This API endpoint is deprecated and will be removed in version 1.0.0"
+        )
         session = db.session()
         Role = ab_models.Role
         dash = (
@@ -1913,16 +1916,14 @@ class Superset(BaseSupersetView):
                 return json_success(json.dumps({"published": dash.published}))
             else:
                 return json_error_response(
-                    "ERROR: cannot find dashboard {0}".format(dashboard_id), status=404
+                    f"ERROR: cannot find dashboard {dashboard_id}", status=404
                 )
 
         else:
             edit_perm = is_owner(dash, g.user) or admin_role in get_user_roles()
             if not edit_perm:
                 return json_error_response(
-                    'ERROR: "{0}" cannot alter dashboard "{1}"'.format(
-                        g.user.username, dash.dashboard_title
-                    ),
+                    f'ERROR: "{g.user.username}" cannot alter dashboard "{dash.dashboard_title}"',
                     status=403,
                 )
 

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -316,53 +316,5 @@ class DashboardRestApi(DashboardMixin, BaseSupersetModelRestApi):
         except SQLAlchemyError as e:
             return self.response_422(message=str(e))
 
-    @expose("/<pk>/published", methods=["PUT"])
-    @protect()
-    @safe
-    def published(self, pk):
-        """Toggled publish Dashboard
-        ---
-        put:
-          parameters:
-          - in: path
-            schema:
-              type: integer
-            name: pk
-          responses:
-            200:
-              description: Item changed
-              content:
-                application/json:
-                  schema:
-                    type: object
-                    properties:
-                      result:
-                        type: object
-                        properties:
-                            published:
-                                type: boolean
-            400:
-              $ref: '#/components/responses/400'
-            401:
-              $ref: '#/components/responses/401'
-            404:
-              $ref: '#/components/responses/404'
-            422:
-              $ref: '#/components/responses/422'
-            500:
-              $ref: '#/components/responses/500'
-        """
-        item = self.datamodel.get(pk, self._base_filters)
-        if not item:
-            return self.response_404()
-        item.published = not item.published
-        try:
-            self.datamodel.session.commit()
-            return self.response(
-                200, result={"published": item.published}
-            )
-        except SQLAlchemyError as e:
-            return self.response_422(message=str(e))
-
 
 appbuilder.add_api(DashboardRestApi)

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -171,7 +171,6 @@ class DashboardRestApi(DashboardMixin, BaseSupersetModelRestApi):
         "delete": "delete",
         "info": "list",
         "related": "list",
-        "published": "edit",
     }
     exclude_route_methods = ("info",)
     show_columns = [


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [X] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Following SIP-31, this change deprecates `superset/dashboard/<dashboard_id>/published/` API endpoint. Simply by using the new API PUT method that accepts partial updates.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
