### PR TITLE
chore(security): Renaming access methods

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,9 @@ assists people when migrating to a new version.
 
 ## Next
 
+* [10031](https://github.com/apache/incubator-superset/pull/10030): Renames the following public security manager methods: `can_access_datasource` to `can_access_table`, `all_datasource_access` to `can_access_all_datasources`, `all_database_access` to `can_access_all_databases`, `database_access` to `can_access_database`, `schema_access` to `can_access_schema`, and
+`datasource_access` to `can_access_datasource`. Regrettably it is not viable to provide aliases for the deprecated methods as this would result in a name clash. Finally the `can_access_table` (previously `can_access_database`) method signature has changed, i.e., the optional `schema` argument no longer exists.
+
 * [10030](https://github.com/apache/incubator-superset/pull/10030): Renames the public security manager `schemas_accessible_by_user` method to `get_schemas_accessible_by_user`.
 
 * [9786](https://github.com/apache/incubator-superset/pull/9786): with the upgrade of `werkzeug` from version `0.16.0` to `1.0.1`, the `werkzeug.contrib.cache` module has been moved to a standalone package [cachelib](https://pypi.org/project/cachelib/). For example, to import the `RedisCache` class, please use the following import: `from cachelib.redis import RedisCache`.

--- a/superset/charts/filters.py
+++ b/superset/charts/filters.py
@@ -45,7 +45,7 @@ class ChartNameOrDescriptionFilter(
 
 class ChartFilter(BaseFilter):  # pylint: disable=too-few-public-methods
     def apply(self, query: Query, value: Any) -> Query:
-        if security_manager.all_datasource_access():
+        if security_manager.can_access_all_datasources():
             return query
         perms = security_manager.user_view_menu_names("datasource_access")
         schema_perms = security_manager.user_view_menu_names("schema_access")

--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -62,7 +62,6 @@ class DashboardFilter(BaseFilter):  # pylint: disable=too-few-public-methods
 
         datasource_perms = security_manager.user_view_menu_names("datasource_access")
         schema_perms = security_manager.user_view_menu_names("schema_access")
-        all_datasource_access = security_manager.all_datasource_access()
         published_dash_query = (
             db.session.query(Dashboard.id)
             .join(Dashboard.slices)
@@ -72,7 +71,7 @@ class DashboardFilter(BaseFilter):  # pylint: disable=too-few-public-methods
                     or_(
                         Slice.perm.in_(datasource_perms),
                         Slice.schema_perm.in_(schema_perms),
-                        all_datasource_access,
+                        security_manager.can_access_all_datasources(),
                     ),
                 )
             )

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -433,7 +433,7 @@ class DeleteMixin:  # pylint: disable=too-few-public-methods
 
 class DatasourceFilter(BaseFilter):  # pylint: disable=too-few-public-methods
     def apply(self, query: Query, value: Any) -> Query:
-        if security_manager.all_datasource_access():
+        if security_manager.can_access_all_datasources():
             return query
         datasource_perms = security_manager.user_view_menu_names("datasource_access")
         schema_perms = security_manager.user_view_menu_names("schema_access")

--- a/superset/views/chart/filters.py
+++ b/superset/views/chart/filters.py
@@ -25,7 +25,7 @@ from superset.views.base import BaseFilter
 
 class SliceFilter(BaseFilter):  # pylint: disable=too-few-public-methods
     def apply(self, query: Query, value: Any) -> Query:
-        if security_manager.all_datasource_access():
+        if security_manager.can_access_all_datasources():
             return query
         perms = security_manager.user_view_menu_names("datasource_access")
         schema_perms = security_manager.user_view_menu_names("schema_access")

--- a/superset/views/dashboard/filters.py
+++ b/superset/views/dashboard/filters.py
@@ -47,7 +47,6 @@ class DashboardFilter(BaseFilter):  # pylint: disable=too-few-public-methods
 
         datasource_perms = security_manager.user_view_menu_names("datasource_access")
         schema_perms = security_manager.user_view_menu_names("schema_access")
-        all_datasource_access = security_manager.all_datasource_access()
         published_dash_query = (
             db.session.query(Dashboard.id)
             .join(Dashboard.slices)
@@ -57,7 +56,7 @@ class DashboardFilter(BaseFilter):  # pylint: disable=too-few-public-methods
                     or_(
                         Slice.perm.in_(datasource_perms),
                         Slice.schema_perm.in_(schema_perms),
-                        all_datasource_access,
+                        security_manager.can_access_all_datasources(),
                     ),
                 )
             )

--- a/superset/views/database/decorators.py
+++ b/superset/views/database/decorators.py
@@ -50,9 +50,8 @@ def check_datasource_access(f: Callable[..., Any]) -> Callable[..., Any]:
                 f"database_not_found_{self.__class__.__name__}.select_star"
             )
             return self.response_404()
-        # Check that the user can access the datasource
-        if not self.appbuilder.sm.can_access_datasource(
-            database, Table(table_name_parsed, schema_name_parsed), schema_name_parsed
+        if not self.appbuilder.sm.can_access_table(
+            database, Table(table_name_parsed, schema_name_parsed),
         ):
             self.stats_logger.incr(
                 f"permisssion_denied_{self.__class__.__name__}.select_star"

--- a/superset/views/database/filters.py
+++ b/superset/views/database/filters.py
@@ -32,7 +32,7 @@ class DatabaseFilter(BaseFilter):
         }
 
     def apply(self, query: Query, value: Any) -> Query:
-        if security_manager.all_database_access():
+        if security_manager.can_access_all_databases():
             return query
         database_perms = security_manager.user_view_menu_names("database_access")
         # TODO(bogdan): consider adding datasource access here as well.

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -70,10 +70,7 @@ class CsvToDatabaseForm(DynamicForm):
                 b) if database supports schema
                     user is able to upload to schema in schemas_allowed_for_csv_upload
         """
-        if (
-            security_manager.database_access(database)
-            or security_manager.all_datasource_access()
-        ):
+        if security_manager.can_access_database(database):
             return True
         schemas = database.get_schema_access_for_csv_upload()
         if schemas and security_manager.get_schemas_accessible_by_user(

--- a/superset/views/database/validators.py
+++ b/superset/views/database/validators.py
@@ -50,7 +50,4 @@ def schema_allows_csv_upload(database: Database, schema: Optional[str]) -> bool:
     schemas = database.get_schema_access_for_csv_upload()
     if schemas:
         return schema in schemas
-    return (
-        security_manager.database_access(database)
-        or security_manager.all_datasource_access()
-    )
+    return security_manager.can_access_database(database)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -966,15 +966,18 @@ class CoreTests(SupersetTestCase):
     @mock.patch(
         "superset.security.SupersetSecurityManager.get_schemas_accessible_by_user"
     )
-    @mock.patch("superset.security.SupersetSecurityManager.database_access")
-    @mock.patch("superset.security.SupersetSecurityManager.all_datasource_access")
+    @mock.patch("superset.security.SupersetSecurityManager.can_access_database")
+    @mock.patch("superset.security.SupersetSecurityManager.can_access_all_datasources")
     def test_schemas_access_for_csv_upload_endpoint(
-        self, mock_all_datasource_access, mock_database_access, mock_schemas_accessible
+        self,
+        mock_can_access_all_datasources,
+        mock_can_access_database,
+        mock_schemas_accessible,
     ):
         self.login(username="admin")
         dbobj = self.create_fake_db()
-        mock_all_datasource_access.return_value = False
-        mock_database_access.return_value = False
+        mock_can_access_all_datasources.return_value = False
+        mock_can_access_database.return_value = False
         mock_schemas_accessible.return_value = ["this_schema_is_allowed_too"]
         data = self.get_json_resp(
             url="/superset/schemas_access_for_csv_upload?db_id={db_id}".format(

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -774,45 +774,45 @@ class SecurityManagerTests(SupersetTestCase):
     Testing the Security Manager.
     """
 
-    @patch("superset.security.SupersetSecurityManager.datasource_access")
-    def test_assert_datasource_permission(self, mock_datasource_access):
+    @patch("superset.security.SupersetSecurityManager.can_access_datasource")
+    def test_assert_datasource_permission(self, mock_can_access_datasource):
         datasource = self.get_datasource_mock()
 
         # Datasource with the "datasource_access" permission.
-        mock_datasource_access.return_value = True
+        mock_can_access_datasource.return_value = True
         security_manager.assert_datasource_permission(datasource)
 
         # Datasource without the "datasource_access" permission.
-        mock_datasource_access.return_value = False
+        mock_can_access_datasource.return_value = False
 
         with self.assertRaises(SupersetSecurityException):
             security_manager.assert_datasource_permission(datasource)
 
-    @patch("superset.security.SupersetSecurityManager.datasource_access")
-    def test_assert_query_context_permission(self, mock_datasource_access):
+    @patch("superset.security.SupersetSecurityManager.can_access_datasource")
+    def test_assert_query_context_permission(self, mock_can_access_datasource):
         query_context = Mock()
         query_context.datasource = self.get_datasource_mock()
 
         # Query context with the "datasource_access" permission.
-        mock_datasource_access.return_value = True
+        mock_can_access_datasource.return_value = True
         security_manager.assert_query_context_permission(query_context)
 
         # Query context without the "datasource_access" permission.
-        mock_datasource_access.return_value = False
+        mock_can_access_datasource.return_value = False
 
         with self.assertRaises(SupersetSecurityException):
             security_manager.assert_query_context_permission(query_context)
 
-    @patch("superset.security.SupersetSecurityManager.datasource_access")
-    def test_assert_viz_permission(self, mock_datasource_access):
+    @patch("superset.security.SupersetSecurityManager.can_access_datasource")
+    def test_assert_viz_permission(self, mock_can_access_datasource):
         test_viz = viz.TableViz(self.get_datasource_mock(), form_data={})
 
         # Visualization with the "datasource_access" permission.
-        mock_datasource_access.return_value = True
+        mock_can_access_datasource.return_value = True
         security_manager.assert_viz_permission(test_viz)
 
         # Visualization without the "datasource_access" permission.
-        mock_datasource_access.return_value = False
+        mock_can_access_datasource.return_value = False
 
         with self.assertRaises(SupersetSecurityException):
             security_manager.assert_viz_permission(test_viz)


### PR DESCRIPTION
### SUMMARY

This PR addresses the following: 

1. Ensures consistent naming of the "access" methods for the security manager, i.e., previously we had methods named `can_access_all_queries` and `all_datasource_access` (note the singular "datasource"). The former is prefer as the return type is implied. Note I believe the later existed for possible consistency with the underlying FAB per names, however this isn't a requirement per the `can_access_all_queries` example. The renaming is as follows:

    - `can_access_datasource` -> `can_access_table` (more explicit and resolves naming conflict with the `datasource_access` rename)
    - `all_datasource_access` -> `can_access_all_datasources` (plural)
    - `all_database_access` -> `can_access_all_databases` (plural)
    - `database_access` -> `can_access_database` 
    - `schema_access` -> `can_access_schema`
    - `datasource_access` -> `can_access_datasource`

2. The `can_access_table` (previously named `can_access_datasource`) method signature has changed. The optional schema argument no longer exists as it is defined within the `Table` object.
 
3. Removes unnecessary checks, i.e., previous logic was in the form, 

```python
if security_manager.database_access(database) or security_manager.all_datasource_access():
    ...
```

however the `database_access` method (now named `can_access_database`) first checks whether the user can access all datasources (per [here](https://github.com/apache/incubator-superset/blob/91517a56a3bcacd4c8f2dca233d8df248bfca10e/superset/security/manager.py#L241)) and thus the second check is irrelevant.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
