### PR TITLE
docs: Update the link to ClickHouse official website

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,7 +109,7 @@ The following RDBMS are currently supported:
 - `Apache Pinot <https://pinot.incubator.apache.org/>`_
 - `Apache Spark SQL <https://spark.apache.org/sql/>`_
 - `BigQuery <https://cloud.google.com/bigquery/>`_
-- `ClickHouse <https://clickhouse.yandex/>`_
+- `ClickHouse <https://clickhouse.tech/>`_
 - `CockroachDB <https://www.cockroachlabs.com/>`_
 - `Dremio <https://dremio.com/>`_
 - `Elasticsearch <https://www.elastic.co/elasticsearch/>`_


### PR DESCRIPTION
### SUMMARY
ClickHouse official domain have moved to a new domain earlier this year. Update the link instead of relying on redirect.

### TEST PLAN
Click the link

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
