### PR TITLE
[fix] dashboard filter indicator no showing single number value

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/FilterIndicatorsContainer_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/FilterIndicatorsContainer_spec.jsx
@@ -85,4 +85,25 @@ describe('FilterIndicatorsContainer', () => {
     const wrapper = setup({ dashboardFilters: overwriteDashboardFilters });
     expect(wrapper.find(FilterIndicator)).toHaveLength(0);
   });
+
+  it('should show single number type value', () => {
+    const overwriteDashboardFilters = {
+      ...dashboardFilters,
+      [filterId]: {
+        ...dashboardFilters[filterId],
+        columns: {
+          testField: 0,
+        },
+      },
+    };
+    const wrapper = setup({ dashboardFilters: overwriteDashboardFilters });
+    expect(wrapper.find(FilterIndicator)).toHaveLength(1);
+
+    const indicatorProps = wrapper
+      .find(FilterIndicator)
+      .first()
+      .props().indicator;
+    expect(indicatorProps.label).toEqual('testField');
+    expect(indicatorProps.values).toEqual([0]);
+  });
 });

--- a/superset-frontend/src/dashboard/components/FilterIndicatorsContainer.jsx
+++ b/superset-frontend/src/dashboard/components/FilterIndicatorsContainer.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isEmpty } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 
 import FilterIndicator from './FilterIndicator';
 import FilterIndicatorGroup from './FilterIndicatorGroup';
@@ -101,6 +101,15 @@ export default class FilterIndicatorsContainer extends React.PureComponent {
                 chartId,
                 column: name,
               });
+
+              // filter values could be single value or array of values
+              const values =
+                isNil(columns[name]) ||
+                (isDateFilter && columns[name] === 'No filter') ||
+                (Array.isArray(columns[name]) && columns[name].length === 0)
+                  ? []
+                  : [].concat(columns[name]);
+
               const indicator = {
                 chartId,
                 colorCode: dashboardFiltersColorMap[colorMapKey],
@@ -110,11 +119,7 @@ export default class FilterIndicatorsContainer extends React.PureComponent {
                 isInstantFilter,
                 name,
                 label: labels[name] || name,
-                values:
-                  isEmpty(columns[name]) ||
-                  (isDateFilter && columns[name] === 'No filter')
-                    ? []
-                    : [].concat(columns[name]),
+                values,
                 isFilterFieldActive:
                   chartId === filterFieldOnFocus.chartId &&
                   name === filterFieldOnFocus.column,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Superset filter box allow user to choose 1 value, or multiple value. If filter is applied to a chart, the filter indicator in the chart should show filter value. Currently because of a js bug, if filter box is single, number type of value, indicator can not display the selected value.

<img width="538" alt="Screen Shot 2020-03-26 at 2 49 44 PM" src="https://user-images.githubusercontent.com/27990562/77729576-3b70bb80-6fbc-11ea-96e1-72dbc8548fda.png">

### TEST PLAN
added unit test

### REVIEWERS
@etr2460 @ktmud 