### PR TITLE
Run CI on all pushes / PR's

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -1,9 +1,6 @@
 name: E2E
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   cypress:

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -1,13 +1,6 @@
 name: Frontend
 
-on:
-  push:
-    branches: [ master ]
-    paths:
-    - superset-frontend/**
-  pull_request:
-    paths:
-    - superset-frontend/**
+on: [push, pull_request]
 
 jobs:
   frontend-build:

--- a/.github/workflows/superset-python.yml
+++ b/.github/workflows/superset-python.yml
@@ -1,23 +1,6 @@
 name: Python
 
-on:
-  # only build on direct push to `master` branch
-  push:
-    branches: [ master ]
-    paths:
-    - ./**/*.py
-    - superset/**
-    - tests/**
-    - requirements*.txt
-  # but also build on pull requests to any branch
-  # (the so-called feature branch)
-  pull_request:
-    paths:
-    - ./**/*.py
-    - superset/**
-    - tests/**
-    - setup.py
-    - requirements*.txt
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
* Sets CI (GH Actions) to run for each push/PR

The intent of switching to GH Actions is to move away from Travis. In order to accomplish this, we need to configure the required merge checks properly for the repo as to gate merges properly. If not all CI results are required, it's possible that a failing check could slip through. If not all workflows are run for each PR, then we can't REQUIRE those which run conditionally.
