### PR TITLE
[core] Fix, sanitize errors returned from testconn

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1336,7 +1336,7 @@ class Superset(BaseSupersetView):
                 conn.scalar(select([1]))
                 return json_success('"OK"')
         except NoSuchModuleError as e:
-            logger.info(f"Invalid driver {e}")
+            logger.info("Invalid driver %s", e)
             driver_name = make_url(uri).drivername
             return json_error_response(
                 _(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1346,20 +1346,20 @@ class Superset(BaseSupersetView):
                 400,
             )
         except ArgumentError as e:
-            logger.info(f"Invalid URI {e}")
+            logger.info("Invalid URI %s", e)
             return json_error_response(
                 _(
-                    "Invalid connnection string, a valid string follows: \n"
-                    " 'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
+                    "Invalid connection string, a valid string usually follows: \n"
+                    "'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
                 )
             )
         except OperationalError as e:
-            logger.warning(f"Connection failed {e}")
+            logger.warning("Connection failed %s", e)
             return json_error_response(
                 _("Connection failed, please check your connection settings."), 400
             )
         except Exception as e:
-            logger.error(f"Unexpected error {e}")
+            logger.error("Unexpected error %s", e)
             return json_error_response(_("Unexpected error occurred."), 400)
 
     @api

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1349,7 +1349,7 @@ class Superset(BaseSupersetView):
             logger.info("Invalid URI %s", e)
             return json_error_response(
                 _(
-                    "Invalid connection string, a valid string usually follows: \n"
+                    "Invalid connection string, a valid string usually follows:\n"
                     "'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
                 )
             )

--- a/superset/views/database/validators.py
+++ b/superset/views/database/validators.py
@@ -36,9 +36,9 @@ def sqlalchemy_uri_validator(
     except (ArgumentError, AttributeError):
         raise exception(
             _(
-                "Invalid connection string, a valid string usually follows: "
-                " 'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
-                " <p>Example:'postgresql://user:password@your-postgres-db/database'</p>"
+                "Invalid connection string, a valid string usually follows:"
+                "'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
+                "<p>Example:'postgresql://user:password@your-postgres-db/database'</p>"
             )
         )
 

--- a/superset/views/database/validators.py
+++ b/superset/views/database/validators.py
@@ -36,7 +36,7 @@ def sqlalchemy_uri_validator(
     except (ArgumentError, AttributeError):
         raise exception(
             _(
-                "Invalid connnection string, a valid string follows: "
+                "Invalid connection string, a valid string usually follows: "
                 " 'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
                 " <p>Example:'postgresql://user:password@your-postgres-db/database'</p>"
             )

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -476,9 +476,7 @@ class CoreTests(SupersetTestCase):
         assert response.status_code == 400
         assert response.headers["Content-Type"] == "application/json"
         response_body = json.loads(response.data.decode("utf-8"))
-        expected_body = {
-            "error": "Connection failed!\n\nThe error message returned was:\nCan't load plugin: sqlalchemy.dialects:broken"
-        }
+        expected_body = {"error": "Could not load database driver: broken"}
         assert response_body == expected_body, "%s != %s" % (
             response_body,
             expected_body,


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Test connection API `testconn` does not sanitize errors generated from SQLAlchemy or dbapi drivers. This PR distinguish between URI parse errors, drInivers not installed on the system and OperationalError.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

Connection failed:
![image](https://user-images.githubusercontent.com/4025227/74956200-ab0feb80-53fd-11ea-8bd0-c33298166d20.png)

Invalid URI:
![image](https://user-images.githubusercontent.com/4025227/74956105-8451b500-53fd-11ea-84bc-60ed6ff77113.png)

After:

Connection failed (OperationalError):
![image](https://user-images.githubusercontent.com/4025227/74947794-4c457480-53f3-11ea-8637-0c489dae98d6.png)

Invalid URI:
![image](https://user-images.githubusercontent.com/4025227/74956025-63895f80-53fd-11ea-80fe-14f9f43998ae.png)

Invalid driver:
![image](https://user-images.githubusercontent.com/4025227/74947910-75fe9b80-53f3-11ea-89c6-d186dde1574e.png)


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@robdiciuccio 