### PR TITLE
Fix chart annotation source type showing perpetual loading when re-se…

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
@@ -240,12 +240,16 @@ export default class AnnotationLayer extends React.PureComponent {
   }
 
   handleAnnotationSourceType(sourceType) {
-    this.setState({
-      sourceType,
-      isLoadingOptions: true,
-      validationErrors: {},
-      value: null,
-    });
+    const { sourceType: prevSourceType } = this.state;
+
+    if (prevSourceType !== sourceType) {
+      this.setState({
+        sourceType,
+        isLoadingOptions: true,
+        validationErrors: {},
+        value: null,
+      });
+    }
   }
 
   handleValue(value) {

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -96,6 +96,8 @@ export default class SelectControl extends React.PureComponent {
     }
   }
 
+  // Beware: This is acting like an on-click instead of an on-change
+  // (firing every time user chooses vs firing only if a new option is chosen).
   onChange(opt) {
     let optionValue = null;
     if (opt) {


### PR DESCRIPTION
Fixes issue in Annotation Source field of the Add Annotation Layer form of chart builder that caused the Annotation Layer field to get stuck in an infinite load. Solution was a simple if statement to check if the value had changed before setting the component to a loading state.

Before:
![23fad23f-4dd0-48ea-9ffa-6b7466229750](https://user-images.githubusercontent.com/3860613/84326443-bf553100-ab31-11ea-852c-50215f728f0d.png)

After:
<img width="485" alt="Screen Shot 2020-06-10 at 3 40 16 PM" src="https://user-images.githubusercontent.com/3860613/84326586-207d0480-ab32-11ea-81a2-7155d5bcb06c.png">


