### PR TITLE
[fix] pydruid export_pandas

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1263,7 +1263,7 @@ class DruidDatasource(Model, BaseDatasource):
             if phase == 1:
                 return query_str
             query_str += "// Phase 2 (built based on phase one's results)\n"
-            df = client.export_pandas()
+            df = client.export_pandas() or pd.DataFrame()
             qry["filter"] = self._add_filter_from_pre_query_data(
                 df, [pre_qry["dimension"]], filters
             )
@@ -1331,7 +1331,7 @@ class DruidDatasource(Model, BaseDatasource):
                 if phase == 1:
                     return query_str
                 query_str += "// Phase 2 (built based on phase one's results)\n"
-                df = client.export_pandas()
+                df = client.export_pandas() or pd.DataFrame()
                 qry["filter"] = self._add_filter_from_pre_query_data(
                     df, pre_qry["dimensions"], filters
                 )
@@ -1375,7 +1375,7 @@ class DruidDatasource(Model, BaseDatasource):
         qry_start_dttm = datetime.now()
         client = self.cluster.get_pydruid_client()
         query_str = self.get_query_str(client=client, query_obj=query_obj, phase=2)
-        df = client.export_pandas()
+        df = client.export_pandas() or pd.DataFrame()
 
         if df.empty:
             return QueryResult(

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1263,7 +1263,9 @@ class DruidDatasource(Model, BaseDatasource):
             if phase == 1:
                 return query_str
             query_str += "// Phase 2 (built based on phase one's results)\n"
-            df = client.export_pandas() or pd.DataFrame()
+            df = client.export_pandas()
+            if df is None:
+                df = pd.DataFrame()
             qry["filter"] = self._add_filter_from_pre_query_data(
                 df, [pre_qry["dimension"]], filters
             )
@@ -1331,7 +1333,9 @@ class DruidDatasource(Model, BaseDatasource):
                 if phase == 1:
                     return query_str
                 query_str += "// Phase 2 (built based on phase one's results)\n"
-                df = client.export_pandas() or pd.DataFrame()
+                df = client.export_pandas()
+                if df is None:
+                    df = pd.DataFrame()
                 qry["filter"] = self._add_filter_from_pre_query_data(
                     df, pre_qry["dimensions"], filters
                 )
@@ -1375,7 +1379,9 @@ class DruidDatasource(Model, BaseDatasource):
         qry_start_dttm = datetime.now()
         client = self.cluster.get_pydruid_client()
         query_str = self.get_query_str(client=client, query_obj=query_obj, phase=2)
-        df = client.export_pandas() or pd.DataFrame()
+        df = client.export_pandas()
+        if df is None:
+            df = pd.DataFrame()
 
         if df.empty:
             return QueryResult(


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes a regression introduced in https://github.com/apache/incubator-superset/pull/8948 where I mistook that the `pydruid` `export_pandas` method alway returned an `pd.DataFrame` object (I missed the if statement [here](https://github.com/druid-io/pydruid/blob/80cf6fe767817c8c30e908ea2e145bee09aa6d9b/pydruid/query.py#L164) and thus it could be `None`. 

I noticed another case where we don't check whether the Pandas dataframe exists (see [here](https://github.com/apache/incubator-superset/blob/1f6f4ed879a3bb34a50a48b55fc42c570ece8b51/superset/connectors/druid/models.py#L987)) but this is outside of the scope of the original PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @michellethomas @mistercrunch @villebro 