### PR TITLE
build: only conditionally skip fossa for pull_request events

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -19,6 +19,11 @@ jobs:
         FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       run: |
         set -eo pipefail
+        if [[ "${{github.event_name}}" != "pull_request" ]]; then 
+          ./scripts/fossa.sh
+          exit 0
+        fi
+
         URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
         FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/apache/incubator-superset/pull/9814 introduced a change to only run fossa when a PR changes dependency files, this caused master builds to fail since the logic in the script assumes it's a pull requests that's being built. This PR fixes this to only apply the conditional logic to `pull_request` events 
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- CI passes for PR
- CI passes for master when PR is merged

@rusackas 