### PR TITLE
feat: [filter_box] disable instant_filtering by defult

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.js
@@ -85,6 +85,9 @@ export default () =>
         .focus({ force: true })
         .type('uth Asia{enter}', { force: true });
 
+      // by default, need to click Apply button to apply filter
+      cy.get('.filter_box button').click({ force: true });
+
       // wait again after applied filters
       cy.wait(aliases.filter(x => x !== getAlias(filterId))).then(requests => {
         requests.forEach(xhr => {

--- a/superset-frontend/src/explore/controlPanels/FilterBox.jsx
+++ b/superset-frontend/src/explore/controlPanels/FilterBox.jsx
@@ -55,10 +55,10 @@ export default {
               type: 'CheckboxControl',
               label: t('Instant Filtering'),
               renderTrigger: true,
-              default: true,
-              description:
-                'Whether to apply filters as they change, or wait for ' +
-                'users to hit an [Apply] button',
+              default: false,
+              description: t(
+                'Check to apply filters instantly as they change instead of displaying [Apply] button',
+              ),
             },
           },
         ],

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -89,7 +89,7 @@ const defaultProps = {
   showSqlaTimeColumn: false,
   showDruidTimeGrain: false,
   showDruidTimeOrigin: false,
-  instantFiltering: true,
+  instantFiltering: false,
 };
 
 class FilterBox extends React.Component {


### PR DESCRIPTION
### SUMMARY
Currently filter_box's setting **instant_filtering** is set to true by default. We found airbnb users usually make large filter_box with multiple filter_fields. When user change filter fields one by one,  instant filtering will generate many temporary queries but no use.

This PR is to set default value be false. This change will not affect any existed filter_box settings.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screen_Shot_2020-05-29_at_10_08_48_AM](https://user-images.githubusercontent.com/27990562/83286318-8cf01f00-a194-11ea-9756-6fce6d44ee72.jpg)


### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
