### PR TITLE
[database] [log] Fix, Limit the amount of info on response

### DIFF
--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -53,19 +53,7 @@ class DatabaseRestApi(DatabaseMixin, ModelRestApi):
         "allows_cost_estimate",
         "backend",
     ]
-    show_columns = [
-        "database_name",
-        "expose_in_sqllab",
-        "allow_ctas",
-        "force_ctas_schema",
-        "allow_run_async",
-        "allow_dml",
-        "allow_multi_schema_metadata_fetch",
-        "allow_csv_upload",
-        "allows_subquery",
-        "allows_cost_estimate",
-        "backend",
-    ]
+    show_columns = list_columns
 
     # Removes the local limit for the page size
     max_page_size = -1

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -53,6 +53,20 @@ class DatabaseRestApi(DatabaseMixin, ModelRestApi):
         "allows_cost_estimate",
         "backend",
     ]
+    show_columns = [
+        "database_name",
+        "expose_in_sqllab",
+        "allow_ctas",
+        "force_ctas_schema",
+        "allow_run_async",
+        "allow_dml",
+        "allow_multi_schema_metadata_fetch",
+        "allow_csv_upload",
+        "allows_subquery",
+        "allows_cost_estimate",
+        "backend",
+    ]
+
     # Removes the local limit for the page size
     max_page_size = -1
     validators_columns = {"sqlalchemy_uri": sqlalchemy_uri_validator}

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -38,6 +38,7 @@ class LogRestApi(LogMixin, ModelRestApi):
     resource_name = "log"
     allow_browser_login = True
     list_columns = ("user.username", "action", "dttm")
+    show_columns = ("user.username", "action", "dttm")
 
 
 if (

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -38,7 +38,7 @@ class LogRestApi(LogMixin, ModelRestApi):
     resource_name = "log"
     allow_browser_login = True
     list_columns = ("user.username", "action", "dttm")
-    show_columns = ("user.username", "action", "dttm")
+    show_columns = list_columns
 
 
 if (


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Limit the amount of fields returned by get methods on Log and database API

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
