### PR TITLE
feat: Add controlGroups to formData

### DIFF
--- a/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
@@ -23,7 +23,9 @@ import { t } from '@superset-ui/translation';
 import {
   getControlConfig,
   getControlState,
+  getFormDataFromControls,
   applyMapStateToPropsToControl,
+  getAllControlsState,
 } from '../../../src/explore/controlUtils';
 import ColumnOption from '../../../src/components/ColumnOption';
 
@@ -107,6 +109,7 @@ describe('controlUtils', () => {
                   name: 'all_columns',
                   config: {
                     type: 'SelectControl',
+                    controlGroup: 'columns',
                     multi: true,
                     label: t('Columns'),
                     default: [],
@@ -244,6 +247,14 @@ describe('controlUtils', () => {
     it('validates the control, returns an error if empty', () => {
       const control = getControlState('metric', 'table', state, null);
       expect(control.validationErrors).toEqual(['cannot be empty']);
+    });
+  });
+
+  describe('controlGroup', () => {
+    it('in formData', () => {
+      const controlsState = getAllControlsState('table', 'table', {}, {});
+      const formData = getFormDataFromControls(controlsState);
+      expect(formData.controlGroups).toEqual({ all_columns: 'columns' });
     });
   });
 });

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -22,8 +22,13 @@ import * as SECTIONS from './controlPanels/sections';
 
 export function getFormDataFromControls(controlsState) {
   const formData = {};
+  formData.controlGroups = {};
   Object.keys(controlsState).forEach(controlName => {
-    formData[controlName] = controlsState[controlName].value;
+    const control = controlsState[controlName];
+    formData[controlName] = control.value;
+    if (control.hasOwnProperty('controlGroup')) {
+      formData.controlGroups[controlName] = control.controlGroup;
+    }
   });
   return formData;
 }

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -125,6 +125,7 @@ const timeColumnOption = {
 
 const groupByControl = {
   type: 'SelectControl',
+  controlGroup: 'groupby',
   multi: true,
   freeForm: true,
   label: t('Group by'),
@@ -156,6 +157,7 @@ const groupByControl = {
 
 const metrics = {
   type: 'MetricsControl',
+  controlGroup: 'metrics',
   multi: true,
   label: t('Metrics'),
   validators: [validateNonEmpty],


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This adds a field `controlGroups` to `formData` to facilitate automatic control grouping for chart data requests.

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9187
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@kristw @rusackas @suddjian 