### PR TITLE
[table editor] hide Edit Datasource option when no onDatasourceSave

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
@@ -20,6 +20,7 @@ import React from 'react';
 import sinon from 'sinon';
 import configureStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
+import { MenuItem } from 'react-bootstrap';
 import DatasourceModal from '../../../../src/datasource/DatasourceModal';
 import ChangeDatasourceModal from '../../../../src/datasource/ChangeDatasourceModal';
 import DatasourceControl from '../../../../src/explore/components/controls/DatasourceControl';
@@ -44,10 +45,14 @@ const defaultProps = {
 };
 
 describe('DatasourceControl', () => {
-  function setup() {
+  function setup(overrideProps) {
     const mockStore = configureStore([]);
     const store = mockStore({});
-    return shallow(<DatasourceControl {...defaultProps} />, {
+    const props = {
+      ...defaultProps,
+      ...overrideProps,
+    };
+    return shallow(<DatasourceControl {...props} />, {
       context: { store },
     });
   }
@@ -60,5 +65,27 @@ describe('DatasourceControl', () => {
   it('renders a ChangeDatasourceModal', () => {
     const wrapper = setup();
     expect(wrapper.find(ChangeDatasourceModal)).toHaveLength(1);
+  });
+
+  it('show or hide Edit Datasource option', () => {
+    let wrapper = setup();
+    expect(wrapper.find('#datasource_menu')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('#datasource_menu')
+        .dive()
+        .find(MenuItem),
+    ).toHaveLength(2);
+
+    wrapper = setup({
+      onDatasourceSave: () => {},
+    });
+    expect(wrapper.find('#datasource_menu')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('#datasource_menu')
+        .dive()
+        .find(MenuItem),
+    ).toHaveLength(3);
   });
 });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -48,7 +48,7 @@ const propTypes = {
 
 const defaultProps = {
   onChange: () => {},
-  onDatasourceSave: () => {},
+  onDatasourceSave: null,
   value: null,
 };
 
@@ -150,9 +150,11 @@ class DatasourceControl extends React.PureComponent {
                   {t('Explore in SQL Lab')}
                 </MenuItem>
               )}
-              <MenuItem eventKey="3" onClick={this.toggleEditDatasourceModal}>
-                {t('Edit Datasource')}
-              </MenuItem>
+              {this.props.onDatasourceSave && (
+                <MenuItem eventKey="3" onClick={this.toggleEditDatasourceModal}>
+                  {t('Edit Datasource')}
+                </MenuItem>
+              )}
             </DropdownButton>
           </TooltipWrapper>
           <OverlayTrigger

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -150,7 +150,7 @@ class DatasourceControl extends React.PureComponent {
                   {t('Explore in SQL Lab')}
                 </MenuItem>
               )}
-              {this.props.onDatasourceSave && (
+              {!!this.props.onDatasourceSave && (
                 <MenuItem eventKey="3" onClick={this.toggleEditDatasourceModal}>
                   {t('Edit Datasource')}
                 </MenuItem>


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This PR will hide `Edit Datasource` option when no onDatasourceSave props is passed in.

<img width="395" alt="Screen Shot 2020-04-30 at 11 21 01 AM" src="https://user-images.githubusercontent.com/27990562/80745542-4e077480-8ad5-11ea-8bf4-e6b2682d988e.png">


### TEST PLAN
CI and manual test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 @mistercrunch @michellethomas 