### PR TITLE
[WIP] RFC: Introduce a new format to download charts

### DIFF
--- a/superset-frontend/src/explore/components/ExploreActionButtons.jsx
+++ b/superset-frontend/src/explore/components/ExploreActionButtons.jsx
@@ -49,6 +49,7 @@ export default function ExploreActionButtons({
   });
   const doExportCSV = exportChart.bind(this, latestQueryFormData, 'csv');
   const doExportChart = exportChart.bind(this, latestQueryFormData, 'json');
+  const doExportXYZ = exportChart.bind(this, latestQueryFormData, 'xyz');
 
   return (
     <div className="btn-group results" role="group">
@@ -84,6 +85,17 @@ export default function ExploreActionButtons({
           rel="noopener noreferrer"
         >
           <i className="fa fa-file-text-o" /> .csv
+        </a>
+      )}
+      {latestQueryFormData && (
+        <a
+          onClick={doExportXYZ}
+          className={exportToCSVClasses}
+          title={t('Export to .xyz format')}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <i className="fa fa-file-text-o" /> .xyz
         </a>
       )}
       <DisplayQueryButton

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -67,7 +67,7 @@ export function getURIDirectory(formData, endpointType = 'base') {
   // Building the directory part of the URI
   let directory = '/superset/explore/';
   if (
-    ['json', 'csv', 'query', 'results', 'samples'].indexOf(endpointType) >= 0
+    ['json', 'csv', 'xyz' ,'query', 'results', 'samples'].indexOf(endpointType) >= 0
   ) {
     directory = '/superset/explore_json/';
   }
@@ -160,6 +160,9 @@ export function getExploreUrlAndPayload({
   }
   if (endpointType === 'csv') {
     search.csv = 'true';
+  }
+  if (endpointType === 'xyz') {
+    search.xyz = 'true';
   }
   if (endpointType === 'standalone') {
     search.standalone = 'true';

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -617,8 +617,7 @@ class Superset(BaseSupersetView):
         return self.json_response({"data": viz_obj.get_samples()})
 
     def generate_json(
-        self, viz_obj, csv=False, query=False, results=False, samples=False
-    ):
+        self,viz_obj, csv=False, xyz=False,query=False, results=False, samples=False):
         if csv:
             return CsvResponse(
                 viz_obj.get_csv(),
@@ -635,6 +634,15 @@ class Superset(BaseSupersetView):
 
         if samples:
             return self.get_samples(viz_obj)
+
+        if xyz:
+            logging.debug("Hello XYZ.>................")
+            return CsvResponse(
+                viz_obj.get_csv(),
+                status=200,
+                headers=generate_download_headers("csv"),
+                mimetype="application/csv",
+            )
 
         payload = viz_obj.get_payload()
         return data_payload_response(*viz_obj.payload_json_and_has_error(payload))
@@ -693,11 +701,13 @@ class Superset(BaseSupersetView):
 
         TODO: break into one endpoint for each return shape"""
         csv = request.args.get("csv") == "true"
+        xyz = request.args.get("xyz") == "true"
         query = request.args.get("query") == "true"
         results = request.args.get("results") == "true"
         samples = request.args.get("samples") == "true"
         force = request.args.get("force") == "true"
         form_data = get_form_data()[0]
+
 
         try:
             datasource_id, datasource_type = get_datasource_info(
@@ -714,7 +724,7 @@ class Superset(BaseSupersetView):
         )
 
         return self.generate_json(
-            viz_obj, csv=csv, query=query, results=results, samples=samples
+            viz_obj,xyz=xyz, csv=csv, query=query, results=results, samples=samples,
         )
 
     @event_logger.log_this


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Request for comments regarding how to introduce new chart formats.
I am able to follow the backend with the explore_json api, where we take care of format.
But in my implementation the link formed for some reason hits ```/explore``` api instead of ```explore_json``` .

For which I need a review.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@mistercrunch 