### PR TITLE
refactor: remove settooltip

### DIFF
--- a/superset-frontend/src/chart/ChartRenderer.jsx
+++ b/superset-frontend/src/chart/ChartRenderer.jsx
@@ -21,7 +21,6 @@ import { snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { SuperChart } from '@superset-ui/chart';
-import { Tooltip } from 'react-bootstrap';
 import { Logger, LOG_ACTIONS_RENDER_CHART } from '../logger/LogUtils';
 
 const propTypes = {
@@ -62,11 +61,8 @@ const defaultProps = {
 class ChartRenderer extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {};
-
     this.hasQueryResponseChange = false;
 
-    this.setTooltip = this.setTooltip.bind(this);
     this.handleAddFilter = this.handleAddFilter.bind(this);
     this.handleRenderSuccess = this.handleRenderSuccess.bind(this);
     this.handleRenderFailure = this.handleRenderFailure.bind(this);
@@ -76,13 +72,12 @@ class ChartRenderer extends React.Component {
       onAddFilter: this.handleAddFilter,
       onError: this.handleRenderFailure,
       setControlValue: this.handleSetControlValue,
-      setTooltip: this.setTooltip,
       onFilterMenuOpen: this.props.onFilterMenuOpen,
       onFilterMenuClose: this.props.onFilterMenuClose,
     };
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(nextProps) {
     const resultsReady =
       nextProps.queryResponse &&
       ['success', 'rendered'].indexOf(nextProps.chartStatus) > -1 &&
@@ -98,7 +93,6 @@ class ChartRenderer extends React.Component {
         nextProps.annotationData !== this.props.annotationData ||
         nextProps.height !== this.props.height ||
         nextProps.width !== this.props.width ||
-        nextState.tooltip !== this.state.tooltip ||
         nextProps.triggerRender ||
         nextProps.formData.color_scheme !== this.props.formData.color_scheme
       ) {
@@ -106,10 +100,6 @@ class ChartRenderer extends React.Component {
       }
     }
     return false;
-  }
-
-  setTooltip(tooltip) {
-    this.setState({ tooltip });
   }
 
   handleAddFilter(col, vals, merge = true, refresh = true) {
@@ -164,33 +154,6 @@ class ChartRenderer extends React.Component {
     }
   }
 
-  renderTooltip() {
-    const { tooltip } = this.state;
-    if (tooltip && tooltip.content) {
-      return (
-        <Tooltip
-          className="chart-tooltip"
-          id="chart-tooltip"
-          placement="right"
-          positionTop={tooltip.y + 30}
-          positionLeft={tooltip.x + 30}
-          arrowOffsetTop={10}
-        >
-          {typeof tooltip.content === 'string' ? (
-            <div // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{
-                __html: dompurify.sanitize(tooltip.content),
-              }}
-            />
-          ) : (
-            tooltip.content
-          )}
-        </Tooltip>
-      );
-    }
-    return null;
-  }
-
   render() {
     const {
       chartAlert,
@@ -233,25 +196,22 @@ class ChartRenderer extends React.Component {
         : snakeCaseVizType;
 
     return (
-      <>
-        {this.renderTooltip()}
-        <SuperChart
-          disableErrorBoundary
-          id={`chart-id-${chartId}`}
-          className={chartClassName}
-          chartType={vizType}
-          width={width}
-          height={height}
-          annotationData={annotationData}
-          datasource={datasource}
-          initialValues={initialValues}
-          formData={formData}
-          hooks={this.hooks}
-          queryData={queryResponse}
-          onRenderSuccess={this.handleRenderSuccess}
-          onRenderFailure={this.handleRenderFailure}
-        />
-      </>
+      <SuperChart
+        disableErrorBoundary
+        id={`chart-id-${chartId}`}
+        className={chartClassName}
+        chartType={vizType}
+        width={width}
+        height={height}
+        annotationData={annotationData}
+        datasource={datasource}
+        initialValues={initialValues}
+        formData={formData}
+        hooks={this.hooks}
+        queryData={queryResponse}
+        onRenderSuccess={this.handleRenderSuccess}
+        onRenderFailure={this.handleRenderFailure}
+      />
     );
   }
 }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Refactor

### SUMMARY
Historically, `setTooltip` hook was pass from Superset to visualization components. The visualization components call this function and let tooltip rendering be handled by `ChartRenderer.jsx`. This has been used by the `deck.gl` plugins only. 

The recent changes in 
https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/12 and
https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/13 
make the `deck.gl` charts handle their own tooltips within components.

There is no longer needed for this `setTooltip` mechanism after #9325 (bump version) is merged.

### TEST PLAN
Run locally

### REVIEWERS
@etr2460 @ktmud 