### PR TITLE
[sql_lab] Improve performance, only use slow func when needed

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -60,12 +60,14 @@ class ParsedQuery:
         logger.debug("Parsing with sqlparse statement: %s", self.sql)
         self._parsed = sqlparse.parse(self.stripped())
         for statement in self._parsed:
-            self.__extract_from_token(statement)
             self._limit = _extract_limit_from_query(statement)
-        self._table_names = self._table_names - self._alias_names
 
     @property
     def tables(self) -> Set[str]:
+        if not self._table_names:
+            for statement in self._parsed:
+                self.__extract_from_token(statement)
+            self._table_names = self._table_names - self._alias_names
         return self._table_names
 
     @property


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When quering the examples table `wb_health_population` on SQLLab including all the columns on the statement:

``` sql
SELECT "NY_GNP_PCAP_CD",
       "SE_ADT_1524_LT_FM_ZS",
       "SE_ADT_1524_LT_MA_ZS",
       "SE_ADT_1524_LT_ZS",
       "SE_ADT_LITR_FE_ZS",
  ... (8551 characters truncated) ... _IN_ZS",
       "SP_UWT_TFRT",
       country_code,
       country_name,
       region,
       year
FROM public.wb_health_population
```

The query would take approximately 50s to 70s to complete, yet the query itself only takes 10-20ms to execute. This is due to `ParsedQuery.__extract_from_token` function that extracts all the tables from a query, noticed that the property `tables` itself is seldom used/needed. This is a simple fix, that reduces the time to execute from 50s-70s to 10s-20s so 1/6 of the total time.

Expected, since sql_json execution path instantiates ParsedQuery 6 times.

Simple fix, but the `__extract_from_token` recursive loop should be visited and improved (@lilykuang).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@robdiciuccio @willbarrett 

