### PR TITLE
Fix api limits in react CRUD

### DIFF
--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -64,6 +64,10 @@ class BaseSupersetModelRestApi(ModelRestApi):
     Extends FAB's ModelResApi to implement specific superset generic functionality
     """
 
+    # Removes the local limit for the page size
+    # React CRUD UI cannot handle pagination yet.
+    max_page_size = -1
+    page_size = -1
     csrf_exempt = False
     method_permission_name = {
         "get_list": "list",


### PR DESCRIPTION
### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Currently react CRUD is only limited to the 20 items for the api requests.
This PR sets page size to -1 to remove this restriction.
This bug makes filtering by related fields unusable.

e.g. https://github.com/apache/incubator-superset/blob/5e535062da95135b133f9b924fe93501ae6fcc41/superset-frontend/src/dashboard/components/PropertiesModal.jsx#L116

### TEST PLAN
Tested locally 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@dpgaspar 
@nytai 
@villebro 