### PR TITLE
feat: owners profile icon on dataset list view

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -24659,6 +24659,23 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-avatar": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/react-avatar/-/react-avatar-3.9.7.tgz",
+      "integrity": "sha512-UX1prYgo4gS1g2u16tZbx/Vy45M/BxyHHexIoRj6m9hI3ZR0FdHTDt66X5GpTtf6PRYE8KlvwHte1x5n8B0/XQ==",
+      "requires": {
+        "core-js": "^3.6.1",
+        "is-retina": "^1.0.3",
+        "md5": "^2.0.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+        }
+      }
+    },
     "react-base16-styling": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.5.3.tgz",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -140,6 +140,7 @@
     "re-resizable": "^4.3.1",
     "react": "^16.13.0",
     "react-ace": "^5.10.0",
+    "react-avatar": "^3.9.7",
     "react-bootstrap": "^0.33.1",
     "react-bootstrap-dialog": "^0.10.0",
     "react-bootstrap-slider": "2.1.5",

--- a/superset-frontend/src/components/AvatarIcon.tsx
+++ b/superset-frontend/src/components/AvatarIcon.tsx
@@ -24,7 +24,7 @@ import Avatar, { ConfigProvider } from 'react-avatar';
 
 interface Props {
   firstName: string;
-  iconSize: number;
+  iconSize: string;
   lastName: string;
   tableName: string;
   userName: string;
@@ -52,12 +52,7 @@ export default function AvatarIcon({
         placement="right"
         overlay={<Tooltip id={`${uniqueKey}-tooltip`}>{fullName}</Tooltip>}
       >
-        <StyledAvatar
-          key={`${uniqueKey}`}
-          name={fullName}
-          size={`${iconSize}`}
-          round
-        />
+        <StyledAvatar key={uniqueKey} name={fullName} size={iconSize} round />
       </OverlayTrigger>
     </ConfigProvider>
   );

--- a/superset-frontend/src/components/AvatarIcon.tsx
+++ b/superset-frontend/src/components/AvatarIcon.tsx
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { PureComponent } from 'react';
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
+import Avatar, { ConfigProvider } from 'react-avatar';
+
+interface Props {
+  firstName: string;
+  iconSize: string;
+  lastName: string;
+  tableName: string;
+  userName: string;
+}
+
+export default class AvatarIcon extends PureComponent<Props> {
+  render() {
+    const { tableName, firstName, lastName, userName, iconSize } = this.props;
+    const uniqueKey = tableName.concat('_', userName);
+    const fullName = firstName.concat(' ', lastName);
+    const colors = [
+      '#20A7C9',
+      '#59C189',
+      '#A868B6',
+      '#E04355',
+      '#FBC700',
+      '#FF7F43',
+    ];
+    return (
+      <ConfigProvider colors={colors}>
+        <OverlayTrigger
+          placement="right"
+          overlay={<Tooltip id={`${uniqueKey}-tooltip`}>{fullName}</Tooltip>}
+        >
+          <Avatar
+            key={`${uniqueKey}`}
+            name={fullName}
+            size={iconSize}
+            round
+            style={{ margin: '0px 5px' }}
+          />
+        </OverlayTrigger>
+      </ConfigProvider>
+    );
+  }
+}

--- a/superset-frontend/src/components/AvatarIcon.tsx
+++ b/superset-frontend/src/components/AvatarIcon.tsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import styled from '@superset-ui/style';
+import { getCategoricalSchemeRegistry } from '@superset-ui/color';
 import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 import Avatar, { ConfigProvider } from 'react-avatar';
 
@@ -29,14 +30,7 @@ interface Props {
   userName: string;
 }
 
-const colorList = [
-  '#20A7C9',
-  '#59C189',
-  '#A868B6',
-  '#E04355',
-  '#FBC700',
-  '#FF7F43',
-];
+const colorList = getCategoricalSchemeRegistry().get();
 
 const StyledAvatar = styled(Avatar)`
   margin: 0px 5px;
@@ -53,7 +47,7 @@ export default function AvatarIcon({
   const fullName = `${firstName} ${lastName}`;
 
   return (
-    <ConfigProvider colors={colorList}>
+    <ConfigProvider colors={colorList && colorList.colors}>
       <OverlayTrigger
         placement="right"
         overlay={<Tooltip id={`${uniqueKey}-tooltip`}>{fullName}</Tooltip>}

--- a/superset-frontend/src/components/AvatarIcon.tsx
+++ b/superset-frontend/src/components/AvatarIcon.tsx
@@ -16,46 +16,55 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { PureComponent } from 'react';
+import React from 'react';
+import styled from '@superset-ui/style';
 import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 import Avatar, { ConfigProvider } from 'react-avatar';
 
 interface Props {
   firstName: string;
-  iconSize: string;
+  iconSize: number;
   lastName: string;
   tableName: string;
   userName: string;
 }
 
-export default class AvatarIcon extends PureComponent<Props> {
-  render() {
-    const { tableName, firstName, lastName, userName, iconSize } = this.props;
-    const uniqueKey = tableName.concat('_', userName);
-    const fullName = firstName.concat(' ', lastName);
-    const colors = [
-      '#20A7C9',
-      '#59C189',
-      '#A868B6',
-      '#E04355',
-      '#FBC700',
-      '#FF7F43',
-    ];
-    return (
-      <ConfigProvider colors={colors}>
-        <OverlayTrigger
-          placement="right"
-          overlay={<Tooltip id={`${uniqueKey}-tooltip`}>{fullName}</Tooltip>}
-        >
-          <Avatar
-            key={`${uniqueKey}`}
-            name={fullName}
-            size={iconSize}
-            round
-            style={{ margin: '0px 5px' }}
-          />
-        </OverlayTrigger>
-      </ConfigProvider>
-    );
-  }
+const colorList = [
+  '#20A7C9',
+  '#59C189',
+  '#A868B6',
+  '#E04355',
+  '#FBC700',
+  '#FF7F43',
+];
+
+const StyledAvatar = styled(Avatar)`
+  margin: 0px 5px;
+`;
+
+export default function AvatarIcon({
+  tableName,
+  firstName,
+  lastName,
+  userName,
+  iconSize,
+}: Props) {
+  const uniqueKey = `${tableName}-${userName}`;
+  const fullName = `${firstName} ${lastName}`;
+
+  return (
+    <ConfigProvider colors={colorList}>
+      <OverlayTrigger
+        placement="right"
+        overlay={<Tooltip id={`${uniqueKey}-tooltip`}>{fullName}</Tooltip>}
+      >
+        <StyledAvatar
+          key={`${uniqueKey}`}
+          name={fullName}
+          size={`${iconSize}`}
+          round
+        />
+      </OverlayTrigger>
+    </ConfigProvider>
+  );
 }

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -27,6 +27,7 @@ import { Panel } from 'react-bootstrap';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import ListView from 'src/components/ListView/ListView';
 import SubMenu from 'src/components/Menu/SubMenu';
+import AvatarIcon from 'src/components/AvatarIcon';
 import {
   FetchDataConfig,
   FilterOperatorMap,
@@ -35,6 +36,13 @@ import {
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 
 const PAGE_SIZE = 25;
+
+type Owner = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  username: string;
+};
 
 interface Props {
   addDangerToast: (msg: string) => void;
@@ -54,13 +62,14 @@ interface State {
 }
 
 interface Dataset {
+  changed_by: string;
   changed_by_name: string;
   changed_by_url: string;
-  changed_by: string;
   changed_on: string;
   databse_name: string;
   explore_url: string;
   id: number;
+  owners: Array<Owner>;
   schema: string;
   table_name: string;
 }
@@ -182,8 +191,28 @@ class DatasetList extends React.PureComponent<Props, State> {
       hidden: true,
     },
     {
-      accessor: 'owners',
-      hidden: true,
+      Cell: ({
+        row: {
+          original: { owners, table_name: tableName },
+        },
+      }: any) => {
+        if (!owners) {
+          return null;
+        }
+        return owners
+          .slice(0, 5)
+          .map((owner: Owner) => (
+            <AvatarIcon
+              tableName={tableName}
+              firstName={owner.first_name}
+              lastName={owner.last_name}
+              userName={owner.username}
+              iconSize="20"
+            />
+          ));
+      },
+      Header: t('Owners'),
+      id: 'owners',
     },
     {
       accessor: 'is_sqllab_view',

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -207,7 +207,7 @@ class DatasetList extends React.PureComponent<Props, State> {
               firstName={owner.first_name}
               lastName={owner.last_name}
               userName={owner.username}
-              iconSize={20}
+              iconSize="20"
             />
           ));
       },

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -207,7 +207,7 @@ class DatasetList extends React.PureComponent<Props, State> {
               firstName={owner.first_name}
               lastName={owner.last_name}
               userName={owner.username}
-              iconSize="20"
+              iconSize={20}
             />
           ));
       },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This profile icon is part of the dataset redesign [SIP-34](https://github.com/apache/incubator-superset/issues/8976). 
- Add a new react component [react-avatar](https://www.sitebase.be/react-avatar)
- Add `owners` column to dataset list view 
- Implement circle icon with owner's initials as owners' profile icon
- `owners` column displays maximum of 5 icons
- When `:hover`, tooltip should contain the owner's name

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
updated color scheme: 
<img width="1792" alt="Screen Shot 2020-06-12 at 9 44 20 AM" src="https://user-images.githubusercontent.com/5705598/84526032-7916e380-ac91-11ea-9c33-ad1445599836.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
