### PR TITLE
fix: bump click in setup.py and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ billiard==3.6.3.0         # via celery
 bleach==3.1.0             # via apache-superset (setup.py)
 celery==4.4.1             # via apache-superset (setup.py)
 cffi==1.13.2              # via cryptography
-click==6.7                # via apache-superset (setup.py), flask, flask-appbuilder
+click==7.1.1              # via apache-superset (setup.py), flask, flask-appbuilder
 colorama==0.4.3           # via apache-superset (setup.py), flask-appbuilder
 contextlib2==0.6.0.post1  # via apache-superset (setup.py)
 croniter==0.3.31          # via apache-superset (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "backoff>=1.8.0",
         "bleach>=3.0.2, <4.0.0",
         "celery>=4.3.0, <5.0.0",
-        "click>=6.0, <7.0.0",  # `click`>=7 forces "-" instead of "_"
+        "click<8",
         "colorama",
         "contextlib2",
         "croniter>=0.3.28",

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -36,7 +36,24 @@ from superset.utils import core as utils
 logger = logging.getLogger(__name__)
 
 
-@click.group(cls=FlaskGroup, create_app=create_app)
+def normalize_token(token_name: str) -> str:
+    """
+    As of click>=7, underscores in function names are replaced by dashes.
+    To avoid the need to rename all cli functions, e.g. load_examples to
+    load-examples, this function is used to convert dashes back to
+    underscores.
+
+    :param token_name: token name possibly containing dashes
+    :return: token name where dashes are replaced with underscores
+    """
+    return token_name.replace("_", "-")
+
+
+@click.group(
+    cls=FlaskGroup,
+    create_app=create_app,
+    context_settings={"token_normalize_func": normalize_token},
+)
 @with_appcontext
 def superset():
     """This is a management script for the Superset application."""


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
As of #9277 , `pip-tools` was bumped to `4.5.1`, which requires `click>=7`:  [link](https://github.com/jazzband/pip-tools/blob/4.5.1/setup.py#L29). This is currently at odds with `setup.py`, which requires `click<7.0.0`. This PR bumps click to the latest version, which seems to work well with Superset.

### TEST PLAN
Tested locally + CI

### REVIEWERS
@john-bodley 