### PR TITLE
fix: adhoc metric bug in chord diagram

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1719,7 +1719,7 @@ class ChordViz(BaseViz):
         qry = super().query_obj()
         fd = self.form_data
         qry["groupby"] = [fd.get("groupby"), fd.get("columns")]
-        qry["metrics"] = [utils.get_metric_name(fd.get("metric"))]
+        qry["metrics"] = [fd.get("metric")]
         return qry
 
     def get_data(self, df: pd.DataFrame) -> VizData:


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The chord viz currently doesn't work with ad-hoc metrics due to the metric being replaced by the metric name. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/33317356/74595177-257bec80-5047-11ea-9da0-dd3a26c70ca4.png)

After:
![image](https://user-images.githubusercontent.com/33317356/74595162-054c2d80-5047-11ea-8af4-fda4ccad8179.png)


### TEST PLAN
Tested locally to ensure that it works both with datasource metrics and ad-hoc metrics. Unit tests not added due to planned refactoring of `viz.py` in the near future.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #8977
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@hefeng11725 @mtomov
