### PR TITLE
chore: Bump requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,81 +4,85 @@
 #
 #    pip-compile --output-file=requirements.txt setup.py
 #
-alembic==1.0.11           # via flask-migrate
-amqp==2.5.0               # via kombu
+alembic==1.3.2            # via flask-migrate
+amqp==2.5.2               # via kombu
 apispec[yaml]==1.3.3      # via flask-appbuilder
-asn1crypto==0.24.0        # via cryptography
-attrs==19.1.0             # via jsonschema
-babel==2.7.0              # via flask-babel
-backoff==1.8.0
-billiard==3.6.0.0         # via celery
+attrs==19.3.0             # via jsonschema
+babel==2.8.0              # via flask-babel
+backoff==1.10.0
+billiard==3.6.1.0         # via celery
 bleach==3.1.0
-celery==4.3.0
-cffi==1.12.3              # via cryptography
+celery==4.4.0
+cffi==1.13.2              # via cryptography
 click==6.7
-colorama==0.4.1
-contextlib2==0.5.5
-croniter==0.3.30
-cryptography==2.7
-decorator==4.4.0          # via retry
+colorama==0.4.3
+contextlib2==0.6.0.post1
+croniter==0.3.31
+cryptography==2.8
+decorator==4.4.1          # via retry
 defusedxml==0.6.0         # via python3-openid
 flask-appbuilder==2.2.1
 flask-babel==0.12.2       # via flask-appbuilder
-flask-caching==1.7.2
+flask-caching==1.8.0
 flask-compress==1.4.0
-flask-jwt-extended==3.20.0  # via flask-appbuilder
+flask-jwt-extended==3.24.1  # via flask-appbuilder
 flask-login==0.4.1        # via flask-appbuilder
 flask-migrate==2.5.2
 flask-openid==1.2.5       # via flask-appbuilder
-flask-sqlalchemy==2.4.0   # via flask-appbuilder, flask-migrate
+flask-sqlalchemy==2.4.1   # via flask-appbuilder, flask-migrate
 flask-talisman==0.7.0
 flask-wtf==0.14.2
 flask==1.1.1
-future==0.17.1            # via parsedatetime
-geographiclib==1.49       # via geopy
+geographiclib==1.50       # via geopy
 geopy==1.20.0
-gunicorn==20.0.2
+gunicorn==20.0.4
 humanize==0.5.1
+importlib-metadata==1.4.0  # via jsonschema, kombu
 isodate==0.6.0
 itsdangerous==1.1.0       # via flask
-jinja2==2.10.1            # via flask, flask-babel
-jsonschema==3.0.1         # via flask-appbuilder
-kombu==4.6.3              # via celery
-mako==1.0.14              # via alembic
+jinja2==2.10.3            # via flask, flask-babel
+jsonschema==3.2.0         # via flask-appbuilder
+kombu==4.6.7              # via celery
+mako==1.1.1               # via alembic
 markdown==3.1.1
 markupsafe==1.1.1         # via jinja2, mako
-marshmallow-enum==1.4.1   # via flask-appbuilder
-marshmallow-sqlalchemy==0.17.0  # via flask-appbuilder
+marshmallow-enum==1.5.1   # via flask-appbuilder
+marshmallow-sqlalchemy==0.21.0  # via flask-appbuilder
 marshmallow==2.19.5       # via flask-appbuilder, marshmallow-enum, marshmallow-sqlalchemy
-msgpack==0.6.1
-numpy==1.17.0             # via pandas, pyarrow
+more-itertools==8.1.0     # via zipp
+msgpack==0.6.2
+numpy==1.18.1             # via pandas, pyarrow
 pandas==0.25.3
-parsedatetime==2.4
-pathlib2==2.3.4
+parsedatetime==2.5
+pathlib2==2.3.5
 polyline==1.4.0
 prison==0.1.2             # via flask-appbuilder
-py==1.8.0                 # via retry
+py==1.8.1                 # via retry
 pyarrow==0.15.1
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via flask-appbuilder, flask-jwt-extended
-pyrsistent==0.15.4        # via jsonschema
-python-dateutil==2.8.0
-python-dotenv==0.10.3
+pyrsistent==0.15.7        # via jsonschema
+python-dateutil==2.8.1
+python-dotenv==0.10.5
 python-editor==1.0.4      # via alembic
 python-geohash==0.8.5
 python3-openid==3.1.0     # via flask-openid
-pytz==2019.2              # via babel, celery, pandas
-pyyaml==5.1.2
+pytz==2019.3              # via babel, celery, pandas
+pyyaml==5.3
 retry==0.9.2
 selenium==3.141.0
-simplejson==3.16.0
-six==1.12.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, pathlib2, polyline, prison, pyarrow, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
-sqlalchemy-utils==0.34.1
-sqlalchemy==1.3.6
+simplejson==3.17.0
+six==1.14.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, pathlib2, polyline, prison, pyarrow, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
+sqlalchemy-utils==0.36.1
+sqlalchemy==1.3.12
 sqlparse==0.3.0
-urllib3==1.25.3           # via selenium
+urllib3==1.25.8           # via selenium
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
-werkzeug==0.15.5          # via flask, flask-jwt-extended
+werkzeug==0.16.0          # via flask, flask-jwt-extended
 wtforms-json==0.3.3
 wtforms==2.2.1            # via flask-wtf, wtforms-json
+zipp==2.0.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

The current pinned dependencies are to some degree getting stale and far away from `setup.py`, and are causing trouble with some stable `sqlalchemy` dialect versions, namely `snowflake-sqlalchemy` which currently requires `asn1crypto>0.24`. The good news is that bumping `cryptography` from `2.7` to `2.8` removes the `asn1crypto` dependency all together. This has been tested locally to work well, and doesn't seem to contain any dramatic updates.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
