### PR TITLE
fix: display python_date_format in react views as well

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -299,6 +299,22 @@ class TableColumn(Model, BaseColumn):
         # TODO(john-bodley): SIP-15 will explicitly require a type conversion.
         return f"""'{dttm.strftime("%Y-%m-%d %H:%M:%S.%f")}'"""
 
+    @property
+    def data(self) -> Dict[str, Any]:
+        attrs = (
+            "id",
+            "column_name",
+            "verbose_name",
+            "description",
+            "expression",
+            "filterable",
+            "groupby",
+            "is_dttm",
+            "type",
+            "python_date_format",
+        )
+        return {s: getattr(self, s) for s in attrs if hasattr(self, s)}
+
 
 class SqlMetric(Model, BaseMetric):
 


### PR DESCRIPTION
### SUMMARY
Exposed python_date_format to the column data api to fix the issue with the data source editor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Now python date format is displayed and will not be wiped out on save
![image](https://user-images.githubusercontent.com/5727938/83076232-09b2ba00-a02a-11ea-9ec4-c25a59fb50b7.png)


### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/9932
