### PR TITLE
fix: use snake_case for error_type

### DIFF
--- a/superset-frontend/spec/javascripts/utils/getClientErrorObject_spec.ts
+++ b/superset-frontend/spec/javascripts/utils/getClientErrorObject_spec.ts
@@ -48,7 +48,7 @@ describe('getClientErrorObject()', () => {
     const jsonError = {
       errors: [
         {
-          errorType: ErrorTypeEnum.GENERIC_DB_ENGINE_ERROR,
+          error_type: ErrorTypeEnum.GENERIC_DB_ENGINE_ERROR,
           extra: { engine: 'presto', link: 'https://www.google.com' },
           level: 'error',
           message: 'presto error: test error',

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -40,7 +40,7 @@ export default function ErrorMessageWithStackTrace({
   // Check if a custom error message component was registered for this message
   if (error) {
     const ErrorMessageComponent = getErrorMessageComponentRegistry().get(
-      error.errorType,
+      error.error_type,
     );
     if (ErrorMessageComponent) {
       return <ErrorMessageComponent error={error} />;

--- a/superset-frontend/src/components/ErrorMessage/types.ts
+++ b/superset-frontend/src/components/ErrorMessage/types.ts
@@ -47,7 +47,7 @@ export type ErrorType = ValueOf<typeof ErrorTypeEnum>;
 export type ErrorLevel = 'info' | 'warning' | 'error';
 
 export type SupersetError = {
-  errorType: ErrorType;
+  error_type: ErrorType;
   extra: Record<string, any> | null;
   level: ErrorLevel;
   message: string;


### PR DESCRIPTION
### SUMMARY
To match the api standard, `errorType` should be `error_type` instead

### TEST PLAN
CI, ensure the error message component is overridden when a custom message is registered

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @graceguo-supercat @john-bodley @kristw 