### PR TITLE
[dashboard] clean up usage for old filter immune metadata

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/fixtures/mockDashboardInfo.js
+++ b/superset-frontend/spec/javascripts/dashboard/fixtures/mockDashboardInfo.js
@@ -19,10 +19,7 @@
 export default {
   id: 1234,
   slug: 'dashboardSlug',
-  metadata: {
-    filterImmuneSlices: [],
-    filterImmuneSliceFields: {},
-  },
+  metadata: {},
   userId: 'mock_user_id',
   dash_edit_perm: true,
   dash_save_perm: true,

--- a/superset-frontend/src/dashboard/reducers/getInitialState.js
+++ b/superset-frontend/src/dashboard/reducers/getInitialState.js
@@ -101,9 +101,6 @@ export default function(bootstrapData) {
   let newSlicesContainer;
   let newSlicesContainerWidth = 0;
 
-  const filterImmuneSliceFields =
-    dashboard.metadata.filter_immune_slice_fields || {};
-  const filterImmuneSlices = dashboard.metadata.filter_immune_slices || [];
   const filterScopes = dashboard.metadata.filter_scopes || {};
 
   const chartQueries = {};
@@ -188,8 +185,6 @@ export default function(bootstrapData) {
           });
         }
 
-        // backward compatible:
-        // merge scoped filter settings with old global immune settings
         const scopesByChartId = Object.keys(columns).reduce((map, column) => {
           const scopeSettings = {
             ...filterScopes[key],
@@ -198,20 +193,12 @@ export default function(bootstrapData) {
             ...DASHBOARD_FILTER_SCOPE_GLOBAL,
             ...scopeSettings[column],
           };
-          const immuneChartIds = new Set(filterImmuneSlices);
-          Object.keys(filterImmuneSliceFields)
-            .filter(strChartId =>
-              filterImmuneSliceFields[strChartId].includes(column),
-            )
-            .forEach(strChartId => {
-              immuneChartIds.add(parseInt(strChartId, 10));
-            });
 
           return {
             ...map,
             [column]: {
               scope,
-              immune: [...immuneChartIds].concat(immune),
+              immune,
             },
           };
         }, {});

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1264,7 +1264,7 @@ class Superset(BaseSupersetView):
         if "timed_refresh_immune_slices" not in md:
             md["timed_refresh_immune_slices"] = []
         if "filter_scopes" in data:
-            md["filter_scopes"] = json.loads(data.get("filter_scopes", "{}"))
+            md["filter_scopes"] = json.loads(data["filter_scopes"] or "{}")
         md["expanded_slices"] = data["expanded_slices"]
         md["refresh_frequency"] = data.get("refresh_frequency", 0)
         default_filters_data = json.loads(data.get("default_filters", "{}"))

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1263,16 +1263,8 @@ class Superset(BaseSupersetView):
 
         if "timed_refresh_immune_slices" not in md:
             md["timed_refresh_immune_slices"] = []
-
         if "filter_scopes" in data:
-            md.pop("filter_immune_slices", None)
-            md.pop("filter_immune_slice_fields", None)
             md["filter_scopes"] = json.loads(data.get("filter_scopes", "{}"))
-        else:
-            if "filter_immune_slices" not in md:
-                md["filter_immune_slices"] = []
-            if "filter_immune_slice_fields" not in md:
-                md["filter_immune_slice_fields"] = {}
         md["expanded_slices"] = data["expanded_slices"]
         md["refresh_frequency"] = data.get("refresh_frequency", 0)
         default_filters_data = json.loads(data.get("default_filters", "{}"))


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
After migration/convert old filter immune attribute in #9109 and #9145, dashboard front-end doesn't have to handle backward compatibility issue with old metadata. This PR is to clean up the usage for `filter_immune_slices` and `filter_immune_slice_fields` everywhere.


### TEST PLAN
CI and manual tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9109 #9145

### REVIEWERS
@john-bodley @serenajiang @etr2460 @mistercrunch 