### PR TITLE
Fix missing points on Mapbox

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2110,8 +2110,8 @@ class MapboxViz(BaseViz):
         }
 
         x_series, y_series = df[fd.get("all_columns_x")], df[fd.get("all_columns_y")]
-        south_west = [x_series.min(), y_series.min()]
-        north_east = [x_series.max(), y_series.max()]
+        south_west = [math.floor(x_series.min()), math.floor(y_series.min())]
+        north_east = [math.ceil(x_series.max()), math.ceil(y_series.max())]
 
         return {
             "geoJSON": geo_json,


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

On the mapbox visualization the supercluster package is used to group several points at specific zoom levels. On one of my installations I came across a bug where some points where not rendered.

After some debug I found that when the mapbox is rendered, when retrieving the list of clusters to render [here](https://github.com/apache-superset/superset-ui-plugins/blob/master/packages/superset-ui-legacy-plugin-chart-map-box/src/MapBox.jsx#L112), on the [getClusters](https://github.com/mapbox/supercluster/blob/575d32dd106885d9e05cbc9c89e372757d2f012e/index.js#L71) function the range considered [here](https://github.com/mapbox/supercluster/blob/575d32dd106885d9e05cbc9c89e372757d2f012e/index.js#L87) will not cover the points.

I tried increasing the precision [here](https://github.com/mapbox/supercluster/blob/575d32dd106885d9e05cbc9c89e372757d2f012e/index.js#L50) and [here](https://github.com/mapbox/supercluster/blob/575d32dd106885d9e05cbc9c89e372757d2f012e/index.js#L61) to Float64Array but it didn't fix.

The ideal solution would be to use the viewport bounds as bounds for the getClusters method but I dont't think we can get those.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

How to reproduce:
1. Go to SQL Editor, run the following query and click explore
`
select 52.34852 as latitude , 4.8843 as longitude
UNION
select 52.35091, 4.87888
`
2. For the visualization type select **MapBox** and select the latitude and longitude fields on the associated select under the Query section and run.
3. At a certain zoom both points aren't displayed

**Before:**
![before](https://user-images.githubusercontent.com/23409890/75997081-bcc1ba80-5ef6-11ea-9782-3a397badcf47.png)

**After**
![after](https://user-images.githubusercontent.com/23409890/75997087-bfbcab00-5ef6-11ea-9854-138773c315af.png)

Environment:

- superset version: `0.35.1`
- python version: `3.6.9`
- node.js version: `v10.19.0`
- npm version: `6.13.4`


### TEST PLAN
check the bounds being used [here](https://github.com/mapbox/supercluster/blob/575d32dd106885d9e05cbc9c89e372757d2f012e/index.js#L87) and compare them to tree.points[...].x and tree.points[...].y

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #8479 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@kristw 