### PR TITLE
feat: Add schema to function retrieval and implement for Snowflake

### DIFF
--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -27,7 +27,6 @@ import os
 
 from werkzeug.contrib.cache import FileSystemCache
 
-
 logger = logging.getLogger()
 
 
@@ -65,7 +64,7 @@ SQLALCHEMY_DATABASE_URI = "%s://%s:%s@%s:%s/%s" % (
 REDIS_HOST = get_env_variable("REDIS_HOST")
 REDIS_PORT = get_env_variable("REDIS_PORT")
 
-RESULTS_BACKEND = FileSystemCache('/app/superset_home/sqllab')
+RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
 
 
 class CeleryConfig(object):

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -786,7 +786,12 @@ export function queryEditorSetSchemaOptions(queryEditor, options) {
 }
 
 export function queryEditorSetTableOptions(queryEditor, options, functions) {
-  return { type: QUERY_EDITOR_SET_TABLE_OPTIONS, queryEditor, options, functions };
+  return {
+    type: QUERY_EDITOR_SET_TABLE_OPTIONS,
+    queryEditor,
+    options,
+    functions,
+  };
 }
 
 export function queryEditorSetAutorun(queryEditor, autorun) {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -50,7 +50,8 @@ export const QUERY_EDITOR_SETDB = 'QUERY_EDITOR_SETDB';
 export const QUERY_EDITOR_SET_SCHEMA = 'QUERY_EDITOR_SET_SCHEMA';
 export const QUERY_EDITOR_SET_SCHEMA_OPTIONS =
   'QUERY_EDITOR_SET_SCHEMA_OPTIONS';
-export const QUERY_EDITOR_SET_TABLE_OPTIONS = 'QUERY_EDITOR_SET_TABLE_OPTIONS';
+export const QUERY_EDITOR_SET_SCHEMA_OBJECT_OPTIONS =
+  'QUERY_EDITOR_SET_SCHEMA_OBJECT_OPTIONS';
 export const QUERY_EDITOR_SET_TITLE = 'QUERY_EDITOR_SET_TITLE';
 export const QUERY_EDITOR_SET_AUTORUN = 'QUERY_EDITOR_SET_AUTORUN';
 export const QUERY_EDITOR_SET_SQL = 'QUERY_EDITOR_SET_SQL';
@@ -785,12 +786,16 @@ export function queryEditorSetSchemaOptions(queryEditor, options) {
   return { type: QUERY_EDITOR_SET_SCHEMA_OPTIONS, queryEditor, options };
 }
 
-export function queryEditorSetTableOptions(queryEditor, options, functions) {
+export function queryEditorSetTableOptions(
+  queryEditor,
+  tableOptions,
+  functionOptions,
+) {
   return {
-    type: QUERY_EDITOR_SET_TABLE_OPTIONS,
+    type: QUERY_EDITOR_SET_SCHEMA_OBJECT_OPTIONS,
     queryEditor,
-    options,
-    functions,
+    tableOptions,
+    functionOptions,
   };
 }
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -785,8 +785,8 @@ export function queryEditorSetSchemaOptions(queryEditor, options) {
   return { type: QUERY_EDITOR_SET_SCHEMA_OPTIONS, queryEditor, options };
 }
 
-export function queryEditorSetTableOptions(queryEditor, options) {
-  return { type: QUERY_EDITOR_SET_TABLE_OPTIONS, queryEditor, options };
+export function queryEditorSetTableOptions(queryEditor, options, functions) {
+  return { type: QUERY_EDITOR_SET_TABLE_OPTIONS, queryEditor, options, functions };
 }
 
 export function queryEditorSetAutorun(queryEditor, autorun) {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -786,7 +786,7 @@ export function queryEditorSetSchemaOptions(queryEditor, options) {
   return { type: QUERY_EDITOR_SET_SCHEMA_OPTIONS, queryEditor, options };
 }
 
-export function queryEditorSetTableOptions(
+export function queryEditorSetSchemaObjectOptions(
   queryEditor,
   tableOptions,
   functionOptions,

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -343,9 +343,7 @@ class SqlEditor extends React.PureComponent {
             sql={this.props.queryEditor.sql}
             schemas={this.props.queryEditor.schemaOptions}
             tables={this.props.queryEditor.tableOptions}
-            functionNames={
-              this.props.database ? this.props.database.function_names : []
-            }
+            functionNames={this.props.queryEditor.functionOptions}
             extendedTables={this.props.tables}
             height={`${aceEditorHeight}px`}
             hotkeys={hotkeys}

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -59,10 +59,11 @@ export default class SqlEditorLeftBar extends React.PureComponent {
       schemas,
     );
   }
-  onTablesLoad(tables) {
+  onTablesLoad(tables, functions) {
     this.props.actions.queryEditorSetTableOptions(
       this.props.queryEditor,
       tables,
+      functions,
     );
   }
   onDbChange(db) {

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -60,7 +60,7 @@ export default class SqlEditorLeftBar extends React.PureComponent {
     );
   }
   onTablesLoad(tables, functions) {
-    this.props.actions.queryEditorSetTableOptions(
+    this.props.actions.queryEditorSetSchemaObjectOptions(
       this.props.queryEditor,
       tables,
       functions,

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -450,6 +450,7 @@ export default function sqlLabReducer(state = {}, action) {
     [actions.QUERY_EDITOR_SET_TABLE_OPTIONS]() {
       return alterInArr(state, 'queryEditors', action.queryEditor, {
         tableOptions: action.options,
+        functionOptions: action.functions,
       });
     },
     [actions.QUERY_EDITOR_SET_TITLE]() {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -447,7 +447,7 @@ export default function sqlLabReducer(state = {}, action) {
         schemaOptions: action.options,
       });
     },
-    [actions.QUERY_EDITOR_SET_TABLE_OPTIONS]() {
+    [actions.QUERY_EDITOR_SET_SCHEMA_OBJECT_OPTIONS]() {
       return alterInArr(state, 'queryEditors', action.queryEditor, {
         tableOptions: action.options,
         functionOptions: action.functions,

--- a/superset-frontend/src/components/TableSelector.jsx
+++ b/superset-frontend/src/components/TableSelector.jsx
@@ -88,12 +88,15 @@ export default class TableSelector extends React.PureComponent {
     this.props.onSchemaChange(null);
     this.props.onDbChange(db);
     this.fetchSchemas(dbId, force);
-    this.setState({
-      dbId,
-      schema: null,
-      tableOptions: [],
-      functionOptions: [],
-    }, this.onChange);
+    this.setState(
+      {
+        dbId,
+        schema: null,
+        tableOptions: [],
+        functionOptions: [],
+      },
+      this.onChange,
+    );
   }
   onChange() {
     this.props.onChange({

--- a/superset-frontend/src/components/TableSelector.jsx
+++ b/superset-frontend/src/components/TableSelector.jsx
@@ -66,6 +66,7 @@ export default class TableSelector extends React.PureComponent {
       schemaOptions: [],
       tableLoading: false,
       tableOptions: [],
+      functionOptions: [],
       dbId: props.dbId,
       schema: props.schema,
       tableName: props.tableName,
@@ -87,7 +88,12 @@ export default class TableSelector extends React.PureComponent {
     this.props.onSchemaChange(null);
     this.props.onDbChange(db);
     this.fetchSchemas(dbId, force);
-    this.setState({ dbId, schema: null, tableOptions: [] }, this.onChange);
+    this.setState({
+      dbId,
+      schema: null,
+      tableOptions: [],
+      functionOptions: [],
+    }, this.onChange);
   }
   onChange() {
     this.props.onChange({
@@ -136,7 +142,11 @@ export default class TableSelector extends React.PureComponent {
     const forceRefresh = force || false;
     const { dbId, schema } = this.state;
     if (dbId && schema) {
-      this.setState(() => ({ tableLoading: true, tableOptions: [] }));
+      this.setState(() => ({
+        tableLoading: true,
+        tableOptions: [],
+        functionOptions: [],
+      }));
       const endpoint = encodeURI(
         `/superset/tables/${dbId}/` +
           `${encodeURIComponent(schema)}/${encodeURIComponent(
@@ -155,11 +165,16 @@ export default class TableSelector extends React.PureComponent {
           this.setState(() => ({
             tableLoading: false,
             tableOptions: options,
+            functionOptions: json.functions,
           }));
-          this.props.onTablesLoad(json.options);
+          this.props.onTablesLoad(json.options, json.functions);
         })
         .catch(() => {
-          this.setState(() => ({ tableLoading: false, tableOptions: [] }));
+          this.setState(() => ({
+            tableLoading: false,
+            tableOptions: [],
+            functionOptions: [],
+          }));
           this.props.handleError(t('Error while fetching table list'));
         });
     }

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -123,7 +123,7 @@ class QueryContext:
 
     @staticmethod
     def get_data(  # pylint: disable=invalid-name,no-self-use
-        df: pd.DataFrame
+        df: pd.DataFrame,
     ) -> List[Dict]:
         return df.to_dict(orient="records")
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -844,12 +844,15 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return sqla_column_type.compile(dialect=dialect).upper()
 
     @classmethod
-    def get_function_names(cls, database: "Database") -> List[str]:
+    def get_function_names(
+        cls, database: "Database", schema: Optional[str]
+    ) -> List[str]:
         """
         Get a list of function names that are able to be called on the database.
         Used for SQL Lab autocomplete.
 
         :param database: The database to get functions for
+        :param schema: The schema to get functions for
         :return: A list of function names useable in the database
         """
         return []

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -429,12 +429,15 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     @classmethod
     @cache.memoize()
-    def get_function_names(cls, database: "Database") -> List[str]:
+    def get_function_names(
+        cls, database: "Database", schema: Optional[str]
+    ) -> List[str]:
         """
         Get a list of function names that are able to be called on the database.
         Used for SQL Lab autocomplete.
 
         :param database: The database to get functions for
+        :param schema: The schema to get functions for (N/A for Hive)
         :return: A list of function names useable in the database
         """
         return database.get_df("SHOW FUNCTIONS")["tab_name"].tolist()

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -429,6 +429,17 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     @classmethod
     @cache.memoize()
+    def _get_function_names(cls, database: "Database") -> List[str]:
+        """
+        Get a list of function names that are able to be called on the database.
+        Execution in separate function without schema to avoid caching per schema.
+
+        :param database: The database to get functions for
+        :return: A list of function names useable in the database
+        """
+        return database.get_df("SHOW FUNCTIONS")["tab_name"].tolist()
+
+    @classmethod
     def get_function_names(
         cls, database: "Database", schema: Optional[str]
     ) -> List[str]:
@@ -440,4 +451,4 @@ class HiveEngineSpec(PrestoEngineSpec):
         :param schema: The schema to get functions for (N/A for Hive)
         :return: A list of function names useable in the database
         """
-        return database.get_df("SHOW FUNCTIONS")["tab_name"].tolist()
+        return cls._get_function_names(database)

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -949,12 +949,15 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     @cache.memoize()
-    def get_function_names(cls, database: "Database") -> List[str]:
+    def get_function_names(
+        cls, database: "Database", schema: Optional[str]
+    ) -> List[str]:
         """
         Get a list of function names that are able to be called on the database.
         Used for SQL Lab autocomplete.
 
         :param database: The database to get functions for
+        :param schema: The schema to get functions for (N/A for Presto)
         :return: A list of function names useable in the database
         """
         return database.get_df("SHOW FUNCTIONS")["Function"].tolist()

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -949,6 +949,17 @@ class PrestoEngineSpec(BaseEngineSpec):
 
     @classmethod
     @cache.memoize()
+    def _get_function_names(cls, database: "Database") -> List[str]:
+        """
+        Get a list of function names that are able to be called on the database.
+        Execution in separate function without schema to avoid caching per schema.
+
+        :param database: The database to get functions for
+        :return: A list of function names useable in the database
+        """
+        return database.get_df("SHOW FUNCTIONS")["Function"].tolist()
+
+    @classmethod
     def get_function_names(
         cls, database: "Database", schema: Optional[str]
     ) -> List[str]:
@@ -960,4 +971,4 @@ class PrestoEngineSpec(BaseEngineSpec):
         :param schema: The schema to get functions for (N/A for Presto)
         :return: A list of function names useable in the database
         """
-        return database.get_df("SHOW FUNCTIONS")["Function"].tolist()
+        return cls._get_function_names(database)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -162,9 +162,8 @@ class Database(
     def allows_subquery(self) -> bool:
         return self.db_engine_spec.allows_subqueries
 
-    @property
-    def function_names(self) -> List[str]:
-        return self.db_engine_spec.get_function_names(self)
+    def get_function_names(self, schema: Optional[str]) -> List[str]:
+        return self.db_engine_spec.get_function_names(self, schema)
 
     @property
     def allows_cost_estimate(self) -> bool:

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -24,6 +24,15 @@ def view_cache_key(*_, **__) -> str:
     return "view/{}/{}".format(request.path, args_hash)
 
 
+def function_cache_key(*args) -> str:
+    """Function that returns a cache key for the `get_function_names` method in
+    db_engine_specs. Assumes that the first argument is a database instance and
+    the second optional argument is the schema name.
+    """
+    schema = args[1] if len(args) == 2 else None
+    return f"db:{args[0].id}:schema:{schema}:functions"
+
+
 def memoized_func(key=view_cache_key, attribute_in_key=None):
     """Use this decorator to cache functions that have predefined first arg.
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1104,6 +1104,8 @@ class Superset(BaseSupersetView):
             views = database.get_all_view_names_in_database(
                 cache=True, force=False, cache_timeout=24 * 60 * 60
             )
+
+        functions = database.get_function_names(schema)
         tables = security_manager.get_datasources_accessible_by_user(
             database, tables, schema
         )
@@ -1156,7 +1158,11 @@ class Superset(BaseSupersetView):
             ]
         )
         table_options.sort(key=lambda value: value["label"])
-        payload = {"tableLength": len(tables) + len(views), "options": table_options}
+        payload = {
+            "tableLength": len(tables) + len(views),
+            "options": table_options,
+            "functions": functions,
+        }
         return json_success(json.dumps(payload))
 
     @api

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -131,7 +131,6 @@ class DatabaseRestApi(DatabaseMixin, BaseSupersetModelRestApi):
         "allows_subquery",
         "allows_cost_estimate",
         "backend",
-        "function_names",
     ]
     show_columns = list_columns
 

--- a/tests/database_api_tests.py
+++ b/tests/database_api_tests.py
@@ -50,7 +50,6 @@ class DatabaseApiTests(SupersetTestCase):
             "database_name",
             "expose_in_sqllab",
             "force_ctas_schema",
-            "function_names",
             "id",
         ]
         self.assertEqual(response["count"], 2)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Some databases, like Snowflake, support defining UDFs per schema. This PR adds the possibility to retrieve both global functions and schema-specific UDFs, and implements said functionality for Snowflake. Achieving this required moving the function retrieval logic from the database API to the table API, and making small modifications in the frontend code.

### SCREENSHOTS
In the first picture we are browsing a schema where the UDF `SFWHO` is available: 
<img width="697" alt="Screenshot 2020-01-28 at 17 51 54" src="https://user-images.githubusercontent.com/33317356/73281746-1567ae80-41f9-11ea-9d0c-07a7d7135d12.png">

When browsing a schema without UDFs, only the global functions show up:
<img width="698" alt="Screenshot 2020-01-28 at 17 51 16" src="https://user-images.githubusercontent.com/33317356/73281661-fc5efd80-41f8-11ea-80a7-13a342060e7c.png">

### TEST PLAN
Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
