### PR TITLE
fix: add connection testing params for snowflake

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -529,7 +529,11 @@ The role and warehouse can be omitted if defaults are defined for the user, i.e.
 
 Make sure the user has privileges to access and use all required
 databases/schemas/tables/views/warehouses, as the Snowflake SQLAlchemy engine does
-not test for user rights during engine creation.
+not test for user/role rights during engine creation by default. However, when
+pressing the "Test Connection" button in the Create or Edit Database dialog,
+user/role credentials are validated by passing `"validate_default_parameters": True`
+to the `connect()` method during engine creation. If the user/role is not authorized
+to access the database, an error is recorded in the Superset logs.
 
 See `Snowflake SQLAlchemy <https://github.com/snowflakedb/snowflake-sqlalchemy>`_.
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -942,3 +942,14 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         if data and type(data[0]).__name__ == "Row":
             data = [tuple(row) for row in data]
         return data
+
+    @staticmethod
+    def mutate_database_for_connection_testing(database: "Database") -> None:
+        """
+        Some databases require passing additional parameters for validating database
+        connections. This method makes it possible to mutate the database instance prior
+        to testing if a connection is ok.
+
+        :param database: instance to be mutated
+        """
+        return None

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -944,7 +944,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return data
 
     @staticmethod
-    def mutate_database_for_connection_testing(database: "Database") -> None:
+    def mutate_db_for_connection_test(database: "Database") -> None:
         """
         Some databases require passing additional parameters for validating database
         connections. This method makes it possible to mutate the database instance prior

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -14,13 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import json
 from datetime import datetime
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 from urllib import parse
 
 from sqlalchemy.engine.url import URL
 
 from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
+
+if TYPE_CHECKING:
+    from superset.models.core import Database  # pylint: disable=unused-import
 
 
 class SnowflakeEngineSpec(PostgresBaseEngineSpec):
@@ -77,3 +81,19 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         if tt == "TIMESTAMP":
             return f"""TO_TIMESTAMP('{dttm.isoformat(timespec="microseconds")}')"""
         return None
+
+    @staticmethod
+    def mutate_database_for_connection_testing(database: "Database") -> None:
+        """
+        By default, snowflake doesn't validate if the user/role has access to the chosen
+        database.
+
+        :param database: instance to be mutated
+        """
+        extra = json.loads(database.extra or "{}")
+        engine_params = extra.get("engine_params", {})
+        connect_args = engine_params.get("connect_args", {})
+        connect_args["validate_default_parameters"] = True
+        engine_params["connect_args"] = connect_args
+        extra["engine_params"] = engine_params
+        database.extra = json.dumps(extra)

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -83,7 +83,7 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         return None
 
     @staticmethod
-    def mutate_database_for_connection_testing(database: "Database") -> None:
+    def mutate_db_for_connection_test(database: "Database") -> None:
         """
         By default, snowflake doesn't validate if the user/role has access to the chosen
         database.

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1360,6 +1360,7 @@ class Superset(BaseSupersetView):
                 encrypted_extra=json.dumps(request.json.get("encrypted_extra", {})),
             )
             database.set_sqlalchemy_uri(uri)
+            database.db_engine_spec.mutate_database_for_connection_testing(database)
 
             username = g.user.username if g.user is not None else None
             engine = database.get_sqla_engine(user_name=username)
@@ -1395,7 +1396,9 @@ class Superset(BaseSupersetView):
             return json_error_response(_(str(e)), 400)
         except Exception as e:
             logger.error("Unexpected error %s", e)
-            return json_error_response(_("Unexpected error occurred."), 400)
+            return json_error_response(
+                _("Unexpected error occurred, please check your logs for details"), 400
+            )
 
     @api
     @has_access_api

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1360,7 +1360,7 @@ class Superset(BaseSupersetView):
                 encrypted_extra=json.dumps(request.json.get("encrypted_extra", {})),
             )
             database.set_sqlalchemy_uri(uri)
-            database.db_engine_spec.mutate_database_for_connection_testing(database)
+            database.db_engine_spec.mutate_db_for_connection_test(database)
 
             username = g.user.username if g.user is not None else None
             engine = database.get_sqla_engine(user_name=username)

--- a/tests/db_engine_specs/snowflake_tests.py
+++ b/tests/db_engine_specs/snowflake_tests.py
@@ -36,8 +36,8 @@ class SnowflakeTestCase(DbEngineSpecTestCase):
 
     def test_database_connection_test_mutator(self):
         database = Database(sqlalchemy_uri="snowflake://abc")
-        SnowflakeEngineSpec.mutate_database_for_connection_testing(database)
-        engine_params = json.loads(database.extra or {})
+        SnowflakeEngineSpec.mutate_db_for_connection_test(database)
+        engine_params = json.loads(database.extra or "{}")
 
         self.assertDictEqual(
             {"engine_params": {"connect_args": {"validate_default_parameters": True}}},

--- a/tests/db_engine_specs/snowflake_tests.py
+++ b/tests/db_engine_specs/snowflake_tests.py
@@ -14,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from sqlalchemy import column
+import json
 
 from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
+from superset.models.core import Database
 from tests.db_engine_specs.base_tests import DbEngineSpecTestCase
 
 
@@ -24,16 +25,21 @@ class SnowflakeTestCase(DbEngineSpecTestCase):
     def test_convert_dttm(self):
         dttm = self.get_dttm()
 
-        self.assertEqual(
-            SnowflakeEngineSpec.convert_dttm("DATE", dttm), "TO_DATE('2019-01-02')"
-        )
+        test_cases = {
+            "DATE": "TO_DATE('2019-01-02')",
+            "DATETIME": "CAST('2019-01-02T03:04:05.678900' AS DATETIME)",
+            "TIMESTAMP": "TO_TIMESTAMP('2019-01-02T03:04:05.678900')",
+        }
 
-        self.assertEqual(
-            SnowflakeEngineSpec.convert_dttm("DATETIME", dttm),
-            "CAST('2019-01-02T03:04:05.678900' AS DATETIME)",
-        )
+        for type_, expected in test_cases.items():
+            self.assertEqual(SnowflakeEngineSpec.convert_dttm(type_, dttm), expected)
 
-        self.assertEqual(
-            SnowflakeEngineSpec.convert_dttm("TIMESTAMP", dttm),
-            "TO_TIMESTAMP('2019-01-02T03:04:05.678900')",
+    def test_database_connection_test_mutator(self):
+        database = Database(sqlalchemy_uri="snowflake://abc")
+        SnowflakeEngineSpec.mutate_database_for_connection_testing(database)
+        engine_params = json.loads(database.extra or {})
+
+        self.assertDictEqual(
+            {"engine_params": {"connect_args": {"validate_default_parameters": True}}},
+            engine_params,
         )


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
When connecting to a Snowflake database, the "Test Connection" button reports "Seems OK!", even if the user does not have proper rights to access the relevant database, schema, role or warehouse. This is problematic, because the connector introduces irregular behavior if proper authorization is missing, for instance returning duplicated schema names during calls to `inspector.get_schema_names()`. This PR introduces a method `BaseEngineSpec.mutate_db_for_connection_test` which can be overridden by a db spec to introduce connection validation, and implements the mostly undocumented `validate_default_parameters` flag (disabled by default, probably due to performance reasons) for Snowflake that validates the connection params when pressing "Test Connection".

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/76334809-4826bb80-62fc-11ea-82ac-898a5f7b89f9.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/76334675-1150a580-62fc-11ea-9352-b6fe872aec3a.png)
![image](https://user-images.githubusercontent.com/33317356/76334713-22011b80-62fc-11ea-934c-6d5e0ac5c0fc.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
