### PR TITLE
[sqllab] fix exception caused by casting string to int with psycopg2

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -284,6 +284,7 @@ DEFAULT_FEATURE_FLAGS = {
     "PRESTO_EXPAND_DATA": False,
     "SHARE_QUERIES_VIA_KV_STORE": False,
     "TAGGING_SYSTEM": False,
+    "SQLLAB_BACKEND_PERSISTENCE": False,
 }
 
 # This is merely a default.

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2715,6 +2715,7 @@ class Superset(BaseSupersetView):
                 )
             except DataError as e:
                 logger.error(e, exc_info=True)
+                db.session.rollback()
                 user_queries = []
 
             queries = {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -37,7 +37,6 @@ from sqlalchemy import and_, Integer, or_, select
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import (
     ArgumentError,
-    DataError,
     NoSuchModuleError,
     OperationalError,
     SQLAlchemyError,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2685,7 +2685,7 @@ class Superset(BaseSupersetView):
             .filter_by(user_id=user_id)
             .all()
         )
-        tab_state_ids = [tab_state[0] for tab_state in tabs_state]
+        tab_state_ids = [str(tab_state[0]) for tab_state in tabs_state]
         # return first active tab, or fallback to another one if no tab is active
         active_tab = (
             db.session.query(TabState)
@@ -2705,19 +2705,13 @@ class Superset(BaseSupersetView):
                 }
                 for database in db.session.query(models.Database).all()
             }
-            try:
-                # return all user queries associated with existing SQL editors
-                user_queries = (
-                    db.session.query(Query)
-                    .filter_by(user_id=user_id)
-                    .filter(Query.sql_editor_id.cast(Integer).in_(tab_state_ids))
-                    .all()
-                )
-            except DataError as e:
-                logger.error(e, exc_info=True)
-                db.session.rollback()
-                user_queries = []
-
+            # return all user queries associated with existing SQL editors
+            user_queries = (
+                db.session.query(Query)
+                .filter_by(user_id=user_id)
+                .filter(Query.sql_editor_id.in_(tab_state_ids))
+                .all()
+            )
             queries = {
                 query.client_id: {k: v for k, v in query.to_dict().items()}
                 for query in user_queries


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There's an issue with running the feature SQLLAB_BACKEND_PERSISTENCE whole using postgres as the metadata db. 
For the expression `CAST('JUScSB3M_' as INTEGER)`  MySQL and SQLite produce `0`, postgres raises an exception: `sqlalchemy.exc.DataError: (psycopg2.errors.InvalidTextRepresentation) invalid input syntax for integer: "JUScSB3M_"`. 

This causes an unhandled exception at this line: https://github.com/apache/incubator-superset/pull/8769/files#r384774308

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
error can be reproduced by:
- run superset with pg as meta db
- create a few tabs in sqllab and run a few queries in each tab
- enable feature flag SQLLAB_BACKEND_PERSISTENCE
- reload/visit sqllab 
- notice a 500 from the server due to postgres raising an exception trying to cast a string to an int

With the changes in this PR the above exception no longer occurs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@betodealmeida @robdiciuccio @villebro @craig-rueda @robdiciuccio 