### PR TITLE
Re-enable the AnnotationLayerModelView read API

### DIFF
--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -95,7 +95,7 @@ class AnnotationLayerModelView(
     SupersetModelView, DeleteMixin
 ):  # pylint: disable=too-many-ancestors
     datamodel = SQLAInterface(AnnotationLayer)
-    include_route_methods = RouteMethod.CRUD_SET | { RouteMethod.API_READ }
+    include_route_methods = RouteMethod.CRUD_SET | {RouteMethod.API_READ}
 
     list_title = _("List Annotation Layer")
     show_title = _("Show Annotation Layer")

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -95,7 +95,7 @@ class AnnotationLayerModelView(
     SupersetModelView, DeleteMixin
 ):  # pylint: disable=too-many-ancestors
     datamodel = SQLAInterface(AnnotationLayer)
-    include_route_methods = RouteMethod.CRUD_SET
+    include_route_methods = RouteMethod.CRUD_SET | { RouteMethod.API_READ }
 
     list_title = _("List Annotation Layer")
     show_title = _("Show Annotation Layer")


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
According to https://github.com/apache/incubator-superset/blob/291306392443a5a0d0e2ee0cc4a95d37c56d4589/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx#L265, this API is still being used on the client side. This fixes a regression from https://github.com/apache/incubator-superset/pull/8960 where the endpoint was accidentally removed.

In the future we should probably migrate the client to use a new endpoint, but for now this fixes the regression.

### TEST PLAN
CI, ensure the annotationlayer selector loads instead of returning a 404

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @mistercrunch @john-bodley @dpgaspar 