### PR TITLE
fix: native annotations

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -196,6 +196,7 @@ class QueryContext:
                 extra_cache_keys=extra_cache_keys,
                 rls=security_manager.get_rls_ids(self.datasource)
                 if config["ENABLE_ROW_LEVEL_SECURITY"]
+                and self.datasource.is_rls_supported
                 else [],
                 changed_on=self.datasource.changed_on,
                 **kwargs

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -84,6 +84,9 @@ class BaseDatasource(
     # Used to do code highlighting when displaying the query in the UI
     query_language: Optional[str] = None
 
+    # Only some datasources support Row Level Security
+    is_rls_supported: bool = False
+
     @property
     def name(self) -> str:
         # can be a Column or a property pointing to one

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -394,6 +394,7 @@ class SqlaTable(Model, BaseDatasource):
 
     type = "table"
     query_language = "sql"
+    is_rls_supported = True
     metric_class = SqlMetric
     column_class = TableColumn
     owner_class = security_manager.user_model

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=C,R,W
 import logging
-import re
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Any, Dict, Hashable, List, NamedTuple, Optional, Tuple, Union

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -103,7 +103,7 @@ class AnnotationLayerModelView(SupersetModelView):  # pylint: disable=too-many-a
     add_title = _("Add Annotation Layer")
     edit_title = _("Edit Annotation Layer")
 
-    list_columns = ["name", "descr"]
+    list_columns = ["id", "name", "descr"]
     edit_columns = ["name", "descr"]
     add_columns = edit_columns
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -43,10 +43,9 @@ from dateutil import relativedelta as rdelta
 from flask import request
 from flask_babel import lazy_gettext as _
 from geopy.point import Point
-from markdown import markdown
 from pandas.tseries.frequencies import to_offset
 
-from superset import app, cache, get_manifest_files, security_manager
+from superset import app, cache, security_manager
 from superset.constants import NULL_STRING
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
@@ -405,7 +404,7 @@ class BaseViz:
         cache_dict["extra_cache_keys"] = self.datasource.get_extra_cache_keys(query_obj)
         cache_dict["rls"] = (
             security_manager.get_rls_ids(self.datasource)
-            if config["ENABLE_ROW_LEVEL_SECURITY"]
+            if config["ENABLE_ROW_LEVEL_SECURITY"] and self.datasource.is_rls_supported
             else []
         )
         cache_dict["changed_on"] = self.datasource.changed_on

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -177,12 +177,18 @@ class CoreTests(SupersetTestCase):
         db.session.add(annotation)
         db.session.commit()
 
-        resp = self.get_resp(
+        resp_annotations = json.loads(
+            self.get_resp("annotationlayermodelview/api/read")
+        )
+        self.assertIn("id", resp_annotations["result"][0])
+        self.assertIn("name", resp_annotations["result"][0])
+        self.assertIn("descr", resp_annotations["result"][0])
+
+        layer = self.get_resp(
             f"/superset/annotation_json/{layer.id}?form_data="
             + quote(json.dumps({"time_range": "100 years ago : now"}))
         )
-
-        assert "my_annotation" in resp
+        self.assertIn("my_annotation", layer)
 
     def test_admin_only_permissions(self):
         def assert_admin_permission_in(role_name, assert_func):

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -180,9 +180,9 @@ class CoreTests(SupersetTestCase):
         resp_annotations = json.loads(
             self.get_resp("annotationlayermodelview/api/read")
         )
+        # the UI needs id and name to function
         self.assertIn("id", resp_annotations["result"][0])
         self.assertIn("name", resp_annotations["result"][0])
-        self.assertIn("descr", resp_annotations["result"][0])
 
         layer = self.get_resp(
             f"/superset/annotation_json/{layer.id}?form_data="


### PR DESCRIPTION
### SUMMARY
Native annotations are currently broken due to regressions in recent PRs:

### BEFORE
Bug number 1: RLS breaks annotations as they only apply to SQL datasources if `ENABLE_ROW_LEVEL_SECURITY` is enabled:
![image](https://user-images.githubusercontent.com/33317356/84373128-d012af00-abe4-11ea-9322-3c7c7d0823e3.png)

Bug number 2: The `id` of the annotation layer was dropped in #9888 , hence can't be selected:
![captured (1)](https://user-images.githubusercontent.com/33317356/84373096-c4bf8380-abe4-11ea-892d-da5aca120e9d.gif)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/84372600-056acd00-abe4-11ea-8146-468dca8ecf01.png)
![captured (2)](https://user-images.githubusercontent.com/33317356/84373635-86769400-abe5-11ea-9279-7e9948ab0c6f.gif)

### TEST PLAN
Local testing + new test + CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
