### PR TITLE
Enable beautiful json for dashboard metadata editor

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -111,6 +111,7 @@
     "interweave": "^11.2.0",
     "jquery": "^3.4.1",
     "json-bigint": "^0.3.0",
+    "json-stringify-pretty-compact": "^2.0.0",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.14",
     "mathjs": "^3.20.2",

--- a/superset-frontend/src/dashboard/components/PropertiesModal.jsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal.jsx
@@ -24,6 +24,7 @@ import Select from 'react-select';
 import AceEditor from 'react-ace';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
+import stringify from 'json-stringify-pretty-compact';
 import '../stylesheets/buttons.less';
 
 import getClientErrorObject from '../../utils/getClientErrorObject';
@@ -41,6 +42,14 @@ const defaultProps = {
   onHide: () => {},
   onDashboardSave: () => {},
   show: false,
+};
+
+const prettyJSON = jsonString => {
+  try {
+    return stringify(JSON.parse(jsonString));
+  } catch (err) {
+    return jsonString;
+  }
 };
 
 class PropertiesModal extends React.PureComponent {
@@ -99,7 +108,8 @@ class PropertiesModal extends React.PureComponent {
             ...state.values,
             dashboard_title: dashboard.dashboard_title || '',
             slug: dashboard.slug || '',
-            json_metadata: dashboard.json_metadata || '',
+            // always reformat to pretty json at initial opening
+            json_metadata: prettyJSON(dashboard.json_metadata) || '',
           },
         }));
         const initialSelectedValues = dashboard.owners.map(owner => ({
@@ -281,7 +291,6 @@ class PropertiesModal extends React.PureComponent {
                     <AceEditor
                       mode="json"
                       name="json_metadata"
-                      defaultValue={this.defaultMetadataValue}
                       value={values.json_metadata}
                       onChange={this.onMetadataChange}
                       theme="textmate"


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Reformat JSON strings in the dashboard metadata modal input so it's easier to edit.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before
![Snip20200405_58](https://user-images.githubusercontent.com/335541/78528120-7bd9f180-7793-11ea-87b7-2d4ac43cdbdd.png)

#### After
![Snip20200405_57](https://user-images.githubusercontent.com/335541/78528123-80060f00-7793-11ea-937f-65b4041c1ff0.png)

### TEST PLAN

1. Pick a random dashboard with filters
2. Edit metadata via "Edit dashboard" -> "<Caret dropdown menu>" -> "Edit dashboard properties" -> "Advanced".

The JSON string in the code editor should be formatted.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@graceguo-supercat @etr2460 