### PR TITLE
[database] Fix, test connection error message for module not found

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1376,7 +1376,7 @@ class Superset(BaseSupersetView):
         except CertificateException as ex:
             logger.info(ex.message)
             return json_error_response(ex.message)
-        except NoSuchModuleError as ex:
+        except (NoSuchModuleError, ModuleNotFoundError) as ex:
             logger.info("Invalid driver %s", ex)
             driver_name = make_url(uri).drivername
             return json_error_response(

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -551,6 +551,25 @@ class CoreTests(SupersetTestCase):
             expected_body,
         )
 
+        data = json.dumps(
+            {
+                "uri": "mssql+pymssql://url",
+                "name": "examples",
+                "impersonate_user": False,
+            }
+        )
+        response = self.client.post(
+            "/superset/testconn", data=data, content_type="application/json"
+        )
+        assert response.status_code == 400
+        assert response.headers["Content-Type"] == "application/json"
+        response_body = json.loads(response.data.decode("utf-8"))
+        expected_body = {"error": "Could not load database driver: mssql+pymssql"}
+        assert response_body == expected_body, "%s != %s" % (
+            response_body,
+            expected_body,
+        )
+
     def test_testconn_unsafe_uri(self, username="admin"):
         self.login(username=username)
         app.config["PREVENT_UNSAFE_DB_CONNECTIONS"] = True


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
On MSSQL and probably using other drivers, if `pymssql` is missing `testconn` API response is "Unexpected error occurred, please check your logs for details" and should be "Could not load database driver: ..."

### TEST PLAN
- Create a database connection with: `mssql+pymssql://someserver:1433/test`
- Check that the error reported is "ERROR: Could not load database driver: mssql+pymssql"

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
