### PR TITLE
[dashboard] fix filter_scopes when copy dashboard with duplicate_slices

### DIFF
--- a/superset/utils/dashboard_filter_scopes_converter.py
+++ b/superset/utils/dashboard_filter_scopes_converter.py
@@ -70,3 +70,17 @@ def convert_filter_scopes(json_metadata: Dict, filters: List[Slice]):
             filter_scopes[filter_id] = filter_fields
 
     return filter_scopes
+
+
+def copy_filter_scopes(
+    old_to_new_slc_id_dict: Dict[int, int], old_filter_scopes: Dict[str, Dict]
+) -> Dict:
+    new_filter_scopes = {}
+    for (slice_id, scopes) in old_filter_scopes.items():
+        new_filter_key = old_to_new_slc_id_dict[int(slice_id)]
+        new_filter_scopes[str(new_filter_key)] = scopes
+        for scope in scopes.values():
+            scope["immune"] = [
+                old_to_new_slc_id_dict[slice_id] for slice_id in scope.get("immune")
+            ]
+    return new_filter_scopes

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -86,6 +86,7 @@ from superset.models.user_attributes import UserAttribute
 from superset.sql_parse import ParsedQuery
 from superset.sql_validators import get_validator_by_name
 from superset.utils import core as utils, dashboard_import_export
+from superset.utils.dashboard_filter_scopes_converter import copy_filter_scopes
 from superset.utils.dates import now_as_float
 from superset.utils.decorators import etag_cache, stats_timing
 from superset.views.chart import views as chart_views
@@ -1174,40 +1175,32 @@ class Superset(BaseSupersetView):
 
         if data["duplicate_slices"]:
             # Duplicating slices as well, mapping old ids to new ones
-            old_to_new_sliceids = {}
+            old_to_new_sliceids: Dict[int, int] = {}
             for slc in original_dash.slices:
                 new_slice = slc.clone()
                 new_slice.owners = [g.user] if g.user else []
                 session.add(new_slice)
                 session.flush()
                 new_slice.dashboards.append(dash)
-                old_to_new_sliceids["{}".format(slc.id)] = "{}".format(new_slice.id)
+                old_to_new_sliceids[slc.id] = new_slice.id
 
             # update chartId of layout entities
-            # in v2_dash positions json data, chartId should be integer,
-            # while in older version slice_id is string type
             for value in data["positions"].values():
                 if (
                     isinstance(value, dict)
                     and value.get("meta")
                     and value.get("meta").get("chartId")
                 ):
-                    old_id = "{}".format(value.get("meta").get("chartId"))
-                    new_id = int(old_to_new_sliceids[old_id])
+                    old_id = value.get("meta").get("chartId")
+                    new_id = old_to_new_sliceids[old_id]
                     value["meta"]["chartId"] = new_id
 
+            # replace filter_id and immune ids from old slice id to new slice id:
             if "filter_scopes" in data:
-                old_filter_scopes = json.loads(data["filter_scopes"] or "{}")
-                new_filter_scopes = {}
-                # replace filter_id and immune ids from old slice id to new slice id:
-                for (slice_id, scopes) in old_filter_scopes.items():
-                    new_filter_key = old_to_new_sliceids[slice_id]
-                    new_filter_scopes[new_filter_key] = scopes
-                    for scope in scopes.values():
-                        scope["immune"] = [
-                            int(old_to_new_sliceids[str(slice_id)])
-                            for slice_id in scope.get("immune")
-                        ]
+                new_filter_scopes = copy_filter_scopes(
+                    old_to_new_slc_id_dict=old_to_new_sliceids,
+                    old_filter_scopes=json.loads(data["filter_scopes"] or "{}"),
+                )
                 data["filter_scopes"] = json.dumps(new_filter_scopes)
         else:
             dash.slices = original_dash.slices

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1195,6 +1195,20 @@ class Superset(BaseSupersetView):
                     old_id = "{}".format(value.get("meta").get("chartId"))
                     new_id = int(old_to_new_sliceids[old_id])
                     value["meta"]["chartId"] = new_id
+
+            if "filter_scopes" in data:
+                old_filter_scopes = json.loads(data["filter_scopes"] or "{}")
+                new_filter_scopes = {}
+                # replace filter_id and immune ids from old slice id to new slice id:
+                for (slice_id, scopes) in old_filter_scopes.items():
+                    new_filter_key = old_to_new_sliceids[slice_id]
+                    new_filter_scopes[new_filter_key] = scopes
+                    for scope in scopes.values():
+                        scope["immune"] = [
+                            int(old_to_new_sliceids[str(slice_id)])
+                            for slice_id in scope.get("immune")
+                        ]
+                data["filter_scopes"] = json.dumps(new_filter_scopes)
         else:
             dash.slices = original_dash.slices
         dash.params = original_dash.params


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When user copy dashboard with `also copy (duplicate) charts`, dashboard duplicates each slices in the old dash and use new slice_id in the new dash. We should update filter_scopes with new slice ids.


### TEST PLAN
CI and manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9109 #9146 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@serenajiang @john-bodley 