### PR TITLE
fix: Fix for updated cache dependency

### DIFF
--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -58,7 +58,7 @@ pip install {{ range .Values.additionalRequirements }}{{ . }} {{ end }}
 
 {{- define "superset-config" }}
 import os
-from flask_caching.backends.rediscache import RedisCache
+from cachelib.redis import RedisCache
 
 def env(key, default=None):
     return os.getenv(key, default)

--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -58,7 +58,7 @@ pip install {{ range .Values.additionalRequirements }}{{ . }} {{ end }}
 
 {{- define "superset-config" }}
 import os
-from werkzeug.contrib.cache import RedisCache
+from flask_caching.backends.rediscache import RedisCache
 
 def env(key, default=None):
     return os.getenv(key, default)

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -24,6 +24,7 @@ replicaCount: 1
 ## These requirements are used to build a requirements file which is then applied on init
 ## of superset containers
 additionalRequirements:
+  - "Flask-Caching==1.8.0"
   - "psycopg2==2.8.5"
   - "redis==3.2.1"
 

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -24,7 +24,6 @@ replicaCount: 1
 ## These requirements are used to build a requirements file which is then applied on init
 ## of superset containers
 additionalRequirements:
-  - "Flask-Caching==1.8.0"
   - "psycopg2==2.8.5"
   - "redis==3.2.1"
 


### PR DESCRIPTION
### SUMMARY
We recently upgraded the Wekrkzeug library to 1.0 which removed support for cache backends. The resolution is to switch over to Flask-Caching instead.
 
@nytai