### PR TITLE
fix(revert): Using request context rather than globals

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1745,13 +1745,9 @@ class Superset(BaseSupersetView):
                     force=True,
                 )
 
-                # Temporarily define the form-data in the request context which may be
-                # leveraged by the Jinja macros.
-                with app.test_request_context(
-                    data={"form_data": json.dumps(form_data)}
-                ):
-                    payload = obj.get_payload()
-
+                g.form_data = form_data
+                payload = obj.get_payload()
+                delattr(g, "form_data")
                 error = payload["errors"] or None
                 status = payload["status"]
             except Exception as ex:

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib import parse
 
 import simplejson as json
-from flask import request
+from flask import g, request
 
 import superset.models.core as models
 from superset import app, db, is_feature_enabled
@@ -110,6 +110,10 @@ def get_form_data(
     # request params can overwrite the body
     if request_args_data:
         form_data.update(json.loads(request_args_data))
+
+    # Fallback to using the Flask globals (used for cache warmup) if defined.
+    if not form_data and hasattr(g, "form_data"):
+        form_data = getattr(g, "form_data")
 
     url_id = request.args.get("r")
     if url_id:

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1300,3 +1300,19 @@ class UtilsTestCase(SupersetTestCase):
             )
 
             self.assertEqual(slc, None)
+
+    def test_get_form_data_globals(self) -> None:
+        with app.test_request_context():
+            g.form_data = {"foo": "bar"}
+            form_data, slc = get_form_data()
+            delattr(g, "form_data")
+
+            self.assertEqual(
+                form_data,
+                {
+                    "foo": "bar",
+                    "time_range_endpoints": get_time_range_endpoints(form_data={}),
+                },
+            )
+
+            self.assertEqual(slc, None)


### PR DESCRIPTION
### SUMMARY

This PR reverts https://github.com/apache/incubator-superset/pull/9715 as it seems like `g.user` is not logged in when using the `test_request_context` context manager.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
