### PR TITLE
[Explore] Add Test SQL button to table explore view

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -261,6 +261,8 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):
     datamodel = SQLAInterface(models.SqlaTable)
     include_route_methods = RouteMethod.CRUD_SET
 
+    edit_template = "superset/models/table/edit.html"
+
     list_title = _("Tables")
     show_title = _("Show Table")
     add_title = _("Import a table definition")

--- a/superset/templates/superset/models/table/edit.html
+++ b/superset/templates/superset/models/table/edit.html
@@ -1,0 +1,25 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+#}
+{% extends "appbuilder/general/model/edit.html" %}
+
+{% import "superset/models/table/macros.html" as macros %}
+{% block tail_js %}
+  {{ super() }}
+  {{ macros.testsql() }}
+{% endblock %}

--- a/superset/templates/superset/models/table/macros.html
+++ b/superset/templates/superset/models/table/macros.html
@@ -1,0 +1,64 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+#}
+{% macro testsql() %}
+  <script>
+    $("#TableColumnInlineView").find("#expression").parent().append('<button id="TableColumnInlineViewtestsql" class="btn btn-sm btn-primary">{{ _("Test SQL Expression") }}</button>');
+    $("#SqlMetricInlineView").find("#expression").parent().append('<button id="SqlMetricInlineViewtestsql" class="btn btn-sm btn-primary">{{ _("Test SQL Expression") }}</button>');
+
+    function testsqlquery(e) {
+      e.preventDefault();
+      var url = "/superset/sql_json";
+      var csrf_token = "{{ csrf_token() if csrf_token else '' }}";
+
+      $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+          if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader("X-CSRFToken", csrf_token);
+          }
+        }
+      });
+
+      var data = JSON.stringify({
+        "database_id": $("#database").find("option:selected").val(),
+        "schema": $("#schema").val(),
+        "sql": "SELECT " + e.currentTarget.parentElement.children[0].value + " FROM "+ $("#table_name").val()+" LIMIT 1",
+      });
+
+      $.ajax({
+        method: "POST",
+        url: url,
+        data: data,
+        dataType: 'json',
+        contentType: "application/json; charset=utf-8"
+      }).done(function(data) {
+          alert("Seems OK!");
+      }).fail(function(error) {
+          var respJSON = error.responseJSON;
+          var errorMsg = error.responseText;
+          if (respJSON && respJSON.error) {
+              errorMsg = respJSON.error;
+          }
+          alert("ERROR: " + errorMsg);
+      });
+      return false;
+    }
+    $("#TableColumnInlineViewtestsql").click(testsqlquery);
+    $("#SqlMetricInlineViewtestsql").click(testsqlquery);
+  </script>
+{% endmacro %}

--- a/superset/templates/superset/models/table/macros.html
+++ b/superset/templates/superset/models/table/macros.html
@@ -18,8 +18,8 @@
 #}
 {% macro testsql() %}
   <script>
-    $("#TableColumnInlineView").find("#expression").parent().append('<button id="TableColumnInlineViewtestsql" class="btn btn-sm btn-primary">{{ _("Test SQL Expression") }}</button>');
-    $("#SqlMetricInlineView").find("#expression").parent().append('<button id="SqlMetricInlineViewtestsql" class="btn btn-sm btn-primary">{{ _("Test SQL Expression") }}</button>');
+    $("#TableColumnInlineView").find("#expression").parent().append('<button id="TableColumnInlineViewtestsql" class="btn btn-sm btn-primary">{{ _("Run SQL Expression") }}</button>');
+    $("#SqlMetricInlineView").find("#expression").parent().append('<button id="SqlMetricInlineViewtestsql" class="btn btn-sm btn-primary">{{ _("Run SQL Expression") }}</button>');
 
     function testsqlquery(e) {
       e.preventDefault();
@@ -60,5 +60,8 @@
     }
     $("#TableColumnInlineViewtestsql").click(testsqlquery);
     $("#SqlMetricInlineViewtestsql").click(testsqlquery);
+
+    $("#TableColumnInlineViewtestsql").attr('title', "{{ _('This will run the query to test it') }}");
+    $("#SqlMetricInlineViewtestsql").attr('title', "{{ _('This will run the query to test it') }}");
   </script>
 {% endmacro %}


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Fix issue https://github.com/apache/incubator-superset/issues/5417
This add a new button to check user SQL function in the table explore view when :
- creating a new fields in a table
- creating a new metrics in a table

- I used the sql_json API to not create a new API
- Used a popup as the test connection button. 
- Launch a query SELECT {expression} FROM {table} LIMIT 1 as suggested in the bug description

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
the button is present in the column tab and metric tab. this display a popup saying OK if it seems OK or display the SQL error :
![testsql_feature_popup](https://user-images.githubusercontent.com/3482221/75182045-dec17d00-573f-11ea-97ee-ab5e1f9ad49c.png)
![testsql_feature](https://user-images.githubusercontent.com/3482221/75182059-e2ed9a80-573f-11ea-91a0-4be04e0fc7a7.png)
![testsql_feature_popup_error](https://user-images.githubusercontent.com/3482221/75182068-e5e88b00-573f-11ea-8215-9aa6ea1d3220.png)


### TEST PLAN
Manual test for the most of it (different column, tables, bases and with user with restricted access or not)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: Fix #5417 
- [X] Changes UI : see screenshot
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
