### PR TITLE
fix: fetch all owners for dashboard and chart listview filters and properties modal

### DIFF
--- a/superset-frontend/spec/javascripts/views/chartList/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/chartList/ChartList_spec.jsx
@@ -102,7 +102,7 @@ describe('ChartList', () => {
     const callsD = fetchMock.calls(/chart\/\?q/);
     expect(callsD).toHaveLength(1);
     expect(callsD[0][0]).toMatchInlineSnapshot(
-      `"/http//localhost/api/v1/chart/?q={%22order_column%22:%22changed_on%22,%22order_direction%22:%22desc%22,%22page%22:0,%22page_size%22:25}"`,
+      `"/http//localhost/api/v1/chart/?q=(order_column:changed_on,order_direction:desc,page:0,page_size:25)"`,
     );
   });
 });

--- a/superset-frontend/spec/javascripts/views/dashboardList/DashboardList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/dashboardList/DashboardList_spec.jsx
@@ -92,7 +92,7 @@ describe('DashboardList', () => {
     const callsD = fetchMock.calls(/dashboard\/\?q/);
     expect(callsD).toHaveLength(1);
     expect(callsD[0][0]).toMatchInlineSnapshot(
-      `"/http//localhost/api/v1/dashboard/?q={%22order_column%22:%22changed_on%22,%22order_direction%22:%22desc%22,%22page%22:0,%22page_size%22:25}"`,
+      `"/http//localhost/api/v1/dashboard/?q=(order_column:changed_on,order_direction:desc,page:0,page_size:25)"`,
     );
   });
   it('edits', () => {

--- a/superset-frontend/spec/javascripts/views/datasetList/DatasetList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/datasetList/DatasetList_spec.jsx
@@ -92,7 +92,7 @@ describe('DatasetList', () => {
     const callsD = fetchMock.calls(/dataset\/\?q/);
     expect(callsD).toHaveLength(1);
     expect(callsD[0][0]).toMatchInlineSnapshot(
-      `"/http//localhost/api/v1/dataset/?q={%22order_column%22:%22changed_on%22,%22order_direction%22:%22desc%22,%22page%22:0,%22page_size%22:25}"`,
+      `"/http//localhost/api/v1/dataset/?q=(order_column:changed_on,order_direction:desc,page:0,page_size:25)"`,
     );
   });
 });

--- a/superset-frontend/src/components/ListView/Filters.tsx
+++ b/superset-frontend/src/components/ListView/Filters.tsx
@@ -116,7 +116,7 @@ function SelectFilter({
     // TODO: allow real async search with `inputValue`
     if (optionsCache.current) return optionsCache.current;
     if (fetchSelects) {
-      const selectValues = await fetchSelects();
+      const selectValues = await fetchSelects(inputValue);
       // update matching option at initial load
       const matchingOption = result.find(x => x.value === initialValue);
       if (matchingOption) {

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -37,7 +37,11 @@ export interface Filter {
   unfilteredLabel?: string;
   selects?: SelectOption[];
   onFilterOpen?: () => void;
-  fetchSelects?: () => Promise<SelectOption[]>;
+  fetchSelects?: (
+    filterValue?: string,
+    pageIndex?: number,
+    pageSize?: number,
+  ) => Promise<SelectOption[]>;
 }
 
 export type Filters = Filter[];

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -245,6 +245,7 @@ export function useListViewState({
     const updatedFilters = updateInList(internalFilters, index, update);
     setInternalFilters(updatedFilters);
     setAllFilters(convertFilters(updatedFilters));
+    gotoPage(0); // clear pagination on filter
   };
 
   const removeFilterAndApply = (index: number) => {

--- a/superset-frontend/src/explore/components/PropertiesModal.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal.tsx
@@ -120,7 +120,11 @@ function PropertiesModal({ slice, onHide, onSave }: InternalProps) {
   }, []);
 
   const loadOptions = (input = '') => {
-    const query = rison.encode({ filter: input });
+    const query = rison.encode({
+      filter: input,
+      page_index: -1,
+      page_size: -1,
+    });
     return SupersetClient.get({
       endpoint: `/api/v1/chart/related/owners?q=${query}`,
     }).then(

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -21,6 +21,7 @@ import { t } from '@superset-ui/translation';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
+import rison from 'rison';
 // @ts-ignore
 import { Panel } from 'react-bootstrap';
 import Link from 'src/components/Link';
@@ -273,9 +274,9 @@ class DatasetList extends React.PureComponent<Props, State> {
 
   handleBulkDatasetDelete = (datasets: Dataset[]) => {
     SupersetClient.delete({
-      endpoint: `/api/v1/dataset/?q=!(${datasets
-        .map(({ id }) => id)
-        .join(',')})`,
+      endpoint: `/api/v1/dataset/?q=${rison.encode(
+        datasets.map(({ id }) => id),
+      )}`,
     }).then(
       ({ json = {} }) => {
         const { lastFetchDataConfig } = this.state;
@@ -310,7 +311,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       value,
     }));
 
-    const queryParams = JSON.stringify({
+    const queryParams = rison.encode({
       order_column: sortBy[0].id,
       order_direction: sortBy[0].desc ? 'desc' : 'asc',
       page: pageIndex,


### PR DESCRIPTION
# SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Superset api limits records to 20 by default. @bkyryliuk recently opened a PR(https://github.com/apache/incubator-superset/pull/9667) to fix some of the owners dropdowns so that all records are returned by the api. The pr received some push back since changing the defaults probably isn't the best approach. This PR requests all records for the owners endpoints to fix the issue flagged in https://github.com/apache/incubator-superset/pull/9667. 

Originally we intended to add pagination (via infinite scroll) and backend filtering. While trying to implement that approach I hit some limitations in react-select's async mode that caused me to reimplement fetching using react-select in non async mode, code is here: https://github.com/apache/incubator-superset/pull/9784/commits/90f7f79c3e8772385e726c1cd2bd3081ffadbc62

Also since there is currently an upgrade for react-select in progress (https://github.com/apache/incubator-superset/pull/9628) I opted for holding off on adding more complexity until the upgrade is complete. React select is fairly fast at searching and I don't think we should expect the owners list to be that large, so I'm not convinced that adding pagination will result in a more performant end user experience than fetching all records after mount and searching locally. 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

- [x] tested locally with 55 user records

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
