### PR TITLE
[fix] Removing erroneous slice parameters resulting in cache key  inconsistencies

### DIFF
--- a/superset/migrations/versions/f9a30386bd74_cleanup_time_grainularity.py
+++ b/superset/migrations/versions/f9a30386bd74_cleanup_time_grainularity.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""cleanup_time_grainularity
+
+Revision ID: f9a30386bd74
+Revises: b5998378c225
+Create Date: 2020-03-25 10:42:11.047328
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "f9a30386bd74"
+down_revision = "b5998378c225"
+
+import json
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+    viz_type = Column(String(250))
+
+
+def upgrade():
+    """
+    Remove any erroneous time grainularity fields from slices foor those visualization
+    types which do not support time granularity.
+
+    :see: https://github.com/apache/incubator-superset/pull/8674
+    :see: https://github.com/apache/incubator-superset/pull/8764
+    :see: https://github.com/apache/incubator-superset/pull/8800
+    :see: https://github.com/apache/incubator-superset/pull/8825
+    """
+
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    # Visualization types which support time grainularity (hence negate).
+    viz_types = [
+        "area",
+        "bar",
+        "big_number",
+        "compare",
+        "dual_line",
+        "line",
+        "pivot_table",
+        "table",
+        "time_pivot",
+        "time_table",
+    ]
+
+    # Erroneous time grainularity fields for either Druid NoSQL or SQL slices which do
+    # not support time grainularity.
+    erroneous = ["grainularity", "time_grain_sqla"]
+
+    for slc in session.query(Slice).filter(Slice.viz_type.notin_(viz_types)).all():
+        try:
+            params = json.loads(slc.params)
+
+            if any(field in params for field in erroneous):
+                for field in erroneous:
+                    if field in params:
+                        del params[field]
+
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    pass

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -330,7 +330,7 @@ class BaseViz:
             "druid_time_origin": form_data.get("druid_time_origin", ""),
             "having": form_data.get("having", ""),
             "having_druid": form_data.get("having_filters", []),
-            "time_grain_sqla": form_data.get("time_grain_sqla", ""),
+            "time_grain_sqla": form_data.get("time_grain_sqla"),
             "time_range_endpoints": form_data.get("time_range_endpoints"),
             "where": form_data.get("where", ""),
         }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Whilst testing some caching logic I realized that for some slices the cache key was different between the `/superset/warm_up_cache/?slice_id=<id>`  and `/superset/slice/<id>/` endpoints. 

The reasons being is that the `time_grain_sqla` (SQL) and `grainularity` (Druid NoSQL) fields are now optional for a number of visualization types and the frontend removes any erroneous fields which are not defined by the chart controls resulting in inconsistent form data. 

For reference I introduced these regressions via the following PRs:

-  https://github.com/apache/incubator-superset/pull/8674
- https://github.com/apache/incubator-superset/pull/8764
- https://github.com/apache/incubator-superset/pull/8800
- https://github.com/apache/incubator-superset/pull/8825 

This PR: 

1. Adds a migration to clean up erroneous `time_grain_sqla` (SQL) and `grainularity` (Druid NoSQL) fields in saved slice parameters. 
2. Encodes `time_grain_sqla` form-data as `None` as opposed to `""` for consistency. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Tested locally (using both `db upgrade` and `db downgrade`) and confirmed that the cache keys were identical. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @ktmud @villebro 