### PR TITLE
[cache] Cleaning up viz/cache logic

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -213,6 +213,8 @@ class QueryContext:
                 df = query_result["df"]
                 if status != utils.QueryStatus.FAILED:
                     stats_logger.incr("loaded_from_source")
+                    if not self.force:
+                        stats_logger.incr("loaded_from_source_without_force")
                     is_loaded = True
             except Exception as e:  # pylint: disable=broad-except
                 logger.exception(e)

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -232,23 +232,6 @@ class Slice(
     def changed_by_url(self) -> str:
         return f"/superset/profile/{self.created_by.username}"
 
-    def get_viz(self, force: bool = False) -> BaseViz:
-        """Creates :py:class:viz.BaseViz object from the url_params_multidict.
-
-        :return: object of the 'viz_type' type that is taken from the
-            url_params_multidict or self.params.
-        :rtype: :py:class:viz.BaseViz
-        """
-        slice_params = json.loads(self.params)
-        slice_params["slice_id"] = self.id
-        slice_params["json"] = "false"
-        slice_params["slice_name"] = self.slice_name
-        slice_params["viz_type"] = self.viz_type if self.viz_type else "table"
-
-        return viz_types[slice_params.get("viz_type")](
-            self.datasource, form_data=slice_params, force=force
-        )
-
     @property
     def icons(self) -> str:
         return f"""

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -187,7 +187,7 @@ def check_datasource_perms(
     except SupersetException as e:
         raise SupersetSecurityException(str(e))
 
-    viz_obj = get_viz(
+    viz_obj = get_viz(  # type: ignore
         datasource_type=datasource_type,
         datasource_id=datasource_id,
         form_data=form_data,
@@ -575,27 +575,6 @@ class Superset(BaseSupersetView):
             session.delete(r)
         session.commit()
         return redirect("/accessrequestsmodelview/list/")
-
-    def get_viz(
-        self,
-        slice_id=None,
-        form_data=None,
-        datasource_type=None,
-        datasource_id=None,
-        force=False,
-    ):
-        if slice_id:
-            slc = db.session.query(Slice).filter_by(id=slice_id).one()
-            return slc.get_viz()
-        else:
-            viz_type = form_data.get("viz_type", "table")
-            datasource = ConnectorRegistry.get_datasource(
-                datasource_type, datasource_id, db.session
-            )
-            viz_obj = viz.viz_types[viz_type](
-                datasource, form_data=form_data, force=force
-            )
-            return viz_obj
 
     @has_access
     @expose("/slice/<slice_id>/")
@@ -2782,19 +2761,6 @@ class Superset(BaseSupersetView):
         return self.render_template(
             "superset/basic.html", entry="sqllab", bootstrap_data=bootstrap_data
         )
-
-    @api
-    @handle_api_exception
-    @has_access_api
-    @expose("/slice_query/<slice_id>/")
-    def slice_query(self, slice_id):
-        """
-        This method exposes an API endpoint to
-        get the database query string for this slice
-        """
-        viz_obj = get_viz(slice_id)
-        security_manager.assert_viz_permission(viz_obj)
-        return self.get_query_string_response(viz_obj)
 
     @api
     @has_access_api

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -80,12 +80,11 @@ def get_permissions(user):
 
 
 def get_viz(
-    slice_id=None, form_data=None, datasource_type=None, datasource_id=None, force=False
+    form_data: Dict[str, Any],
+    datasource_type: str,
+    datasource_id: int,
+    force: bool = False,
 ):
-    if slice_id:
-        slc = db.session.query(Slice).filter_by(id=slice_id).one()
-        return slc.get_viz()
-
     viz_type = form_data.get("viz_type", "table")
     datasource = ConnectorRegistry.get_datasource(
         datasource_type, datasource_id, db.session

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -443,6 +443,8 @@ class BaseViz:
                 df = self.get_df(query_obj)
                 if self.status != utils.QueryStatus.FAILED:
                     stats_logger.incr("loaded_from_source")
+                    if not self.force:
+                        stats_logger.incr("loaded_from_source_without_force")
                     is_loaded = True
             except Exception as e:
                 logger.exception(e)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -731,15 +731,6 @@ class CoreTests(SupersetTestCase):
         self.get_json_resp(slc_url, {"form_data": json.dumps(slc.form_data)})
         self.assertEqual(1, qry.count())
 
-    def test_slice_query_endpoint(self):
-        # API endpoint for query string
-        self.login(username="admin")
-        slc = self.get_slice("Girls", db.session)
-        resp = self.get_resp("/superset/slice_query/{}/".format(slc.id))
-        assert "query" in resp
-        assert "language" in resp
-        self.logout()
-
     def test_import_csv(self):
         self.login(username="admin")
         table_name = "".join(random.choice(string.ascii_uppercase) for _ in range(5))


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Whilst looking into the chart caching logic I got tripped up on a few issues specifically: 

1. There were two `get_viz` methods which were near identical and `views.utils.get_viz` and `views.core.Superset:get_viz` and only the former was being used. 
2. These methods where not forcing a new query if the `slice_id` was defined, i.e., 

```python
 if slice_id:	
    slc = db.session.query(Slice).filter_by(id=slice_id).one()	
    return slc.get_viz()
```

one would expect the last line to read `return slc.get_viz(force=force)`. Upon further investigation it seems like the only place that was calling the `get_viz` method with the `slice_id` argument was the obsolete `/slice_query/<slice_id>/` route (I checked it wasn't being used in [superset-ui](https://github.com/apache-superset/superset-ui/search?q=slice_query&unscoped_q=slice_query) repo as well) and thus jettisoned  the endpoint and the `models.slices.Slice:get_viz` method. 

3. The statsD logging for `loaded_from_source` (which is useful for determining the cache hit rate, i.e., `loaded_from_cache` / (`loaded_from_cache` + `loaded_from_source`) was agnostic of whether the it was loaded because of force load and thus the denominator is over counting. Ideally an `is_force` tag would be beneficial however statsD doesn't support these (Datadog does though) and thus I updated the logic to only increment the `loaded_from_source` counter if it is not forced. The other option is to leave the logic unchanged and add a `loaded_from_cache_non_forced` (or similar) counter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @villebro 