### PR TITLE
style(mypy): Enforcing typing for views.dashboard

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ order_by_type = false
 ignore_missing_imports = true
 no_implicit_optional = true
 
-[mypy-superset.bin.*,superset.charts.*,superset.commands.*,superset.common.*,superset.connectors.*,superset.dao.*,superset.dashboards.*,superset.datasets.*,superset.db_engine_specs.*,superset.db_engines.*,superset.examples.*,superset.migrations.*,superset.models.*,uperset.queries.*,superset.security.*,superset.sql_validators.*,superset.tasks.*,superset.translations.*]
+[mypy-superset.bin.*,superset.charts.*,superset.commands.*,superset.common.*,superset.connectors.*,superset.dao.*,superset.dashboards.*,superset.datasets.*,superset.db_engine_specs.*,superset.db_engines.*,superset.examples.*,superset.migrations.*,superset.models.*,uperset.queries.*,superset.security.*,superset.sql_validators.*,superset.tasks.*,superset.translations.*,superset.views.dashboard.*]
 check_untyped_defs = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true

--- a/superset/views/dashboard/filters.py
+++ b/superset/views/dashboard/filters.py
@@ -14,7 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any
+
 from sqlalchemy import and_, or_
+from sqlalchemy.orm.query import Query
 
 from superset import db, security_manager
 from superset.models.core import FavStar
@@ -37,7 +40,7 @@ class DashboardFilter(BaseFilter):  # pylint: disable=too-few-public-methods
     if they wish to see those dashboards which are published first
     """
 
-    def apply(self, query, value):
+    def apply(self, query: Query, value: Any) -> Query:
         user_roles = [role.name.lower() for role in list(get_user_roles())]
         if "admin" in user_roles:
             return query

--- a/superset/views/dashboard/mixin.py
+++ b/superset/views/dashboard/mixin.py
@@ -82,5 +82,5 @@ class DashboardMixin:  # pylint: disable=too-few-public-methods
         "table_names": _("Underlying Tables"),
     }
 
-    def pre_delete(self, item):  # pylint: disable=no-self-use
+    def pre_delete(self, item: "DashboardMixin") -> None:  # pylint: disable=no-self-use
         check_ownership(item)

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import re
+from typing import List, Union
 
 from flask import g, redirect, request, Response
 from flask_appbuilder import expose
@@ -26,6 +27,7 @@ from flask_babel import gettext as __, lazy_gettext as _
 import superset.models.core as models
 from superset import app, db, event_logger
 from superset.constants import RouteMethod
+from superset.typing import FlaskResponse
 from superset.utils import core as utils
 
 from ..base import (
@@ -53,14 +55,16 @@ class DashboardModelView(
 
     @has_access
     @expose("/list/")
-    def list(self):
+    def list(self) -> FlaskResponse:
         if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
             return super().list()
 
         return super().render_app_template()
 
     @action("mulexport", __("Export"), __("Export dashboards?"), "fa-database")
-    def mulexport(self, items):  # pylint: disable=no-self-use
+    def mulexport(  # pylint: disable=no-self-use
+        self, items: Union["DashboardModelView", List["DashboardModelView"]]
+    ) -> FlaskResponse:
         if not isinstance(items, list):
             items = [items]
         ids = "".join("&id={}".format(d.id) for d in items)
@@ -69,7 +73,7 @@ class DashboardModelView(
     @event_logger.log_this
     @has_access
     @expose("/export_dashboards_form")
-    def download_dashboards(self):
+    def download_dashboards(self) -> FlaskResponse:
         if request.args.get("action") == "go":
             ids = request.args.getlist("id")
             return Response(
@@ -81,7 +85,7 @@ class DashboardModelView(
             "superset/export_dashboards.html", dashboards_url="/dashboard/list"
         )
 
-    def pre_add(self, item):
+    def pre_add(self, item: "DashboardModelView") -> None:
         item.slug = item.slug or None
         if item.slug:
             item.slug = item.slug.strip()
@@ -95,7 +99,7 @@ class DashboardModelView(
         for slc in item.slices:
             slc.owners = list(set(owners) | set(slc.owners))
 
-    def pre_update(self, item):
+    def pre_update(self, item: "DashboardModelView") -> None:
         check_ownership(item)
         self.pre_add(item)
 
@@ -105,7 +109,7 @@ class Dashboard(BaseSupersetView):
 
     @has_access
     @expose("/new/")
-    def new(self):  # pylint: disable=no-self-use
+    def new(self) -> FlaskResponse:  # pylint: disable=no-self-use
         """Creates a new, blank dashboard and redirects to it in edit mode"""
         new_dashboard = models.Dashboard(
             dashboard_title="[ untitled dashboard ]", owners=[g.user]


### PR DESCRIPTION
### SUMMARY

Adding `mypy` type enforcement for the `superset.views.dashboard` module. Note because the `superset.views` module is quite large I opted to break the type enforcement into smaller more digestible chunks.

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
