### PR TITLE
refactor(sql): optimize sql query parser

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -219,9 +219,10 @@ class ParsedQuery:
         <Identifier> store a list of subtokens and <IdentifierList> store lists of
         subtoken list.
 
-        It extracts <IdentifierList> and <Identifier> from :param token: and loops through
-        all subtokens recursively. It finds table_name_preceding_token and passes
-        <IdentifierList> and <Identifier> to self._process_tokenlist to populate self._tables.
+        It extracts <IdentifierList> and <Identifier> from :param token: and loops
+        through all subtokens recursively. It finds table_name_preceding_token and
+        passes <IdentifierList> and <Identifier> to self._process_tokenlist to populate
+        self._tables.
 
         :param token: instance of Token or child class, e.g. TokenList, to be processed
         """

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -224,11 +224,9 @@ class ParsedQuery:
             return
 
         table_name_preceding_token = False
+        tokens = self.__process_token_group(token.tokens)
 
-        for item in token.tokens:
-            if item.is_group and not self._is_identifier(item):
-                self._extract_from_token(item)
-
+        for item in tokens:
             if item.ttype in Keyword and (
                 item.normalized in PRECEDES_TABLE_NAME
                 or item.normalized.endswith(" JOIN")
@@ -251,6 +249,15 @@ class ParsedQuery:
                 for token2 in item.tokens:
                     if not self._is_identifier(token2):
                         self._extract_from_token(item)
+
+    def __process_token_group(self, tokens):  # flatten nested tokens to 1D array
+        while any(i.is_group and not self._is_identifier(i) for i in tokens):
+            tokens = [
+                j
+                for i in tokens
+                for j in (i if i.is_group and not self._is_identifier(i) else [i])
+            ]
+        return tokens
 
     def set_or_update_query_limit(self, new_limit: int) -> str:
         """Returns the query with the specified limit.

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -216,7 +216,12 @@ class ParsedQuery:
 
     def _extract_from_token(self, token: Token):  # pylint: disable=too-many-branches
         """
-        Populate self._tables from token
+        <Identifier> store a list of subtokens and <IdentifierList> store lists of
+        subtoken list.
+
+        It extracts <IdentifierList> and <Identifier> from :param token: and loops through
+        all subtokens recursively. It finds table_name_preceding_token and passes
+        <IdentifierList> and <Identifier> to self._process_tokenlist to populate self._tables.
 
         :param token: instance of Token or child class, e.g. TokenList, to be processed
         """

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -224,9 +224,11 @@ class ParsedQuery:
             return
 
         table_name_preceding_token = False
-        tokens = self.__process_token_group(token.tokens)
 
-        for item in tokens:
+        for item in token.tokens:
+            if item.is_group and not self._is_identifier(item):
+                self._extract_from_token(item)
+
             if item.ttype in Keyword and (
                 item.normalized in PRECEDES_TABLE_NAME
                 or item.normalized.endswith(" JOIN")
@@ -246,18 +248,8 @@ class ParsedQuery:
                         if isinstance(token2, TokenList):
                             self._process_tokenlist(token2)
             elif isinstance(item, IdentifierList):
-                for token2 in item.tokens:
-                    if not self._is_identifier(token2):
-                        self._extract_from_token(item)
-
-    def __process_token_group(self, tokens):  # flatten nested tokens to 1D array
-        while any(i.is_group and not self._is_identifier(i) for i in tokens):
-            tokens = [
-                j
-                for i in tokens
-                for j in (i if i.is_group and not self._is_identifier(i) else [i])
-            ]
-        return tokens
+                if any(not self._is_identifier(token2) for token2 in item.tokens):
+                    self._extract_from_token(item)
 
     def set_or_update_query_limit(self, new_limit: int) -> str:
         """Returns the query with the specified limit.


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When I was researching on optimizing sql parser, I have tried using [`flatten`](https://sqlparse.readthedocs.io/en/latest/analyzing/#sqlparse.sql.TokenList.flatten) method to reduce processing time. However, `flatten` turns sql query into 1 dimensional iterator and it loses the ability to identify item as tokenList. TokenList is used as identifier to process as a table, see below https://github.com/apache/incubator-superset/blob/e5c3e8964d8933069569809325200474157592c2/superset/sql_parse.py#L171-L175

I have found that  `_extract_from_token` was recursively called on the same `item` for n times (n is length of `item.tokens`). It could be called only one time for `item`


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
