### PR TITLE
[charts] New, custom filter for name OR description

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ croniter==0.3.31          # via apache-superset (setup.py)
 cryptography==2.8         # via apache-superset (setup.py)
 decorator==4.4.1          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.3.1   # via apache-superset (setup.py)
+flask-appbuilder==2.3.2   # via apache-superset (setup.py)
 flask-babel==1.0.0        # via flask-appbuilder
 flask-caching==1.8.0
 flask-compress==1.4.0
@@ -56,7 +56,7 @@ pandas==0.25.3
 parsedatetime==2.5
 pathlib2==2.3.5
 polyline==1.4.0
-prison==0.1.2             # via flask-appbuilder
+prison==0.1.3             # via flask-appbuilder
 py==1.8.1                 # via retry
 pyarrow==0.16.0
 pycparser==2.19           # via cffi

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -35,7 +35,7 @@ from superset.charts.commands.exceptions import (
     ChartUpdateFailedError,
 )
 from superset.charts.commands.update import UpdateChartCommand
-from superset.charts.filters import ChartFilter
+from superset.charts.filters import ChartFilter, ChartNameOrDescriptionFilter
 from superset.charts.schemas import (
     ChartPostSchema,
     ChartPutSchema,
@@ -105,6 +105,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
     )
     base_order = ("changed_on", "desc")
     base_filters = [["id", ChartFilter, lambda: []]]
+    search_filters = {"slice_name": [ChartNameOrDescriptionFilter]}
 
     # Will just affect _info endpoint
     edit_columns = ["slice_name"]

--- a/superset/charts/filters.py
+++ b/superset/charts/filters.py
@@ -16,11 +16,31 @@
 # under the License.
 from typing import Any
 
+from flask_babel import lazy_gettext as _
 from sqlalchemy import or_
 from sqlalchemy.orm.query import Query
 
 from superset import security_manager
+from superset.models.slice import Slice
 from superset.views.base import BaseFilter
+
+
+class ChartNameOrDescriptionFilter(
+    BaseFilter
+):  # pylint: disable=too-few-public-methods
+    name = _("Name or Description")
+    arg_name = "name_or_description"
+
+    def apply(self, query: Query, value: Any) -> Query:
+        if not value:
+            return query
+        ilike_value = f"%{value}%"
+        return query.filter(
+            or_(
+                Slice.slice_name.ilike(ilike_value),
+                Slice.description.ilike(ilike_value),
+            )
+        )
 
 
 class ChartFilter(BaseFilter):  # pylint: disable=too-few-public-methods

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -579,7 +579,9 @@ class ChartApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
         arguments = {
             "filters": [
                 {"col": "slice_name", "opr": "name_or_description", "value": "zy_"}
-            ]
+            ],
+            "order_column": "slice_name",
+            "order_direction": "asc",
         }
         self.login(username="admin")
         uri = f"api/v1/chart/?q={prison.dumps(arguments)}"
@@ -587,6 +589,17 @@ class ChartApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(data["count"], 3)
+
+        expected_response = [
+            {"description": "ZY_bar", "slice_name": "foo",},
+            {"description": "desc1zy_", "slice_name": "foo",},
+            {"description": "desc1", "slice_name": "zy_foo",},
+        ]
+        for index, item in enumerate(data["result"]):
+            self.assertEqual(
+                item["description"], expected_response[index]["description"]
+            )
+            self.assertEqual(item["slice_name"], expected_response[index]["slice_name"])
 
         self.logout()
         self.login(username="gamma")


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Add a custom filter to charts so that it's possible to filter by chart name and description at the same time. This is a requirement for future chart list view design. Requires FAB 2.3.2

Needs this first:
https://github.com/apache/incubator-superset/pull/9491

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@nytai @willbarrett 