### PR TITLE
fix(security): can_access with None crashes on builtin roles

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -254,11 +254,11 @@ class SupersetSecurityManager(SecurityManager):
         :param datasource: The Superset datasource
         :returns: Whether the user can access the datasource's schema
         """
-
+        schema_perm = datasource.schema_perm or ""
         return (
             self.all_datasource_access()
             or self.database_access(datasource.database)
-            or self.can_access("schema_access", datasource.schema_perm)
+            or self.can_access("schema_access", schema_perm)
         )
 
     def datasource_access(self, datasource: "BaseDatasource") -> bool:
@@ -268,9 +268,9 @@ class SupersetSecurityManager(SecurityManager):
         :param datasource: The Superset datasource
         :returns: Whether the use can access the Superset datasource
         """
-
+        perm = datasource.perm or ""
         return self.schema_access(datasource) or self.can_access(
-            "datasource_access", datasource.perm
+            "datasource_access", perm
         )
 
     def get_datasource_access_error_msg(self, datasource: "BaseDatasource") -> str:


### PR DESCRIPTION
### SUMMARY
Calling `can_access` with `None` values causes an exception when using builtin roles. Will make this more resilient on FAB, but this should be fixed here also.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
