### PR TITLE
[SQL Lab] Improve autocomplete performance

### DIFF
--- a/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
+++ b/superset/assets/src/SqlLab/components/AceEditorWrapper.jsx
@@ -153,7 +153,12 @@ class AceEditorWrapper extends React.PureComponent {
         });
       },
     };
-    const words = this.state.words.map(word => ({ ...word, completer }));
+    // Mutate instead of object spread here for performance
+    const words = this.state.words.map(word => {
+      /* eslint-disable-next-line no-param-reassign */
+      word.completer = completer;
+      return word;
+    });
     callback(null, words);
   }
   setAutoCompleter(props) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Our instance of superset has large numbers of schemas and tables, so the sql lab autocomplete corpus can be around 40k elements long. Performing the object spread operator was taking up about 50% of the execution time, and removing was able to improve performance from 100ms per keystroke to 40ms.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screen Shot 2020-01-31 at 3 47 47 PM](https://user-images.githubusercontent.com/7409244/73582366-b5b01400-4441-11ea-993d-0a783f3e84e9.png)

After:
![Screen Shot 2020-01-31 at 3 48 01 PM](https://user-images.githubusercontent.com/7409244/73582368-b9dc3180-4441-11ea-887b-6a3514e9930d.png)

### TEST PLAN
Test autocomplete for all types of words, ensure it still works

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @graceguo-supercat @betodealmeida @michellethomas @john-bodley 