### PR TITLE
fix: Quick fix for bad regex in GH Workflow

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -33,7 +33,7 @@ jobs:
         
         EOF
 
-        if [[ "$FILES" =~ ^(.*package*\.json|.*requirements*\.txt)$ ]]; then
+        if [[ "${FILES}" =~ (.*package*\.json|requirements.*\.txt|setup\.py) ]]; then
           echo "Detected dependency changes... running fossa check"
 
           ./scripts/fossa.sh


### PR DESCRIPTION
### SUMMARY
Fixes borked regex that was filtering out non-dependency related changes from getting Fossa checks.