### PR TITLE
fix: reenable table chart page length

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -6898,24 +6898,14 @@
       }
     },
     "@superset-ui/legacy-plugin-chart-table": {
-      "version": "0.13.16",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-plugin-chart-table/-/legacy-plugin-chart-table-0.13.16.tgz",
-      "integrity": "sha512-4j1bLmKhWEB9pXT4PEPUijLzpFmeskZU2WRBDNaidWUgw8vw0R5vSbSzlf9P5UIBnEgb2RfF/cWMT/FelDG3ug==",
+      "version": "0.13.21",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-plugin-chart-table/-/legacy-plugin-chart-table-0.13.21.tgz",
+      "integrity": "sha512-D18Y5dUNJIJ2MTYfCd4vBWQfG++8JDnf/X2pzhpAzN7tshAWYRx6DV4kUAry8eZfRAvOVjAj2Fc4YiLVkdHRIw==",
       "requires": {
         "@types/datatables.net": "^1.10.18",
         "@types/react-dom": "^16.9.6",
         "datatables.net-bs": "^1.10.20",
         "xss": "^1.0.6"
-      },
-      "dependencies": {
-        "@types/react-dom": {
-          "version": "16.9.8",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
-          "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
-          "requires": {
-            "@types/react": "*"
-          }
-        }
       }
     },
     "@superset-ui/legacy-plugin-chart-treemap": {
@@ -10396,28 +10386,28 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
@@ -10428,14 +10418,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
@@ -10446,35 +10436,35 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "optional": true,
@@ -10484,35 +10474,35 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
@@ -10529,7 +10519,7 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "optional": true,
@@ -10544,14 +10534,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
@@ -10561,7 +10551,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "optional": true,
@@ -10571,7 +10561,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
@@ -10582,21 +10572,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
@@ -10606,14 +10596,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
@@ -10630,14 +10620,14 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "dev": true,
               "optional": true,
@@ -10649,7 +10639,7 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "dev": true,
               "optional": true,
@@ -10668,7 +10658,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
@@ -10679,14 +10669,14 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "dev": true,
               "optional": true,
@@ -10697,7 +10687,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
@@ -10710,21 +10700,21 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
@@ -10734,21 +10724,21 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
@@ -10759,21 +10749,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
@@ -10786,7 +10776,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
@@ -10802,7 +10792,7 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "optional": true,
@@ -10812,49 +10802,49 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
@@ -10866,7 +10856,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
@@ -10876,7 +10866,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
@@ -10886,21 +10876,21 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
@@ -10910,7 +10900,7 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
@@ -14724,28 +14714,28 @@
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                   "dev": true,
                   "optional": true
                 },
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "dev": true,
                   "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "dev": true,
                   "optional": true
                 },
                 "are-we-there-yet": {
                   "version": "1.1.5",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                   "dev": true,
                   "optional": true,
@@ -14756,14 +14746,14 @@
                 },
                 "balanced-match": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                   "dev": true,
                   "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "dev": true,
                   "optional": true,
@@ -14774,35 +14764,35 @@
                 },
                 "code-point-at": {
                   "version": "1.1.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "dev": true,
                   "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "dev": true,
                   "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true,
                   "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true,
                   "optional": true
                 },
                 "debug": {
                   "version": "4.1.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                   "dev": true,
                   "optional": true,
@@ -14812,35 +14802,35 @@
                 },
                 "deep-extend": {
                   "version": "0.6.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                   "dev": true,
                   "optional": true
                 },
                 "delegates": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true,
                   "optional": true
                 },
                 "detect-libc": {
                   "version": "1.0.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                   "dev": true,
                   "optional": true
                 },
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true,
                   "optional": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "optional": true,
@@ -14857,7 +14847,7 @@
                 },
                 "glob": {
                   "version": "7.1.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                   "dev": true,
                   "optional": true,
@@ -14872,14 +14862,14 @@
                 },
                 "has-unicode": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                   "dev": true,
                   "optional": true
                 },
                 "iconv-lite": {
                   "version": "0.4.24",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                   "dev": true,
                   "optional": true,
@@ -14889,7 +14879,7 @@
                 },
                 "ignore-walk": {
                   "version": "3.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                   "dev": true,
                   "optional": true,
@@ -14899,7 +14889,7 @@
                 },
                 "inflight": {
                   "version": "1.0.6",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
                   "optional": true,
@@ -14910,21 +14900,21 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                   "dev": true,
                   "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                   "dev": true,
                   "optional": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "optional": true,
@@ -14934,14 +14924,14 @@
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true,
                   "optional": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "optional": true,
@@ -14951,14 +14941,14 @@
                 },
                 "ms": {
                   "version": "2.1.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                   "dev": true,
                   "optional": true
                 },
                 "needle": {
                   "version": "2.3.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                   "dev": true,
                   "optional": true,
@@ -14970,7 +14960,7 @@
                 },
                 "node-pre-gyp": {
                   "version": "0.12.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                   "dev": true,
                   "optional": true,
@@ -14989,7 +14979,7 @@
                 },
                 "nopt": {
                   "version": "4.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                   "dev": true,
                   "optional": true,
@@ -15000,14 +14990,14 @@
                 },
                 "npm-bundled": {
                   "version": "1.0.6",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                   "dev": true,
                   "optional": true
                 },
                 "npm-packlist": {
                   "version": "1.4.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                   "dev": true,
                   "optional": true,
@@ -15018,7 +15008,7 @@
                 },
                 "npmlog": {
                   "version": "4.1.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                   "dev": true,
                   "optional": true,
@@ -15031,21 +15021,21 @@
                 },
                 "number-is-nan": {
                   "version": "1.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                   "dev": true,
                   "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "dev": true,
                   "optional": true
                 },
                 "once": {
                   "version": "1.4.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "optional": true,
@@ -15055,21 +15045,21 @@
                 },
                 "os-homedir": {
                   "version": "1.0.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "dev": true,
                   "optional": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "dev": true,
                   "optional": true
                 },
                 "osenv": {
                   "version": "0.1.5",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                   "dev": true,
                   "optional": true,
@@ -15080,21 +15070,21 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true,
                   "optional": true
                 },
                 "process-nextick-args": {
                   "version": "2.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                   "dev": true,
                   "optional": true
                 },
                 "rc": {
                   "version": "1.2.8",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                   "dev": true,
                   "optional": true,
@@ -15107,7 +15097,7 @@
                 },
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "dev": true,
                   "optional": true,
@@ -15123,7 +15113,7 @@
                 },
                 "rimraf": {
                   "version": "2.6.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                   "dev": true,
                   "optional": true,
@@ -15133,49 +15123,49 @@
                 },
                 "safe-buffer": {
                   "version": "5.1.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                   "dev": true,
                   "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                   "dev": true,
                   "optional": true
                 },
                 "sax": {
                   "version": "1.2.4",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                   "dev": true,
                   "optional": true
                 },
                 "semver": {
                   "version": "5.7.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                   "dev": true,
                   "optional": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true,
                   "optional": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "dev": true,
                   "optional": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "optional": true,
@@ -15187,7 +15177,7 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "dev": true,
                   "optional": true,
@@ -15197,7 +15187,7 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "optional": true,
@@ -15207,21 +15197,21 @@
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                   "dev": true,
                   "optional": true
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true,
                   "optional": true
                 },
                 "wide-align": {
                   "version": "1.1.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                   "dev": true,
                   "optional": true,
@@ -15231,7 +15221,7 @@
                 },
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "dev": true,
                   "optional": true

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -84,7 +84,7 @@
     "@superset-ui/legacy-plugin-chart-rose": "^0.13.10",
     "@superset-ui/legacy-plugin-chart-sankey": "^0.13.10",
     "@superset-ui/legacy-plugin-chart-sunburst": "^0.13.7",
-    "@superset-ui/legacy-plugin-chart-table": "^0.13.16",
+    "@superset-ui/legacy-plugin-chart-table": "^0.13.21",
     "@superset-ui/legacy-plugin-chart-treemap": "^0.13.10",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.13.10",
     "@superset-ui/legacy-preset-chart-big-number": "^0.13.14",


### PR DESCRIPTION
# SUMMARY

Bump @superset-ui/legacy-preset-chart-table to fix missing
page length support.

See https://github.com/apache-superset/superset-ui/pull/522


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Added unit-test in superset-ui.

Manual testing:

- Go to a table chart
- Change page length in Customize
- Make sure pagination still works

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
