### PR TITLE
Add raw number/integer option to d3 number formats

### DIFF
--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -83,6 +83,8 @@ export const PRIMARY_COLOR = { r: 0, g: 122, b: 135, a: 1 };
 // input choices & options
 export const D3_FORMAT_OPTIONS = [
   ['SMART_NUMBER', 'Adaptative formating'],
+  [' ', 'Original value'],
+  [',d', ',d (12345.432 => 12,345)'],
   ['.1s', '.1s (12345.432 => 10k)'],
   ['.3s', '.3s (12345.432 => 12.3k)'],
   [',.1%', ',.1% (12345.432 => 1,234,543.2%)'],


### PR DESCRIPTION
### CATEGORY


- [x] Enhancement (new features, refinement)

### SUMMARY

@graceguo-supercat mentioned we don't even have an integer type in number formatting. So let's add one. Also add a "original number" type in case users want to see the raw number.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![image](https://user-images.githubusercontent.com/335541/79514619-77b39c80-7ffb-11ea-9a14-0e8e9f677854.png)
![image](https://user-images.githubusercontent.com/335541/79514722-b77a8400-7ffb-11ea-962d-3eb134ddd23c.png)

### TEST PLAN

1. Go to any chart with number formatting (e.g. Big Number).
2. Make sure the supported formats work as expected.

### ADDITIONAL INFORMATION

- [x] Changes UI

### REVIEWERS

@graceguo-supercat @kristw @evans 