### PR TITLE
fix(tests): custom filter flaky tests on dash and charts

### DIFF
--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -556,9 +556,9 @@ class ChartApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
         Chart API: Test get charts custom filter
         """
         admin = self.get_user("admin")
-        chart1 = self.insert_chart("foo", [admin.id], 1, description="ZY_bar")
+        chart1 = self.insert_chart("foo_a", [admin.id], 1, description="ZY_bar")
         chart2 = self.insert_chart("zy_foo", [admin.id], 1, description="desc1")
-        chart3 = self.insert_chart("foo", [admin.id], 1, description="desc1zy_")
+        chart3 = self.insert_chart("foo_b", [admin.id], 1, description="desc1zy_")
         chart4 = self.insert_chart("bar", [admin.id], 1, description="foo")
 
         arguments = {
@@ -567,6 +567,8 @@ class ChartApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
             ],
             "order_column": "slice_name",
             "order_direction": "asc",
+            "keys": ["none"],
+            "columns": ["slice_name", "description"],
         }
         self.login(username="admin")
         uri = f"api/v1/chart/?q={prison.dumps(arguments)}"
@@ -576,8 +578,8 @@ class ChartApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
         self.assertEqual(data["count"], 3)
 
         expected_response = [
-            {"description": "ZY_bar", "slice_name": "foo",},
-            {"description": "desc1zy_", "slice_name": "foo",},
+            {"description": "ZY_bar", "slice_name": "foo_a",},
+            {"description": "desc1zy_", "slice_name": "foo_b",},
             {"description": "desc1", "slice_name": "zy_foo",},
         ]
         for index, item in enumerate(data["result"]):

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -195,9 +195,9 @@ class DashboardApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
         Dashboard API: Test get dashboards custom filter
         """
         admin = self.get_user("admin")
-        dashboard1 = self.insert_dashboard("foo", "ZY_bar", [admin.id])
+        dashboard1 = self.insert_dashboard("foo_a", "ZY_bar", [admin.id])
         dashboard2 = self.insert_dashboard("zy_foo", "slug1", [admin.id])
-        dashboard3 = self.insert_dashboard("foo", "slug1zy_", [admin.id])
+        dashboard3 = self.insert_dashboard("foo_b", "slug1zy_", [admin.id])
         dashboard4 = self.insert_dashboard("bar", "foo", [admin.id])
 
         arguments = {
@@ -206,6 +206,8 @@ class DashboardApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
             ],
             "order_column": "dashboard_title",
             "order_direction": "asc",
+            "keys": ["none"],
+            "columns": ["dashboard_title", "slug"],
         }
         self.login(username="admin")
         uri = f"api/v1/dashboard/?q={prison.dumps(arguments)}"
@@ -215,8 +217,8 @@ class DashboardApiTests(SupersetTestCase, ApiOwnersTestCaseMixin):
         self.assertEqual(data["count"], 3)
 
         expected_response = [
-            {"slug": "ZY_bar", "dashboard_title": "foo",},
-            {"slug": "slug1zy_", "dashboard_title": "foo",},
+            {"slug": "ZY_bar", "dashboard_title": "foo_a",},
+            {"slug": "slug1zy_", "dashboard_title": "foo_b",},
             {"slug": "slug1", "dashboard_title": "zy_foo",},
         ]
         for index, item in enumerate(data["result"]):


### PR DESCRIPTION
### CATEGORY

- [X] Bug Fix

### SUMMARY
Tests for custom filters on dashboards and charts are flaky, since we have two rows with "foo"

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
