### PR TITLE
[SQL Lab] Lock result set controls to be always visible

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.jsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.jsx
@@ -143,48 +143,42 @@ export default class ResultSet extends React.PureComponent {
       }
       return (
         <div className="ResultSetControls">
-          <div className="clearfix">
-            <div className="pull-left">
-              <ButtonGroup>
-                {this.props.visualize && (
-                  <ExploreResultsButton
-                    query={this.props.query}
-                    database={this.props.database}
-                    actions={this.props.actions}
-                  />
-                )}
-                {this.props.csv && (
-                  <Button
-                    bsSize="small"
-                    href={'/superset/csv/' + this.props.query.id}
-                  >
-                    <i className="fa fa-file-text-o" /> {t('.CSV')}
-                  </Button>
-                )}
+          <div className="ResultSetButtons">
+            {this.props.visualize && (
+              <ExploreResultsButton
+                query={this.props.query}
+                database={this.props.database}
+                actions={this.props.actions}
+              />
+            )}
+            {this.props.csv && (
+              <Button
+                bsSize="small"
+                href={'/superset/csv/' + this.props.query.id}
+              >
+                <i className="fa fa-file-text-o" /> {t('.CSV')}
+              </Button>
+            )}
 
-                <CopyToClipboard
-                  text={prepareCopyToClipboardTabularData(data)}
-                  wrapped={false}
-                  copyNode={
-                    <Button bsSize="small">
-                      <i className="fa fa-clipboard" /> {t('Clipboard')}
-                    </Button>
-                  }
-                />
-              </ButtonGroup>
-            </div>
-            <div className="pull-right">
-              {this.props.search && (
-                <input
-                  type="text"
-                  onChange={this.changeSearch}
-                  value={this.state.searchText}
-                  className="form-control input-sm"
-                  placeholder={t('Filter Results')}
-                />
-              )}
-            </div>
+            <CopyToClipboard
+              text={prepareCopyToClipboardTabularData(data)}
+              wrapped={false}
+              copyNode={
+                <Button bsSize="small">
+                  <i className="fa fa-clipboard" /> {t('Clipboard')}
+                </Button>
+              }
+            />
           </div>
+          {this.props.search && (
+            <input
+              type="text"
+              onChange={this.changeSearch}
+              value={this.state.searchText}
+              className="form-control input-sm"
+              placeholder={t('Filter Results')}
+            />
+          )}
         </div>
       );
     }

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -359,7 +359,21 @@ div.tablePopover {
 }
 
 .ResultSetControls {
+  display: flex;
+  justify-content: space-between;
   padding: 8px 0;
+  position: fixed;
+}
+
+.ResultSetButtons {
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: 4px;
+  padding-right: 8px;
+}
+
+.filterable-table-container {
+  margin-top: 48px;
 }
 
 .ace_editor {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently, it's possible to scroll the result set controls off screen when you have a very wide result set. This change fixes them to the top of the result set pane so they're always visible and useable


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="1600" alt="Screen Shot 2020-04-19 at 4 35 15 PM" src="https://user-images.githubusercontent.com/7409244/79702959-65389d80-825d-11ea-96b6-c42db4e8d431.png">

After:
<img width="1609" alt="Screen Shot 2020-04-19 at 4 42 27 PM" src="https://user-images.githubusercontent.com/7409244/79702964-6a95e800-825d-11ea-8674-89e4746f26ba.png">

### TEST PLAN
Scroll horizontally in the result pane, see the buttons stick around

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @graceguo-supercat @rusackas @nytai 