### PR TITLE
[sqllab] Showing schema length only when schema selected

### DIFF
--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -370,10 +370,11 @@ export default class TableSelector extends React.PureComponent {
       <div className="section">
         <ControlLabel>
           {t('See table schema')}{' '}
-          <small>
-            ({this.state.tableOptions.length} {t('in')}{' '}
-            <i>{this.props.schema}</i>)
-          </small>
+          {this.props.schema && (
+            <small>
+              ({this.state.tableOptions.length} in <i>{this.props.schema}</i>)
+            </small>
+          )}
         </ControlLabel>
       </div>
     );


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

In SQL Lab if you haven't selected a schema you see a message `See table schema (0 in )` which seems a tad crude. This PR only shows the `(...)` if a schema is selected.  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE 

![Screen Shot 2020-01-28 at 6 22 16 PM](https://user-images.githubusercontent.com/4567245/73323253-b0618800-41fb-11ea-84d6-a6dcab511c68.png)

#### AFTER 

![Screen Shot 2020-01-28 at 6 24 59 PM](https://user-images.githubusercontent.com/4567245/73323240-a50e5c80-41fb-11ea-9fe2-5d9b5a8c4a4b.png)
![Screen Shot 2020-01-28 at 6 25 07 PM](https://user-images.githubusercontent.com/4567245/73323241-a5a6f300-41fb-11ea-8cf0-0489604a88a9.png)


### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @williaster 