### PR TITLE
fix: [dashboard] add row padding in dashboard edit mode

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/components/row.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/row.less
@@ -57,10 +57,18 @@
   .dashboard-component-tabs > .hover-menu + div:after {
     border: 1px dashed @gray-light;
   }
+
+  /* provide hit area in case row contents is edge to edge */
+  .dashboard-component-tabs-content {
+    .dragdroppable-row {
+      padding-top: 16px;
+    }
+  }
 }
 
 .grid-row.grid-row--empty {
-  align-items: center; /* this centers the empty note content */
+  /* this centers the empty note content */
+  align-items: center;
   height: 100px;
 
   &:before {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is currently an issue affecting dashboards using tabs layout where if the content of a tab row occupies the entire row it's very difficult to insert components between rows. Since there is no area where the row is exposed the only way to target a drag and drop on the row is to have the mouse hover over the 1px row border. Even then it can be quite tricky to activate the drag and drop on the row. This issue is only present in tabs since the grid layout includes a margin between rows.

 This PR fixes the issue by adding some padding to the row when in edit dashboard mode. By exposing a 16px region, instead of 1px, it's easier to move the cursor over the row and activate the row as a target for the drop. There is a small visual change to the layout (spacing between rows) however it's only present when in edit mode. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
create a dashboard using tab layout with multiple rows. Adjust content of each of the rows so that the content fills the entire row. 
- can easily insert a new row between existing rows. 
- can easily drag a chart and insert it between new rows, thus creating a new row. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat 