### PR TITLE
style(mypy): Fix memoize watch type

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -281,7 +281,7 @@ class Database(
                 effective_username = g.user.username
         return effective_username
 
-    @utils.memoized(watch=["impersonate_user", "sqlalchemy_uri_decrypted", "extra"])
+    @utils.memoized(watch=("impersonate_user", "sqlalchemy_uri_decrypted", "extra"))
     def get_sqla_engine(
         self,
         schema: Optional[str] = None,

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -147,11 +147,11 @@ class _memoized:
     should account for instance variable changes.
     """
 
-    def __init__(self, func: Callable, watch: Optional[List[str]] = None) -> None:
+    def __init__(self, func: Callable, watch: Optional[Tuple[str, ...]] = None) -> None:
         self.func = func
         self.cache: Dict[Any, Any] = {}
         self.is_method = False
-        self.watch = watch or []
+        self.watch = watch or ()
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         key = [args, frozenset(kwargs.items())]
@@ -181,7 +181,7 @@ class _memoized:
 
 
 def memoized(
-    func: Optional[Callable] = None, watch: Optional[List[str]] = None
+    func: Optional[Callable] = None, watch: Optional[Tuple[str, ...]] = None
 ) -> Callable:
     if func:
         return _memoized(func)


### PR DESCRIPTION
### SUMMARY

The `watch` variable type was incorrectly encoded as as I wasn't aware of (or forgot) the `...` syntax for defining a tuple of arbitrary length, i.e., `Tuple[str, ...]`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @serenajiang 

