### PR TITLE
[dashboard] Fix a typo in set prop value for metadata modal

### DIFF
--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -449,7 +449,7 @@ class Header extends React.PureComponent {
 
           {this.state.showingPropertiesModal && (
             <PropertiesModal
-              dahboardId={dashboardInfo.id}
+              dashboardId={dashboardInfo.id}
               show={this.state.showingPropertiesModal}
               onHide={this.hidePropertiesModal}
               onDashboardSave={updates => {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
dashboard metadata modal:
<img width="1167" alt="Screen Shot 2020-03-25 at 2 08 53 PM" src="https://user-images.githubusercontent.com/27990562/77589109-56eaa200-6ea8-11ea-8115-8ff386131b58.png">


### TEST PLAN
Manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9211
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@serenajiang @john-bodley @suddjian 