### PR TITLE
build: conditionally run fossa check based on dependency file changes

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -17,6 +17,24 @@ jobs:
     - name: Generate fossa report
       env:
         FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-      run: ./scripts/fossa.sh
+      run: |
+        set -eo pipefail
+        URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
+        FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
+
+        cat<<EOF
+        CHANGED FILES:
+        $FILES
+        
+        EOF
+
+        if [[ "$FILES" =~ ^(.*package*\.json|.*requirements*\.txt)$ ]]; then
+          echo "Detected dependency changes... running fossa check"
+
+          ./scripts/fossa.sh
+        else
+          echo "No dependency changes... skiping fossa check"
+        fi
+      shell: bash
     - name: Run license check
       run: ./scripts/check_license.sh


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Last week fossa command became flaky and failed to install. This blocked PRs from passing build and merging. A PR to fix this was opened (https://github.com/apache/incubator-superset/pull/9769) but it didn't fix it. Eventually fossa started working again. This PR introduces a check for the fossa command and logs, but does not fail the build, if the fossa command cannot be found.  

How important is it to have the fossa check? I haven't had much experience with it, is it actively monitored. Should we fail the build if a fossa report cannot be generated? 

If the fossa check is absolutely necessary, can we only run it when dependency files change, eg requirements*.txt, package*.json?  

#### UPDATE FROM DISCUSSION
This PR checks for changes to dependency files (\*.package\*\.json and \*.requirements\*\.json) and runs fossa *only* if those files have changed. 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [x] build passes

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
