### PR TITLE
Refactor sql editor autocomplete

### DIFF
--- a/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
+++ b/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
@@ -24,31 +24,14 @@ import 'brace/theme/github';
 import 'brace/ext/language_tools';
 import ace from 'brace';
 import { areArraysShallowEqual } from '../../reduxUtils';
+import sqlKeywords from '../utils/sqlKeywords';
+import {
+  SCHEMA_AUTOCOMPLETE_SCORE,
+  TABLE_AUTOCOMPLETE_SCORE,
+  COLUMN_AUTOCOMPLETE_SCORE,
+} from '../constants';
 
 const langTools = ace.acequire('ace/ext/language_tools');
-
-const SQL_KEYWORD_AUTOCOMPLETE_SCORE = 100;
-const SCHEMA_AUTOCOMPLETE_SCORE = 60;
-const TABLE_AUTOCOMPLETE_SCORE = 55;
-const COLUMN_AUTOCOMPLETE_SCORE = 50;
-
-const keywords =
-  'SELECT|INSERT|UPDATE|DELETE|FROM|WHERE|AND|OR|GROUP|BY|ORDER|LIMIT|OFFSET|HAVING|AS|CASE|' +
-  'WHEN|THEN|ELSE|END|TYPE|LEFT|RIGHT|JOIN|ON|OUTER|DESC|ASC|UNION|CREATE|TABLE|PRIMARY|KEY|IF|' +
-  'FOREIGN|NOT|REFERENCES|DEFAULT|NULL|INNER|CROSS|NATURAL|DATABASE|DROP|GRANT|SUM|MAX|MIN|COUNT|' +
-  'AVG|DISTINCT';
-
-const dataTypes =
-  'INT|NUMERIC|DECIMAL|DATE|VARCHAR|CHAR|BIGINT|FLOAT|DOUBLE|BIT|BINARY|TEXT|SET|TIMESTAMP|' +
-  'MONEY|REAL|NUMBER|INTEGER';
-
-const sqlKeywords = [].concat(keywords.split('|'), dataTypes.split('|'));
-export const sqlWords = sqlKeywords.map(s => ({
-  name: s,
-  value: s,
-  score: SQL_KEYWORD_AUTOCOMPLETE_SCORE,
-  meta: 'sql',
-}));
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -200,7 +183,7 @@ class AceEditorWrapper extends React.PureComponent {
     const words = schemaWords
       .concat(tableWords)
       .concat(columnWords)
-      .concat(sqlWords);
+      .concat(sqlKeywords);
 
     this.setState({ words }, () => {
       const completer = {

--- a/superset/assets/src/SqlLab/constants.js
+++ b/superset/assets/src/SqlLab/constants.js
@@ -58,3 +58,9 @@ export const LOCALSTORAGE_MAX_QUERY_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 export const LOCALSTORAGE_MAX_USAGE_KB = 5 * 1024; // 5M
 export const LOCALSTORAGE_WARNING_THRESHOLD = 0.9;
 export const LOCALSTORAGE_WARNING_MESSAGE_THROTTLE_MS = 8000; // danger type toast duration
+
+// autocomplete score weights
+export const SQL_KEYWORD_AUTOCOMPLETE_SCORE = 100;
+export const SCHEMA_AUTOCOMPLETE_SCORE = 60;
+export const TABLE_AUTOCOMPLETE_SCORE = 55;
+export const COLUMN_AUTOCOMPLETE_SCORE = 50;

--- a/superset/assets/src/SqlLab/utils/sqlKeywords.ts
+++ b/superset/assets/src/SqlLab/utils/sqlKeywords.ts
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SQL_KEYWORD_AUTOCOMPLETE_SCORE } from '../constants';
+
+const SQL_KEYWORDS = [
+  'AND',
+  'AS',
+  'ASC',
+  'AVG',
+  'BY',
+  'CASE',
+  'COUNT',
+  'CREATE',
+  'CROSS',
+  'DATABASE',
+  'DEFAULT',
+  'DELETE',
+  'DESC',
+  'DISTINCT',
+  'DROP',
+  'ELSE',
+  'END',
+  'FOREIGN',
+  'FROM',
+  'GRANT',
+  'GROUP',
+  'HAVING',
+  'IF',
+  'INNER',
+  'INSERT',
+  'JOIN',
+  'KEY',
+  'LEFT',
+  'LIMIT',
+  'MAX',
+  'MIN',
+  'NATURAL',
+  'NOT',
+  'NULL',
+  'OFFSET',
+  'ON',
+  'OR',
+  'ORDER',
+  'OUTER',
+  'PRIMARY',
+  'REFERENCES',
+  'RIGHT',
+  'SELECT',
+  'SUM',
+  'TABLE',
+  'THEN',
+  'TYPE',
+  'UNION',
+  'UPDATE',
+  'WHEN',
+  'WHERE',
+];
+
+const SQL_DATA_TYPES = [
+  'BIGINT',
+  'BINARY',
+  'BIT',
+  'CHAR',
+  'DATE',
+  'DECIMAL',
+  'DOUBLE',
+  'FLOAT',
+  'INT',
+  'INTEGER',
+  'MONEY',
+  'NUMBER',
+  'NUMERIC',
+  'REAL',
+  'SET',
+  'TEXT',
+  'TIMESTAMP',
+  'VARCHAR',
+];
+
+const allKeywords = SQL_KEYWORDS.concat(SQL_DATA_TYPES);
+
+const sqlKeywords = allKeywords.map((keyword) => ({
+  meta: 'sql',
+  name: keyword,
+  score: SQL_KEYWORD_AUTOCOMPLETE_SCORE,
+  value: keyword,
+}));
+
+export default sqlKeywords;

--- a/superset/assets/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
@@ -27,7 +27,7 @@ import { FormGroup } from 'react-bootstrap';
 import VirtualizedSelect from 'react-virtualized-select';
 import { t } from '@superset-ui/translation';
 
-import { sqlWords } from '../../SqlLab/components/AceEditorWrapper';
+import sqlKeywords from '../../SqlLab/utils/sqlKeywords';
 import AdhocFilter, { EXPRESSION_TYPES, CLAUSES } from '../AdhocFilter';
 import adhocMetricType from '../propTypes/adhocMetricType';
 import columnType from '../propTypes/columnType';
@@ -68,7 +68,7 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
     };
 
     if (langTools) {
-      const words = sqlWords.concat(
+      const words = sqlKeywords.concat(
         this.props.options.map(option => {
           if (option.column_name) {
             return {

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -41,7 +41,7 @@ import AdhocMetricEditPopoverTitle from './AdhocMetricEditPopoverTitle';
 import columnType from '../propTypes/columnType';
 import AdhocMetric, { EXPRESSION_TYPES } from '../AdhocMetric';
 import ColumnOption from '../../components/ColumnOption';
-import { sqlWords } from '../../SqlLab/components/AceEditorWrapper';
+import sqlKeywords from '../../SqlLab/utils/sqlKeywords';
 
 const langTools = ace.acequire('ace/ext/language_tools');
 
@@ -88,7 +88,7 @@ export default class AdhocMetricEditPopover extends React.Component {
       selectWrap: VirtualizedSelect,
     };
     if (langTools) {
-      const words = sqlWords.concat(
+      const words = sqlKeywords.concat(
         this.props.columns.map(column => ({
           name: column.column_name,
           value: column.column_name,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Moves constants into the constants file, the `sqlKeywords` array into a separate util file that other components can import, make the util file use typescript, and remove the string splitting on `|`

### TEST PLAN
Ensure SQL keywords autocomplete in SQL Lab, the metric editor popover and the filter editor popover

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @graceguo-supercat @mistercrunch @willbarrett 