### PR TITLE
feat: Add post processing to QueryObject

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ marshmallow==2.19.5       # via flask-appbuilder, marshmallow-enum, marshmallow-
 more-itertools==8.1.0     # via zipp
 msgpack==0.6.2            # via apache-superset (setup.py)
 numpy==1.18.1             # via pandas, pyarrow
-pandas==0.25.3            # via apache-superset (setup.py)
+pandas==1.0.3             # via apache-superset (setup.py)
 parsedatetime==2.5        # via apache-superset (setup.py)
 pathlib2==2.3.5           # via apache-superset (setup.py)
 polyline==1.4.0           # via apache-superset (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "isodate",
         "markdown>=3.0",
         "msgpack>=0.6.1, <0.7.0",
-        "pandas>=0.25.3, <1.0",
+        "pandas>=1.0.3, <1.1",
         "parsedatetime",
         "pathlib2",
         "polyline",

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -51,7 +51,7 @@ class QueryContext:
     custom_cache_timeout: Optional[int]
 
     # TODO: Type datasource and query_object dictionary with TypedDict when it becomes
-    # a vanilla python type https://github.com/python/mypy/issues/5288
+    #  a vanilla python type https://github.com/python/mypy/issues/5288
     def __init__(
         self,
         datasource: Dict[str, Any],
@@ -70,8 +70,8 @@ class QueryContext:
         """Returns a pandas dataframe based on the query object"""
 
         # Here, we assume that all the queries will use the same datasource, which is
-        # is a valid assumption for current setting. In a long term, we may or maynot
-        # support multiple queries from different data source.
+        # a valid assumption for current setting. In the long term, we may
+        # support multiple queries from different data sources.
 
         timestamp_format = None
         if self.datasource.type == "table":
@@ -105,6 +105,9 @@ class QueryContext:
                 self.df_metrics_to_num(df, query_object)
 
             df.replace([np.inf, -np.inf], np.nan)
+
+        df = query_object.exec_post_processing(df)
+
         return {
             "query": result.query,
             "status": result.status,

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -25,7 +25,7 @@ from flask_babel import gettext as _
 from pandas import DataFrame
 
 from superset import app
-from superset.exceptions import SupersetException
+from superset.exceptions import ChartDataValidationError
 from superset.utils import core as utils, pandas_postprocessing
 from superset.views.utils import get_time_range_endpoints
 
@@ -161,15 +161,16 @@ class QueryObject:
         :param df: DataFrame returned from database model.
         :return: new DataFrame to which all post processing operations have been
                  applied
+        :raises ChartDataValidationError: If the post processing operation in incorrect
         """
         for post_process in self.post_processing:
             operation = post_process.get("operation")
             if not operation:
-                raise SupersetException(
+                raise ChartDataValidationError(
                     _("`operation` property of post processing object undefined")
                 )
             if not hasattr(pandas_postprocessing, operation):
-                raise SupersetException(
+                raise ChartDataValidationError(
                     _(
                         "Unsupported post processing operation: %(operation)s",
                         type=operation,

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=R
+# pylint: disable=invalid-name
 import hashlib
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -25,7 +25,7 @@ from flask_babel import gettext as _
 from pandas import DataFrame
 
 from superset import app
-from superset.exceptions import ChartDataValidationError
+from superset.exceptions import QueryObjectValidationError
 from superset.utils import core as utils, pandas_postprocessing
 from superset.views.utils import get_time_range_endpoints
 
@@ -166,11 +166,11 @@ class QueryObject:
         for post_process in self.post_processing:
             operation = post_process.get("operation")
             if not operation:
-                raise ChartDataValidationError(
+                raise QueryObjectValidationError(
                     _("`operation` property of post processing object undefined")
                 )
             if not hasattr(pandas_postprocessing, operation):
-                raise ChartDataValidationError(
+                raise QueryObjectValidationError(
                     _(
                         "Unsupported post processing operation: %(operation)s",
                         type=operation,

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -20,13 +20,16 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
 
 import simplejson as json
+from flask_babel import gettext as _
+from pandas import DataFrame
 
 from superset import app
-from superset.utils import core as utils
+from superset.exceptions import SupersetException
+from superset.utils import core as utils, pandas_postprocessing
 from superset.views.utils import get_time_range_endpoints
 
 # TODO: Type Metrics dictionary with TypedDict when it becomes a vanilla python type
-# https://github.com/python/mypy/issues/5288
+#  https://github.com/python/mypy/issues/5288
 
 
 class QueryObject:
@@ -50,6 +53,7 @@ class QueryObject:
     extras: Dict
     columns: List[str]
     orderby: List[List]
+    post_processing: List[Dict[str, Any]]
 
     def __init__(
         self,
@@ -67,6 +71,7 @@ class QueryObject:
         extras: Optional[Dict] = None,
         columns: Optional[List[str]] = None,
         orderby: Optional[List[List]] = None,
+        post_processing: Optional[List[Dict[str, Any]]] = None,
         relative_start: str = app.config["DEFAULT_RELATIVE_START_TIME"],
         relative_end: str = app.config["DEFAULT_RELATIVE_END_TIME"],
     ):
@@ -81,8 +86,9 @@ class QueryObject:
         self.time_range = time_range
         self.time_shift = utils.parse_human_timedelta(time_shift)
         self.groupby = groupby or []
+        self.post_processing = post_processing or []
 
-        # Temporal solution for backward compatability issue due the new format of
+        # Temporary solution for backward compatibility issue due the new format of
         # non-ad-hoc metric which needs to adhere to superset-ui per
         # https://git.io/Jvm7P.
         self.metrics = [
@@ -138,9 +144,36 @@ class QueryObject:
         if self.time_range:
             cache_dict["time_range"] = self.time_range
         json_data = self.json_dumps(cache_dict, sort_keys=True)
+        if self.post_processing:
+            cache_dict["post_processing"] = self.post_processing
         return hashlib.md5(json_data.encode("utf-8")).hexdigest()
 
     def json_dumps(self, obj: Any, sort_keys: bool = False) -> str:
         return json.dumps(
             obj, default=utils.json_int_dttm_ser, ignore_nan=True, sort_keys=sort_keys
         )
+
+    def exec_post_processing(self, df: DataFrame) -> DataFrame:
+        """
+        Perform post processing operations on DataFrame.
+
+        :param df: DataFrame returned from database model.
+        :return: new DataFrame to which all post processing operations have been
+                 applied
+        """
+        for post_process in self.post_processing:
+            operation = post_process.get("operation")
+            if not operation:
+                raise SupersetException(
+                    _("`operation` property of post processing object undefined")
+                )
+            if not hasattr(pandas_postprocessing, operation):
+                raise SupersetException(
+                    _(
+                        "Unsupported post processing operation: %(operation)s",
+                        type=operation,
+                    )
+                )
+            options = post_process.get("options", {})
+            df = getattr(pandas_postprocessing, operation)(df, **options)
+        return df

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=R
-# pylint: disable=invalid-name
 import hashlib
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -70,5 +70,5 @@ class DatabaseNotFound(SupersetException):
     status = 400
 
 
-class ChartDataValidationError(SupersetException):
-    pass
+class QueryObjectValidationError(SupersetException):
+    status = 400

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -68,3 +68,7 @@ class CertificateException(SupersetException):
 
 class DatabaseNotFound(SupersetException):
     status = 400
+
+
+class ChartDataValidationError(SupersetException):
+    pass

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -21,7 +21,7 @@ import numpy as np
 from flask_babel import gettext as _
 from pandas import DataFrame, NamedAgg
 
-from superset.exceptions import NullValueException, SupersetException
+from superset.exceptions import SupersetException
 
 SUPPORTED_NUMPY_FUNCTIONS = (
     "average",
@@ -63,6 +63,32 @@ def _get_aggregate_funcs(aggregates: Dict[str, Dict[str, Any]],) -> Dict[str, Na
         agg_funcs[name] = NamedAgg(column=column, aggfunc=partial(func, **options))
 
     return agg_funcs
+
+
+def _append_columns(
+    base_df: DataFrame, append_df: DataFrame, columns: Dict[str, str]
+) -> DataFrame:
+    """
+    Function for adding columns from one DataFrame to another DataFrame. Calls the
+    assign method, which overwrites the original column in `base_df` if the column
+    already exists, and appends the column if the name is not defined.
+
+    :param base_df: DataFrame which to use as the base
+    :param append_df: DataFrame from which to select data.
+    :param columns: columns on which to append, mapping source column to
+           target column. For instance, `{'y': 'y'}` will replace the values in
+           column `y` in `base_df` with the values in `y` in `append_df`,
+           while `{'y': 'y2'}` will add a column `y2` to `base_df` based
+           on values in column `y` in `append_df`, leaving the original column `y`
+           in `base_df` unchanged.
+    :return: new DataFrame with combined data from `base_df` and `append_df`
+    """
+    return base_df.assign(
+        **{
+            target: append_df[append_df.columns[idx]]
+            for idx, target in enumerate(columns.values())
+        }
+    )
 
 
 def pivot(
@@ -145,19 +171,21 @@ def aggregate(
     return df.groupby(by=groupby).agg(**aggregate_funcs)
 
 
-def sort(df: DataFrame, by: Dict[str, bool]) -> DataFrame:
+def sort(df: DataFrame, columns: Dict[str, bool]) -> DataFrame:
     """
     Sort a DataFrame.
 
-    df: DataFrame to sort.
-    by: columns by by which to sort. The key specifies the column name, value
-        specifies if sorting in ascending order.
+    :param df: DataFrame to sort.
+    :param by: columns by by which to sort. The key specifies the column name, value
+               specifies if sorting in ascending order.
+    :return: Sorted DataFrame
     """
-    return df.sort_values(by=by.keys(), ascending=by.values())
+    return df.sort_values(by=list(columns.keys()), ascending=list(columns.values()))
 
 
 def rolling(
     df: DataFrame,
+    columns: Dict[str, str],
     rolling_type: str,
     center: bool = False,
     win_type: Optional[str] = None,
@@ -169,15 +197,21 @@ def rolling(
     https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rolling.html
 
     :param df: DataFrame on which the rolling period will be based.
+    :param columns: columns on which to perform rolling, mapping source column to
+           target column. For instance, `{'y': 'y'}` will replace the column `y` with
+           the rolling value in `y`, while `{'y': 'y2'}` will add a column `y2` based
+           on rolling values calculated from `y`, leaving the original column `y`
+           unchanged.
     :param rolling_type: Type of rolling window. Any numpy function will work.
     :param center: Should the label be at the center of the window.
     :param win_type: Type of window function.
     :param window: Size of the window.
     :param min_periods:
-    :return:
+    :return: DataFrame with the rolling columns
     """
+    df_rolling = df[columns.keys()]
     if rolling_type == "cumsum":
-        df = df.cumsum()
+        df_rolling = df_rolling.cumsum()
     else:
         kwargs: Dict[str, Union[str, int]] = {}
         if window is not None:
@@ -189,13 +223,46 @@ def rolling(
         if win_type is not None:
             kwargs["win_type"] = win_type
 
-        df_rolling = df.rolling(**kwargs)
+        df_rolling = df_rolling.rolling(**kwargs)
         if not hasattr(df_rolling, rolling_type):
             raise SupersetException(
                 _("Unsupported rolling_type: %(type)s", type=rolling_type)
             )
-        df = getattr(df_rolling, rolling_type)()
-
+        df_rolling = getattr(df_rolling, rolling_type)()
+    df = _append_columns(df, df_rolling, columns)
     if min_periods:
         df = df[min_periods:]
     return df
+
+
+def select(df: DataFrame, columns: Dict[str, str],) -> DataFrame:
+    """
+    Only select a subset of columns in the original dataset. Can be useful for
+    removing unnecessary intermediate results, renaming and reordering columns.
+
+    :param df: DataFrame on which the rolling period will be based.
+    :param columns: Columns on which to perform dff, mapping the
+                    column name to its alias. For instance, `{'y': 'y'}` will return
+                    a DataFrame with only the contents of column `y`,
+                    while `{'y': 'y2'}` return a DataFrame with the column `y2`
+                    containing the values from column `y`.
+    :return: Subset of columns in original DataFrame
+    """
+    return df[columns.keys()].rename(columns=columns)
+
+
+def diff(df: DataFrame, columns: Dict[str, str], periods: int = 1,) -> DataFrame:
+    """
+
+    :param df: DataFrame on which the rolling period will be based.
+    :param columns: columns on which to perform diff, mapping source column to
+           target column. For instance, `{'y': 'y'}` will replace the column `y` with
+           the rollong value in `y`, while `{'y': 'y2'}` will add a column `y2` based
+           on rolling values calculated from `y`, leaving the original column `y`
+           unchanged.
+    :param periods:
+    :return:
+    """
+    df_diff = df[columns.keys()]
+    df_diff = df_diff.diff(periods=periods)
+    return _append_columns(df, df_diff, columns)

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -1,0 +1,210 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from functools import partial
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+from flask_babel import gettext as _
+from pandas import DataFrame, NamedAgg
+
+from superset.exceptions import NullValueException, SupersetException
+
+SUPPORTED_NUMPY_FUNCTIONS = (
+    "average",
+    "argmin",
+    "argmax",
+    "cumsum",
+    "cumprod",
+    "max",
+    "mean",
+    "median",
+    "nansum" "nanmin" "nanmax" "nanmean",
+    "nanmedian",
+    "min",
+    "percentile",
+    "prod",
+    "product",
+    "std",
+    "sum",
+    "var",
+)
+
+
+def _get_aggregate_funcs(aggregates: Dict[str, Dict[str, Any]],) -> Dict[str, NamedAgg]:
+    """
+    Converts a set of aggregate config objects into functions that pandas can use as
+    aggregators. Currently only numpy aggregators are supported.
+
+    :param aggregates: Mapping from column name to aggregat config.
+    :return: Mapping from metric name to function that takes a single input argument.
+    """
+    agg_funcs: Dict[str, NamedAgg] = {}
+    for name, agg_obj in aggregates.items():
+        column = agg_obj.get("column", name)
+        operator = agg_obj.get("operator") or "sum"
+        if operator not in SUPPORTED_NUMPY_FUNCTIONS:
+            raise SupersetException("Unsupported numpy function: %")
+        func = getattr(np, operator)
+        options = agg_obj.get("options", {})
+        agg_funcs[name] = NamedAgg(column=column, aggfunc=partial(func, **options))
+
+    return agg_funcs
+
+
+def pivot(
+    df: DataFrame,
+    index: List[str],
+    columns: List[str],
+    aggregates: Dict[str, Dict[str, Any]],
+    metric_fill_value: Optional[Any] = None,
+    column_fill_value: Optional[str] = None,
+    drop_missing_columns: Optional[bool] = True,
+    combine_value_with_metric=False,
+    marginal_distributions: Optional[bool] = None,
+    marginal_distribution_name: Optional[str] = None,
+) -> DataFrame:
+    """
+    Perform a pivot operation on a DataFrame.
+
+    :param df: Object on which pivot operation will be performed
+    :param index: Columns to group by on the table index (=rows)
+    :param columns: Columns to group by on the table columns
+    :param metric_fill_value: Value to replace missing values with
+    :param column_fill_value: Value to replace missing pivot columns with
+    :param drop_missing_columns: Do not include columns whose entries are all missing
+    :param combine_value_with_metric: Display metrics side by side within each column,
+           as opposed to each column being displayed side by side for each metric.
+    :param aggregates: A mapping from aggregate column name to the the aggregate
+           config.
+    :param marginal_distributions: Add totals for row/column. Default to False
+    :param marginal_distribution_name: Name of row/column with marginal distribution.
+           Default to 'All'.
+    :return: A pivot table
+    """
+    if not index:
+        raise SupersetException(_("Pivot operation requires at least one index"))
+    if not columns:
+        raise SupersetException(_("Pivot operation requires at least one column"))
+    if not aggregates:
+        raise SupersetException(_("Pivot operation specifying aggregates"))
+
+    if column_fill_value:
+        df[columns] = df[columns].fillna(value=column_fill_value)
+
+    aggregate_funcs = _get_aggregate_funcs(aggregates)
+
+    # TODO (villebro): Pandas 1.0.3 doesn't yet support NamedAgg in pivot_table.
+    #  Remove once support is added.
+    aggfunc = {na.column: na.aggfunc for na in aggregate_funcs.values()}
+
+    df = df.pivot_table(
+        values=aggfunc.keys(),
+        index=index,
+        columns=columns,
+        aggfunc=aggfunc,
+        fill_value=metric_fill_value,
+        dropna=drop_missing_columns,
+        margins=marginal_distributions,
+        margins_name=marginal_distribution_name,
+    )
+
+    if combine_value_with_metric:
+        df = df.stack(0).unstack()
+
+    return df
+
+
+def aggregate(
+    df: DataFrame, groupby: List[str], aggregates: Dict[str, Dict[str, Any]]
+) -> DataFrame:
+    """
+    Apply aggregations to a DataFrame.
+
+    :param df: Object to aggregate.
+    :param groupby: columns to aggregate
+    :param aggregates: A mapping from metric column to the function used to
+           aggregate values.
+    :return: Aggregated DataFrame
+    """
+    aggregates = aggregates or {}
+    aggregate_funcs = _get_aggregate_funcs(aggregates)
+    return df.groupby(by=groupby).agg(**aggregate_funcs)
+
+
+def sort(
+    df: DataFrame,
+    by: List[str],
+    ascending: Optional[Union[bool, Dict[str, bool]]] = True,
+) -> DataFrame:
+    """
+    Sort a DataFrame.
+
+    df: DataFrame to sort.
+    by: columns by by which to sort `df`.
+    ascending: Sort order. Defaults to True. If bool, applies same sort order to all
+               columns. If dict, applies sorting per column, defaulting to True if
+               missing.
+    """
+    if isinstance(ascending, dict):
+        ascending = [ascending.get(col, True) for col in by]
+
+    return df.sort_values(by=by, ascending=ascending)
+
+
+def rolling(
+    df: DataFrame,
+    rolling_type: str,
+    center: bool = False,
+    win_type: Optional[str] = None,
+    window: Optional[int] = None,
+    min_periods: Optional[int] = None,
+) -> DataFrame:
+    """
+    Apply a rolling window on the dataset. See the Pandas docs for further details:
+    https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rolling.html
+
+    :param df: DataFrame on which the rolling period will be based.
+    :param rolling_type: Type of rolling window. Any numpy function will work.
+    :param center: Should the label be at the center of the window.
+    :param win_type: Type of window function.
+    :param window: Size of the window.
+    :param min_periods:
+    :return:
+    """
+    if rolling_type == "cumsum":
+        df = df.cumsum()
+    else:
+        kwargs = {}
+        if window is not None:
+            kwargs["window"] = window
+        if min_periods is not None:
+            kwargs["min_periods"] = min_periods
+        if center is not None:
+            kwargs["center"] = center
+        if win_type is not None:
+            kwargs["win_type"] = win_type
+
+        df_rolling = df.rolling(**kwargs)
+        if not hasattr(df_rolling, rolling_type):
+            raise SupersetException(
+                _("Unsupported rolling_type: %(type)s", type=rolling_type)
+            )
+        df = getattr(df_rolling, rolling_type)()
+
+    if min_periods:
+        df = df[min_periods:]
+    return df

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -145,24 +145,15 @@ def aggregate(
     return df.groupby(by=groupby).agg(**aggregate_funcs)
 
 
-def sort(
-    df: DataFrame,
-    by: List[str],
-    ascending: Optional[Union[bool, Dict[str, bool]]] = True,
-) -> DataFrame:
+def sort(df: DataFrame, by: Dict[str, bool]) -> DataFrame:
     """
     Sort a DataFrame.
 
     df: DataFrame to sort.
-    by: columns by by which to sort `df`.
-    ascending: Sort order. Defaults to True. If bool, applies same sort order to all
-               columns. If dict, applies sorting per column, defaulting to True if
-               missing.
+    by: columns by by which to sort. The key specifies the column name, value
+        specifies if sorting in ascending order.
     """
-    if isinstance(ascending, dict):
-        ascending = [ascending.get(col, True) for col in by]
-
-    return df.sort_values(by=by, ascending=ascending)
+    return df.sort_values(by=by.keys(), ascending=by.values())
 
 
 def rolling(
@@ -188,7 +179,7 @@ def rolling(
     if rolling_type == "cumsum":
         df = df.cumsum()
     else:
-        kwargs = {}
+        kwargs: Dict[str, Union[str, int]] = {}
         if window is not None:
             kwargs["window"] = window
         if min_periods is not None:

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -90,7 +90,7 @@ def _get_aggregate_funcs(
             raise QueryObjectValidationError(
                 _("Operator undefined for aggregator: %(name)s", name=name,)
             )
-        operator = agg_obj.get("operator", "sum")
+        operator = agg_obj["operator"]
         if operator not in SUPPORTED_NUMPY_FUNCTIONS:
             raise QueryObjectValidationError(
                 _("Unsupported numpy function: %(operator)s", operator=operator,)
@@ -128,7 +128,7 @@ def _append_columns(
     )
 
 
-@validate_column_args("index", "columns", "aggregates")
+@validate_column_args("index", "columns")
 def pivot(  # pylint: disable=too-many-arguments
     df: DataFrame,
     index: List[str],

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -48,7 +48,7 @@ SUPPORTED_NUMPY_FUNCTIONS = (
 
 
 def validate_column_args(*argnames: str) -> Callable:
-    def wrapper(fn):
+    def wrapper(func):
         def wrapped(df, **options):
             columns = df.columns.tolist()
             for name in argnames:
@@ -58,7 +58,7 @@ def validate_column_args(*argnames: str) -> Callable:
                     raise QueryObjectValidationError(
                         _("Referenced columns not available in DataFrame.")
                     )
-            return fn(df, **options)
+            return func(df, **options)
 
         return wrapped
 

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -91,7 +91,7 @@ def _append_columns(
     )
 
 
-def pivot(
+def pivot(  # pylint: disable=too-many-arguments
     df: DataFrame,
     index: List[str],
     columns: List[str],
@@ -183,7 +183,7 @@ def sort(df: DataFrame, columns: Dict[str, bool]) -> DataFrame:
     return df.sort_values(by=list(columns.keys()), ascending=list(columns.values()))
 
 
-def rolling(
+def rolling(  # pylint: disable=too-many-arguments
     df: DataFrame,
     columns: Dict[str, str],
     rolling_type: str,

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -306,7 +306,16 @@ def rolling(  # pylint: disable=too-many-arguments
         raise QueryObjectValidationError(
             _("Invalid rolling_type: %(type)s", type=rolling_type)
         )
-    df_rolling = getattr(df_rolling, rolling_type)(**rolling_type_options)
+    try:
+        df_rolling = getattr(df_rolling, rolling_type)(**rolling_type_options)
+    except TypeError:
+        raise QueryObjectValidationError(
+            _(
+                "Invalid options for %(rolling_type)s: %(options)s",
+                rolling_type=rolling_type,
+                options=rolling_type_options,
+            )
+        )
     df = _append_columns(df, df_rolling, columns)
     if min_periods:
         df = df[min_periods:]
@@ -344,8 +353,8 @@ def diff(df: DataFrame, columns: Dict[str, str], periods: int = 1,) -> DataFrame
     :param df: DataFrame on which the diff will be based.
     :param columns: columns on which to perform diff, mapping source column to
            target column. For instance, `{'y': 'y'}` will replace the column `y` with
-           the rollong value in `y`, while `{'y': 'y2'}` will add a column `y2` based
-           on rolling values calculated from `y`, leaving the original column `y`
+           the diff value in `y`, while `{'y': 'y2'}` will add a column `y2` based
+           on diff values calculated from `y`, leaving the original column `y`
            unchanged.
     :param periods: periods to shift for calculating difference.
     :return: DataFrame with diffed columns
@@ -363,8 +372,8 @@ def cum(df: DataFrame, columns: Dict[str, str], operator: str) -> DataFrame:
     :param df: DataFrame on which the cumulative operation will be based.
     :param columns: columns on which to perform a cumulative operation, mapping source
            column to target column. For instance, `{'y': 'y'}` will replace the column
-           `y` with the rollong value in `y`, while `{'y': 'y2'}` will add a column
-           `y2` based on rolling values calculated from `y`, leaving the original
+           `y` with the cumulative value in `y`, while `{'y': 'y2'}` will add a column
+           `y2` based on cumulative values calculated from `y`, leaving the original
            column `y` unchanged.
     :param operator: cumulative operator, e.g. `sum`, `prod`, `min`, `max`
     :return:

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -159,10 +159,7 @@ class CoreTests(SupersetTestCase):
                         },
                         {
                             "operation": "sort",
-                            "options": {
-                                "by": ["q1", "state"],
-                                "ascending": {"q1": False},
-                            },
+                            "options": {"columns": {"q1": False, "state": True},},
                         },
                     ],
                 }

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -111,7 +111,7 @@ class CoreTests(SupersetTestCase):
         resp = self.client.get("/superset/slice/-1/")
         assert resp.status_code == 404
 
-    def _get_query_context_dict(self) -> Dict[str, Any]:
+    def _get_query_context(self) -> Dict[str, Any]:
         self.login(username="admin")
         slc = self.get_slice("Girl Name Cloud", db.session)
         return {
@@ -127,7 +127,7 @@ class CoreTests(SupersetTestCase):
             ],
         }
 
-    def _get_query_context_dict_with_post_processing(self) -> Dict[str, Any]:
+    def _get_query_context_with_post_processing(self) -> Dict[str, Any]:
         self.login(username="admin")
         slc = self.get_slice("Girl Name Cloud", db.session)
         return {
@@ -179,7 +179,7 @@ class CoreTests(SupersetTestCase):
         self.assertNotEqual(cache_key, viz.cache_key(qobj))
 
     def test_cache_key_changes_when_datasource_is_updated(self):
-        qc_dict = self._get_query_context_dict()
+        qc_dict = self._get_query_context()
 
         # construct baseline cache_key
         query_context = QueryContext(**qc_dict)
@@ -207,7 +207,7 @@ class CoreTests(SupersetTestCase):
         self.assertNotEqual(cache_key_original, cache_key_new)
 
     def test_query_context_time_range_endpoints(self):
-        query_context = QueryContext(**self._get_query_context_dict())
+        query_context = QueryContext(**self._get_query_context())
         query_object = query_context.queries[0]
         extras = query_object.to_dict()["extras"]
         self.assertTrue("time_range_endpoints" in extras)
@@ -256,14 +256,14 @@ class CoreTests(SupersetTestCase):
 
     def test_api_v1_query_endpoint(self):
         self.login(username="admin")
-        qc_dict = self._get_query_context_dict()
+        qc_dict = self._get_query_context()
         data = json.dumps(qc_dict)
         resp = json.loads(self.get_resp("/api/v1/query/", {"query_context": data}))
         self.assertEqual(resp[0]["rowcount"], 100)
 
     def test_api_v1_query_endpoint_with_post_processing(self):
         self.login(username="admin")
-        qc_dict = self._get_query_context_dict_with_post_processing()
+        qc_dict = self._get_query_context_with_post_processing()
         data = json.dumps(qc_dict)
         resp = json.loads(self.get_resp("/api/v1/query/", {"query_context": data}))
         self.assertEqual(resp[0]["rowcount"], 6)

--- a/tests/fixtures/dataframes.py
+++ b/tests/fixtures/dataframes.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import date
+
+from pandas import DataFrame, to_datetime
+
+names_df = DataFrame(
+    [
+        {
+            "dt": date(2020, 1, 2),
+            "name": "John",
+            "country": "United Kingdom",
+            "cars": 3,
+            "bikes": 1,
+            "seconds": 30,
+        },
+        {
+            "dt": date(2020, 1, 2),
+            "name": "Peter",
+            "country": "Sweden",
+            "cars": 4,
+            "bikes": 2,
+            "seconds": 1,
+        },
+        {
+            "dt": date(2020, 1, 3),
+            "name": "Mary",
+            "country": "Finland",
+            "cars": 5,
+            "bikes": 3,
+            "seconds": None,
+        },
+        {
+            "dt": date(2020, 1, 3),
+            "name": "Peter",
+            "country": "India",
+            "cars": 6,
+            "bikes": 4,
+            "seconds": 12,
+        },
+        {
+            "dt": date(2020, 1, 4),
+            "name": "John",
+            "country": "Portugal",
+            "cars": 7,
+            "bikes": None,
+            "seconds": 75,
+        },
+        {
+            "dt": date(2020, 1, 4),
+            "name": "Peter",
+            "country": "Italy",
+            "cars": None,
+            "bikes": 5,
+            "seconds": 600,
+        },
+        {
+            "dt": date(2020, 1, 4),
+            "name": "Mary",
+            "country": None,
+            "cars": 9,
+            "bikes": 6,
+            "seconds": 2,
+        },
+        {
+            "dt": date(2020, 1, 4),
+            "name": None,
+            "country": "Australia",
+            "cars": 10,
+            "bikes": 7,
+            "seconds": 99,
+        },
+        {
+            "dt": date(2020, 1, 1),
+            "name": "John",
+            "country": "USA",
+            "cars": 1,
+            "bikes": 8,
+            "seconds": None,
+        },
+        {
+            "dt": date(2020, 1, 1),
+            "name": "Mary",
+            "country": "Fiji",
+            "cars": 2,
+            "bikes": 9,
+            "seconds": 50,
+        },
+    ]
+)
+
+categories_df = DataFrame(
+    {
+        "constant": ["dummy" for _ in range(0, 101)],
+        "category": [f"cat{i%3}" for i in range(0, 101)],
+        "dept": [f"dept{i%5}" for i in range(0, 101)],
+        "name": [f"person{i}" for i in range(0, 101)],
+        "asc_idx": [i for i in range(0, 101)],
+        "desc_idx": [i for i in range(100, -1, -1)],
+        "idx_nulls": [i if i % 5 == 0 else None for i in range(0, 101)],
+    }
+)
+
+timeseries_df = DataFrame(
+    index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
+    data={"y": [1.0, 2.0, 3.0, 4.0]},
+)

--- a/tests/fixtures/dataframes.py
+++ b/tests/fixtures/dataframes.py
@@ -117,5 +117,5 @@ categories_df = DataFrame(
 
 timeseries_df = DataFrame(
     index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
-    data={"y": [1.0, 2.0, 3.0, 4.0]},
+    data={"label": ["x", "y", "z", "q"], "y": [1.0, 2.0, 3.0, 4.0]},
 )

--- a/tests/pandas_postprocessing_test.py
+++ b/tests/pandas_postprocessing_test.py
@@ -80,9 +80,7 @@ class PostProcessingTestCase(SupersetTestCase):
         self.assertEqual(df.sum()[0], 382)
 
     def test_sort(self):
-        df = proc.sort(
-            df=categories_df, by=["category", "asc_idx"], ascending={"asc_idx": False}
-        )
+        df = proc.sort(df=categories_df, by={"category": True, "asc_idx": False})
         self.assertEqual(96, df["asc_idx"].reset_index(drop=True)[1])
 
     def test_rolling(self):

--- a/tests/pandas_postprocessing_test.py
+++ b/tests/pandas_postprocessing_test.py
@@ -15,10 +15,31 @@
 # specific language governing permissions and limitations
 # under the License.
 # isort:skip_file
+import math
+from typing import Any, List
+
+from pandas import Series
+
 from superset.utils import pandas_postprocessing as proc
 
 from .base_tests import SupersetTestCase
 from .fixtures.dataframes import categories_df, timeseries_df
+
+
+def series_to_list(series: Series) -> List[Any]:
+    """
+    Converts a `Series` to a regular list, and replaces non-numeric values to
+    Nones.
+
+    :param series: Series to convert
+    :return: list without nan or inf
+    """
+    return [
+        None
+        if not isinstance(val, str) and (math.isnan(val) or math.isinf(val))
+        else val
+        for val in series.tolist()
+    ]
 
 
 class PostProcessingTestCase(SupersetTestCase):
@@ -39,11 +60,9 @@ class PostProcessingTestCase(SupersetTestCase):
         df = proc.aggregate(
             df=categories_df, groupby=["constant"], aggregates=aggregates
         )
-        data = df.to_dict(orient="series")
-
-        self.assertEqual(data["asc sum"][0], 5050)
-        self.assertEqual(data["asc q2"][0], 75)
-        self.assertEqual(data["desc q1"][0], 25)
+        self.assertEqual(series_to_list(df["asc sum"])[0], 5050)
+        self.assertEqual(series_to_list(df["asc q2"])[0], 75)
+        self.assertEqual(series_to_list(df["desc q1"])[0], 25)
 
     def test_pivot_basic_functionality(self):
         aggregates = {"idx_nulls": {"operator": "sum"}}
@@ -55,7 +74,8 @@ class PostProcessingTestCase(SupersetTestCase):
             aggregates=aggregates,
         )
         self.assertListEqual(
-            list(idx[1] for idx in df.columns), ["cat0", "cat1", "cat2"]
+            df.columns.tolist(),
+            [("idx_nulls", "cat0"), ("idx_nulls", "cat1"), ("idx_nulls", "cat2")],
         )
         self.assertEqual(len(df), 101)
         self.assertEqual(df.sum()[0], 315)
@@ -80,26 +100,72 @@ class PostProcessingTestCase(SupersetTestCase):
         self.assertEqual(df.sum()[0], 382)
 
     def test_sort(self):
-        df = proc.sort(df=categories_df, by={"category": True, "asc_idx": False})
-        self.assertEqual(96, df["asc_idx"].reset_index(drop=True)[1])
+        df = proc.sort(df=categories_df, columns={"category": True, "asc_idx": False})
+        self.assertEqual(96, series_to_list(df["asc_idx"])[1])
 
     def test_rolling(self):
-        post_df = proc.rolling(df=timeseries_df, rolling_type="cumsum", window=0)
-
-        self.assertListEqual(post_df["y"].tolist(), [1.0, 3.0, 6.0, 10.0])
-
         post_df = proc.rolling(
-            df=timeseries_df, rolling_type="sum", window=2, min_periods=0
+            df=timeseries_df, columns={"y": "y2"}, rolling_type="cumsum", window=0
         )
 
-        self.assertListEqual(post_df["y"].tolist(), [1.0, 3.0, 5.0, 7.0])
+        self.assertListEqual(post_df.columns.tolist(), ["label", "y", "y2"])
+        self.assertListEqual(series_to_list(post_df["label"]), ["x", "y", "z", "q"])
+        self.assertListEqual(series_to_list(post_df["y"]), [1.0, 2.0, 3.0, 4.0])
+        self.assertListEqual(series_to_list(post_df["y2"]), [1.0, 3.0, 6.0, 10.0])
 
         post_df = proc.rolling(
-            df=timeseries_df, rolling_type="mean", window=10, min_periods=0
+            df=timeseries_df,
+            columns={"y": "y"},
+            rolling_type="sum",
+            window=2,
+            min_periods=0,
         )
-        self.assertListEqual(post_df["y"].tolist(), [1.0, 1.5, 2.0, 2.5])
+
+        self.assertListEqual(post_df.columns.tolist(), ["label", "y"])
+        self.assertListEqual(series_to_list(post_df["y"]), [1.0, 3.0, 5.0, 7.0])
 
         post_df = proc.rolling(
-            df=timeseries_df, rolling_type="count", window=10, min_periods=0
+            df=timeseries_df,
+            rolling_type="mean",
+            columns={"y": "y"},
+            window=10,
+            min_periods=0,
         )
-        self.assertListEqual(post_df["y"].tolist(), [1.0, 2.0, 3.0, 4.0])
+        self.assertListEqual(post_df.columns.tolist(), ["label", "y"])
+        self.assertListEqual(series_to_list(post_df["y"]), [1.0, 1.5, 2.0, 2.5])
+
+        post_df = proc.rolling(
+            df=timeseries_df,
+            rolling_type="count",
+            columns={"y": "y"},
+            window=10,
+            min_periods=0,
+        )
+        self.assertListEqual(post_df.columns.tolist(), ["label", "y"])
+        self.assertListEqual(series_to_list(post_df["y"]), [1.0, 2.0, 3.0, 4.0])
+
+    def test_select(self):
+        post_df = proc.select(df=timeseries_df, columns={"y": "y", "label": "label"})
+        self.assertListEqual(post_df.columns.tolist(), ["y", "label"])
+
+        post_df = proc.select(df=timeseries_df, columns={"label": "label"})
+        self.assertListEqual(post_df.columns.tolist(), ["label"])
+
+        post_df = proc.select(df=timeseries_df, columns={"y": "y1"})
+        self.assertListEqual(post_df.columns.tolist(), ["y1"])
+
+        post_df = proc.select(df=timeseries_df, columns={"label": "label", "y": "y1"})
+        self.assertListEqual(post_df.columns.tolist(), ["label", "y1"])
+
+    def test_diff(self):
+        post_df = proc.diff(df=timeseries_df, columns={"y": "y"})
+        self.assertListEqual(post_df.columns.tolist(), ["label", "y"])
+        self.assertListEqual(series_to_list(post_df["y"]), [None, 1.0, 1.0, 1.0])
+
+        post_df = proc.diff(df=timeseries_df, columns={"y": "y1"})
+        self.assertListEqual(post_df.columns.tolist(), ["label", "y", "y1"])
+        self.assertListEqual(series_to_list(post_df["y"]), [1.0, 2.0, 3.0, 4.0])
+        self.assertListEqual(series_to_list(post_df["y1"]), [None, 1.0, 1.0, 1.0])
+
+        post_df = proc.diff(df=timeseries_df, columns={"y": "y1"}, periods=-1)
+        self.assertListEqual(series_to_list(post_df["y1"]), [-1.0, -1.0, -1.0, None])

--- a/tests/pandas_postprocessing_test.py
+++ b/tests/pandas_postprocessing_test.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file
+from superset.utils import pandas_postprocessing as proc
+
+from .base_tests import SupersetTestCase
+from .fixtures.dataframes import categories_df, timeseries_df
+
+
+class PostProcessingTestCase(SupersetTestCase):
+    def test_aggregate_with_named_aggregators(self):
+        aggregates = {
+            "asc sum": {"column": "asc_idx", "operator": "sum"},
+            "asc q2": {
+                "column": "asc_idx",
+                "operator": "percentile",
+                "options": {"q": 75},
+            },
+            "desc q1": {
+                "column": "desc_idx",
+                "operator": "percentile",
+                "options": {"q": 25},
+            },
+        }
+        df = proc.aggregate(
+            df=categories_df, groupby=["constant"], aggregates=aggregates
+        )
+        data = df.to_dict(orient="series")
+
+        self.assertEqual(data["asc sum"][0], 5050)
+        self.assertEqual(data["asc q2"][0], 75)
+        self.assertEqual(data["desc q1"][0], 25)
+
+    def test_pivot_basic_functionality(self):
+        aggregates = {"idx_nulls": {"operator": "sum"}}
+
+        df = proc.pivot(
+            df=categories_df,
+            index=["name"],
+            columns=["category"],
+            aggregates=aggregates,
+        )
+        self.assertListEqual(
+            list(idx[1] for idx in df.columns), ["cat0", "cat1", "cat2"]
+        )
+        self.assertEqual(len(df), 101)
+        self.assertEqual(df.sum()[0], 315)
+
+        df = proc.pivot(
+            df=categories_df,
+            index=["dept"],
+            columns=["category"],
+            aggregates=aggregates,
+        )
+        self.assertEqual(len(df), 5)
+
+    def test_pivot_metric_fill_value(self):
+        aggregates = {"idx_nulls": {}}  # should default to sum
+        df = proc.pivot(
+            df=categories_df,
+            index=["name"],
+            columns=["category"],
+            metric_fill_value=1,
+            aggregates=aggregates,
+        )
+        self.assertEqual(df.sum()[0], 382)
+
+    def test_sort(self):
+        df = proc.sort(
+            df=categories_df, by=["category", "asc_idx"], ascending={"asc_idx": False}
+        )
+        self.assertEqual(96, df["asc_idx"].reset_index(drop=True)[1])
+
+    def test_rolling(self):
+        post_df = proc.rolling(df=timeseries_df, rolling_type="cumsum", window=0)
+
+        self.assertListEqual(post_df["y"].tolist(), [1.0, 3.0, 6.0, 10.0])
+
+        post_df = proc.rolling(
+            df=timeseries_df, rolling_type="sum", window=2, min_periods=0
+        )
+
+        self.assertListEqual(post_df["y"].tolist(), [1.0, 3.0, 5.0, 7.0])
+
+        post_df = proc.rolling(
+            df=timeseries_df, rolling_type="mean", window=10, min_periods=0
+        )
+        self.assertListEqual(post_df["y"].tolist(), [1.0, 1.5, 2.0, 2.5])
+
+        post_df = proc.rolling(
+            df=timeseries_df, rolling_type="count", window=10, min_periods=0
+        )
+        self.assertListEqual(post_df["y"].tolist(), [1.0, 2.0, 3.0, 4.0])


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently the `/api/v1/query` endpoint doesn't support post-SQL data processing. This functionality is necessary for decoupling the backend from the frontend, as many of the data operations necessary for advanced visualizations often require data processing either not readily available in SQL, the JavaScript ecosystem, or are unfeasible due to network/computational expense.

This PR adds post-query data processing functionality to Superset necessary for deprecating `viz.py`, namely
- `aggregate` (same as SQL `GROUP BY`)
- `pivot` (grouping by into column values and aggregation by cell value)
- `sort` (same as `ORDER BY`)
- `rolling` (e.g. moving sums, averages)

This is done by leveraging functionality readily available in Pandas and Numpy. To leverage this functionality, post processing operations can be defined as part of the `queries` attribute in the `QueryContext` object. Below is an example from the unit tests, where the mean and 1st quantile are computed on an already aggregated query, which is lastly sorted by the 1st quantile value (descending) and state (ascending by default):

```python
{
    "queries": [
        {
            "granularity": "ds",
            "groupby": ["name", "state"],
            "metrics": [{"label": "sum__num"}],
            "filters": [],
            "row_limit": 100,
            "post_processing": [
                {
                    "operation": "aggregate",
                    "options": {
                        "groupby": ["state"],
                        "aggregates": {
                            "q1": {
                                "operator": "percentile",
                                "column": "sum__num",
                                "options": {"q": 25},
                            },
                            "median": {
                                "operator": "median",
                                "column": "sum__num",
                            },
                        },
                    },
                },
                {
                    "operation": "sort",
                    "options": {
                        "by": ["q1", "state"],
                        "ascending": {"q1": False},
                    },
                },
            ],
        }
    ],
}
```

This feature should be seen as experimental at this stage. Furthermore, additional unit tests and documentation will be added later, probably in the form of OpenAPI specs.

### TEST PLAN
CI + local tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #9187
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@rusackas @suddjian @kristw @john-bodley @etr2460 