### PR TITLE
fix: issue with duplicated dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,11 +114,14 @@ ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 ######################################################################
 FROM lean AS dev
 
-COPY ./requirements-dev.txt ./docker/requirements* /app/
+COPY ./requirements* ./docker/requirements* /app/
 
 USER root
+# Cache everything for dev purposes...
 RUN cd /app \
-    && pip install --no-cache -r requirements-dev.txt \
-    && pip install --no-cache -r requirements-extra.txt \
-    && pip install --no-cache -r requirements-local.txt || true
+    && pip install --ignore-installed -e . \
+    && pip install --ignore-installed -r requirements.txt \
+    && pip install --ignore-installed -r requirements-dev.txt \
+    && pip install --ignore-installed -r requirements-extra.txt \
+    && pip install --ignore-installed -r requirements-local.txt || true
 USER superset

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,7 @@ COPY ./requirements-dev.txt ./docker/requirements* /app/
 
 USER root
 RUN cd /app \
-    && pip install --no-cache -r requirements-dev.txt -r requirements-extra.txt \
+    && pip install --no-cache -r requirements-dev.txt \
+    && pip install --no-cache -r requirements-extra.txt \
     && pip install --no-cache -r requirements-local.txt || true
 USER superset

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+######################################################################
+# Dev image...
+######################################################################
+FROM preset/superset:dev
+
+COPY ./requirements* ./docker/requirements* /app/
+
+USER root
+RUN cd /app \
+    && pip install -e . \
+    && pip install --no-cache -r requirements.txt -r requirements-dev.txt \
+    && pip install --no-cache -r requirements-extra.txt \
+    && pip install --no-cache -r requirements-local.txt || true
+USER superset

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,6 @@ services:
       REDIS_RESULTS_DB: 3
       REDIS_HOST: localhost
     network_mode: host
-    restart: unless-stopped
     depends_on: *superset-depends-on
     volumes: *superset-volumes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,7 @@ x-superset-build: &superset-build
   args:
     NPM_BUILD_CMD: build-dev
   context: ./
-  dockerfile: Dockerfile
-  target: dev
+  dockerfile: Dockerfile-dev
 x-superset-depends-on: &superset-depends-on
   - db
   - redis


### PR DESCRIPTION
### SUMMARY
* Fixes issue with `pip` install failing when dependencies are duplicated across requirements files.
* Removes `restart: always` from tests worker as it crash-loops during "normal" operation. 
* Adds `Dockerfile-dev` which depends on `preset/superset:dev` which acts as a cache for local development

