### PR TITLE
[dashboard] fix, enable info endpoint

### DIFF
--- a/superset/constants.py
+++ b/superset/constants.py
@@ -59,4 +59,4 @@ class RouteMethod:  # pylint: disable=too-few-public-methods
     # Commonly used sets
     CRUD_SET = {ADD, LIST, EDIT, DELETE, ACTION_POST}
     RELATED_VIEW_SET = {ADD, LIST, EDIT, DELETE}
-    REST_MODEL_VIEW_CRUD_SET = {DELETE, GET, GET_LIST, POST, PUT}
+    REST_MODEL_VIEW_CRUD_SET = {DELETE, GET, GET_LIST, POST, PUT, INFO}

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -46,6 +46,7 @@ class RouteMethod:  # pylint: disable=too-few-public-methods
     EDIT = "edit"
     LIST = "list"
     SHOW = "show"
+    INFO = "info"
 
     # RestModelView specific
     EXPORT = "export"

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -134,6 +134,7 @@ class DashboardRestApi(DashboardMixin, BaseOwnedModelRestApi):
     include_route_methods = RouteMethod.REST_MODEL_VIEW_CRUD_SET | {
         RouteMethod.EXPORT,
         RouteMethod.RELATED,
+        RouteMethod.INFO,
         "bulk_delete",  # not using RouteMethod since locally defined
     }
     resource_name = "dashboard"

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -134,7 +134,6 @@ class DashboardRestApi(DashboardMixin, BaseOwnedModelRestApi):
     include_route_methods = RouteMethod.REST_MODEL_VIEW_CRUD_SET | {
         RouteMethod.EXPORT,
         RouteMethod.RELATED,
-        RouteMethod.INFO,
         "bulk_delete",  # not using RouteMethod since locally defined
     }
     resource_name = "dashboard"


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The new dashboard list view https://github.com/apache/incubator-superset/pull/8845 depends on the info endpoint to generate filters and check delete/export permissions. It seems it was disabled in the recent work to remove unused routes. This PR re-enabled that endpoint for the rest apis.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- Dashboard List view works. 
- `_info` endpoint does not error out on loading the dashboard list view. 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@dpgaspar @mistercrunch 