### PR TITLE
fix: choose language link for local dev

### DIFF
--- a/superset-frontend/src/setup/setupApp.ts
+++ b/superset-frontend/src/setup/setupApp.ts
@@ -67,7 +67,7 @@ export default function setupApp() {
     ) {
       ev.preventDefault();
       SupersetClient.get({
-        endpoint: ev.currentTarget.href,
+        url: ev.currentTarget.href,
         parseMethod: null,
       }).then(() => {
         location.reload();


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix

### SUMMARY

@superset-ui/connection will [add protocol and host](https://github.com/apache-superset/superset-ui/blob/245db6ef79de7e8f95da39ec9e2af4022418525e/packages/superset-ui-connection/src/SupersetClientClass.ts#L155-L171
) to an "endpoint" call. `e.currentTarget.href` may return the full URL instead of the relative url. This sometimes results in invalid URLs for change language API calls.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

In local dev environment, change language will result in a 404 error:

![Snip20200226_6](https://user-images.githubusercontent.com/335541/75408262-165c3080-58ca-11ea-85c9-be84b78a6b9e.png)

![image](https://user-images.githubusercontent.com/335541/75408229-fc225280-58c9-11ea-876b-34e2632998b2.png)

The result should be gone after this fix.

### TEST PLAN

Change language in local dev box will work and should not throw an error in the browser console.

### ADDITIONAL INFORMATION

N/A

### REVIEWERS

@kristw 