### PR TITLE
docs: fix bad extras_require reference

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -402,7 +402,8 @@ Here's a list of some of the recommended packages.
 |                  | sqlalchemy-vertica-python``           |                                                 |
 +------------------+---------------------------------------+-------------------------------------------------+
 | Hana             | ``pip install hdbcli sqlalchemy-hana``|  ``hana://``                                    |
-|                  | or ``pip install superset[hana]``     |                                                 |
+|                  | or                                    |                                                 |
+|                  | ``pip install apache-superset[hana]`` |                                                 |
 +------------------+---------------------------------------+-------------------------------------------------+
 
 


### PR DESCRIPTION
Package name moved from `superset` to `apache-superset` at some point and this didn't get caught. I found it after commenting on https://github.com/apache/incubator-superset/pull/8958 and looking for similar issues.