### PR TITLE
build: Add python 3.8 to the build matrix

### DIFF
--- a/.github/workflows/superset-python.yml
+++ b/.github/workflows/superset-python.yml
@@ -76,8 +76,7 @@ jobs:
     strategy:
       matrix:
         # run unit tests in multiple version just for fun
-        # (3.8 is not supported yet, some dependencies need an update)
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.superset_test_config

--- a/docker/requirements-extra.txt
+++ b/docker/requirements-extra.txt
@@ -15,5 +15,5 @@
 # limitations under the License.
 #
 gevent==1.4.0
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.5
 redis==3.2.1

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 ## These requirements are used to build a requirements file which is then applied on init
 ## of superset containers
 additionalRequirements:
-  - "psycopg2==2.8.3"
+  - "psycopg2==2.8.5"
   - "redis==3.2.1"
 
 ## The name of the secret which we will use to generate a superset_config.py file
@@ -84,7 +84,7 @@ supersetNode:
     - "/bin/sh"
     - "-c"
     - ". {{ .Values.configMountPath }}/superset_bootstrap.sh; /usr/bin/docker-entrypoint.sh"
-  connections: 
+  connections:
     redis_host: '{{ template "superset.fullname" . }}-redis-headless'
     redis_port: "6379"
     db_host: '{{ template "superset.fullname" . }}-postgresql'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ mypy==0.770
 nose==1.3.7
 pip-tools==5.1.2
 pre-commit==1.17.0
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.5
 pycodestyle==2.5.0
 pydruid==0.5.9
 pyhive==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
         "gsheets": ["gsheetsdb>=0.1.9"],
         "hive": ["pyhive[hive]>=0.6.1", "tableschema", "thrift>=0.11.0, <1.0.0"],
         "mysql": ["mysqlclient==1.4.2.post1"],
-        "postgres": ["psycopg2-binary==2.7.5"],
+        "postgres": ["psycopg2-binary==2.8.5"],
         "presto": ["pyhive[presto]>=0.4.0"],
         "elasticsearch": ["elasticsearch-dbapi>=0.1.0, <0.2.0"],
         "druid": ["pydruid==0.5.7", "requests==2.22.0"],

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -16,10 +16,10 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset"""
-import cgi
 import csv
 import datetime
 import doctest
+import html
 import io
 import json
 import logging
@@ -1150,7 +1150,11 @@ class CoreTests(SupersetTestCase):
             {"FOO": lambda x: 1, "super": "set"},
             default=utils.pessimistic_json_iso_dttm_ser,
         )
-        html = cgi.escape(encoded).replace("'", "&#39;").replace('"', "&#34;")
+        html_string = (
+            html.escape(encoded, quote=False)
+            .replace("'", "&#39;")
+            .replace('"', "&#34;")
+        )
 
         urls = [
             "/superset/sqllab",
@@ -1161,7 +1165,7 @@ class CoreTests(SupersetTestCase):
         ]
         for url in urls:
             data = self.get_resp(url)
-            self.assertTrue(html in data)
+            self.assertTrue(html_string in data)
 
     @mock.patch.dict(
         "superset.extensions.feature_flag_manager._feature_flags",


### PR DESCRIPTION
### SUMMARY
Upgrades some deps to support 3.6 through 3.8 and removes a deprecated function.

Note that this does not guarantee support for all db engines, only support for postgres

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @john-bodley @craig-rueda @villebro @bkyryliuk 