### PR TITLE
build: upgrade typescript to 3.8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,6 @@ rat-results.txt
 *.js.map
 node_modules
 npm-debug.log*
-superset-frontend/coverage/*
-superset-frontend/cypress/screenshots
-superset-frontend/cypress/videos
 superset/static/assets
 superset/static/version_info.json
 yarn-error.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -488,7 +488,7 @@ best practices.
 
 Superset supports a server-wide feature flag system, which eases the incremental development of features. To add a new feature flag, simply modify `superset_config.py` with something like the following:
 
-```
+```python
 FEATURE_FLAGS = {
     'SCOPED_FILTER': True,
 }
@@ -496,7 +496,7 @@ FEATURE_FLAGS = {
 
 If you want to use the same flag in the client code, also add it to the FeatureFlag TypeScript enum in `superset-frontend/src/featureFlags.ts`. For example,
 
-```
+```typescript
 export enum FeatureFlag {
   SCOPED_FILTER = 'SCOPED_FILTER',
 }

--- a/superset-frontend/.eslintignore
+++ b/superset-frontend/.eslintignore
@@ -25,5 +25,6 @@ stylesheets/*
 vendor/*
 docs/*
 src/dashboard/deprecated/*
+src/temp/*
 **/node_modules
 *.d.ts

--- a/superset-frontend/.gitignore
+++ b/superset-frontend/.gitignore
@@ -1,0 +1,4 @@
+coverage/*
+cypress/screenshots
+cypress/videos
+src/temp

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -24712,9 +24712,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
     "typpy": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -218,7 +218,7 @@
     "ts-jest": "^24.0.2",
     "ts-loader": "^5.4.5",
     "tslib": "^1.10.0",
-    "typescript": "^3.5.3",
+    "typescript": "^3.8.2",
     "url-loader": "^1.0.1",
     "webpack": "^4.19.0",
     "webpack-assets-manifest": "^3.0.1",

--- a/superset-frontend/spec/javascripts/utils/safeStringify_spec.ts
+++ b/superset-frontend/spec/javascripts/utils/safeStringify_spec.ts
@@ -19,7 +19,7 @@
 import { safeStringify } from '../../../src/utils/safeStringify';
 
 class Noise {
-  public next: Noise;
+  public next?: Noise;
 }
 
 describe('Stringify utility testing', () => {

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -281,7 +281,7 @@ const config = {
     hot: true,
     index: '', // This line is needed to enable root proxying
     inline: true,
-    stats: { colors: true },
+    stats: 'minimal',
     overlay: true,
     port: devserverPort,
     // Only serves bundled files from webpack-dev-server


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY

Some `@superset-ui-plugin` uses newer version of Typescript and the build may fail when you try to import the Typescript directly via `npm link`.
 
- Upgrade Typescript to 3.8.2 and fix minor linting issues.
- Change webpack stats to "minimal" so build errors are more readable.
- Move .gitignore for frontend code to its own subfolder.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![image](https://user-images.githubusercontent.com/335541/75081004-947f9800-54c2-11ea-963c-e5d61bb7c2d7.png)


### TEST PLAN

All CI/CD should pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
