### PR TITLE
fix: raise error in sqllab when using reserved column name

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
@@ -101,6 +101,7 @@ describe('ExploreResultsButton', () => {
       '1',
       '123',
       'CASE WHEN 1=1 THEN 1 ELSE 0 END',
+      '__TIMESTAMP',
     ]);
 
     const msgWrapper = shallow(wrapper.instance().renderInvalidColumnMessage());

--- a/superset-frontend/spec/javascripts/sqllab/fixtures.js
+++ b/superset-frontend/spec/javascripts/sqllab/fixtures.js
@@ -315,6 +315,16 @@ export const queryWithBadColumns = {
         name: 'CASE WHEN 1=1 THEN 1 ELSE 0 END',
         type: 'STRING',
       },
+      {
+        is_date: true,
+        name: '_TIMESTAMP',
+        type: 'TIMESTAMP',
+      },
+      {
+        is_date: true,
+        name: '__TIMESTAMP',
+        type: 'TIMESTAMP',
+      },
     ],
   },
 };

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -104,10 +104,11 @@ class ExploreResultsButton extends React.PureComponent {
   getInvalidColumns() {
     const re1 = /^[A-Za-z_]\w*$/; // starts with char or _, then only alphanum
     const re2 = /__\d+$/; // does not finish with __ and then a number which screams dup col name
+    const re3 = /^__/; // is not a reserved column name e.g. __timestamp
 
     return this.props.query.results.selected_columns
       .map(col => col.name)
-      .filter(col => !re1.test(col) || re2.test(col));
+      .filter(col => !re1.test(col) || re2.test(col) || re3.test(col));
   }
   datasourceName() {
     const { query } = this.props;
@@ -194,13 +195,13 @@ class ExploreResultsButton extends React.PureComponent {
         </code>
         {t('cannot be used as a column name. Please use aliases (as in ')}
         <code>
-          SELECT count(*)
+          SELECT count(*)&nbsp;
           <strong>AS my_alias</strong>
         </code>
         ){' '}
-        {t(`limited to alphanumeric characters and underscores. Column aliases ending with
-          double underscores followed by a numeric value are not allowed for reasons
-          discussed in Github issue #5739.
+        {t(`limited to alphanumeric characters and underscores. Column aliases starting
+          with double underscores or ending with double underscores followed by a
+          numeric value are not allowed for reasons discussed in Github issue #5739.
           `)}
       </div>
     );


### PR DESCRIPTION
### SUMMARY
Currently SQL Lab accepts the column name `__timestamp`, which causes problems when pressing the "Explore" button. This usually happens when clicking the "Run in SQL Lab" button on a timeseries chart. This adds a check for column names starting with double underscores.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/82447710-54c05080-9ab1-11ea-9354-91181055157e.png)
![image](https://user-images.githubusercontent.com/33317356/82447785-6f92c500-9ab1-11ea-892a-c3ff8334c25a.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/82447724-5d188b80-9ab1-11ea-9c3f-eb7877cb460c.png)

### TEST PLAN
Local testing + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
