### PR TITLE
[list views] add work-break css for table layouts

### DIFF
--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -60,6 +60,10 @@
   .action-button {
     margin: 0 8px;
   }
+
+  .table-cell {
+    word-break: break-all;
+  }
 }
 
 @keyframes shimmer {

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -85,7 +85,11 @@ export default function TableCollection({
                 const columnCellProps = cell.column.cellProps || {};
 
                 return (
-                  <td {...cell.getCellProps()} {...columnCellProps}>
+                  <td
+                    className="table-cell"
+                    {...cell.getCellProps()}
+                    {...columnCellProps}
+                  >
                     <span>{cell.render('Cell')}</span>
                   </td>
                 );


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Long names (eg, using a google sheet for tables) can cause some layout issues due to work breaking using the table layout. This allows breaking at any point. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@rusackas 
