### PR TITLE
[fix] warm up cache error handling

### DIFF
--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -610,7 +610,9 @@ class CoreTests(SupersetTestCase):
     def test_warm_up_cache(self):
         slc = self.get_slice("Girls", db.session)
         data = self.get_json_resp("/superset/warm_up_cache?slice_id={}".format(slc.id))
-        self.assertEqual(data, [{"slice_id": slc.id, "slice_name": slc.slice_name}])
+        self.assertEqual(
+            data, [{"slice_id": slc.id, "viz_error": None, "viz_status": "success"}]
+        )
 
         data = self.get_json_resp(
             "/superset/warm_up_cache?table_name=energy_usage&db_name=main"


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR checks ensures that a slice which fails to be successfully warmed is reported as such. 
Additionally I've updated the response to always return a 200 and changed the response payload to include the status/error. Previously the method would short circuit if an exception was thrown (resulting in a 500) however it wasn't evident which slice failed to be warmed nor would it try to warm and remaining slices.

### TEST PLAN

Tested locally and error errors were being propagated for failed queries. 

```
[
    {
        "slice_id": 1, 
        "viz_error": "presto error: Query exceeded maximum time limit of 300.00s", 
        "viz_status": "failed"
    }
]
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @graceguo-supercat @villebro 
