### PR TITLE
docs: point our README the maintained Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Installation & Configuration
 Resources
 -------------
 * [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
-* [Docker image](https://hub.docker.com/r/amancevice/superset/) (community contributed)
+* [Docker image](https://hub.docker.com/r/preset/superset/)
 * [Slides from Strata (March 2016)](https://drive.google.com/open?id=0B5PVE0gzO81oOVJkdF9aNkJMSmM)
 * [Stackoverflow tag](https://stackoverflow.com/questions/tagged/apache-superset)
 * [Join our Slack](https://join.slack.com/t/apache-superset/shared_invite/enQtNDMxMDY5NjM4MDU0LWJmOTcxYjlhZTRhYmEyYTMzOWYxOWEwMjcwZDZiNWRiNDY2NDUwNzcwMDFhNzE1ZmMxZTZlZWY0ZTQ2MzMyNTU)


### PR DESCRIPTION
Our README now points to a not-so-well-maintain, community-contributed
Docker image. The docker image we link to here is managed and
supported by actual committers under the Preset org.

