### PR TITLE
[datasources] Fix, Prevent gamma user's from accessing save datasources

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -105,6 +105,7 @@ class SupersetSecurityManager(SecurityManager):
         "DruidColumnInlineView",
         "DruidDatasourceModelView",
         "DruidMetricInlineView",
+        "Datasource",
     } | READ_ONLY_MODEL_VIEWS
 
     ADMIN_ONLY_VIEW_MENUS = {
@@ -131,7 +132,7 @@ class SupersetSecurityManager(SecurityManager):
         "all_query_access",
     }
 
-    READ_ONLY_PERMISSION = {"can_show", "can_list"}
+    READ_ONLY_PERMISSION = {"can_show", "can_list", "can_get", "can_external_metadata"}
 
     ALPHA_ONLY_PERMISSIONS = {
         "muldelete",


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Prevent `Gamma` user's from saving/updating datasources. Will remove can_save on Datasource from Gamma Role 

https://superset.incubator.apache.org/security.html#gamma

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@willbarrett 