### PR TITLE
[Bug Fix] Returning timeseries_limit_metric in table viz get_data

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -585,6 +585,12 @@ class TableViz(BaseViz):
             self.form_data.get("all_columns") or self.form_data.get("groupby") or []
         ) + utils.get_metric_names(self.form_data.get("metrics") or [])
 
+        timeseries_limit_metric = utils.get_metric_name(
+            self.form_data.get("timeseries_limit_metric")
+        )
+        if timeseries_limit_metric:
+            non_percent_metric_columns.append(timeseries_limit_metric)
+
         percent_metric_columns = utils.get_metric_names(
             self.form_data.get("percent_metrics") or []
         )

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -575,15 +575,21 @@ class TableViz(BaseViz):
         the percent metrics have yet to be transformed.
         """
 
-        if not self.should_be_timeseries() and DTTM_ALIAS in df:
-            del df[DTTM_ALIAS]
-
+        non_percent_metric_columns = []
         # Transform the data frame to adhere to the UI ordering of the columns and
         # metrics whilst simultaneously computing the percentages (via normalization)
         # for the percent metrics.
-        non_percent_metric_columns = (
+
+        if not self.should_be_timeseries() and DTTM_ALIAS in df:
+            del df[DTTM_ALIAS]
+        elif self.should_be_timeseries() and DTTM_ALIAS in df:
+            non_percent_metric_columns.append(DTTM_ALIAS)
+
+        non_percent_metric_columns.extend(
             self.form_data.get("all_columns") or self.form_data.get("groupby") or []
-        ) + utils.get_metric_names(self.form_data.get("metrics") or [])
+        )
+
+        non_percent_metric_columns.extend(utils.get_metric_names(self.form_data.get("metrics") or []))
 
         timeseries_limit_metric = utils.get_metric_name(
             self.form_data.get("timeseries_limit_metric")

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -589,7 +589,9 @@ class TableViz(BaseViz):
             self.form_data.get("all_columns") or self.form_data.get("groupby") or []
         )
 
-        non_percent_metric_columns.extend(utils.get_metric_names(self.form_data.get("metrics") or []))
+        non_percent_metric_columns.extend(
+            utils.get_metric_names(self.form_data.get("metrics") or [])
+        )
 
         timeseries_limit_metric = utils.get_metric_name(
             self.form_data.get("timeseries_limit_metric")

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -580,10 +580,11 @@ class TableViz(BaseViz):
         # metrics whilst simultaneously computing the percentages (via normalization)
         # for the percent metrics.
 
-        if not self.should_be_timeseries() and DTTM_ALIAS in df:
-            del df[DTTM_ALIAS]
-        elif self.should_be_timeseries() and DTTM_ALIAS in df:
-            non_percent_metric_columns.append(DTTM_ALIAS)
+        if DTTM_ALIAS in df:
+            if self.should_be_timeseries():
+                non_percent_metric_columns.append(DTTM_ALIAS)
+            else:
+                del df[DTTM_ALIAS]
 
         non_percent_metric_columns.extend(
             self.form_data.get("all_columns") or self.form_data.get("groupby") or []

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -427,7 +427,7 @@ class TableVizTestCase(SupersetTestCase):
             "order_desc": False,
         }
 
-        df = pd.DataFrame({"SUM(value1)": [15], "sum_value": [15],})
+        df = pd.DataFrame({"SUM(value1)": [15], "sum_value": [15]})
         datasource = self.get_datasource_mock()
         test_viz = viz.TableViz(datasource, form_data)
         data = test_viz.get_data(df)

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -407,6 +407,32 @@ class TableVizTestCase(SupersetTestCase):
         with self.assertRaises(Exception):
             test_viz.should_be_timeseries()
 
+    def test_adhoc_metric_with_sortby(self):
+        metrics = [
+            {
+                "expressionType": "SIMPLE",
+                "aggregate": "SUM",
+                "label": "sum_value",
+                "column": {"column_name": "value1", "type": "DOUBLE"},
+            }
+        ]
+        form_data = {
+            "metrics": metrics,
+            "timeseries_limit_metric": {
+                "expressionType": "SIMPLE",
+                "aggregate": "SUM",
+                "label": "SUM(value1)",
+                "column": {"column_name": "value1", "type": "DOUBLE"},
+            },
+            "order_desc": False,
+        }
+
+        df = pd.DataFrame({"SUM(value1)": [15], "sum_value": [15],})
+        datasource = self.get_datasource_mock()
+        test_viz = viz.TableViz(datasource, form_data)
+        data = test_viz.get_data(df)
+        self.assertEqual(["sum_value", "SUM(value1)"], data["columns"])
+
 
 class DistBarVizTestCase(SupersetTestCase):
     def test_groupby_nulls(self):


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
[This](https://github.com/apache/incubator-superset/pull/9122) change update the table viz's get_data, but was missing returning the timeseries_limit_metric (sort_by). If a metric has a custom label and a sort by field, not returning the sort_by field doesn't show the metric.

### TEST PLAN
Tested a metric with a label and a sort by field

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley 