### PR TITLE
[filter_box] Fix ; separated filter_box default values

### DIFF
--- a/superset/assets/spec/javascripts/dashboard/util/getFilterConfigsFromFormdata_spec.js
+++ b/superset/assets/spec/javascripts/dashboard/util/getFilterConfigsFromFormdata_spec.js
@@ -62,7 +62,26 @@ describe('getFilterConfigsFromFormdata', () => {
       show_sqla_time_column: true,
     });
     expect(result.columns).toMatchObject({
-      state: 'CA',
+      state: ['CA'],
+    });
+  });
+
+  it('should read multi values from form_data', () => {
+    const result = getFilterConfigsFromFormdata({
+      ...testFormdata,
+      filter_configs: [
+        {
+          asc: true,
+          clearable: true,
+          column: 'state',
+          defaultValue: 'CA;NY',
+          key: 'fvwncPjUf',
+          multiple: true,
+        },
+      ],
+    });
+    expect(result.columns).toMatchObject({
+      state: ['CA', 'NY'],
     });
   });
 });

--- a/superset/assets/src/dashboard/util/getFilterConfigsFromFormdata.js
+++ b/superset/assets/src/dashboard/util/getFilterConfigsFromFormdata.js
@@ -31,9 +31,15 @@ export default function getFilterConfigsFromFormdata(form_data = {}) {
   } = form_data;
   let configs = filter_configs.reduce(
     ({ columns, labels }, config) => {
+      let defaultValues = config.defaultValue;
+      // defaultValue could be ; separated values,
+      // could be null or ''
+      if (config.defaultValue) {
+        defaultValues = config.defaultValue.split(';');
+      }
       const updatedColumns = {
         ...columns,
-        [config.column]: config.vals || config.defaultValue,
+        [config.column]: config.vals || defaultValues,
       };
       const updatedLabels = {
         ...labels,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Superset allow user set multi values for filter field default value, separated by `;`:
<img width="518" alt="Screen Shot 2020-01-11 at 3 20 27 PM" src="https://user-images.githubusercontent.com/27990562/72211807-30f75900-3486-11ea-813a-c995910096a4.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
<img width="927" alt="Screen Shot 2020-01-11 at 3 21 08 PM" src="https://user-images.githubusercontent.com/27990562/72211814-3c4a8480-3486-11ea-867c-48453f1f6979.png">

**After:**
<img width="930" alt="Screen Shot 2020-01-11 at 3 20 35 PM" src="https://user-images.githubusercontent.com/27990562/72211812-3a80c100-3486-11ea-88f8-cb5d7c1df591.png">


### TEST PLAN
new unit test is created. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #8812


### REVIEWERS
@michellethomas  @etr2460 