### PR TITLE
Make JSX Menu links open in new tab

### DIFF
--- a/superset-frontend/src/components/Menu/Menu.jsx
+++ b/superset-frontend/src/components/Menu/Menu.jsx
@@ -72,13 +72,21 @@ export default function Menu({
         <Nav className="navbar-right">
           {!navbarRight.user_is_anonymous && <NewMenu />}
           {navbarRight.documentation_url && (
-            <NavItem href={navbarRight.documentation_url} title="Documentation">
+            <NavItem
+              href={navbarRight.documentation_url}
+              target="_blank"
+              title="Documentation"
+            >
               <i className="fa fa-question" />
               &nbsp;
             </NavItem>
           )}
           {navbarRight.bug_report_url && (
-            <NavItem href={navbarRight.bug_report_url} title="Report a Bug">
+            <NavItem
+              href={navbarRight.bug_report_url}
+              target="_blank"
+              title="Report a Bug"
+            >
               <i className="fa fa-bug" />
               &nbsp;
             </NavItem>


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When the new React navbar was built, the functionality of bug reporting and documentation links opening in a new tab wasn't ported over. This fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
looks like this before and after:
![image](https://user-images.githubusercontent.com/7409244/75084263-ec72ca80-54d3-11ea-9c13-bdf9caacb49e.png)

### TEST PLAN
Set the config value for the DOCUMENTATION_URL, click the link, see it open in another tab

See other links open in the current tab as before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @willbarrett @graceguo-supercat @john-bodley @zuzana-vej