### PR TITLE
Remove endpoints allowing arbitrary cache access

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2007,25 +2007,6 @@ class Superset(BaseSupersetView):
         return self.render_template("superset/theme.html")
 
     @has_access_api
-    @expose("/cached_key/<key>/")
-    @event_logger.log_this
-    def cached_key(self, key):
-        """Returns a key from the cache"""
-        resp = cache.get(key)
-        if resp:
-            return resp
-        return "nope"
-
-    @has_access_api
-    @expose("/cache_key_exist/<key>/")
-    @event_logger.log_this
-    def cache_key_exist(self, key):
-        """Returns if a key from cache exist"""
-        key_exist = True if cache.get(key) else False
-        status = 200 if key_exist else 404
-        return json_success(json.dumps({"key_exist": key_exist}), status=status)
-
-    @has_access_api
     @expose("/results/<key>/")
     @event_logger.log_this
     def results(self, key):


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Remove debugging endpoints that allow arbitrary cache access. These endpoints are unnecessary in a development environment and not leveraged by the application.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [X] Removes existing feature or API

### REVIEWERS
@craig-rueda @dpgaspar @graceguo-supercat @betodealmeida 