### PR TITLE
Add explore control tabOverride at the section level

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -198,7 +198,10 @@ class ControlPanelsContainer extends React.Component {
     const querySectionsToRender = [];
     const displaySectionsToRender = [];
     allSectionsToRender.forEach(section => {
+      // if at least one control in the secion is not `renderTrigger`
+      // or asks to be displayed at the Data tab
       if (
+        section.tabOverride === 'data' ||
         section.controlSetRows.some(rows =>
           rows.some(
             control =>

--- a/superset-frontend/src/explore/controlPanels/BigNumber.jsx
+++ b/superset-frontend/src/explore/controlPanels/BigNumber.jsx
@@ -29,6 +29,7 @@ export default {
     },
     {
       label: t('Options'),
+      tabOverride: 'data',
       expanded: true,
       controlSetRows: [
         [


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

https://github.com/apache/incubator-superset/pull/9440 unintentionally moved the "Options" section for Big Number chart to the "Customize" tab.

This is because [ControlPanelsContainer](https://github.com/apache/incubator-superset/blob/06c4795fba48ed64e54e74eb8eb2f5a202c01fc8/superset-frontend/src/explore/components/ControlPanelsContainer.jsx#L203) checks whether a section needs to display in the Data tab by checking whether any of the control in that section must trigger new queries when updated (`renderTrigger: false`) or has `tabOverride = data`. But it uses the config in the shared controls file, and assumes the control configs passed along are names of the shared controls, and could be used to look up the shared control from [controls.jsx](https://github.com/apache/incubator-superset/blob/b6bca9f137b069716938ac1df5862c0b5d2c3461/superset-frontend/src/explore/controls.jsx#L1158). However, when these controls are refactored into custom configs, they become objects and `ControlPanelsContainer` then fails to find the shared control, hence the `renderTrigger` and `tabOverride` info.

Ideally this `tabOverride` option should probably be at the section level. 

A bigger refactor is need to let `ControlPanelsContainer` always read from parsed control configs (instead of the control keys). This PR is just a quick fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

The "Options" section is displayed in the "Customize" tab.
![Snip20200408_63](https://user-images.githubusercontent.com/335541/78845614-e1a9c180-79bd-11ea-990e-eb90e186684c.png)


#### After

The "Options" section is displayed in the "Data" tab like before.

![image](https://user-images.githubusercontent.com/335541/78845591-d3f43c00-79bd-11ea-9df0-646e04a548df.png)


### TEST PLAN

- Check any big number chart with trendlines.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@rusackas @michellethomas 