### PR TITLE
[UPDATING] Add metadata cache changes to 0.29.0

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -153,6 +153,8 @@ the deploy finishes).
 * India was removed from the "Country Map" visualization as the geojson
   file included in the package was very large
 
+* [5933](https://github.com/apache/incubator-superset/pull/5933)/[6078](https://github.com/apache/incubator-superset/pull/6078): changes which add schema and table metadata cache timeout logic at the database level. If left undefined caching of metadata is disabled.
+
 ## Superset 0.28.0
 * Support for Python 2 is deprecated, we only support >=3.6 from
   `0.28.0` onwards


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY

At Airbnb we were recently tripped out by this (even though it's been in production for quite some time) as the schema/table metadata cache logic introduced a breaking change in v0.29.0 which we weren't aware of. 

Given that this change is breaking, i.e., it does not fallback to the previous non-database specific caching configuration,  I thought it was prudent to add this in case other deployments were tripped up by this change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @betodealmeida @etr2460 @mistercrunch 