### PR TITLE
Make cache work again for annotations

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -84,6 +84,7 @@ class AnnotationDatasource(BaseDatasource):
     """
 
     cache_timeout = 0
+    changed_on = None
 
     def query(self, query_obj: Dict[str, Any]) -> QueryResult:
         error_message = None


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix

### SUMMARY
Partially fixes: https://github.com/apache/incubator-superset/issues/9545
There is another issue with RLS and annotations, will have a separate PR for it.

`cache_dict["changed_on"] = self.datasource.changed_on` - causes the issue
https://github.com/apache/incubator-superset/blob/8d2165d96d85024483226090cd2a8825a934422c/superset/viz.py#L403
AnnotationDatasource doesn't have a table and is a dummy object, this all sqllachemy fields are not working and are returning the empty objects that are not serializable.

Fix here is just to set changed_on to the None.

```
class AnnotationDatasource(BaseDatasource):
    """ Dummy object so we can query annotations using 'Viz' objects just like
        regular datasources.
    """
```
https://github.com/apache/incubator-superset/blob/955a4fe7925c76b2ffdd838c68099952f9595ed7/superset/connectors/sqla/models.py#L81

### TEST PLAN
Locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:

### REVIEWERS
@dpgaspar @villebro 