### PR TITLE
Fixing ACE editor font jank (again?!)

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -364,10 +364,6 @@ div.tablePopover {
 
 .ace_editor {
   border: 1px solid @gray-light;
-}
-
-.ace_editor,
-.ace_editor div {
   font-feature-settings: @font-feature-settings;
   font-family: @font-family-monospace;
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Fixes #9253

Playing whack-a-mole with a font width/tracking issue in ACE editor(s). Tried to fix it in Safari, which seemed to work, but somehow now causes issue in Chrome. Undoing the fix, with a net delta of a new typeface, SEEMS to me, to work in both Chrome AND Safari, but I feel like I could use a sanity check from @etr2460 or anyone else.

Also of note, `react-ace` is on v5 in Superset, where they're on v8. I tried upgrading, and ran into all sorts of upgrade woes. It DID seem to solve solve this font width issue, however. I'll try to make an upgrade somewhere between v6 and v8 on a separate PR, so heads up about that, and speak up with any experience/warnings/objections if you have them.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Chrome:
![chrome](https://user-images.githubusercontent.com/812905/76239602-1542d180-61ef-11ea-8648-944a68dede6e.gif)

Safari:
![safari](https://user-images.githubusercontent.com/812905/76239826-75397800-61ef-11ea-8ea7-73bb35e3380c.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 