### PR TITLE
[query] New, readonly API

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -131,6 +131,7 @@ class SupersetAppInitializer:
             Druid,
         )
         from superset.datasets.api import DatasetRestApi
+        from superset.queries.api import QueryRestApi
         from superset.connectors.sqla.views import (
             TableColumnInlineView,
             SqlMetricInlineView,
@@ -184,6 +185,7 @@ class SupersetAppInitializer:
         appbuilder.add_api(DashboardRestApi)
         appbuilder.add_api(DatabaseRestApi)
         appbuilder.add_api(DatasetRestApi)
+        appbuilder.add_api(QueryRestApi)
         #
         # Setup regular views
         #

--- a/superset/queries/__init__.py
+++ b/superset/queries/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+
+from superset.constants import RouteMethod
+from superset.models.sql_lab import Query
+from superset.queries.filters import QueryFilter
+from superset.views.base_api import BaseSupersetModelRestApi
+
+logger = logging.getLogger(__name__)
+
+
+class QueryRestApi(BaseSupersetModelRestApi):
+    datamodel = SQLAInterface(Query)
+
+    resource_name = "query"
+    allow_browser_login = True
+    include_route_methods = {RouteMethod.GET, RouteMethod.GET_LIST}
+
+    class_permission_name = "QueryView"
+    list_columns = [
+        "user.username",
+        "database.database_name",
+        "status",
+        "start_time",
+        "end_time",
+    ]
+    show_columns = [
+        "client_id",
+        "tmp_table_name",
+        "tmp_schema_name",
+        "status",
+        "tab_name",
+        "sql_editor_id",
+        "schema",
+        "sql",
+        "select_sql",
+        "executed_sql",
+        "limit",
+        "select_as_cta",
+        "select_as_cta_used",
+        "progress",
+        "rows",
+        "error_message",
+        "results_key",
+        "start_time",
+        "start_running_time",
+        "end_time",
+        "end_result_backend_time",
+        "tracking_url",
+        "changed_on",
+    ]
+    base_filters = [["id", QueryFilter, lambda: []]]
+    base_order = ("changed_on", "desc")
+
+    openapi_spec_tag = "Queries"

--- a/superset/queries/dao.py
+++ b/superset/queries/dao.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+
+from superset.dao.base import BaseDAO
+from superset.models.sql_lab import Query
+from superset.queries.filters import QueryFilter
+
+logger = logging.getLogger(__name__)
+
+
+class QueryDAO(BaseDAO):
+    model_cls = Query
+    base_filter = QueryFilter

--- a/superset/queries/filters.py
+++ b/superset/queries/filters.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Callable
+
+from flask import g
+from flask_sqlalchemy import BaseQuery
+
+from superset import security_manager
+from superset.models.sql_lab import Query
+from superset.views.base import BaseFilter
+
+
+class QueryFilter(BaseFilter):  # pylint: disable=too-few-public-methods
+    def apply(self, query: BaseQuery, value: Callable) -> BaseQuery:
+        """
+        Filter queries to only those owned by current user. If
+        can_access_all_queries permission is set a user can list all queries
+
+        :returns: query
+        """
+        if not security_manager.can_access_all_queries():
+            query = query.filter(Query.user_id == g.user.get_user_id())
+        return query

--- a/tests/queries/__init__.py
+++ b/tests/queries/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/queries/api_tests.py
+++ b/tests/queries/api_tests.py
@@ -1,0 +1,247 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file
+"""Unit tests for Superset"""
+import json
+import uuid
+import random
+import string
+
+import prison
+from sqlalchemy.sql import func
+
+import tests.test_app
+from superset import db, security_manager
+from superset.models.core import Database
+from superset.utils.core import get_example_database
+from superset.models.sql_lab import Query
+
+from tests.base_tests import SupersetTestCase
+
+
+class QueryApiTests(SupersetTestCase):
+    def insert_query(
+        self,
+        database_id: int,
+        user_id: int,
+        client_id: str,
+        sql: str = "",
+        select_sql: str = "",
+        executed_sql: str = "",
+        limit: int = 100,
+        progress: int = 100,
+        rows: int = 100,
+        tab_name: str = "",
+        status: str = "success",
+    ) -> Query:
+        database = db.session.query(Database).get(database_id)
+        user = db.session.query(security_manager.user_model).get(user_id)
+        query = Query(
+            database=database,
+            user=user,
+            client_id=client_id,
+            sql=sql,
+            select_sql=select_sql,
+            executed_sql=executed_sql,
+            limit=limit,
+            progress=progress,
+            rows=rows,
+            tab_name=tab_name,
+            status=status,
+        )
+        db.session.add(query)
+        db.session.commit()
+        return query
+
+    @staticmethod
+    def get_random_string(length: int = 10):
+        letters = string.ascii_letters
+        return "".join(random.choice(letters) for i in range(length))
+
+    def test_get_query(self):
+        """
+            Query API: Test get query
+        """
+        admin = self.get_user("admin")
+        client_id = self.get_random_string()
+        query = self.insert_query(
+            get_example_database().id,
+            admin.id,
+            client_id,
+            sql="SELECT col1, col2 from table1",
+            select_sql="SELECT col1, col2 from table1",
+            executed_sql="SELECT col1, col2 from table1 LIMIT 100",
+        )
+        self.login(username="admin")
+        uri = f"api/v1/query/{query.id}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+
+        expected_result = {
+            "client_id": client_id,
+            "end_result_backend_time": None,
+            "error_message": None,
+            "executed_sql": "SELECT col1, col2 from table1 LIMIT 100",
+            "limit": 100,
+            "progress": 100,
+            "results_key": None,
+            "rows": 100,
+            "schema": None,
+            "select_as_cta": None,
+            "select_as_cta_used": False,
+            "select_sql": "SELECT col1, col2 from table1",
+            "sql": "SELECT col1, col2 from table1",
+            "sql_editor_id": None,
+            "status": "success",
+            "tab_name": "",
+            "tmp_schema_name": None,
+            "tmp_table_name": None,
+            "tracking_url": None,
+        }
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertIn("changed_on", data["result"])
+        for key, value in data["result"].items():
+            # We can't assert timestamp
+            if key not in (
+                "changed_on",
+                "end_time",
+                "start_running_time",
+                "start_time",
+            ):
+                self.assertEqual(value, expected_result[key])
+        # rollback changes
+        db.session.delete(query)
+        db.session.commit()
+
+    def test_get_query_not_found(self):
+        """
+            Query API: Test get query not found
+        """
+        admin = self.get_user("admin")
+        client_id = self.get_random_string()
+        self.insert_query(get_example_database().id, admin.id, client_id)
+        max_id = db.session.query(func.max(Query.id)).scalar()
+        self.login(username="admin")
+        uri = f"api/v1/query/{max_id + 1}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 404)
+
+    def test_get_query_no_data_access(self):
+        """
+            Query API: Test get dashboard without data access
+        """
+        gamma1 = self.create_user(
+            "gamma_1", "password", "Gamma", email="gamma1@superset.org"
+        )
+        gamma2 = self.create_user(
+            "gamma_2", "password", "Gamma", email="gamma2@superset.org"
+        )
+
+        gamma1_client_id = self.get_random_string()
+        gamma2_client_id = self.get_random_string()
+        query_gamma1 = self.insert_query(
+            get_example_database().id, gamma1.id, gamma1_client_id
+        )
+        query_gamma2 = self.insert_query(
+            get_example_database().id, gamma2.id, gamma2_client_id
+        )
+
+        # Gamma1 user, only sees his own queries
+        self.login(username="gamma_1", password="password")
+        uri = f"api/v1/query/{query_gamma2.id}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 404)
+        uri = f"api/v1/query/{query_gamma1.id}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+
+        # Gamma2 user, only sees his own queries
+        self.logout()
+        self.login(username="gamma_2", password="password")
+        uri = f"api/v1/query/{query_gamma1.id}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 404)
+        uri = f"api/v1/query/{query_gamma2.id}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+
+        # Admin's have the "all query access" permission
+        self.logout()
+        self.login(username="admin")
+        uri = f"api/v1/query/{query_gamma1.id}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+        uri = f"api/v1/query/{query_gamma2.id}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+
+        # rollback changes
+        db.session.delete(query_gamma1)
+        db.session.delete(query_gamma2)
+        db.session.delete(gamma1)
+        db.session.delete(gamma2)
+        db.session.commit()
+
+    def test_get_query_filter(self):
+        """
+            Query API: Test get queries filter
+        """
+        admin = self.get_user("admin")
+        client_id = self.get_random_string()
+        query = self.insert_query(
+            get_example_database().id,
+            admin.id,
+            client_id,
+            sql="SELECT col1, col2 from table1",
+        )
+
+        self.login(username="admin")
+        arguments = {"filters": [{"col": "sql", "opr": "sw", "value": "SELECT col1"}]}
+        uri = f"api/v1/query/?q={prison.dumps(arguments)}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(data["count"], 1)
+
+        # rollback changes
+        db.session.delete(query)
+        db.session.commit()
+
+    def test_get_dashboards_no_data_access(self):
+        """
+            Query API: Test get queries no data access
+        """
+        admin = self.get_user("admin")
+        client_id = self.get_random_string()
+        query = self.insert_query(
+            get_example_database().id,
+            admin.id,
+            client_id,
+            sql="SELECT col1, col2 from table1",
+        )
+
+        self.login(username="gamma")
+        arguments = {"filters": [{"col": "sql", "opr": "sw", "value": "SELECT col1"}]}
+        uri = f"api/v1/query/?q={prison.dumps(arguments)}"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(data["count"], 0)
+
+        # rollback changes
+        db.session.delete(query)
+        db.session.commit()

--- a/tests/queries/api_tests.py
+++ b/tests/queries/api_tests.py
@@ -221,7 +221,7 @@ class QueryApiTests(SupersetTestCase):
         db.session.delete(query)
         db.session.commit()
 
-    def test_get_dashboards_no_data_access(self):
+    def test_get_queries_no_data_access(self):
         """
             Query API: Test get queries no data access
         """


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Implements 2 endpoints on `/api/v1/query` API namespace has readonly.

![image](https://user-images.githubusercontent.com/4025227/77770809-c219ad00-703d-11ea-8d01-b5ce07b10878.png)

Fetches all executed queries following the currently defined data security, where a user with `all query access on all_query_access` permission can get all queries, and all the other user's can only get their own queries 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
