### PR TITLE
[mssql] Fix, apply limit and set alias for functions

### DIFF
--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -16,9 +16,8 @@
 # under the License.
 import logging
 import re
-from typing import TYPE_CHECKING
 from datetime import datetime
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, TYPE_CHECKING
 
 from sqlalchemy.types import String, TypeEngine, UnicodeText
 
@@ -87,13 +86,5 @@ class MssqlEngineSpec(BaseEngineSpec):
 
     @classmethod
     def apply_limit_to_sql(cls, sql: str, limit: int, database: "Database") -> str:
-        """
-        Alters the SQL statement to apply a LIMIT clause
-
-        :param sql: SQL query
-        :param limit: Maximum number of rows to be returned by the query
-        :param database: Database instance
-        :return: SQL query with limit clause
-        """
         new_sql = ParsedQuery(sql).set_alias()
         return super().apply_limit_to_sql(new_sql, limit, database)

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -283,7 +283,7 @@ class ParsedQuery:
             elif isinstance(token, Function) and token.ttype is None:
                 if not token.has_alias():
                     token.value = (
-                        f"{token.value} as {token.get_real_name()}_{changed_counter}"
+                        f"{token.value} AS {token.get_real_name()}_{changed_counter}"
                     )
                 new_sql += str(token.value)
             # Nothing to change, assemble what we have

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -263,6 +263,7 @@ class ParsedQuery:
         :return: String with new aliased SQL query
         """
         new_sql = ""
+        changed_counter = 1
         for token in self._parsed[0].tokens:
             # Identifier list (list of columns)
             if isinstance(token, IdentifierList) and token.ttype is None:
@@ -270,8 +271,10 @@ class ParsedQuery:
                     # Functions are anonymous on MSSQL
                     if isinstance(identifier, Function) and not identifier.has_alias():
                         identifier.value = (
-                            f"{identifier.value} as {identifier.get_real_name()}"
+                            f"{identifier.value} as"
+                            f" {identifier.get_real_name()}_{changed_counter}"
                         )
+                        changed_counter += 1
                     new_sql += str(identifier.value)
                     # If not last identifier
                     if i != len(list(token.get_identifiers())) - 1:
@@ -279,7 +282,9 @@ class ParsedQuery:
             # Just a lonely function?
             elif isinstance(token, Function) and token.ttype is None:
                 if not token.has_alias():
-                    token.value = f"{token.value} as {token.get_real_name()}"
+                    token.value = (
+                        f"{token.value} as {token.get_real_name()}_{changed_counter}"
+                    )
                 new_sql += str(token.value)
             # Nothing to change, assemble what we have
             else:

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -271,7 +271,7 @@ class ParsedQuery:
                     # Functions are anonymous on MSSQL
                     if isinstance(identifier, Function) and not identifier.has_alias():
                         identifier.value = (
-                            f"{identifier.value} as"
+                            f"{identifier.value} AS"
                             f" {identifier.get_real_name()}_{changed_counter}"
                         )
                         changed_counter += 1

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -256,6 +256,12 @@ class ParsedQuery:
         return str_res
 
     def set_alias(self) -> str:
+        """
+        Returns a new query string where all functions have alias.
+        This is particularly necessary for MSSQL engines.
+
+        :return: String with new aliased SQL query
+        """
         new_sql = ""
         for token in self._parsed[0].tokens:
             # Identifier list (list of columns)

--- a/tests/db_engine_specs/mssql_tests.py
+++ b/tests/db_engine_specs/mssql_tests.py
@@ -119,7 +119,7 @@ class MssqlEngineSpecTest(DbEngineSpecTestCase):
 
             expected_sql = (
                 "SELECT TOP 1000 * \n"
-                "FROM (SELECT COUNT(*) as COUNT FROM FOO_TABLE) AS inner_qry"
+                "FROM (SELECT COUNT(*) as COUNT_1 FROM FOO_TABLE) AS inner_qry"
             )
             self.assertEqual(expected_sql, limited_sql)
 
@@ -128,7 +128,7 @@ class MssqlEngineSpecTest(DbEngineSpecTestCase):
 
             expected_sql = (
                 "SELECT TOP 1000 * \n"
-                "FROM (SELECT COUNT(*) as COUNT, SUM(id) as SUM FROM FOO_TABLE) "
+                "FROM (SELECT COUNT(*) as COUNT_1, SUM(id) as SUM_2 FROM FOO_TABLE) "
                 "AS inner_qry"
             )
             self.assertEqual(expected_sql, limited_sql)
@@ -138,8 +138,17 @@ class MssqlEngineSpecTest(DbEngineSpecTestCase):
 
             expected_sql = (
                 "SELECT TOP 1000 * \n"
-                "FROM (SELECT COUNT(*) as COUNT, "
+                "FROM (SELECT COUNT(*) as COUNT_1, "
                 "FOO_COL1 FROM FOO_TABLE GROUP BY FOO_COL1)"
+                " AS inner_qry"
+            )
+            self.assertEqual(expected_sql, limited_sql)
+
+            test_sql = "SELECT COUNT(*), COUNT(*) FROM FOO_TABLE"
+            limited_sql = MssqlEngineSpec.apply_limit_to_sql(test_sql, 1000, database)
+            expected_sql = (
+                "SELECT TOP 1000 * \n"
+                "FROM (SELECT COUNT(*) as COUNT_1, COUNT(*) as COUNT_2 FROM FOO_TABLE)"
                 " AS inner_qry"
             )
             self.assertEqual(expected_sql, limited_sql)

--- a/tests/db_engine_specs/mssql_tests.py
+++ b/tests/db_engine_specs/mssql_tests.py
@@ -119,7 +119,7 @@ class MssqlEngineSpecTest(DbEngineSpecTestCase):
 
             expected_sql = (
                 "SELECT TOP 1000 * \n"
-                "FROM (SELECT COUNT(*) as COUNT_1 FROM FOO_TABLE) AS inner_qry"
+                "FROM (SELECT COUNT(*) AS COUNT_1 FROM FOO_TABLE) AS inner_qry"
             )
             self.assertEqual(expected_sql, limited_sql)
 
@@ -128,7 +128,7 @@ class MssqlEngineSpecTest(DbEngineSpecTestCase):
 
             expected_sql = (
                 "SELECT TOP 1000 * \n"
-                "FROM (SELECT COUNT(*) as COUNT_1, SUM(id) as SUM_2 FROM FOO_TABLE) "
+                "FROM (SELECT COUNT(*) AS COUNT_1, SUM(id) AS SUM_2 FROM FOO_TABLE) "
                 "AS inner_qry"
             )
             self.assertEqual(expected_sql, limited_sql)
@@ -138,7 +138,7 @@ class MssqlEngineSpecTest(DbEngineSpecTestCase):
 
             expected_sql = (
                 "SELECT TOP 1000 * \n"
-                "FROM (SELECT COUNT(*) as COUNT_1, "
+                "FROM (SELECT COUNT(*) AS COUNT_1, "
                 "FOO_COL1 FROM FOO_TABLE GROUP BY FOO_COL1)"
                 " AS inner_qry"
             )
@@ -148,7 +148,7 @@ class MssqlEngineSpecTest(DbEngineSpecTestCase):
             limited_sql = MssqlEngineSpec.apply_limit_to_sql(test_sql, 1000, database)
             expected_sql = (
                 "SELECT TOP 1000 * \n"
-                "FROM (SELECT COUNT(*) as COUNT_1, COUNT(*) as COUNT_2 FROM FOO_TABLE)"
+                "FROM (SELECT COUNT(*) AS COUNT_1, COUNT(*) AS COUNT_2 FROM FOO_TABLE)"
                 " AS inner_qry"
             )
             self.assertEqual(expected_sql, limited_sql)

--- a/tests/db_engine_specs/mssql_tests.py
+++ b/tests/db_engine_specs/mssql_tests.py
@@ -15,15 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest.mock as mock
+from typing import Optional
 
 from sqlalchemy import column, table
 from sqlalchemy.dialects import mssql
 from sqlalchemy.dialects.mssql import DATE, NTEXT, NVARCHAR, TEXT, VARCHAR
-from sqlalchemy.sql import select
+from sqlalchemy.sql import select, Select
 from sqlalchemy.types import String, UnicodeText
 
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.mssql import MssqlEngineSpec
+from superset.extensions import db
+from superset.models.core import Database
 from tests.db_engine_specs.base_tests import DbEngineSpecTestCase
 
 
@@ -95,47 +98,53 @@ class MssqlEngineSpecTest(DbEngineSpecTestCase):
             self.assertEqual(actual, expected)
 
     def test_apply_limit(self):
-        from superset.models.core import Database
-        from superset.extensions import db
+        def compile_sqla_query(qry: Select, schema: Optional[str] = None) -> str:
+            return str(
+                qry.compile(
+                    dialect=mssql.dialect(), compile_kwargs={"literal_binds": True}
+                )
+            )
 
-        mssql_database = Database(
+        database = Database(
             database_name="mssql_test",
             sqlalchemy_uri="mssql+pymssql://sa:Password_123@localhost:1433/msdb",
         )
-        db.session.add(mssql_database)
+        db.session.add(database)
         db.session.commit()
 
-        test_sql = "SELECT COUNT(*) FROM FOO_TABLE"
+        with mock.patch.object(database, "compile_sqla_query", new=compile_sqla_query):
+            test_sql = "SELECT COUNT(*) FROM FOO_TABLE"
 
-        limited_sql = MssqlEngineSpec.apply_limit_to_sql(test_sql, 1000, mssql_database)
+            limited_sql = MssqlEngineSpec.apply_limit_to_sql(test_sql, 1000, database)
 
-        expected_sql = (
-            "SELECT TOP 1000 * \n"
-            "FROM (SELECT COUNT(*) as COUNT FROM FOO_TABLE) AS inner_qry"
-        )
-        self.assertEqual(expected_sql, limited_sql)
+            expected_sql = (
+                "SELECT TOP 1000 * \n"
+                "FROM (SELECT COUNT(*) as COUNT FROM FOO_TABLE) AS inner_qry"
+            )
+            self.assertEqual(expected_sql, limited_sql)
 
-        test_sql = "SELECT COUNT(*), SUM(id) FROM FOO_TABLE"
-        limited_sql = MssqlEngineSpec.apply_limit_to_sql(test_sql, 1000, mssql_database)
+            test_sql = "SELECT COUNT(*), SUM(id) FROM FOO_TABLE"
+            limited_sql = MssqlEngineSpec.apply_limit_to_sql(test_sql, 1000, database)
 
-        expected_sql = (
-            "SELECT TOP 1000 * \n"
-            "FROM (SELECT COUNT(*) as COUNT, SUM(id) as SUM FROM FOO_TABLE) "
-            "AS inner_qry"
-        )
-        self.assertEqual(expected_sql, limited_sql)
+            expected_sql = (
+                "SELECT TOP 1000 * \n"
+                "FROM (SELECT COUNT(*) as COUNT, SUM(id) as SUM FROM FOO_TABLE) "
+                "AS inner_qry"
+            )
+            self.assertEqual(expected_sql, limited_sql)
 
-        test_sql = "SELECT COUNT(*), FOO_COL1 FROM FOO_TABLE GROUP BY FOO_COL1"
-        limited_sql = MssqlEngineSpec.apply_limit_to_sql(test_sql, 1000, mssql_database)
+            test_sql = "SELECT COUNT(*), FOO_COL1 FROM FOO_TABLE GROUP BY FOO_COL1"
+            limited_sql = MssqlEngineSpec.apply_limit_to_sql(test_sql, 1000, database)
 
-        expected_sql = (
-            "SELECT TOP 1000 * \n"
-            "FROM (SELECT COUNT(*) as COUNT, FOO_COL1 FROM FOO_TABLE GROUP BY FOO_COL1)"
-            " AS inner_qry"
-        )
-        self.assertEqual(expected_sql, limited_sql)
+            expected_sql = (
+                "SELECT TOP 1000 * \n"
+                "FROM (SELECT COUNT(*) as COUNT, "
+                "FOO_COL1 FROM FOO_TABLE GROUP BY FOO_COL1)"
+                " AS inner_qry"
+            )
+            self.assertEqual(expected_sql, limited_sql)
 
-        db.session.delete(mssql_database)
+        db.session.delete(database)
         db.session.commit()
 
     @mock.patch.object(


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [X] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
On MSSQL queries executed on SQLLab that contained functions were failing. Found that this was mainly related to the fact that functions on MSSQL are anonymous, this raises errors when applying limits or even without applying any limit.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
