### PR TITLE
[druid] Making scaning/refreshing Druid datasource view items optional

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -411,24 +411,26 @@ class SupersetAppInitializer:
             appbuilder.add_view_no_menu(DruidMetricInlineView)
             appbuilder.add_view_no_menu(DruidColumnInlineView)
             appbuilder.add_view_no_menu(Druid)
-            appbuilder.add_link(
-                "Scan New Datasources",
-                label=__("Scan New Datasources"),
-                href="/druid/scan_new_datasources/",
-                category="Sources",
-                category_label=__("Sources"),
-                category_icon="fa-database",
-                icon="fa-refresh",
-            )
-            appbuilder.add_link(
-                "Refresh Druid Metadata",
-                label=__("Refresh Druid Metadata"),
-                href="/druid/refresh_datasources/",
-                category="Sources",
-                category_label=__("Sources"),
-                category_icon="fa-database",
-                icon="fa-cog",
-            )
+
+            if self.config["DRUID_METADATA_LINKS_ENABLED"]:
+                appbuilder.add_link(
+                    "Scan New Datasources",
+                    label=__("Scan New Datasources"),
+                    href="/druid/scan_new_datasources/",
+                    category="Sources",
+                    category_label=__("Sources"),
+                    category_icon="fa-database",
+                    icon="fa-refresh",
+                )
+                appbuilder.add_link(
+                    "Refresh Druid Metadata",
+                    label=__("Refresh Druid Metadata"),
+                    href="/druid/refresh_datasources/",
+                    category="Sources",
+                    category_label=__("Sources"),
+                    category_icon="fa-database",
+                    icon="fa-cog",
+                )
             appbuilder.add_separator("Sources")
 
     def init_app_in_ctx(self) -> None:

--- a/superset/config.py
+++ b/superset/config.py
@@ -191,11 +191,16 @@ FAB_API_SWAGGER_UI = True
 DRUID_TZ = tz.tzutc()
 DRUID_ANALYSIS_TYPES = ["cardinality"]
 
-# Legacy Druid connector
+# Legacy Druid NoSQL (native) connector
 # Druid supports a SQL interface in its newer versions.
 # Setting this flag to True enables the deprecated, API-based Druid
 # connector. This feature may be removed at a future date.
 DRUID_IS_ACTIVE = False
+
+# If Druid is active whether to include the links to scan/refresh Druid datasources.
+# This should be disabled if you are trying to wean yourself off of the Druid NoSQL
+# connector.
+DRUID_METADATA_LINKS_ENABLED = True
 
 # ----------------------------------------------------
 # AUTHENTICATION CONFIG


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Some deployments with charts backed by the legacy Druid NoSQL connector can't simply go cold turkey on fully disabling Druid however we would like to wean ourselves off of Druid starting by removing the option to scan for new or refresh the metadata of the Druid datasources. Note the later menu item is somewhat of a misnomer as it refreshes all Druid datasource from the source and not just those currently registered in Superset. 

This PR adds a config option to simply remove the view items for scanning/refreshing Druid datasources.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE 

When `DRUID_IS_ACTIVE = True` (non-default) and `DRUID_METADATA_LINKS_ENABLED = True` (default)

![Screen Shot 2020-01-22 at 1 27 45 PM](https://user-images.githubusercontent.com/4567245/72936451-1346b100-3d1c-11ea-9608-11c91cc76a85.png)

#### AFTER 

When `DRUID_IS_ACTIVE = True` (non-default) and `DRUID_METADATA_LINKS_ENABLED = False` (non-default)

![Screen Shot 2020-01-22 at 1 27 25 PM](https://user-images.githubusercontent.com/4567245/72936465-193c9200-3d1c-11ea-9aa6-08ef023146ed.png)

### TEST PLAN

CI and tested locally. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @michellethomas @mistercrunch @willbarrett 