### PR TITLE
[fix] remove chart id from filter_scopes metadata if chart is not in dash anymore

### DIFF
--- a/superset/utils/dashboard_filter_scopes_converter.py
+++ b/superset/utils/dashboard_filter_scopes_converter.py
@@ -76,14 +76,14 @@ def copy_filter_scopes(
     old_to_new_slc_id_dict: Dict[int, int], old_filter_scopes: Dict[str, Dict]
 ) -> Dict:
     new_filter_scopes = {}
-    for (slice_id, scopes) in old_filter_scopes.items():
-        new_filter_key = old_to_new_slc_id_dict.get(int(slice_id))
+    for (filter_id, scopes) in old_filter_scopes.items():
+        new_filter_key = old_to_new_slc_id_dict.get(int(filter_id))
         if new_filter_key:
             new_filter_scopes[str(new_filter_key)] = scopes
             for scope in scopes.values():
                 scope["immune"] = [
-                    old_to_new_slc_id_dict[slice_id]
-                    for slice_id in scope.get("immune")
-                    if old_to_new_slc_id_dict.get(slice_id) is not None
+                    old_to_new_slc_id_dict[int(slice_id)]
+                    for slice_id in scope.get("immune", [])
+                    if int(slice_id) in old_to_new_slc_id_dict
                 ]
     return new_filter_scopes

--- a/superset/utils/dashboard_filter_scopes_converter.py
+++ b/superset/utils/dashboard_filter_scopes_converter.py
@@ -77,10 +77,13 @@ def copy_filter_scopes(
 ) -> Dict:
     new_filter_scopes = {}
     for (slice_id, scopes) in old_filter_scopes.items():
-        new_filter_key = old_to_new_slc_id_dict[int(slice_id)]
-        new_filter_scopes[str(new_filter_key)] = scopes
-        for scope in scopes.values():
-            scope["immune"] = [
-                old_to_new_slc_id_dict[slice_id] for slice_id in scope.get("immune")
-            ]
+        new_filter_key = old_to_new_slc_id_dict.get(int(slice_id))
+        if new_filter_key:
+            new_filter_scopes[str(new_filter_key)] = scopes
+            for scope in scopes.values():
+                scope["immune"] = [
+                    old_to_new_slc_id_dict[slice_id]
+                    for slice_id in scope.get("immune")
+                    if old_to_new_slc_id_dict.get(slice_id) is not None
+                ]
     return new_filter_scopes

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1233,6 +1233,12 @@ class Superset(BaseSupersetView):
         dash = session.query(Dashboard).get(dashboard_id)
         check_ownership(dash, raise_if_false=True)
         data = json.loads(request.form.get("data"))
+        if "filter_scopes" in data:
+            new_filter_scopes = copy_filter_scopes(
+                old_to_new_slc_id_dict={slc.id: slc.id for slc in dash.slices},
+                old_filter_scopes=json.loads(data["filter_scopes"] or "{}"),
+            )
+            data["filter_scopes"] = json.dumps(new_filter_scopes)
         self._set_dash_metadata(dash, data)
         session.merge(dash)
         session.commit()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1207,6 +1207,14 @@ class Superset(BaseSupersetView):
                 data["filter_scopes"] = json.dumps(new_filter_scopes)
         else:
             dash.slices = original_dash.slices
+            # remove slice id from filter_scopes metadata if slice is removed from dashboard
+            if "filter_scopes" in data:
+                new_filter_scopes = copy_filter_scopes(
+                    old_to_new_slc_id_dict={slc.id: slc.id for slc in dash.slices},
+                    old_filter_scopes=json.loads(data["filter_scopes"] or "{}"),
+                )
+                data["filter_scopes"] = json.dumps(new_filter_scopes)
+
         dash.params = original_dash.params
 
         self._set_dash_metadata(dash, data)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
when user or db migration removed a chart from dashboard, we didn't update filter_scopes metadata. It didn't cause any issue when we load filters in dashboard. But when user copy dashboard with slices, it will show error because dashboard can't find the new slice id from the copied dashboard:
<img width="610" alt="Screen Shot 2020-02-26 at 12 18 08 PM" src="https://user-images.githubusercontent.com/27990562/75393360-bdc56d00-58a2-11ea-8662-270c11ff496b.png">



### TEST PLAN
CI and manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #9188 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@serenajiang @michellethomas 