### PR TITLE
[table] [columns] remove generic checkbox API

### DIFF
--- a/superset/templates/superset/fab_overrides/list_with_checkboxes.html
+++ b/superset/templates/superset/fab_overrides/list_with_checkboxes.html
@@ -82,7 +82,7 @@
                           {{'checked' if item[value] }}
                           name="{{ '{}__{}'.format(pk, value) }}"
                           id="{{ '{}__{}'.format(pk, value) }}"
-                          data-checkbox-api-prefix="/superset/checkbox/{{ modelview_name }}/{{ pk }}/{{ value }}/">
+                          disabled readonly/>
                     {% else %}
                       {{ item[value] }}
                     {% endif %}

--- a/superset/templates/superset/fab_overrides/list_with_checkboxes.html
+++ b/superset/templates/superset/fab_overrides/list_with_checkboxes.html
@@ -79,6 +79,7 @@
                       <input
                           class="form-control"
                           type="checkbox"
+                          data-toggle="tooltip" rel="tooltip" title="{{_('Use the edit buttom to change this field')}}"
                           {{'checked' if item[value] }}
                           name="{{ '{}__{}'.format(pk, value) }}"
                           id="{{ '{}__{}'.format(pk, value) }}"

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1059,26 +1059,6 @@ class Superset(BaseSupersetView):
 
     @api
     @has_access_api
-    @expose("/checkbox/<model_view>/<id_>/<attr>/<value>", methods=["GET"])
-    def checkbox(self, model_view, id_, attr, value):
-        """endpoint for checking/unchecking any boolean in a sqla model"""
-        modelview_to_model = {
-            "{}ColumnInlineView".format(name.capitalize()): source.column_class
-            for name, source in ConnectorRegistry.sources.items()
-        }
-        model = modelview_to_model[model_view]
-        col = db.session.query(model).get(id_)
-        checked = value == "true"
-        if col:
-            setattr(col, attr, checked)
-            if checked:
-                metrics = col.get_metrics().values()
-                col.datasource.add_missing_metrics(metrics)
-            db.session.commit()
-        return json_success('"OK"')
-
-    @api
-    @has_access_api
     @expose("/schemas/<db_id>/")
     @expose("/schemas/<db_id>/<force_refresh>/")
     def schemas(self, db_id, force_refresh="false"):


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Removes generic checkbox API. Checkboxes are set to disabled on the list view. Users have to change this values on the edit form.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/4025227/73345523-1db4fd80-427c-11ea-8680-13f4f7a4d160.png)


After:
![image](https://user-images.githubusercontent.com/4025227/73345437-fe1dd500-427b-11ea-9388-5edf9f352eb6.png)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
