### PR TITLE
fix: Oracle fetch_query and datetime conversion

### DIFF
--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -17,11 +17,10 @@
 from datetime import datetime
 from typing import Optional
 
-from superset.db_engine_specs.base import LimitMethod
-from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
+from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 
 
-class OracleEngineSpec(PostgresBaseEngineSpec):
+class OracleEngineSpec(BaseEngineSpec):
     engine = "oracle"
     limit_method = LimitMethod.WRAP_SQL
     force_column_alias_quotes = True
@@ -44,6 +43,16 @@ class OracleEngineSpec(PostgresBaseEngineSpec):
         tt = target_type.upper()
         if tt == "DATE":
             return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
+        if tt == "DATETIME":
+            return f"""TO_DATE('{dttm.isoformat(timespec="seconds")}', 'YYYY-MM-DD"T"HH24:MI:SS')"""  # pylint: disable=line-too-long
         if tt == "TIMESTAMP":
             return f"""TO_TIMESTAMP('{dttm.isoformat(timespec="microseconds")}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""  # pylint: disable=line-too-long
         return None
+
+    @classmethod
+    def epoch_to_dttm(cls) -> str:
+        return "TO_DATE('1970-01-01','YYYY-MM-DD')+(1/24/60/60)*{col}"
+
+    @classmethod
+    def epoch_ms_to_dttm(cls) -> str:
+        return "TO_DATE('1970-01-01','YYYY-MM-DD')+(1/24/60/60/1000)*{col}"

--- a/tests/db_engine_specs/oracle_tests.py
+++ b/tests/db_engine_specs/oracle_tests.py
@@ -45,6 +45,11 @@ class OracleTestCase(DbEngineSpecTestCase):
         )
 
         self.assertEqual(
+            OracleEngineSpec.convert_dttm("DATETIME", dttm),
+            """TO_DATE('2019-01-02T03:04:05', 'YYYY-MM-DD"T"HH24:MI:SS')""",
+        )
+
+        self.assertEqual(
             OracleEngineSpec.convert_dttm("TIMESTAMP", dttm),
             """TO_TIMESTAMP('2019-01-02T03:04:05.678900', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')""",
         )


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The Oracle spec extended `PostgresBaseEngineSpec`, which didn't really make any sense, as Oracle has very little in common with Postgres. As `FixedOffsetTimezone` was added to `PostgresBaseEngineSpec` recently, data fetching was consequently broken, as it isn't needed for Oracle. Changes in this PR:
- `OracleEngineSpec` now extends `BaseEngineSpec`. This fixes `fetch_data`.
- Epoch (second and ms) expressions were implemented and tested to work
- `DATETIME` expression was added + unit test

### TEST PLAN
Test locally + CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #9237 . The issue reported was actually already fixed, but it exposed the regression and shortcomings that are addressed here.
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
