### PR TITLE
fix: Emit a warning message rather than an exception on query failure

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1082,7 +1082,7 @@ class SqlaTable(Model, BaseDatasource):
         except Exception as ex:
             df = pd.DataFrame()
             status = utils.QueryStatus.FAILED
-            logger.exception(f"Query {sql} on schema {self.schema} failed")
+            logger.warning(f"Query {sql} on schema {self.schema} failed")
             db_engine_spec = self.database.db_engine_spec
             errors = db_engine_spec.extract_errors(ex)
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1082,7 +1082,7 @@ class SqlaTable(Model, BaseDatasource):
         except Exception as ex:
             df = pd.DataFrame()
             status = utils.QueryStatus.FAILED
-            logger.warning(f"Query {sql} on schema {self.schema} failed")
+            logger.warning(f"Query {sql} on schema {self.schema} failed", exc_info=True)
             db_engine_spec = self.database.db_engine_spec
             errors = db_engine_spec.extract_errors(ex)
 


### PR DESCRIPTION
### SUMMARY
Exception messages are frequently bubbled up to error aggregators like Sentry, Airbrake, and the like from web applications. As queries can fail for a wide variety of reasons, most of which are beyond the ability of Superset to catch and fix before execution, I'd like to downgrade the messaging around analytical query failures to the warning level. This will keep the events in log streams but largely remove them from error aggregators.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
* Trigger an error in an analytical query
* Ensure that it is logged at the "warning" level rather than the "exception" level.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### Reviewers
@craig-rueda @rusackas @john-bodley 