### PR TITLE
Do not show stacktraces on some intentionally-thrown errors

### DIFF
--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -60,8 +60,8 @@
       }).fail(function(error) {
           var respJSON = error.responseJSON;
           var errorMsg = error.responseText;
-          if (respJSON && respJSON.message) {
-              errorMsg = respJSON.message;
+          if (respJSON && respJSON.error) {
+              errorMsg = respJSON.error;
           }
           alert("ERROR: " + errorMsg);
       });

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -63,12 +63,9 @@ def get_error_msg():
     return error_msg
 
 
-def json_error_response(msg=None, status=500, stacktrace=None, payload=None, link=None):
+def json_error_response(msg=None, status=500, payload=None, link=None):
     if not payload:
         payload = {"error": "{}".format(msg)}
-    if not stacktrace:
-        stacktrace = utils.get_stacktrace()
-    payload["stacktrace"] = stacktrace
     if link:
         payload["link"] = link
 
@@ -124,30 +121,19 @@ def handle_api_exception(f):
         except SupersetSecurityException as e:
             logging.exception(e)
             return json_error_response(
-                utils.error_msg_from_exception(e),
-                status=e.status,
-                stacktrace=utils.get_stacktrace(),
-                link=e.link,
+                utils.error_msg_from_exception(e), status=e.status, link=e.link
             )
         except SupersetException as e:
             logging.exception(e)
             return json_error_response(
-                utils.error_msg_from_exception(e),
-                stacktrace=utils.get_stacktrace(),
-                status=e.status,
+                utils.error_msg_from_exception(e), status=e.status
             )
         except HTTPException as e:
             logging.exception(e)
-            return json_error_response(
-                utils.error_msg_from_exception(e),
-                stacktrace=traceback.format_exc(),
-                status=e.code,
-            )
+            return json_error_response(utils.error_msg_from_exception(e), status=e.code)
         except Exception as e:  # pylint: disable=broad-except
             logging.exception(e)
-            return json_error_response(
-                utils.error_msg_from_exception(e), stacktrace=utils.get_stacktrace()
-            )
+            return json_error_response(utils.error_msg_from_exception(e))
 
     return functools.update_wrapper(wraps, f)
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2713,11 +2713,11 @@ class Superset(BaseSupersetView):
                 database, schemas_allowed, False
             )
             return self.json_response(schemas_allowed_processed)
-        except Exception:
+        except Exception as e:
+            self.logger.exception(e)
             return json_error_response(
                 "Failed to fetch schemas allowed for csv upload in this database! "
-                "Please contact your Superset Admin!",
-                stacktrace=utils.get_stacktrace(),
+                "Please contact your Superset Admin!"
             )
 
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1364,7 +1364,7 @@ class Superset(BaseSupersetView):
             logging.exception(e)
             return json_error_response(
                 "Connection failed!\n\n"
-                "The error message returned was:\n{}".format(e),
+                f"The error message returned was:\n{e}",
                 400,
             )
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1363,9 +1363,7 @@ class Superset(BaseSupersetView):
         except Exception as e:
             logging.exception(e)
             return json_error_response(
-                "Connection failed!\n\n"
-                f"The error message returned was:\n{e}",
-                400,
+                "Connection failed!\n\n" f"The error message returned was:\n{e}", 400
             )
 
     @api

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1363,7 +1363,9 @@ class Superset(BaseSupersetView):
         except Exception as e:
             logging.exception(e)
             return json_error_response(
-                "Connection failed!\n\n" "The error message returned was:\n{}".format(e)
+                "Connection failed!\n\n"
+                "The error message returned was:\n{}".format(e),
+                400,
             )
 
     @api

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -416,6 +416,26 @@ class CoreTests(SupersetTestCase):
         assert response.status_code == 200
         assert response.headers["Content-Type"] == "application/json"
 
+    def test_testconn_failed_conn(self, username="admin"):
+        self.login(username=username)
+
+        data = json.dumps(
+            {"uri": "broken://url", "name": "examples", "impersonate_user": False}
+        )
+        response = self.client.post(
+            "/superset/testconn", data=data, content_type="application/json"
+        )
+        assert response.status_code == 400
+        assert response.headers["Content-Type"] == "application/json"
+        response_body = json.loads(response.data.decode("utf-8"))
+        expected_body = {
+            "error": "Connection failed!\n\nThe error message returned was:\nCan't load plugin: sqlalchemy.dialects:broken"
+        }
+        assert response_body == expected_body, "%s != %s" % (
+            response_body,
+            expected_body,
+        )
+
     def test_custom_password_store(self):
         database = utils.get_example_database()
         conn_pre = sqla.engine.url.make_url(database.sqlalchemy_uri_decrypted)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some endpoints on Superset, notably the connection test endpoint, would display full stacktraces when a connection test failed. We want to display the underlying error message to help with configuration of database connections, but not the full stacktrace. The connection test endpoint was also returning a 500 when a connection did not succeed - a 400 would be more accurate, as the system is attempting to validate user input.

The front-end of this endpoint was looking at the wrong key in the returned dictionary for the error message as well.

Eventually this should be moved under /api/v1, but I'll save that for a different PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [ ] Attempt a connection test that fails
- [ ] Verify that the resulting response does not contain a stacktrace

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [X] Removes existing feature or API

### REVIEWERS
@villebro @mistercrunch @etr2460 