### PR TITLE
[api] enable CSRF by default

### DIFF
--- a/superset-frontend/spec/javascripts/utils/parseCookie_spec.ts
+++ b/superset-frontend/spec/javascripts/utils/parseCookie_spec.ts
@@ -16,24 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* eslint no-console: 0 */
-import { SupersetClient } from '@superset-ui/connection';
 import parseCookie from 'src/utils/parseCookie';
 
-export default function setupClient() {
-  const csrfNode = document.querySelector('#csrf_token');
-  const csrfToken = csrfNode ? csrfNode.value : null;
+describe('parseCookie', () => {
+  let cookieVal = '';
+  Object.defineProperty(document, 'cookie', {
+    get: jest.fn().mockImplementation(() => {
+      return cookieVal;
+    }),
+  });
+  it('parses cookie strings', () => {
+    cookieVal = 'val1=foo; val2=bar';
+    expect(parseCookie()).toEqual({ val1: 'foo', val2: 'bar' });
+  });
 
-  // when using flask-jwt-extended csrf is set in cookies
-  const cookieCSRFToken = parseCookie().csrf_access_token || '';
+  it('parses empty cookie strings', () => {
+    cookieVal = '';
+    expect(parseCookie()).toEqual({});
+  });
 
-  SupersetClient.configure({
-    protocol: (window.location && window.location.protocol) || '',
-    host: (window.location && window.location.host) || '',
-    csrfToken: csrfToken || cookieCSRFToken,
-  })
-    .init()
-    .catch(error => {
-      console.warn('Error initializing SupersetClient', error);
-    });
-}
+  it('accepts an arg', () => {
+    expect(parseCookie('val=foo')).toEqual({ val: 'foo' });
+  });
+});

--- a/superset-frontend/src/utils/parseCookie.ts
+++ b/superset-frontend/src/utils/parseCookie.ts
@@ -16,24 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* eslint no-console: 0 */
-import { SupersetClient } from '@superset-ui/connection';
-import parseCookie from 'src/utils/parseCookie';
 
-export default function setupClient() {
-  const csrfNode = document.querySelector('#csrf_token');
-  const csrfToken = csrfNode ? csrfNode.value : null;
+type CookieMap = { [cookieId: string]: string };
 
-  // when using flask-jwt-extended csrf is set in cookies
-  const cookieCSRFToken = parseCookie().csrf_access_token || '';
-
-  SupersetClient.configure({
-    protocol: (window.location && window.location.protocol) || '',
-    host: (window.location && window.location.host) || '',
-    csrfToken: csrfToken || cookieCSRFToken,
-  })
-    .init()
-    .catch(error => {
-      console.warn('Error initializing SupersetClient', error);
-    });
+export default function parseCookie(cookie = document.cookie): CookieMap {
+  return Object.fromEntries(
+    cookie
+      .split('; ')
+      .filter(x => x)
+      .map(x => x.split('=')),
+  );
 }

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -62,7 +62,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
     """
     Extends FAB's ModelResApi to implement specific superset generic functionality
     """
-
+    csrf_exempt = False
     method_permission_name = {
         "get_list": "list",
         "get": "show",

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -62,6 +62,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
     """
     Extends FAB's ModelResApi to implement specific superset generic functionality
     """
+
     csrf_exempt = False
     method_permission_name = {
         "get_list": "list",


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Enables CSRF on the new REST API by default. Uses Flask-WTF CSRF protection.
Thank you @nytai for helping out on the frontend side.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
