### PR TITLE
[domain sharding] Freeup main domain when domain sharding is enabled

### DIFF
--- a/superset/assets/spec/javascripts/explore/utils_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/utils_spec.jsx
@@ -163,13 +163,8 @@ describe('exploreUtils', () => {
         endpointType: 'json',
         allowDomainSharding: true,
       }).url;
-      expect(url).toMatch(availableDomains[0]);
-
-      url = getExploreUrlAndPayload({
-        formData,
-        endpointType: 'json',
-        allowDomainSharding: true,
-      }).url;
+      // skip main domain for fetching chart if domain sharding is enabled
+      // to leave main domain free for other calls like fav star, save change, etc.
       expect(url).toMatch(availableDomains[1]);
 
       url = getExploreUrlAndPayload({
@@ -192,7 +187,7 @@ describe('exploreUtils', () => {
         endpointType: 'json',
         allowDomainSharding: true,
       }).url;
-      expect(url).toMatch(availableDomains[0]);
+      expect(url).toMatch(availableDomains[1]);
     });
     it('not generate url to different domains without flag', () => {
       let csvURL = getExploreUrlAndPayload({

--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -33,7 +33,7 @@ import { addDangerToast } from '../messageToasts/actions';
 import { logEvent } from '../logger/actions';
 import { Logger, LOG_ACTIONS_LOAD_CHART } from '../logger/LogUtils';
 import getClientErrorObject from '../utils/getClientErrorObject';
-import { allowCrossDomain } from '../utils/hostNamesConfig';
+import { allowCrossDomain as allowDomainSharding } from '../utils/hostNamesConfig';
 
 export const CHART_UPDATE_STARTED = 'CHART_UPDATE_STARTED';
 export function chartUpdateStarted(queryController, latestQueryFormData, key) {
@@ -212,7 +212,7 @@ export function exploreJSON(
       formData,
       endpointType: 'json',
       force,
-      allowDomainSharding: true,
+      allowDomainSharding,
       method,
     });
     const logStart = Logger.getTimestamp();
@@ -227,7 +227,7 @@ export function exploreJSON(
       signal,
       timeout: timeout * 1000,
     };
-    if (allowCrossDomain) {
+    if (allowDomainSharding) {
       querySettings = {
         ...querySettings,
         mode: 'cors',

--- a/superset/assets/src/explore/exploreUtils.js
+++ b/superset/assets/src/explore/exploreUtils.js
@@ -32,14 +32,16 @@ let requestCounter = 0;
 function getHostName(allowDomainSharding = false) {
   let currentIndex = 0;
   if (allowDomainSharding) {
+    currentIndex = requestCounter % availableDomains.length;
+    requestCounter += 1;
+
     // if domain sharding is enabled, skip main domain for fetching chart API
     // leave main domain free for other calls like fav star, save change, etc.
     // to make dashboard be responsive when it's loading large number of charts
-    if (requestCounter % availableDomains.length === 0) {
+    if (currentIndex === 0) {
+      currentIndex += 1;
       requestCounter += 1;
     }
-    currentIndex = requestCounter % availableDomains.length;
-    requestCounter += 1;
   }
 
   return availableDomains[currentIndex];

--- a/superset/assets/src/explore/exploreUtils.js
+++ b/superset/assets/src/explore/exploreUtils.js
@@ -32,6 +32,12 @@ let requestCounter = 0;
 function getHostName(allowDomainSharding = false) {
   let currentIndex = 0;
   if (allowDomainSharding) {
+    // if domain sharding is enabled, skip main domain for fetching chart API
+    // leave main domain free for other calls like fav star, save change, etc.
+    // to make dashboard be responsive when it's loading large number of charts
+    if (requestCounter % availableDomains.length === 0) {
+      requestCounter += 1;
+    }
     currentIndex = requestCounter % availableDomains.length;
     requestCounter += 1;
   }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When user opens a large dashboard, it may trigger a large amount of data request to backend. Most browser only allow 6 concurrent requests to the same domain. So we use sub-domains (and domain sharding) in airbnb to allow more concurrent requests. If the chart data is well cached, the result of domain-sharding is very positive.

When user open a large dashboard and its content is not well cached, all the slots are blocked by slow queries. At the same time if user tries to make API call to backend, there will be no response in the page. for example, check/uncheck fav star, save dashboard edit etc. This make user confused and feel dashboard is broken.

In the environment with domain sharding feature enabled, we can allocate a domain dedicated for user events. This PR is to free the main domain away from chart loading (which will only use sub-domains provided by configuration **SUPERSET_WEBSERVER_DOMAINS**), so that user interactivity won't be blocked by slow queries.

### TEST PLAN
added unit test



### REVIEWERS
@etr2460 @robdiciuccio @mistercrunch 