### PR TITLE
[fix] allow force refresh for No Results chart

### DIFF
--- a/superset-frontend/src/chart/chartReducer.js
+++ b/superset-frontend/src/chart/chartReducer.js
@@ -49,6 +49,7 @@ export default function chartReducer(charts = {}, action) {
         chartStatus: 'success',
         queryResponse: action.queryResponse,
         chartAlert: null,
+        chartUpdateEndTime: now(),
       };
     },
     [actions.CHART_UPDATE_STARTED](state) {

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -133,7 +133,10 @@ class SliceHeaderControls extends React.PureComponent {
         </Dropdown.Toggle>
 
         <Dropdown.Menu>
-          <MenuItem onClick={this.refreshChart} disabled={!updatedDttm}>
+          <MenuItem
+            onClick={this.refreshChart}
+            disabled={this.props.chartStatus === 'loading'}
+          >
             {t('Force refresh')}
             <div className="refresh-tooltip">{refreshTooltip}</div>
           </MenuItem>


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix


### SUMMARY
When there is no results return for a chart, we show No Results message. but this chart's `Force refresh` button is disabled by a bug: 
<img width="610" alt="Screen Shot 2020-03-25 at 3 12 25 PM" src="https://user-images.githubusercontent.com/27990562/77817069-46dbe980-7085-11ea-9a79-a4ddd3f375c6.png">


### TEST PLAN
manual test


### REVIEWERS
@etr2460 @ktmud 