### PR TITLE
fix: handle list of lists from fetch_data

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -20,13 +20,14 @@
 import datetime
 import json
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 
 from superset import db_engine_specs
+from superset.typing import DbapiDescription, DbapiResult
 from superset.utils import core as utils
 
 logger = logging.getLogger(__name__)
@@ -70,8 +71,8 @@ def stringify_values(array: np.ndarray) -> np.ndarray:
 class SupersetResultSet:
     def __init__(
         self,
-        data: List[Union[List[Any], Tuple[Any, ...]]],
-        cursor_description: Union[List[Any], Tuple[Any, ...]],
+        data: DbapiResult,
+        cursor_description: DbapiDescription,
         db_engine_spec: Type[db_engine_specs.BaseEngineSpec],
     ):
         self.db_engine_spec = db_engine_spec
@@ -95,9 +96,10 @@ class SupersetResultSet:
             # generate numpy structured array dtype
             numpy_dtype = [(column_name, "object") for column_name in column_names]
 
-        # put data in a structured array so we can efficiently access each column.
-        # cast `data` as list due to MySQL (others?) wrapping results with a tuple.
-        array = np.array([tuple(row) for row in data], dtype=numpy_dtype)
+        # only do expensive recasting if datatype is not standard list of tuples
+        if data and (not isinstance(data, list) or not isinstance(data[0], tuple)):
+            data = [tuple(row) for row in data]
+        array = np.array(data, dtype=numpy_dtype)
         if array.size > 0:
             for column in column_names:
                 try:

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -20,7 +20,7 @@
 import datetime
 import json
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -70,8 +70,8 @@ def stringify_values(array: np.ndarray) -> np.ndarray:
 class SupersetResultSet:
     def __init__(
         self,
-        data: List[Tuple[Any, ...]],
-        cursor_description: Tuple[Any, ...],
+        data: List[Union[List[Any], Tuple[Any, ...]]],
+        cursor_description: Union[List[Any], Tuple[Any, ...]],
         db_engine_spec: Type[db_engine_specs.BaseEngineSpec],
     ):
         self.db_engine_spec = db_engine_spec
@@ -97,7 +97,7 @@ class SupersetResultSet:
 
         # put data in a structured array so we can efficiently access each column.
         # cast `data` as list due to MySQL (others?) wrapping results with a tuple.
-        array = np.array(list(data), dtype=numpy_dtype)
+        array = np.array([tuple(row) for row in data], dtype=numpy_dtype)
         if array.size > 0:
             for column in column_names:
                 try:

--- a/superset/typing.py
+++ b/superset/typing.py
@@ -14,10 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from flask import Flask
 from flask_caching import Cache
 
 CacheConfig = Union[Callable[[Flask], Cache], Dict[str, Any]]
+DbapiDescriptionRow = Tuple[
+    str, str, Optional[str], Optional[str], Optional[int], Optional[int], bool
+]
+DbapiDescription = Union[List[DbapiDescriptionRow], Tuple[DbapiDescriptionRow, ...]]
+DbapiResult = List[Union[List[Any], Tuple[Any, ...]]]
 VizData = Optional[Union[List[Any], Dict[Any, Any]]]

--- a/tests/result_set_tests.py
+++ b/tests/result_set_tests.py
@@ -109,12 +109,18 @@ class SupersetResultSetTestCase(SupersetTestCase):
         results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
         self.assertEqual(results.columns[0]["type"], "BIGINT")
 
-    def test_data_from_list_of_lists(self):
-        data = [["a"], ["b"]]
-        cursor_descr = [("user_id", "STRING", None, None, None, None, True)]
+    def test_data_as_list_of_lists(self):
+        data = [[1, "a"], [2, "b"]]
+        cursor_descr = [
+            ("user_id", "INT", None, None, None, None, True),
+            ("username", "STRING", None, None, None, None, True),
+        ]
         results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
         df = results.to_pandas_df()
-        self.assertEqual(df_to_records(df), [{"user_id": "a"}, {"user_id": "b"}])
+        self.assertEqual(
+            df_to_records(df),
+            [{"user_id": 1, "username": "a"}, {"user_id": 2, "username": "b"}],
+        )
 
     def test_nullable_bool(self):
         data = [(None,), (True,), (None,), (None,), (None,), (None,)]

--- a/tests/result_set_tests.py
+++ b/tests/result_set_tests.py
@@ -109,6 +109,13 @@ class SupersetResultSetTestCase(SupersetTestCase):
         results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
         self.assertEqual(results.columns[0]["type"], "BIGINT")
 
+    def test_data_from_list_of_lists(self):
+        data = [["a"], ["b"]]
+        cursor_descr = [("user_id", "STRING", None, None, None, None, True)]
+        results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
+        df = results.to_pandas_df()
+        self.assertEqual(df_to_records(df), [{"user_id": "a"}, {"user_id": "b"}])
+
     def test_nullable_bool(self):
         data = [(None,), (True,), (None,), (None,), (None,), (None,)]
         cursor_descr = [("is_test", "bool", None, None, None, None, True)]


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently `SupersetResultSet` is unable to handle results that are coming in as a list of lists. This causes trouble later when converting the result into a numpy array. While the convention for PEP-249 is to return a list of tuples, this is not strictly enforced, and hence many connectors return a list of lists.

This PR ensures that the result set is a list of tuples that numpy can handle properly. A test case is also added that fails without the change.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/76957017-b8959400-691d-11ea-85b7-95c6e3690e97.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/76956918-90a63080-691d-11ea-85ee-15d09b518c97.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@robdiciuccio @dpgaspar @kunaldawn