### PR TITLE
fix: remove duplicate metric from bullet chart

### DIFF
--- a/superset-frontend/src/explore/controlPanels/Bullet.js
+++ b/superset-frontend/src/explore/controlPanels/Bullet.js
@@ -30,7 +30,6 @@ export default {
       label: t('Chart Options'),
       expanded: true,
       controlSetRows: [
-        ['metric'],
         ['ranges', 'range_labels'],
         ['markers', 'marker_labels'],
         ['marker_lines', 'marker_line_labels'],


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In the Bullet Chart control panel, `metric` is defined twice, causing a weird user experience and duplicated metrics in the viz request payload.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/76364274-6e188400-632d-11ea-98b0-664d96a9c8d7.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/76364325-8ab4bc00-632d-11ea-8744-777c8e23b0e4.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
