### PR TITLE
fix: add lineWidth to Shared_DeckGL.jsx

### DIFF
--- a/superset-frontend/src/explore/controlPanels/Shared_DeckGL.jsx
+++ b/superset-frontend/src/explore/controlPanels/Shared_DeckGL.jsx
@@ -243,7 +243,7 @@ export const lineWidth = {
     isInt: true,
     default: 10,
     description: t('The width of the lines'),
-  }
+  },
 };
 
 export const fillColorPicker = {

--- a/superset-frontend/src/explore/controlPanels/Shared_DeckGL.jsx
+++ b/superset-frontend/src/explore/controlPanels/Shared_DeckGL.jsx
@@ -234,6 +234,18 @@ export const lineColumn = {
   },
 };
 
+export const lineWidth = {
+  name: 'line_width',
+  config: {
+    type: 'TextControl',
+    label: t('Line width'),
+    renderTrigger: true,
+    isInt: true,
+    default: 10,
+    description: t('The width of the lines'),
+  }
+};
+
 export const fillColorPicker = {
   name: 'fill_color_picker',
   config: {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
#9455 caused a regression by dropping `lineWidth` from the shared DeckGL controls.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@rusackas 