### PR TITLE
fix: [filter_box] fix 2 issues in single value filter_box

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/FilterBoxItemControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/FilterBoxItemControl_spec.jsx
@@ -91,9 +91,14 @@ describe('FilterBoxItemControl', () => {
       multiple: false,
     });
     inst.setState = sinon.spy();
-    inst.onControlChange('defaultValue', '1');
 
+    inst.onControlChange('defaultValue', '1');
     expect(inst.setState.callCount).toBe(1);
     expect(inst.setState.getCall(0).args[0]).toEqual({ defaultValue: 1 });
+
+    // user input is invalid for number type column
+    inst.onControlChange('defaultValue', 'abc');
+    expect(inst.setState.callCount).toBe(2);
+    expect(inst.setState.getCall(1).args[0]).toEqual({ defaultValue: null });
   });
 });

--- a/superset-frontend/spec/javascripts/explore/components/FilterBoxItemControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/FilterBoxItemControl_spec.jsx
@@ -52,4 +52,48 @@ describe('FilterBoxItemControl', () => {
     const popover = shallow(inst.renderForm());
     expect(popover.find(FormRow)).toHaveLength(7);
   });
+
+  it('convert type for single value filter_box', () => {
+    inst = getWrapper({
+      datasource: {
+        columns: [
+          {
+            column_name: 'SP_POP_TOTL',
+            description: null,
+            expression: null,
+            filterable: true,
+            groupby: true,
+            id: 312,
+            is_dttm: false,
+            type: 'FLOAT',
+            verbose_name: null,
+          },
+        ],
+        metrics: [
+          {
+            d3format: null,
+            description: null,
+            expression: 'sum("SP_POP_TOTL")',
+            id: 3,
+            metric_name: 'sum__SP_POP_TOTL',
+            verbose_name: null,
+            warning_text: null,
+          },
+        ],
+      },
+    }).instance();
+    inst.setState({
+      asc: true,
+      clearable: true,
+      column: 'SP_POP_TOTL',
+      defaultValue: 254454778,
+      metric: undefined,
+      multiple: false,
+    });
+    inst.setState = sinon.spy();
+    inst.onControlChange('defaultValue', '1');
+
+    expect(inst.setState.callCount).toBe(1);
+    expect(inst.setState.getCall(0).args[0]).toEqual({ defaultValue: 1 });
+  });
 });

--- a/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.js
+++ b/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.js
@@ -18,7 +18,10 @@
  */
 /* eslint-disable camelcase */
 import { TIME_FILTER_MAP } from '../../visualizations/FilterBox/FilterBox';
-import { TIME_FILTER_LABELS } from '../../explore/constants';
+import {
+  FILTER_CONFIG_ATTRIBUTES,
+  TIME_FILTER_LABELS,
+} from '../../explore/constants';
 
 export default function getFilterConfigsFromFormdata(form_data = {}) {
   const {
@@ -31,10 +34,13 @@ export default function getFilterConfigsFromFormdata(form_data = {}) {
   } = form_data;
   let configs = filter_configs.reduce(
     ({ columns, labels }, config) => {
-      let defaultValues = config.defaultValue;
+      let defaultValues = config[FILTER_CONFIG_ATTRIBUTES.DEFAULT_VALUE];
       // defaultValue could be ; separated values,
       // could be null or ''
-      if (config.defaultValue && config.multiple) {
+      if (
+        config[FILTER_CONFIG_ATTRIBUTES.DEFAULT_VALUE] &&
+        config[FILTER_CONFIG_ATTRIBUTES.MULTIPLE]
+      ) {
         defaultValues = config.defaultValue.split(';');
       }
       const updatedColumns = {

--- a/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.js
+++ b/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.js
@@ -34,7 +34,7 @@ export default function getFilterConfigsFromFormdata(form_data = {}) {
       let defaultValues = config.defaultValue;
       // defaultValue could be ; separated values,
       // could be null or ''
-      if (config.defaultValue) {
+      if (config.defaultValue && config.multiple) {
         defaultValues = config.defaultValue.split(';');
       }
       const updatedColumns = {

--- a/superset-frontend/src/explore/constants.js
+++ b/superset-frontend/src/explore/constants.js
@@ -78,3 +78,8 @@ export const TIME_FILTER_LABELS = {
   druid_time_origin: t('Origin'),
   granularity: t('Time Granularity'),
 };
+
+export const FILTER_CONFIG_ATTRIBUTES = {
+  DEFAULT_VALUE: 'defaultValue',
+  MULTIPLE: 'multiple',
+};

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -31,7 +31,10 @@ import OnPasteSelect from '../../components/OnPasteSelect';
 import VirtualizedRendererWrap from '../../components/VirtualizedRendererWrap';
 import { getDashboardFilterKey } from '../../dashboard/util/getDashboardFilterKey';
 import { getFilterColorMap } from '../../dashboard/util/dashboardFiltersColorMap';
-import { TIME_FILTER_LABELS } from '../../explore/constants';
+import {
+  FILTER_CONFIG_ATTRIBUTES,
+  TIME_FILTER_LABELS,
+} from '../../explore/constants';
 import FilterBadgeIcon from '../../components/FilterBadgeIcon';
 
 import './FilterBox.less';
@@ -259,19 +262,22 @@ class FilterBox extends React.Component {
     let value = selectedValues[key] || null;
 
     // Assign default value if required
-    if (value === undefined && filterConfig.defaultValue) {
-      if (filterConfig.multiple) {
+    if (
+      value === undefined &&
+      filterConfig[FILTER_CONFIG_ATTRIBUTES.DEFAULT_VALUE]
+    ) {
+      if (filterConfig[FILTER_CONFIG_ATTRIBUTES.MULTIPLE]) {
         // Support for semicolon-delimited multiple values
-        value = filterConfig.defaultValue.split(';');
+        value = filterConfig[FILTER_CONFIG_ATTRIBUTES.DEFAULT_VALUE].split(';');
       } else {
-        value = filterConfig.defaultValue;
+        value = filterConfig[FILTER_CONFIG_ATTRIBUTES.DEFAULT_VALUE];
       }
     }
     return (
       <OnPasteSelect
         placeholder={t('Select [%s]', label)}
         key={key}
-        multi={filterConfig.multiple}
+        multi={filterConfig[FILTER_CONFIG_ATTRIBUTES.MULTIPLE]}
         clearable={filterConfig.clearable}
         value={value}
         options={data.map(opt => {

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -259,7 +259,7 @@ class FilterBox extends React.Component {
     let value = selectedValues[key] || null;
 
     // Assign default value if required
-    if (!value && filterConfig.defaultValue) {
+    if (value === undefined && filterConfig.defaultValue) {
       if (filterConfig.multiple) {
         // Support for semicolon-delimited multiple values
         value = filterConfig.defaultValue.split(';');


### PR DESCRIPTION
### SUMMARY
This PR is to fix 2 issues in **single value** filter_box.

### BEFORE

1. Issue 1: Clear filter_box won't clear filter's default value
![gGtwLBI2qw](https://user-images.githubusercontent.com/27990562/82166530-9365c900-986d-11ea-89a6-c60e68c8ab32.gif)


1. Issue 2: Set default value for a single value filter_box, the column's data type is FLOAT:
<img width="570" alt="Screen Shot 2020-05-17 at 6 48 57 PM" src="https://user-images.githubusercontent.com/27990562/82167010-34a14f00-986f-11ea-9a14-1516e9939aea.png">
In dashboard, this string value doesn't match with filter's data type, so that it looks the same option show twice:
<img width="760" alt="Screen Shot 2020-05-17 at 6 50 46 PM" src="https://user-images.githubusercontent.com/27990562/82167070-6d412880-986f-11ea-8b5f-21e83cb0cf8b.png">

Proposed solution:

1. Issue 1: When user clear filter_box, the option value should be null. While when filter_box value is undefined, should use defaultValue.
2. Issue 2: When user update defaultValue for filter_box, add type cast for numeric and boolean type column.
 

### TEST PLAN
CI and manual test.

@mistercrunch @ktmud @etr2460 