### PR TITLE
feat: improve loading speed for legacy table chart

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -43,11 +43,11 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-          "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
           "requires": {
-            "regenerator-runtime": "^0.13.2"
+            "regenerator-runtime": "^0.13.4"
           }
         },
         "aphrodite": {
@@ -137,6 +137,11 @@
             "prop-types": "^15.6.0",
             "react-lifecycles-compat": "^3.0.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
         },
         "uuid": {
           "version": "3.4.0",
@@ -1789,9 +1794,9 @@
           "dev": true
         },
         "@babel/types": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
-          "integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -2267,28 +2272,40 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.4.tgz",
-      "integrity": "sha512-7jU2FgNqNHX6yTuU/Dr/vH5/O8eVL9U85MG5aDw1LzGfCvvhXC1shdXfVzCQDsoY967yrAKeLujRv7l8BU+dZA==",
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.7.tgz",
+      "integrity": "sha512-R8zbPiv25S0pGfMqAr55dRRxWB8vUeo3wicI4g9PFVBKmsy/9wmQUV1AaYW/kxRHUhx42TTh6F0+QO+4pwfYWg==",
       "requires": {
         "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       },
       "dependencies": {
         "core-js": {
           "version": "2.6.11",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
           "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
         }
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
-      "integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
+      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
       "requires": {
         "core-js-pure": "^3.0.0",
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+        }
       }
     },
     "@babel/template": {
@@ -2757,6 +2774,11 @@
             "d3-time": "1",
             "d3-time-format": "2"
           }
+        },
+        "resize-observer-polyfill": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
+          "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
         }
       }
     },
@@ -3290,6 +3312,11 @@
           "version": "16.13.0",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
           "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
+        },
+        "resize-observer-polyfill": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
+          "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
         }
       }
     },
@@ -3720,12 +3747,17 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-          "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
           "requires": {
-            "regenerator-runtime": "^0.13.2"
+            "regenerator-runtime": "^0.13.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
         }
       }
     },
@@ -3885,6 +3917,15 @@
         "gl-matrix": "^3.0.0"
       }
     },
+    "@math.gl/web-mercator": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.1.3.tgz",
+      "integrity": "sha512-aU+3upxkdA9yObA7EudfEKfN/QH4o5impyc7s/a34J2hZKPsihgREphxnKzl2RknXD/KoL7MnQv589LToAJGMQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "gl-matrix": "^3.0.0"
+      }
+    },
     "@probe.gl/stats": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.2.1.tgz",
@@ -3947,11 +3988,6 @@
             "prop-types": "^15.6.1",
             "resize-observer-polyfill": "1.5.1"
           }
-        },
-        "resize-observer-polyfill": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-          "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         }
       }
     },
@@ -3981,11 +4017,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
           "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
-        },
-        "resize-observer-polyfill": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-          "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         }
       }
     },
@@ -4177,11 +4208,6 @@
             "d3-time": "1",
             "d3-time-format": "2"
           }
-        },
-        "resize-observer-polyfill": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-          "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         }
       }
     },
@@ -4327,14 +4353,31 @@
       }
     },
     "@superset-ui/legacy-plugin-chart-table": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-plugin-chart-table/-/legacy-plugin-chart-table-0.11.15.tgz",
-      "integrity": "sha512-ekB9CpSsZn7h2NUL0rWyrfFE2/brpupsi+6P4gkhMFCnVZ9bOcxw0Hk+Ie0oKRHKrHMY3FZ0wJRfcPbwLPN6KQ==",
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-plugin-chart-table/-/legacy-plugin-chart-table-0.11.16.tgz",
+      "integrity": "sha512-6oZYVYBgQTL65vLHfJtosykGQnUddTop5qcKon3lA4SJkxWUz5yw8jtU0xzD8nk55n6QKccqFOjKyaz10V2WLQ==",
       "requires": {
-        "d3": "^3.5.17",
-        "datatables.net-bs": "^1.10.15",
-        "dompurify": "^2.0.6",
-        "prop-types": "^15.6.2"
+        "datatables.net-bs": "^1.10.20",
+        "xss": "^1.0.6"
+      },
+      "dependencies": {
+        "datatables.net": {
+          "version": "1.10.20",
+          "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.20.tgz",
+          "integrity": "sha512-4E4S7tTU607N3h0fZPkGmAtr9mwy462u+VJ6gxYZ8MxcRIjZqHy3Dv1GNry7i3zQCktTdWbULVKBbkAJkuHEnQ==",
+          "requires": {
+            "jquery": ">=1.7"
+          }
+        },
+        "datatables.net-bs": {
+          "version": "1.10.20",
+          "resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.20.tgz",
+          "integrity": "sha512-NsMoOOYZ6NlteOpzhltw21lXsNdhjIMbIOxnqmcrb62ntl8eL9pYzk2AeiDXBlIKY4e550ZrExCq3CYKQ9myEg==",
+          "requires": {
+            "datatables.net": "1.10.20",
+            "jquery": ">=1.7"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-treemap": {
@@ -4379,10 +4422,12 @@
       }
     },
     "@superset-ui/legacy-preset-chart-deckgl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.2.0.tgz",
-      "integrity": "sha512-Z2+QzeHec+qvCrxG3FPwGBrQq4FmeA5L3aU/346ZM7KwnYbCij6UGcYOl9+d87RuglwTDqpGygU5VR47b7xibg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.2.1.tgz",
+      "integrity": "sha512-FS8RPo2tZC+1xcGvFl91hVP3mNxlO/XrTeEFPHvwdlzrnKDJ2GwyV5F7G4Av0YLnesUzTRArQ8ArRzlsbyLZBA==",
       "requires": {
+        "@math.gl/web-mercator": "^3.1.3",
+        "@types/d3-array": "^2.0.0",
         "bootstrap-slider": "^10.0.0",
         "d3-array": "^1.2.4",
         "d3-color": "^1.2.0",
@@ -4397,8 +4442,7 @@
         "react-bootstrap-slider": "2.1.5",
         "react-map-gl": "^4.0.10",
         "underscore": "^1.8.3",
-        "urijs": "^1.18.10",
-        "viewport-mercator-project": "^6.1.1"
+        "urijs": "^1.18.10"
       }
     },
     "@superset-ui/legacy-preset-chart-nvd3": {
@@ -4442,14 +4486,14 @@
       }
     },
     "@superset-ui/preset-chart-xy": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/@superset-ui/preset-chart-xy/-/preset-chart-xy-0.11.15.tgz",
-      "integrity": "sha512-VOuMYzAtXVFg5njWdVMc+tmgkPT4fLH1KIgLthepsgXKgXThI4P6YpEWObuMlvZJ80s33s3frYJGKto7u7NZFw==",
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@superset-ui/preset-chart-xy/-/preset-chart-xy-0.11.16.tgz",
+      "integrity": "sha512-ZAI5B8YkZj1WLSLcMVp2iVt7bgztlgRqMLA7VvkZNgcVrw/rw1sR5M4H3Cj314RiLcP3OjtINcYc8tqSnCdWtw==",
       "requires": {
         "@data-ui/theme": "^0.0.84",
         "@data-ui/xy-chart": "^0.0.84",
         "@types/d3-scale": "^2.1.1",
-        "@vx/axis": "^0.0.194",
+        "@vx/axis": "^0.0.195",
         "@vx/group": "^0.0.194",
         "@vx/legend": "^0.0.194",
         "@vx/responsive": "^0.0.194",
@@ -4466,24 +4510,54 @@
       },
       "dependencies": {
         "@vx/axis": {
-          "version": "0.0.194",
-          "resolved": "https://registry.npmjs.org/@vx/axis/-/axis-0.0.194.tgz",
-          "integrity": "sha512-In3nKOkRE6koUk5ydaGkP4AnRaXrgz0NhDUwPN5O6T69a04+MQ6ONZw5ye9WFquw0rZ7bOi5E76ceHDxEXq7jw==",
+          "version": "0.0.195",
+          "resolved": "https://registry.npmjs.org/@vx/axis/-/axis-0.0.195.tgz",
+          "integrity": "sha512-oGbZ83tOfefJRkxQW8WGMmvt48Y7O3VzrWPC0mG+2xcfGzg5m04H6w7GvcqfEkOtgvyAXEDhiKJ3i6hH6QixsA==",
           "requires": {
             "@types/classnames": "^2.2.9",
             "@types/react": "*",
-            "@vx/group": "0.0.194",
-            "@vx/point": "0.0.194",
-            "@vx/shape": "0.0.194",
-            "@vx/text": "0.0.194",
+            "@vx/group": "0.0.195",
+            "@vx/point": "0.0.195",
+            "@vx/shape": "0.0.195",
+            "@vx/text": "0.0.195",
             "classnames": "^2.2.5",
             "prop-types": "^15.6.0"
+          },
+          "dependencies": {
+            "@vx/group": {
+              "version": "0.0.195",
+              "resolved": "https://registry.npmjs.org/@vx/group/-/group-0.0.195.tgz",
+              "integrity": "sha512-XzbCIb2dVR3b51gbiG+gfc8J/H7IaepQ7mQEOKKXnb4gP66kYU/Rtr7WTZzLD3uwsBDXjJaa2y16arnMmhUlNQ==",
+              "requires": {
+                "@types/classnames": "^2.2.9",
+                "@types/react": "*",
+                "classnames": "^2.2.5",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "@vx/shape": {
+              "version": "0.0.195",
+              "resolved": "https://registry.npmjs.org/@vx/shape/-/shape-0.0.195.tgz",
+              "integrity": "sha512-14I1E0t25hWx4/NCVj6cggm7ewD5a5UDMndXmcpUkV/wx/4SYkXhQ7uDdbAuYNcb/dh0wsFh8vmqmMJxm7DA/w==",
+              "requires": {
+                "@types/classnames": "^2.2.9",
+                "@types/d3-path": "^1.0.8",
+                "@types/d3-shape": "^1.3.1",
+                "@types/react": "*",
+                "@vx/curve": "0.0.195",
+                "@vx/group": "0.0.195",
+                "classnames": "^2.2.5",
+                "d3-path": "^1.0.5",
+                "d3-shape": "^1.2.0",
+                "prop-types": "^15.5.10"
+              }
+            }
           }
         },
         "@vx/curve": {
-          "version": "0.0.194",
-          "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.194.tgz",
-          "integrity": "sha512-6B+rHxsdK+PWdO8kYhT00kwBIwl9HIzpuxE+bRndrXC/nyoJVfSA7E4cLhZiIJYt0ukwkIPE3YsSIuT1OmW+1A==",
+          "version": "0.0.195",
+          "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.195.tgz",
+          "integrity": "sha512-fQXvd1530ou/K5v6fzH/RWy8HjXCKKScmtk9DfSdp/wkhm5u+1jkoe6r53PLAdJhUnMI6U8OsiVlaLF8nADuMw==",
           "requires": {
             "@types/d3-shape": "^1.3.1",
             "d3-shape": "^1.0.6"
@@ -4514,9 +4588,9 @@
           }
         },
         "@vx/point": {
-          "version": "0.0.194",
-          "resolved": "https://registry.npmjs.org/@vx/point/-/point-0.0.194.tgz",
-          "integrity": "sha512-G5/xErPn12UAsnYCqVIS+M5iEBgpT2ecplQMDSx3iS68thHQWrY2r+r24VXubTGT85GOYp3uurTYY6j2Ez4EsA=="
+          "version": "0.0.195",
+          "resolved": "https://registry.npmjs.org/@vx/point/-/point-0.0.195.tgz",
+          "integrity": "sha512-2m16lfs4v8BwjWMhGNDC4lBBOwaimRL4BapFTS1UQWYSV12y0KlsJGD17fPdR6X9RzYWJTnOL/yaQuGCBa9AdQ=="
         },
         "@vx/responsive": {
           "version": "0.0.194",
@@ -4574,12 +4648,23 @@
             "d3-path": "^1.0.5",
             "d3-shape": "^1.2.0",
             "prop-types": "^15.5.10"
+          },
+          "dependencies": {
+            "@vx/curve": {
+              "version": "0.0.194",
+              "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.194.tgz",
+              "integrity": "sha512-6B+rHxsdK+PWdO8kYhT00kwBIwl9HIzpuxE+bRndrXC/nyoJVfSA7E4cLhZiIJYt0ukwkIPE3YsSIuT1OmW+1A==",
+              "requires": {
+                "@types/d3-shape": "^1.3.1",
+                "d3-shape": "^1.0.6"
+              }
+            }
           }
         },
         "@vx/text": {
-          "version": "0.0.194",
-          "resolved": "https://registry.npmjs.org/@vx/text/-/text-0.0.194.tgz",
-          "integrity": "sha512-sKXkp0jNcyjAad8wo3+aineNdbe7mYmT5FkwQNeALNi344Qh6GPbhYKYqWW1xrjkXz4k9HMzTJck8LWsbo5QwA==",
+          "version": "0.0.195",
+          "resolved": "https://registry.npmjs.org/@vx/text/-/text-0.0.195.tgz",
+          "integrity": "sha512-yp/d9r3JKMD3sz+f5n/RZfZRPre2wOdiz45JiDQNM3v/thnEjeRZzQ2vDi5j0h2H5/TjTCARj7iCD9ON6vJ49Q==",
           "requires": {
             "@types/classnames": "^2.2.9",
             "@types/lodash": "^4.14.146",
@@ -4628,11 +4713,6 @@
           "version": "16.13.0",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
           "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
-        },
-        "resize-observer-polyfill": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-          "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         }
       }
     },
@@ -4757,6 +4837,11 @@
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-3.5.38.tgz",
       "integrity": "sha1-dvjy6RWa5WKWWy+g5vvuGqZDobw="
     },
+    "@types/d3-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-2.0.0.tgz",
+      "integrity": "sha512-rGqfPVowNDTszSFvwoZIXvrPG7s/qKzm9piCRIH6xwTTRu7pPZ3ootULFnPkTt74B6i5lN0FpLQL24qGOw1uZA=="
+    },
     "@types/d3-format": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.3.1.tgz",
@@ -4768,9 +4853,9 @@
       "integrity": "sha512-AZGHWslq/oApTAHu9+yH/Bnk63y9oFOMROtqPAtxl5uB6qm1x2lueWdVEjsjjV3Qc2+QfuzKIwIR5MvVBakfzA=="
     },
     "@types/d3-scale": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.1.1.tgz",
-      "integrity": "sha512-kNTkbZQ+N/Ip8oX9PByXfDLoCSaZYm+VUOasbmsa6KD850/ziMdYepg/8kLg2plHzoLANdMqPoYQbvExevLUHg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.0.tgz",
+      "integrity": "sha512-oQFanN0/PiR2oySHfj+zAAkK1/p4LD32Nt1TMVmzk+bYHk7vgIg/iTXQWitp1cIkDw4LMdcgvO63wL+mNs47YA==",
       "requires": {
         "@types/d3-time": "*"
       }
@@ -7604,25 +7689,29 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7632,13 +7721,15 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7648,37 +7739,43 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7687,25 +7784,29 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7714,13 +7815,15 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7736,7 +7839,8 @@
             },
             "glob": {
               "version": "7.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7750,13 +7854,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7765,7 +7871,8 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7774,7 +7881,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7784,19 +7892,22 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7805,13 +7916,15 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7820,13 +7933,15 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true,
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7836,7 +7951,8 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7845,7 +7961,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7854,13 +7971,15 @@
             },
             "ms": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7871,7 +7990,8 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7889,7 +8009,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7899,13 +8020,15 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7915,7 +8038,8 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7927,19 +8051,22 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7948,19 +8075,22 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7970,19 +8100,22 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7994,7 +8127,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }
@@ -8002,7 +8136,8 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8017,7 +8152,8 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8026,43 +8162,50 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8073,7 +8216,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8082,7 +8226,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8091,13 +8236,15 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8112,13 +8259,15 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8127,13 +8276,15 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "dev": true,
               "optional": true
             }
@@ -9337,6 +9488,11 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "cssnano": {
       "version": "4.1.10",
@@ -11875,25 +12031,29 @@
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                   "dev": true,
                   "optional": true
                 },
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "dev": true,
                   "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "dev": true,
                   "optional": true
                 },
                 "are-we-there-yet": {
                   "version": "1.1.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -11903,13 +12063,15 @@
                 },
                 "balanced-match": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                   "dev": true,
                   "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -11919,37 +12081,43 @@
                 },
                 "chownr": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                   "dev": true,
                   "optional": true
                 },
                 "code-point-at": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "dev": true,
                   "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "dev": true,
                   "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true,
                   "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true,
                   "optional": true
                 },
                 "debug": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -11958,25 +12126,29 @@
                 },
                 "deep-extend": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                   "dev": true,
                   "optional": true
                 },
                 "delegates": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true,
                   "optional": true
                 },
                 "detect-libc": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                   "dev": true,
                   "optional": true
                 },
                 "fs-minipass": {
                   "version": "1.2.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -11985,13 +12157,15 @@
                 },
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true,
                   "optional": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12007,7 +12181,8 @@
                 },
                 "glob": {
                   "version": "7.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12021,13 +12196,15 @@
                 },
                 "has-unicode": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                   "dev": true,
                   "optional": true
                 },
                 "iconv-lite": {
                   "version": "0.4.24",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12036,7 +12213,8 @@
                 },
                 "ignore-walk": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12045,7 +12223,8 @@
                 },
                 "inflight": {
                   "version": "1.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12055,19 +12234,22 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                   "dev": true,
                   "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                   "dev": true,
                   "optional": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12076,13 +12258,15 @@
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true,
                   "optional": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12091,13 +12275,15 @@
                 },
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true,
                   "optional": true
                 },
                 "minipass": {
                   "version": "2.3.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12107,7 +12293,8 @@
                 },
                 "minizlib": {
                   "version": "1.2.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12116,7 +12303,8 @@
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12125,13 +12313,15 @@
                 },
                 "ms": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                   "dev": true,
                   "optional": true
                 },
                 "needle": {
                   "version": "2.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12142,7 +12332,8 @@
                 },
                 "node-pre-gyp": {
                   "version": "0.12.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12160,7 +12351,8 @@
                 },
                 "nopt": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12170,13 +12362,15 @@
                 },
                 "npm-bundled": {
                   "version": "1.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                   "dev": true,
                   "optional": true
                 },
                 "npm-packlist": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12186,7 +12380,8 @@
                 },
                 "npmlog": {
                   "version": "4.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12198,19 +12393,22 @@
                 },
                 "number-is-nan": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                   "dev": true,
                   "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "dev": true,
                   "optional": true
                 },
                 "once": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12219,19 +12417,22 @@
                 },
                 "os-homedir": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "dev": true,
                   "optional": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "dev": true,
                   "optional": true
                 },
                 "osenv": {
                   "version": "0.1.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12241,19 +12442,22 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true,
                   "optional": true
                 },
                 "process-nextick-args": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                   "dev": true,
                   "optional": true
                 },
                 "rc": {
                   "version": "1.2.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12265,7 +12469,8 @@
                   "dependencies": {
                     "minimist": {
                       "version": "1.2.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                       "dev": true,
                       "optional": true
                     }
@@ -12273,7 +12478,8 @@
                 },
                 "readable-stream": {
                   "version": "2.3.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12288,7 +12494,8 @@
                 },
                 "rimraf": {
                   "version": "2.6.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12297,43 +12504,50 @@
                 },
                 "safe-buffer": {
                   "version": "5.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                   "dev": true,
                   "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                   "dev": true,
                   "optional": true
                 },
                 "sax": {
                   "version": "1.2.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                   "dev": true,
                   "optional": true
                 },
                 "semver": {
                   "version": "5.7.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                   "dev": true,
                   "optional": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true,
                   "optional": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "dev": true,
                   "optional": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12344,7 +12558,8 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12353,7 +12568,8 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12362,13 +12578,15 @@
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                   "dev": true,
                   "optional": true
                 },
                 "tar": {
                   "version": "4.4.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12383,13 +12601,15 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true,
                   "optional": true
                 },
                 "wide-align": {
                   "version": "1.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -12398,13 +12618,15 @@
                 },
                 "wrappy": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "dev": true,
                   "optional": true
                 },
                 "yallist": {
                   "version": "3.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                   "dev": true,
                   "optional": true
                 }
@@ -15303,25 +15525,29 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15331,13 +15557,15 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15347,37 +15575,43 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15386,25 +15620,29 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15413,13 +15651,15 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15435,7 +15675,8 @@
             },
             "glob": {
               "version": "7.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15449,13 +15690,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15464,7 +15707,8 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15473,7 +15717,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15483,19 +15728,22 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15504,13 +15752,15 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15519,13 +15769,15 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true,
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15535,7 +15787,8 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15544,7 +15797,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15553,13 +15807,15 @@
             },
             "ms": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15570,7 +15826,8 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15588,7 +15845,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15598,13 +15856,15 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15614,7 +15874,8 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15626,19 +15887,22 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15647,19 +15911,22 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15669,19 +15936,22 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15693,7 +15963,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }
@@ -15701,7 +15972,8 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15716,7 +15988,8 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15725,43 +15998,50 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15772,7 +16052,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15781,7 +16062,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15790,13 +16072,15 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15811,13 +16095,15 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15826,13 +16112,15 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "dev": true,
               "optional": true
             }
@@ -22372,9 +22660,9 @@
       "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resize-observer-polyfill": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
-      "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.8.1",
@@ -25881,25 +26169,29 @@
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                   "dev": true,
                   "optional": true
                 },
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "dev": true,
                   "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "dev": true,
                   "optional": true
                 },
                 "are-we-there-yet": {
                   "version": "1.1.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -25909,13 +26201,15 @@
                 },
                 "balanced-match": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                   "dev": true,
                   "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -25925,37 +26219,43 @@
                 },
                 "chownr": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                   "dev": true,
                   "optional": true
                 },
                 "code-point-at": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "dev": true,
                   "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "dev": true,
                   "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true,
                   "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true,
                   "optional": true
                 },
                 "debug": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -25964,25 +26264,29 @@
                 },
                 "deep-extend": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                   "dev": true,
                   "optional": true
                 },
                 "delegates": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true,
                   "optional": true
                 },
                 "detect-libc": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                   "dev": true,
                   "optional": true
                 },
                 "fs-minipass": {
                   "version": "1.2.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -25991,13 +26295,15 @@
                 },
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true,
                   "optional": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26013,7 +26319,8 @@
                 },
                 "glob": {
                   "version": "7.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26027,13 +26334,15 @@
                 },
                 "has-unicode": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                   "dev": true,
                   "optional": true
                 },
                 "iconv-lite": {
                   "version": "0.4.24",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26042,7 +26351,8 @@
                 },
                 "ignore-walk": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26051,7 +26361,8 @@
                 },
                 "inflight": {
                   "version": "1.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26061,19 +26372,22 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                   "dev": true,
                   "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                   "dev": true,
                   "optional": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26082,13 +26396,15 @@
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true,
                   "optional": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26097,13 +26413,15 @@
                 },
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true,
                   "optional": true
                 },
                 "minipass": {
                   "version": "2.3.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26113,7 +26431,8 @@
                 },
                 "minizlib": {
                   "version": "1.2.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26122,7 +26441,8 @@
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26131,13 +26451,15 @@
                 },
                 "ms": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                   "dev": true,
                   "optional": true
                 },
                 "needle": {
                   "version": "2.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26148,7 +26470,8 @@
                 },
                 "node-pre-gyp": {
                   "version": "0.12.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26166,7 +26489,8 @@
                 },
                 "nopt": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26176,13 +26500,15 @@
                 },
                 "npm-bundled": {
                   "version": "1.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                   "dev": true,
                   "optional": true
                 },
                 "npm-packlist": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26192,7 +26518,8 @@
                 },
                 "npmlog": {
                   "version": "4.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26204,19 +26531,22 @@
                 },
                 "number-is-nan": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                   "dev": true,
                   "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "dev": true,
                   "optional": true
                 },
                 "once": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26225,19 +26555,22 @@
                 },
                 "os-homedir": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "dev": true,
                   "optional": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "dev": true,
                   "optional": true
                 },
                 "osenv": {
                   "version": "0.1.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26247,19 +26580,22 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true,
                   "optional": true
                 },
                 "process-nextick-args": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                   "dev": true,
                   "optional": true
                 },
                 "rc": {
                   "version": "1.2.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26271,7 +26607,8 @@
                   "dependencies": {
                     "minimist": {
                       "version": "1.2.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                       "dev": true,
                       "optional": true
                     }
@@ -26279,7 +26616,8 @@
                 },
                 "readable-stream": {
                   "version": "2.3.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26294,7 +26632,8 @@
                 },
                 "rimraf": {
                   "version": "2.6.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26303,43 +26642,50 @@
                 },
                 "safe-buffer": {
                   "version": "5.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                   "dev": true,
                   "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                   "dev": true,
                   "optional": true
                 },
                 "sax": {
                   "version": "1.2.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                   "dev": true,
                   "optional": true
                 },
                 "semver": {
                   "version": "5.7.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                   "dev": true,
                   "optional": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true,
                   "optional": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "dev": true,
                   "optional": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26350,7 +26696,8 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26359,7 +26706,8 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26368,13 +26716,15 @@
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                   "dev": true,
                   "optional": true
                 },
                 "tar": {
                   "version": "4.4.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26389,13 +26739,15 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true,
                   "optional": true
                 },
                 "wide-align": {
                   "version": "1.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -26404,13 +26756,15 @@
                 },
                 "wrappy": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "dev": true,
                   "optional": true
                 },
                 "yallist": {
                   "version": "3.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                   "dev": true,
                   "optional": true
                 }
@@ -27918,6 +28272,15 @@
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
       "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
       "dev": true
+    },
+    "xss": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.6.tgz",
+      "integrity": "sha512-6Q9TPBeNyoTRxgZFk5Ggaepk/4vUOYdOsIUYvLehcsIZTFjaavbVnsuAkLA5lIFuug5hw8zxcB9tm01gsjph2A==",
+      "requires": {
+        "commander": "^2.9.0",
+        "cssfilter": "0.0.10"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -76,7 +76,7 @@
     "@superset-ui/legacy-plugin-chart-rose": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-sankey": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-sunburst": "^0.11.15",
-    "@superset-ui/legacy-plugin-chart-table": "^0.11.15",
+    "@superset-ui/legacy-plugin-chart-table": "^0.11.16",
     "@superset-ui/legacy-plugin-chart-treemap": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-word-cloud": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.11.15",

--- a/superset-frontend/src/chart/ChartRenderer.jsx
+++ b/superset-frontend/src/chart/ChartRenderer.jsx
@@ -222,13 +222,15 @@ class ChartRenderer extends React.Component {
       queryResponse,
     } = this.props;
 
-    let chartClassName = snakeCase(vizType);
     // It's bad practice to use unprefixed `vizType` as classnames for chart
-    // container. It may cause css conflicts as in the case of table chart.
-    // When migrating legacy chart types, we should gradually add the prefix
-    // `superset-chart-` to each one of them.
-    chartClassName =
-      vizType === 'table' ? `superset-chart-${chartClassName}` : chartClassName;
+    // container. It may cause css conflicts as in the case of legacy table chart.
+    // When migrating charts, we should gradually add a `superset-chart-` prefix
+    // to each one of them.
+    const snakeCaseVizType = snakeCase(vizType);
+    const chartClassName =
+      vizType === 'table'
+        ? `superset-chart-${snakeCaseVizType}`
+        : snakeCaseVizType;
 
     return (
       <>

--- a/superset-frontend/src/chart/ChartRenderer.jsx
+++ b/superset-frontend/src/chart/ChartRenderer.jsx
@@ -222,13 +222,22 @@ class ChartRenderer extends React.Component {
       queryResponse,
     } = this.props;
 
+    let chartClassName = snakeCase(vizType);
+    // It's bad practice to use unprefixed `vizType` as classnames for chart
+    // container. It may cause css conflicts as in the case of table chart.
+    // When migrating legacy chart types, we should gradually add the prefix
+    // `superset-chart-` to each one of them.
+    if (vizType === 'table') {
+      chartClassName = `superset-chart-${chartClassName}`;
+    }
+
     return (
       <>
         {this.renderTooltip()}
         <SuperChart
           disableErrorBoundary
           id={`chart-id-${chartId}`}
-          className={`${snakeCase(vizType)}`}
+          className={chartClassName}
           chartType={vizType}
           width={width}
           height={height}

--- a/superset-frontend/src/chart/ChartRenderer.jsx
+++ b/superset-frontend/src/chart/ChartRenderer.jsx
@@ -227,9 +227,8 @@ class ChartRenderer extends React.Component {
     // container. It may cause css conflicts as in the case of table chart.
     // When migrating legacy chart types, we should gradually add the prefix
     // `superset-chart-` to each one of them.
-    if (vizType === 'table') {
-      chartClassName = `superset-chart-${chartClassName}`;
-    }
+    chartClassName =
+      vizType === 'table' ? `superset-chart-${chartClassName}` : chartClassName;
 
     return (
       <>

--- a/superset-frontend/src/dashboard/stylesheets/dashboard.less
+++ b/superset-frontend/src/dashboard/stylesheets/dashboard.less
@@ -60,6 +60,7 @@ body {
   position: relative;
   font-size: @font-size-l;
   font-weight: @font-weight-bold;
+  margin-bottom: 4px;
 
   .dropdown.btn-group {
     position: absolute;


### PR DESCRIPTION
### CATEGORY

- [x] Enhancement (new features, refinement)

### SUMMARY

One of the main pain points with the table chart is that it loads too slow for large datasets. This PR upgrades it to an updated version with improved performance. See [superset-ui-plugins PR#385](https://github.com/apache-superset/superset-ui-plugins/pull/385) for details.

In addition to upgrade the table chart plugin, this PR also refactors some styling code related to it. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Tested with a ~10,000 rows, 7 columns table in Superset, pagination enabled:

### Before 

![legacy-table--old](https://user-images.githubusercontent.com/335541/75824956-4b98d080-5d59-11ea-9f86-4a17d0770e6c.gif)

Takes about 6 secs to load.

![Snip20200303_3](https://user-images.githubusercontent.com/335541/75825254-d8dc2500-5d59-11ea-8da1-8091c8afcc8b.png)


### After

![legacy-table--new](https://user-images.githubusercontent.com/335541/75824966-4dfb2a80-5d59-11ea-83a4-0a3468f9f7c4.gif)

Takes only 3 secs to load!

![Snip20200303_4](https://user-images.githubusercontent.com/335541/75825271-dda0d900-5d59-11ea-98a9-e04fc2445aac.png)


### TEST PLAN

- Query a large dataset, increase row limit to a very high number
- Feel the difference in reactiveness and loading speed of the table chart

### ADDITIONAL INFORMATION

- [x] Has associated issue:  this does not fix #8273 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

### REVIEWERS

@kristw @graceguo-supercat @etr2460 @rusackas 