### PR TITLE
perf(dashboards): improve API performance for dashboards

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ croniter==0.3.31          # via apache-superset (setup.py)
 cryptography==2.8         # via apache-superset (setup.py)
 decorator==4.4.1          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.3.2   # via apache-superset (setup.py)
+flask-appbuilder==2.3.4   # via apache-superset (setup.py)
 flask-babel==1.0.0        # via flask-appbuilder
 flask-caching==1.8.0      # via apache-superset (setup.py)
 flask-compress==1.4.0     # via apache-superset (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=2.3.2, <2.4.0",
+        "flask-appbuilder>=2.3.4, <2.4.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -95,20 +95,26 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     ]
     order_columns = ["dashboard_title", "changed_on", "published", "changed_by_fk"]
     list_columns = [
+        "id",
+        "published",
+        "slug",
+        "url",
+        "css",
+        "position_json",
+        "json_metadata",
+        "thumbnail_url",
+        "changed_by.first_name",
+        "changed_by.last_name",
+        "changed_by.username",
+        "changed_by.id",
         "changed_by_name",
         "changed_by_url",
-        "changed_by.username",
         "changed_on",
         "dashboard_title",
         "owners.id",
         "owners.username",
         "owners.first_name",
         "owners.last_name",
-        "id",
-        "published",
-        "slug",
-        "url",
-        "thumbnail_url",
     ]
     edit_columns = [
         "dashboard_title",


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [X] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Uses new FAB 2.3.4 that improves performance on table joins. Again like stated on #9619, when using properties has virtual columns, we should to make sure that the method references columns already referenced on `list_columns` or SQLAlchemy will issue a new query

Note: We should merge #9703 first

Before:
[stats_logger] (timing) DashboardRestApi.get_list.time 110ms - 150ms

After:
[stats_logger] (timing) DashboardRestApi.get_list.time 15ms - 30ms

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@willbarrett @nytai 