### PR TITLE
[app] Fix, manage menu should be before charts

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -210,14 +210,6 @@ class SupersetAppInitializer:
             category_icon="",
         )
         appbuilder.add_view(
-            SliceModelView,
-            "Charts",
-            label=__("Charts"),
-            icon="fa-bar-chart",
-            category="",
-            category_icon="",
-        )
-        appbuilder.add_view(
             DatabaseView,
             "Databases",
             label=__("Databases"),
@@ -225,6 +217,14 @@ class SupersetAppInitializer:
             category="Sources",
             category_label=__("Sources"),
             category_icon="fa-database",
+        )
+        appbuilder.add_view(
+            SliceModelView,
+            "Charts",
+            label=__("Charts"),
+            icon="fa-bar-chart",
+            category="",
+            category_icon="",
         )
         appbuilder.add_view(
             DashboardModelView,


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Manage menu category should be before charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/4025227/72145622-cc0f0680-3392-11ea-9a24-78bee7f67115.png)


After:
![image](https://user-images.githubusercontent.com/4025227/72145580-b863a000-3392-11ea-8cf6-d7d8a2659b2e.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@craig-rueda 