### PR TITLE
style: beautify roles CRUD

### DIFF
--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -576,3 +576,6 @@ td.filtered {
 .table-name {
   font-size: @font-size-l;
 }
+.select2-container-multi {
+  width: 100% !important;
+}

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -95,6 +95,10 @@ PermissionViewModelView.include_route_methods = {RouteMethod.LIST}
 PermissionModelView.include_route_methods = {RouteMethod.LIST}
 ViewMenuModelView.include_route_methods = {RouteMethod.LIST}
 
+RoleModelView.list_columns = ["name"]
+RoleModelView.edit_columns = ["name", "permissions", "user"]
+RoleModelView.related_views = []
+
 
 class SupersetSecurityManager(SecurityManager):
     userstatschartview = None


### PR DESCRIPTION
Making `Roles` CRUD look a little bit better.

## before
<img width="1115" alt="Screen Shot 2020-05-22 at 6 21 42 PM" src="https://user-images.githubusercontent.com/487433/82718735-31d0a080-9c59-11ea-9055-2e2f1dc358b6.png">
<img width="1163" alt="Screen Shot 2020-05-22 at 6 21 51 PM" src="https://user-images.githubusercontent.com/487433/82718734-31380a00-9c59-11ea-8b25-9530ba163cd1.png">


## after
<img width="1109" alt="Screen Shot 2020-05-22 at 6 21 09 PM" src="https://user-images.githubusercontent.com/487433/82718738-36955480-9c59-11ea-8018-f2973284c12e.png">
<img width="1209" alt="Screen Shot 2020-05-22 at 6 20 54 PM" src="https://user-images.githubusercontent.com/487433/82718740-37c68180-9c59-11ea-8356-e6b81e683237.png">

