### PR TITLE
fix: adhoc filter 'equals' doesn't let you save

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,celery,click,colorama,contextlib2,croniter,cryptography,dataclasses,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,celery,click,colorama,contextlib2,croniter,cryptography,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/superset-frontend/spec/javascripts/explore/AdhocFilter_spec.js
+++ b/superset-frontend/spec/javascripts/explore/AdhocFilter_spec.js
@@ -153,6 +153,36 @@ describe('AdhocFilter', () => {
     });
     // eslint-disable-next-line no-unused-expressions
     expect(adhocFilter5.isValid()).toBe(true);
+
+    const adhocFilter6 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: 'value',
+      operator: '==',
+      comparator: 1,
+      clause: CLAUSES.WHERE,
+    });
+    // eslint-disable-next-line no-unused-expressions
+    expect(adhocFilter6.isValid()).toBe(true);
+
+    const adhocFilter7 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: 'value',
+      operator: '==',
+      comparator: 0,
+      clause: CLAUSES.WHERE,
+    });
+    // eslint-disable-next-line no-unused-expressions
+    expect(adhocFilter7.isValid()).toBe(true);
+
+    const adhocFilter8 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: 'value',
+      operator: '==',
+      comparator: null,
+      clause: CLAUSES.WHERE,
+    });
+    // eslint-disable-next-line no-unused-expressions
+    expect(adhocFilter8.isValid()).toBe(false);
   });
 
   it('can translate from simple expressions to sql expressions', () => {

--- a/superset-frontend/src/explore/AdhocFilter.js
+++ b/superset-frontend/src/explore/AdhocFilter.js
@@ -135,13 +135,17 @@ export default class AdhocFilter {
         return !!(this.operator && this.subject);
       }
 
-      return !!(
-        this.operator &&
-        this.subject &&
-        this.comparator &&
-        this.comparator.length > 0 &&
-        this.clause
-      );
+      if (this.operator && this.subject && this.clause) {
+        if (Array.isArray(this.comparator)) {
+          if (this.comparator.length > 0) {
+            // A non-empty array of values ('IN' or 'NOT IN' clauses)
+            return true;
+          }
+        } else if (this.comparator !== null) {
+          // A value has been selected or typed
+          return true;
+        }
+      }
     } else if (this.expressionType === EXPRESSION_TYPES.SQL) {
       return !!(this.sqlExpression && this.clause);
     }

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from dataclasses import dataclass
 from typing import List, Optional, Set
 from urllib import parse
 
 import sqlparse
-from dataclasses import dataclass
 from sqlparse.sql import (
     Function,
     Identifier,


### PR DESCRIPTION
## before
<img width="346" alt="Screen Shot 2020-04-25 at 7 03 10 PM" src="https://user-images.githubusercontent.com/487433/80295427-6e2ae280-8727-11ea-8d13-edd10fb56d01.png">

## after
<img width="365" alt="Screen Shot 2020-04-25 at 7 02 46 PM" src="https://user-images.githubusercontent.com/487433/80295429-6ff4a600-8727-11ea-9a5b-c0ea5318f450.png">

Applies to `equals` and `does not equal`