### PR TITLE
[dashboard][api] Fix, PUT publish/draft to not clean slug and owners

### DIFF
--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -88,12 +88,10 @@ class BaseDashboardSchema(BaseOwnedSchema):
     @pre_load
     def pre_load(self, data):  # pylint: disable=no-self-use
         super().pre_load(data)
-        if "slug" in data:
-            data["slug"] = data.get("slug")
-            if data["slug"]:
-                data["slug"] = data["slug"].strip()
-                data["slug"] = data["slug"].replace(" ", "-")
-                data["slug"] = re.sub(r"[^\w\-]+", "", data["slug"])
+        if data.get("slug"):
+            data["slug"] = data["slug"].strip()
+            data["slug"] = data["slug"].replace(" ", "-")
+            data["slug"] = re.sub(r"[^\w\-]+", "", data["slug"])
         if "owners" in data:
             data["owners"] = data.get("owners", [])
 

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -88,12 +88,14 @@ class BaseDashboardSchema(BaseOwnedSchema):
     @pre_load
     def pre_load(self, data):  # pylint: disable=no-self-use
         super().pre_load(data)
-        data["slug"] = data.get("slug")
-        data["owners"] = data.get("owners", [])
-        if data["slug"]:
-            data["slug"] = data["slug"].strip()
-            data["slug"] = data["slug"].replace(" ", "-")
-            data["slug"] = re.sub(r"[^\w\-]+", "", data["slug"])
+        if "slug" in data:
+            data["slug"] = data.get("slug")
+            if data["slug"]:
+                data["slug"] = data["slug"].strip()
+                data["slug"] = data["slug"].replace(" ", "-")
+                data["slug"] = re.sub(r"[^\w\-]+", "", data["slug"])
+        if "owners" in data:
+            data["owners"] = data.get("owners", [])
 
 
 class DashboardPostSchema(BaseDashboardSchema):

--- a/superset/views/dashboard/api.py
+++ b/superset/views/dashboard/api.py
@@ -92,8 +92,8 @@ class BaseDashboardSchema(BaseOwnedSchema):
             data["slug"] = data["slug"].strip()
             data["slug"] = data["slug"].replace(" ", "-")
             data["slug"] = re.sub(r"[^\w\-]+", "", data["slug"])
-        if "owners" in data:
-            data["owners"] = data.get("owners", [])
+        if "owners" in data and data["owners"] is None:
+            data["owners"] = []
 
 
 class DashboardPostSchema(BaseDashboardSchema):

--- a/tests/dashboard_api_tests.py
+++ b/tests/dashboard_api_tests.py
@@ -477,6 +477,28 @@ class DashboardApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
         db.session.delete(model)
         db.session.commit()
 
+    def test_update_published(self):
+        """
+            Dashboard API: Test update published patch
+        """
+        admin = self.get_user("admin")
+        gamma = self.get_user("gamma")
+
+        dashboard = self.insert_dashboard("title1", "slug1", [admin.id, gamma.id])
+        dashboard_data = {"published": True}
+        self.login(username="admin")
+        uri = f"api/v1/dashboard/{dashboard.id}"
+        rv = self.client.put(uri, json=dashboard_data)
+        self.assertEqual(rv.status_code, 200)
+
+        model = db.session.query(models.Dashboard).get(dashboard.id)
+        self.assertEqual(model.published, True)
+        self.assertEqual(model.slug, "slug1")
+        self.assertIn(admin, model.owners)
+        self.assertIn(gamma, model.owners)
+        db.session.delete(model)
+        db.session.commit()
+
     def test_update_dashboard_not_owned(self):
         """
             Dashboard API: Test update dashboard not owned


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Fix bug on the dashboard API, "Draft" Button Clears Slug and Owners from Dashboard.

Note: We are planning to refactor this soon to comply to SIP-35

### TEST PLAN
Create a new dashboard with a slug and several owners, then publish the dashboard using the dashboard view itself. Verify that slug and owner do not get cleaned  

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
