### PR TITLE
build: tox leveraging conditional factors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,13 +23,15 @@ commands =
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
+    mysql: .[mysql]
+    postgres: .[postgres]
 setenv =
     PYTHONPATH = {toxinidir}
     SUPERSET_CONFIG = tests.superset_test_config
     SUPERSET_HOME = {envtmpdir}
-    py36-mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
-    py36-postgres: SUPERSET__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://superset:superset@localhost/test
-    py36-sqlite: SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
+    mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
+    postgres: SUPERSET__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://superset:superset@localhost/test
+    sqlite: SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
 whitelist_externals =
     npm
 
@@ -136,18 +138,6 @@ commands =
     mypy setup.py superset tests
 deps =
     -rrequirements-dev.txt
-
-[testenv:py36-mysql]
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
-    .[mysql]
-
-[testenv:py36-postgres]
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
-    .[postgres]
 
 [testenv:pylint]
 commands =


### PR DESCRIPTION
### SUMMARY

Cleaning up `tox.ini` to leverage [conditional factors](https://tox.readthedocs.io/en/2.5.0/config.html#factors-and-factor-conditional-settings) which reduce the footprint and remove the explicit Python version.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Verified locally by running `tox -e py36-mysql`. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
