### PR TITLE
[requirements] Telling Celery version 4.4.1 it is not welcome here

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ ipdb==0.12
 isort==4.3.21
 mypy==0.670
 nose==1.3.7
-pip-tools==3.7.0
+pip-tools==4.5.1
 pre-commit==1.17.0
 psycopg2-binary==2.7.5
 pycodestyle==2.5.0

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     install_requires=[
         "backoff>=1.8.0",
         "bleach>=3.0.2, <4.0.0",
-        "celery>=4.3.0, <5.0.0",
+        "celery>=4.3.0, <5.0.0, !=4.4.1",
         "click<8",
         "colorama",
         "contextlib2",


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Per https://github.com/apache/incubator-superset/pull/9323 there is merit in preventing Celery version 4.4.1 from being installed. Note that version 4.4.2 was released recently and currently we're unsure if this is also problematic for our configuration. Should we only allow no higher than 4.4.0?
 
### TEST PLAN

Ran `pip-compile setup.py`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @villebro 
