### PR TITLE
forcing fixed width fonts on ace editor (fixes #9095)

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -238,10 +238,6 @@ div.Workspace {
     flex-grow: 1;
   }
 
-  .ace_editor, .ace_editor div {
-    font-family: @font-family-monospace;
-  }
-
   .ace_content {
     height: 100%;
   }
@@ -368,6 +364,10 @@ div.tablePopover {
 
 .ace_editor {
   border: 1px solid @gray-light;
+}
+
+.ace_editor, .ace_editor div {
+  font-family: @font-family-monospace;
 }
 
 .Select-menu-outer {

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -366,7 +366,8 @@ div.tablePopover {
   border: 1px solid @gray-light;
 }
 
-.ace_editor, .ace_editor div {
+.ace_editor,
+.ace_editor div {
   font-family: @font-family-monospace;
 }
 

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -238,6 +238,10 @@ div.Workspace {
     flex-grow: 1;
   }
 
+  .ace_editor, .ace_editor div {
+    font-family: @font-family-monospace;
+  }
+
   .ace_content {
     height: 100%;
   }

--- a/superset-frontend/src/dashboard/stylesheets/popover-menu.less
+++ b/superset-frontend/src/dashboard/stylesheets/popover-menu.less
@@ -51,7 +51,8 @@
   cursor: default;
   z-index: @z-index-max;
 
-  &, .menu-item {
+  &,
+  .menu-item {
     display: flex;
     flex-direction: row;
     align-items: center;


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Adds some CSS to force fixed width fonts onto the ace editor (sql editor) so Safari knows where to place the cursor. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before ("SELECT" is kerned/tracked too far, cursor is too far inward
<img width="199" alt="Screen Shot 2020-02-20 at 5 07 23 PM" src="https://user-images.githubusercontent.com/812905/74994712-a3ebdc00-5403-11ea-8f13-466b96b28441.png">


after ("SELECT" is fixed-width, cursor is at the end of the text as expected)
<img width="322" alt="Screen Shot 2020-02-20 at 5 06 55 PM" src="https://user-images.githubusercontent.com/812905/74994719-a77f6300-5403-11ea-8fa4-c1d410d66df8.png">

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #9095
- [x] Changes UI (barely... minor font tracking)
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
