### PR TITLE
[druid] make cluster_name editable

### DIFF
--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -205,7 +205,7 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):
     list_columns = ["cluster_name", "metadata_last_refreshed"]
     search_columns = ("cluster_name",)
     label_columns = {
-        "cluster_name": _("Cluster"),
+        "cluster_name": _("Cluster Name"),
         "broker_host": _("Broker Host"),
         "broker_port": _("Broker Port"),
         "broker_user": _("Broker Username"),
@@ -234,14 +234,6 @@ class DruidClusterModelView(SupersetModelView, DeleteMixin, YamlExportMixin):
     }
 
     yaml_dict_key = "databases"
-
-    edit_form_extra_fields = {
-        "cluster_name": QuerySelectField(
-            "Cluster",
-            query_factory=lambda: db.session().query(models.DruidCluster),
-            widget=Select2Widget(extra_classes="readonly"),
-        )
-    }
 
     def pre_add(self, cluster):
         security_manager.add_permission_view_menu("database_access", cluster.perm)


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
After #8576, `DruidCluster.cluster_name` is safe to edit because it is no longer a foreign key (it was previously made read-only in #7073).

Adding this mainly because it'd be nice to be able to edit `cluster_name`s without manually touching the database.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/14146019/72941691-81907100-3d26-11ea-95e7-357059a88ec4.png)


### TEST PLAN
Confirmed on dev box.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley 