### PR TITLE
[Caching] Ensure cache is always created

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -35,6 +35,7 @@ from dateutil import tz
 from flask_appbuilder.security.manager import AUTH_DB
 
 from superset.stats_logger import DummyStatsLogger
+from superset.typing import CacheConfig
 from superset.utils.log import DBEventLogger
 from superset.utils.logging_configurator import DefaultLoggingConfigurator
 
@@ -311,8 +312,8 @@ IMG_UPLOAD_URL = "/static/uploads/"
 # IMG_SIZE = (300, 200, True)
 
 CACHE_DEFAULT_TIMEOUT = 60 * 60 * 24
-CACHE_CONFIG: Dict[str, Any] = {"CACHE_TYPE": "null"}
-TABLE_NAMES_CACHE_CONFIG = {"CACHE_TYPE": "null"}
+CACHE_CONFIG: CacheConfig = {"CACHE_TYPE": "null"}
+TABLE_NAMES_CACHE_CONFIG: CacheConfig = {"CACHE_TYPE": "null"}
 
 # CORS Options
 ENABLE_CORS = False
@@ -570,10 +571,6 @@ SMTP_USER = "superset"
 SMTP_PORT = 25
 SMTP_PASSWORD = "superset"
 SMTP_MAIL_FROM = "superset@superset.com"
-
-if not CACHE_DEFAULT_TIMEOUT:
-    CACHE_DEFAULT_TIMEOUT = CACHE_CONFIG["CACHE_DEFAULT_TIMEOUT"]
-
 
 ENABLE_CHUNK_ENCODING = False
 

--- a/superset/typing.py
+++ b/superset/typing.py
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any, Callable, Dict, Union
+
+from flask import Flask
+from flask_caching import Cache
+
+CacheConfig = Union[Callable[[Flask], Cache], Dict[str, Any]]

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -14,10 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Callable, Dict, Optional, Union
-
 from flask import Flask
 from flask_caching import Cache
+
+from superset.typing import CacheConfig
 
 
 class CacheManager:
@@ -27,27 +27,26 @@ class CacheManager:
         self._tables_cache = None
         self._cache = None
 
-    def init_app(self, app: Flask):
+    def init_app(self, app: Flask) -> None:
         self._cache = self._setup_cache(app, app.config["CACHE_CONFIG"])
         self._tables_cache = self._setup_cache(
             app, app.config["TABLE_NAMES_CACHE_CONFIG"]
         )
 
     @staticmethod
-    def _setup_cache(app: Flask, cache_config: Union[Callable[[Flask], Cache], Dict[str, Any]]) -> Cache:
+    def _setup_cache(app: Flask, cache_config: CacheConfig) -> Cache:
         """Setup the flask-cache on a flask app"""
         if isinstance(cache_config, dict):
             return Cache(app, config=cache_config)
-        else:
-            # Accepts a custom cache initialization function,
-            # returning an object compatible with Flask-Caching API
-            return cache_config(app)
 
+        # Accepts a custom cache initialization function, returning an object compatible
+        # with Flask-Caching API.
+        return cache_config(app)
 
     @property
-    def tables_cache(self):
+    def tables_cache(self) -> Cache:
         return self._tables_cache
 
     @property
-    def cache(self):
+    def cache(self) -> Cache:
         return self._cache

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -38,8 +38,7 @@ class CacheManager:
         """Setup the flask-cache on a flask app"""
         if cache_config:
             if isinstance(cache_config, dict):
-                if cache_config.get("CACHE_TYPE") != "null":
-                    return Cache(app, config=cache_config)
+                return Cache(app, config=cache_config)
             else:
                 # Accepts a custom cache initialization function,
                 # returning an object compatible with Flask-Caching API

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 from flask import Flask
 from flask_caching import Cache
@@ -27,24 +27,22 @@ class CacheManager:
         self._tables_cache = None
         self._cache = None
 
-    def init_app(self, app):
-        self._cache = self._setup_cache(app, app.config.get("CACHE_CONFIG"))
+    def init_app(self, app: Flask):
+        self._cache = self._setup_cache(app, app.config["CACHE_CONFIG"])
         self._tables_cache = self._setup_cache(
-            app, app.config.get("TABLE_NAMES_CACHE_CONFIG")
+            app, app.config["TABLE_NAMES_CACHE_CONFIG"]
         )
 
     @staticmethod
-    def _setup_cache(app: Flask, cache_config) -> Optional[Cache]:
+    def _setup_cache(app: Flask, cache_config: Union[Callable[[Flask], Cache], Dict[str, Any]]) -> Cache:
         """Setup the flask-cache on a flask app"""
-        if cache_config:
-            if isinstance(cache_config, dict):
-                return Cache(app, config=cache_config)
-            else:
-                # Accepts a custom cache initialization function,
-                # returning an object compatible with Flask-Caching API
-                return cache_config(app)
+        if isinstance(cache_config, dict):
+            return Cache(app, config=cache_config)
+        else:
+            # Accepts a custom cache initialization function,
+            # returning an object compatible with Flask-Caching API
+            return cache_config(app)
 
-        return None
 
     @property
     def tables_cache(self):

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -822,15 +822,10 @@ class UtilsTestCase(SupersetTestCase):
         self.assertIsNone(parse_js_uri_path_item(None))
         self.assertIsNotNone(parse_js_uri_path_item("item"))
 
-    def test_setup_cache_no_config(self):
-        app = Flask(__name__)
-        cache_config = None
-        self.assertIsNone(CacheManager._setup_cache(app, cache_config))
-
     def test_setup_cache_null_config(self):
         app = Flask(__name__)
         cache_config = {"CACHE_TYPE": "null"}
-        self.assertIsNone(CacheManager._setup_cache(app, cache_config))
+        assert isinstance(CacheManager._setup_cache(app, cache_config), Cache)
 
     def test_setup_cache_standard_config(self):
         app = Flask(__name__)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Flask-Caching supports passing in `"null"` as the cache type, which resolves to no caching at all (https://flask-caching.readthedocs.io/en/latest/#nullcache). This is preferred to setting the cache to `None` so that we can assume a cache is always initialized and calls to `cache.memoize()` will never fail.

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @john-bodley @craig-rueda @villebro @mistercrunch 