### PR TITLE
Add support for Cockroach DB

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,6 +109,7 @@ The following RDBMS are currently supported:
 - `Apache Spark SQL <https://spark.apache.org/sql/>`_
 - `BigQuery <https://cloud.google.com/bigquery/>`_
 - `ClickHouse <https://clickhouse.yandex/>`_
+- `CockroachDB <https://www.cockroachlabs.com/>`_
 - `Dremio <https://dremio.com/>`_
 - `Elasticsearch <https://www.elastic.co/products/elasticsearch/>`_
 - `Exasol <https://www.exasol.com/>`_

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -372,6 +372,8 @@ Here's a list of some of the recommended packages.
 +------------------+---------------------------------------+-------------------------------------------------+
 | ClickHouse       | ``pip install sqlalchemy-clickhouse`` |                                                 |
 +------------------+---------------------------------------+-------------------------------------------------+
+| CockroachDB      | ``pip install cockroachdb``           | ``cockroachdb://``                              |
++------------------+---------------------------------------+-------------------------------------------------+
 | Dremio           | ``pip install sqlalchemy_dremio``     | ``dremio://user:pwd@host:31010/``               |
 +------------------+---------------------------------------+-------------------------------------------------+
 | Elasticsearch    | ``pip install elasticsearch-dbapi``   | ``elasticsearch+http://``                       |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,6 @@
 #
 black==19.3b0
 coverage==4.5.3
-cockroachdb==0.3.3
 flask-cors==3.0.7
 flask-testing==0.7.1
 ipdb==0.12

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,7 @@
 #
 black==19.3b0
 coverage==4.5.3
+cockroachdb==0.3.3
 flask-cors==3.0.7
 flask-testing==0.7.1
 ipdb==0.12

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(
         "druid": ["pydruid==0.5.7", "requests==2.22.0"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "dremio": ["sqlalchemy_dremio>=0.5.0dev0"],
+        "cockroachdb": ["cockroachdb==0.3.3"],
     },
     python_requires="~=3.6",
     author="Apache Software Foundation",

--- a/superset/db_engine_specs/cockroachdb.py
+++ b/superset/db_engine_specs/cockroachdb.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import datetime
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+from pytz import _FixedOffset  # type: ignore
+from sqlalchemy.dialects.postgresql.base import PGInspector
+
+from superset.db_engine_specs.base import LimitMethod
+from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+if TYPE_CHECKING:
+    # prevent circular imports
+    from superset.models.core import Database  # pylint: disable=unused-import
+
+class CockroachDbEngineSpec(PostgresEngineSpec):
+    engine = "cockroachdb"
+

--- a/superset/db_engine_specs/cockroachdb.py
+++ b/superset/db_engine_specs/cockroachdb.py
@@ -14,18 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime
-from typing import List, Optional, Tuple, TYPE_CHECKING
-
-from pytz import _FixedOffset  # type: ignore
-from sqlalchemy.dialects.postgresql.base import PGInspector
-
-from superset.db_engine_specs.base import LimitMethod
 from superset.db_engine_specs.postgres import PostgresEngineSpec
-
-if TYPE_CHECKING:
-    # prevent circular imports
-    from superset.models.core import Database  # pylint: disable=unused-import
 
 class CockroachDbEngineSpec(PostgresEngineSpec):
     engine = "cockroachdb"

--- a/superset/db_engine_specs/cockroachdb.py
+++ b/superset/db_engine_specs/cockroachdb.py
@@ -16,6 +16,6 @@
 # under the License.
 from superset.db_engine_specs.postgres import PostgresEngineSpec
 
+
 class CockroachDbEngineSpec(PostgresEngineSpec):
     engine = "cockroachdb"
-


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Adds support for Cockroach DB.

I could not test the change becaues the container always fails with
```
superset_1         | standard_init_linux.go:211: exec user process caused "no such file or directory"
```
but this seems unrelated to my change.

So far I could use Cockroach DB in superset even without explicit support, only the time grain options were missing. 

I verified that the time grain options declared by PostgresEngineSpec work with Cockroach DB.

### TEST PLAN
Add a Cockroach DB datasource, add tables and test charts.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #9032
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
