### PR TITLE
Ensure proper JSON serialization of numpy.ndarray

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -40,7 +40,7 @@ from urllib.parse import unquote_plus
 
 import bleach
 import markdown as md
-import numpy
+import numpy as np
 import pandas as pd
 import parsedatetime
 import sqlalchemy as sa
@@ -343,10 +343,12 @@ def format_timedelta(td: timedelta) -> str:
 def base_json_conv(obj):
     if isinstance(obj, memoryview):
         obj = obj.tobytes()
-    if isinstance(obj, numpy.int64):
+    if isinstance(obj, np.int64):
         return int(obj)
-    elif isinstance(obj, numpy.bool_):
+    elif isinstance(obj, np.bool_):
         return bool(obj)
+    elif isinstance(obj, np.ndarray):
+        return obj.tolist()
     elif isinstance(obj, set):
         return list(obj)
     elif isinstance(obj, decimal.Decimal):

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -121,6 +121,7 @@ class UtilsTestCase(SupersetTestCase):
     def test_base_json_conv(self):
         assert isinstance(base_json_conv(numpy.bool_(1)), bool) is True
         assert isinstance(base_json_conv(numpy.int64(1)), int) is True
+        assert isinstance(base_json_conv(numpy.array([1, 2, 3])), list) is True
         assert isinstance(base_json_conv(set([1])), list) is True
         assert isinstance(base_json_conv(Decimal("1.0")), float) is True
         assert isinstance(base_json_conv(uuid.uuid4()), str) is True


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When querying a Presto datasource with a column of type `ARRAY` asynchronously, the following error would be raised: 
```
TypeError: Unserializable object [] of type <class 'numpy.ndarray'>
```

This fix ensures proper conversion of the `numpy.ndarray` to a list for JSON serialization.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Ensure queries against a Presto table containing nested data type columns work correctly. Repeat for other supported DBs having nested data type columns.

This fix was tested against Presto 0.227 in both async and sync queries.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @craig-rueda @dpgaspar @villebro 