### PR TITLE
feat: implement csv upload configuration func for the schema enforcement

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -586,10 +586,22 @@ CSV_TO_HIVE_UPLOAD_S3_BUCKET = None
 # The directory within the bucket specified above that will
 # contain all the external tables
 CSV_TO_HIVE_UPLOAD_DIRECTORY = "EXTERNAL_HIVE_TABLES/"
+# Function that creates upload directory dynamically based on the database used, user and schema provided.
+CSV_TO_HIVE_UPLOAD_DIRECTORY_FUNC: Callable[
+    ["Database", "models.User", str], Optional[str]
+] = lambda database, user, schema: CSV_TO_HIVE_UPLOAD_DIRECTORY
 
 # The namespace within hive where the tables created from
 # uploading CSVs will be stored.
+# Make it a func, e.g. /hive/warehouse/<dbname>.db/<tablename>
 UPLOADED_CSV_HIVE_NAMESPACE = None
+
+# database
+ALLOWED_USER_CSV_SCHEMA_FUNC: Callable[
+    ["Database", "models.User"], Optional[str]
+] = lambda database, user: [
+    UPLOADED_CSV_HIVE_NAMESPACE
+] if UPLOADED_CSV_HIVE_NAMESPACE else []
 
 # A dictionary of items that gets merged into the Jinja context for
 # SQL Lab. The existing context gets updated with this dictionary,

--- a/superset/config.py
+++ b/superset/config.py
@@ -586,21 +586,25 @@ CSV_TO_HIVE_UPLOAD_S3_BUCKET = None
 # The directory within the bucket specified above that will
 # contain all the external tables
 CSV_TO_HIVE_UPLOAD_DIRECTORY = "EXTERNAL_HIVE_TABLES/"
-# Function that creates upload directory dynamically based on the database used, user and schema provided.
+# Function that creates upload directory dynamically based on the
+# database used, user and schema provided.
 CSV_TO_HIVE_UPLOAD_DIRECTORY_FUNC: Callable[
     ["Database", "models.User", str], Optional[str]
 ] = lambda database, user, schema: CSV_TO_HIVE_UPLOAD_DIRECTORY
 
 # The namespace within hive where the tables created from
 # uploading CSVs will be stored.
-# Make it a func, e.g. /hive/warehouse/<dbname>.db/<tablename>
 UPLOADED_CSV_HIVE_NAMESPACE = None
 
-# database
+# Function that computes the allowed schemas for the CSV uploads.
+# Allowed schemas will be a union of schemas_allowed_for_csv_upload
+# db configuration and a result of this function.
+
+# mypy doesn't catch that if case ensures list content being always str
 ALLOWED_USER_CSV_SCHEMA_FUNC: Callable[
-    ["Database", "models.User"], Optional[str]
+    ["Database", "models.User"], List[str]
 ] = lambda database, user: [
-    UPLOADED_CSV_HIVE_NAMESPACE
+    UPLOADED_CSV_HIVE_NAMESPACE  # type: ignore
 ] if UPLOADED_CSV_HIVE_NAMESPACE else []
 
 # A dictionary of items that gets merged into the Jinja context for

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -18,7 +18,6 @@
 import hashlib
 import json
 import logging
-import os
 import re
 from contextlib import closing
 from datetime import datetime
@@ -49,7 +48,6 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import quoted_name, text
 from sqlalchemy.sql.expression import ColumnClause, ColumnElement, Select, TextAsFrom
 from sqlalchemy.types import TypeEngine
-from wtforms.form import Form
 
 from superset import app, sql_parse
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -454,55 +452,27 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         df.to_sql(**kwargs)
 
     @classmethod
-    def create_table_from_csv(cls, form: Form, database: "Database") -> None:
+    def create_table_from_csv(  # pylint: disable=too-many-arguments
+        cls,
+        filename: str,
+        table_name: str,
+        schema_name: str,
+        database: "Database",
+        csv_to_df_kwargs: Dict[str, Any],
+        df_to_sql_kwargs: Dict[str, Any],
+    ) -> None:
         """
         Create table from contents of a csv. Note: this method does not create
         metadata for the table.
-
-        :param form: Parameters defining how to process data
-        :param database: Database model object for the target database
         """
-
-        def _allowed_file(filename: str) -> bool:
-            # Only allow specific file extensions as specified in the config
-            extension = os.path.splitext(filename)[1].lower()
-            return (
-                extension is not None and extension[1:] in config["ALLOWED_EXTENSIONS"]
-            )
-
-        filename = form.csv_file.data.filename
-
-        if not _allowed_file(filename):
-            raise Exception("Invalid file type selected")
-        csv_to_df_kwargs = {
-            "filepath_or_buffer": filename,
-            "sep": form.sep.data,
-            "header": form.header.data if form.header.data else 0,
-            "index_col": form.index_col.data,
-            "mangle_dupe_cols": form.mangle_dupe_cols.data,
-            "skipinitialspace": form.skipinitialspace.data,
-            "skiprows": form.skiprows.data,
-            "nrows": form.nrows.data,
-            "skip_blank_lines": form.skip_blank_lines.data,
-            "parse_dates": form.parse_dates.data,
-            "infer_datetime_format": form.infer_datetime_format.data,
-            "chunksize": 10000,
-        }
-        df = cls.csv_to_df(**csv_to_df_kwargs)
-
+        df = cls.csv_to_df(filepath_or_buffer=filename, **csv_to_df_kwargs,)
         engine = cls.get_engine(database)
-
-        df_to_sql_kwargs = {
-            "df": df,
-            "name": form.name.data,
-            "con": engine,
-            "schema": form.schema.data,
-            "if_exists": form.if_exists.data,
-            "index": form.index.data,
-            "index_label": form.index_label.data,
-            "chunksize": 10000,
-        }
-        cls.df_to_sql(**df_to_sql_kwargs)
+        if schema_name:
+            # only add schema when it is preset and non empty
+            df_to_sql_kwargs["schema"] = schema_name
+        if engine.dialect.supports_multivalues_insert:
+            df_to_sql_kwargs["method"] = "multi"
+        cls.df_to_sql(df=df, con=engine, **df_to_sql_kwargs)
 
     @classmethod
     def convert_dttm(cls, target_type: str, dttm: datetime) -> Optional[str]:

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -52,6 +52,7 @@ from sqlalchemy.types import TypeEngine
 from superset import app, sql_parse
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.models.sql_lab import Query
+from superset.sql_parse import Table
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
@@ -455,8 +456,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     def create_table_from_csv(  # pylint: disable=too-many-arguments
         cls,
         filename: str,
-        table_name: str,
-        schema_name: str,
+        table: Table,
         database: "Database",
         csv_to_df_kwargs: Dict[str, Any],
         df_to_sql_kwargs: Dict[str, Any],
@@ -467,9 +467,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         df = cls.csv_to_df(filepath_or_buffer=filename, **csv_to_df_kwargs,)
         engine = cls.get_engine(database)
-        if schema_name:
+        if table.schema:
             # only add schema when it is preset and non empty
-            df_to_sql_kwargs["schema"] = schema_name
+            df_to_sql_kwargs["schema"] = table.schema
         if engine.dialect.supports_multivalues_insert:
             df_to_sql_kwargs["method"] = "multi"
         cls.df_to_sql(df=df, con=engine, **df_to_sql_kwargs)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -609,6 +609,11 @@ class Database(
     def get_schema_access_for_csv_upload(  # pylint: disable=invalid-name
         self,
     ) -> List[str]:
+        if hasattr(g, "user"):
+            allowed_databases = config["ALLOWED_USER_CSV_SCHEMA_FUNC"](self, g.user)
+            if allowed_databases:
+                return allowed_databases
+
         return self.get_extra().get("schemas_allowed_for_csv_upload", [])
 
     @property

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -609,12 +609,13 @@ class Database(
     def get_schema_access_for_csv_upload(  # pylint: disable=invalid-name
         self,
     ) -> List[str]:
+        allowed_databases = self.get_extra().get("schemas_allowed_for_csv_upload", [])
         if hasattr(g, "user"):
-            allowed_databases = config["ALLOWED_USER_CSV_SCHEMA_FUNC"](self, g.user)
-            if allowed_databases:
-                return allowed_databases
-
-        return self.get_extra().get("schemas_allowed_for_csv_upload", [])
+            extra_allowed_databases = config["ALLOWED_USER_CSV_SCHEMA_FUNC"](
+                self, g.user
+            )
+            allowed_databases += extra_allowed_databases
+        return sorted(set(allowed_databases))
 
     @property
     def sqlalchemy_uri_decrypted(self) -> str:

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -24,6 +24,8 @@ import io
 import json
 import logging
 import os
+from typing import Dict, List, Optional
+
 import pytz
 import random
 import re
@@ -769,102 +771,130 @@ class CoreTests(SupersetTestCase):
         self.get_json_resp(slc_url, {"form_data": json.dumps(slc.form_data)})
         self.assertEqual(1, qry.count())
 
-    def test_import_csv(self):
-        self.login(username="admin")
-        table_name = "".join(random.choice(string.ascii_uppercase) for _ in range(5))
+    def create_sample_csvfile(self, filename: str, content: List[str]) -> None:
+        with open(filename, "w+") as test_file:
+            for l in content:
+                test_file.write(f"{l}\n")
 
-        filename_1 = "testCSV.csv"
-        test_file_1 = open(filename_1, "w+")
-        test_file_1.write("a,b\n")
-        test_file_1.write("john,1\n")
-        test_file_1.write("paul,2\n")
-        test_file_1.close()
-
-        filename_2 = "testCSV2.csv"
-        test_file_2 = open(filename_2, "w+")
-        test_file_2.write("b,c,d\n")
-        test_file_2.write("john,1,x\n")
-        test_file_2.write("paul,2,y\n")
-        test_file_2.close()
-
-        example_db = utils.get_example_database()
-        example_db.allow_csv_upload = True
-        db_id = example_db.id
+    def enable_csv_upload(self, database: models.Database) -> None:
+        """Enables csv upload in the given database."""
+        database.allow_csv_upload = True
         db.session.commit()
+        add_datasource_page = self.get_resp("/databaseview/list/")
+        self.assertIn("Upload a CSV", add_datasource_page)
+
+        form_get = self.get_resp("/csvtodatabaseview/form")
+        self.assertIn("CSV to Database configuration", form_get)
+
+    def upload_csv(
+        self, filename: str, table_name: str, extra: Optional[Dict[str, str]] = None
+    ):
         form_data = {
-            "csv_file": open(filename_1, "rb"),
+            "csv_file": open(filename, "rb"),
             "sep": ",",
             "name": table_name,
-            "con": db_id,
+            "con": utils.get_example_database().id,
             "if_exists": "fail",
             "index_label": "test_label",
             "mangle_dupe_cols": False,
         }
-        url = "/databaseview/list/"
-        add_datasource_page = self.get_resp(url)
-        self.assertIn("Upload a CSV", add_datasource_page)
+        if extra:
+            form_data.update(extra)
+        return self.get_resp("/csvtodatabaseview/form", data=form_data)
 
-        url = "/csvtodatabaseview/form"
-        form_get = self.get_resp(url)
-        self.assertIn("CSV to Database configuration", form_get)
+    @mock.patch(
+        "superset.models.core.config",
+        {**app.config, "ALLOWED_USER_CSV_SCHEMA_FUNC": lambda d, u: ["admin_database"]},
+    )
+    def test_import_csv_enforced_schema(self):
+        if utils.get_example_database().backend == "sqlite":
+            # sqlite doesn't support schema / database creation
+            return
+        self.login(username="admin")
+        table_name = "".join(random.choice(string.ascii_lowercase) for _ in range(5))
+        full_table_name = f"admin_database.{table_name}"
+        filename = "testCSV.csv"
+        self.create_sample_csvfile(filename, ["a,b", "john,1", "paul,2"])
+        try:
+            self.enable_csv_upload(utils.get_example_database())
+
+            # no schema specified, fail upload
+            resp = self.upload_csv(filename, table_name)
+            self.assertIn(
+                'Database "examples" schema "None" is not allowed for csv uploads', resp
+            )
+
+            # user specified schema matches the expected schema, append
+            success_msg = f'CSV file "{filename}" uploaded to table "{full_table_name}"'
+            resp = self.upload_csv(
+                filename,
+                table_name,
+                extra={"schema": "admin_database", "if_exists": "append"},
+            )
+            self.assertIn(success_msg, resp)
+
+            resp = self.upload_csv(
+                filename,
+                table_name,
+                extra={"schema": "admin_database", "if_exists": "replace"},
+            )
+            self.assertIn(success_msg, resp)
+
+            # user specified schema doesn't match, fail
+            resp = self.upload_csv(filename, table_name, extra={"schema": "gold"})
+            self.assertIn(
+                'Database "examples" schema "gold" is not allowed for csv uploads',
+                resp,
+            )
+        finally:
+            os.remove(filename)
+
+    def test_import_csv(self):
+        self.login(username="admin")
+        table_name = "".join(random.choice(string.ascii_uppercase) for _ in range(5))
+
+        f1 = "testCSV.csv"
+        self.create_sample_csvfile(f1, ["a,b", "john,1", "paul,2"])
+        f2 = "testCSV2.csv"
+        self.create_sample_csvfile(f2, ["b,c,d", "john,1,x", "paul,2,y"])
+        self.enable_csv_upload(utils.get_example_database())
 
         try:
+            success_msg_f1 = f'CSV file "{f1}" uploaded to table "{table_name}"'
+
             # initial upload with fail mode
-            resp = self.get_resp(url, data=form_data)
-            self.assertIn(
-                f'CSV file "{filename_1}" uploaded to table "{table_name}"', resp
-            )
+            resp = self.upload_csv(f1, table_name)
+            self.assertIn(success_msg_f1, resp)
 
             # upload again with fail mode; should fail
-            form_data["csv_file"] = open(filename_1, "rb")
-            resp = self.get_resp(url, data=form_data)
-            self.assertIn(
-                f'Unable to upload CSV file "{filename_1}" to table "{table_name}"',
-                resp,
-            )
+            fail_msg = f'Unable to upload CSV file "{f1}" to table "{table_name}"'
+            resp = self.upload_csv(f1, table_name)
+            self.assertIn(fail_msg, resp)
 
             # upload again with append mode
-            form_data["csv_file"] = open(filename_1, "rb")
-            form_data["if_exists"] = "append"
-            resp = self.get_resp(url, data=form_data)
-            self.assertIn(
-                f'CSV file "{filename_1}" uploaded to table "{table_name}"', resp
-            )
+            resp = self.upload_csv(f1, table_name, extra={"if_exists": "append"})
+            self.assertIn(success_msg_f1, resp)
 
             # upload again with replace mode
-            form_data["csv_file"] = open(filename_1, "rb")
-            form_data["if_exists"] = "replace"
-            resp = self.get_resp(url, data=form_data)
-            self.assertIn(
-                f'CSV file "{filename_1}" uploaded to table "{table_name}"', resp
-            )
+            resp = self.upload_csv(f1, table_name, extra={"if_exists": "replace"})
+            self.assertIn(success_msg_f1, resp)
 
             # try to append to table from file with different schema
-            form_data["csv_file"] = open(filename_2, "rb")
-            form_data["if_exists"] = "append"
-            resp = self.get_resp(url, data=form_data)
-            self.assertIn(
-                f'Unable to upload CSV file "{filename_2}" to table "{table_name}"',
-                resp,
-            )
+            resp = self.upload_csv(f2, table_name, extra={"if_exists": "append"})
+            fail_msg_f2 = f'Unable to upload CSV file "{f2}" to table "{table_name}"'
+            self.assertIn(fail_msg_f2, resp)
 
             # replace table from file with different schema
-            form_data["csv_file"] = open(filename_2, "rb")
-            form_data["if_exists"] = "replace"
-            resp = self.get_resp(url, data=form_data)
-            self.assertIn(
-                f'CSV file "{filename_2}" uploaded to table "{table_name}"', resp
-            )
-            table = (
-                db.session.query(SqlaTable)
-                .filter_by(table_name=table_name, database_id=db_id)
-                .first()
-            )
+            resp = self.upload_csv(f2, table_name, extra={"if_exists": "replace"})
+            success_msg_f2 = f'CSV file "{f2}" uploaded to table "{table_name}"'
+            self.assertIn(success_msg_f2, resp)
+
+            table = self.get_table_by_name(table_name)
             # make sure the new column name is reflected in the table metadata
             self.assertIn("d", table.column_names)
         finally:
-            os.remove(filename_1)
-            os.remove(filename_2)
+            os.remove(f1)
+            os.remove(f2)
 
     def test_dataframe_timezone(self):
         tz = pytz.FixedOffset(60)


### PR DESCRIPTION
Implement function controlled csv upload schema

Refactor + fix tests

### CATEGORY

Choose one

- [x] Enhancement (new features, refinement)
- [x] Refactor
- [x] Add tests

### SUMMARY
This PR implements a standard schema enforcements for the base and hive csv upload. In addition to that it introduces ALLOWED_USER_CSV_SCHEMA_FUNC and CSV_TO_HIVE_UPLOAD_DIRECTORY_FUNC config variables that can programmatically set a schema for the user during the file upload.

Also added csv_explore_db param to the db extras, to enable hive upload & presto explore. Not documenting it for now as will work soon on the similar functionality for the CTAS.

In addition to that there are 3 refactoring:
1. simplified `create_table_from_csv` and pushed more logics & validation in to the `form_post` to bring more clarity to the function and not pass a generic form around
2. refactored the tests to make them more reusable across the functions / test cases
3. enabled multi insert for the database that support it and reduced the batch size to make it more performant. Prior to this there was separate insert command for 1 row.

### TEST PLAN
[x] Unit tests
[x] Local testing
[x] Dropbox staging
[ ] Dropbox prod [being rolled out]

### REVIEWERS
@john-bodley , @villebro I think you know this part of the code base, it would be great to get a code review from you