### PR TITLE
[statsd] Send time metrics in ms not seconds

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1239,7 +1239,7 @@ def time_function(func: Callable, *args, **kwargs) -> Tuple[float, Any]:
     start = default_timer()
     response = func(*args, **kwargs)
     stop = default_timer()
-    return stop - start, response
+    return (stop - start) * 1000.0, response
 
 
 def MediumText() -> Variant:


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Fix, statsd metrics were being reported in seconds, while all other metrics were in milliseconds (better). Simple PR that fixes it. This avoids loosing granularity also

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@lilykuang 