### PR TITLE
Catch db_engine_spec.get_function_names exceptions

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -165,7 +165,13 @@ class Database(
 
     @property
     def function_names(self) -> List[str]:
-        return self.db_engine_spec.get_function_names(self)
+        try:
+            return self.db_engine_spec.get_function_names(self)
+        except Exception as ex:  # pylint: disable=broad-except
+            # function_names property is used in bulk APIs and should not hard crash
+            # more info in: https://github.com/apache/incubator-superset/issues/9678
+            logger.error(f"Failed to fetch database function names with error: {ex}")
+        return []
 
     @property
     def allows_cost_estimate(self) -> bool:


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix

### SUMMARY
Short term fix for the https://github.com/apache/incubator-superset/issues/9678
Databases api fetches all database function names, it requires the databases to be online and return the values successfully to be able to fetch the list of the databases.
If it fails sqllab is not able to get the list of the databases and becomes disfunctional

### TEST PLAN
tested on the dropbox staging environment, provided bad DB url and made sure that sqllab works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:

### REVIEWERS
@villebro @dpgaspar 