### PR TITLE
FilterBox,BigNumber,WorldMap: Handle empty results - second attempt

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1932,7 +1932,7 @@ class FilterBoxViz(BaseViz):
             col = flt.get("column")
             metric = flt.get("metric")
             df = self.dataframes.get(col)
-            if df is not None:
+            if df is not None and not df.empty:
                 if metric:
                     df = df.sort_values(
                         utils.get_metric_name(metric), ascending=flt.get("asc")
@@ -1947,6 +1947,8 @@ class FilterBoxViz(BaseViz):
                         {"id": row[0], "text": row[0]}
                         for row in df.itertuples(index=False)
                     ]
+            else:
+                df[col] = []
         return d
 
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1123,6 +1123,9 @@ class BigNumberViz(BaseViz):
         return d
 
     def get_data(self, df: pd.DataFrame) -> VizData:
+        if df.empty:
+            return None
+
         df = df.pivot_table(
             index=DTTM_ALIAS,
             columns=[],

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1861,6 +1861,9 @@ class WorldMapViz(BaseViz):
         return qry
 
     def get_data(self, df: pd.DataFrame) -> VizData:
+        if df.empty:
+            return None
+
         from superset.examples import countries
 
         fd = self.form_data


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
This pull request is a follow up of #9671, reverted in #9755 due to a regression introduced to the FilterBox. I broke down the commit into three, and improved the code for the FilterBox.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
See screenshots in #9671.

### TEST PLAN
Trying various combination of FilterBox, WorldMap and BigNumber charts with empty results.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
