### PR TITLE
[fix] Reverting metic logic from #8901

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -81,7 +81,14 @@ class QueryObject:
         self.time_shift = utils.parse_human_timedelta(time_shift)
         self.groupby = groupby or []
 
-        self.metrics = [utils.get_metric_name(metric) for metric in metrics]
+        # Temporal solution for backward compatability issue due the new format of
+        # non-ad-hoc metric which needs to adhere to superset-ui per
+        # https://git.io/Jvm7P.
+        self.metrics = [
+            metric if "expressionType" in metric else metric["label"]  # type: ignore
+            for metric in metrics
+        ]
+
         self.row_limit = row_limit
         self.filter = filters or []
         self.timeseries_limit = timeseries_limit

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -109,7 +109,7 @@ class CoreTests(SupersetTestCase):
                 {
                     "granularity": "ds",
                     "groupby": ["name"],
-                    "metrics": ["sum__num"],
+                    "metrics": [{"label": "sum__num"}],
                     "filters": [],
                     "row_limit": 100,
                 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR reverts the metric cleanup logic defined in https://github.com/apache/incubator-superset/pull/8901 as the superset-ui currently defines the metrics in the form `{"label": <name>}` per [here](https://github.com/apache-superset/superset-ui/blob/master/packages/superset-ui-query/src/convertMetric.ts#L20). 

Given that the superset-ui build is currently broken (though is actively being worked on) it seems like reverting the so-called temporary logic probably makes the most sense for now.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @villebro 
cc: @williaster 
