### PR TITLE
[SQL Lab] Disable autocomplete when typing numbers

### DIFF
--- a/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
+++ b/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
@@ -131,6 +131,11 @@ class AceEditorWrapper extends React.PureComponent {
     this.props.onChange(text);
   }
   getCompletions(aceEditor, session, pos, prefix, callback) {
+    // If the prefix starts with a number, don't try to autocomplete with a
+    // table name or schema or anything else
+    if (!isNaN(parseInt(prefix, 10))) {
+      return;
+    }
     const completer = {
       insertMatch: (editor, data) => {
         if (data.meta === 'table') {


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
We have a lot of table names with numbers in them, which then results in really bad autocompletes with phrases like `GROUP BY 1` or `LIMIT 1000` autocompleting to `GROUP BY long_table_name_v01` or `LIMIT bigger_table_10_plus_100` (for example). This PR disables autocomplete when you start a word with a number, so prefixes like `2019` and `10foo` won't autocomplete, but `superset_v01` and `foo29` will.

### TEST PLAN
Test the above examples and ensure the behavior is correct, `npm run lint`, and CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @graceguo-supercat @john-bodley @mistercrunch @betodealmeida 