### PR TITLE
fix: stop using `css` as a prop

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/HeaderActionsDropdown_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/HeaderActionsDropdown_spec.jsx
@@ -32,7 +32,7 @@ describe('HeaderActionsDropdown', () => {
     dashboardId: 1,
     dashboardTitle: 'Title',
     hasUnsavedChanges: false,
-    css: '',
+    customCss: '',
     onChange: () => {},
     updateCss: () => {},
     forceRefreshAllCharts: () => {},

--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -56,7 +56,7 @@ const propTypes = {
   charts: PropTypes.objectOf(chartPropShape).isRequired,
   layout: PropTypes.object.isRequired,
   expandedSlices: PropTypes.object.isRequired,
-  css: PropTypes.string.isRequired,
+  customCss: PropTypes.string.isRequired,
   colorNamespace: PropTypes.string,
   colorScheme: PropTypes.string,
   isStarred: PropTypes.bool.isRequired,
@@ -301,7 +301,7 @@ class Header extends React.PureComponent {
       dashboardTitle,
       layout,
       expandedSlices,
-      css,
+      customCss,
       colorNamespace,
       colorScheme,
       onUndo,
@@ -476,7 +476,7 @@ class Header extends React.PureComponent {
             dashboardTitle={dashboardTitle}
             layout={layout}
             expandedSlices={expandedSlices}
-            css={css}
+            customCss={customCss}
             colorNamespace={colorNamespace}
             colorScheme={colorScheme}
             onSave={onSave}

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -37,7 +37,7 @@ const propTypes = {
   dashboardId: PropTypes.number.isRequired,
   dashboardTitle: PropTypes.string.isRequired,
   hasUnsavedChanges: PropTypes.bool.isRequired,
-  css: PropTypes.string.isRequired,
+  customCss: PropTypes.string.isRequired,
   colorNamespace: PropTypes.string,
   colorScheme: PropTypes.string,
   onChange: PropTypes.func.isRequired,
@@ -69,7 +69,7 @@ class HeaderActionsDropdown extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      css: props.css,
+      css: props.customCss,
       cssTemplates: [],
     };
 
@@ -116,7 +116,7 @@ class HeaderActionsDropdown extends React.PureComponent {
       forceRefreshAllCharts,
       refreshFrequency,
       editMode,
-      css,
+      customCss,
       colorNamespace,
       colorScheme,
       hasUnsavedChanges,
@@ -150,7 +150,7 @@ class HeaderActionsDropdown extends React.PureComponent {
             layout={layout}
             expandedSlices={expandedSlices}
             refreshFrequency={refreshFrequency}
-            css={css}
+            customCss={customCss}
             colorNamespace={colorNamespace}
             colorScheme={colorScheme}
             onSave={onSave}

--- a/superset-frontend/src/dashboard/components/SaveModal.jsx
+++ b/superset-frontend/src/dashboard/components/SaveModal.jsx
@@ -36,7 +36,7 @@ const propTypes = {
   layout: PropTypes.object.isRequired,
   saveType: PropTypes.oneOf([SAVE_TYPE_OVERWRITE, SAVE_TYPE_NEWDASHBOARD]),
   triggerNode: PropTypes.node.isRequired,
-  css: PropTypes.string.isRequired,
+  customCss: PropTypes.string.isRequired,
   colorNamespace: PropTypes.string,
   colorScheme: PropTypes.string,
   onSave: PropTypes.func.isRequired,
@@ -95,7 +95,7 @@ class SaveModal extends React.PureComponent {
     const {
       dashboardTitle,
       layout: positions,
-      css,
+      customCss,
       colorNamespace,
       colorScheme,
       expandedSlices,
@@ -110,7 +110,7 @@ class SaveModal extends React.PureComponent {
     const labelColors = colorScheme ? scale.getColorMap() : {};
     const data = {
       positions,
-      css,
+      css: customCss,
       color_namespace: colorNamespace,
       color_scheme: colorScheme,
       label_colors: labelColors,

--- a/superset-frontend/src/dashboard/containers/DashboardHeader.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardHeader.jsx
@@ -71,7 +71,7 @@ function mapStateToProps({
     ).text,
     expandedSlices: dashboardState.expandedSlices,
     refreshFrequency: dashboardState.refreshFrequency,
-    css: dashboardState.css,
+    customCss: dashboardState.css,
     colorNamespace: dashboardState.colorNamespace,
     colorScheme: dashboardState.colorScheme,
     charts,


### PR DESCRIPTION
### CATEGORY

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

An emotion plugin `@emotion/babel-preset-css-prop` was added to the webpack config recently, which uses the `css` prop for emotion styling. This effectively makes `css` a "reserved" prop, which breaks dashboards that have custom css applied because they were using `css` as a plain old prop to pass the string around. So this change renames that prop to `customCss`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@rusackas 