### PR TITLE
perf(dataset): improve performance on get list

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -68,14 +68,16 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "refresh",
     }
     list_columns = [
+        "id",
+        "database_id",
         "database_name",
+        "changed_by_fk",
         "changed_by_name",
         "changed_by_url",
         "changed_by.username",
         "changed_on",
-        "database_name",
+        "default_endpoint",
         "explore_url",
-        "id",
         "schema",
         "table_name",
     ]

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -86,9 +86,12 @@ class DatasetApiTests(SupersetTestCase):
         response = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(response["count"], 1)
         expected_columns = [
+            "database_id",
             "changed_by",
             "changed_by_name",
             "changed_by_url",
+            "changed_by_fk",
+            "default_endpoint",
             "changed_on",
             "database_name",
             "explore_url",

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -86,14 +86,14 @@ class DatasetApiTests(SupersetTestCase):
         response = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(response["count"], 1)
         expected_columns = [
-            "database_id",
             "changed_by",
+            "changed_by_fk",
             "changed_by_name",
             "changed_by_url",
-            "changed_by_fk",
-            "default_endpoint",
             "changed_on",
+            "database_id",
             "database_name",
+            "default_endpoint",
             "explore_url",
             "id",
             "schema",


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Like stated on #9619, when using properties has virtual columns, we should to make sure that the method references columns already referenced on list_columns or SQLAlchemy will issue a new query

Before:
[stats_logger] (timing) DatasetRestApi.get_list.time 110ms - 150ms

After:
[stats_logger] (timing) DatasetRestApi.get_list.time 25ms - 35ms

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
