### PR TITLE
fix: add flag for time series table

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.js
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTableChartPlugin.js
@@ -25,6 +25,7 @@ const metadata = new ChartMetadata({
   name: t('Time-series Table'),
   description: '',
   thumbnail,
+  useLegacyApi: true,
 });
 
 export default class TimeTableChartPlugin extends ChartPlugin {


### PR DESCRIPTION
### SUMMARY

Charts that requires the legacy api now has to explicitly state so with `useLegacyApi` flag. 
The `time_table` chart was migrated to plugin earlier in the days, probably before when this flag was introduced.

### TEST PLAN
Test locally

