### PR TITLE
[dashboard] remove loading spinner in missing chart holder

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/MissingChart_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/MissingChart_spec.jsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Loading from '../../../../src/components/Loading';
 import MissingChart from '../../../../src/dashboard/components/MissingChart';
 
 describe('MissingChart', () => {
@@ -36,10 +35,5 @@ describe('MissingChart', () => {
   it('renders a .missing-chart-body', () => {
     const wrapper = setup();
     expect(wrapper.find('.missing-chart-body')).toHaveLength(1);
-  });
-
-  it('renders a Loading', () => {
-    const wrapper = setup();
-    expect(wrapper.find(Loading)).toHaveLength(1);
   });
 });

--- a/superset-frontend/src/dashboard/components/MissingChart.jsx
+++ b/superset-frontend/src/dashboard/components/MissingChart.jsx
@@ -20,8 +20,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { t } from '@superset-ui/translation';
 
-import Loading from '../../components/Loading';
-
 const propTypes = {
   height: PropTypes.number.isRequired,
 };
@@ -29,9 +27,6 @@ const propTypes = {
 export default function MissingChart({ height }) {
   return (
     <div className="missing-chart-container" style={{ height: height + 20 }}>
-      <div className="loading-container">
-        <Loading />
-      </div>
       <div className="missing-chart-body">
         {t(
           'There is no chart definition associated with this component, could it have been deleted?',

--- a/superset-frontend/src/dashboard/stylesheets/components/chart.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/chart.less
@@ -29,14 +29,12 @@
     flex-direction: column;
     align-items: center;
     overflow-y: auto;
+    justify-content: center;
 
     .missing-chart-body {
       font-size: @font-size-s;
-    }
-
-    .loading-container {
       position: relative;
-      height: 40%;
+      display: flex;
     }
   }
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
remove spinner since the chart is not actually loading any data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**before**
<img width="302" alt="Screen Shot 2020-02-13 at 4 11 07 PM" src="https://user-images.githubusercontent.com/27990562/74490640-09791f00-4e7e-11ea-81ba-e0bc9980348e.png">

**after**
<img width="352" alt="Screen Shot 2020-02-13 at 4 33 29 PM" src="https://user-images.githubusercontent.com/27990562/74490800-97550a00-4e7e-11ea-994b-c1f5709f76ea.png">




### TEST PLAN
unit test.


### REVIEWERS
@kristw @john-bodley @williaster 