### PR TITLE
fix: pinot select query logic

### DIFF
--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -79,9 +79,12 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         else:
             seconds_or_ms = "MILLISECONDS" if pdf == "epoch_ms" else "SECONDS"
             tf = f"1:{seconds_or_ms}:EPOCH"
-        granularity = cls.get_time_grain_expressions().get(time_grain)
-        if not granularity:
-            raise NotImplementedError("No pinot grain spec for " + str(time_grain))
+        if time_grain:
+            granularity = cls.get_time_grain_expressions().get(time_grain)
+            if not granularity:
+                raise NotImplementedError("No pinot grain spec for " + str(time_grain))
+        else:
+            return TimestampExpression(f"{{col}}", col)
         # In pinot the output is a string since there is no timestamp column like pg
         time_expr = f'DATETIMECONVERT({{col}}, "{tf}", "{tf}", "{granularity}")'
         return TimestampExpression(time_expr, col)
@@ -90,13 +93,4 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
     def make_select_compatible(
         cls, groupby_exprs: Dict[str, ColumnElement], select_exprs: List[ColumnElement]
     ) -> List[ColumnElement]:
-        # Pinot does not want the group by expr's to appear in the select clause
-        select_sans_groupby = []
-        # We want identity and not equality, so doing the filtering manually
-        for sel in select_exprs:
-            for gr in groupby_exprs:
-                if sel is gr:
-                    break
-            else:
-                select_sans_groupby.append(sel)
-        return select_sans_groupby
+        return select_exprs

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -86,7 +86,7 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         else:
             return TimestampExpression(f"{{col}}", col)
         # In pinot the output is a string since there is no timestamp column like pg
-        time_expr = f'DATETIMECONVERT({{col}}, "{tf}", "{tf}", "{granularity}")'
+        time_expr = f"DATETIMECONVERT({{col}}, '{tf}', '{tf}', '{granularity}')"
         return TimestampExpression(time_expr, col)
 
     @classmethod

--- a/tests/db_engine_specs/pinot_tests.py
+++ b/tests/db_engine_specs/pinot_tests.py
@@ -29,5 +29,5 @@ class PinotTestCase(DbEngineSpecTestCase):
         result = str(expr.compile())
         self.assertEqual(
             result,
-            'DATETIMECONVERT(tstamp, "1:SECONDS:EPOCH", "1:SECONDS:EPOCH", "1:MONTHS")',
+            "DATETIMECONVERT(tstamp, '1:SECONDS:EPOCH', '1:SECONDS:EPOCH', '1:MONTHS')",
         )  # noqa


### PR DESCRIPTION
### SUMMARY
Update Pinot selection query logic. 
<!--- Describe the change below, including rationale and design decisions -->
1. Direct return the field if it time grain is None.
2. No need to remove groupby fields from selection list anymore.