### PR TITLE
[dashboard] Fix metadata state

### DIFF
--- a/superset/assets/src/dashboard/components/PropertiesModal.jsx
+++ b/superset/assets/src/dashboard/components/PropertiesModal.jsx
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import { Row, Col, Button, Modal, FormControl } from 'react-bootstrap';
 import Dialog from 'react-bootstrap-dialog';
 import Select from 'react-select';
+import AceEditor from 'react-ace';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
 
@@ -49,19 +50,25 @@ const defaultProps = {
 class PropertiesModal extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.defaultMetadataValue = JSON.stringify(
+      props.dashboardInfo.metadata,
+      null,
+      2,
+    );
     this.state = {
       errors: [],
       values: {
         dashboard_title: props.dashboardTitle,
         slug: props.dashboardInfo.slug,
         owners: props.owners || [],
-        json_metadata: JSON.stringify(props.dashboardInfo.metadata),
+        json_metadata: this.defaultMetadataValue,
       },
       isOwnersLoaded: false,
       userOptions: null,
       isAdvancedOpen: false,
     };
     this.onChange = this.onChange.bind(this);
+    this.onMetadataChange = this.onMetadataChange.bind(this);
     this.onOwnersChange = this.onOwnersChange.bind(this);
     this.save = this.save.bind(this);
     this.toggleAdvanced = this.toggleAdvanced.bind(this);
@@ -91,16 +98,19 @@ class PropertiesModal extends React.PureComponent {
   }
 
   onOwnersChange(value) {
-    this.setState(state => ({
-      values: {
-        ...state.values,
-        owners: value,
-      },
-    }));
+    this.updateFormState('owners', value);
+  }
+
+  onMetadataChange(metadata) {
+    this.updateFormState('json_metadata', metadata);
   }
 
   onChange(e) {
     const { name, value } = e.target;
+    this.updateFormState(name, value);
+  }
+
+  updateFormState(name, value) {
     this.setState(state => ({
       values: {
         ...state.values,
@@ -245,14 +255,16 @@ class PropertiesModal extends React.PureComponent {
                     <label className="control-label" htmlFor="json_metadata">
                       {t('JSON Metadata')}
                     </label>
-                    <FormControl
-                      componentClass="textarea"
-                      style={{ maxWidth: '100%' }}
+                    <AceEditor
+                      mode="json"
                       name="json_metadata"
-                      type="text"
-                      bsSize="sm"
+                      defaultValue={this.defaultMetadataValue}
                       value={values.json_metadata}
-                      onChange={this.onChange}
+                      onChange={this.onMetadataChange}
+                      theme="textmate"
+                      tabSize={2}
+                      width="100%"
+                      height="200px"
                     />
                     <p className="help-block">
                       {t(

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -280,10 +280,7 @@ export default function(bootstrapData) {
     dashboardInfo: {
       id: dashboard.id,
       slug: dashboard.slug,
-      metadata: {
-        timed_refresh_immune_slices:
-          dashboard.metadata.timed_refresh_immune_slices,
-      },
+      metadata: dashboard.metadata,
       userId: user_id,
       dash_edit_perm: dashboard.dash_edit_perm,
       dash_save_perm: dashboard.dash_save_perm,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`json_metadata` fields weren't being properly populated from the bootstrap data in `getInitialState`. Now all fields are present. Not sure why we were doing extra work to exclude those fields from the state object.

I also swapped out the plain old `<textarea>` for a fancy schmancy `<AceEditor>`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="882" alt="Screen Shot 2020-02-05 at 10 23 29 AM" src="https://user-images.githubusercontent.com/1858430/73870852-9f1f0980-4801-11ea-8539-5fd2c09ed8e8.png">
After:
<img width="872" alt="Screen Shot 2020-02-04 at 6 09 39 PM" src="https://user-images.githubusercontent.com/1858430/73804711-879c3e00-4779-11ea-968d-4ec9cbbc39e7.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
I verified these locally:
1. Make sure dashboard metadata is displayed in its entirety instead of just specific fields.
2. Make sure that including all the metadata fields does not somehow break other dashboard functionality. 
3. Edit data, save, reload, make sure edits were persisted.
4. Try to provide broken data to the new JSON editor

Could use some additional verification on item 2.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
