### PR TITLE
[charts] Fix, double registration of charts API

### DIFF
--- a/superset/views/chart/api.py
+++ b/superset/views/chart/api.py
@@ -22,7 +22,6 @@ from marshmallow import fields, post_load, validates_schema, ValidationError
 from marshmallow.validate import Length
 from sqlalchemy.orm.exc import NoResultFound
 
-from superset import appbuilder
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.exceptions import SupersetException
 from superset.models.dashboard import Dashboard

--- a/superset/views/chart/api.py
+++ b/superset/views/chart/api.py
@@ -174,6 +174,3 @@ class ChartRestApi(SliceMixin, BaseOwnedModelRestApi):
         "owners": ("first_name", "asc"),
     }
     filter_rel_fields_field = {"owners": "first_name", "dashboards": "dashboard_title"}
-
-
-appbuilder.add_api(ChartRestApi)


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Was causing no impact but it's an error, Chart API is already being registered on app.py

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
