### PR TITLE
fix: remove -1,-1 from owners request in charts, dashboards list and propertiesModal

### DIFF
--- a/superset-frontend/src/components/ListView/Filters.tsx
+++ b/superset-frontend/src/components/ListView/Filters.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import styled from '@superset-ui/style';
 import { withTheme } from 'emotion-theming';
 
@@ -97,9 +97,6 @@ function SelectFilter({
   };
 
   const options = [clearFilterSelect, ...selects];
-  const optionsCache: React.MutableRefObject<SelectOption[] | null> = useRef(
-    null,
-  );
 
   const [selectedOption, setSelectedOption] = useState(clearFilterSelect);
   const onChange = (selected: SelectOption | null) => {
@@ -110,11 +107,8 @@ function SelectFilter({
     setSelectedOption(selected);
   };
   const fetchAndFormatSelects = async (inputValue: string) => {
-    // only include clear filter when filter value exists
+    // only include clear filter when filter value does not exist
     let result = inputValue ? [] : [clearFilterSelect];
-    // only call fetch once
-    // TODO: allow real async search with `inputValue`
-    if (optionsCache.current) return optionsCache.current;
     if (fetchSelects) {
       const selectValues = await fetchSelects(inputValue);
       // update matching option at initial load
@@ -124,7 +118,6 @@ function SelectFilter({
       }
       result = [...result, ...selectValues];
     }
-    optionsCache.current = result;
     return result;
   };
 

--- a/superset-frontend/src/explore/components/PropertiesModal.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal.tsx
@@ -122,8 +122,6 @@ function PropertiesModal({ slice, onHide, onSave }: InternalProps) {
   const loadOptions = (input = '') => {
     const query = rison.encode({
       filter: input,
-      page_index: -1,
-      page_size: -1,
     });
     return SupersetClient.get({
       endpoint: `/api/v1/chart/related/owners?q=${query}`,

--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -364,13 +364,17 @@ class ChartList extends React.PureComponent<Props, State> {
       });
   };
 
-  fetchOwners = async (filterValue = '', pageIndex = -1, pageSize = -1) => {
+  fetchOwners = async (
+    filterValue = '',
+    pageIndex?: number,
+    pageSize?: number,
+  ) => {
     const resource = '/api/v1/chart/related/owners';
 
     try {
       const queryParams = rison.encode({
-        page: pageIndex,
-        page_size: pageSize,
+        ...(pageIndex ? { page: pageIndex } : {}),
+        ...(pageSize ? { page_ize: pageSize } : {}),
         ...(filterValue ? { filter: filterValue } : {}),
       });
       const { json = {} } = await SupersetClient.get({
@@ -384,6 +388,7 @@ class ChartList extends React.PureComponent<Props, State> {
         }),
       );
     } catch (e) {
+      console.error(e);
       this.props.addDangerToast(
         t(
           'An error occurred while fetching chart owner values: %s',

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -389,13 +389,17 @@ class DashboardList extends React.PureComponent<Props, State> {
       });
   };
 
-  fetchOwners = async (filterValue = '', pageIndex = -1, pageSize = -1) => {
+  fetchOwners = async (
+    filterValue = '',
+    pageIndex?: number,
+    pageSize?: number,
+  ) => {
     const resource = '/api/v1/dashboard/related/owners';
 
     try {
       const queryParams = rison.encode({
-        page: pageIndex,
-        page_size: pageSize,
+        ...(pageIndex ? { page: pageIndex } : {}),
+        ...(pageSize ? { page_ize: pageSize } : {}),
         ...(filterValue ? { filter: filterValue } : {}),
       });
       const { json = {} } = await SupersetClient.get({
@@ -409,6 +413,7 @@ class DashboardList extends React.PureComponent<Props, State> {
         }),
       );
     } catch (e) {
+      console.error(e);
       this.props.addDangerToast(
         t(
           'An error occurred while fetching chart owner values: %s',


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
followup from: https://github.com/apache/incubator-superset/pull/9988

This removes the problematic `LIMIT -1, -1` from the request for all owners. Search is implemented however owners fetch will be limited to 25 records as per FAB defaults. 

 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- CI
- tested locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
