### PR TITLE
feat: finalize Word Cloud move to new chart data endpoint

### DIFF
--- a/superset-frontend/spec/javascripts/chart/chartActions_spec.js
+++ b/superset-frontend/spec/javascripts/chart/chartActions_spec.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import URI from 'urijs';
 import fetchMock from 'fetch-mock';
 import sinon from 'sinon';
 
@@ -25,17 +26,16 @@ import * as exploreUtils from 'src/explore/exploreUtils';
 import * as actions from 'src/chart/chartAction';
 
 describe('chart actions', () => {
-  const V1_URL = '/http//localhost/api/v1/chart/data';
   const MOCK_URL = '/mockURL';
   let dispatch;
-  let urlStub;
+  let getExploreUrlStub;
+  let getChartDataUriStub;
   let metadataRegistryStub;
   let buildQueryRegistryStub;
   let fakeMetadata;
 
   const setupDefaultFetchMock = () => {
     fetchMock.post(MOCK_URL, { json: {} }, { overwriteRoutes: true });
-    fetchMock.post(V1_URL, { json: {} }, { overwriteRoutes: true });
   };
 
   beforeAll(() => {
@@ -46,9 +46,12 @@ describe('chart actions', () => {
 
   beforeEach(() => {
     dispatch = sinon.spy();
-    urlStub = sinon
+    getExploreUrlStub = sinon
       .stub(exploreUtils, 'getExploreUrl')
       .callsFake(() => MOCK_URL);
+    getChartDataUriStub = sinon
+      .stub(exploreUtils, 'getChartDataUri')
+      .callsFake(() => URI(MOCK_URL));
     fakeMetadata = { useLegacyApi: true };
     metadataRegistryStub = sinon
       .stub(chartlib, 'getChartMetadataRegistry')
@@ -65,7 +68,8 @@ describe('chart actions', () => {
   });
 
   afterEach(() => {
-    urlStub.restore();
+    getExploreUrlStub.restore();
+    getChartDataUriStub.restore();
     fetchMock.resetHistory();
     metadataRegistryStub.restore();
     buildQueryRegistryStub.restore();
@@ -80,8 +84,8 @@ describe('chart actions', () => {
       const actionThunk = actions.postChartFormData({});
       await actionThunk(dispatch);
 
-      expect(fetchMock.calls(V1_URL)).toHaveLength(1);
-      expect(fetchMock.calls(V1_URL)[0][1].body).toBe(
+      expect(fetchMock.calls(MOCK_URL)).toHaveLength(1);
+      expect(fetchMock.calls(MOCK_URL)[0][1].body).toBe(
         JSON.stringify({
           some_param: 'fake query!',
           result_type: 'full',

--- a/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
@@ -227,9 +227,9 @@ describe('ExploreResultsButton', () => {
       setTimeout(() => {
         expect(datasourceSpy.callCount).toBe(1);
         expect(exploreUtils.exploreChart.callCount).toBe(1);
-        expect(
-          exploreUtils.exploreChart.getCall(0).args[0].datasource,
-        ).toBe('107__table');
+        expect(exploreUtils.exploreChart.getCall(0).args[0].datasource).toBe(
+          '107__table',
+        );
         expect(infoToastSpy.callCount).toBe(1);
         done();
       });

--- a/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
@@ -225,9 +225,9 @@ describe('ExploreResultsButton', () => {
       setTimeout(() => {
         expect(datasourceSpy.callCount).toBe(1);
         expect(exploreUtils.exportChart.callCount).toBe(1);
-        expect(exploreUtils.exportChart.getCall(0).args[0].datasource).toBe(
-          '107__table',
-        );
+        expect(
+          exploreUtils.exportChart.getCall(0).args[0].formData.datasource,
+        ).toBe('107__table');
         expect(infoToastSpy.callCount).toBe(1);
         done();
       });

--- a/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
@@ -179,12 +179,14 @@ describe('ExploreResultsButton', () => {
     beforeEach(() => {
       sinon.stub(exploreUtils, 'getExploreUrl').callsFake(() => 'mockURL');
       sinon.spy(exploreUtils, 'exportChart');
+      sinon.spy(exploreUtils, 'exploreChart');
       sinon
         .stub(wrapper.instance(), 'buildVizOptions')
         .callsFake(() => mockOptions);
     });
     afterEach(() => {
       exploreUtils.getExploreUrl.restore();
+      exploreUtils.exploreChart.restore();
       exploreUtils.exportChart.restore();
       wrapper.instance().buildVizOptions.restore();
       fetchMock.reset();
@@ -224,9 +226,9 @@ describe('ExploreResultsButton', () => {
 
       setTimeout(() => {
         expect(datasourceSpy.callCount).toBe(1);
-        expect(exploreUtils.exportChart.callCount).toBe(1);
+        expect(exploreUtils.exploreChart.callCount).toBe(1);
         expect(
-          exploreUtils.exportChart.getCall(0).args[0].formData.datasource,
+          exploreUtils.exploreChart.getCall(0).args[0].datasource,
         ).toBe('107__table');
         expect(infoToastSpy.callCount).toBe(1);
         done();

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx
@@ -77,7 +77,7 @@ class ExploreCtasResultsButton extends React.PureComponent {
         );
 
         // open new window for data visualization
-        exportChart(formData);
+        exportChart({ formData });
       })
       .catch(() => {
         this.props.actions.addDangerToast(

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -150,7 +150,7 @@ class ExploreResultsButton extends React.PureComponent {
         );
 
         // open new window for data visualization
-        exportChart(formData);
+        exportChart({ formData });
       })
       .catch(() => {
         this.props.actions.addDangerToast(

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -27,7 +27,7 @@ import { t } from '@superset-ui/translation';
 import { InfoTooltipWithTrigger } from '@superset-ui/control-utils';
 
 import shortid from 'shortid';
-import { exportChart } from '../../explore/exploreUtils';
+import { exploreChart } from '../../explore/exploreUtils';
 import * as actions from '../actions/sqlLab';
 import Button from '../../components/Button';
 
@@ -150,7 +150,7 @@ class ExploreResultsButton extends React.PureComponent {
         );
 
         // open new window for data visualization
-        exportChart({ formData });
+        exploreChart(formData);
       })
       .catch(() => {
         this.props.actions.addDangerToast(

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -29,6 +29,7 @@ import { isFeatureEnabled, FeatureFlag } from '../featureFlags';
 import {
   getExploreUrl,
   getAnnotationJsonUrl,
+  getLegacyEndpointType,
   postForm,
 } from '../explore/exploreUtils';
 import {
@@ -115,11 +116,7 @@ const legacyChartDataRequest = async (
   method = 'POST',
   requestParams = {},
 ) => {
-  const endpointType = ['base', 'csv', 'results', 'samples'].includes(
-    resultType,
-  )
-    ? resultType
-    : resultFormat;
+  const endpointType = getLegacyEndpointType({ resultFormat, resultType });
   const url = getExploreUrl({
     formData,
     endpointType,

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -26,10 +26,12 @@ import { isFeatureEnabled, FeatureFlag } from '../featureFlags';
 import {
   getAnnotationJsonUrl,
   getExploreUrl,
+  getHostName,
   getLegacyEndpointType,
   buildV1ChartDataPayload,
   postForm,
   shouldUseLegacyApi,
+  getChartDataUri,
 } from '../explore/exploreUtils';
 import {
   requiresQuery,
@@ -156,11 +158,15 @@ const v1ChartDataRequest = async (
   const qs = requestParams.dashboard_id
     ? { dashboard_id: requestParams.dashboard_id }
     : {};
-  const url = URI('/api/v1/chart/data').search(qs).toString();
+  const url = getChartDataUri({
+    path: '/api/v1/chart/data',
+    qs,
+    allowDomainSharding,
+  }).toString();
 
   const querySettings = {
     ...requestParams,
-    endpoint: url,
+    url,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   };

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -175,14 +175,16 @@ const v1ChartDataRequest = async (
   });
 };
 
-export async function getChartDataRequest(
+export async function getChartDataRequest({
   formData,
   resultFormat = 'json',
   resultType = 'full',
   force = false,
   method = 'POST',
   requestParams = {},
-) {
+}) {
+  console.log(formData, resultFormat, resultType);
+
   let querySettings = {
     ...requestParams,
   };
@@ -337,14 +339,14 @@ export function exploreJSON(
     };
     if (dashboardId) requestParams.dashboard_id = dashboardId;
 
-    const chartDataRequest = getChartDataRequest(
+    const chartDataRequest = getChartDataRequest({
       formData,
-      'json',
-      'full',
+      resultFormat: 'json',
+      resultType: 'full',
       force,
       method,
       requestParams,
-    );
+    });
 
     dispatch(chartUpdateStarted(controller, formData, key));
 
@@ -460,24 +462,17 @@ export function postChartFormData(
 
 export function redirectSQLLab(formData) {
   return dispatch => {
-    const url = getExploreUrl({
-      formData,
-      endpointType: 'query',
-    });
-    return SupersetClient.post({
-      url,
-      postPayload: { form_data: formData },
-    })
-      .then(({ json }) => {
+    getChartDataRequest({ formData, resultFormat: 'json', resultType: 'query' })
+      .then(({ result }) => {
         const redirectUrl = '/superset/sqllab';
         const payload = {
           datasourceKey: formData.datasource,
-          sql: json.query,
+          sql: result[0].query,
         };
         postForm(redirectUrl, payload);
       })
-      .catch(() =>
-        dispatch(addDangerToast(t('An error occurred while loading the SQL'))),
+      .catch(error =>
+        addDangerToast(t('An error occurred while loading the SQL')),
       );
   };
 }

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -26,7 +26,7 @@ import {
   getAnnotationJsonUrl,
   getExploreUrl,
   getLegacyEndpointType,
-  getV1ChartDataPayload,
+  buildV1ChartDataPayload,
   postForm,
   shouldUseLegacyApi,
 } from '../explore/exploreUtils';
@@ -146,7 +146,7 @@ const v1ChartDataRequest = async (
   force,
   requestParams,
 ) => {
-  const payload = getV1ChartDataPayload({ formData, force });
+  const payload = buildV1ChartDataPayload({ formData, force });
   // TODO: remove once these are added to superset-ui/query
   payload.result_type = resultType;
   payload.result_format = resultFormat;

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -21,12 +21,12 @@
 import moment from 'moment';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
-import { getChartBuildQueryRegistry } from '@superset-ui/chart';
 import { isFeatureEnabled, FeatureFlag } from '../featureFlags';
 import {
   getAnnotationJsonUrl,
   getExploreUrl,
   getLegacyEndpointType,
+  getV1ChartDataPayload,
   postForm,
   shouldUseLegacyApi,
 } from '../explore/exploreUtils';
@@ -146,11 +146,7 @@ const v1ChartDataRequest = async (
   force,
   requestParams,
 ) => {
-  const buildQuery = await getChartBuildQueryRegistry().get(formData.viz_type);
-  const payload = buildQuery({
-    ...formData,
-    force,
-  });
+  const payload = getV1ChartDataPayload({formData, force});
   // TODO: remove once these are added to superset-ui/query
   payload.result_type = resultType;
   payload.result_format = resultFormat;
@@ -459,8 +455,8 @@ export function redirectSQLLab(formData) {
         };
         postForm(redirectUrl, payload);
       })
-      .catch(error =>
-        addDangerToast(t('An error occurred while loading the SQL')),
+      .catch(() =>
+        dispatch(addDangerToast(t('An error occurred while loading the SQL'))),
       );
   };
 }

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -18,6 +18,7 @@
  */
 /* eslint no-undef: 'error' */
 /* eslint no-param-reassign: ["error", { "props": false }] */
+import URI from 'urijs';
 import moment from 'moment';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
@@ -150,9 +151,16 @@ const v1ChartDataRequest = async (
   // TODO: remove once these are added to superset-ui/query
   payload.result_type = resultType;
   payload.result_format = resultFormat;
+
+  // The dashboard id is added to query params for tracking purposes
+  const qs = requestParams.dashboard_id
+    ? { dashboard_id: requestParams.dashboard_id }
+    : {};
+  const url = URI('/api/v1/chart/data').search(qs).toString();
+
   const querySettings = {
     ...requestParams,
-    endpoint: '/api/v1/chart/data',
+    endpoint: url,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   };

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -21,16 +21,14 @@
 import moment from 'moment';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
-import {
-  getChartBuildQueryRegistry,
-  getChartMetadataRegistry,
-} from '@superset-ui/chart';
+import { getChartBuildQueryRegistry } from '@superset-ui/chart';
 import { isFeatureEnabled, FeatureFlag } from '../featureFlags';
 import {
-  getExploreUrl,
   getAnnotationJsonUrl,
+  getExploreUrl,
   getLegacyEndpointType,
   postForm,
+  shouldUseLegacyApi,
 } from '../explore/exploreUtils';
 import {
   requiresQuery,
@@ -102,11 +100,6 @@ export const ANNOTATION_QUERY_FAILED = 'ANNOTATION_QUERY_FAILED';
 export function annotationQueryFailed(annotation, queryResponse, key) {
   return { type: ANNOTATION_QUERY_FAILED, annotation, queryResponse, key };
 }
-
-const shouldUseLegacyApi = formData => {
-  const { useLegacyApi } = getChartMetadataRegistry().get(formData.viz_type);
-  return useLegacyApi || false;
-};
 
 const legacyChartDataRequest = async (
   formData,
@@ -180,8 +173,6 @@ export async function getChartDataRequest({
   method = 'POST',
   requestParams = {},
 }) {
-  console.log(formData, resultFormat, resultType);
-
   let querySettings = {
     ...requestParams,
   };

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -146,7 +146,7 @@ const v1ChartDataRequest = async (
   force,
   requestParams,
 ) => {
-  const payload = getV1ChartDataPayload({formData, force});
+  const payload = getV1ChartDataPayload({ formData, force });
   // TODO: remove once these are added to superset-ui/query
   payload.result_type = resultType;
   payload.result_format = resultFormat;

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -19,7 +19,7 @@
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { exportChart } from '../../../explore/exploreUtils';
+import { exploreChart, exportChart } from '../../../explore/exploreUtils';
 import SliceHeader from '../SliceHeader';
 import ChartContainer from '../../../chart/ChartContainer';
 import MissingChart from '../MissingChart';
@@ -191,7 +191,7 @@ class Chart extends React.Component {
       slice_id: this.props.slice.slice_id,
       is_cached: this.props.isCached,
     });
-    exportChart({ formData: this.props.formData });
+    exploreChart(this.props.formData);
   }
 
   exportCSV() {
@@ -199,7 +199,11 @@ class Chart extends React.Component {
       slice_id: this.props.slice.slice_id,
       is_cached: this.props.isCached,
     });
-    exportChart({ formData: this.props.formData, resultType: 'results', resultFormat: 'csv' });
+    exportChart({
+      formData: this.props.formData,
+      resultType: 'results',
+      resultFormat: 'csv',
+    });
   }
 
   forceRefresh() {

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -191,7 +191,7 @@ class Chart extends React.Component {
       slice_id: this.props.slice.slice_id,
       is_cached: this.props.isCached,
     });
-    exportChart(this.props.formData);
+    exportChart({ formData: this.props.formData });
   }
 
   exportCSV() {
@@ -199,7 +199,7 @@ class Chart extends React.Component {
       slice_id: this.props.slice.slice_id,
       is_cached: this.props.isCached,
     });
-    exportChart(this.props.formData, 'csv');
+    exportChart({ formData: this.props.formData, endpointType: 'csv' });
   }
 
   forceRefresh() {

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -199,7 +199,7 @@ class Chart extends React.Component {
       slice_id: this.props.slice.slice_id,
       is_cached: this.props.isCached,
     });
-    exportChart({ formData: this.props.formData, endpointType: 'csv' });
+    exportChart({ formData: this.props.formData, resultType: 'results', resultFormat: 'csv' });
   }
 
   forceRefresh() {

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -90,7 +90,11 @@ export class DisplayQueryButton extends React.PureComponent {
   beforeOpen(resultType) {
     this.setState({ isLoading: true });
 
-    getChartDataRequest(this.props.latestQueryFormData, 'json', resultType)
+    getChartDataRequest({
+      formData: this.props.latestQueryFormData,
+      resultFormat: 'json',
+      resultType,
+    })
       .then(response => {
         // Currently displaying of only first query is supported
         const result = response.result[0];

--- a/superset-frontend/src/explore/components/ExploreActionButtons.jsx
+++ b/superset-frontend/src/explore/components/ExploreActionButtons.jsx
@@ -49,11 +49,13 @@ export default function ExploreActionButtons({
   });
   const doExportCSV = exportChart.bind(this, {
     formData: latestQueryFormData,
-    endpointType: 'csv',
+    resultType: 'results',
+    resultFormat: 'csv',
   });
   const doExportChart = exportChart.bind(this, {
     formData: latestQueryFormData,
-    endpointType: 'results',
+    resultType: 'results',
+    resultFormat: 'json',
   });
 
   return (

--- a/superset-frontend/src/explore/components/ExploreActionButtons.jsx
+++ b/superset-frontend/src/explore/components/ExploreActionButtons.jsx
@@ -47,8 +47,14 @@ export default function ExploreActionButtons({
   const exportToCSVClasses = cx('btn btn-default btn-sm', {
     'disabled disabledButton': !canDownload,
   });
-  const doExportCSV = exportChart.bind(this, latestQueryFormData, 'csv');
-  const doExportChart = exportChart.bind(this, latestQueryFormData, 'results');
+  const doExportCSV = exportChart.bind(this, {
+    formData: latestQueryFormData,
+    endpointType: 'csv',
+  });
+  const doExportChart = exportChart.bind(this, {
+    formData: latestQueryFormData,
+    endpointType: 'results',
+  });
 
   return (
     <div className="btn-group results" role="group">

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -192,7 +192,7 @@ export const shouldUseLegacyApi = formData => {
   return useLegacyApi || false;
 };
 
-export const getV1ChartDataPayload = ({ formData, force }) => {
+export const buildV1ChartDataPayload = ({ formData, force }) => {
   const buildQuery = getChartBuildQueryRegistry().get(formData.viz_type);
   return buildQuery({
     ...formData,

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -201,7 +201,6 @@ export const getV1ChartDataPayload = ({ formData, force }) => {
 };
 
 export const getLegacyEndpointType = ({ resultType, resultFormat }) => {
-  console.log(resultType, resultFormat);
   return resultFormat === 'csv' ? resultFormat : resultType;
 };
 

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -19,8 +19,9 @@
 /* eslint camelcase: 0 */
 import URI from 'urijs';
 import { SupersetClient } from '@superset-ui/connection';
-import { allowCrossDomain, availableDomains } from '../utils/hostNamesConfig';
-import { safeStringify } from '../utils/safeStringify';
+import { allowCrossDomain, availableDomains } from 'src/utils/hostNamesConfig';
+import { shouldUseLegacyApi } from 'src/chart/chartAction';
+import { safeStringify } from 'src/utils/safeStringify';
 
 const MAX_URL_LENGTH = 8000;
 
@@ -208,7 +209,7 @@ export function postForm(url, payload, target = '_blank') {
   document.body.removeChild(hiddenForm);
 }
 
-export function exportChart(formData, endpointType) {
+export function exportChart({ formData, endpointType }) {
   const url = getExploreUrl({
     formData,
     endpointType,

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -110,6 +110,14 @@ export function getExploreLongUrl(
   return url;
 }
 
+export function getLegacyEndpointType({ resultType = 'base', resultFormat = 'json' }) {
+  return ['base', 'csv', 'results', 'samples'].includes(
+      resultType,
+    )
+      ? resultType
+      : resultFormat;
+}
+
 export function getExploreUrl({
   formData,
   endpointType = 'base',
@@ -209,7 +217,8 @@ export function postForm(url, payload, target = '_blank') {
   document.body.removeChild(hiddenForm);
 }
 
-export function exportChart({ formData, endpointType }) {
+export function exportChart({ formData, resultType, resultFormat }) {
+  const endpointType = getLegacyEndpointType({ resultType, resultFormat });
   const url = getExploreUrl({
     formData,
     endpointType,

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -34,7 +34,7 @@ export function getChartKey(explore) {
 }
 
 let requestCounter = 0;
-function getHostName(allowDomainSharding = false) {
+export function getHostName(allowDomainSharding = false) {
   let currentIndex = 0;
   if (allowDomainSharding) {
     currentIndex = requestCounter % availableDomains.length;
@@ -48,7 +48,6 @@ function getHostName(allowDomainSharding = false) {
       requestCounter += 1;
     }
   }
-
   return availableDomains[currentIndex];
 }
 
@@ -113,6 +112,22 @@ export function getExploreLongUrl(
   return url;
 }
 
+export function getChartDataUri({ path, qs, allowDomainSharding = false }) {
+  // The search params from the window.location are carried through,
+  // but can be specified with curUrl (used for unit tests to spoof
+  // the window.location).
+  let uri = new URI({
+    protocol: location.protocol.slice(0, -1),
+    hostname: getHostName(allowDomainSharding),
+    port: location.port ? location.port : '',
+    path,
+  });
+  if (qs) {
+    uri = uri.search(qs);
+  }
+  return uri;
+}
+
 export function getExploreUrl({
   formData,
   endpointType = 'base',
@@ -125,17 +140,7 @@ export function getExploreUrl({
   if (!formData.datasource) {
     return null;
   }
-
-  // The search params from the window.location are carried through,
-  // but can be specified with curUrl (used for unit tests to spoof
-  // the window.location).
-  let uri = new URI({
-    protocol: location.protocol.slice(0, -1),
-    hostname: getHostName(allowDomainSharding),
-    port: location.port ? location.port : '',
-    path: '/',
-  });
-
+  let uri = getChartDataUri({ path: '/', allowDomainSharding });
   if (curUrl) {
     uri = URI(URI(curUrl).search());
   }

--- a/superset/assets/src/SqlLab/components/ExploreCtasResultsButton.jsx
+++ b/superset/assets/src/SqlLab/components/ExploreCtasResultsButton.jsx
@@ -76,7 +76,7 @@ class ExploreCtasResultsButton extends React.PureComponent {
         );
 
         // open new window for data visualization
-        exportChart(formData);
+        exportChart({formData});
       })
       .catch(() => {
         this.props.actions.addDangerToast(

--- a/superset/assets/src/SqlLab/components/ExploreCtasResultsButton.jsx
+++ b/superset/assets/src/SqlLab/components/ExploreCtasResultsButton.jsx
@@ -76,7 +76,7 @@ class ExploreCtasResultsButton extends React.PureComponent {
         );
 
         // open new window for data visualization
-        exportChart({formData});
+        exploreChart(formData);
       })
       .catch(() => {
         this.props.actions.addDangerToast(

--- a/superset/assets/src/SqlLab/components/ExploreCtasResultsButton.jsx
+++ b/superset/assets/src/SqlLab/components/ExploreCtasResultsButton.jsx
@@ -24,7 +24,7 @@ import Dialog from 'react-bootstrap-dialog';
 import { t } from '@superset-ui/translation';
 import { InfoTooltipWithTrigger } from '@superset-ui/control-utils';
 
-import { exportChart } from '../../explore/exploreUtils';
+import { exploreChart } from '../../explore/exploreUtils';
 import * as actions from '../actions/sqlLab';
 import Button from '../../components/Button';
 

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import json
 import logging
 from typing import Any, Dict
 
@@ -55,13 +56,14 @@ from superset.exceptions import SupersetSecurityException
 from superset.extensions import event_logger, security_manager
 from superset.models.slice import Slice
 from superset.tasks.thumbnails import cache_chart_thumbnail
-from superset.utils.core import json_int_dttm_ser
+from superset.utils.core import ChartDataResultFormat, json_int_dttm_ser
 from superset.utils.screenshots import ChartScreenshot
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
     statsd_metrics,
 )
+from superset.views.core import CsvResponse, generate_download_headers
 from superset.views.filters import FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
@@ -431,10 +433,16 @@ class ChartRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
             """
-        if not request.is_json:
+
+        if request.is_json:
+            json_body = request.json
+        elif request.form.get("form_data"):
+            # CSV export submits regular form data
+            json_body = json.loads(request.form["form_data"])
+        else:
             return self.response_400(message="Request is not JSON")
         try:
-            query_context, errors = ChartDataQueryContextSchema().load(request.json)
+            query_context, errors = ChartDataQueryContextSchema().load(json_body)
             if errors:
                 return self.response_400(
                     message=_("Request is incorrect: %(error)s", error=errors)
@@ -445,13 +453,25 @@ class ChartRestApi(BaseSupersetModelRestApi):
             security_manager.assert_query_context_permission(query_context)
         except SupersetSecurityException:
             return self.response_401()
-        payload_json = query_context.get_payload()
-        response_data = simplejson.dumps(
-            {"result": payload_json}, default=json_int_dttm_ser, ignore_nan=True
-        )
-        resp = make_response(response_data, 200)
-        resp.headers["Content-Type"] = "application/json; charset=utf-8"
-        return resp
+        payload = query_context.get_payload()
+        result_format = query_context.result_format
+        if result_format == ChartDataResultFormat.CSV:
+            # return the first result
+            result = payload[0]["data"]
+            return CsvResponse(
+                result,
+                status=200,
+                headers=generate_download_headers("csv"),
+                mimetype="application/csv",
+            )
+        elif result_format == ChartDataResultFormat.JSON:
+            response_data = simplejson.dumps(
+                {"result": payload}, default=json_int_dttm_ser, ignore_nan=True
+            )
+            resp = make_response(response_data, 200)
+            resp.headers["Content-Type"] = "application/json; charset=utf-8"
+            return resp
+        raise self.response_400(message=f"Unsupported result_format: {result_format}")
 
     @expose("/<pk>/thumbnail/<digest>/", methods=["GET"])
     @protect()

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -157,7 +157,6 @@ class QueryContext:
             query_obj.post_processing = []
             query_obj.row_limit = min(row_limit, config["SAMPLES_ROW_LIMIT"])
             query_obj.columns = [o.column_name for o in self.datasource.columns]
-
         payload = self.get_df_payload(query_obj)
         df = payload["df"]
         status = payload["status"]
@@ -167,6 +166,8 @@ class QueryContext:
             else:
                 payload["data"] = self.get_data(df)
         del payload["df"]
+        if self.result_type == utils.ChartDataResultType.RESULTS:
+            return {"data": payload["data"]}
         return payload
 
     def get_payload(self) -> List[Dict[str, Any]]:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -824,24 +824,6 @@ class SeparatorViz(MarkupViz):
     verbose_name = _("Separator")
 
 
-class WordCloudViz(BaseViz):
-
-    """Build a colorful word cloud
-
-    Uses the nice library at:
-    https://github.com/jasondavies/d3-cloud
-    """
-
-    viz_type = "word_cloud"
-    verbose_name = _("Word Cloud")
-    is_timeseries = False
-
-    def query_obj(self) -> QueryObjectDict:
-        d = super().query_obj()
-        d["groupby"] = [self.form_data.get("series")]
-        return d
-
-
 class TreemapViz(BaseViz):
 
     """Tree map visualisation for hierarchical data."""

--- a/superset/viz_sip38.py
+++ b/superset/viz_sip38.py
@@ -860,19 +860,6 @@ class SeparatorViz(MarkupViz):
     verbose_name = _("Separator")
 
 
-class WordCloudViz(BaseViz):
-
-    """Build a colorful word cloud
-
-    Uses the nice library at:
-    https://github.com/jasondavies/d3-cloud
-    """
-
-    viz_type = "word_cloud"
-    verbose_name = _("Word Cloud")
-    is_timeseries = False
-
-
 class TreemapViz(BaseViz):
 
     """Tree map visualisation for hierarchical data."""


### PR DESCRIPTION
### SUMMARY
This fixes the last remaining components that were solely relying on the legacy `explore_json` endpoint, and removes Word Cloud from `viz.py`. Some other minor changes/improvements:
- Add support for domain sharding to v1 chart data requests
- Add `dashboard_id` to v1 chart data request url parameters to comply with legacy request signature

From an end user perspective the only visible change is the export JSON functionality, which now returns an array of results for v1 charts as opposed to a single result.

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
