### PR TITLE
style(mypy): Enforcing typing for superset.translations module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ order_by_type = false
 ignore_missing_imports = true
 no_implicit_optional = true
 
-[mypy-superset.bin.*,superset.charts.*,superset.datasets.*,superset.dashboards.*,superset.commands.*,superset.common.*,superset.dao.*,superset.db_engine_specs.*,superset.db_engines.*,superset.examples.*,superset.migrations.*,superset.queries.*,superset.security.*,superset.sql_validators.*,superset.tasks.*]
+[mypy-superset.bin.*,superset.charts.*,superset.datasets.*,superset.dashboards.*,superset.commands.*,superset.common.*,superset.dao.*,superset.db_engine_specs.*,superset.db_engines.*,superset.examples.*,superset.migrations.*,superset.queries.*,superset.security.*,superset.sql_validators.*,superset.tasks.*,superset.translations.*]
 check_untyped_defs = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true

--- a/superset/translations/utils.py
+++ b/superset/translations/utils.py
@@ -16,15 +16,15 @@
 # under the License.
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 # Global caching for JSON language packs
-ALL_LANGUAGE_PACKS: Dict[str, Dict[Any, Any]] = {"en": {}}
+ALL_LANGUAGE_PACKS: Dict[str, Dict[str, Any]] = {"en": {}}
 
 DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def get_language_pack(locale):
+def get_language_pack(locale: str) -> Optional[Dict[str, Any]]:
     """Get/cache a language pack
 
     Returns the langugage pack from cache if it exists, caches otherwise
@@ -38,7 +38,7 @@ def get_language_pack(locale):
         try:
             with open(filename, encoding="utf8") as f:
                 pack = json.load(f)
-                ALL_LANGUAGE_PACKS[locale] = pack
+                ALL_LANGUAGE_PACKS[locale] = pack or {}
         except Exception:  # pylint: disable=broad-except
             # Assuming english, client side falls back on english
             pass


### PR DESCRIPTION
### SUMMARY

Adding `mypy` type enforcement to the `superset.translations` module.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### Reviewers

to: @etr2460 @villebro 