### PR TITLE
style(mypy): enforcing mypy typing for superset.connectors module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dataclasses,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 
@@ -53,7 +53,7 @@ order_by_type = false
 ignore_missing_imports = true
 no_implicit_optional = true
 
-[mypy-superset.bin.*,superset.charts.*,superset.datasets.*,superset.dashboards.*,superset.commands.*,superset.common.*,superset.dao.*,superset.db_engine_specs.*,superset.db_engines.*,superset.examples.*,superset.migrations.*,superset.models.*,superset.queries.*,superset.security.*,superset.sql_validators.*,superset.tasks.*,superset.translations.*]
+[mypy-superset.bin.*,superset.charts.*,superset.commands.*,superset.common.*,superset.connectors.*,superset.dao.*,superset.dashboards.*,superset.datasets.*,superset.db_engine_specs.*,superset.db_engines.*,superset.examples.*,superset.migrations.*,superset.models.*,uperset.queries.*,superset.security.*,superset.sql_validators.*,superset.tasks.*,superset.translations.*]
 check_untyped_defs = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -20,12 +20,12 @@ from typing import Any, Dict, Hashable, List, Optional, Type
 from flask_appbuilder.security.sqla.models import User
 from sqlalchemy import and_, Boolean, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import foreign, Query, relationship
+from sqlalchemy.orm import foreign, Query, relationship, RelationshipProperty
 
 from superset.constants import NULL_STRING
 from superset.models.helpers import AuditMixinNullable, ImportMixin, QueryResult
 from superset.models.slice import Slice
-from superset.typing import FilterValue, FilterValues
+from superset.typing import FilterValue, FilterValues, QueryObjectDict
 from superset.utils import core as utils
 
 METRIC_FORM_DATA_PARAMS = [
@@ -93,7 +93,7 @@ class BaseDatasource(
     update_from_object_fields: List[str]
 
     @declared_attr
-    def slices(self):
+    def slices(self) -> RelationshipProperty:
         return relationship(
             "Slice",
             primaryjoin=lambda: and_(
@@ -117,7 +117,7 @@ class BaseDatasource(
         return sorted([c.column_name for c in self.columns], key=lambda x: x or "")
 
     @property
-    def columns_types(self) -> Dict:
+    def columns_types(self) -> Dict[str, str]:
         return {c.column_name: c.type for c in self.columns}
 
     @property
@@ -125,7 +125,7 @@ class BaseDatasource(
         return "timestamp"
 
     @property
-    def datasource_name(self):
+    def datasource_name(self) -> str:
         raise NotImplementedError()
 
     @property
@@ -143,7 +143,7 @@ class BaseDatasource(
         return sorted([c.column_name for c in self.columns if c.filterable])
 
     @property
-    def dttm_cols(self) -> List:
+    def dttm_cols(self) -> List[str]:
         return []
 
     @property
@@ -182,7 +182,7 @@ class BaseDatasource(
         }
 
     @property
-    def select_star(self):
+    def select_star(self) -> Optional[str]:
         pass
 
     @property
@@ -336,18 +336,18 @@ class BaseDatasource(
                 values = None
         return values
 
-    def external_metadata(self):
+    def external_metadata(self) -> List[Dict[str, str]]:
         """Returns column information from the external system"""
         raise NotImplementedError()
 
-    def get_query_str(self, query_obj) -> str:
+    def get_query_str(self, query_obj: QueryObjectDict) -> str:
         """Returns a query as a string
 
         This is used to be displayed to the user so that she/he can
         understand what is taking place behind the scene"""
         raise NotImplementedError()
 
-    def query(self, query_obj) -> QueryResult:
+    def query(self, query_obj: QueryObjectDict) -> QueryResult:
         """Executes the query and returns a dataframe
 
         query_obj is a dictionary representing Superset's query interface.
@@ -363,7 +363,7 @@ class BaseDatasource(
         raise NotImplementedError()
 
     @staticmethod
-    def default_query(qry) -> Query:
+    def default_query(qry: Query) -> Query:
         return qry
 
     def get_column(self, column_name: Optional[str]) -> Optional["BaseColumn"]:
@@ -376,8 +376,8 @@ class BaseDatasource(
 
     @staticmethod
     def get_fk_many_from_list(
-        object_list, fkmany, fkmany_class, key_attr
-    ):  # pylint: disable=too-many-locals
+        object_list: List[Any], fkmany: List[Column], fkmany_class: Type, key_attr: str,
+    ) -> List[Column]:  # pylint: disable=too-many-locals
         """Update ORM one-to-many list from object list
 
         Used for syncing metrics and columns using the same code"""
@@ -390,8 +390,9 @@ class BaseDatasource(
         # sync existing fks
         for fk in fkmany:
             obj = object_dict.get(getattr(fk, key_attr))
-            for attr in fkmany_class.update_from_object_fields:
-                setattr(fk, attr, obj.get(attr))
+            if obj:
+                for attr in fkmany_class.update_from_object_fields:
+                    setattr(fk, attr, obj.get(attr))
 
         # create new fks
         new_fks = []
@@ -409,7 +410,7 @@ class BaseDatasource(
         fkmany += new_fks
         return fkmany
 
-    def update_from_object(self, obj) -> None:
+    def update_from_object(self, obj: Dict[str, Any]) -> None:
         """Update datasource from a data structure
 
         The UI's table editor crafts a complex data structure that
@@ -426,18 +427,26 @@ class BaseDatasource(
         self.owners = obj.get("owners", [])
 
         # Syncing metrics
-        metrics = self.get_fk_many_from_list(
-            obj.get("metrics"), self.metrics, self.metric_class, "metric_name"
+        metrics = (
+            self.get_fk_many_from_list(
+                obj["metrics"], self.metrics, self.metric_class, "metric_name"
+            )
+            if self.metric_class and "metrics" in obj
+            else []
         )
         self.metrics = metrics
 
         # Syncing columns
-        self.columns = self.get_fk_many_from_list(
-            obj.get("columns"), self.columns, self.column_class, "column_name"
+        self.columns = (
+            self.get_fk_many_from_list(
+                obj["columns"], self.columns, self.column_class, "column_name"
+            )
+            if self.column_class and "columns" in obj
+            else []
         )
 
     def get_extra_cache_keys(  # pylint: disable=no-self-use
-        self, query_obj: Dict[str, Any]  # pylint: disable=unused-argument
+        self, query_obj: QueryObjectDict  # pylint: disable=unused-argument
     ) -> List[Hashable]:
         """ If a datasource needs to provide additional keys for calculation of
         cache keys, those can be provided via this method
@@ -474,7 +483,7 @@ class BaseColumn(AuditMixinNullable, ImportMixin):
     # [optional] Set this to support import/export functionality
     export_fields: List[Any] = []
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.column_name
 
     num_types = (
@@ -505,11 +514,11 @@ class BaseColumn(AuditMixinNullable, ImportMixin):
         return self.type and any(map(lambda t: t in self.type.upper(), self.str_types))
 
     @property
-    def expression(self):
+    def expression(self) -> Column:
         raise NotImplementedError()
 
     @property
-    def python_date_format(self):
+    def python_date_format(self) -> Column:
         raise NotImplementedError()
 
     @property
@@ -557,11 +566,11 @@ class BaseMetric(AuditMixinNullable, ImportMixin):
     """
 
     @property
-    def perm(self):
+    def perm(self) -> Optional[str]:
         raise NotImplementedError()
 
     @property
-    def expression(self):
+    def expression(self) -> Column:
         raise NotImplementedError()
 
     @property

--- a/superset/connectors/base/views.py
+++ b/superset/connectors/base/views.py
@@ -16,12 +16,13 @@
 # under the License.
 from flask import Markup
 
+from superset.connectors.base.models import BaseDatasource
 from superset.exceptions import SupersetException
 from superset.views.base import SupersetModelView
 
 
 class DatasourceModelView(SupersetModelView):
-    def pre_delete(self, item):
+    def pre_delete(self, item: BaseDatasource) -> None:
         if item.slices:
             raise SupersetException(
                 Markup(

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=unused-argument
-import dataclasses
 import hashlib
 import json
 import logging
@@ -34,6 +33,7 @@ from typing import (
     Union,
 )
 
+import dataclasses
 import pandas as pd
 import sqlparse
 from flask import g

--- a/superset/errors.py
+++ b/superset/errors.py
@@ -15,9 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=too-few-public-methods,invalid-name
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional
+
+from dataclasses import dataclass
 
 
 class SupersetErrorType(str, Enum):

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from dataclasses import dataclass
 from typing import List, Optional, Set
 from urllib import parse
 
 import sqlparse
+from dataclasses import dataclass
 from sqlparse.sql import Identifier, IdentifierList, remove_quotes, Token, TokenList
 from sqlparse.tokens import Keyword, Name, Punctuation, String, Whitespace
 from sqlparse.utils import imt

--- a/superset/typing.py
+++ b/superset/typing.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from flask import Flask
 from flask_caching import Cache
+from werkzeug.wrappers import Response
 
 CacheConfig = Union[Callable[[Flask], Cache], Dict[str, Any]]
 DbapiDescriptionRow = Tuple[
@@ -27,4 +28,15 @@ DbapiDescription = Union[List[DbapiDescriptionRow], Tuple[DbapiDescriptionRow, .
 DbapiResult = List[Union[List[Any], Tuple[Any, ...]]]
 FilterValue = Union[float, int, str]
 FilterValues = Union[FilterValue, List[FilterValue], Tuple[FilterValue]]
+Granularity = Union[str, Dict[str, Union[str, float]]]
+Metric = Union[Dict[str, str], str]
+QueryObjectDict = Dict[str, Any]
 VizData = Optional[Union[List[Any], Dict[Any, Any]]]
+
+# Flask response.
+Base = Union[bytes, str]
+Status = Union[int, str]
+Headers = Dict[str, Any]
+FlaskResponse = Union[
+    Response, Base, Tuple[Base, Status], Tuple[Base, Status, Headers],
+]

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -43,10 +43,12 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Set,
     Tuple,
     TYPE_CHECKING,
@@ -79,6 +81,7 @@ from superset.exceptions import (
     SupersetException,
     SupersetTimeoutException,
 )
+from superset.typing import Metric
 from superset.utils.dates import datetime_to_epoch, EPOCH
 
 try:
@@ -101,7 +104,7 @@ JS_MAX_INTEGER = 9007199254740991  # Largest int Java Script can handle 2^53-1
 try:
     # Having might not have been imported.
     class DimSelector(Having):
-        def __init__(self, **args):
+        def __init__(self, **args: Any) -> None:
             # Just a hack to prevent any exceptions
             Having.__init__(self, type="equalTo", aggregation=None, value=None)
 
@@ -118,7 +121,7 @@ except NameError:
     pass
 
 
-def flasher(msg, severity=None):
+def flasher(msg: str, severity: str) -> None:
     """Flask's flash if available, logging call if not"""
     try:
         flash(msg, severity)
@@ -235,7 +238,7 @@ def list_minus(l: List, minus: List) -> List:
     return [o for o in l if o not in minus]
 
 
-def parse_human_datetime(s: Optional[str]) -> Optional[datetime]:
+def parse_human_datetime(s: str) -> datetime:
     """
     Returns ``datetime.datetime`` from human readable strings
 
@@ -256,8 +259,6 @@ def parse_human_datetime(s: Optional[str]) -> Optional[datetime]:
     >>> year_ago_1 == year_ago_2
     True
     """
-    if not s:
-        return None
     try:
         dttm = parse(s)
     except Exception:
@@ -564,7 +565,9 @@ def generic_find_uq_constraint_name(table, columns, insp):
             return uq["name"]
 
 
-def get_datasource_full_name(database_name, datasource_name, schema=None):
+def get_datasource_full_name(
+    database_name: str, datasource_name: str, schema: Optional[str] = None
+) -> str:
     if not schema:
         return "[{}].[{}]".format(database_name, datasource_name)
     return "[{}].[{}].[{}]".format(database_name, schema, datasource_name)
@@ -792,7 +795,7 @@ def get_email_address_list(address_string: str) -> List[str]:
     return [x.strip() for x in address_string_list if x.strip()]
 
 
-def choicify(values):
+def choicify(values: Iterable[Any]) -> List[Tuple[Any, Any]]:
     """Takes an iterable and makes an iterable of tuples with it"""
     return [(v, v) for v in values]
 
@@ -967,7 +970,7 @@ def get_example_database() -> "Database":
     return get_or_create_db("examples", db_uri)
 
 
-def is_adhoc_metric(metric) -> bool:
+def is_adhoc_metric(metric: Metric) -> bool:
     return bool(
         isinstance(metric, dict)
         and (
@@ -985,11 +988,11 @@ def is_adhoc_metric(metric) -> bool:
     )
 
 
-def get_metric_name(metric):
-    return metric["label"] if is_adhoc_metric(metric) else metric
+def get_metric_name(metric: Metric) -> str:
+    return metric["label"] if is_adhoc_metric(metric) else metric  # type: ignore
 
 
-def get_metric_names(metrics):
+def get_metric_names(metrics: Sequence[Metric]) -> List[str]:
     return [get_metric_name(metric) for metric in metrics]
 
 

--- a/superset/utils/import_datasource.py
+++ b/superset/utils/import_datasource.py
@@ -15,15 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from typing import Callable, Optional
 
+from flask_appbuilder import Model
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.session import make_transient
 
 logger = logging.getLogger(__name__)
 
 
 def import_datasource(
-    session, i_datasource, lookup_database, lookup_datasource, import_time
-):
+    session: Session,
+    i_datasource: Model,
+    lookup_database: Callable,
+    lookup_datasource: Callable,
+    import_time: Optional[int] = None,
+) -> int:
     """Imports the datasource from the object to the database.
 
      Metrics and columns and datasource will be overrided if exists.
@@ -75,7 +82,7 @@ def import_datasource(
     return datasource.id
 
 
-def import_simple_obj(session, i_obj, lookup_obj):
+def import_simple_obj(session: Session, i_obj: Model, lookup_obj: Callable) -> Model:
     make_transient(i_obj)
     i_obj.id = None
     i_obj.table = None

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -21,7 +21,6 @@ These objects represent the backend of all the visualizations that
 Superset can render.
 """
 import copy
-import dataclasses
 import hashlib
 import inspect
 import logging
@@ -34,6 +33,7 @@ from datetime import datetime, timedelta
 from itertools import product
 from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 
+import dataclasses
 import geohash
 import numpy as np
 import pandas as pd
@@ -1049,9 +1049,9 @@ class BubbleViz(NVD3Viz):
         # dedup groupby if it happens to be the same
         d["groupby"] = list(dict.fromkeys(d["groupby"]))
 
-        self.x_metric = form_data.get("x")
-        self.y_metric = form_data.get("y")
-        self.z_metric = form_data.get("size")
+        self.x_metric = form_data["x"]
+        self.y_metric = form_data["y"]
+        self.z_metric = form_data["size"]
         self.entity = form_data.get("entity")
         self.series = form_data.get("series") or self.entity
         d["row_limit"] = form_data.get("limit")
@@ -1093,7 +1093,7 @@ class BulletViz(NVD3Viz):
     def query_obj(self):
         form_data = self.form_data
         d = super().query_obj()
-        self.metric = form_data.get("metric")
+        self.metric = form_data["metric"]
 
         d["metrics"] = [self.metric]
         if not self.metric:
@@ -1451,8 +1451,8 @@ class NVD3DualLineViz(NVD3Viz):
                 _("Pick a time granularity for your time series")
             )
 
-        metric = utils.get_metric_name(fd.get("metric"))
-        metric_2 = utils.get_metric_name(fd.get("metric_2"))
+        metric = utils.get_metric_name(fd["metric"])
+        metric_2 = utils.get_metric_name(fd["metric_2"])
         df = df.pivot_table(index=DTTM_ALIAS, values=[metric, metric_2])
 
         chart_data = self.to_series(df)
@@ -1507,7 +1507,7 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
         df = df.pivot_table(
             index=DTTM_ALIAS,
             columns="series",
-            values=utils.get_metric_name(fd.get("metric")),
+            values=utils.get_metric_name(fd["metric"]),
         )
         chart_data = self.to_series(df)
         for serie in chart_data:
@@ -1690,8 +1690,12 @@ class SunburstViz(BaseViz):
         fd = self.form_data
         cols = fd.get("groupby") or []
         cols.extend(["m1", "m2"])
-        metric = utils.get_metric_name(fd.get("metric"))
-        secondary_metric = utils.get_metric_name(fd.get("secondary_metric"))
+        metric = utils.get_metric_name(fd["metric"])
+        secondary_metric = (
+            utils.get_metric_name(fd["secondary_metric"])
+            if "secondary_metric" in fd
+            else None
+        )
         if metric == secondary_metric or secondary_metric is None:
             df.rename(columns={df.columns[-1]: "m1"}, inplace=True)
             df["m2"] = df["m1"]
@@ -1872,8 +1876,12 @@ class WorldMapViz(BaseViz):
 
         fd = self.form_data
         cols = [fd.get("entity")]
-        metric = utils.get_metric_name(fd.get("metric"))
-        secondary_metric = utils.get_metric_name(fd.get("secondary_metric"))
+        metric = utils.get_metric_name(fd["metric"])
+        secondary_metric = (
+            utils.get_metric_name(fd["secondary_metric"])
+            if "secondary_metric" in fd
+            else None
+        )
         columns = ["country", "m1", "m2"]
         if metric == secondary_metric:
             ndf = df[cols]

--- a/superset/viz_sip38.py
+++ b/superset/viz_sip38.py
@@ -21,7 +21,6 @@ These objects represent the backend of all the visualizations that
 Superset can render.
 """
 import copy
-import dataclasses
 import hashlib
 import inspect
 import logging
@@ -34,6 +33,7 @@ from datetime import datetime, timedelta
 from itertools import product
 from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 
+import dataclasses
 import geohash
 import numpy as np
 import pandas as pd
@@ -1077,9 +1077,9 @@ class BubbleViz(NVD3Viz):
         form_data = self.form_data
         d = super().query_obj()
 
-        self.x_metric = form_data.get("x")
-        self.y_metric = form_data.get("y")
-        self.z_metric = form_data.get("size")
+        self.x_metric = form_data["x"]
+        self.y_metric = form_data["y"]
+        self.z_metric = form_data["size"]
         self.entity = form_data.get("entity")
         self.series = form_data.get("series") or self.entity
         d["row_limit"] = form_data.get("limit")
@@ -1476,8 +1476,8 @@ class NVD3DualLineViz(NVD3Viz):
                 _("Pick a time granularity for your time series")
             )
 
-        metric = utils.get_metric_name(fd.get("metric"))
-        metric_2 = utils.get_metric_name(fd.get("metric_2"))
+        metric = utils.get_metric_name(fd["metric"])
+        metric_2 = utils.get_metric_name(fd["metric_2"])
         df = df.pivot_table(index=DTTM_ALIAS, values=[metric, metric_2])
 
         chart_data = self.to_series(df)
@@ -1532,7 +1532,7 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
         df = df.pivot_table(
             index=DTTM_ALIAS,
             columns="series",
-            values=utils.get_metric_name(fd.get("metric")),
+            values=utils.get_metric_name(fd["metric"]),
         )
         chart_data = self.to_series(df)
         for serie in chart_data:
@@ -1710,8 +1710,12 @@ class SunburstViz(BaseViz):
         fd = self.form_data
         cols = fd.get("groupby") or []
         cols.extend(["m1", "m2"])
-        metric = utils.get_metric_name(fd.get("metric"))
-        secondary_metric = utils.get_metric_name(fd.get("secondary_metric"))
+        metric = utils.get_metric_name(fd["metric"])
+        secondary_metric = (
+            utils.get_metric_name(fd["secondary_metric"])
+            if "secondary_metric" in fd
+            else None
+        )
         if metric == secondary_metric or secondary_metric is None:
             df.rename(columns={df.columns[-1]: "m1"}, inplace=True)
             df["m2"] = df["m1"]
@@ -1868,8 +1872,12 @@ class WorldMapViz(BaseViz):
 
         fd = self.form_data
         cols = [fd.get("entity")]
-        metric = utils.get_metric_name(fd.get("metric"))
-        secondary_metric = utils.get_metric_name(fd.get("secondary_metric"))
+        metric = utils.get_metric_name(fd["metric"])
+        secondary_metric = (
+            utils.get_metric_name(fd["secondary_metric"])
+            if "secondary_metric" in fd
+            else None
+        )
         columns = ["country", "m1", "m2"]
         if metric == secondary_metric:
             ndf = df[cols]


### PR DESCRIPTION
### SUMMARY

Adding `mypy` type enforcement to the `superset.connectors` module.

Note this PR was much more involved/complex than I had originally thought given the dependency on other modules which were untyped. Additionally the overall code quality is quite poor; large complex functions, numerous variables which were either optional or with mixed types (`Union`), variable redefinition, etc. meant that the logic was quite hard to grok.

Note this PR may introduce some regressions due to the necessary restructuring, however I sense long-term benefits of having the entire repo typed outweighs the short-term concerns regarding possibly (minor) regressions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
