### PR TITLE
fix: autocomplete search in AdhocFilter operator dropdown

### DIFF
--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -313,7 +313,11 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
         .filter(operator =>
           this.isOperatorRelevant(operator, adhocFilter.subject),
         )
-        .map(operator => ({ operator })),
+        .map(operator => ({
+          operator,
+          label: translateOperator(operator),
+          value: operator,
+        })),
       value: adhocFilter.operator,
       onChange: this.onOperatorChange,
       optionRenderer: VirtualizedRendererWrap(operator =>


### PR DESCRIPTION
Searching for 'equ' in AdhocFilter's operator dropdown doesn't find the
options who's label contain that substring.

I'd write a unit test but it's pretty tricky. 

## before
<img width="358" alt="Screen Shot 2020-04-25 at 8 25 38 PM" src="https://user-images.githubusercontent.com/487433/80296829-f2cf2e00-8732-11ea-9394-40892d999291.png">

## after
<img width="356" alt="Screen Shot 2020-04-25 at 8 21 16 PM" src="https://user-images.githubusercontent.com/487433/80296831-f367c480-8732-11ea-892c-1c795281987d.png">
