### PR TITLE
[logging] Add flag for document visibility

### DIFF
--- a/superset/assets/src/middleware/loggerMiddleware.js
+++ b/superset/assets/src/middleware/loggerMiddleware.js
@@ -107,6 +107,7 @@ const loggerMiddleware = store => next => action => {
       ...eventData,
       event_type: 'user',
       event_id: lastEventId,
+      visibility: document.visibilityState,
     };
   }
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

When we measure dashboard performance, we use dashboard's TTI (time to interactive), which is duration from document load till all charts finished render. But when a user opens a dashboard and visits another browser tab right away, the dashboard won’t start loading its slices until the user goes back to focus on this browser tab: [https://superuser.com/questions/779021/google-chrome-background-tabs-dont-load-build-until-selected]

Modern browser supports Page Visibility API to detect current webpage's visibility:
https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
This PR is to check if user is focused on other browser tab and Superset dashboard is hidden. If so, we should log it as a special case:
<img width="992" alt="Screen Shot 2020-02-01 at 11 03 14 PM" src="https://user-images.githubusercontent.com/27990562/73604941-baadba00-454c-11ea-9a42-fb798430507e.png">



### TEST PLAN
CI and manual test


### REVIEWERS
@etr2460 @serenajiang 