### PR TITLE
[fix] Ensure that is_adhoc_metric returns a boolean

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -941,7 +941,7 @@ def get_example_database():
 
 
 def is_adhoc_metric(metric) -> bool:
-    return (
+    return bool(
         isinstance(metric, dict)
         and (
             (


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR ensures that the `is_adhoc_metric` method returns a boolean. Previous it could return a string as some of the expressions evaluate to a string.
  
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @michellethomas 
