### PR TITLE
set SUPERSET_WEBSERVER timeout for urllib opener

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -258,7 +258,7 @@ def _get_slice_data(schedule):
 
     opener = urllib.request.build_opener()
     opener.addheaders.append(("Cookie", f"session={cookies['session']}"))
-    response = opener.open(slice_url)
+    response = opener.open(slice_url, timeout=config["SUPERSET_WEBSERVER_TIMEOUT"])
     if response.getcode() != 200:
         raise URLError(response.getcode())
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In the scheduler, there is an urllib opener exists that get data and email it from the superset URL. so the timeout of this opener should be set SUPERSET_WEBSERVER
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
