### PR TITLE
[dashboards] Fix, API update slug uniqueness refusing empty string

### DIFF
--- a/superset/dashboards/commands/update.py
+++ b/superset/dashboards/commands/update.py
@@ -57,7 +57,7 @@ class UpdateDashboardCommand(BaseCommand):
     def validate(self) -> None:
         exceptions: List[ValidationError] = []
         owner_ids: Optional[List[int]] = self._properties.get("owners")
-        slug: str = self._properties.get("slug", "")
+        slug: Optional[str] = self._properties.get("slug")
 
         # Validate/populate model exists
         self._model = DashboardDAO.find_by_id(self._model_id)

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from typing import List
+from typing import List, Optional
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -39,8 +39,8 @@ class DashboardDAO(BaseDAO):
         return not db.session.query(dashboard_query.exists()).scalar()
 
     @staticmethod
-    def validate_update_slug_uniqueness(dashboard_id: int, slug: str) -> bool:
-        if slug:
+    def validate_update_slug_uniqueness(dashboard_id: int, slug: Optional[str]) -> bool:
+        if slug is not None:
             dashboard_query = db.session.query(Dashboard).filter(
                 Dashboard.slug == slug, Dashboard.id != dashboard_id
             )

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -40,10 +40,12 @@ class DashboardDAO(BaseDAO):
 
     @staticmethod
     def validate_update_slug_uniqueness(dashboard_id: int, slug: str) -> bool:
-        dashboard_query = db.session.query(Dashboard).filter(
-            Dashboard.slug == slug, Dashboard.id != dashboard_id
-        )
-        return not db.session.query(dashboard_query.exists()).scalar()
+        if slug:
+            dashboard_query = db.session.query(Dashboard).filter(
+                Dashboard.slug == slug, Dashboard.id != dashboard_id
+            )
+            return not db.session.query(dashboard_query.exists()).scalar()
+        return True
 
     @staticmethod
     def bulk_delete(models: List[Dashboard], commit=True):


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When updating a dashboard with an empty slug and another dashboard with an empty slug exists, the API refuses to accept the update with a slug must be unique message. This PR fixes this.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@suddjian