### PR TITLE
[fix] Fixing issue with Jinja filter_values

### DIFF
--- a/tests/jinja_context_tests.py
+++ b/tests/jinja_context_tests.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+from unittest import mock
+
+from superset.jinja_context import filter_values
+from tests.base_tests import SupersetTestCase
+
+
+class Jinja2ContextTests(SupersetTestCase):
+    def test_filter_values_default(self) -> None:
+        request = mock.MagicMock()
+        request.form = {}
+
+        with mock.patch("superset.jinja_context.request", request):
+            self.assertEquals(filter_values("name", "foo"), ["foo"])
+
+    def test_filter_values_no_default(self) -> None:
+        request = mock.MagicMock()
+        request.form = {}
+
+        with mock.patch("superset.jinja_context.request", request):
+            self.assertEquals(filter_values("name"), [])
+
+    def test_filter_values_adhoc_filters(self) -> None:
+        request = mock.MagicMock()
+
+        request.form = {
+            "form_data": json.dumps(
+                {
+                    "adhoc_filters": [
+                        {
+                            "clause": "WHERE",
+                            "comparator": "foo",
+                            "expressionType": "SIMPLE",
+                            "operator": "in",
+                            "subject": "name",
+                        }
+                    ],
+                }
+            )
+        }
+
+        with mock.patch("superset.jinja_context.request", request):
+            self.assertEquals(filter_values("name"), ["foo"])
+
+        request.form = {
+            "form_data": json.dumps(
+                {
+                    "adhoc_filters": [
+                        {
+                            "clause": "WHERE",
+                            "comparator": ["foo", "bar"],
+                            "expressionType": "SIMPLE",
+                            "operator": "in",
+                            "subject": "name",
+                        }
+                    ],
+                }
+            )
+        }
+
+        with mock.patch("superset.jinja_context.request", request):
+            self.assertEquals(filter_values("name"), ["foo", "bar"])
+
+    def test_filter_values_extra_filters(self) -> None:
+        request = mock.MagicMock()
+
+        request.form = {
+            "form_data": json.dumps(
+                {"extra_filters": [{"col": "name", "op": "in", "val": "foo"}]}
+            )
+        }
+
+        with mock.patch("superset.jinja_context.request", request):
+            self.assertEquals(filter_values("name"), ["foo"])


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

This PR fixes an issue where the Jinja `filter_values` was only adhering to legacy filter constructs (which are still used by the filter box) and thus a query could differ whether executed from a dashboard or from the explorer where the filters are inherited (though in the form of ad-hoc filters). 

The fix is merely to convert the legacy filters to ad-hoc and and merge the extra filters inline with other portions of the code.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Added unit tests and tested manually.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @villebro 
