### PR TITLE
Propose cache type simple

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -311,7 +311,7 @@ IMG_UPLOAD_URL = "/static/uploads/"
 # IMG_SIZE = (300, 200, True)
 
 CACHE_DEFAULT_TIMEOUT = 60 * 60 * 24
-CACHE_CONFIG: Dict[str, Any] = {"CACHE_TYPE": "null"}
+CACHE_CONFIG: Dict[str, Any] = {"CACHE_TYPE": "simple"}
 TABLE_NAMES_CACHE_CONFIG = {"CACHE_TYPE": "null"}
 
 # CORS Options


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Seems like #9019 makes startup fail on a default configuration. Tests pass because they set cache to simple. We can revert/fix #9019 or change cache default to simple (assuming it's limitations): https://flask-caching.readthedocs.io/en/latest/#simplecache

Startup error:
```
class PrestoEngineSpec(BaseEngineSpec):
  File "/home/dpgaspar/workarea/preset/preset_fork_superset/superset/db_engine_specs/presto.py", line 950, in PrestoEngineSpec
    @cache.memoize()
  File "/home/dpgaspar/workarea/preset/v_superset/lib/python3.6/site-packages/werkzeug/local.py", line 348, in __getattr__
    return getattr(self._get_current_object(), name)
AttributeError: 'NoneType' object has no attribute 'memoize'
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
