### PR TITLE
feat: Add owners and physical/virtual status to Datasets API list endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 .bento*
 .cache-loader
 .coverage
+cover
 .DS_Store
 .eggs
 .envrc

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -52,9 +52,9 @@ COLUMN_FORM_DATA_PARAMS = [
 ]
 
 
-class DatasourceKind(Enum):
-    virtual = "virtual"
-    physical = "physical"
+class DatasourceKind(str, Enum):
+    VIRTUAL = "virtual"
+    PHYSICAL = "physical"
 
 
 class BaseDatasource(

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
+from enum import Enum
 from typing import Any, Dict, Hashable, List, Optional, Type, Union
 
 from flask_appbuilder.security.sqla.models import User
@@ -50,6 +51,10 @@ COLUMN_FORM_DATA_PARAMS = [
     "series",
 ]
 
+
+class DatasourceKind(Enum):
+    virtual = "virtual"
+    physical = "physical"
 
 class BaseDatasource(
     AuditMixinNullable, ImportMixin
@@ -100,6 +105,13 @@ class BaseDatasource(
     sql: Optional[str] = None
     owners: List[User]
     update_from_object_fields: List[str]
+
+    @property
+    def kind(self) -> str:
+        if self.sql:
+            return DatasourceKind.virtual.value
+
+        return DatasourceKind.physical.value
 
     @declared_attr
     def slices(self) -> RelationshipProperty:

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -110,9 +110,9 @@ class BaseDatasource(
     @property
     def kind(self) -> str:
         if self.sql:
-            return DatasourceKind.virtual.value
+            return DatasourceKind.VIRTUAL.value
 
-        return DatasourceKind.physical.value
+        return DatasourceKind.PHYSICAL.value
 
     @declared_attr
     def slices(self) -> RelationshipProperty:

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -56,6 +56,7 @@ class DatasourceKind(Enum):
     virtual = "virtual"
     physical = "physical"
 
+
 class BaseDatasource(
     AuditMixinNullable, ImportMixin
 ):  # pylint: disable=too-many-public-methods

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -78,6 +78,11 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "changed_on",
         "default_endpoint",
         "explore_url",
+        "kind",
+        "owners.id",
+        "owners.username",
+        "owners.first_name",
+        "owners.last_name",
         "schema",
         "table_name",
     ]

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -23,6 +23,7 @@ import prison
 import yaml
 from sqlalchemy.sql import func
 
+import tests.test_app
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.dao.exceptions import (
     DAOCreateFailedError,
@@ -96,6 +97,8 @@ class DatasetApiTests(SupersetTestCase):
             "default_endpoint",
             "explore_url",
             "id",
+            "kind",
+            "owners",
             "schema",
             "table_name",
         ]


### PR DESCRIPTION
### SUMMARY
In https://github.com/apache/incubator-superset/pull/9959 we ran into issues with joins from FAB, and while we are working on a fix for both that bug and adding the option to specify a base query, those will not be ready immediately. This PR adds the un-blocked fields from the previous PR to the datasets list API endpoint for consumption in an updated Datasets UI.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
See https://github.com/apache/incubator-superset/pull/9959

### TEST PLAN
See https://github.com/apache/incubator-superset/pull/9959

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API

# Reviewers
@dpgaspar @nytai @mistercrunch 
