### PR TITLE
chore: Migrate unique FilterBox controls from controls.jsx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -970,7 +970,6 @@ Note not all fields are correctly catagorized. The fields vary based on visualiz
 
 | Field                  | Type            | Notes                                 |
 | ---------------------- | --------------- | ------------------------------------- |
-| `date_filter`          | _N/A_           | _Deprecated?_                         |
 | `date_time_format`     | _N/A_           | _Deprecated?_                         |
 | `druid_time_origin`    | _string_        | The Druid **Origin** widget           |
 | `granularity`          | _string_        | The Druid **Time Granularity** widget |
@@ -1101,7 +1100,6 @@ Note the `y_axis_format` is defined under various section for some charts.
 | `comparison type`               | _N/A_ |       |
 | `contribution`                  | _N/A_ |       |
 | `country_fieldtype`             | _N/A_ |       |
-| `date_filter`                   | _N/A_ |       |
 | `default_filters`               | _N/A_ |       |
 | `entity`                        | _N/A_ |       |
 | `expanded_slices`               | _N/A_ |       |
@@ -1116,7 +1114,6 @@ Note the `y_axis_format` is defined under various section for some charts.
 | `flt_op_1`                      | _N/A_ |       |
 | `goto_dash`                     | _N/A_ |       |
 | `import_time`                   | _N/A_ |       |
-| `instant_filtering`             | _N/A_ |       |
 | `label`                         | _N/A_ |       |
 | `linear_color_scheme`           | _N/A_ |       |
 | `log_scale`                     | _N/A_ |       |
@@ -1150,11 +1147,7 @@ Note the `y_axis_format` is defined under various section for some charts.
 | `show_brush`                    | _N/A_ |       |
 | `show_bubbles`                  | _N/A_ |       |
 | `show_controls`                 | _N/A_ |       |
-| `show_druid_time_granularity`   | _N/A_ |       |
-| `show_druid_time_origin`        | _N/A_ |       |
 | `show_labels`                   | _N/A_ |       |
-| `show_sqla_time_column`         | _N/A_ |       |
-| `show_sqla_time_granularity`    | _N/A_ |       |
 | `show_values`                   | _N/A_ |       |
 | `slice_name`                    | _N/A_ |       |
 | `table_filter`                  | _N/A_ |       |

--- a/superset-frontend/src/explore/controlPanels/FilterBox.jsx
+++ b/superset-frontend/src/explore/controlPanels/FilterBox.jsx
@@ -27,9 +27,70 @@ export default {
       controlSetRows: [
         ['filter_configs'],
         [<hr />],
-        ['date_filter', 'instant_filtering'],
-        ['show_sqla_time_granularity', 'show_sqla_time_column'],
-        ['show_druid_time_granularity', 'show_druid_time_origin'],
+        [
+          {
+            name: 'date_filter',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Date Filter'),
+              default: true,
+              description: t('Whether to include a time filter'),
+            },
+          },
+          {
+            name: 'instant_filtering',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Instant Filtering'),
+              renderTrigger: true,
+              default: true,
+              description:
+                'Whether to apply filters as they change, or wait for ' +
+                'users to hit an [Apply] button',
+            },
+          },
+        ],
+        [
+          {
+            name: 'show_sqla_time_granularity',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show SQL Granularity Dropdown'),
+              default: false,
+              description: t('Check to include SQL Granularity dropdown'),
+            },
+          },
+          ,
+          {
+            name: 'show_sqla_time_column',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show SQL Time Column'),
+              default: false,
+              description: t('Check to include Time Column dropdown'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'show_druid_time_granularity',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show Druid Granularity Dropdown'),
+              default: false,
+              description: t('Check to include Druid Granularity dropdown'),
+            },
+          },
+          {
+            name: 'show_druid_time_origin',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show Druid Time Origin'),
+              default: false,
+              description: t('Check to include Time Origin dropdown'),
+            },
+          },
+        ],
         ['adhoc_filters'],
       ],
     },

--- a/superset-frontend/src/explore/controlPanels/FilterBox.jsx
+++ b/superset-frontend/src/explore/controlPanels/FilterBox.jsx
@@ -60,7 +60,6 @@ export default {
               description: t('Check to include SQL Granularity dropdown'),
             },
           },
-          ,
           {
             name: 'show_sqla_time_column',
             config: {

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -922,16 +922,6 @@ export const controls = {
     ),
   },
 
-  instant_filtering: {
-    type: 'CheckboxControl',
-    label: t('Instant Filtering'),
-    renderTrigger: true,
-    default: true,
-    description:
-      'Whether to apply filters as they change, or wait for ' +
-      'users to hit an [Apply] button',
-  },
-
   show_brush: {
     type: 'SelectControl',
     label: t('Show Range Filter'),
@@ -944,41 +934,6 @@ export const controls = {
       ['auto', 'Auto'],
     ],
     description: t('Whether to display the time range interactive selector'),
-  },
-
-  date_filter: {
-    type: 'CheckboxControl',
-    label: t('Date Filter'),
-    default: true,
-    description: t('Whether to include a time filter'),
-  },
-
-  show_sqla_time_granularity: {
-    type: 'CheckboxControl',
-    label: t('Show SQL Granularity Dropdown'),
-    default: false,
-    description: t('Check to include SQL Granularity dropdown'),
-  },
-
-  show_sqla_time_column: {
-    type: 'CheckboxControl',
-    label: t('Show SQL Time Column'),
-    default: false,
-    description: t('Check to include Time Column dropdown'),
-  },
-
-  show_druid_time_granularity: {
-    type: 'CheckboxControl',
-    label: t('Show Druid Granularity Dropdown'),
-    default: false,
-    description: t('Check to include Druid Granularity dropdown'),
-  },
-
-  show_druid_time_origin: {
-    type: 'CheckboxControl',
-    label: t('Show Druid Time Origin'),
-    default: false,
-    description: t('Check to include Time Origin dropdown'),
   },
 
   table_filter: {


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Move controls only used by FilterBox away from `controls.jsx`.

### TEST PLAN
CI + local testing by clicking through Dashboards with FilterBox and exploring FilterBox chart to ensure everything works like before.

### REVIEWERS
@rusackas @suddjian @kristw 