### PR TITLE
[logging] Add data_age for cached chart

### DIFF
--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -257,7 +257,7 @@ export function exploreJSON(
             viz_type: formData.viz_type,
             data_age: json.is_cached
               ? moment(new Date()).diff(moment.utc(json.cached_dttm))
-              : 0,
+              : null,
           }),
         );
         return dispatch(chartUpdateSucceeded(json, key));

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -18,6 +18,7 @@
  */
 /* eslint no-undef: 'error' */
 /* eslint no-param-reassign: ["error", { "props": false }] */
+import moment from 'moment';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
@@ -254,6 +255,9 @@ export function exploreJSON(
             has_extra_filters:
               formData.extra_filters && formData.extra_filters.length > 0,
             viz_type: formData.viz_type,
+            data_age: json.is_cached
+              ? moment(new Date()).diff(moment.utc(json.cached_dttm))
+              : 0,
           }),
         );
         return dispatch(chartUpdateSucceeded(json, key));


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Add a `data_age` in logging data when chart has is_cached flag.

### TEST PLAN
CI and manual test

### REVIEWERS
@serenajiang @etr2460 