### PR TITLE
feat: Add the ability to set the user profile page as the welcome page

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -186,6 +186,9 @@ APP_ICON_WIDTH = 126
 # e.g. setting it to '/welcome' would take the user to '/superset/welcome'
 LOGO_TARGET_PATH = None
 
+# Set this to true to change the default welcome page to the user's profile page
+WELCOME_WITH_USER_PROFILE = False
+
 # Enables SWAGGER UI for superset openapi spec
 # ex: http://localhost:8080/swaggerview/v1
 FAB_API_SWAGGER_UI = True

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2728,6 +2728,9 @@ class Superset(BaseSupersetView):
             "common": common_bootstrap_payload(),
         }
 
+        if config["WELCOME_WITH_USER_PROFILE"]:
+            return self.profile(g.user.username)
+
         return self.render_template(
             "superset/welcome.html",
             entry="welcome",

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1209,6 +1209,16 @@ class CoreTests(SupersetTestCase):
         payload = views.Superset._get_sqllab_tabs(user_id=user_id)
         self.assertEqual(len(payload["queries"]), 1)
 
+    def test_welcome_flag(self):
+        self.login(username="admin")
+        app.config["WELCOME_WITH_USER_PROFILE"] = False
+        resp = self.get_resp("/superset/welcome")
+        self.assertNotIn("<!-- Bundle js profile START -->", resp)
+
+        app.config["WELCOME_WITH_USER_PROFILE"] = True
+        resp = self.get_resp("/superset/welcome")
+        self.assertIn("<!-- Bundle js profile START -->", resp)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### SUMMARY
I've added a `WELCOME_WITH_USER_PROFILE` config setting (which defaults to `false` to remain consistent with the current behaviour).  If set to `true` the current user's profile page will be loaded in place of the standard welcome page.

A welcome dashboard, if set, will still take precedence.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
1. Set `WELCOME_WITH_USER_PROFILE` to `true` and log in.
1. Set `WELCOME_WITH_USER_PROFILE` to `false` and log in.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #9792 
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/9792
- [x] Changes UI (mildly)
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
# #9792 