### PR TITLE
Bump pandas to 0.25.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ marshmallow-sqlalchemy==0.17.0  # via flask-appbuilder
 marshmallow==2.19.5       # via flask-appbuilder, marshmallow-enum, marshmallow-sqlalchemy
 msgpack==0.6.1
 numpy==1.17.0             # via pandas, pyarrow
-pandas==0.24.2
+pandas==0.25.3
 parsedatetime==2.4
 pathlib2==2.3.4
 polyline==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         "isodate",
         "markdown>=3.0",
         "msgpack>=0.6.1, <0.7.0",
-        "pandas>=0.24.2, <0.25.0",
+        "pandas>=0.25.3, <1.0",
         "parsedatetime",
         "pathlib2",
         "polyline",

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -91,9 +91,11 @@ class SupersetResultSet:
                     if sample and isinstance(sample, datetime.datetime):
                         try:
                             if sample.tzinfo:
+                                tz = sample.tzinfo
                                 series = pd.Series(array[:, i], dtype="datetime64[ns]")
+                                series = pd.to_datetime(series).dt.tz_localize(tz)
                                 pa_data[i] = pa.Array.from_pandas(
-                                    series, type=pa.timestamp("ns", tz=sample.tzinfo)
+                                    series, type=pa.timestamp("ns", tz=tz)
                                 )
                         except Exception as e:
                             logging.exception(e)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

On the "What’s new in 1.0.0 (??)" page https://dev.pandas.io/docs/whatsnew/v1.0.0.html , the following is stated: "It is recommended to first upgrade to pandas 0.25 and to ensure your code is working without warnings, before upgrading to pandas 1.0." As Superset is still on `0.24`, it makes sense to bump to `0.25` now, as `1.0` is currently nearing release.

Bumping required a small change in `superset.result_set.py` due to Pandas now being more explicit about timezones. The new logic in `0.25` caused the original datetimes to be shifted by the UTC offset, as they were interpreted as being UTC due to the missing tzinfo. I traced back the change to this PR: https://github.com/pandas-dev/pandas/pull/25263