### PR TITLE
[fix] tox running of specific tests

### DIFF
--- a/tests/base_api_tests.py
+++ b/tests/base_api_tests.py
@@ -20,6 +20,7 @@ import json
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 import prison
 
+import tests.test_app
 from superset import db, security_manager
 from superset.extensions import appbuilder
 from superset.models.dashboard import Dashboard

--- a/tests/dashboard_api_tests.py
+++ b/tests/dashboard_api_tests.py
@@ -14,12 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 """Unit tests for Superset"""
 import json
 from typing import List
 
 import prison
 
+import tests.test_app
 from superset import db, security_manager
 from superset.models import core as models
 from superset.models.slice import Slice

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 """Unit tests for Superset"""
 import json
 import unittest
@@ -22,6 +23,7 @@ from random import random
 from flask import escape
 from sqlalchemy import func
 
+import tests.test_app
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.models import core as models

--- a/tests/database_api_tests.py
+++ b/tests/database_api_tests.py
@@ -14,11 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 """Unit tests for Superset"""
 import json
 
 import prison
 
+import tests.test_app
 from superset import db
 from superset.models.core import Database
 from superset.utils.core import get_example_database

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -14,9 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 import numpy as np
 import pandas as pd
 
+import tests.test_app
 from superset.dataframe import df_to_records
 from superset.db_engine_specs import BaseEngineSpec
 from superset.result_set import SupersetResultSet

--- a/tests/druid_func_tests.py
+++ b/tests/druid_func_tests.py
@@ -14,10 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 import json
 import unittest
 from unittest.mock import Mock
 
+import tests.test_app
 import superset.connectors.druid.models as models
 from superset.connectors.druid.models import DruidColumn, DruidDatasource, DruidMetric
 from superset.exceptions import SupersetException

--- a/tests/log_api_tests.py
+++ b/tests/log_api_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 """Unit tests for Superset"""
 import json
 from typing import Optional
@@ -21,6 +22,7 @@ from typing import Optional
 import prison
 from flask_appbuilder.security.sqla.models import User
 
+import tests.test_app
 from superset import db
 from superset.models.core import Log
 

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -14,12 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 import textwrap
 import unittest
 
 import pandas
 from sqlalchemy.engine.url import make_url
 
+import tests.test_app
 from superset import app
 from superset.models.core import Database
 from superset.utils.core import get_example_database, QueryStatus

--- a/tests/result_set_tests.py
+++ b/tests/result_set_tests.py
@@ -14,11 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 from datetime import datetime
 
 import numpy as np
 import pandas as pd
 
+import tests.test_app
 from superset.dataframe import df_to_records
 from superset.db_engine_specs import BaseEngineSpec
 from superset.result_set import dedup, SupersetResultSet

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -14,12 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 import inspect
 import unittest
 from unittest.mock import Mock, patch
 
 import prison
 
+import tests.test_app
 from superset import app, appbuilder, db, security_manager, viz
 from superset.connectors.druid.models import DruidCluster, DruidDatasource
 from superset.connectors.sqla.models import SqlaTable

--- a/tests/sql_validator_tests.py
+++ b/tests/sql_validator_tests.py
@@ -14,12 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 """Unit tests for Sql Lab"""
 import unittest
 from unittest.mock import MagicMock, patch
 
 from pyhive.exc import DatabaseError
 
+import tests.test_app
 from superset import app
 from superset.sql_validators import SQLValidationAnnotation
 from superset.sql_validators.base import BaseSQLValidator

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
+import tests.test_app
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.db_engine_specs.druid import DruidEngineSpec
 from superset.utils.core import get_example_database

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 """Unit tests for Sql Lab"""
 import json
 from datetime import datetime, timedelta
@@ -21,6 +22,7 @@ from random import random
 
 import prison
 
+import tests.test_app
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.dataframe import df_to_records

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -14,10 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 """Unit tests for Superset cache warmup"""
 import json
 from unittest.mock import MagicMock
 
+import tests.test_app
 from superset import db
 from superset.models.core import Log
 from superset.models.tags import get_tag, ObjectTypes, TaggedObject, TagTypes

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 import unittest
 import uuid
 from datetime import date, datetime, time, timedelta
@@ -25,6 +26,7 @@ from flask import Flask
 from flask_caching import Cache
 from sqlalchemy.exc import ArgumentError
 
+import tests.test_app
 from superset import app, db, security_manager
 from superset.exceptions import SupersetException
 from superset.models.core import Database

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 import uuid
 from datetime import datetime
 from math import nan
@@ -22,6 +23,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pandas as pd
 
+import tests.test_app
 import superset.viz as viz
 from superset import app
 from superset.constants import NULL_STRING

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     {toxinidir}/superset/bin/superset db upgrade
     {toxinidir}/superset/bin/superset init
     nosetests tests/load_examples_test.py
-    nosetests -e load_examples_test tests {posargs}
+    nosetests --exclude=load_examples_test {posargs:tests}
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR corrects running of specific tests in `tox`, i.e., 

```bash
tox -e py36-mysql tests/sqllab_tests.py 
```

whereas previously this would have run as, 

```bash
tox -e py36-mysql tests tests/sqllab_tests.py 
```

meaning the entire test suite was run prior to the test(s) for interest. `tox` provides a mechanism for default positional arguments (per [here](https://tox.readthedocs.io/en/latest/example/general.html#interactively-passing-positional-arguments)) and thus these are equivalent (the first being the default) for running the entire suite:

```bash
tox -e py36-mysql
tox -e py36-mysql tests
```

Note when running individual tests I ran into the `RuntimeError: Working outside of application context.` error during the import phase. The fix is to add the `import tests.test_app` import (which creates the app context) where necessary. I believe the entire test suite worked only because the first file alphabetically included the import.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: craig-rueda @etr2460 @mistercrunch @villebro 