### PR TITLE
[chart] fix, bulk delete endpoint and error message

### DIFF
--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -280,11 +280,9 @@ class ChartList extends React.PureComponent<Props, State> {
     );
   };
 
-  handleBulkDashboardDelete = (charts: Chart[]) => {
+  handleBulkChartDelete = (charts: Chart[]) => {
     SupersetClient.delete({
-      endpoint: `/api/v1/dashboard/?q=!(${charts
-        .map(({ id }) => id)
-        .join(',')})`,
+      endpoint: `/api/v1/chart/?q=!(${charts.map(({ id }) => id).join(',')})`,
     }).then(
       ({ json = {} }) => {
         const { lastFetchDataConfig } = this.state;
@@ -296,7 +294,7 @@ class ChartList extends React.PureComponent<Props, State> {
       (err: any) => {
         console.error(err);
         this.props.addDangerToast(
-          t('There was an issue deleting the selected dashboards'),
+          t('There was an issue deleting the selected charts'),
         );
       },
     );
@@ -408,7 +406,7 @@ class ChartList extends React.PureComponent<Props, State> {
             description={t(
               'Are you sure you want to delete the selected charts?',
             )}
-            onConfirm={this.handleBulkDashboardDelete}
+            onConfirm={this.handleBulkChartDelete}
           >
             {confirmDelete => {
               const bulkActions = [];


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The endpoint and error message are wrong for chart bulk delete is wrong. This pr fixes it. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- bulk delete charts present the correct error messagr when deleted. 
- the delete request hits the endpoint `/api/v1/chart/?q!(...`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@dpgaspar 