### PR TITLE
[dashboard] fix, add config to optionally enable react replacement fo…

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -699,6 +699,10 @@ DOCUMENTATION_URL = None
 DOCUMENTATION_TEXT = "Documentation"
 DOCUMENTATION_ICON = None  # Recommended size: 16x16
 
+# Enables the replacement react views for all the FAB views: list, edit, show.
+# This is a work in progress so not all features available in FAB have been implemented
+ENABLE_REACT_CRUD_VIEWS = False
+
 # What is the Last N days relative in the time selector to:
 # 'today' means it is midnight (00:00:00) in the local timezone
 # 'now' means it is relative to the query issue time

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -25,7 +25,7 @@ from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __, lazy_gettext as _
 
 import superset.models.core as models
-from superset import db, event_logger
+from superset import app, db, event_logger
 from superset.constants import RouteMethod
 from superset.utils import core as utils
 
@@ -39,6 +39,8 @@ from ..base import (
 )
 from ..utils import bootstrap_user_data
 from .mixin import DashboardMixin
+
+config = app.config
 
 
 class DashboardModelView(
@@ -57,6 +59,8 @@ class DashboardModelView(
     @has_access
     @expose("/list/")
     def list(self):
+        if not config["ENABLE_REACT_CRUD_VIEWS"]:
+            return super().list()
         payload = {
             "user": bootstrap_user_data(g.user),
             "common": common_bootstrap_payload(),

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -40,8 +40,6 @@ from ..base import (
 from ..utils import bootstrap_user_data
 from .mixin import DashboardMixin
 
-config = app.config
-
 
 class DashboardModelView(
     DashboardMixin, SupersetModelView, DeleteMixin
@@ -59,7 +57,7 @@ class DashboardModelView(
     @has_access
     @expose("/list/")
     def list(self):
-        if not config["ENABLE_REACT_CRUD_VIEWS"]:
+        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
             return super().list()
         payload = {
             "user": bootstrap_user_data(g.user),


### PR DESCRIPTION
…r CRUD views

### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As the recent work to replace the FAB CRUD views does not support all the features provided by FAB (mainly, the various filters), a config option is necessary. This config allows for the server rendered CRUD view replacement work to proceed in master without a user facing loss of functionality. Users can also optionally enable the new react views.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- toggling ENABLE_REACT_CRUD_VIEWS on renders the new react list view.
- toggling ENABLE_REACT_CRUD_VIEWS off renders the old FAB CRUD list view.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 @dpgaspar @mistercrunch 