### PR TITLE
[dashboard] handle markdown error

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
@@ -69,7 +69,7 @@ const propTypes = {
 
 const defaultProps = {};
 
-const markdownPlaceHolder = `# ✨Markdown
+const MARKDOWN_PLACE_HOLDER = `# ✨Markdown
 ## ✨Markdown
 ### ✨Markdown
 
@@ -77,9 +77,7 @@ const markdownPlaceHolder = `# ✨Markdown
 
 Click here to edit [markdown](https://bit.ly/1dQOfRK)`;
 
-const emergencyCode = `
-  This markdown component has an error.
-`;
+const MARKDOWN_ERROR_MESSAGE = t('This markdown component has an error.');
 
 function isSafeMarkup(node) {
   if (node.type === 'html') {
@@ -243,7 +241,7 @@ class Markdown extends React.PureComponent {
           // thisl allows "select all => delete" to give an empty editor
           typeof this.state.markdownSource === 'string'
             ? this.state.markdownSource
-            : markdownPlaceHolder
+            : MARKDOWN_PLACE_HOLDER
         }
         readOnly={false}
         onLoad={this.setEditor}
@@ -257,8 +255,8 @@ class Markdown extends React.PureComponent {
       <ReactMarkdown
         source={
           hasError
-            ? emergencyCode
-            : this.state.markdownSource || markdownPlaceHolder
+            ? MARKDOWN_ERROR_MESSAGE
+            : this.state.markdownSource || MARKDOWN_PLACE_HOLDER
         }
         escapeHtml={false}
         allowNode={isSafeMarkup}

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -35,6 +35,7 @@ import {
 } from '../actions/dashboardLayout';
 import { setDirectPathToChild } from '../actions/dashboardState';
 import { logEvent } from '../../logger/actions';
+import { addDangerToast } from '../../messageToasts/actions';
 
 const propTypes = {
   component: componentShape.isRequired,
@@ -66,6 +67,8 @@ function mapStateToProps(
     component,
     parentComponent: dashboardLayout[parentId],
     editMode: dashboardState.editMode,
+    undoLength: undoableLayout.past.length,
+    redoLength: undoableLayout.future.length,
     filters: getActiveFilters(),
     directPathToChild: dashboardState.directPathToChild,
     directPathLastUpdated: dashboardState.directPathLastUpdated,
@@ -97,6 +100,7 @@ function mapStateToProps(
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
+      addDangerToast,
       createComponent,
       deleteComponent,
       updateComponents,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Superset Dashboard allow user to add markdown component with Markdown syntax. But user that not familiar with html may type invalid html tags that cause react throws exception and break whole page. 
For example, an airbnb user typed in `</br></br>` in markdown component, and the whole dashboard is crashed.

### BEFORE
when user open a dashboard with bad markdown component, or adding a bad markdown into dashboard in edit mode:
<img width="1304" alt="Screen Shot 2020-03-11 at 10 48 12 AM" src="https://user-images.githubusercontent.com/27990562/77349737-b30ec400-6cf8-11ea-82fb-04f09a9b4e72.png">

### AFTER

- if user opens a dashboard with bad markdown component:
<img width="1060" alt="Screen Shot 2020-03-11 at 8 13 19 PM" src="https://user-images.githubusercontent.com/27990562/77349903-f6693280-6cf8-11ea-9e2e-ac846c860e46.png">

- if user adds a bad component in edit mode:
<img width="1056" alt="Screen Shot 2020-03-11 at 8 16 03 PM" src="https://user-images.githubusercontent.com/27990562/77350123-4811bd00-6cf9-11ea-9886-d3f5981115f8.png">

![UMGSzj3abW](https://user-images.githubusercontent.com/27990562/77591779-ed6d9200-6ead-11ea-9ff9-6743c3781489.gif)

### TEST PLAN
Manual test


### REVIEWERS
@etr2460 @williaster 