### PR TITLE
fix: Revert "[sqllab] fix, strip comments before parsing statements"

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -82,10 +82,7 @@ class ParsedQuery:
         self._limit: Optional[int] = None
 
         logger.debug("Parsing with sqlparse statement: %s", self.sql)
-        self._parsed = sqlparse.parse(
-            sqlparse.format(self.stripped(), strip_comments=True)
-        )
-
+        self._parsed = sqlparse.parse(self.stripped())
         for statement in self._parsed:
             self._limit = _extract_limit_from_query(statement)
 

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -534,17 +534,6 @@ class SupersetTestCase(unittest.TestCase):
         expected = ["SELECT * FROM birth_names", "SELECT * FROM birth_names LIMIT 1"]
         self.assertEqual(statements, expected)
 
-    def test_comment_breakdown_statements(self):
-        multi_sql = """
-        SELECT * FROM birth_names;
-        -- some comment
-        """
-        parsed = ParsedQuery(multi_sql)
-        statements = parsed.get_statements()
-        self.assertEqual(len(statements), 1)
-        expected = ["SELECT * FROM birth_names"]
-        self.assertEqual(statements, expected)
-
     def test_messy_breakdown_statements(self):
         multi_sql = """
         SELECT 1;\t\n\n\n  \t


### PR DESCRIPTION
This reverts commit 949c4eae280a5e39202855a7928f0b578d6436b3.

### SUMMARY

This PR reverts https://github.com/apache/incubator-superset/pull/9692 as we should probably preserve comments to ensure that any database error references the correct line number. There's been confusion with a number of users where an error references the wrong line when compared to SQL Lab as lines containing comments have been stripped.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @nytai 