### PR TITLE
fix: Disable save button when can_add: false, can_overwrite: false

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -349,7 +349,7 @@ class ExploreViewContainer extends React.Component {
               }}
             >
               <QueryAndSaveBtns
-                canAdd="True"
+                canAdd={!!(this.props.can_add || this.props.can_overwrite)}
                 onQuery={this.onQuery}
                 onSave={this.toggleModal}
                 onStop={this.onStop}
@@ -396,6 +396,7 @@ function mapStateToProps(state) {
     datasourceId: explore.datasource_id,
     controls: explore.controls,
     can_overwrite: !!explore.can_overwrite,
+    can_add: !!explore.can_add,
     can_download: !!explore.can_download,
     column_formats: explore.datasource
       ? explore.datasource.column_formats

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -24,7 +24,7 @@ import classnames from 'classnames';
 import Button from '../../components/Button';
 
 const propTypes = {
-  canAdd: PropTypes.string.isRequired,
+  canAdd: PropTypes.bool.isRequired,
   onQuery: PropTypes.func.isRequired,
   onSave: PropTypes.func,
   onStop: PropTypes.func,
@@ -49,7 +49,7 @@ export default function QueryAndSaveBtns({
   errorMessage,
 }) {
   const saveClasses = classnames({
-    'disabled disabledButton': canAdd !== 'True',
+    'disabled disabledButton': !canAdd,
   });
 
   let qryButtonStyle = 'default';


### PR DESCRIPTION
fix #8302 (except the hotkey part)

I put off fixing the hotkey copy because it isn't quite accurate anyways, so I'm not sure what it should say. For instance, you can't `ctrl-s` to save on a slice unless it exists and you have overwrite permissions, and on a mac `ctrl-r` doesn't work anyhow. 

### CATEGORY
- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Disable chart save button when `can_add: false, can_overwrite: false`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before: ![image](https://user-images.githubusercontent.com/8343799/78296152-d7398480-74f2-11ea-892f-7cbef78913de.png)

after: ![image](https://user-images.githubusercontent.com/8343799/78296127-cb4dc280-74f2-11ea-8b82-d0b70cc06422.png)


### TEST PLAN
Configure a role such that it can view a chart but not edit/save it, then view a chart with that user.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #8302
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@willbarrett maybe?
