### PR TITLE
fix: old unique constraint remnance

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -373,7 +373,11 @@ class SqlaTable(Model, BaseDatasource):
     owner_class = security_manager.user_model
 
     __tablename__ = "tables"
-    __table_args__ = (UniqueConstraint("database_id", "table_name"),)
+    __table_args__ = (
+        UniqueConstraint(
+            "database_id", "schema", "table_name", name="_customer_location_uc",
+        ),
+    )
 
     table_name = Column(String(250), nullable=False)
     main_dttm_col = Column(String(250))

--- a/superset/migrations/versions/4e6a06bad7a8_init.py
+++ b/superset/migrations/versions/4e6a06bad7a8_init.py
@@ -127,7 +127,9 @@ def upgrade():
             "changed_by_fk", sa.Integer(), sa.ForeignKey("ab_user.id"), nullable=True
         ),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("table_name"),
+        # Commenting out spring 2020 to avoid flimsy delete in
+        # subsequent migration b4456560d4f3_change_table_unique_constraint.py
+        # sa.UniqueConstraint("table_name"),
     )
     op.create_table(
         "columns",

--- a/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
+++ b/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
@@ -30,13 +30,15 @@ down_revision = "bb51420eaf83"
 
 def upgrade():
     try:
-        # Trying to drop the constraint if it exists
-        op.drop_constraint("tables_table_name_key", "tables", type_="unique")
+        with op.batch_alter_table("tables") as batch_op:
+            # Trying to drop the constraint if it exists
+            batch_op.drop_constraint("tables_table_name_key", type_="unique")
     except Exception:
         pass
-    op.create_unique_constraint(
-        "_customer_location_uc", "tables", ["database_id", "schema", "table_name"]
-    )
+    with op.batch_alter_table("tables") as batch_op:
+        batch_op.create_unique_constraint(
+            "_customer_location_uc", ["database_id", "schema", "table_name"],
+        )
 
 
 def downgrade():

--- a/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
+++ b/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
@@ -30,18 +30,14 @@ down_revision = "bb51420eaf83"
 
 def upgrade():
     try:
-        # Trying since sqlite doesn't like constraints
+        # Trying to drop the constraint if it exists
         op.drop_constraint("tables_table_name_key", "tables", type_="unique")
-        op.create_unique_constraint(
-            "_customer_location_uc", "tables", ["database_id", "schema", "table_name"]
-        )
     except Exception:
         pass
+    op.create_unique_constraint(
+        "_customer_location_uc", "tables", ["database_id", "schema", "table_name"]
+    )
 
 
 def downgrade():
-    try:
-        # Trying since sqlite doesn't like constraints
-        op.drop_constraint(u"_customer_location_uc", "tables", type_="unique")
-    except Exception:
-        pass
+    op.drop_constraint(u"_customer_location_uc", "tables", type_="unique")

--- a/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
+++ b/superset/migrations/versions/b4456560d4f3_change_table_unique_constraint.py
@@ -27,19 +27,24 @@ from alembic import op
 revision = "b4456560d4f3"
 down_revision = "bb51420eaf83"
 
+conv = {
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+}
+
 
 def upgrade():
     try:
-        with op.batch_alter_table("tables") as batch_op:
-            # Trying to drop the constraint if it exists
-            batch_op.drop_constraint("tables_table_name_key", type_="unique")
+        with op.get_context().autocommit_block():
+            with op.batch_alter_table("tables", naming_convention=conv) as batch_op:
+                # Trying to drop the constraint if it exists
+                batch_op.drop_constraint("tables_table_name_key", type_="unique")
     except Exception:
         pass
-    with op.batch_alter_table("tables") as batch_op:
+    with op.batch_alter_table("tables", naming_convention=conv) as batch_op:
         batch_op.create_unique_constraint(
             "_customer_location_uc", ["database_id", "schema", "table_name"],
         )
 
 
 def downgrade():
-    op.drop_constraint(u"_customer_location_uc", "tables", type_="unique")
+    op.drop_constraint("_customer_location_uc", "tables", type_="unique")


### PR DESCRIPTION
### SUMMARY
closes https://github.com/apache/incubator-superset/issues/8871

When constraints names aren't defined in sqlalchemy/alembic, they are non-deterministic, and it makes it hard/impossible to delete them in subsequent migrations. Here a bad constraint was created originally without a name, and some other migration tries to re-create it, and may fail on a subset of database engines. Also I think sqlite doesn't support constraint making the whole thing more of a headache.

I decided to go back to the first migration and prevent the constraint to be created in the first place. Try to delete the constraint in the subsequent migrations, and finally create the appropriate one.

TODO: We should squash [at least a subset of] migrations eventually.