### PR TITLE
Fix add chart page translation not work

### DIFF
--- a/superset-frontend/src/addSlice/App.tsx
+++ b/superset-frontend/src/addSlice/App.tsx
@@ -26,7 +26,7 @@ import AddSliceContainer from './AddSliceContainer';
 setupApp();
 setupPlugins();
 
-const addSliceContainer = document.getElementById('js-add-slice-container');
+const addSliceContainer = document.getElementById('app');
 const bootstrapData = JSON.parse(
   addSliceContainer?.getAttribute('data-bootstrap') || '{}',
 );

--- a/superset-frontend/src/addSlice/index.tsx
+++ b/superset-frontend/src/addSlice/index.tsx
@@ -20,4 +20,4 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('js-add-slice-container'));
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/superset/templates/superset/add_slice.html
+++ b/superset/templates/superset/add_slice.html
@@ -24,7 +24,7 @@
 
 {% block body %}
   <div
-    id="js-add-slice-container"
+    id="app"
     data-bootstrap="{{ bootstrap_data }}"
   ></div>
 {% endblock %}

--- a/superset/views/chart/views.py
+++ b/superset/views/chart/views.py
@@ -26,7 +26,12 @@ from superset.constants import RouteMethod
 from superset.models.slice import Slice
 from superset.typing import FlaskResponse
 from superset.utils import core as utils
-from superset.views.base import check_ownership, DeleteMixin, SupersetModelView
+from superset.views.base import (
+    check_ownership,
+    common_bootstrap_payload,
+    DeleteMixin,
+    SupersetModelView,
+)
 from superset.views.chart.mixin import SliceMixin
 
 
@@ -58,11 +63,12 @@ class SliceModelView(
             {"value": str(d.id) + "__" + d.type, "label": repr(d)}
             for d in ConnectorRegistry.get_all_datasources(db.session)
         ]
+        payload = {
+            "datasources": sorted(datasources, key=lambda d: d["label"]),
+            "common": common_bootstrap_payload(),
+        }
         return self.render_template(
-            "superset/add_slice.html",
-            bootstrap_data=json.dumps(
-                {"datasources": sorted(datasources, key=lambda d: d["label"])}
-            ),
+            "superset/add_slice.html", bootstrap_data=json.dumps(payload)
         )
 
     @expose("/list/")


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
the `chart/add` page translation not work, because of:
1. language pack not loaded before render template
2. translator in `preamble.js` only try to get language pack from node `id="app"`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![image](https://user-images.githubusercontent.com/240147/76944189-8b57de80-693b-11ea-8d06-26aa6680083e.png)

after:
![image](https://user-images.githubusercontent.com/240147/76944109-68c5c580-693b-11ea-89d4-f19cbd46df31.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
