### PR TITLE
Fix email reports

### DIFF
--- a/superset/models/schedules.py
+++ b/superset/models/schedules.py
@@ -87,8 +87,8 @@ class SliceEmailSchedule(Model, AuditMixinNullable, ImportMixin, EmailSchedule):
 
 
 def get_scheduler_model(report_type: ScheduleType) -> Optional[Type[EmailSchedule]]:
-    if report_type == ScheduleType.dashboard:
+    if report_type == ScheduleType.dashboard.value:
         return DashboardEmailSchedule
-    elif report_type == ScheduleType.slice:
+    elif report_type == ScheduleType.slice.value:
         return SliceEmailSchedule
     return None

--- a/superset/models/schedules.py
+++ b/superset/models/schedules.py
@@ -29,17 +29,17 @@ from superset.models.helpers import AuditMixinNullable, ImportMixin
 metadata = Model.metadata  # pylint: disable=no-member
 
 
-class ScheduleType(enum.Enum):
+class ScheduleType(str, enum.Enum):
     slice = "slice"
     dashboard = "dashboard"
 
 
-class EmailDeliveryType(enum.Enum):
+class EmailDeliveryType(str, enum.Enum):
     attachment = "Attachment"
     inline = "Inline"
 
 
-class SliceEmailReportFormat(enum.Enum):
+class SliceEmailReportFormat(str, enum.Enum):
     visualization = "Visualization"
     data = "Raw data"
 
@@ -87,8 +87,8 @@ class SliceEmailSchedule(Model, AuditMixinNullable, ImportMixin, EmailSchedule):
 
 
 def get_scheduler_model(report_type: ScheduleType) -> Optional[Type[EmailSchedule]]:
-    if report_type == ScheduleType.dashboard.value:
+    if report_type == ScheduleType.dashboard:
         return DashboardEmailSchedule
-    elif report_type == ScheduleType.slice.value:
+    elif report_type == ScheduleType.slice:
         return SliceEmailSchedule
     return None

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -391,9 +391,9 @@ def schedule_email_report(  # pylint: disable=unused-argument
         schedule.id = schedule_id
         schedule.recipients = recipients
 
-    if report_type == ScheduleType.dashboard:
+    if report_type == ScheduleType.dashboard.value:
         deliver_dashboard(schedule)
-    elif report_type == ScheduleType.slice:
+    elif report_type == ScheduleType.slice.value:
         deliver_slice(schedule)
     else:
         raise RuntimeError("Unknown report type")

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -391,9 +391,9 @@ def schedule_email_report(  # pylint: disable=unused-argument
         schedule.id = schedule_id
         schedule.recipients = recipients
 
-    if report_type == ScheduleType.dashboard.value:
+    if report_type == ScheduleType.dashboard:
         deliver_dashboard(schedule)
-    elif report_type == ScheduleType.slice.value:
+    elif report_type == ScheduleType.slice:
         deliver_slice(schedule)
     else:
         raise RuntimeError("Unknown report type")

--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -156,7 +156,7 @@ class EmailScheduleView(
 class DashboardEmailScheduleView(
     EmailScheduleView
 ):  # pylint: disable=too-many-ancestors
-    schedule_type = ScheduleType.dashboard.value
+    schedule_type = ScheduleType.dashboard
     schedule_type_model = Dashboard
 
     add_title = _("Schedule Email Reports for Dashboards")
@@ -215,7 +215,7 @@ class DashboardEmailScheduleView(
 
 
 class SliceEmailScheduleView(EmailScheduleView):  # pylint: disable=too-many-ancestors
-    schedule_type = ScheduleType.slice.value
+    schedule_type = ScheduleType.slice
     schedule_type_model = Slice
     add_title = _("Schedule Email Reports for Charts")
     edit_title = add_title


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix

### SUMMARY
report_type is serialized and expected to be a string, currently emails are not working on the master. Using ScheduleType.dashboard.value instead of ScheduleType.dashboard fixes the problem.

Introduced in https://github.com/apache/incubator-superset/pull/9586

### TEST PLAN
Tested on the dropbox staging environment

### REVIEWERS
@john-bodley @villebro @dpgaspar 