### PR TITLE
Wrap tagging endpoints in a feature flag (disabled by default)

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -277,7 +277,9 @@ class SupersetAppInitializer:
         appbuilder.add_view_no_menu(TableModelView)
         appbuilder.add_view_no_menu(TableSchemaView)
         appbuilder.add_view_no_menu(TabStateView)
-        appbuilder.add_view_no_menu(TagView)
+
+        if feature_flag_manager.is_feature_enabled("TAGGING_ENDPOINTS"):
+            appbuilder.add_view_no_menu(TagView)
 
         #
         # Add links

--- a/superset/app.py
+++ b/superset/app.py
@@ -278,7 +278,7 @@ class SupersetAppInitializer:
         appbuilder.add_view_no_menu(TableSchemaView)
         appbuilder.add_view_no_menu(TabStateView)
 
-        if feature_flag_manager.is_feature_enabled("TAGGING_ENDPOINTS"):
+        if feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
             appbuilder.add_view_no_menu(TagView)
 
         #

--- a/superset/config.py
+++ b/superset/config.py
@@ -276,6 +276,7 @@ DEFAULT_FEATURE_FLAGS = {
     "CLIENT_CACHE": False,
     "ENABLE_EXPLORE_JSON_CSRF_PROTECTION": False,
     "PRESTO_EXPAND_DATA": False,
+    "TAGGING_SYSTEM": False,
 }
 
 # This is merely a default.

--- a/superset/config.py
+++ b/superset/config.py
@@ -276,7 +276,6 @@ DEFAULT_FEATURE_FLAGS = {
     "CLIENT_CACHE": False,
     "ENABLE_EXPLORE_JSON_CSRF_PROTECTION": False,
     "PRESTO_EXPAND_DATA": False,
-    "TAGGING_ENDPOINTS": False,
 }
 
 # This is merely a default.

--- a/superset/config.py
+++ b/superset/config.py
@@ -276,6 +276,7 @@ DEFAULT_FEATURE_FLAGS = {
     "CLIENT_CACHE": False,
     "ENABLE_EXPLORE_JSON_CSRF_PROTECTION": False,
     "PRESTO_EXPAND_DATA": False,
+    "TAGGING_ENDPOINTS": False,
 }
 
 # This is merely a default.

--- a/tests/tagging_tests.py
+++ b/tests/tagging_tests.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest import skipUnless
+
+from superset import is_feature_enabled
+from tests.base_tests import SupersetTestCase
+
+
+class TaggingTests(SupersetTestCase):
+    @skipUnless(
+        (is_feature_enabled("TAGGING_ENDPOINTS") == False),
+        "skipping as tagging endpoints are not enabled",
+    )
+    def test_tag_view_attachment_disabled(self):
+        response = self.client.get("/tagview/tagged_objects/")
+        self.assertEqual(404, response.status_code)
+
+    @skipUnless(
+        is_feature_enabled("TAGGING_ENDPOINTS"),
+        "skipping as tagging endpoints are enabled",
+    )
+    def test_tag_view_attachment_enabled(self):
+        response = self.client.get("/tagview/tagged_objects/")
+        self.assertEqual(200, response.status_code)

--- a/tests/tagging_tests.py
+++ b/tests/tagging_tests.py
@@ -23,7 +23,7 @@ from tests.base_tests import SupersetTestCase
 
 class TaggingTests(SupersetTestCase):
     @skipUnless(
-        (is_feature_enabled("TAGGING_ENDPOINTS") == False),
+        (is_feature_enabled("TAGGING_SYSTEM") == False),
         "skipping as tagging endpoints are not enabled",
     )
     def test_tag_view_attachment_disabled(self):
@@ -31,7 +31,7 @@ class TaggingTests(SupersetTestCase):
         self.assertEqual(404, response.status_code)
 
     @skipUnless(
-        is_feature_enabled("TAGGING_ENDPOINTS"),
+        is_feature_enabled("TAGGING_SYSTEM"),
         "skipping as tagging endpoints are enabled",
     )
     def test_tag_view_attachment_enabled(self):


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently the tagging system only has a back-end that's part of the Superset codebase. We would like to be able to disable these endpoints inside of Preset until a front-end is adopted. In order to do that, I have added a feature flag to selectively enable the endpoints provided by `TagView`. I believe this change will primarily impact the deployment at Lyft (@betodealmeida @DiggidyDave)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- CI
- Ensure endpoints supplied by `TagView` are not accessible after the change by default
- Enable the `TAGGING_ENDPONTS` feature flag and ensure the endpoints supplied by `TagView` are operational.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@betodealmeida @DiggidyDave @dpgaspar @craig-rueda 