### PR TITLE
[fix] reduce table metadata fetch for latest_partition check

### DIFF
--- a/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
@@ -95,15 +95,18 @@ export default class AdhocFilterControl extends React.Component {
   componentDidMount() {
     const { datasource } = this.props;
     if (datasource && datasource.type === 'table') {
-      const dbId = datasource.database ? datasource.database.id : null;
-      const datasourceName = datasource.datasource_name;
-      const datasourceSchema = datasource.schema;
+      const dbId = datasource.database?.id;
+      const {
+        datasource_name: name,
+        schema,
+        is_sqllab_view: isSqllabView,
+      } = datasource;
 
-      if (dbId && datasourceName && datasourceSchema) {
+      if (!isSqllabView && dbId && name && schema) {
         SupersetClient.get({
-          endpoint: `/superset/extra_table_metadata/${dbId}/${datasourceName}/${datasourceSchema}/`,
-        }).then(
-          ({ json }) => {
+          endpoint: `/superset/extra_table_metadata/${dbId}/${name}/${schema}/`,
+        })
+          .then(({ json }) => {
             if (json && json.partitions) {
               const partitions = json.partitions;
               // for now only show latest_partition option
@@ -125,9 +128,10 @@ export default class AdhocFilterControl extends React.Component {
                 );
               }
             }
-          },
-          // no error handler, in case of error do not show partition option
-        );
+          })
+          .catch(error => {
+            console.log('fetch extra_table_metadata:', error.statusText);
+          });
       }
     }
   }

--- a/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
@@ -130,7 +130,8 @@ export default class AdhocFilterControl extends React.Component {
             }
           })
           .catch(error => {
-            console.log('fetch extra_table_metadata:', error.statusText);
+            /* eslint-disable no-debugger, no-console */
+            console.error('fetch extra_table_metadata:', error.statusText);
           });
       }
     }

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -581,6 +581,7 @@ class SqlaTable(Model, BaseDatasource):
             d["main_dttm_col"] = self.main_dttm_col
             d["fetch_values_predicate"] = self.fetch_values_predicate
             d["template_params"] = self.template_params
+            d["is_sqllab_view"] = self.is_sqllab_view
         return d
 
     def values_for_column(self, column_name: str, limit: int = 10000) -> List:


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In #9637 I added an API call to `/superset/extra_table_metadata` to check datasource table's metadata, if it has partition then show extra adhoc filter operator.  But virtual table (with is_sqllab_view flag is True) doesn't have real table exists, so above metadata check will return server side error. 

This PR is to add is_sqllab_view check before fetching table metadata.

### TEST PLAN
Manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9637 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 