### PR TITLE
fix: suburst chart when secondary metric is defined

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1673,12 +1673,15 @@ class SunburstViz(BaseViz):
     def get_data(self, df: pd.DataFrame) -> VizData:
         fd = self.form_data
         cols = fd.get("groupby") or []
+        cols.extend(["m1", "m2"])
         metric = utils.get_metric_name(fd.get("metric"))
         secondary_metric = utils.get_metric_name(fd.get("secondary_metric"))
         if metric == secondary_metric or secondary_metric is None:
             df.rename(columns={df.columns[-1]: "m1"}, inplace=True)
             df["m2"] = df["m1"]
-            cols.extend(["m1", "m2"])
+        else:
+            df.rename(columns={df.columns[-2]: "m1"}, inplace=True)
+            df.rename(columns={df.columns[-1]: "m2"}, inplace=True)
 
         # Re-order the columns as the query result set column ordering may differ from
         # that listed in the hierarchy.


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently the Sunburst chart only works with a single metric; defining a secondary metric breaks the chart. This is likely a regression introduced by #9011 . 

Note to reviewers: I didn't put a lot of effort into making the code super clean, as we're currently working towards completely deprecating `viz.py` in favour of the new `/api/v1/query` endpoint.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/77236930-cf611280-6bcb-11ea-8f7b-c0a181f88ae5.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/77236923-ba847f00-6bcb-11ea-91f0-dbcfcc1397bf.png)

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@john-bodley 