### PR TITLE
docs: remove focus on Druid in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,31 +88,10 @@ Superset provides:
 Database Support
 ----------------
 
-Superset speaks many SQL dialects through SQLAlchemy, a Python
-ORM that is compatible with
-[most common databases](https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html).
-
-A list of currently supported SQL databases can be found
+Superset speaks many SQL dialects through SQLAlchemy - a Python
+SQL toolkit that is compatible with most databases. A list of
+supported databases can be found
 [here](https://superset.incubator.apache.org/#databases).
-
-Apache Druid (Incubating)!
-------
-
-On top of having the ability to query your relational databases,
-Superset ships with deep integration with Druid (a real time distributed
-column-store). When querying Druid,
-Superset can query humongous amounts of data on top of real time dataset.
-Note that Superset does not require Druid in any way to function, it's simply
-another database backend that it can query.
-
-Here's a description of Druid from the http://druid.io website:
-
-*Druid is an open-source analytics data store designed for
-business intelligence (OLAP) queries on event data. Druid provides low
-latency (real-time) data ingestion, flexible data exploration,
-and fast data aggregation. Existing Druid deployments have scaled to
-trillions of events and petabytes of data. Druid is best used to
-power analytic dashboards and applications.*
 
 
 Installation & Configuration
@@ -128,14 +107,13 @@ Resources
 * [Slides from Strata (March 2016)](https://drive.google.com/open?id=0B5PVE0gzO81oOVJkdF9aNkJMSmM)
 * [Stackoverflow tag](https://stackoverflow.com/questions/tagged/apache-superset)
 * [Join our Slack](https://join.slack.com/t/apache-superset/shared_invite/enQtNDMxMDY5NjM4MDU0LWJmOTcxYjlhZTRhYmEyYTMzOWYxOWEwMjcwZDZiNWRiNDY2NDUwNzcwMDFhNzE1ZmMxZTZlZWY0ZTQ2MzMyNTU)
-* [DEPRECATED Google Group](https://groups.google.com/forum/#!forum/airbnb_superset)
 
 
 Contributing
 ------------
 
 Interested in contributing? Casual hacking? Check out
-[Contributing.MD](https://github.com/apache/incubator-superset/blob/master/CONTRIBUTING.md)
+[Contributing.MD](https://github.com/apache/superset/blob/master/CONTRIBUTING.md)
 
 
 Who uses Apache Superset (incubating)?

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -718,16 +718,9 @@ parameter ::
 Druid
 -----
 
-* From the UI, enter the information about your clusters in the
-  `Sources -> Druid Clusters` menu by hitting the + sign.
-
-* Once the Druid cluster connection information is entered, hit the
-  `Sources -> Refresh Druid Metadata` menu item to populate
-
-* Navigate to your datasources
-
-Note that you can run the ``superset refresh_druid`` command to refresh the
-metadata from your Druid cluster(s)
+The native Druid connector (behind the ``DRUID_IS_ACTIVE`` feature flag)
+is slowly getting deprecated in favor of the SQLAlchemy/DBAPI connector made
+available in the ``pydruid`` library.
 
 Dremio
 ------


### PR DESCRIPTION
The text in the README seemed overly Druid-centric at this time. While
originally (3-4 years ago) Superset was heavily focussed on druid, it's
just not accurate anymore. Druid is just one of the databases that we
support and docs should reflect that.

### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation
