### PR TITLE
fix: move docs image symlink to _static

### DIFF
--- a/.github/workflows/superset-python.yml
+++ b/.github/workflows/superset-python.yml
@@ -47,8 +47,6 @@ jobs:
         run: |
           pip-install
           pip install -r docs/requirements.txt
-    - name: Copy Images
-      run: cp -r superset-frontend/images/ docs/_static/images/
     - name: Build documentation
       run: sphinx-build -b html docs _build/html -W
 

--- a/docs/_static/images
+++ b/docs/_static/images
@@ -1,0 +1,1 @@
+../../superset-frontend/images

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -16,9 +16,7 @@
 # limitations under the License.
 #
 rm -rf _build
-cp -r ../superset-frontend/images/ _static/images/
 make html
-#cp -r ../superset-frontend/images/ _build/html/_static/img/
 rm -rf /tmp/superset-docs
 cp -r _build/html /tmp/superset-docs
 cp -r _build/html ../superset/static/assets/docs

--- a/docs/images
+++ b/docs/images
@@ -1,1 +1,0 @@
-../superset-frontend/images


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [x] Documentation

### SUMMARY
#9098 introduced a regression in the documentation by placing the images symlink to frontend images in the root of `docs`, not `docs/_static`. This removes the old symlink and recreates the symlink in `docs/_static`.

### SCREEHSHOTS
#### BEFORE
![image](https://user-images.githubusercontent.com/33317356/79725191-8945be80-82f1-11ea-9538-a7ecd6ace191.png)
#### AFTER
![image](https://user-images.githubusercontent.com/33317356/79725158-7a5f0c00-82f1-11ea-9f48-5e0d490bf3f2.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [x] Has associated issue: closes #9581 , closes #9584
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
