### PR TITLE
[caching] Using request context rather than globals

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1715,9 +1715,13 @@ class Superset(BaseSupersetView):
                     force=True,
                 )
 
-                g.form_data = form_data
-                payload = obj.get_payload()
-                delattr(g, "form_data")
+                # Temporarily define the form-data in the request context which may be
+                # leveraged by the Jinja macros.
+                with app.test_request_context(
+                    data={"form_data": json.dumps(form_data)}
+                ):
+                    payload = obj.get_payload()
+
                 error = payload["error"]
                 status = payload["status"]
             except Exception as ex:

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib import parse
 
 import simplejson as json
-from flask import g, request
+from flask import request
 
 import superset.models.core as models
 from superset import app, db, is_feature_enabled
@@ -110,10 +110,6 @@ def get_form_data(
     # request params can overwrite the body
     if request_args_data:
         form_data.update(json.loads(request_args_data))
-
-    # Fallback to using the Flask globals (used for cache warmup) if defined.
-    if not form_data and hasattr(g, "form_data"):
-        form_data = getattr(g, "form_data")
 
     url_id = request.args.get("r")
     if url_id:

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1312,19 +1312,3 @@ class UtilsTestCase(SupersetTestCase):
             )
 
             self.assertEqual(slc, None)
-
-    def test_get_form_data_globals(self) -> None:
-        with app.test_request_context():
-            g.form_data = {"foo": "bar"}
-            form_data, slc = get_form_data()
-            delattr(g, "form_data")
-
-            self.assertEqual(
-                form_data,
-                {
-                    "foo": "bar",
-                    "time_range_endpoints": get_time_range_endpoints(form_data={}),
-                },
-            )
-
-            self.assertEqual(slc, None)


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

@villebro I was thinking some more about the cache warmup and the form-data problem, and for testing we were leveraging [test_request_context](https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.test_request_context) which creates a `RequestContext` and I wondered if using that was cleaner than temporarily leveraging `g`.  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS

to: @villebro 