### PR TITLE
fix: restrict werkzeug to <1.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         "sqlalchemy>=1.3.5, <2.0",
         "sqlalchemy-utils>=0.33.2",
         "sqlparse>=0.3.0, <0.4",
+        "werkzeug<1.0",
         "wtforms-json",
     ],
     extras_require={


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
With the release of `werkzeug 1.0.0`, installing via `pip` pulls in a version of `werkzeug` which is not currently compatible with `superset`. This PR restricts the version of `werkzeug` to `<1.0` in `setup.py`, ensuring that installation via `pip` works properly.

### TEST PLAN
Test locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #9110
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
