### PR TITLE
fix: lighten CSS border for data preview table

### DIFF
--- a/superset/assets/src/components/FilterableTable/FilterableTableStyles.less
+++ b/superset/assets/src/components/FilterableTable/FilterableTableStyles.less
@@ -20,7 +20,7 @@
 @import '../../../stylesheets/less/variables.less';
 
 .ReactVirtualized__Grid__innerScrollContainer {
-  border: 1px solid;
+  border: 1px solid @gray-light;
 }
 .ReactVirtualized__Table__headerRow {
   font-weight: @font-weight-bold;


### PR DESCRIPTION
### before
<img width="626" alt="Screen Shot 2020-01-14 at 1 19 37 PM" src="https://user-images.githubusercontent.com/487433/72383574-99d21180-36d0-11ea-8cee-6a66a6accfef.png">

### after
<img width="580" alt="Screen Shot 2020-01-14 at 1 17 48 PM" src="https://user-images.githubusercontent.com/487433/72383576-99d21180-36d0-11ea-9be4-893dde62ceec.png">
