### PR TITLE
[routes] Re-adding FAB API routes for SqlMetricInlineView and TableModelView

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -167,7 +167,7 @@ class TableColumnInlineView(CompactCRUDMixin, SupersetModelView):
 
 class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):
     datamodel = SQLAInterface(models.SqlMetric)
-    include_route_methods = RouteMethod.RELATED_VIEW_SET
+    include_route_methods = RouteMethod.RELATED_VIEW_SET | RouteMethod.API_SET
 
     list_title = _("Metrics")
     show_title = _("Show Metric")
@@ -227,7 +227,7 @@ class SqlMetricInlineView(CompactCRUDMixin, SupersetModelView):
 
 class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):
     datamodel = SQLAInterface(models.SqlaTable)
-    include_route_methods = RouteMethod.CRUD_SET
+    include_route_methods = RouteMethod.CRUD_SET | RouteMethod.API_SET
 
     list_title = _("Tables")
     show_title = _("Show Table")

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -57,6 +57,7 @@ class RouteMethod:  # pylint: disable=too-few-public-methods
     RELATED = "related"
 
     # Commonly used sets
+    API_SET = {API_CREATE, API_DELETE, API_GET, API_READ, API_UPDATE}
     CRUD_SET = {ADD, LIST, EDIT, DELETE, ACTION_POST}
     RELATED_VIEW_SET = {ADD, LIST, EDIT, DELETE}
     REST_MODEL_VIEW_CRUD_SET = {DELETE, GET, GET_LIST, POST, PUT, INFO}


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR re-adds the FAB API endpoints to the `SqlMetricInlineView` and `TableModelView` view classes as currently Airbnb is using these to sync metadata. Note these were removed in https://github.com/apache/incubator-superset/pull/8960.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Tested locally and confirmed that the API endpoints were accessible. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @michellethomas @mistercrunch 