### PR TITLE
Remove redirect endpoint /superset/explorev2

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -759,20 +759,6 @@ class Superset(BaseSupersetView):
 
     @event_logger.log_this
     @has_access
-    @expose("/explorev2/<datasource_type>/<datasource_id>/")
-    def explorev2(self, datasource_type, datasource_id):
-        """Deprecated endpoint, here for backward compatibility of urls"""
-        return redirect(
-            url_for(
-                "Superset.explore",
-                datasource_type=datasource_type,
-                datasource_id=datasource_id,
-                **request.args,
-            )
-        )
-
-    @event_logger.log_this
-    @has_access
     @expose("/explore/<datasource_type>/<datasource_id>/", methods=["GET", "POST"])
     @expose("/explore/", methods=["GET", "POST"])
     def explore(self, datasource_type=None, datasource_id=None):


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The /superset/explorev2 redirect endpoint has been present for quite some time as a backwards-compatibility fix. It is unlikely that this endpoint is still in use.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [X] Removes existing feature or API

### REVIEWERS
@craig-rueda @mistercrunch 