### PR TITLE
[Doc] Update installation doc for Dremio

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -377,7 +377,7 @@ Here's a list of some of the recommended packages.
 +------------------+---------------------------------------+-------------------------------------------------+
 | CockroachDB      | ``pip install cockroachdb``           | ``cockroachdb://``                              |
 +------------------+---------------------------------------+-------------------------------------------------+
-| Dremio           | ``pip install sqlalchemy_dremio``     | ``dremio://user:pwd@host:31010/``               |
+| Dremio           | ``pip install sqlalchemy_dremio``     | ``dremio://``                                   |
 +------------------+---------------------------------------+-------------------------------------------------+
 | Elasticsearch    | ``pip install elasticsearch-dbapi``   | ``elasticsearch+http://``                       |
 +------------------+---------------------------------------+-------------------------------------------------+
@@ -740,7 +740,8 @@ Dremio
 
 Install the following dependencies to connect to Dremio:
 
-* Dremio SQLAlchemy: ``pip install sqlalchemy_dremio``
+* Dremio SQLAlchemy: ``pip install sqlalchemy_dremio``  
+  * If you receive any errors during the installation of ``sqlalchemy_dremio``, make sure to install the prerequisites for PyODBC properly by following the instructions for your OS here: https://github.com/narendrans/sqlalchemy_dremio#installation
 * Dremio's ODBC driver: https://www.dremio.com/drivers/
 
 Example SQLAlchemy URI: ``dremio://dremio:dremio123@localhost:31010/dremio``

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -740,7 +740,8 @@ Dremio
 
 Install the following dependencies to connect to Dremio:
 
-* Dremio SQLAlchemy: ``pip install sqlalchemy_dremio``  
+* Dremio SQLAlchemy: ``pip install sqlalchemy_dremio``
+
   * If you receive any errors during the installation of ``sqlalchemy_dremio``, make sure to install the prerequisites for PyODBC properly by following the instructions for your OS here: https://github.com/narendrans/sqlalchemy_dremio#installation
 * Dremio's ODBC driver: https://www.dremio.com/drivers/
 


### PR DESCRIPTION
Customers fail to install pyodbc properly which on linux systems requires you to install unixodbc-devel package. Updated the instructions to make it clear.

### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
Customers fail to install pyodbc properly which on linux systems requires you to install unixodbc-devel package. Updated the instructions to make it clear.