### PR TITLE
build: Updating the sphinx configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,9 @@ import shlex
 import sys
 
 import sphinx_rtd_theme
+from pandas._typing import ArrayLike  # Somehow required for type-checking.
+
+from superset import security_manager  # Somehow required for type-checking.
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -304,3 +307,7 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
+
+# -- Options for sphinx-autodoc-typehints -------------------------------------
+
+set_type_checking_flag = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,5 +15,5 @@
 # limitations under the License.
 #
 sphinx==3.0.1
-sphinx_autodoc_typehints==1.10.3
+sphinx-autodoc-typehints==1.10.3
 sphinx-rtd-theme==0.4.3

--- a/docs/sqllab.rst
+++ b/docs/sqllab.rst
@@ -79,15 +79,10 @@ Superset's Jinja context:
 
 `Jinja's builtin filters <http://jinja.pocoo.org/docs/dev/templates/>`_ can be also be applied where needed.
 
-.. autofunction:: superset.jinja_context.ExtraCache.current_user_id
-
-.. autofunction:: superset.jinja_context.ExtraCache.current_username
-
-.. autofunction:: superset.jinja_context.ExtraCache.url_param
+.. autoclass:: superset.jinja_context.ExtraCache
+    :members:
 
 .. autofunction:: superset.jinja_context.filter_values
-
-.. autofunction:: superset.jinja_context.ExtraCache.cache_key_wrapper
 
 .. autoclass:: superset.jinja_context.PrestoTemplateProcessor
     :members:


### PR DESCRIPTION
### SUMMARY

This PR fixes an issue which surfaced in https://github.com/apache/incubator-superset/pull/9824 with Sphinx when an auto-doc included a forward reference via `TYPE_CHECKING`. 

The fix is to `set_type_checking_flag = True` in the Sphinx configuration however this raised additional warnings such as `cannot import name 'ArrayLike'` and `cannot import name 'security_manager'`. 

After a decent amount of Googling it's uncertain what the root cause is, but it seems importing these modules into `docs/conf.py` resolves the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Successfully ran `tox -e docs` and verified that the generated HTML was correct.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
