### PR TITLE
Bump node from v10 to v12 in release Dockerfiles

### DIFF
--- a/RELEASING/Dockerfile.from_local_tarball
+++ b/RELEASING/Dockerfile.from_local_tarball
@@ -35,7 +35,7 @@ RUN apt-get install -y build-essential libssl-dev \
 # Install nodejs for custom build
 # https://superset.incubator.apache.org/installation.html#making-your-own-build
 # https://nodejs.org/en/download/package-manager/
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get install -y nodejs
 
 RUN mkdir -p /home/superset

--- a/RELEASING/Dockerfile.from_svn_tarball
+++ b/RELEASING/Dockerfile.from_svn_tarball
@@ -35,7 +35,7 @@ RUN apt-get install -y build-essential libssl-dev \
 # Install nodejs for custom build
 # https://superset.incubator.apache.org/installation.html#making-your-own-build
 # https://nodejs.org/en/download/package-manager/
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get install -y nodejs
 
 RUN mkdir -p /home/superset


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently, Apache releases are being built using Node 10, which will soon transition from Active LTS to Maintenance LTS: https://nodejs.org/en/about/releases/ . This bumps Node to version 12, which is the current recommended LTS version.

### TEST PLAN
Tested locally

### REVIEWERS
@rusackas @etr2460 @dpgaspar @mistercrunch  @kristw 