### PR TITLE
fix: change number format to original value to "~g"

### DIFF
--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -83,7 +83,7 @@ export const PRIMARY_COLOR = { r: 0, g: 122, b: 135, a: 1 };
 // input choices & options
 export const D3_FORMAT_OPTIONS = [
   ['SMART_NUMBER', 'Adaptative formating'],
-  [' ', 'Original value'],
+  ['~g', 'Original value'],
   [',d', ',d (12345.432 => 12,345)'],
   ['.1s', '.1s (12345.432 => 10k)'],
   ['.3s', '.3s (12345.432 => 12.3k)'],


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix

### SUMMARY

https://github.com/apache/incubator-superset/pull/9562 adds number formatters for original value and integers. This PR changes number formatter for original value from `" "` (a space character) to `~g` (decimal or exponential notation without trailing zeros). The original formatter `" "` is a valid d3 format and does return the original value as expected, but cannot be used as a registry key for `superset-ui/number-format`. 

This is because the registry [automatically trims the registry key][1] while creating a formatter, but when obtaining a formatter it [returns `undefined` for an empty string `""`][2]. 

This is problematic when users changes the formatters back and forth in Explore view, resulting in JS errors.

![image](https://user-images.githubusercontent.com/335541/79946402-c2cb1680-8424-11ea-86a9-81dad8963f91.png)


[1]: https://github.com/apache-superset/superset-ui/blob/44ad062dd02d080362dac28782c0327cc9fa3445/packages/superset-ui-number-format/src/NumberFormatterRegistry.ts#L30
[2]: https://github.com/apache-superset/superset-ui/blob/dc804b7a707e0cb8c29fc129bfff2c9aa143fd62/packages/superset-ui-core/src/models/RegistryWithDefaultKey.ts#L36

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A


### TEST PLAN

1. Go to line chart
2. Change number formatters back and forth between "Original value" and others
3. It shouldn't throw JS errors when you hover on the chart for tooltips.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

@etr2460 @kristw @graceguo-supercat 