### PR TITLE
[dashboards] Fix, missing mulexport permission

### DIFF
--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -44,8 +44,7 @@ class DashboardModelView(
     datamodel = SQLAInterface(models.Dashboard)
 
     @action("mulexport", __("Export"), __("Export dashboards?"), "fa-database")
-    @staticmethod
-    def mulexport(items):
+    def mulexport(items):   # pylint: disable=no-self-use
         if not isinstance(items, list):
             items = [items]
         ids = "".join("&id={}".format(d.id) for d in items)

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -44,7 +44,7 @@ class DashboardModelView(
     datamodel = SQLAInterface(models.Dashboard)
 
     @action("mulexport", __("Export"), __("Export dashboards?"), "fa-database")
-    def mulexport(items):   # pylint: disable=no-self-use
+    def mulexport(self, items):  # pylint: disable=no-self-use
         if not isinstance(items, list):
             items = [items]
         ids = "".join("&id={}".format(d.id) for d in items)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Making a FAB action static prevents it's permission from being evaluated and created on the db

### TEST PLAN
Check that the option to export dashboards exists

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
