### PR TITLE
fix(chart): chart datasource explore URL showing datasource name for druid

### DIFF
--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -133,7 +133,7 @@ class Slice(
         if self.table:
             return self.table.explore_url
         datasource = self.datasource
-        return datasource.name if datasource else None
+        return datasource.explore_url if datasource else None
 
     def datasource_name_text(self) -> Optional[str]:
         # pylint: disable=no-member


### PR DESCRIPTION
### SUMMARY
Bug introduced on #9619, URL for druid datasources rendering name instead of `explore_url`

### TEST PLAN
- Create a druid cluster and datasource
- Create a chart for the previous create druid datasource
- Assert that the rendered URL for the datasource on the charts list links to the druid datasource 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
