### PR TITLE
[webpack] fix copying images when running dev server

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -77,11 +77,14 @@ const plugins = [
     checkSyntacticErrors: true,
   }),
 
-  new CopyPlugin([
-    'package.json',
-    { from: 'images', to: 'images' },
-    { from: 'stylesheets', to: 'stylesheets' },
-  ]),
+  new CopyPlugin(
+    [
+      'package.json',
+      { from: 'images', to: 'images' },
+      { from: 'stylesheets', to: 'stylesheets' },
+    ],
+    { copyUnmodified: true },
+  ),
 ];
 
 if (isDevMode) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There's currently an issue with the copy-webpack-plugin (used for copying images and stylesheets) 
that doesn't play nicely with clean-webpack-plugin. This is only an issue when running the dev server and only occurs after a rebuild. 

more info here: https://github.com/webpack-contrib/copy-webpack-plugin/issues/261#issuecomment-552550859

This PR introduces a config option to force the plugin to always copy the assets, even if they're unchanged. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@suddjian @etr2460 @kristw 