### PR TITLE
fix: don't create examples db on 'superset init'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dataclasses,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -68,7 +68,6 @@ def superset():
 @with_appcontext
 def init():
     """Inits the Superset application"""
-    utils.get_example_database()
     appbuilder.add_permissions(update_perms=True)
     security_manager.sync_role_definitions()
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=unused-argument
+import dataclasses
 import hashlib
 import json
 import logging
@@ -33,7 +34,6 @@ from typing import (
     Union,
 )
 
-import dataclasses
 import pandas as pd
 import sqlparse
 from flask import g

--- a/superset/errors.py
+++ b/superset/errors.py
@@ -15,10 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=too-few-public-methods,invalid-name
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional
-
-from dataclasses import dataclass
 
 
 class SupersetErrorType(str, Enum):

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from dataclasses import dataclass
 from typing import List, Optional, Set
 from urllib import parse
 
 import sqlparse
-from dataclasses import dataclass
 from sqlparse.sql import Identifier, IdentifierList, remove_quotes, Token, TokenList
 from sqlparse.tokens import Keyword, Name, Punctuation, String, Whitespace
 from sqlparse.utils import imt

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -14,13 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import dataclasses
 import functools
 import logging
 import traceback
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-import dataclasses
 import simplejson as json
 import yaml
 from flask import abort, flash, g, get_flashed_messages, redirect, Response, session

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -21,6 +21,7 @@ These objects represent the backend of all the visualizations that
 Superset can render.
 """
 import copy
+import dataclasses
 import hashlib
 import inspect
 import logging
@@ -33,7 +34,6 @@ from datetime import datetime, timedelta
 from itertools import product
 from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 
-import dataclasses
 import geohash
 import numpy as np
 import pandas as pd

--- a/superset/viz_sip38.py
+++ b/superset/viz_sip38.py
@@ -21,6 +21,7 @@ These objects represent the backend of all the visualizations that
 Superset can render.
 """
 import copy
+import dataclasses
 import hashlib
 import inspect
 import logging
@@ -33,7 +34,6 @@ from datetime import datetime, timedelta
 from itertools import product
 from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 
-import dataclasses
 import geohash
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
### SUMMARY
`superset init` should not create the examples database as it does now

closes https://github.com/apache/incubator-superset/issues/9879