### PR TITLE
fix: annotation layer json

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -685,6 +685,21 @@ class Superset(BaseSupersetView):
         form_data = get_form_data()[0]
         form_data["layer_id"] = layer_id
         form_data["filters"] = [{"col": "layer_id", "op": "==", "val": layer_id}]
+        # Set all_columns to ensure the TableViz returns the necessary columns to the
+        # frontend.
+        form_data["all_columns"] = [
+            "created_on",
+            "changed_on",
+            "id",
+            "start_dttm",
+            "end_dttm",
+            "layer_id",
+            "short_descr",
+            "long_descr",
+            "json_metadata",
+            "created_by_fk",
+            "changed_by_fk",
+        ]
         datasource = AnnotationDatasource()
         viz_obj = viz.viz_types["table"](datasource, form_data=form_data, force=False)
         payload = viz_obj.get_payload()

--- a/tests/superset_test_config.py
+++ b/tests/superset_test_config.py
@@ -76,3 +76,5 @@ CELERY_CONFIG = CeleryConfig
 CUSTOM_TEMPLATE_PROCESSORS = {
     CustomPrestoTemplateProcessor.engine: CustomPrestoTemplateProcessor
 }
+
+PRESERVE_CONTEXT_ON_EXCEPTION = False


### PR DESCRIPTION
### SUMMARY
The `annotation_json` API makes use of the TableViz to structure the data returned from it. However, in https://github.com/apache/incubator-superset/pull/9122, we started limiting the columns that were returned, breaking this API. No one caught it because annotations were broken for a variety of other reasons, but I believe that this change should resolve all annotation layer issues remaining

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/7409244/82942673-2b8a3f00-9f4d-11ea-96a0-aae384c0a3de.png)

After:
<img width="1115" alt="Screen Shot 2020-05-26 at 11 44 42 AM" src="https://user-images.githubusercontent.com/7409244/82942624-19100580-9f4d-11ea-9f06-7543c26a0d2f.png">


### TEST PLAN
Test a chart with an annotation layer added and see the annotation display on the chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @john-bodley @graceguo-supercat @villebro 