### PR TITLE
FilterBox,BigNumber,WorldMap: Handle empty results

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1129,6 +1129,9 @@ class BigNumberViz(BaseViz):
         return d
 
     def get_data(self, df: pd.DataFrame) -> VizData:
+        if df.empty:
+            return None
+
         df = df.pivot_table(
             index=DTTM_ALIAS,
             columns=[],
@@ -1854,6 +1857,9 @@ class WorldMapViz(BaseViz):
         return qry
 
     def get_data(self, df: pd.DataFrame) -> VizData:
+        if df.empty:
+            return None
+
         from superset.examples import countries
 
         fd = self.form_data
@@ -1928,7 +1934,7 @@ class FilterBoxViz(BaseViz):
             col = flt.get("column")
             metric = flt.get("metric")
             df = self.dataframes.get(col)
-            if df is not None:
+            if df is not None and not df.empty:
                 if metric:
                     df = df.sort_values(
                         utils.get_metric_name(metric), ascending=flt.get("asc")
@@ -1943,6 +1949,8 @@ class FilterBoxViz(BaseViz):
                         {"id": row[0], "text": row[0]}
                         for row in df.itertuples(index=False)
                     ]
+        if not d:
+            return None
         return d
 
 


### PR DESCRIPTION
This change avoids Pandas errors to pop up in chart when no data
is returned (confusing users). In this way a nicer "No Results etc.." is returned.

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Add some checks to avoid Pandas errors to bubble up to the users.

### TEST PLAN
Using "legacy" Druid datasources and setting charts to return no data.
Before the fix:
<img width="366" alt="Screen Shot 2020-05-04 at 12 50 59 PM" src="https://user-images.githubusercontent.com/1536240/80958843-f71bdb00-8e05-11ea-8b07-2ad15ccc688a.png">
<img width="362" alt="Screen Shot 2020-05-04 at 12 50 46 PM" src="https://user-images.githubusercontent.com/1536240/80958844-f84d0800-8e05-11ea-8a67-e6768c4da101.png">

After:
<img width="400" alt="Screen Shot 2020-05-04 at 12 47 39 PM" src="https://user-images.githubusercontent.com/1536240/80958875-07cc5100-8e06-11ea-96ec-bea5807685f3.png">


### ADDITIONAL INFORMATION
None

### REVIEWERS
