### PR TITLE
release: Add support for ZSH in RELEASING and add tagging instructions

### DIFF
--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -65,26 +65,27 @@ the wrong files/using wrong names. There's a script to help you set correctly al
 necessary environment variables. Change your current directory to `superset/RELEASING`
 
 ```bash
-    # usage: . set_release_env.sh <SUPERSET_VERSION_RC> <PGP_KEY_FULLNAME>
-    # example: . set_release_env.sh 0.35.2rc1 myid@apache.org
+    # usage (BASH): . set_release_env.sh <SUPERSET_RC_VERSION> <PGP_KEY_FULLNAME>
+    # usage (ZSH): source set_release_env.sh <SUPERSET_RC_VERSION> <PGP_KEY_FULLNAME>
+    #
+    # example: source set_relese_env.sh 0.36.0rc3 myid@apache.org
 ```
 
-The script will output the exported variables. Here's example for 0.35.2rc2:
+The script will output the exported variables. Here's example for 0.36.0rc3:
 
 ```
     -------------------------------
     Set Release env variables
+    SUPERSET_VERSION=0.36.0
+    SUPERSET_RC=3
+    SUPERSET_GITHUB_BRANCH=0.36
     SUPERSET_PGP_FULLNAME=myid@apache.org
-    SUPERSET_VERSION_RC=0.35.2rc1
-    SUPERSET_GITHUB_BRANCH=0.35
-    SUPERSET_TMP_ASF_SITE_PATH=/tmp/incubator-superset-site-0.35.2
-    SUPERSET_RELEASE_RC=apache-superset-incubating-0.35.2rc1
-    SUPERSET_RELEASE_RC_TARBALL=apache-superset-incubating-0.35.2rc1-source.tar.gz
-    SUPERSET_RC=1
-    SUPERSET_CONFIG_PATH=/Users/ville/superset/superset_config.py
-    SUPERSET_RELEASE=apache-superset-incubating-0.35.2
-    SUPERSET_RELEASE_TARBALL=apache-superset-incubating-0.35.2-source.tar.gz
-    SUPERSET_VERSION=0.35.2
+    SUPERSET_VERSION_RC=0.36.0rc3
+    SUPERSET_RELEASE=apache-superset-incubating-0.36.0
+    SUPERSET_RELEASE_RC=apache-superset-incubating-0.36.0rc3
+    SUPERSET_RELEASE_TARBALL=apache-superset-incubating-0.36.0-source.tar.gz
+    SUPERSET_RELEASE_RC_TARBALL=apache-superset-incubating-0.36.0rc3-source.tar.gz
+    SUPERSET_TMP_ASF_SITE_PATH=/tmp/incubator-superset-site-0.36.0
     -------------------------------
 ```
 
@@ -114,10 +115,19 @@ section for the new release.
 Finally bump the version number on `superset-frontend/package.json` (replace with whichever version is being released excluding the RC version):
 
 ```json
-    "version": "0.35.2"
+    "version": "0.36.0"
 ```
 
-Commit the change with the version number, then git tag the version with the release candidate and push to the branch
+Commit the change with the version number, then git tag the version with the release candidate and push to the branch:
+
+```
+    # add changed files and commit
+    git add ...
+    git commit ...
+    # push new tag
+    git tag ${SUPERSET_VERSION_RC}
+    git push upstream ${SUPERSET_VERSION_RC}
+```
 
 ## Preparing the release candidate
 

--- a/RELEASING/set_release_env.sh
+++ b/RELEASING/set_release_env.sh
@@ -16,18 +16,28 @@
 # limitations under the License.
 #
 usage() {
-   echo "usage: . set_release_env.sh <SUPERSET_RC_VERSION> <PGP_KEY_FULLBANE>"
-   echo "example: . set_relese_env.sh 0.35.2rc1 myid@apache.org"
+   echo "usage (BASH): . set_release_env.sh <SUPERSET_RC_VERSION> <PGP_KEY_FULLNAME>"
+   echo "usage (ZSH): source set_release_env.sh <SUPERSET_RC_VERSION> <PGP_KEY_FULLNAME>"
+   echo
+   echo "example: source set_relese_env.sh 0.36.0rc3 myid@apache.org"
 }
 
 if [ -z "$1" ] || [ -z "$2" ]; then
   usage;
 else
   if [[ ${1} =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)rc([0-9]+)$ ]]; then
-    VERSION_MAJOR="${BASH_REMATCH[1]}"
-    VERSION_MINOR="${BASH_REMATCH[2]}"
-    VERSION_PATCH="${BASH_REMATCH[3]}"
-    VERSION_RC="${BASH_REMATCH[4]}"
+    if [ -n "$ZSH_VERSION" ]; then
+      VERSION_MAJOR="${match[1]}"
+      VERSION_MINOR="${match[2]}"
+      VERSION_PATCH="${match[3]}"
+      VERSION_RC="${match[4]}"
+    elif [ -n "$BASH_VERSION" ]; then
+      VERSION_MAJOR="${BASH_REMATCH[1]}"
+      VERSION_MINOR="${BASH_REMATCH[2]}"
+      VERSION_PATCH="${BASH_REMATCH[3]}"
+      VERSION_RC="${BASH_REMATCH[4]}"
+    fi
+
   else
     echo "unable to parse version string ${1}. Example of valid version string: 0.35.2rc1"
     exit 1

--- a/RELEASING/set_release_env.sh
+++ b/RELEASING/set_release_env.sh
@@ -36,6 +36,9 @@ else
       VERSION_MINOR="${BASH_REMATCH[2]}"
       VERSION_PATCH="${BASH_REMATCH[3]}"
       VERSION_RC="${BASH_REMATCH[4]}"
+    else
+      echo "Unsupported shell type, only zsh and bash supported"
+      exit 1
     fi
 
   else


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [x] Documentation

### SUMMARY
Currently the release script don't support ZSH properly, causing trouble when crafting a release on MacOS Catalina. Also added instructions for tagging and pushing the tag.

### REVIEWERS
@dpgaspar 