### PR TITLE
docs(api): Wrong parameter name on database openapi spec

### DIFF
--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -172,7 +172,7 @@ class DatabaseRestApi(DatabaseMixin, BaseSupersetModelRestApi):
           - in: path
             schema:
               type: string
-            name: schema
+            name: schema_name
             description: Table schema
           responses:
             200:


### PR DESCRIPTION
### SUMMARY
Fix OpenAPI spec wrong parameter name on database table API endpoint 


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
