### PR TITLE
[perf logging] Add timing event when browser tab is hidden

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -30,7 +30,7 @@ import {
   dashboardStatePropShape,
 } from '../util/propShapes';
 import {
-  LOG_ACTIONS_HIDDEN_BROWSER_TAB,
+  LOG_ACTIONS_HIDE_BROWSER_TAB,
   LOG_ACTIONS_MOUNT_DASHBOARD,
   Logger,
 } from '../../logger/LogUtils';
@@ -184,11 +184,11 @@ class Dashboard extends React.PureComponent {
         start_offset: Logger.getTimestamp(),
         ts: new Date().getTime(),
       };
-    } else {
+    } else if (document.visibilityState === 'visible') {
       // from hidden to visible
       const logStart = this.visibilityEventData.start_offset;
-      this.props.actions.logEvent(LOG_ACTIONS_HIDDEN_BROWSER_TAB, {
-        ...this.visibilityEventData.start_offset,
+      this.props.actions.logEvent(LOG_ACTIONS_HIDE_BROWSER_TAB, {
+        ...this.visibilityEventData,
         duration: Logger.getTimestamp() - logStart,
       });
     }

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -29,7 +29,11 @@ import {
   dashboardInfoPropShape,
   dashboardStatePropShape,
 } from '../util/propShapes';
-import { LOG_ACTIONS_MOUNT_DASHBOARD } from '../../logger/LogUtils';
+import {
+  LOG_ACTIONS_HIDDEN_BROWSER_TAB,
+  LOG_ACTIONS_MOUNT_DASHBOARD,
+  Logger,
+} from '../../logger/LogUtils';
 import OmniContainer from '../../components/OmniContainer';
 import { areObjectsEqual } from '../../reduxUtils';
 
@@ -81,6 +85,8 @@ class Dashboard extends React.PureComponent {
   constructor(props) {
     super(props);
     this.appliedFilters = props.activeFilters || {};
+
+    this.onVisibilityChange = this.onVisibilityChange.bind(this);
   }
 
   componentDidMount() {
@@ -90,6 +96,15 @@ class Dashboard extends React.PureComponent {
       eventData.target_id = directLinkComponentId;
     }
     this.props.actions.logEvent(LOG_ACTIONS_MOUNT_DASHBOARD, eventData);
+
+    // Handle browser tab visibility change
+    if (document.visibilityState === 'hidden') {
+      this.visibilityEventData = {
+        start_offset: Logger.getTimestamp(),
+        ts: new Date().getTime(),
+      };
+    }
+    window.addEventListener('visibilitychange', this.onVisibilityChange);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -155,6 +170,27 @@ class Dashboard extends React.PureComponent {
       Dashboard.onBeforeUnload(true);
     } else {
       Dashboard.onBeforeUnload(false);
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('visibilitychange', this.onVisibilityChange);
+  }
+
+  onVisibilityChange() {
+    if (document.visibilityState === 'hidden') {
+      // from visible to hidden
+      this.visibilityEventData = {
+        start_offset: Logger.getTimestamp(),
+        ts: new Date().getTime(),
+      };
+    } else {
+      // from hidden to visible
+      const logStart = this.visibilityEventData.start_offset;
+      this.props.actions.logEvent(LOG_ACTIONS_HIDDEN_BROWSER_TAB, {
+        ...this.visibilityEventData.start_offset,
+        duration: Logger.getTimestamp() - logStart,
+      });
     }
   }
 

--- a/superset-frontend/src/logger/LogUtils.js
+++ b/superset-frontend/src/logger/LogUtils.js
@@ -19,7 +19,7 @@
 // Log event names ------------------------------------------------------------
 export const LOG_ACTIONS_LOAD_CHART = 'load_chart';
 export const LOG_ACTIONS_RENDER_CHART = 'render_chart';
-export const LOG_ACTIONS_HIDDEN_BROWSER_TAB = 'hidden_browser_tab';
+export const LOG_ACTIONS_HIDE_BROWSER_TAB = 'hide_browser_tab';
 
 export const LOG_ACTIONS_MOUNT_DASHBOARD = 'mount_dashboard';
 export const LOG_ACTIONS_MOUNT_EXPLORER = 'mount_explorer';
@@ -42,7 +42,7 @@ export const LOG_ACTIONS_OMNIBAR_TRIGGERED = 'omnibar_triggered';
 export const LOG_EVENT_TYPE_TIMING = new Set([
   LOG_ACTIONS_LOAD_CHART,
   LOG_ACTIONS_RENDER_CHART,
-  LOG_ACTIONS_HIDDEN_BROWSER_TAB,
+  LOG_ACTIONS_HIDE_BROWSER_TAB,
 ]);
 export const LOG_EVENT_TYPE_USER = new Set([
   LOG_ACTIONS_MOUNT_DASHBOARD,

--- a/superset-frontend/src/logger/LogUtils.js
+++ b/superset-frontend/src/logger/LogUtils.js
@@ -19,6 +19,7 @@
 // Log event names ------------------------------------------------------------
 export const LOG_ACTIONS_LOAD_CHART = 'load_chart';
 export const LOG_ACTIONS_RENDER_CHART = 'render_chart';
+export const LOG_ACTIONS_HIDDEN_BROWSER_TAB = 'hidden_browser_tab';
 
 export const LOG_ACTIONS_MOUNT_DASHBOARD = 'mount_dashboard';
 export const LOG_ACTIONS_MOUNT_EXPLORER = 'mount_explorer';
@@ -41,6 +42,7 @@ export const LOG_ACTIONS_OMNIBAR_TRIGGERED = 'omnibar_triggered';
 export const LOG_EVENT_TYPE_TIMING = new Set([
   LOG_ACTIONS_LOAD_CHART,
   LOG_ACTIONS_RENDER_CHART,
+  LOG_ACTIONS_HIDDEN_BROWSER_TAB,
 ]);
 export const LOG_EVENT_TYPE_USER = new Set([
   LOG_ACTIONS_MOUNT_DASHBOARD,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When dashboard is landed in a hidden browser tab, charts are not fetched until user focus on the browser tab again. See this doc: https://developers.google.com/web/updates/2017/03/background_tabs

When airbnb measure dashboard performance, we count page load time is from navigation start till all charts are loaded and rendered in the dashboard. When user open dashboard in a hidden tab, for example, ctrl+click a dashboard link, dashboard will be open in a new tab, but charts will not be loaded until user focus on this tab, and the whole hidden mode time is counted as dashboard load time.

This PR is to add a timing_event in dashboard perf logging data. It should log the total duration time that dashboard is in the hidden tab.

### TEST PLAN
Manual test.


### REVIEWERS
@etr2460 