### PR TITLE
[perf_logging] Add is_cached status when chart has error

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -259,11 +259,12 @@ export function exploreJSON(
         return dispatch(chartUpdateSucceeded(json, key));
       })
       .catch(response => {
-        const appendErrorLog = errorDetails => {
+        const appendErrorLog = (errorDetails, isCached) => {
           dispatch(
             logEvent(LOG_ACTIONS_LOAD_CHART, {
               slice_id: key,
               has_err: true,
+              is_cached: isCached,
               error_details: errorDetails,
               datasource: formData.datasource,
               start_offset: logStart,
@@ -283,7 +284,8 @@ export function exploreJSON(
           return dispatch(chartUpdateStopped(key));
         }
         return getClientErrorObject(response).then(parsedResponse => {
-          appendErrorLog(parsedResponse.error);
+          // query is processed, but error out.
+          appendErrorLog(parsedResponse.error, parsedResponse.is_cached);
           return dispatch(chartUpdateFailed(parsedResponse, key));
         });
       });


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
when user loads a dashboard, if query returns 0 row, we will show `no data` and response 400. Superset front-end treat it as error. But the result will still be cached.
In front-end logging, we don't log is_cached status when chart has error. this may cause our cache rate not accurate. This PR is trying to fix this case (chart has error, and may also has is_cached status).

### TEST PLAN
manual test


### REVIEWERS
@etr2460 