### PR TITLE
Serialize nested columns as JSON strings

### DIFF
--- a/tests/result_set_tests.py
+++ b/tests/result_set_tests.py
@@ -124,6 +124,46 @@ class SupersetResultSetTestCase(SupersetTestCase):
             ],
         )
 
+    def test_nested_types(self):
+        data = [
+            (
+                4,
+                [{"table_name": "unicode_test", "database_id": 1}],
+                [1, 2, 3],
+                {"chart_name": "scatter"},
+            ),
+            (
+                3,
+                [{"table_name": "birth_names", "database_id": 1}],
+                [4, 5, 6],
+                {"chart_name": "plot"},
+            ),
+        ]
+        cursor_descr = [("id",), ("dict_arr",), ("num_arr",), ("map_col",)]
+        results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
+        self.assertEqual(results.columns[0]["type"], "INT")
+        self.assertEqual(results.columns[1]["type"], "STRING")
+        self.assertEqual(results.columns[2]["type"], "STRING")
+        self.assertEqual(results.columns[3]["type"], "STRING")
+        df = results.to_pandas_df()
+        self.assertEqual(
+            df_to_records(df),
+            [
+                {
+                    "id": 4,
+                    "dict_arr": '[{"table_name": "unicode_test", "database_id": 1}]',
+                    "num_arr": "[1, 2, 3]",
+                    "map_col": '{"chart_name": "scatter"}',
+                },
+                {
+                    "id": 3,
+                    "dict_arr": '[{"table_name": "birth_names", "database_id": 1}]',
+                    "num_arr": "[4, 5, 6]",
+                    "map_col": '{"chart_name": "plot"}',
+                },
+            ],
+        )
+
     def test_empty_datetime(self):
         data = [(None,)]
         cursor_descr = [("ds", "timestamp", None, None, None, None, True)]


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
SQL Lab queries against databases with nested columns/results containing structs or maps are failing with the following error:
```
pyarrow.lib.ArrowNotImplementedError: Not implemented type for list in DataFrameBlock: struct<...>
```

Serializing results to JSON is not the ideal solution, mainly for performance reasons, but there are pending fixes yet to be released in Arrow 1.0 that may improve the situation:
https://github.com/apache/arrow/pull/6199

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Ensure queries against databases containing nested columns (particularly arrays containing maps) are successful. Per https://github.com/apache/incubator-superset/issues/8978, the following query should succeed and produce the proper results:
```
SELECT id, json_agg(json_build_object('table_name',table_name,'database_id',database_id)) FROM (SELECT * FROM tables) AS tables GROUP BY id
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #8978
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@lxhoang97 @graceguo-supercat @john-bodley @michellethomas @villebro 