### PR TITLE
chore: remove unnecessary shims from viz.py

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -6947,9 +6947,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-nvd3": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-nvd3/-/legacy-preset-chart-nvd3-0.13.5.tgz",
-      "integrity": "sha512-JJ4d8wodQ/Jryy0V/cXG6kqxbtURhDh0/ESnU77FUQwkeX57YK/RlfcL3l/mB6Pu1APuHsxSWe6ZyMIGW1WXIg==",
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-nvd3/-/legacy-preset-chart-nvd3-0.13.8.tgz",
+      "integrity": "sha512-dvfhhmBr8AGy2ioDQ2sEUFf8MVQ9BhYxYvWu/javxmbYt5LCxQmqmKBXgwLztLOFIgdbNIJy4kWY5d5ebzJpaA==",
       "requires": {
         "@data-ui/xy-chart": "^0.0.84",
         "d3": "^3.5.17",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -87,7 +87,7 @@
     "@superset-ui/legacy-plugin-chart-world-map": "^0.13.6",
     "@superset-ui/legacy-preset-chart-big-number": "^0.13.5",
     "@superset-ui/legacy-preset-chart-deckgl": "^0.2.3",
-    "@superset-ui/legacy-preset-chart-nvd3": "^0.13.5",
+    "@superset-ui/legacy-preset-chart-nvd3": "^0.13.6",
     "@superset-ui/number-format": "^0.13.3",
     "@superset-ui/plugin-chart-word-cloud": "0.13.5",
     "@superset-ui/preset-chart-xy": "^0.13.5",

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -816,24 +816,6 @@ class SeparatorViz(MarkupViz):
     verbose_name = _("Separator")
 
 
-class WordCloudViz(BaseViz):
-
-    """Build a colorful word cloud
-
-    Uses the nice library at:
-    https://github.com/jasondavies/d3-cloud
-    """
-
-    viz_type = "word_cloud"
-    verbose_name = _("Word Cloud")
-    is_timeseries = False
-
-    def query_obj(self):
-        d = super().query_obj()
-        d["groupby"] = [self.form_data.get("series")]
-        return d
-
-
 class TreemapViz(BaseViz):
 
     """Tree map visualisation for hierarchical data."""
@@ -1091,20 +1073,6 @@ class BulletViz(NVD3Viz):
         d = super().query_obj()
         self.metric = form_data.get("metric")
 
-        def as_strings(field):
-            value = form_data.get(field)
-            return value.split(",") if value else []
-
-        def as_floats(field):
-            return [float(x) for x in as_strings(field)]
-
-        self.ranges = as_floats("ranges")
-        self.range_labels = as_strings("range_labels")
-        self.markers = as_floats("markers")
-        self.marker_labels = as_strings("marker_labels")
-        self.marker_lines = as_floats("marker_lines")
-        self.marker_line_labels = as_strings("marker_line_labels")
-
         d["metrics"] = [self.metric]
         if not self.metric:
             raise QueryObjectValidationError(_("Pick a metric to display"))
@@ -1115,12 +1083,6 @@ class BulletViz(NVD3Viz):
         values = df["metric"].values
         return {
             "measures": values.tolist(),
-            "ranges": self.ranges or [0, values.max() * 1.1],
-            "rangeLabels": self.range_labels or None,
-            "markers": self.markers or None,
-            "markerLabels": self.marker_labels or None,
-            "markerLines": self.marker_lines or None,
-            "markerLineLabels": self.marker_line_labels or None,
         }
 
 

--- a/superset/viz_sip38.py
+++ b/superset/viz_sip38.py
@@ -856,19 +856,6 @@ class SeparatorViz(MarkupViz):
     verbose_name = _("Separator")
 
 
-class WordCloudViz(BaseViz):
-
-    """Build a colorful word cloud
-
-    Uses the nice library at:
-    https://github.com/jasondavies/d3-cloud
-    """
-
-    viz_type = "word_cloud"
-    verbose_name = _("Word Cloud")
-    is_timeseries = False
-
-
 class TreemapViz(BaseViz):
 
     """Tree map visualisation for hierarchical data."""
@@ -1120,20 +1107,6 @@ class BulletViz(NVD3Viz):
         d = super().query_obj()
         self.metric = form_data.get("metric")
 
-        def as_strings(field):
-            value = form_data.get(field)
-            return value.split(",") if value else []
-
-        def as_floats(field):
-            return [float(x) for x in as_strings(field)]
-
-        self.ranges = as_floats("ranges")
-        self.range_labels = as_strings("range_labels")
-        self.markers = as_floats("markers")
-        self.marker_labels = as_strings("marker_labels")
-        self.marker_lines = as_floats("marker_lines")
-        self.marker_line_labels = as_strings("marker_line_labels")
-
         d["metrics"] = [self.metric]
         if not self.metric:
             raise QueryObjectValidationError(_("Pick a metric to display"))
@@ -1144,12 +1117,6 @@ class BulletViz(NVD3Viz):
         values = df["metric"].values
         return {
             "measures": values.tolist(),
-            "ranges": self.ranges or [0, values.max() * 1.1],
-            "rangeLabels": self.range_labels or None,
-            "markers": self.markers or None,
-            "markerLabels": self.marker_labels or None,
-            "markerLines": self.marker_lines or None,
-            "markerLineLabels": self.marker_line_labels or None,
         }
 
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This PR removes Word Cloud shims from `viz.py` that is now using the new chart data API ( #9710 ) and removes the backend string manipulation logic in Bullet chart that was recently moved to `superset-ui` ( https://github.com/apache-superset/superset-ui/pull/440 ) 

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9187 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@suddjian @rusackas 