### PR TITLE
[fix] Fixing regression from #9161

### DIFF
--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -17,6 +17,7 @@
 # isort:skip_file
 from typing import Any, Dict, NamedTuple, List, Tuple, Union
 
+import tests.test_app
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.db_engine_specs.druid import DruidEngineSpec
 from superset.models.core import Database

--- a/tox.ini
+++ b/tox.ini
@@ -33,14 +33,6 @@ setenv =
 whitelist_externals =
     npm
 
-[testenv:thumbnails]
-setenv =
-    SUPERSET_CONFIG = tests.superset_test_config_thumbnails
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
-    .[postgres]
-
 [testenv:black]
 commands =
     black --check setup.py superset tests
@@ -99,6 +91,14 @@ setenv =
     SUPERSET_CONFIG = tests.superset_test_config_sqllab_backend_persist
     SUPERSET_HOME = {envtmpdir}
 
+[testenv:docs]
+commands =
+    sphinx-build -b html docs _build/html -W
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+    -rdocs/requirements.txt
+
 [testenv:eslint]
 changedir = {toxinidir}/superset-frontend
 commands =
@@ -156,28 +156,27 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 
-[testenv:docs]
-commands =
-    cp -r superset-frontend/images/ docs/_static/images/
-    sphinx-build -b html docs _build/html -W
+[testenv:thumbnails]
+setenv =
+    SUPERSET_CONFIG = tests.superset_test_config_thumbnails
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
-    -rdocs/requirements.txt
+    .[postgres]
 
 [tox]
 envlist =
-    fossa
     black
     cypress-dashboard
     cypress-explore
     cypress-sqllab
     cypress-sqllab-backend-persist
+    docs
     eslint
+    fossa
     isort
     javascript
+    license-check
     mypy
     pylint
-    license-check
-    docs
 skipsdist = true


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Fixing a regression introduced in https://github.com/apache/incubator-superset/pull/9161 as `tests.test_app` is a requirement if running only the tests in the `sqla_models_tests.py` file. 

This PR also ensures that the `tox.ini` commands are in alphabetical order. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Ran, 

```
tox -e py36-sqlite -- tests/sqla_models_tests.py 
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @etr2460 @villebro 