### PR TITLE
feat: make CRUD annotations inline

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -199,15 +199,6 @@ class SupersetAppInitializer:
             category_icon="",
         )
         appbuilder.add_view(
-            AnnotationModelView,
-            "Annotations",
-            label=__("Annotations"),
-            icon="fa-comments",
-            category="Manage",
-            category_label=__("Manage"),
-            category_icon="",
-        )
-        appbuilder.add_view(
             DatabaseView,
             "Databases",
             label=__("Databases"),
@@ -288,6 +279,7 @@ class SupersetAppInitializer:
         appbuilder.add_view_no_menu(SliceAsync)
         appbuilder.add_view_no_menu(SqlLab)
         appbuilder.add_view_no_menu(SqlMetricInlineView)
+        appbuilder.add_view_no_menu(AnnotationModelView)
         appbuilder.add_view_no_menu(Superset)
         appbuilder.add_view_no_menu(TableColumnInlineView)
         appbuilder.add_view_no_menu(TableModelView)

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from flask_appbuilder import CompactCRUDMixin
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import lazy_gettext as _
 from wtforms.validators import StopValidation
@@ -43,17 +44,17 @@ class StartEndDttmValidator:  # pylint: disable=too-few-public-methods
 
 
 class AnnotationModelView(
-    SupersetModelView, DeleteMixin
+    SupersetModelView, CompactCRUDMixin
 ):  # pylint: disable=too-many-ancestors
     datamodel = SQLAInterface(Annotation)
     include_route_methods = RouteMethod.CRUD_SET
 
-    list_title = _("List Annotation")
+    list_title = _("Annotations")
     show_title = _("Show Annotation")
     add_title = _("Add Annotation")
     edit_title = _("Edit Annotation")
 
-    list_columns = ["layer", "short_descr", "start_dttm", "end_dttm"]
+    list_columns = ["short_descr", "start_dttm", "end_dttm"]
     edit_columns = [
         "layer",
         "short_descr",
@@ -67,10 +68,10 @@ class AnnotationModelView(
 
     label_columns = {
         "layer": _("Layer"),
-        "short_descr": _("Short Descr"),
-        "start_dttm": _("Start Dttm"),
-        "end_dttm": _("End Dttm"),
-        "long_descr": _("Long Descr"),
+        "short_descr": _("Label"),
+        "long_descr": _("Description"),
+        "start_dttm": _("Start"),
+        "end_dttm": _("End"),
         "json_metadata": _("JSON Metadata"),
     }
 
@@ -91,18 +92,16 @@ class AnnotationModelView(
         self.pre_add(item)
 
 
-class AnnotationLayerModelView(
-    SupersetModelView, DeleteMixin
-):  # pylint: disable=too-many-ancestors
+class AnnotationLayerModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
     datamodel = SQLAInterface(AnnotationLayer)
     include_route_methods = RouteMethod.CRUD_SET | {RouteMethod.API_READ}
-
-    list_title = _("List Annotation Layer")
+    related_views = [AnnotationModelView]
+    list_title = _("Annotation Layers")
     show_title = _("Show Annotation Layer")
     add_title = _("Add Annotation Layer")
     edit_title = _("Edit Annotation Layer")
 
-    list_columns = ["id", "name"]
+    list_columns = ["name", "descr"]
     edit_columns = ["name", "descr"]
     add_columns = edit_columns
 

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -22,7 +22,7 @@ from wtforms.validators import StopValidation
 from superset.constants import RouteMethod
 from superset.models.annotations import Annotation, AnnotationLayer
 
-from .base import DeleteMixin, SupersetModelView
+from .base import SupersetModelView
 
 
 class StartEndDttmValidator:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
# Summary
This makes the annotations inline of the "annotation layers". Originally
they were setup as separate ModelViews because of a bug in FAB.

## Before 
<img width="761" alt="Screen Shot 2020-05-22 at 2 47 44 PM" src="https://user-images.githubusercontent.com/487433/82711783-43a34b00-9c3b-11ea-94cb-12e1ffd290e9.png">

## After
<img width="285" alt="Screen Shot 2020-05-22 at 2 23 43 PM" src="https://user-images.githubusercontent.com/487433/82711794-4a31c280-9c3b-11ea-8573-6f915e67f5a8.png">
<img width="1203" alt="Screen Shot 2020-05-22 at 2 23 19 PM" src="https://user-images.githubusercontent.com/487433/82711817-59187500-9c3b-11ea-9203-40ea8370e31c.png">
