### PR TITLE
Fixes #9085 - Add global install of webpack and webpack-cli to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
 
   superset-node:
     image: node:10-jessie
-    command: ["bash", "-c", "cd /app/superset-frontend && npm install && npm run dev"]
+    command: ["bash", "-c", "cd /app/superset-frontend && npm install --global webpack webpack-cli && npm install && npm run dev"]
     env_file: docker/.env
     depends_on: *superset-depends-on
     volumes: *superset-volumes


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`npm` being the unreliable system it is, it occasionally fails to make the `webpack` executable available when building the node container under `docker-compose`. This PR installs `webpack` and `webpack-cli` globally to avoid this problem. Solution suggested by @saltict in response to https://github.com/apache/incubator-superset/issues/9085. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/incubator-superset/issues/9085
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@rusackas @craig-rueda 