### PR TITLE
Update docker readme for `/docker/pythonpath_dev/`

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -28,14 +28,14 @@ Docker is an easy way to get started with Superset.
 
 ## Configuration
 
-The `/app/pythonpath` folder is mounted from [./docker/pythonpath_dev](./docker/pythonpath_dev) 
-which contains a base configuration [./docker/pythonpath/superset_config.py](./docker/pythonpath/superset_config.py) 
+The `/app/pythonpath` folder is mounted from [./docker/pythonpath_dev](./pythonpath_dev) 
+which contains a base configuration [./docker/pythonpath_dev/superset_config.py](./pythonpath_dev/superset_config.py) 
 intended for use with local development.
 
 ### Local overrides
 
-In order to override configuration settings locally, simply make a copy of [./docker/pythonpath/superset_config_local.example](./docker/pythonpath/superset_config_local.example)
-into [./docker/pythonpath/superset_config_docker.py](./docker/pythonpath/superset_config_docker.py) (git ignored) and fill in your overrides.
+In order to override configuration settings locally, simply make a copy of [./docker/pythonpath_dev/superset_config_local.example](./pythonpath_dev/superset_config_local.example)
+into [./docker/pythonpath_dev/superset_config_docker.py](./pythonpath_dev/superset_config_docker.py) (git ignored) and fill in your overrides.
 
 ### Local packages
 

--- a/docker/pythonpath_dev/superset_config_local.example
+++ b/docker/pythonpath_dev/superset_config_local.example
@@ -18,7 +18,7 @@
 #
 # This is an example "local" configuration file. In order to set/override config
 # options that ONLY apply to your local environment, simply copy/rename this file
-# to docker/pythonpath/superset_config_docker.py
+# to docker/pythonpath_dev/superset_config_docker.py
 # It ends up being imported by docker/superset_config.py which is loaded by
 # superset/config.py
 #


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [X] Documentation

### SUMMARY

Fix some links that were pointing to `/docker/pythonpath` instead of `/docker/pythonpath_dev` which is the current name of the directory.
Also update some relative paths in the same .md links. 