### PR TITLE
Bump FAB to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ croniter==0.3.31
 cryptography==2.8
 decorator==4.4.1          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.2.1
+flask-appbuilder==2.2.2
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.8.0
 flask-compress==1.4.0
@@ -83,6 +83,3 @@ werkzeug==0.16.0          # via flask, flask-jwt-extended
 wtforms-json==0.3.3
 wtforms==2.2.1            # via flask-wtf, wtforms-json
 zipp==2.0.0               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=2.2.1, <2.3.0",
+        "flask-appbuilder>=2.2.2, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Bump FAB to 2.2.2 to support #8960

Improvements and Bug fixes on 2.2.2:

Fix, [mvc] List page's pagination start with 1 (#1216)
Fix, AttributeError in manager.py when a permission is null (#1217)
Fix, [api] using default method name when unspecified in method_permission_name (#1235)
New, [api] New, http 403 forbidden on default responses (#1237)
New, [mvc] [api] exclude and include route methods (#1234)
New, [mvc] [security] make userstatschartview optional (#1239)
New, [mvc] Disable old API flag and tests (#1244)
Fix, [mvc] jinja2 crashes with defined actions and removed action routes (#1245)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
