### PR TITLE
fix: flaky test_copy_dash test in dashboard_tests.py

### DIFF
--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -235,7 +235,7 @@ class DashboardTests(SupersetTestCase):
         # exclude modified and changed_on attribute
         for index, slc in enumerate(orig_json_data["slices"]):
             for key in slc:
-                if key not in ["modified", "changed_on"]:
+                if key not in ["modified", "changed_on", "changed_on_humanized"]:
                     self.assertEqual(slc[key], resp["slices"][index][key])
 
     def test_set_dash_metadata(self, username="admin"):


### PR DESCRIPTION
### SUMMARY
Fix a flaky unit test that was caused by the `changed_on_humanized` property in `AuditMixinNullable`: https://github.com/apache/incubator-superset/blob/315518d2d22a63de1b2e5f556e7fb5737669ebd6/superset/models/helpers.py#L383-L385

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/84134630-880f5300-aa51-11ea-9847-ca3e427d05f6.png)

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
