### PR TITLE
[Build] moves prettier check to separate script

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -17,6 +17,7 @@ jobs:
       working-directory: ./superset-frontend
       run: |
         npm run lint
+        npm run prettier-check
     - name: unit tests
       working-directory: ./superset-frontend
       run: |

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -13,7 +13,7 @@ jobs:
       uses: apache-superset/cached-dependencies@adc6f73
       with:
         run: npm-install
-    - name: eslint
+    - name: lint
       working-directory: ./superset-frontend
       run: |
         npm run lint

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -17,7 +17,8 @@
     "build-dev": "cross-env NODE_OPTIONS=--max_old_space_size=8192 NODE_ENV=development webpack --mode=development --colors --progress",
     "build-instrumented": "cross-env NODE_ENV=development BABEL_ENV=instrumented webpack --mode=development --colors --progress",
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 NODE_ENV=production webpack --mode=production --colors --progress",
-    "lint": "prettier --check '{src,stylesheets}/**/*.{css,less,sass,scss}' && eslint --ignore-path=.eslintignore --ext .js,.jsx,.ts,.tsx .",
+    "lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx,.ts,.tsx .",
+    "prettier-check": "prettier --check '{src,stylesheets}/**/*.{css,less,sass,scss}'",
     "lint-fix": "eslint --fix --ignore-path=.eslintignore --ext .js,.jsx,.ts,tsx . && npm run clean-css",
     "clean-css": "prettier --write '{src,stylesheets}/**/*.{css,less,sass,scss}'"
   },


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [x] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added the prettier check script a while back to check formatting in css files. It doesn't need to be part of the regular lint check as it delays running eslint and makes passing flags more complicated. However it does need to run on CI to ensure no unformatted css files slip through (eslint isn't checking style files). 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- CI passes and checks js/ts and style files.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
