### PR TITLE
[explore view] fix long query issue from Run in SQL LAB Button

### DIFF
--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -109,7 +109,7 @@ if (sqlLabMenu) {
 
 const Application = () => (
   <Provider store={store}>
-    <App formData={bootstrapData.form_data} />
+    <App />
   </Provider>
 );
 

--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -46,7 +46,9 @@ setupApp();
 
 const appContainer = document.getElementById('app');
 const bootstrapData = JSON.parse(appContainer.getAttribute('data-bootstrap'));
+
 initFeatureFlags(bootstrapData.common.feature_flags);
+
 const initialState = getInitialState(bootstrapData);
 const sqlLabPersistStateConfig = {
   paths: ['sqlLab'],
@@ -59,7 +61,6 @@ const sqlLabPersistStateConfig = {
         // it caused configurations passed from server-side got override.
         // see PR 6257 for details
         delete state[path].common; // eslint-disable-line no-param-reassign
-
         if (path === 'sqlLab') {
           subset[path] = {
             ...state[path],
@@ -108,7 +109,7 @@ if (sqlLabMenu) {
 
 const Application = () => (
   <Provider store={store}>
-    <App />
+    <App formData={bootstrapData.form_data} />
   </Provider>
 );
 

--- a/superset-frontend/src/SqlLab/components/App.jsx
+++ b/superset-frontend/src/SqlLab/components/App.jsx
@@ -125,7 +125,7 @@ class App extends React.PureComponent {
       content = (
         <>
           <QueryAutoRefresh />
-          <TabbedSqlEditors formData={this.props.formData} />
+          <TabbedSqlEditors />
         </>
       );
     }

--- a/superset-frontend/src/SqlLab/components/App.jsx
+++ b/superset-frontend/src/SqlLab/components/App.jsx
@@ -125,7 +125,7 @@ class App extends React.PureComponent {
       content = (
         <>
           <QueryAutoRefresh />
-          <TabbedSqlEditors />
+          <TabbedSqlEditors formData={this.props.formData} />
         </>
       );
     }

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -39,6 +39,7 @@ const propTypes = {
   databases: PropTypes.object.isRequired,
   queries: PropTypes.object.isRequired,
   queryEditors: PropTypes.array,
+  requestedQuery: PropTypes.object,
   tabHistory: PropTypes.array.isRequired,
   tables: PropTypes.array.isRequired,
   offline: PropTypes.bool,
@@ -48,6 +49,7 @@ const propTypes = {
 const defaultProps = {
   queryEditors: [],
   offline: false,
+  requestedQuery: null,
   saveQueryWarning: null,
   scheduleQueryWarning: null,
 };
@@ -101,7 +103,7 @@ class TabbedSqlEditors extends React.PureComponent {
 
     // merge post form data with GET search params
     const query = {
-      ...this.props.formData,
+      ...this.props.requestedQuery,
       ...URI(window.location).search(true),
     };
 
@@ -379,7 +381,7 @@ class TabbedSqlEditors extends React.PureComponent {
 TabbedSqlEditors.propTypes = propTypes;
 TabbedSqlEditors.defaultProps = defaultProps;
 
-function mapStateToProps({ sqlLab, common }) {
+function mapStateToProps({ sqlLab, common, requestedQuery }) {
   return {
     databases: sqlLab.databases,
     queryEditors: sqlLab.queryEditors,
@@ -393,6 +395,7 @@ function mapStateToProps({ sqlLab, common }) {
     maxRow: common.conf.SQL_MAX_ROW,
     saveQueryWarning: common.conf.SQLLAB_SAVE_WARNING_MESSAGE,
     scheduleQueryWarning: common.conf.SQLLAB_SCHEDULE_WARNING_MESSAGE,
+    requestedQuery,
   };
 }
 function mapDispatchToProps(dispatch) {

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -99,7 +99,12 @@ class TabbedSqlEditors extends React.PureComponent {
         });
     }
 
-    const query = URI(window.location).search(true);
+    // merge post form data with GET search params
+    const query = {
+      ...this.props.formData,
+      ...URI(window.location).search(true),
+    };
+
     // Popping a new tab based on the querystring
     if (query.id || query.sql || query.savedQueryId || query.datasourceKey) {
       if (query.id) {

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -19,8 +19,15 @@
 import { t } from '@superset-ui/translation';
 import getToastsFromPyFlashMessages from '../../messageToasts/utils/getToastsFromPyFlashMessages';
 
-export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
-  /*
+export default function getInitialState({
+  defaultDbId,
+  common,
+  active_tab: activeTab,
+  tab_state_ids: tabStateIds = [],
+  databases,
+  queries: queries_,
+}) {
+  /**
    * Before YYYY-MM-DD, the state for SQL Lab was stored exclusively in the
    * browser's localStorage. The feature flag `SQLLAB_BACKEND_PERSISTENCE`
    * moves the state to the backend instead, migrating it from local storage.
@@ -39,7 +46,7 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
     autorun: false,
     templateParams: null,
     dbId: defaultDbId,
-    queryLimit: restBootstrapData.common.conf.DEFAULT_SQLLAB_LIMIT,
+    queryLimit: common.conf.DEFAULT_SQLLAB_LIMIT,
     validationResult: {
       id: null,
       errors: [],
@@ -52,11 +59,11 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
     },
   };
 
-  /* Load state from the backend. This will be empty if the feature flag
+  /**
+   * Load state from the backend. This will be empty if the feature flag
    * `SQLLAB_BACKEND_PERSISTENCE` is off.
    */
-  const activeTab = restBootstrapData.active_tab;
-  restBootstrapData.tab_state_ids.forEach(({ id, label }) => {
+  tabStateIds.forEach(({ id, label }) => {
     let queryEditor;
     if (activeTab && activeTab.id === id) {
       queryEditor = {
@@ -92,7 +99,6 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
   });
 
   const tabHistory = activeTab ? [activeTab.id.toString()] : [];
-
   const tables = [];
   if (activeTab) {
     activeTab.table_schemas
@@ -126,9 +132,10 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
       });
   }
 
-  const { databases, queries } = restBootstrapData;
+  const queries = { ...queries_ };
 
-  /* If the `SQLLAB_BACKEND_PERSISTENCE` feature flag is off, or if the user
+  /**
+   * If the `SQLLAB_BACKEND_PERSISTENCE` feature flag is off, or if the user
    * hasn't used SQL Lab after it has been turned on, the state will be stored
    * in the browser's local storage.
    */
@@ -174,12 +181,12 @@ export default function getInitialState({ defaultDbId, ...restBootstrapData }) {
       queriesLastUpdate: Date.now(),
     },
     messageToasts: getToastsFromPyFlashMessages(
-      (restBootstrapData.common || {}).flash_messages || [],
+      (common || {}).flash_messages || [],
     ),
     localStorageUsageInKilobytes: 0,
     common: {
-      flash_messages: restBootstrapData.common.flash_messages,
-      conf: restBootstrapData.common.conf,
+      flash_messages: common.flash_messages,
+      conf: common.conf,
     },
   };
 }

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -26,6 +26,7 @@ export default function getInitialState({
   tab_state_ids: tabStateIds = [],
   databases,
   queries: queries_,
+  requested_query: requestedQuery,
 }) {
   /**
    * Before YYYY-MM-DD, the state for SQL Lab was stored exclusively in the
@@ -180,6 +181,7 @@ export default function getInitialState({
       tables,
       queriesLastUpdate: Date.now(),
     },
+    requestedQuery,
     messageToasts: getToastsFromPyFlashMessages(
       (common || {}).flash_messages || [],
     ),

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -25,6 +25,7 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import {
   getExploreUrlAndPayload,
   getAnnotationJsonUrl,
+  postForm,
 } from '../explore/exploreUtils';
 import {
   requiresQuery,
@@ -358,14 +359,12 @@ export function redirectSQLLab(formData) {
       postPayload: { form_data: formData },
     })
       .then(({ json }) => {
-        const redirectUrl = new URL(window.location);
-        redirectUrl.pathname = '/superset/sqllab';
-        for (const key of redirectUrl.searchParams.keys()) {
-          redirectUrl.searchParams.delete(key);
-        }
-        redirectUrl.searchParams.set('datasourceKey', formData.datasource);
-        redirectUrl.searchParams.set('sql', json.query);
-        window.open(redirectUrl.href, '_blank');
+        const redirectUrl = '/superset/sqllab';
+        const payload = {
+          datasourceKey: formData.datasource,
+          sql: json.query,
+        };
+        postForm(redirectUrl, payload);
       })
       .catch(() =>
         dispatch(addDangerToast(t('An error occurred while loading the SQL'))),

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -195,24 +195,24 @@ export function postForm(url, payload, target = '_blank') {
     return;
   }
 
-  const exploreForm = document.createElement('form');
-  exploreForm.action = url;
-  exploreForm.method = 'POST';
-  exploreForm.target = target;
+  const hiddenForm = document.createElement('form');
+  hiddenForm.action = url;
+  hiddenForm.method = 'POST';
+  hiddenForm.target = target;
   const token = document.createElement('input');
   token.type = 'hidden';
   token.name = 'csrf_token';
   token.value = (document.getElementById('csrf_token') || {}).value;
-  exploreForm.appendChild(token);
+  hiddenForm.appendChild(token);
   const data = document.createElement('input');
   data.type = 'hidden';
   data.name = 'form_data';
   data.value = safeStringify(payload);
-  exploreForm.appendChild(data);
+  hiddenForm.appendChild(data);
 
-  document.body.appendChild(exploreForm);
-  exploreForm.submit();
-  document.body.removeChild(exploreForm);
+  document.body.appendChild(hiddenForm);
+  hiddenForm.submit();
+  document.body.removeChild(hiddenForm);
 }
 
 export function exportChart(formData, endpointType) {

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -190,17 +190,15 @@ export function getExploreUrlAndPayload({
   };
 }
 
-export function exportChart(formData, endpointType) {
-  const { url, payload } = getExploreUrlAndPayload({
-    formData,
-    endpointType,
-    allowDomainSharding: false,
-  });
+export function postForm(url, payload, target = '_blank') {
+  if (!url) {
+    return;
+  }
 
   const exploreForm = document.createElement('form');
   exploreForm.action = url;
   exploreForm.method = 'POST';
-  exploreForm.target = '_blank';
+  exploreForm.target = target;
   const token = document.createElement('input');
   token.type = 'hidden';
   token.name = 'csrf_token';
@@ -215,4 +213,13 @@ export function exportChart(formData, endpointType) {
   document.body.appendChild(exploreForm);
   exploreForm.submit();
   document.body.removeChild(exploreForm);
+}
+
+export function exportChart(formData, endpointType) {
+  const { url, payload } = getExploreUrlAndPayload({
+    formData,
+    endpointType,
+    allowDomainSharding: false,
+  });
+  postForm(url, payload);
 }

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2756,8 +2756,13 @@ class Superset(BaseSupersetView):
     def sqllab(self):
         """SQL Editor"""
         payload = self._get_sqllab_payload(g.user.get_id())
+        form_data = request.form.get('form_data')
+        try:
+            payload['form_data'] = json.loads(form_data)
+        except:
+            pass
         bootstrap_data = json.dumps(
-            payload, default=utils.pessimistic_json_iso_dttm_ser
+            payload, default=utils.pessimistic_json_iso_dttm_ser,
         )
 
         return self.render_template(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2756,10 +2756,8 @@ class Superset(BaseSupersetView):
         payload = {
             "defaultDbId": config["SQLLAB_DEFAULT_DBID"],
             "common": common_bootstrap_payload(),
+            **self._get_sqllab_tabs(g.user.get_id()),
         }
-
-        tabs_data = self._get_sqllab_tabs(g.user.get_id())
-        payload.update(tabs_data)
 
         form_data = request.form.get("form_data")
         if form_data:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2752,7 +2752,7 @@ class Superset(BaseSupersetView):
         }
 
     @has_access
-    @expose("/sqllab")
+    @expose("/sqllab", methods=["GET", "POST"])
     def sqllab(self):
         """SQL Editor"""
         payload = self._get_sqllab_payload(g.user.get_id())

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1168,7 +1168,7 @@ class CoreTests(SupersetTestCase):
 
         # we should have only 1 query returned, since the second one is not
         # associated with any tabs
-        payload = views.Superset._get_sqllab_payload(user_id=user_id)
+        payload = views.Superset._get_sqllab_tabs(user_id=user_id)
         self.assertEqual(len(payload["queries"]), 1)
 
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In Explore view, Superset allow user to open current query in SQL Lab:
<img width="1272" alt="Screen Shot 2020-03-21 at 4 20 31 PM" src="https://user-images.githubusercontent.com/27990562/77238703-eda91d00-6b8f-11ea-9398-719b35a5be2c.png">

Current Superset will send a **GET** request with sql query. But when sql query is very complicate, it might be over 4000 characters, and out of the limit of browser/nginx limit. It will display 504 Bad Gateway error message.

This PR is to handle this request by submitting a hidden form with POST method.

### TEST PLAN
1. open explore view,
2. Click Run in SQL Lab button from dropdown menu
3. expect to see query in Sql Lab's query editor.


### REVIEWERS
@ktmud 