### PR TITLE
fix: share column type matching between model and result set

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -123,7 +123,7 @@ class QueryContext:
 
     @staticmethod
     def get_data(  # pylint: disable=invalid-name,no-self-use
-        df: pd.DataFrame
+        df: pd.DataFrame,
     ) -> List[Dict]:
         return df.to_dict(orient="records")
 

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -387,7 +387,7 @@ class BaseColumn(AuditMixinNullable, ImportMixin):
         "DECIMAL",
         "MONEY",
     )
-    date_types = ("DATE", "TIME", "DATETIME")
+    date_types = ("DATE", "TIME")
     str_types = ("VARCHAR", "STRING", "CHAR")
 
     @property

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -391,11 +391,11 @@ class BaseColumn(AuditMixinNullable, ImportMixin):
     str_types = ("VARCHAR", "STRING", "CHAR")
 
     @property
-    def is_num(self) -> bool:
+    def is_numeric(self) -> bool:
         return self.type and any(map(lambda t: t in self.type.upper(), self.num_types))
 
     @property
-    def is_time(self) -> bool:
+    def is_temporal(self) -> bool:
         return self.type and any(map(lambda t: t in self.type.upper(), self.date_types))
 
     @property

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -527,7 +527,7 @@ class DruidDatasource(Model, BaseDatasource):
 
     @property
     def num_cols(self) -> List[str]:
-        return [c.column_name for c in self.columns if c.is_num]
+        return [c.column_name for c in self.columns if c.is_numeric]
 
     @property
     def name(self) -> str:  # type: ignore

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -145,6 +145,27 @@ class TableColumn(Model, BaseColumn):
     update_from_object_fields = [s for s in export_fields if s not in ("table_id",)]
     export_parent = "table"
 
+    @property
+    def is_num(self) -> bool:
+        db_engine_spec = self.table.database.db_engine_spec
+        return db_engine_spec.is_db_column_type_match(
+            self.type, utils.DbColumnType.NUMERIC
+        )
+
+    @property
+    def is_string(self) -> bool:
+        db_engine_spec = self.table.database.db_engine_spec
+        return db_engine_spec.is_db_column_type_match(
+            self.type, utils.DbColumnType.STRING
+        )
+
+    @property
+    def is_time(self) -> bool:
+        db_engine_spec = self.table.database.db_engine_spec
+        return db_engine_spec.is_db_column_type_match(
+            self.type, utils.DbColumnType.TEMPORAL
+        )
+
     def get_sqla_col(self, label: Optional[str] = None) -> Column:
         label = label or self.column_name
         if self.expression:
@@ -1074,7 +1095,7 @@ class SqlaTable(Model, BaseDatasource):
                 logger.exception(e)
             dbcol = dbcols.get(col.name, None)
             if not dbcol:
-                dbcol = TableColumn(column_name=col.name, type=datatype)
+                dbcol = TableColumn(column_name=col.name, type=datatype, table=self)
                 dbcol.sum = dbcol.is_num
                 dbcol.avg = dbcol.is_num
                 dbcol.is_dttm = dbcol.is_time

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -173,7 +173,7 @@ class SupersetResultSet:
     def first_nonempty(items: List) -> Any:
         return next((i for i in items if i), None)
 
-    def is_date(self, db_type_str: Optional[str]) -> bool:
+    def is_temporal(self, db_type_str: Optional[str]) -> bool:
         return self.db_engine_spec.is_db_column_type_match(
             db_type_str, utils.DbColumnType.TEMPORAL
         )
@@ -212,7 +212,7 @@ class SupersetResultSet:
             column = {
                 "name": col.name,
                 "type": db_type_str,
-                "is_date": self.is_date(db_type_str),
+                "is_date": self.is_temporal(db_type_str),
             }
             columns.append(column)
 

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -20,7 +20,6 @@
 import datetime
 import json
 import logging
-import re
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import numpy as np
@@ -75,6 +74,7 @@ class SupersetResultSet:
         cursor_description: Tuple[Any, ...],
         db_engine_spec: Type[db_engine_specs.BaseEngineSpec],
     ):
+        self.db_engine_spec = db_engine_spec
         data = data or []
         column_names: List[str] = []
         pa_data: List[pa.Array] = []
@@ -173,9 +173,10 @@ class SupersetResultSet:
     def first_nonempty(items: List) -> Any:
         return next((i for i in items if i), None)
 
-    @staticmethod
-    def is_date(db_type_str: Optional[str]) -> bool:
-        return db_type_str in ("DATETIME", "TIMESTAMP")
+    def is_date(self, db_type_str: Optional[str]) -> bool:
+        return self.db_engine_spec.is_db_column_type_match(
+            db_type_str, utils.DbColumnType.TEMPORAL
+        )
 
     def data_type(self, col_name: str, pa_dtype: pa.DataType) -> Optional[str]:
         """Given a pyarrow data type, Returns a generic database type"""

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -22,6 +22,7 @@ import functools
 import json
 import logging
 import os
+import re
 import signal
 import smtplib
 import traceback
@@ -922,6 +923,7 @@ def get_or_create_db(database_name, sqlalchemy_uri, *args, **kwargs):
     database = (
         db.session.query(models.Database).filter_by(database_name=database_name).first()
     )
+
     if not database:
         logger.info(f"Creating database reference for {database_name}")
         database = models.Database(database_name=database_name, *args, **kwargs)
@@ -1225,7 +1227,7 @@ class TimeRangeEndpoint(str, Enum):
     UNKNOWN = "unknown"
 
 
-class ReservedUrlParameters(Enum):
+class ReservedUrlParameters(str, Enum):
     """
     Reserved URL parameters that are used internally by Superset. These will not be
     passed to chart queries, as they control the behavior of the UI.
@@ -1243,3 +1245,13 @@ class QuerySource(Enum):
     CHART = 0
     DASHBOARD = 1
     SQL_LAB = 2
+
+
+class DbColumnType(Enum):
+    """
+    Generic database column type
+    """
+
+    NUMERIC = 0
+    STRING = 1
+    TEMPORAL = 2

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -48,7 +48,6 @@ import superset.models.core as models
 from superset import (
     app,
     appbuilder,
-    cache,
     conf,
     dataframe,
     db,

--- a/tests/result_set_tests.py
+++ b/tests/result_set_tests.py
@@ -88,13 +88,13 @@ class SupersetResultSetTestCase(SupersetTestCase):
         data = [("a", 1), ("a", 2)]
         cursor_descr = (("a", "string"), ("a", "string"))
         results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
-        self.assertEqual(results.is_date("DATE"), True)
-        self.assertEqual(results.is_date("DATETIME"), True)
-        self.assertEqual(results.is_date("TIME"), True)
-        self.assertEqual(results.is_date("TIMESTAMP"), True)
-        self.assertEqual(results.is_date("STRING"), False)
-        self.assertEqual(results.is_date(""), False)
-        self.assertEqual(results.is_date(None), False)
+        self.assertEqual(results.is_temporal("DATE"), True)
+        self.assertEqual(results.is_temporal("DATETIME"), True)
+        self.assertEqual(results.is_temporal("TIME"), True)
+        self.assertEqual(results.is_temporal("TIMESTAMP"), True)
+        self.assertEqual(results.is_temporal("STRING"), False)
+        self.assertEqual(results.is_temporal(""), False)
+        self.assertEqual(results.is_temporal(None), False)
 
     def test_dedup_with_data(self):
         data = [("a", 1), ("a", 2)]

--- a/tests/result_set_tests.py
+++ b/tests/result_set_tests.py
@@ -17,9 +17,6 @@
 # isort:skip_file
 from datetime import datetime
 
-import numpy as np
-import pandas as pd
-
 import tests.test_app
 from superset.dataframe import df_to_records
 from superset.db_engine_specs import BaseEngineSpec
@@ -88,12 +85,16 @@ class SupersetResultSetTestCase(SupersetTestCase):
         )
 
     def test_is_date(self):
-        is_date = SupersetResultSet.is_date
-        self.assertEqual(is_date("DATETIME"), True)
-        self.assertEqual(is_date("TIMESTAMP"), True)
-        self.assertEqual(is_date("STRING"), False)
-        self.assertEqual(is_date(""), False)
-        self.assertEqual(is_date(None), False)
+        data = [("a", 1), ("a", 2)]
+        cursor_descr = (("a", "string"), ("a", "string"))
+        results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
+        self.assertEqual(results.is_date("DATE"), True)
+        self.assertEqual(results.is_date("DATETIME"), True)
+        self.assertEqual(results.is_date("TIME"), True)
+        self.assertEqual(results.is_date("TIMESTAMP"), True)
+        self.assertEqual(results.is_date("STRING"), False)
+        self.assertEqual(results.is_date(""), False)
+        self.assertEqual(results.is_date(None), False)
 
     def test_dedup_with_data(self):
         data = [("a", 1), ("a", 2)]

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -37,7 +37,7 @@ class DatabaseModelTestCase(SupersetTestCase):
         self.assertEqual(col.is_dttm, True)
 
         col = TableColumn(column_name="__not_time", type="INTEGER", table=tbl)
-        self.assertEqual(col.is_time, False)
+        self.assertEqual(col.is_temporal, False)
 
     def test_db_column_types(self):
         test_cases: Dict[str, DbColumnType] = {
@@ -62,8 +62,8 @@ class DatabaseModelTestCase(SupersetTestCase):
         tbl = SqlaTable(table_name="col_type_test_tbl", database=get_example_database())
         for str_type, db_col_type in test_cases.items():
             col = TableColumn(column_name="foo", type=str_type, table=tbl)
-            self.assertEqual(col.is_time, db_col_type == DbColumnType.TEMPORAL)
-            self.assertEqual(col.is_num, db_col_type == DbColumnType.NUMERIC)
+            self.assertEqual(col.is_temporal, db_col_type == DbColumnType.TEMPORAL)
+            self.assertEqual(col.is_numeric, db_col_type == DbColumnType.NUMERIC)
             self.assertEqual(col.is_string, db_col_type == DbColumnType.STRING)
 
     def test_has_extra_cache_keys(self):

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 # isort:skip_file
-import tests.test_app
+from typing import Dict
+
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.db_engine_specs.druid import DruidEngineSpec
-from superset.utils.core import get_example_database
+from superset.models.core import Database
+from superset.utils.core import DbColumnType, get_example_database
 
 from .base_tests import SupersetTestCase
 
@@ -26,23 +28,43 @@ from .base_tests import SupersetTestCase
 class DatabaseModelTestCase(SupersetTestCase):
     def test_is_time_druid_time_col(self):
         """Druid has a special __time column"""
-        col = TableColumn(column_name="__time", type="INTEGER")
+
+        database = Database(database_name="druid_db", sqlalchemy_uri="druid://db")
+        tbl = SqlaTable(table_name="druid_tbl", database=database)
+        col = TableColumn(column_name="__time", type="INTEGER", table=tbl)
         self.assertEqual(col.is_dttm, None)
         DruidEngineSpec.alter_new_orm_column(col)
         self.assertEqual(col.is_dttm, True)
 
-        col = TableColumn(column_name="__not_time", type="INTEGER")
+        col = TableColumn(column_name="__not_time", type="INTEGER", table=tbl)
         self.assertEqual(col.is_time, False)
 
-    def test_is_time_by_type(self):
-        col = TableColumn(column_name="foo", type="DATE")
-        self.assertEqual(col.is_time, True)
+    def test_db_column_types(self):
+        test_cases: Dict[str, DbColumnType] = {
+            # string
+            "CHAR": DbColumnType.STRING,
+            "VARCHAR": DbColumnType.STRING,
+            "NVARCHAR": DbColumnType.STRING,
+            "STRING": DbColumnType.STRING,
+            # numeric
+            "INT": DbColumnType.NUMERIC,
+            "BIGINT": DbColumnType.NUMERIC,
+            "FLOAT": DbColumnType.NUMERIC,
+            "DECIMAL": DbColumnType.NUMERIC,
+            "MONEY": DbColumnType.NUMERIC,
+            # temporal
+            "DATE": DbColumnType.TEMPORAL,
+            "DATETIME": DbColumnType.TEMPORAL,
+            "TIME": DbColumnType.TEMPORAL,
+            "TIMESTAMP": DbColumnType.TEMPORAL,
+        }
 
-        col = TableColumn(column_name="foo", type="DATETIME")
-        self.assertEqual(col.is_time, True)
-
-        col = TableColumn(column_name="foo", type="STRING")
-        self.assertEqual(col.is_time, False)
+        tbl = SqlaTable(table_name="col_type_test_tbl", database=get_example_database())
+        for str_type, db_col_type in test_cases.items():
+            col = TableColumn(column_name="foo", type=str_type, table=tbl)
+            self.assertEqual(col.is_time, db_col_type == DbColumnType.TEMPORAL)
+            self.assertEqual(col.is_num, db_col_type == DbColumnType.NUMERIC)
+            self.assertEqual(col.is_string, db_col_type == DbColumnType.STRING)
 
     def test_has_extra_cache_keys(self):
         query = "SELECT '{{ cache_key_wrapper('user_1') }}' as user"


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [x] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When investigating a bug affecting BigQuery time grains, I noticed that Exploring SQL Lab queries don't correctly detect `TIME` and `DATE` types due to the logic being different in the result set code vs the SqlAlchemy model. This PR adds a method to `BaseEngineSpec` for matching database specific column types (e.g. `NVARCHAR`, `DATETIME`, `BIGINT`) to generic types (temporal, numeric and date). In addition, type matching logic in `SupersetResultSet` is replaced with said logic, ensuring that type inference is uniform across models.

### TEST PLAN
Test locally + CI (old + new tests)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
