### PR TITLE
[fix] Support APP_ICON_WIDTH configuration parameter in SPA menu

### DIFF
--- a/superset-frontend/spec/javascripts/components/Menu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/Menu_spec.jsx
@@ -75,6 +75,7 @@ const defaultProps = {
       path: '/superset/profile/admin/',
       icon: '/static/assets/images/superset-logo@2x.png',
       alt: 'Superset',
+      width: '126',
     },
     navbar_right: {
       bug_report_url: null,

--- a/superset-frontend/src/components/Menu/Menu.jsx
+++ b/superset-frontend/src/components/Menu/Menu.jsx
@@ -33,6 +33,7 @@ const propTypes = {
       path: PropTypes.string.isRequired,
       icon: PropTypes.string.isRequired,
       alt: PropTypes.string.isRequired,
+      width: PropTypes.string,
     }).isRequired,
     navbar_right: PropTypes.shape({
       bug_report_url: PropTypes.string,
@@ -59,7 +60,7 @@ export default function Menu({
         <Navbar.Header>
           <Navbar.Brand>
             <a className="navbar-brand" href={brand.path}>
-              <img width="126" src={brand.icon} alt={brand.alt} />
+              <img width={brand.width} src={brand.icon} alt={brand.alt} />
             </a>
           </Navbar.Brand>
           <Navbar.Toggle />

--- a/superset-frontend/src/components/Menu/Menu.jsx
+++ b/superset-frontend/src/components/Menu/Menu.jsx
@@ -33,7 +33,7 @@ const propTypes = {
       path: PropTypes.string.isRequired,
       icon: PropTypes.string.isRequired,
       alt: PropTypes.string.isRequired,
-      width: PropTypes.string,
+      width: PropTypes.string.isRequired,
     }).isRequired,
     navbar_right: PropTypes.shape({
       bug_report_url: PropTypes.string,

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -241,7 +241,7 @@ def menu_data():
             "path": root_path,
             "icon": appbuilder.app_icon,
             "alt": appbuilder.app_name,
-            "width": appbuilder.app.config.get("APP_ICON_WIDTH"),
+            "width": appbuilder.app.config["APP_ICON_WIDTH"],
         },
         "navbar_right": {
             "bug_report_url": appbuilder.app.config.get("BUG_REPORT_URL"),

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -241,6 +241,7 @@ def menu_data():
             "path": root_path,
             "icon": appbuilder.app_icon,
             "alt": appbuilder.app_name,
+            "width": appbuilder.app.config.get("APP_ICON_WIDTH"),
         },
         "navbar_right": {
             "bug_report_url": appbuilder.app.config.get("BUG_REPORT_URL"),


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The SPA menu component was relying on a hardcoded icon width of 126. This change exposes the config.py APP_ICON_WIDTH property to the frontend through the apps bootstrapping process and alters the SPA menu component to consume this value as the logo image width.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
n/a

### TEST PLAN
Set APP_ICON_WIDTH property to a value other than 126 and observe the SPA and template version of the header have matching logo sizes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
