### PR TITLE
build: set up GitHub app PRLint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,3 @@
-### CATEGORY
-
-Choose one
-
-- [ ] Bug Fix
-- [ ] Enhancement (new features, refinement)
-- [ ] Refactor
-- [ ] Add tests
-- [ ] Build / Development Environment
-- [ ] Documentation
-
 ### SUMMARY
 <!--- Describe the change below, including rationale and design decisions -->
 
@@ -27,5 +16,3 @@ Choose one
 - [ ] Confirm DB Migration upgrade and downgrade tested.
 - [ ] Introduces new feature or API
 - [ ] Removes existing feature or API
-
-### REVIEWERS

--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,0 +1,8 @@
+{
+  "title": [
+    {
+      "pattern": "^(build|ci|docs|feat|fix|perf|refactor|style|test|other)((.+))?:\\s.+",
+      "message": "Your title needs to be prefixed with a topic."
+    }
+  ]
+}


### PR DESCRIPTION
~~Sets up [gitlint](https://jorisroovers.com/gitlint/), which enforces [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and sets up the proper post commit hook to enforce it.~~

~~Also modifying the PR template to remove redundant annoying checkbox section. Once we adopt, I'm hoping we can modify our bot to auto-label based on the commit type.~~

~~This requires a bit more discipline upfront, but should lead to a cleaner `git log` in master, meaning better release notes and such.~~

- [x] waiting for Apache infra to install PRLint Github App. [JIRA](https://issues.apache.org/jira/browse/INFRA-20236) 

Sets up [PRLint](https://github.com/apps/prlint), with a single rule matching [Conventional
Commits](https://www.conventionalcommits.org/en/v1.0.0/)

Also modifying the PR template to remove redundant annoying checkbox section.

Once we adopt, I'm hoping we can modify our bot to auto-label based on the commit type.