### PR TITLE
Fix user impersonation with presto

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ pre-commit==1.17.0
 psycopg2-binary==2.7.5
 pycodestyle==2.5.0
 pydruid==0.5.7
-pyhive==0.6.1
+pyhive==0.6.2
 pylint==1.9.2
 redis==3.2.1
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         "hive": ["pyhive[hive]>=0.6.1", "tableschema", "thrift>=0.11.0, <1.0.0"],
         "mysql": ["mysqlclient==1.4.2.post1"],
         "postgres": ["psycopg2-binary==2.7.5"],
-        "presto": ["pyhive[presto]>=0.4.0"],
+        "presto": ["pyhive[presto]>=0.6.2"],
         "elasticsearch": ["elasticsearch-dbapi>=0.1.0, <0.2.0"],
         "druid": ["pydruid==0.5.7", "requests==2.22.0"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Fixes https://github.com/apache/incubator-superset/issues/9406
PyHive 0.6.2 release includes https://github.com/dropbox/PyHive/pull/309 making this change possible.
In presto, credentials are authenticated against a 'principal', that principal can then impersonate a 'user' so queries can be executed with authorisation rules applied to the user (not the principal).
Benefit: a single shared presto data source can be created in superset with a generic account (superuser aka the principal) in the presto connection. Then each user that logs into superset ui does not need to create new datasource, they can go straight to SQLLab and run presto queries on the shared datasource which are being authorised under their username.
