### PR TITLE
Add extra configuration to the email reports

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -751,6 +751,11 @@ WEBDRIVER_CONFIGURATION: Dict[Any, Any] = {}
 
 # The base URL to query for accessing the user interface
 WEBDRIVER_BASEURL = "http://0.0.0.0:8080/"
+# The base URL for the email report hyperlinks.
+WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
+# Time in seconds, selenium will wait for the page to load
+# and render for the email report.
+EMAIL_PAGE_RENDER_WAIT = 30
 
 # Send user to a link where they can report bugs
 BUG_REPORT_URL = None


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
1. Move EMAIL_PAGE_RENDER_WAIT to the config
2. Introduce WEBDRIVER_BASEURL_USER_FRIENDLY for the links in the email for the usecases when WEBDRIVER_BASEURL is a localhost

### TEST PLAN
[x] dropbox staging
[x] dropbox production

### Reviewers
