### PR TITLE
[dashboard] Fix for dashboard edit modal, loading user list

### DIFF
--- a/superset/assets/src/dashboard/components/PropertiesModal.jsx
+++ b/superset/assets/src/dashboard/components/PropertiesModal.jsx
@@ -204,22 +204,18 @@ class PropertiesModal extends React.PureComponent {
                 <label className="control-label" htmlFor="owners">
                   {t('Owners')}
                 </label>
-                <>
-                  <Select
-                    name="owners"
-                    multi
-                    isLoading={!userOptions}
-                    value={values.owners}
-                    options={userOptions || []}
-                    onChange={this.onOwnersChange}
-                    disabled={!userOptions || !isOwnersLoaded}
-                  />
-                  <p className="help-block">
-                    {t(
-                      'Owners is a list of users who can alter the dashboard.',
-                    )}
-                  </p>
-                </>
+                <Select
+                  name="owners"
+                  multi
+                  isLoading={!userOptions}
+                  value={values.owners}
+                  options={userOptions || []}
+                  onChange={this.onOwnersChange}
+                  disabled={!userOptions || !isOwnersLoaded}
+                />
+                <p className="help-block">
+                  {t('Owners is a list of users who can alter the dashboard.')}
+                </p>
               </Col>
             </Row>
             <Row>

--- a/superset/assets/src/dashboard/components/PropertiesModal.jsx
+++ b/superset/assets/src/dashboard/components/PropertiesModal.jsx
@@ -204,24 +204,22 @@ class PropertiesModal extends React.PureComponent {
                 <label className="control-label" htmlFor="owners">
                   {t('Owners')}
                 </label>
-                {userOptions && (
-                  <>
-                    <Select
-                      name="owners"
-                      multi
-                      isLoading={!userOptions}
-                      value={values.owners}
-                      options={userOptions || []}
-                      onChange={this.onOwnersChange}
-                      disabled={!isOwnersLoaded}
-                    />
-                    <p className="help-block">
-                      {t(
-                        'Owners is a list of users who can alter the dashboard.',
-                      )}
-                    </p>
-                  </>
-                )}
+                <>
+                  <Select
+                    name="owners"
+                    multi
+                    isLoading={!userOptions}
+                    value={values.owners}
+                    options={userOptions || []}
+                    onChange={this.onOwnersChange}
+                    disabled={!userOptions || !isOwnersLoaded}
+                  />
+                  <p className="help-block">
+                    {t(
+                      'Owners is a list of users who can alter the dashboard.',
+                    )}
+                  </p>
+                </>
               </Col>
             </Row>
             <Row>

--- a/superset/assets/src/dashboard/components/PropertiesModal.jsx
+++ b/superset/assets/src/dashboard/components/PropertiesModal.jsx
@@ -68,11 +68,12 @@ class PropertiesModal extends React.PureComponent {
   }
 
   componentDidMount() {
-    SupersetClient.get({ endpoint: `/users/api/read` }).then(response => {
-      const options = response.json.result.map((user, i) => ({
-        // ids are in a separate `pks` array in the results... need api v2
-        value: response.json.pks[i],
-        label: `${user.first_name} ${user.last_name}`,
+    SupersetClient.get({
+      endpoint: `/api/v1/dashboard/related/owners`,
+    }).then(response => {
+      const options = response.json.result.map(item => ({
+        value: item.value,
+        label: item.text,
       }));
       this.setState({
         userOptions: options,


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `/users/api/read` endpoint was removed, so this switches to the new `/api/v1/dashboard/related/owners` endpoint, which should also be more accurate regarding which users are returned as potential dashboard owners.

Also tweaked the owners input to display in a disabled state while the user set is loading, instead of being hidden.