### PR TITLE
[SQL Lab] Implement refetch results button properly

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.jsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.jsx
@@ -64,6 +64,11 @@ export default class ResultSet extends React.PureComponent {
       showExploreResultsButton: false,
       data: null,
     };
+
+    this.changeSearch = this.changeSearch.bind(this);
+    this.fetchResults = this.fetchResults.bind(this);
+    this.popSelectStar = this.popSelectStar.bind(this);
+    this.reFetchQueryResults = this.reFetchQueryResults.bind(this);
     this.toggleExploreResultsButton = this.toggleExploreResultsButton.bind(
       this,
     );
@@ -171,7 +176,7 @@ export default class ResultSet extends React.PureComponent {
               {this.props.search && (
                 <input
                   type="text"
-                  onChange={this.changeSearch.bind(this)}
+                  onChange={this.changeSearch}
                   value={this.state.searchText}
                   className="form-control input-sm"
                   placeholder={t('Filter Results')}
@@ -219,7 +224,7 @@ export default class ResultSet extends React.PureComponent {
             <Button
               bsSize="small"
               className="m-r-5"
-              onClick={this.popSelectStar.bind(this)}
+              onClick={this.popSelectStar}
             >
               {t('Query in a new tab')}
             </Button>
@@ -240,7 +245,7 @@ export default class ResultSet extends React.PureComponent {
           : [];
         return (
           <>
-            {this.renderControls.bind(this)()}
+            {this.renderControls()}
             {sql}
             <FilterableTable
               data={data}
@@ -258,19 +263,34 @@ export default class ResultSet extends React.PureComponent {
       }
     }
     if (query.cached || (query.state === 'success' && !query.results)) {
-      return (
-        <Button
-          bsSize="sm"
-          className="fetch"
-          bsStyle="primary"
-          onClick={this.reFetchQueryResults.bind(this, {
-            ...query,
-            isDataPreview: true,
-          })}
-        >
-          {t('Fetch data preview')}
-        </Button>
-      );
+      if (query.isDataPreview) {
+        return (
+          <Button
+            bsSize="sm"
+            className="fetch"
+            bsStyle="primary"
+            onClick={() =>
+              this.reFetchQueryResults({
+                ...query,
+                isDataPreview: true,
+              })
+            }
+          >
+            {t('Fetch data preview')}
+          </Button>
+        );
+      } else if (query.resultsKey) {
+        return (
+          <Button
+            bsSize="sm"
+            className="fetch"
+            bsStyle="primary"
+            onClick={() => this.fetchResults(query)}
+          >
+            {t('Refetch Results')}
+          </Button>
+        );
+      }
     }
     let progressBar;
     let trackingUrl;


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Previously, we were rendering the Fetch data preview button when you switched away from a running query tab and switched back after the query finished. Clicking on this button would just rerun the query again. Now we check to see if a results key is set, and if so we fetch the results from the results cache

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/7409244/75502037-816b3d00-5986-11ea-831c-c4433351670f.png)

### TEST PLAN
Run a query in a tab, switch to another tab, come back and click the fetch results button, see no new query run.

Ensure refetching data previews still works.

Ensure running normal queries still work

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @graceguo-supercat @betodealmeida @rusackas 