### PR TITLE
Create a docker volume for the node_modules directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ x-superset-volumes: &superset-volumes
   - ./docker/pythonpath_dev:/app/pythonpath
   - ./superset:/app/superset
   - ./superset-frontend:/app/superset-frontend
+  - node_modules:/app/superset-frontend/node_modules
   - superset_home:/app/superset_home
 
 version: "3.7"
@@ -84,6 +85,8 @@ services:
 
 volumes:
   superset_home:
+    external: false
+  node_modules:
     external: false
   db_home:
     external: false


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [X] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Use a docker volume for the `node_modules` directory to speed up the build and to make it work on Windows

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

I believe it fixes #8790 , I can only test with Docker for Windows 2.2.0.5 on Windows 10 1909 but `docker-compose up` worked after this change
