### PR TITLE
[dashboard perf logging] add dashboard url anchor component id

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -34,6 +34,7 @@ import OmniContainer from '../../components/OmniContainer';
 import { areObjectsEqual } from '../../reduxUtils';
 
 import '../stylesheets/index.less';
+import getLocationHash from '../util/getLocationHash';
 
 const propTypes = {
   actions: PropTypes.shape({
@@ -83,7 +84,12 @@ class Dashboard extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.props.actions.logEvent(LOG_ACTIONS_MOUNT_DASHBOARD);
+    const eventData = {};
+    const directLinkComponentId = getLocationHash();
+    if (directLinkComponentId) {
+      eventData.target_id = directLinkComponentId;
+    }
+    this.props.actions.logEvent(LOG_ACTIONS_MOUNT_DASHBOARD, eventData);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Dashboard supports nested tabs and charts. But user can add anchor in the request url, and dashboard will be landed with the component in the anchor. For example:
https://superset.d.musta.ch/superset/dashboard/homes/#TAB-DZy3k25d_ will open a specific tab.
https://superset.d.musta.ch/superset/dashboard/homes/#CHART-59WSceLod1 will open a specific chart.

This PR is to add the anchor component into dashboard perf log, so that we can see which tab/charts are more popular. This will help dashboard warm-up tasks.

### TEST PLAN
CI and manual test.

### REVIEWERS
@serenajiang @etr2460 