### PR TITLE
[fix] dashboard filter scope bug

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/util/getFilterScopeFromNodesTree_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/getFilterScopeFromNodesTree_spec.js
@@ -212,5 +212,19 @@ describe('getFilterScopeFromNodesTree', () => {
         immune: [],
       });
     });
+
+    it('mixed row level tab and chart scope', () => {
+      const checkedChartIds = [103, 105, 102];
+      expect(
+        getFilterScopeFromNodesTree({
+          filterKey: '107_region',
+          nodes,
+          checkedChartIds,
+        }),
+      ).toEqual({
+        scope: ['TAB-E4mJaZ-uQM', 'TAB-rLYu-Cryu'],
+        immune: [101],
+      });
+    });
   });
 });

--- a/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.js
+++ b/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.js
@@ -26,14 +26,16 @@ function getTabChildrenScope({
   tabScopes,
   parentNodeValue,
   forceAggregate = false,
+  hasChartSibilings = false,
 }) {
   // if all sub-tabs are in scope, or forceAggregate =  true
   // aggregate scope to parentNodeValue
   if (
     forceAggregate ||
-    Object.entries(tabScopes).every(
-      ([key, { scope }]) => scope && scope.length && key === scope[0],
-    )
+    (!hasChartSibilings &&
+      Object.entries(tabScopes).every(
+        ([key, { scope }]) => scope && scope.length && key === scope[0],
+      ))
   ) {
     return {
       scope: [parentNodeValue],
@@ -98,7 +100,11 @@ function traverse({ currentNode = {}, filterId, checkedChartIds = [] }) {
 
   // has tab children but only some sub-tab in scope
   if (tabChildren.length) {
-    return getTabChildrenScope({ tabScopes, parentNodeValue: currentValue });
+    return getTabChildrenScope({
+      tabScopes,
+      parentNodeValue: currentValue,
+      hasChartSibilings: !isEmpty(chartChildren),
+    });
   }
 
   // no tab children and no chart children in scope


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This PR is to fix a specific case in setting dashboard filter scope. 
The dashboard layout is like this:
--- row 1: has a chart and a filter
--- row 2: has 2 tabs
When user want to set filter only apply to some charts in tabs of row2, it didn't work correctly.

This is a bug fix in the algorithm so there is no UI change.

### TEST PLAN
Added unit test


### REVIEWERS
@ktmud @etr2460 