### PR TITLE
[fix] use filter_scopes in dashboard warmup strategy

### DIFF
--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -50,18 +50,32 @@ def get_form_data(chart_id, dashboard=None):
         return form_data
 
     json_metadata = json.loads(dashboard.json_metadata)
-
-    # do not apply filters if chart is immune to them
-    if chart_id in json_metadata.get("filter_immune_slices", []):
-        return form_data
-
     default_filters = json.loads(json_metadata.get("default_filters", "null"))
     if not default_filters:
         return form_data
 
-    # are some of the fields in the chart immune to filters?
-    filter_immune_slice_fields = json_metadata.get("filter_immune_slice_fields", {})
-    immune_fields = filter_immune_slice_fields.get(str(chart_id), [])
+    # do not apply filters if chart is immune to them
+    immune_fields = []
+    filter_scopes = json_metadata.get("filter_scopes", {})
+    if filter_scopes:
+        for scopes in filter_scopes.values():
+            # for example: scopes = {
+            #   "dim_region": {
+            #     "scope": [
+            #       "ROOT_ID"
+            #     ],
+            #     "immune": [1, 2, 3]
+            #   },
+            #   "dim_is_tier_1_locale": {
+            #     "scope": [
+            #       "ROOT_ID"
+            #     ],
+            #     "immune": [1, 5, 6]
+            #   }
+            # }
+            for (field, scope) in scopes.items():
+                if chart_id in scope.get("immune", []):
+                    immune_fields.append(field)
 
     extra_filters = []
     for filters in default_filters.values():

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -59,20 +59,6 @@ def get_form_data(chart_id, dashboard=None):
     filter_scopes = json_metadata.get("filter_scopes", {})
     if filter_scopes:
         for scopes in filter_scopes.values():
-            # for example: scopes = {
-            #   "dim_region": {
-            #     "scope": [
-            #       "ROOT_ID"
-            #     ],
-            #     "immune": [1, 2, 3]
-            #   },
-            #   "dim_is_tier_1_locale": {
-            #     "scope": [
-            #       "ROOT_ID"
-            #     ],
-            #     "immune": [1, 5, 6]
-            #   }
-            # }
             for (field, scope) in scopes.items():
                 if chart_id in scope.get("immune", []):
                     immune_fields.append(field)

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -58,7 +58,11 @@ class CacheWarmUpTests(SupersetTestCase):
         dashboard = MagicMock()
         dashboard.json_metadata = json.dumps(
             {
-                "filter_immune_slices": [chart_id],
+                "filter_scopes": {
+                    str(filter_box_id): {
+                        "name": {"scope": ["ROOT_ID"], "immune": [chart_id]}
+                    }
+                },
                 "default_filters": json.dumps(
                     {str(filter_box_id): {"name": ["Alice", "Bob"]}}
                 ),
@@ -90,7 +94,11 @@ class CacheWarmUpTests(SupersetTestCase):
                         }
                     }
                 ),
-                "filter_immune_slice_fields": {chart_id: ["__time_range"]},
+                "filter_scopes": {
+                    str(filter_box_id): {
+                        "__time_range": {"scope": ["ROOT_ID"], "immune": [chart_id]}
+                    }
+                },
             }
         )
         result = get_form_data(chart_id, dashboard)
@@ -109,7 +117,11 @@ class CacheWarmUpTests(SupersetTestCase):
                 "default_filters": json.dumps(
                     {str(filter_box_id): {"__time_range": "100 years ago : today"}}
                 ),
-                "filter_immune_slice_fields": {chart_id: ["__time_range"]},
+                "filter_scopes": {
+                    str(filter_box_id): {
+                        "__time_range": {"scope": ["ROOT_ID"], "immune": [chart_id]}
+                    }
+                },
             }
         )
         result = get_form_data(chart_id, dashboard)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
in dashboard cache warmup strategies, we need to check default filters and filter scopes, so that to apply dashboard filter onto charts. this PR is to replace the old filter immune metadata by using `filter_scopes` metadata.


### TEST PLAN
fixed unit tests.


### REVIEWERS
@betodealmeida @serenajiang @etr2460 