### PR TITLE
fix: add datasource metrics to point size dropdown in deckgl scatterplot viz

### DIFF
--- a/superset-frontend/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -97,6 +97,9 @@ export default class FixedOrMetricControl extends React.Component {
     const columns = this.props.datasource
       ? this.props.datasource.columns
       : null;
+    const metrics = this.props.datasource
+      ? this.props.datasource.metrics
+      : null;
     return (
       <div>
         <ControlHeader {...this.props} />
@@ -145,6 +148,7 @@ export default class FixedOrMetricControl extends React.Component {
               <MetricsControl
                 name="metric"
                 columns={columns}
+                savedMetrics={metrics}
                 multi={false}
                 onFocus={() => {
                   this.setType(controlTypes.metric);


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently the `FixedOrMetricControl` that is used in the DeckGL Scatterplot viz is missing saved metrics.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/76737754-08375c80-6772-11ea-932b-4155e5bfbf35.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/76737837-2ac97580-6772-11ea-8106-5f1c162a7bb8.png)

### TEST PLAN
Tested locally.

### REVIEWERS
@kristw @rusackas @etr2460 @mistercrunch 