### PR TITLE
fix: [logging] fix render chart error type

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { Alert } from 'react-bootstrap';
 
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
-import { Logger, LOG_ACTIONS_RENDER_CHART_CONTAINER } from '../logger/LogUtils';
+import { Logger, LOG_ACTIONS_RENDER_CHART } from '../logger/LogUtils';
 import Loading from '../components/Loading';
 import RefreshChartOverlay from '../components/RefreshChartOverlay';
 import ErrorMessageWithStackTrace from '../components/ErrorMessage/ErrorMessageWithStackTrace';
@@ -128,7 +128,7 @@ class Chart extends React.PureComponent {
       info ? info.componentStack : null,
     );
 
-    actions.logEvent(LOG_ACTIONS_RENDER_CHART_CONTAINER, {
+    actions.logEvent(LOG_ACTIONS_RENDER_CHART, {
       slice_id: chartId,
       has_err: true,
       error_details: error.toString(),

--- a/superset-frontend/src/logger/LogUtils.js
+++ b/superset-frontend/src/logger/LogUtils.js
@@ -25,7 +25,6 @@ export const LOG_ACTIONS_MOUNT_DASHBOARD = 'mount_dashboard';
 export const LOG_ACTIONS_MOUNT_EXPLORER = 'mount_explorer';
 
 export const LOG_ACTIONS_SELECT_DASHBOARD_TAB = 'select_dashboard_tab';
-export const LOG_ACTIONS_RENDER_CHART_CONTAINER = 'render_chart_container';
 export const LOG_ACTIONS_FORCE_REFRESH_CHART = 'force_refresh_chart';
 export const LOG_ACTIONS_CHANGE_EXPLORE_CONTROLS = 'change_explore_controls';
 export const LOG_ACTIONS_TOGGLE_EDIT_DASHBOARD = 'toggle_edit_dashboard';
@@ -57,7 +56,6 @@ export const LOG_EVENT_TYPE_USER = new Set([
   LOG_ACTIONS_PERIODIC_RENDER_DASHBOARD,
   LOG_ACTIONS_OMNIBAR_TRIGGERED,
   LOG_ACTIONS_MOUNT_EXPLORER,
-  LOG_ACTIONS_RENDER_CHART_CONTAINER,
 ]);
 
 export const Logger = {


### PR DESCRIPTION
### SUMMARY
This PR is to fix a logging issue: remove an unnecessary user_event `render_chart_container` error type, and use `render_chart` for all chart render errors.

### TEST PLAN
Manual test

@etr2460 @ktmud 