### PR TITLE
[fix] Adding SIP-15 support for the query context

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -23,6 +23,7 @@ import simplejson as json
 
 from superset import app
 from superset.utils import core as utils
+from superset.views.utils import get_time_range_endpoints
 
 # TODO: Type Metrics dictionary with TypedDict when it becomes a vanilla python type
 # https://github.com/python/mypy/issues/5288
@@ -95,6 +96,10 @@ class QueryObject:
         self.timeseries_limit_metric = timeseries_limit_metric
         self.order_desc = order_desc
         self.extras = extras or {}
+
+        if app.config["SIP_15_ENABLED"] and "time_range_endpoints" not in self.extras:
+            self.extras["time_range_endpoints"] = get_time_range_endpoints(form_data={})
+
         self.columns = columns or []
         self.orderby = orderby or []
 

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -165,6 +165,17 @@ class CoreTests(SupersetTestCase):
         # the new cache_key should be different due to updated datasource
         self.assertNotEqual(cache_key_original, cache_key_new)
 
+    def test_query_context_time_range_endpoints(self):
+        query_context = QueryContext(**self._get_query_context_dict())
+        query_object = query_context.queries[0]
+        extras = query_object.to_dict()["extras"]
+        self.assertTrue("time_range_endpoints" in extras)
+
+        self.assertEquals(
+            extras["time_range_endpoints"],
+            (utils.TimeRangeEndpoint.INCLUSIVE, utils.TimeRangeEndpoint.EXCLUSIVE),
+        )
+
     def test_get_superset_tables_not_allowed(self):
         example_db = utils.get_example_database()
         schema_name = self.default_schema_backend_map[example_db.backend]
@@ -973,7 +984,12 @@ class CoreTests(SupersetTestCase):
             "sql": "SELECT * FROM birth_names LIMIT 100",
             "status": utils.QueryStatus.PENDING,
         }
-        serialized_data, selected_columns, all_columns, expanded_columns = sql_lab._serialize_and_expand_data(
+        (
+            serialized_data,
+            selected_columns,
+            all_columns,
+            expanded_columns,
+        ) = sql_lab._serialize_and_expand_data(
             results, db_engine_spec, use_new_deserialization
         )
         payload = {
@@ -1016,7 +1032,12 @@ class CoreTests(SupersetTestCase):
             "sql": "SELECT * FROM birth_names LIMIT 100",
             "status": utils.QueryStatus.PENDING,
         }
-        serialized_data, selected_columns, all_columns, expanded_columns = sql_lab._serialize_and_expand_data(
+        (
+            serialized_data,
+            selected_columns,
+            all_columns,
+            expanded_columns,
+        ) = sql_lab._serialize_and_expand_data(
             results, db_engine_spec, use_new_deserialization
         )
         payload = {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

This PR ensures that the query context sets the query time range endpoints if undefined and SIP-15 is enabled.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Added unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @villebro 