### PR TITLE
fix: re-add all time grain options to the new chart API

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -610,6 +610,10 @@ class ChartDataExtrasSchema(Schema):
                 "P1M",
                 "P0.25Y",
                 "P1Y",
+                "1969-12-28T00:00:00Z/P1W",  # Week starting Sunday
+                "1969-12-29T00:00:00Z/P1W",  # Week starting Monday
+                "P1W/1970-01-03T00:00:00Z",  # Week ending Saturday
+                "P1W/1970-01-04T00:00:00Z",  # Week ending Sunday
             ),
         ),
         required=False,


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
The new chart API doesn't support all the time grains db_engine_specs supports, adding the missing granularities here

### TEST PLAN
CI
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @villebro @john-bodley @craig-rueda @dpgaspar 