### PR TITLE
feat: change default time range from sql lab to no filter

### DIFF
--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -139,8 +139,8 @@ class ExploreResultsButton extends React.PureComponent {
           datasource: `${data.table_id}__table`,
           metrics: [],
           groupby: [],
+          time_range: 'No filter',
           viz_type: 'table',
-          since: '100 years ago',
           all_columns: columns.map(c => c.name),
           row_limit: 1000,
         };


### PR DESCRIPTION
### CATEGORY

- [x] Enhancement (new features, refinement)

### SUMMARY

Currently when clicking on "Explore" button in SQL Lab results, it defaults the time range to "100 years ago : infinity", which is basically equivalent to no filter for most datasources. However, it has implication on how the x-axis will be plotted in certain charts (e.g., recently, the Big Number chart introduced a[ fixed range](https://github.com/apache/incubator-superset/pull/9341) option).

This PR changes the default to "No filter" so the time range filter can be more properly utilized. 

There is also a global default value "[Last week](https://github.com/apache/incubator-superset/blob/893c95521b8147cce85eafade9f718867990ff75/superset-frontend/src/explore/controls.jsx#L846)", which is applied when users create a new chart from `/chart/add`. We are not changing this default value in this PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

When clicking on Explore in SQL Lab:

![image](https://user-images.githubusercontent.com/335541/78172759-75eab600-740b-11ea-840a-1e2389b6c925.png)

#### Before

![image](https://user-images.githubusercontent.com/335541/78172730-69665d80-740b-11ea-924d-ee7bcec67b7d.png)

#### After

![image](https://user-images.githubusercontent.com/335541/78172938-c4985000-740b-11ea-96c3-d13e69c14d94.png)


### TEST PLAN

1. Go to any query results in SQL Lab
2. Click on "Explore"

### ADDITIONAL INFORMATION

- [ ] Has associated issue: 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@kristw 