### PR TITLE
[docs] Fix docstrings in superset/config.py

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -202,7 +202,7 @@ DRUID_IS_ACTIVE = False
 # ----------------------------------------------------
 # The authentication type
 # AUTH_OID : Is for OpenID
-# AUTH_DB : Is for database (username/password()
+# AUTH_DB : Is for database (username/password)
 # AUTH_LDAP : Is for LDAP
 # AUTH_REMOTE_USER : Is for using REMOTE_USER from web server
 AUTH_TYPE = AUTH_DB
@@ -219,7 +219,7 @@ AUTH_TYPE = AUTH_DB
 # The default user self registration role
 # AUTH_USER_REGISTRATION_ROLE = "Public"
 
-# When using LDAP Auth, setup the ldap server
+# When using LDAP Auth, setup the LDAP server
 # AUTH_LDAP_SERVER = "ldap://ldapserver.new"
 
 # Uncomment to setup OpenID providers example for OpenID authentication


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY

Fix docstrings in config.py, specifically:

- Replace ldap with LDAP
- Replace `(username/password()` with `(username/password)`

### TEST PLAN

There is no test plan because no Python code is affected.
