### PR TITLE
fix: construct SupersetErrors properly

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -467,7 +467,7 @@ class BaseViz:
                     SupersetError(
                         message=str(ex),
                         level=ErrorLevel.ERROR,
-                        type=SupersetErrorType.VIZ_GET_DF_ERROR,
+                        error_type=SupersetErrorType.VIZ_GET_DF_ERROR,
                     )
                 )
                 self.errors.append(error)

--- a/superset/viz_sip38.py
+++ b/superset/viz_sip38.py
@@ -507,7 +507,7 @@ class BaseViz:
                     SupersetError(
                         message=str(ex),
                         level=ErrorLevel.ERROR,
-                        type=SupersetErrorType.VIZ_GET_DF_ERROR,
+                        error_type=SupersetErrorType.VIZ_GET_DF_ERROR,
                     )
                 )
                 self.errors.append(error)


### PR DESCRIPTION
### SUMMARY
I'm shocked mypy didn't catch this, but here ya go...

SupersetError should be initialized with an `error_type`, not a `type`
### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @john-bodley @michellethomas @villebro 