### PR TITLE
[tests] refactor, change datasets and charts to it's own folder

### DIFF
--- a/tests/charts/__init__.py
+++ b/tests/charts/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -21,13 +21,13 @@ from typing import List, Optional
 import prison
 from sqlalchemy.sql import func
 
-from superset import db, security_manager
+import tests.test_app
 from superset.connectors.connector_registry import ConnectorRegistry
+from superset.extensions import db, security_manager
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
-
-from .base_api_tests import ApiOwnersTestCaseMixin
-from .base_tests import SupersetTestCase
+from tests.base_api_tests import ApiOwnersTestCaseMixin
+from tests.base_tests import SupersetTestCase
 
 
 class ChartApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):

--- a/tests/datasets/__init__.py
+++ b/tests/datasets/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -23,13 +23,13 @@ import prison
 import yaml
 from sqlalchemy.sql import func
 
-from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.dao.exceptions import (
     DAOCreateFailedError,
     DAODeleteFailedError,
     DAOUpdateFailedError,
 )
+from superset.extensions import db, security_manager
 from superset.models.core import Database
 from superset.utils.core import get_example_database
 from superset.utils.dict_import_export import export_to_dict


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [X] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Follow the new structure for tests, and apply it to charts and datasets. Just like in superset base folder, charts and datasets have their own module. Later we should have tests for commands that could be nicely placed here also.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@willbarrett 