### PR TITLE
Support human readable datetime type for PinotDB

### DIFF
--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -40,7 +40,7 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         "P1Y": "1:YEARS",
     }
 
-    _python_to_java_time_patterns = {
+    _python_to_java_time_patterns: Dict[str, str] = {
         "%Y": "yyyy",
         "%m": "MM",
         "%d": "dd",
@@ -65,13 +65,13 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
                 today.strftime(str(pdf))
             except ValueError:
                 raise ValueError(f"Invalid column datetime format:{str(pdf)}")
-            java_pdf = str(pdf)
+            java_date_format = str(pdf)
             for (
                 python_pattern,
                 java_pattern,
             ) in cls._python_to_java_time_patterns.items():
-                java_pdf.replace(python_pattern, java_pattern)
-            tf = f"1:SECONDS:SIMPLE_DATE_FORMAT:{java_pdf}"
+                java_date_format.replace(python_pattern, java_pattern)
+            tf = f"1:SECONDS:SIMPLE_DATE_FORMAT:{java_date_format}"
         else:
             seconds_or_ms = "MILLISECONDS" if pdf == "epoch_ms" else "SECONDS"
             tf = f"1:{seconds_or_ms}:EPOCH"

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import datetime
 from typing import Dict, List, Optional
 
 from sqlalchemy.sql.expression import ColumnClause, ColumnElement
@@ -44,13 +45,32 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         cls, col: ColumnClause, pdf: Optional[str], time_grain: Optional[str]
     ) -> TimestampExpression:
         is_epoch = pdf in ("epoch_s", "epoch_ms")
-        if not is_epoch:
-            raise NotImplementedError("Pinot currently only supports epochs")
+
         # The DATETIMECONVERT pinot udf is documented at
         # Per https://github.com/apache/incubator-pinot/wiki/dateTimeConvert-UDF
         # We are not really converting any time units, just bucketing them.
-        seconds_or_ms = "MILLISECONDS" if pdf == "epoch_ms" else "SECONDS"
-        tf = f"1:{seconds_or_ms}:EPOCH"
+        tf = ""
+        if not is_epoch:
+            try:
+                today = datetime.datetime.today()
+                today.strftime(str(pdf))
+            except ValueError:
+                raise NotImplementedError(
+                    "Pinot currently doesn't support date formate: " + str(pdf)
+                )
+            java_pdf = (
+                str(pdf)
+                .replace("%Y", "yyyy")
+                .replace("%m", "MM")
+                .replace("%d", "dd")
+                .replace("%H", "HH")
+                .replace("%M", "mm")
+                .replace("%S", "ss")
+            )
+            tf = f"1:SECONDS:SIMPLE_DATE_FORMAT:{java_pdf}"
+        else:
+            seconds_or_ms = "MILLISECONDS" if pdf == "epoch_ms" else "SECONDS"
+            tf = f"1:{seconds_or_ms}:EPOCH"
         granularity = cls.get_time_grain_functions().get(time_grain)
         if not granularity:
             raise NotImplementedError("No pinot grain spec for " + str(time_grain))


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Support human readable datetime type for PinotDB
Now we can support datetime like '%Y-%m-%d' for time Series.
![image](https://user-images.githubusercontent.com/1202120/74492768-ce2e1e80-4e84-11ea-973f-903a7b87f027.png)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
