### PR TITLE
Catch TypeError on PyArrow array instantiation

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -106,6 +106,7 @@ class SupersetResultSet:
                     pa.lib.ArrowInvalid,
                     pa.lib.ArrowTypeError,
                     pa.lib.ArrowNotImplementedError,
+                    TypeError,  # this is super hackey, https://issues.apache.org/jira/browse/ARROW-7855
                 ):
                     # attempt serialization of values as strings
                     stringified_arr = stringify_values(array[column])

--- a/tests/result_set_tests.py
+++ b/tests/result_set_tests.py
@@ -200,6 +200,16 @@ class SupersetResultSetTestCase(SupersetTestCase):
             ],
         )
 
+    def test_nested_list_types(self):
+        data = [([{"TestKey": [123456, "foo"]}],)]
+        cursor_descr = [("metadata",)]
+        results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
+        self.assertEqual(results.columns[0]["type"], "STRING")
+        df = results.to_pandas_df()
+        self.assertEqual(
+            df_to_records(df), [{"metadata": '[{"TestKey": [123456, "foo"]}]'}]
+        )
+
     def test_empty_datetime(self):
         data = [(None,)]
         cursor_descr = [("ds", "timestamp", None, None, None, None, True)]


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The following (Postgres) query fails with `TypeError: an integer is required (got type str)`:
```
SELECT json_build_object('test', json_build_array(123456, 'test')) AS data;
```
This is also raised when columnar data from Presto is in the following format (mixed array data types):
```
{'TestKey': [123456, 'foo']}
```

See also: https://github.com/apache/incubator-superset/pull/9096#issuecomment-584449351

*NOTE: this is meant to be a temporary fix until the [Arrow ticket](https://issues.apache.org/jira/browse/ARROW-7855) is resolved.*

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Ensure the following query against Postgres succeeds:
```
SELECT json_build_object('test', json_build_array(123456, 'test')) AS data;
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley @serenajiang @nytai @willbarrett @dpgaspar @suddjian 