### PR TITLE
[BugFix] superset-node fails due to superset-frontend absence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ x-superset-volumes: &superset-volumes
   - ./docker/docker-init.sh:/app/docker-init.sh
   - ./docker/pythonpath_dev:/app/pythonpath
   - ./superset:/app/superset
+  - ./superset-frontend:/app/superset-frontend
   - superset_home:/app/superset_home
 
 version: "3.7"


### PR DESCRIPTION
This seems to have been due to the recent change to prevent duplication of code in https://github.com/apache/incubator-superset/commit/291306392443a5a0d0e2ee0cc4a95d37c56d4589

The command to run by superset-node has been updated from 

`command: ["bash", "-c", "cd /app/superset/assets && npm install && npm run dev"]` 

to 

`command: ["bash", "-c", "cd /app/superset-frontend && npm install && npm run dev"]`

but the directory that it expects - `/app/superset-frontend` is not available leading to `docker-compose up` to break with the error:
```
superset-node_1    | bash: line 0: cd: /app/superset-frontend: No such file or directory
```

This just adds the required volume mounts.

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

`docker-compose up` breaks after https://github.com/apache/incubator-superset/commit/291306392443a5a0d0e2ee0cc4a95d37c56d4589. This is supposed to fix that

Note that `docker-compose up` succeeds, but when you open the UI, after login, nothing loads

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Run `docker-compose up` before and after the change
