### PR TITLE
[SQL Lab] Remove space after schema autocomplete

### DIFF
--- a/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
+++ b/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
@@ -149,7 +149,9 @@ class AceEditorWrapper extends React.PureComponent {
           );
         }
         editor.completer.insertMatch({
-          value: `${data.caption}${data.meta === 'function' ? '' : ' '}`,
+          value: `${data.caption}${
+            ['function', 'schema'].includes(data.meta) ? '' : ' '
+          }`,
         });
       },
     };


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Schemas almost always are followed by a `.` and not a space, so let's not add a space when autocompleting

### TEST PLAN
Ensure schemas and functions don't get spaces added after them when autocompleting, but all other words (table names, sql keywords, etc.) do

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley @betodealmeida @graceguo-supercat 