### PR TITLE
Use monospace font in the superset timers

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -158,6 +158,7 @@ div.Workspace {
 
       &:last-child {
         margin-right: 0;
+        font-feature-settings: 'kern' 1, 'tnum' 1;
       }
     }
   }


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix

### SUMMARY
Truncates timer to seconds, ms make ui very jiggly
More info in https://github.com/apache/incubator-superset/issues/9708

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![jumpy_timer_sqllab](https://user-images.githubusercontent.com/5727938/80824560-879eb500-8b93-11ea-9cd2-476889a108e9.gif)
after
![timer_in_seconds](https://user-images.githubusercontent.com/5727938/80824675-c9c7f680-8b93-11ea-8e73-8b7d7848dc7c.gif)


### TEST PLAN
Locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/9708
- [x] Changes UI

### REVIEWERS
