### PR TITLE
[fix] copy filter_scopes with duplicate charts

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1243,7 +1243,6 @@ class Superset(BaseSupersetView):
     def _set_dash_metadata(
         dashboard, data, old_to_new_slice_ids: Optional[Dict[int, int]] = None
     ):
-        old_to_new_slice_ids = old_to_new_slice_ids or {}
         positions = data["positions"]
         # find slices in the position data
         slice_ids = []
@@ -1288,10 +1287,17 @@ class Superset(BaseSupersetView):
         if "filter_scopes" in data:
             # replace filter_id and immune ids from old slice id to new slice id:
             # and remove slice ids that are not in dash anymore
+            slc_id_dict: Dict[int, int] = {}
+            if old_to_new_slice_ids:
+                slc_id_dict = {
+                    old: new
+                    for old, new in old_to_new_slice_ids.items()
+                    if new in slice_ids
+                }
+            else:
+                slc_id_dict = {sid: sid for sid in slice_ids}
             new_filter_scopes = copy_filter_scopes(
-                old_to_new_slc_id_dict={
-                    sid: old_to_new_slice_ids.get(sid, sid) for sid in slice_ids
-                },
+                old_to_new_slc_id_dict=slc_id_dict,
                 old_filter_scopes=json.loads(data["filter_scopes"] or "{}"),
             )
         if new_filter_scopes:

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -274,18 +274,17 @@ class DashboardTests(SupersetTestCase):
         positions.pop(removed_component[0], None)
 
         data.update({"positions": positions})
-        old_to_new_sliceids = {slc.id: slc.id + 10 for slc in dash.slices}
-        views.Superset._set_dash_metadata(dash, data, old_to_new_sliceids)
+        views.Superset._set_dash_metadata(dash, data)
         updated_metadata = json.loads(dash.json_metadata)
-        updated_filter_scopes = {
-            str(filter_slice.id + 10): {
+        expected_filter_scopes = {
+            str(filter_slice.id): {
                 "region": {
                     "scope": ["ROOT_ID"],
-                    "immune": [slc.id + 10 for slc in immune_slices],
+                    "immune": [slc.id for slc in immune_slices],
                 }
             }
         }
-        self.assertEqual(updated_metadata["filter_scopes"], updated_filter_scopes)
+        self.assertEqual(updated_metadata["filter_scopes"], expected_filter_scopes)
 
         # reset dash to original data
         views.Superset._set_dash_metadata(dash, original_data)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
in code refactor PR #9224, it introduced a bug:
https://github.com/apache/incubator-superset/blob/7a91498cf1a9e56d4b3d7b3805076137525ea277/superset/views/core.py#L1293
here we should use old slice's id as key instead of `sid` which is new or copied slice's id

### TEST PLAN
fixed unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9224


### REVIEWERS
@serenajiang @john-bodley 