### PR TITLE
fixes: limit no authorization error for sentry

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -141,9 +141,6 @@ def api(f):
     def wraps(self, *args, **kwargs):
         try:
             return f(self, *args, **kwargs)
-        except SupersetSecurityException as ex:
-            logger.exception(ex)
-            return self.response_401()
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception(ex)
             return json_error_response(get_error_msg())
@@ -162,7 +159,7 @@ def handle_api_exception(f):
         try:
             return f(self, *args, **kwargs)
         except SupersetSecurityException as ex:
-            logger.exception(ex)
+            logger.warning(ex)
             return json_errors_response(
                 errors=[ex.error], status=ex.status, payload=ex.payload
             )

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -141,6 +141,9 @@ def api(f):
     def wraps(self, *args, **kwargs):
         try:
             return f(self, *args, **kwargs)
+        except SupersetSecurityException as ex:
+            logger.exception(ex)
+            return self.response_401()
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception(ex)
             return json_error_response(get_error_msg())


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We user [sentry](https://sentry.io/) to help us keep tracking errors and fix crashes. `flask_jwt_extended/view_decorators.py` in `_decode_jwt_from_request` at `line 312` has ` raise NoAuthorizationError(err_msg)`. Sentry reports `NoAuthorizationError` expectedly but this error is not an actual crash.  We want filter error out to reduce noise. It will log a 401 instead of throwing error to sentry.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
