### PR TITLE
docs: Disable sphinx-autodoc-typehints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ import sphinx_rtd_theme
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.viewcode"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,9 +31,6 @@ import shlex
 import sys
 
 import sphinx_rtd_theme
-from pandas._typing import ArrayLike  # Somehow required for type-checking.
-
-from superset import security_manager  # Somehow required for type-checking.
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -48,7 +45,7 @@ from superset import security_manager  # Somehow required for type-checking.
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx_autodoc_typehints"]
+extensions = ["sphinx.ext.viewcode"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -307,7 +304,3 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
-
-# -- Options for sphinx-autodoc-typehints -------------------------------------
-
-set_type_checking_flag = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 sphinx==3.0.1
-sphinx-autodoc-typehints==1.10.3
 sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
### SUMMARY

This PR disables `sphinx-autodoc-typehints` which seem to be problematic when forward reference type checking is used even when applying the [recommendations](https://pypi.org/project/sphinx-autodoc-typehints/) for circular imports. 

It seems for https://github.com/apache/incubator-superset/pull/9824 which required `set_type_checking_flag = True` there were problems with Flask-Login and the LocalProxy in addition to the requirements added in https://github.com/apache/incubator-superset/pull/9833. Furthermore there seems to be a number of open [issues](https://github.com/agronholm/sphinx-autodoc-typehints/issues) with the package, and thus I wondered if there was merit in disabling this until we have Python 3.7 as the minimum version when we can leverage [postponed evaluations and annotations](https://docs.python.org/3/whatsnew/3.7.html#pep-563-postponed-evaluation-of-annotations).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
