### PR TITLE
fix: Don't parseFloat numeric inputs when the *already numeric* value ends in a decimal

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextControl.jsx
@@ -55,7 +55,7 @@ export default class TextControl extends React.Component {
       if (error) {
         errors.push(error);
       } else {
-        value = parseFloat(value);
+        value = value.match(/.*(\.)$/g) ? value : parseFloat(value);
       }
     }
     if (value !== '' && this.props.isInt) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There was a funny issue I noticed with form controls, where if a `TextControl` has the `isFloat` prop set, you can't actually _type_ a decimal point. This is because when that prop is set, a `parseFloat` strips the decimal place off. This teensy PR just looks to see if the value ends in a decimal place. If so, it lets it slide through. If not, it runs the `parseFloat`. The value already went through a check to see if the value is numeric, so you can't type junk like `1.1.1` or something. There may still be edge cases around spaces or something, but at least this allows the user to type a decimal number.

As a repro case, you can empty the Treemap's "Ratio" input and the try to type a decimal number.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@kristw @etr2460 