### PR TITLE
fix: bump legacy-table-chart to 0.11.20

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -4353,9 +4353,9 @@
       }
     },
     "@superset-ui/legacy-plugin-chart-table": {
-      "version": "0.11.18",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-plugin-chart-table/-/legacy-plugin-chart-table-0.11.18.tgz",
-      "integrity": "sha512-wefCQVqRK+eFVbbuVsyIawL5U6NO3obZGCmL3RoQZ9ka+g+t8oyZIJykcwmOh3O6wXqvch4gwUPnnsKoUGd2Rw==",
+      "version": "0.11.20",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-plugin-chart-table/-/legacy-plugin-chart-table-0.11.20.tgz",
+      "integrity": "sha512-PEBO8ww07/7gXj9JB2pe0A2MsH5WmL5AiV++6Md7aZB4lqViKDf+KeS8sFnaoECmoxB50ADS3jBuwsXF/0NBVA==",
       "requires": {
         "datatables.net-bs": "^1.10.20",
         "xss": "^1.0.6"
@@ -7670,28 +7670,28 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
@@ -7702,14 +7702,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
@@ -7720,42 +7720,42 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "optional": true,
@@ -7765,28 +7765,28 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "dev": true,
               "optional": true,
@@ -7796,14 +7796,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
@@ -7820,7 +7820,7 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "optional": true,
@@ -7835,14 +7835,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
@@ -7852,7 +7852,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "optional": true,
@@ -7862,7 +7862,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
@@ -7873,21 +7873,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
@@ -7897,14 +7897,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
@@ -7914,14 +7914,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true,
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "dev": true,
               "optional": true,
@@ -7932,7 +7932,7 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "dev": true,
               "optional": true,
@@ -7942,7 +7942,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "optional": true,
@@ -7952,14 +7952,14 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "dev": true,
               "optional": true,
@@ -7971,7 +7971,7 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "dev": true,
               "optional": true,
@@ -7990,7 +7990,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
@@ -8001,14 +8001,14 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "dev": true,
               "optional": true,
@@ -8019,7 +8019,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
@@ -8032,21 +8032,21 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
@@ -8056,21 +8056,21 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
@@ -8081,21 +8081,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
@@ -8108,7 +8108,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
@@ -8117,7 +8117,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
@@ -8133,7 +8133,7 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "optional": true,
@@ -8143,49 +8143,49 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
@@ -8197,7 +8197,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
@@ -8207,7 +8207,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
@@ -8217,14 +8217,14 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "dev": true,
               "optional": true,
@@ -8240,14 +8240,14 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
@@ -8257,14 +8257,14 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "dev": true,
               "optional": true
@@ -12012,28 +12012,28 @@
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                   "dev": true,
                   "optional": true
                 },
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "dev": true,
                   "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "dev": true,
                   "optional": true
                 },
                 "are-we-there-yet": {
                   "version": "1.1.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                   "dev": true,
                   "optional": true,
@@ -12044,14 +12044,14 @@
                 },
                 "balanced-match": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                   "dev": true,
                   "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "dev": true,
                   "optional": true,
@@ -12062,42 +12062,42 @@
                 },
                 "chownr": {
                   "version": "1.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                   "dev": true,
                   "optional": true
                 },
                 "code-point-at": {
                   "version": "1.1.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "dev": true,
                   "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "dev": true,
                   "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true,
                   "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true,
                   "optional": true
                 },
                 "debug": {
                   "version": "4.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                   "dev": true,
                   "optional": true,
@@ -12107,28 +12107,28 @@
                 },
                 "deep-extend": {
                   "version": "0.6.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                   "dev": true,
                   "optional": true
                 },
                 "delegates": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true,
                   "optional": true
                 },
                 "detect-libc": {
                   "version": "1.0.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                   "dev": true,
                   "optional": true
                 },
                 "fs-minipass": {
                   "version": "1.2.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                   "dev": true,
                   "optional": true,
@@ -12138,14 +12138,14 @@
                 },
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true,
                   "optional": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "optional": true,
@@ -12162,7 +12162,7 @@
                 },
                 "glob": {
                   "version": "7.1.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                   "dev": true,
                   "optional": true,
@@ -12177,14 +12177,14 @@
                 },
                 "has-unicode": {
                   "version": "2.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                   "dev": true,
                   "optional": true
                 },
                 "iconv-lite": {
                   "version": "0.4.24",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                   "dev": true,
                   "optional": true,
@@ -12194,7 +12194,7 @@
                 },
                 "ignore-walk": {
                   "version": "3.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                   "dev": true,
                   "optional": true,
@@ -12204,7 +12204,7 @@
                 },
                 "inflight": {
                   "version": "1.0.6",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
                   "optional": true,
@@ -12215,21 +12215,21 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                   "dev": true,
                   "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                   "dev": true,
                   "optional": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "optional": true,
@@ -12239,14 +12239,14 @@
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true,
                   "optional": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "optional": true,
@@ -12256,14 +12256,14 @@
                 },
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true,
                   "optional": true
                 },
                 "minipass": {
                   "version": "2.3.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                   "dev": true,
                   "optional": true,
@@ -12274,7 +12274,7 @@
                 },
                 "minizlib": {
                   "version": "1.2.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                   "dev": true,
                   "optional": true,
@@ -12284,7 +12284,7 @@
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "dev": true,
                   "optional": true,
@@ -12294,14 +12294,14 @@
                 },
                 "ms": {
                   "version": "2.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                   "dev": true,
                   "optional": true
                 },
                 "needle": {
                   "version": "2.3.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                   "dev": true,
                   "optional": true,
@@ -12313,7 +12313,7 @@
                 },
                 "node-pre-gyp": {
                   "version": "0.12.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                   "dev": true,
                   "optional": true,
@@ -12332,7 +12332,7 @@
                 },
                 "nopt": {
                   "version": "4.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                   "dev": true,
                   "optional": true,
@@ -12343,14 +12343,14 @@
                 },
                 "npm-bundled": {
                   "version": "1.0.6",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                   "dev": true,
                   "optional": true
                 },
                 "npm-packlist": {
                   "version": "1.4.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                   "dev": true,
                   "optional": true,
@@ -12361,7 +12361,7 @@
                 },
                 "npmlog": {
                   "version": "4.1.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                   "dev": true,
                   "optional": true,
@@ -12374,21 +12374,21 @@
                 },
                 "number-is-nan": {
                   "version": "1.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                   "dev": true,
                   "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "dev": true,
                   "optional": true
                 },
                 "once": {
                   "version": "1.4.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "optional": true,
@@ -12398,21 +12398,21 @@
                 },
                 "os-homedir": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "dev": true,
                   "optional": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "dev": true,
                   "optional": true
                 },
                 "osenv": {
                   "version": "0.1.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                   "dev": true,
                   "optional": true,
@@ -12423,21 +12423,21 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true,
                   "optional": true
                 },
                 "process-nextick-args": {
                   "version": "2.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                   "dev": true,
                   "optional": true
                 },
                 "rc": {
                   "version": "1.2.8",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                   "dev": true,
                   "optional": true,
@@ -12450,7 +12450,7 @@
                   "dependencies": {
                     "minimist": {
                       "version": "1.2.0",
-                      "resolved": "",
+                      "resolved": false,
                       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                       "dev": true,
                       "optional": true
@@ -12459,7 +12459,7 @@
                 },
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "dev": true,
                   "optional": true,
@@ -12475,7 +12475,7 @@
                 },
                 "rimraf": {
                   "version": "2.6.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                   "dev": true,
                   "optional": true,
@@ -12485,49 +12485,49 @@
                 },
                 "safe-buffer": {
                   "version": "5.1.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                   "dev": true,
                   "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                   "dev": true,
                   "optional": true
                 },
                 "sax": {
                   "version": "1.2.4",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                   "dev": true,
                   "optional": true
                 },
                 "semver": {
                   "version": "5.7.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                   "dev": true,
                   "optional": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true,
                   "optional": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "dev": true,
                   "optional": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "optional": true,
@@ -12539,7 +12539,7 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "dev": true,
                   "optional": true,
@@ -12549,7 +12549,7 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "optional": true,
@@ -12559,14 +12559,14 @@
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                   "dev": true,
                   "optional": true
                 },
                 "tar": {
                   "version": "4.4.8",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                   "dev": true,
                   "optional": true,
@@ -12582,14 +12582,14 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true,
                   "optional": true
                 },
                 "wide-align": {
                   "version": "1.1.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                   "dev": true,
                   "optional": true,
@@ -12599,14 +12599,14 @@
                 },
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "dev": true,
                   "optional": true
                 },
                 "yallist": {
                   "version": "3.0.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                   "dev": true,
                   "optional": true
@@ -15506,28 +15506,28 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
@@ -15538,14 +15538,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
@@ -15556,42 +15556,42 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "optional": true,
@@ -15601,28 +15601,28 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "dev": true,
               "optional": true,
@@ -15632,14 +15632,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
@@ -15656,7 +15656,7 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "optional": true,
@@ -15671,14 +15671,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
@@ -15688,7 +15688,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "optional": true,
@@ -15698,7 +15698,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
@@ -15709,21 +15709,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
@@ -15733,14 +15733,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
@@ -15750,14 +15750,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true,
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "dev": true,
               "optional": true,
@@ -15768,7 +15768,7 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "dev": true,
               "optional": true,
@@ -15778,7 +15778,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "optional": true,
@@ -15788,14 +15788,14 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "dev": true,
               "optional": true,
@@ -15807,7 +15807,7 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "dev": true,
               "optional": true,
@@ -15826,7 +15826,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
@@ -15837,14 +15837,14 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "dev": true,
               "optional": true,
@@ -15855,7 +15855,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
@@ -15868,21 +15868,21 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
@@ -15892,21 +15892,21 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
@@ -15917,21 +15917,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
@@ -15944,7 +15944,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
@@ -15953,7 +15953,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
@@ -15969,7 +15969,7 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "optional": true,
@@ -15979,49 +15979,49 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
@@ -16033,7 +16033,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
@@ -16043,7 +16043,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
@@ -16053,14 +16053,14 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "dev": true,
               "optional": true,
@@ -16076,14 +16076,14 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
@@ -16093,14 +16093,14 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "dev": true,
               "optional": true
@@ -26150,28 +26150,28 @@
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                   "dev": true,
                   "optional": true
                 },
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "dev": true,
                   "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "dev": true,
                   "optional": true
                 },
                 "are-we-there-yet": {
                   "version": "1.1.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                   "dev": true,
                   "optional": true,
@@ -26182,14 +26182,14 @@
                 },
                 "balanced-match": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                   "dev": true,
                   "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "dev": true,
                   "optional": true,
@@ -26200,42 +26200,42 @@
                 },
                 "chownr": {
                   "version": "1.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                   "dev": true,
                   "optional": true
                 },
                 "code-point-at": {
                   "version": "1.1.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "dev": true,
                   "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "dev": true,
                   "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true,
                   "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true,
                   "optional": true
                 },
                 "debug": {
                   "version": "4.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                   "dev": true,
                   "optional": true,
@@ -26245,28 +26245,28 @@
                 },
                 "deep-extend": {
                   "version": "0.6.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                   "dev": true,
                   "optional": true
                 },
                 "delegates": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true,
                   "optional": true
                 },
                 "detect-libc": {
                   "version": "1.0.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                   "dev": true,
                   "optional": true
                 },
                 "fs-minipass": {
                   "version": "1.2.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                   "dev": true,
                   "optional": true,
@@ -26276,14 +26276,14 @@
                 },
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true,
                   "optional": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "optional": true,
@@ -26300,7 +26300,7 @@
                 },
                 "glob": {
                   "version": "7.1.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                   "dev": true,
                   "optional": true,
@@ -26315,14 +26315,14 @@
                 },
                 "has-unicode": {
                   "version": "2.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                   "dev": true,
                   "optional": true
                 },
                 "iconv-lite": {
                   "version": "0.4.24",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                   "dev": true,
                   "optional": true,
@@ -26332,7 +26332,7 @@
                 },
                 "ignore-walk": {
                   "version": "3.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                   "dev": true,
                   "optional": true,
@@ -26342,7 +26342,7 @@
                 },
                 "inflight": {
                   "version": "1.0.6",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
                   "optional": true,
@@ -26353,21 +26353,21 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                   "dev": true,
                   "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                   "dev": true,
                   "optional": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "optional": true,
@@ -26377,14 +26377,14 @@
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true,
                   "optional": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "optional": true,
@@ -26394,14 +26394,14 @@
                 },
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true,
                   "optional": true
                 },
                 "minipass": {
                   "version": "2.3.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                   "dev": true,
                   "optional": true,
@@ -26412,7 +26412,7 @@
                 },
                 "minizlib": {
                   "version": "1.2.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                   "dev": true,
                   "optional": true,
@@ -26422,7 +26422,7 @@
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "dev": true,
                   "optional": true,
@@ -26432,14 +26432,14 @@
                 },
                 "ms": {
                   "version": "2.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                   "dev": true,
                   "optional": true
                 },
                 "needle": {
                   "version": "2.3.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                   "dev": true,
                   "optional": true,
@@ -26451,7 +26451,7 @@
                 },
                 "node-pre-gyp": {
                   "version": "0.12.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                   "dev": true,
                   "optional": true,
@@ -26470,7 +26470,7 @@
                 },
                 "nopt": {
                   "version": "4.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                   "dev": true,
                   "optional": true,
@@ -26481,14 +26481,14 @@
                 },
                 "npm-bundled": {
                   "version": "1.0.6",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                   "dev": true,
                   "optional": true
                 },
                 "npm-packlist": {
                   "version": "1.4.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                   "dev": true,
                   "optional": true,
@@ -26499,7 +26499,7 @@
                 },
                 "npmlog": {
                   "version": "4.1.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                   "dev": true,
                   "optional": true,
@@ -26512,21 +26512,21 @@
                 },
                 "number-is-nan": {
                   "version": "1.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                   "dev": true,
                   "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "dev": true,
                   "optional": true
                 },
                 "once": {
                   "version": "1.4.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "optional": true,
@@ -26536,21 +26536,21 @@
                 },
                 "os-homedir": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "dev": true,
                   "optional": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "dev": true,
                   "optional": true
                 },
                 "osenv": {
                   "version": "0.1.5",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                   "dev": true,
                   "optional": true,
@@ -26561,21 +26561,21 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true,
                   "optional": true
                 },
                 "process-nextick-args": {
                   "version": "2.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                   "dev": true,
                   "optional": true
                 },
                 "rc": {
                   "version": "1.2.8",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                   "dev": true,
                   "optional": true,
@@ -26588,7 +26588,7 @@
                   "dependencies": {
                     "minimist": {
                       "version": "1.2.0",
-                      "resolved": "",
+                      "resolved": false,
                       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                       "dev": true,
                       "optional": true
@@ -26597,7 +26597,7 @@
                 },
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "dev": true,
                   "optional": true,
@@ -26613,7 +26613,7 @@
                 },
                 "rimraf": {
                   "version": "2.6.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                   "dev": true,
                   "optional": true,
@@ -26623,49 +26623,49 @@
                 },
                 "safe-buffer": {
                   "version": "5.1.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                   "dev": true,
                   "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                   "dev": true,
                   "optional": true
                 },
                 "sax": {
                   "version": "1.2.4",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                   "dev": true,
                   "optional": true
                 },
                 "semver": {
                   "version": "5.7.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                   "dev": true,
                   "optional": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true,
                   "optional": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "dev": true,
                   "optional": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "optional": true,
@@ -26677,7 +26677,7 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "dev": true,
                   "optional": true,
@@ -26687,7 +26687,7 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "optional": true,
@@ -26697,14 +26697,14 @@
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                   "dev": true,
                   "optional": true
                 },
                 "tar": {
                   "version": "4.4.8",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                   "dev": true,
                   "optional": true,
@@ -26720,14 +26720,14 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true,
                   "optional": true
                 },
                 "wide-align": {
                   "version": "1.1.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                   "dev": true,
                   "optional": true,
@@ -26737,14 +26737,14 @@
                 },
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "dev": true,
                   "optional": true
                 },
                 "yallist": {
                   "version": "3.0.3",
-                  "resolved": "",
+                  "resolved": false,
                   "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                   "dev": true,
                   "optional": true

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -76,7 +76,7 @@
     "@superset-ui/legacy-plugin-chart-rose": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-sankey": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-sunburst": "^0.11.15",
-    "@superset-ui/legacy-plugin-chart-table": "^0.11.18",
+    "@superset-ui/legacy-plugin-chart-table": "^0.11.20",
     "@superset-ui/legacy-plugin-chart-treemap": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-word-cloud": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.11.15",


### PR DESCRIPTION
### CATEGORY

- [x ] Bug Fix

### SUMMARY

Minor fixes for the data table:

- [Fix scroll body height on very long column names and in very small containers](https://github.com/apache-superset/superset-ui-plugins/pull/398)
- [Adjust the position of the sort icons to align them at the bottom of table head](https://github.com/apache-superset/superset-ui-plugins/pull/399)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before
![image](https://user-images.githubusercontent.com/335541/76459684-de5cef00-6399-11ea-92b6-3f8087680033.png)

- After
![image](https://user-images.githubusercontent.com/335541/76459394-54148b00-6399-11ea-80bf-81810fc59df2.png)

### TEST PLAN

1. Create a table with a very long metric name
2. Put it into a small grid container in the dashboard
3. The table should not overflow out of the chart container.

### ADDITIONAL INFORMATION

N/A

### REVIEWERS

@etr2460 @graceguo-supercat @kristw 
