### PR TITLE
[fix] Enforce the QueryResult.df to be a pandas.DataFrame object (Phase I)

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -988,11 +988,9 @@ class DruidDatasource(Model, BaseDatasource):
     def get_query_str(self, query_obj, phase=1, client=None):
         return self.run_query(client=client, phase=phase, **query_obj)
 
-    def _add_filter_from_pre_query_data(
-        self, df: Optional[pd.DataFrame], dimensions, dim_filter
-    ):
+    def _add_filter_from_pre_query_data(self, df: pd.DataFrame, dimensions, dim_filter):
         ret = dim_filter
-        if df is not None and not df.empty:
+        if not df.empty:
             new_filters = []
             for unused, row in df.iterrows():
                 fields = []
@@ -1379,7 +1377,7 @@ class DruidDatasource(Model, BaseDatasource):
 
         if df is None or df.size == 0:
             return QueryResult(
-                df=pd.DataFrame([]),
+                df=pd.DataFrame(),
                 query=query_str,
                 duration=datetime.now() - qry_start_dttm,
             )

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -85,7 +85,6 @@ class AnnotationDatasource(BaseDatasource):
     cache_timeout = 0
 
     def query(self, query_obj: Dict[str, Any]) -> QueryResult:
-        df = None
         error_message = None
         qry = db.session.query(Annotation)
         qry = qry.filter(Annotation.layer_id == query_obj["filter"][0]["val"])
@@ -97,6 +96,7 @@ class AnnotationDatasource(BaseDatasource):
         try:
             df = pd.read_sql_query(qry.statement, db.engine)
         except Exception as e:
+            df = pd.DataFrame()
             status = utils.QueryStatus.FAILED
             logging.exception(e)
             error_message = utils.error_msg_from_exception(e)
@@ -995,7 +995,7 @@ class SqlaTable(Model, BaseDatasource):
         try:
             df = self.database.get_df(sql, self.schema, mutator)
         except Exception as e:
-            df = None
+            df = pd.DataFrame()
             status = utils.QueryStatus.FAILED
             logging.exception(f"Query {sql} on schema {self.schema} failed")
             db_engine_spec = self.database.db_engine_spec

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -24,6 +24,7 @@ from typing import List, Optional
 # isort and pylint disagree, isort should win
 # pylint: disable=ungrouped-imports
 import humanize
+import pandas as pd
 import sqlalchemy as sa
 import yaml
 from flask import escape, g, Markup
@@ -368,11 +369,11 @@ class QueryResult:  # pylint: disable=too-few-public-methods
     def __init__(  # pylint: disable=too-many-arguments
         self, df, query, duration, status=QueryStatus.SUCCESS, error_message=None
     ):
-        self.df = df  # pylint: disable=invalid-name
-        self.query = query
-        self.duration = duration
-        self.status = status
-        self.error_message = error_message
+        self.df: pd.DataFrame = df  # pylint: disable=invalid-name
+        self.query: str = query
+        self.duration: int = duration
+        self.status: str = status
+        self.error_message: Optional[str] = error_message
 
 
 class ExtraJSONMixin:

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -251,7 +251,7 @@ class SqlaTableModelTestCase(SupersetTestCase):
         else:
             self.assertNotIn("JOIN", sql.upper())
         spec.allows_joins = old_inner_join
-        self.assertIsNotNone(qr.df)
+        self.assertFalse(qr.df.empty)
         return qr.df
 
     def test_query_with_expr_groupby_timeseries(self):
@@ -262,8 +262,9 @@ class SqlaTableModelTestCase(SupersetTestCase):
 
         df1 = self.query_with_expr_helper(is_timeseries=True, inner_join=True)
         df2 = self.query_with_expr_helper(is_timeseries=True, inner_join=False)
-        self.assertIsNotNone(df2)  # df1 can be none if the db does not support join
-        if df1 is not None:
+        self.assertFalse(df2.empty)
+        # df1 can be empty if the db does not support join
+        if not df1.empty:
             pandas.testing.assert_frame_equal(
                 cannonicalize_df(df1), cannonicalize_df(df2)
             )


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

In the past we have discussed whether we should use an empty `pandas.DataFrame` object or `None` to represent no-data. Previously `df` attribute of the [`QueryResult`](https://github.com/apache/incubator-superset/blob/5b690f94116b5b77c0af566d24f298cc6db469b9/superset/models/helpers.py#L364) class could either be `None` or a `pandas.DataFrame` object and was inconsistency defined, i.e., the Druid native connector used the former whereas the SQL connector used the later. This was problematic as the `None` type wasn't always handled, e.g. [here](https://github.com/apache/incubator-superset/blob/5b690f94116b5b77c0af566d24f298cc6db469b9/superset/connectors/sqla/models.py#L932) and [here](https://github.com/apache/incubator-superset/blob/5b690f94116b5b77c0af566d24f298cc6db469b9/superset/viz.py#L191) would both throw an exception if `df` was `None`.

This PR ensures that the `df` attribute is always a `pandas.DataFrame` object which can be empty. 

Additionally I’ve also added some basic typing to help enforce a non-optional `pandas.DataFrame` and also provided a short circuit when processing of data for the `NVD3TimeSeriesViz` class if the data-frame is empty. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @michellethomas @mistercrunch @serenajiang @villebro @willbarrett 