### PR TITLE
[sqllab] fix, strip comments before parsing statements

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -65,7 +65,10 @@ class ParsedQuery:
         self._limit: Optional[int] = None
 
         logger.debug("Parsing with sqlparse statement: %s", self.sql)
-        self._parsed = sqlparse.parse(self.stripped())
+        self._parsed = sqlparse.parse(
+            sqlparse.format(self.stripped(), strip_comments=True)
+        )
+
         for statement in self._parsed:
             self._limit = _extract_limit_from_query(statement)
 

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -487,6 +487,17 @@ class SupersetTestCase(unittest.TestCase):
         expected = ["SELECT * FROM birth_names", "SELECT * FROM birth_names LIMIT 1"]
         self.assertEqual(statements, expected)
 
+    def test_comment_breakdown_statements(self):
+        multi_sql = """
+        SELECT * FROM birth_names;
+        -- some comment
+        """
+        parsed = sql_parse.ParsedQuery(multi_sql)
+        statements = parsed.get_statements()
+        self.assertEqual(len(statements), 1)
+        expected = ["SELECT * FROM birth_names"]
+        self.assertEqual(statements, expected)
+
     def test_messy_breakdown_statements(self):
         multi_sql = """
         SELECT 1;\t\n\n\n  \t


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
running the following statement in sqllab causes an error if DML is not allowed for a DB.
```sql
-- Note: Unless you save your query, these tabs will NOT persist if you clear your cookies or change browsers.;

SELECT * from flights;
-- test. 
```

The issue is that parsesql is parsing the second comment as a separate statement. We check to see if the statement is a SELECT (it's a comment) and throw an error since the db is readonly. The fix is to stip comments before parsing the query into statements. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@dpgaspar @willbarrett 