### PR TITLE
control to turn off table bar-chart backgrounds

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -8268,9 +8268,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-big-number": {
-      "version": "0.11.21",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-big-number/-/legacy-preset-chart-big-number-0.11.21.tgz",
-      "integrity": "sha512-LvDrCfpNTUGaXFUvrd1vHFJqPsBZlva97Z/Wy8izn7ZRv7PrrsvxJ584mh+JBfPg2YiklYB7E2F18MN1NaJEmw==",
+      "version": "0.12.13",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-big-number/-/legacy-preset-chart-big-number-0.12.13.tgz",
+      "integrity": "sha512-4TQzN702nyTL6tHgoa93HMcrUvKKqlE3Tm7Gxaa0uQEi+BKPuP77u957oZzZwJBR0SY81A6ASk0ztN90gpVsQg==",
       "requires": {
         "@data-ui/xy-chart": "^0.0.84",
         "@types/d3-color": "^1.2.2",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -83,7 +83,7 @@
     "@superset-ui/legacy-plugin-chart-treemap": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-word-cloud": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.11.15",
-    "@superset-ui/legacy-preset-chart-big-number": "^0.11.21",
+    "@superset-ui/legacy-preset-chart-big-number": "^0.12.13",
     "@superset-ui/legacy-preset-chart-deckgl": "^0.2.3",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.11.15",
     "@superset-ui/number-format": "^0.12.10",

--- a/superset-frontend/src/explore/controlPanels/Table.js
+++ b/superset-frontend/src/explore/controlPanels/Table.js
@@ -183,6 +183,19 @@ export default {
             },
           },
         ],
+        [
+          {
+            name: 'show_cell_bars',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show Cell Bars'),
+              renderTrigger: true,
+              default: true,
+              description: t('Enable to display bar chart background elements in table columns'),
+            },
+          },
+          null,
+        ],
       ],
     },
   ],

--- a/superset-frontend/src/explore/controlPanels/Table.js
+++ b/superset-frontend/src/explore/controlPanels/Table.js
@@ -185,13 +185,13 @@ export default {
         ],
         [
           {
-            name: 'show_cell_bars',
+            name: 'hide_cell_bars',
             config: {
               type: 'CheckboxControl',
-              label: t('Show Cell Bars'),
+              label: t('Hide Cell Bars'),
               renderTrigger: true,
-              default: true,
-              description: t('Enable to display bar chart background elements in table columns'),
+              default: false,
+              description: t('Disable display of bar chart background elements in table columns'),
             },
           },
           null,

--- a/superset-frontend/src/explore/controlPanels/Table.js
+++ b/superset-frontend/src/explore/controlPanels/Table.js
@@ -191,7 +191,9 @@ export default {
               label: t('Show Cell Bars'),
               renderTrigger: true,
               default: true,
-              description: t('Enable to display bar chart background elements in table columns'),
+              description: t(
+                'Enable to display bar chart background elements in table columns',
+              ),
             },
           },
           null,

--- a/superset-frontend/src/explore/controlPanels/Table.js
+++ b/superset-frontend/src/explore/controlPanels/Table.js
@@ -191,7 +191,9 @@ export default {
               label: t('Hide Cell Bars'),
               renderTrigger: true,
               default: false,
-              description: t('Disable display of bar chart background elements in table columns'),
+              description: t(
+                'Disable display of bar chart background elements in table columns',
+              ),
             },
           },
           null,

--- a/superset-frontend/src/explore/controlPanels/Table.js
+++ b/superset-frontend/src/explore/controlPanels/Table.js
@@ -185,15 +185,13 @@ export default {
         ],
         [
           {
-            name: 'hide_cell_bars',
+            name: 'show_cell_bars',
             config: {
               type: 'CheckboxControl',
-              label: t('Hide Cell Bars'),
+              label: t('Show Cell Bars'),
               renderTrigger: true,
-              default: false,
-              description: t(
-                'Disable display of bar chart background elements in table columns',
-              ),
+              default: true,
+              description: t('Enable to display bar chart background elements in table columns'),
             },
           },
           null,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes, in coordination with [this superset-ui PR](https://github.com/apache-superset/superset-ui/pull/352), #9499. Adds a toggle to hide/show bars.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before: 
![image](https://user-images.githubusercontent.com/812905/79027516-5c4f1a00-7b41-11ea-9360-067244da53cf.png)

After:
![after](https://user-images.githubusercontent.com/812905/79099667-852a0780-7d19-11ea-922a-8e461ddf9633.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:  #9499 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@kristw 