### PR TITLE
fix(SankeyViz): enforce source/target order

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1737,7 +1737,14 @@ class SankeyViz(BaseViz):
         return qry
 
     def get_data(self, df: pd.DataFrame) -> VizData:
-        df.columns = ["source", "target", "value"]
+        df.rename(
+            columns={
+                self.form_data["groupby"][0]: "source",
+                self.form_data["groupby"][1]: "target",
+                df.columns[-1]: "value",
+            },
+            inplace=True,
+        )
         df["source"] = df["source"].astype(str)
         df["target"] = df["target"].astype(str)
         recs = df.to_dict(orient="records")

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1738,14 +1738,9 @@ class SankeyViz(BaseViz):
 
     def get_data(self, df: pd.DataFrame) -> VizData:
         source, target = self.groupby
-        value, = self.metric_labels
+        (value,) = self.metric_labels
         df.rename(
-            columns={
-                source: "source",
-                target: "target",
-                value: "value",
-            },
-            inplace=True,
+            columns={source: "source", target: "target", value: "value",}, inplace=True,
         )
         df["source"] = df["source"].astype(str)
         df["target"] = df["target"].astype(str)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1737,11 +1737,13 @@ class SankeyViz(BaseViz):
         return qry
 
     def get_data(self, df: pd.DataFrame) -> VizData:
+        source, target = self.groupby
+        value, = self.metric_labels
         df.rename(
             columns={
-                self.form_data["groupby"][0]: "source",
-                self.form_data["groupby"][1]: "target",
-                df.columns[-1]: "value",
+                source: "source",
+                target: "target",
+                value: "value",
             },
             inplace=True,
         )


### PR DESCRIPTION
### SUMMARY
The SankeyViz assumes that the first column in the query object is the source and the second is the target. This changes unpredictably, so the SankeyViz sometimes switches randomly between the two options, even after a simple refresh.

This PR ensures that the `source` and `target` correspond to the first and second `groupby` columns.

### TEST PLAN
Test both configurations of source and target.

@etr2460 @ktmud ?