### PR TITLE
fix: Removing the logic to add timeseries_limit_metric to the data for table

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -637,12 +637,6 @@ class TableViz(BaseViz):
             utils.get_metric_names(self.form_data.get("metrics") or [])
         )
 
-        timeseries_limit_metric = utils.get_metric_name(
-            self.form_data.get("timeseries_limit_metric")
-        )
-        if timeseries_limit_metric:
-            non_percent_metric_columns.append(timeseries_limit_metric)
-
         percent_metric_columns = utils.get_metric_names(
             self.form_data.get("percent_metrics") or []
         )

--- a/superset/viz_sip38.py
+++ b/superset/viz_sip38.py
@@ -676,12 +676,6 @@ class TableViz(BaseViz):
             utils.get_metric_names(self.form_data.get("metrics") or [])
         )
 
-        timeseries_limit_metric = utils.get_metric_name(
-            self.form_data.get("timeseries_limit_metric")
-        )
-        if timeseries_limit_metric:
-            non_percent_metric_columns.append(timeseries_limit_metric)
-
         percent_metric_columns = utils.get_metric_names(
             self.form_data.get("percent_metrics") or []
         )

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -431,7 +431,7 @@ class TableVizTestCase(SupersetTestCase):
         datasource = self.get_datasource_mock()
         test_viz = viz.TableViz(datasource, form_data)
         data = test_viz.get_data(df)
-        self.assertEqual(["sum_value", "SUM(value1)"], data["columns"])
+        self.assertEqual(["sum_value"], data["columns"])
 
 
 class DistBarVizTestCase(SupersetTestCase):


### PR DESCRIPTION
### SUMMARY
Removing logic to add the timeseries_limit_metric to data for Table viz. This was previously necessary in the old Table viz to fix a bug where labeled metrics with a sortby wouldn't show up. This is no longer necessary in the new Table viz and causes an extra column to show up on the table.

### TEST PLAN
Testing table viz with and without sortby, with and without labeled metrics.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


@john-bodley @etr2460 @ktmud