### PR TITLE
fix: bump pydruid to 0.6.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ pip-tools==5.1.2
 pre-commit==1.17.0
 psycopg2-binary==2.8.5
 pycodestyle==2.5.0
-pydruid==0.5.9
+pydruid==0.5.11
 pyhive==0.6.2
 pylint==1.9.2
 redis==3.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ pip-tools==5.1.2
 pre-commit==1.17.0
 psycopg2-binary==2.8.5
 pycodestyle==2.5.0
-pydruid==0.5.11
+pydruid==0.6.0
 pyhive==0.6.2
 pylint==1.9.2
 redis==3.5.1

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "postgres": ["psycopg2-binary==2.8.5"],
         "presto": ["pyhive[presto]>=0.4.0"],
         "elasticsearch": ["elasticsearch-dbapi>=0.1.0, <0.2.0"],
-        "druid": ["pydruid==0.5.7", "requests==2.22.0"],
+        "druid": ["pydruid==0.5.11", "requests==2.22.0"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "dremio": ["sqlalchemy_dremio>=1.1.0"],
         "cockroachdb": ["cockroachdb==0.3.3"],

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "postgres": ["psycopg2-binary==2.8.5"],
         "presto": ["pyhive[presto]>=0.4.0"],
         "elasticsearch": ["elasticsearch-dbapi>=0.1.0, <0.2.0"],
-        "druid": ["pydruid==0.5.11", "requests==2.22.0"],
+        "druid": ["pydruid==0.6.0", "requests==2.22.0"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "dremio": ["sqlalchemy_dremio>=1.1.0"],
         "cockroachdb": ["cockroachdb==0.3.3"],


### PR DESCRIPTION
### SUMMARY
Bump version of pydruid: 0.5.9 to 0.6.0
Version 0.5.9 causes installation errors with python 3.7 when running `pip install -r requirements-dev.txt`. This is fixed by bumping said version.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
* Check that superset can now be fresh installed smoothly in 3.7 envs and doesn't cause errors on other envs.
* Should be tested in different python envs with druid datasources to check it doesn't break stuff.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #9830
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
