### PR TITLE
fix: Row Level Security get_rls_filters func SELECT statement

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -918,7 +918,7 @@ class SupersetSecurityManager(SecurityManager):
                 .subquery()
             )
             filter_roles = (
-                db.session.query(RLSFilterRoles.c.id)
+                db.session.query(RLSFilterRoles.c.rls_filter_id)
                 .filter(RLSFilterRoles.c.role_id.in_(user_roles))
                 .subquery()
             )

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -833,10 +833,11 @@ class RowLevelSecurityTests(SupersetTestCase):
         self.rls_entry.table = (
             session.query(SqlaTable).filter_by(table_name="birth_names").first()
         )
-        self.rls_entry.clause = "gender = 'male'"
+        self.rls_entry.clause = "gender = 'boy'"
         self.rls_entry.roles.append(
             security_manager.find_role("Gamma")
         )  # db.session.query(Role).filter_by(name="Gamma").first())
+        self.rls_entry.roles.append(security_manager.find_role("Alpha"))
         db.session.add(self.rls_entry)
 
         db.session.commit()
@@ -849,7 +850,7 @@ class RowLevelSecurityTests(SupersetTestCase):
     # Do another test to make sure it doesn't alter another query
     def test_rls_filter_alters_query(self):
         g.user = self.get_user(
-            username="gamma"
+            username="alpha"
         )  # self.login() doesn't actually set the user
         tbl = self.get_table_by_name("birth_names")
         query_obj = dict(
@@ -864,7 +865,7 @@ class RowLevelSecurityTests(SupersetTestCase):
             extras={},
         )
         sql = tbl.get_query_str(query_obj)
-        self.assertIn("gender = 'male'", sql)
+        self.assertIn("gender = 'boy'", sql)
 
     def test_rls_filter_doesnt_alter_query(self):
         g.user = self.get_user(
@@ -883,4 +884,4 @@ class RowLevelSecurityTests(SupersetTestCase):
             extras={},
         )
         sql = tbl.get_query_str(query_obj)
-        self.assertNotIn("gender = 'male'", sql)
+        self.assertNotIn("gender = 'boy'", sql)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It appears that **get_rls_filters()** func have the following SELECT statement issue:
The **filter_roles** subquery should select **rls_filter_id** (corresponding to existing **role_id**) instead of selecting the **id** of (role_id, rls_filter_id) pair. This way the proper filters can then be selected from **row_level_security_filters** table.

The query in **get_rls_filters()** should look as follows:

SELECT row_level_security_filters.id AS row_level_security_filters_id, row_level_security_filters.clause AS row_level_security_filters_clause 
FROM row_level_security_filters 
WHERE row_level_security_filters.table_id = %(table_id_1)s AND row_level_security_filters.id IN (SELECT rls_filter_roles.**rls_filter_id** 
FROM rls_filter_roles 
WHERE rls_filter_roles.role_id IN (SELECT ab_user_role.role_id 
FROM ab_user_role 
WHERE ab_user_role.user_id = %(user_id_1)s))


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: no issue
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
