### PR TITLE
fix: re-enable table filter

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -40,6 +40,7 @@ import {
 import { UPDATE_COMPONENTS_PARENTS_LIST } from '../actions/dashboardLayout';
 import serializeActiveFilterValues from '../util/serializeActiveFilterValues';
 import serializeFilterScopes from '../util/serializeFilterScopes';
+import isFilterChart from '../util/isFilterChart';
 import { getActiveFilters } from '../util/activeDashboardFilters';
 import { safeStringify } from '../../utils/safeStringify';
 
@@ -285,7 +286,7 @@ export function addSliceToDashboard(id, component) {
     ]).then(() => {
       dispatch(addSlice(selectedSlice));
 
-      if (selectedSlice && selectedSlice.viz_type === 'filter_box') {
+      if (selectedSlice && isFilterChart(selectedSlice)) {
         dispatch(addFilter(id, component, selectedSlice.form_data));
       }
     });
@@ -295,7 +296,7 @@ export function addSliceToDashboard(id, component) {
 export function removeSliceFromDashboard(id) {
   return (dispatch, getState) => {
     const sliceEntity = getState().sliceEntities.slices[id];
-    if (sliceEntity && sliceEntity.viz_type === 'filter_box') {
+    if (sliceEntity && isFilterChart(sliceEntity)) {
       dispatch(removeFilter(id));
     }
 

--- a/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.js
+++ b/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.js
@@ -48,7 +48,6 @@ function getFilterConfigsFromFilterBox(form_data = {}) {
     show_druid_time_origin,
     show_sqla_time_column,
     show_sqla_time_granularity,
-    table_filter,
   } = form_data;
   const configs = { columns: {}, labels: {} };
 

--- a/superset-frontend/src/dashboard/util/isFilterChart.js
+++ b/superset-frontend/src/dashboard/util/isFilterChart.js
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-disable camelcase */
+
+/**
+ * Check if a chart is one of the filter chart types, i.e., FilterBox
+ * and any charts with `table_filter = TRUE`.
+ *
+ * TODO: change `table_filter` to a more generic name.
+ */
+export default function isFilterChart(slice) {
+  const { form_data = {} } = slice;
+  const vizType = slice.viz_type || form_data.viz_type;
+  return vizType === 'filter_box' || !!form_data.table_filter;
+}

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -546,10 +546,6 @@ tr.reactable-column-header th.reactable-header-sortable {
   text-align: right;
 }
 
-td.filtered {
-  background-color: lighten(desaturate(@brand-primary, 50%), 50%);
-}
-
 .table-name {
   font-size: @font-size-l;
 }


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix

### SUMMARY

"Emit filter events" on table and deck.gl chart has been broken since the introduction of scoped filters. This PR tries to re-enable it by:

1. Re-enable "emit filter events" in Table chart
2. Treat charts with `table_filter == TRUE` as the same as FilterBox in many places.

Must wait for the accompanying `superet-ui` PR: https://github.com/apache-superset/superset-ui/pull/344

Fixes #8273 #8683 .


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Clicking on non-metric table cells should trigger a filter update:

![image](https://user-images.githubusercontent.com/335541/79723435-9b484280-829a-11ea-9061-aa655a6b1cb5.png)

`lightcyan` is the selected filter. `lightorange` is the hover state.

Users can edit the scopes of a table chart with filter events in the dashboard's filter scope editor:

![image](https://user-images.githubusercontent.com/335541/79780753-3d931500-82f1-11ea-97fb-837b3b80b05d.png)



### TEST PLAN

1. Go to any dashboard with either a FilterBox or table chart with "Emit Filter Events" enabled.
2. Make sure filters and filter event works, make sure you can still edit the dashboard and filter scope.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:  closes #8273 , closes #8683  superset/superset-ui#344
- [x] Changes UI


### REVIEWERS

@graceguo-supercat @kristw @etr2460 @williaster 