### PR TITLE
fix: bump pydruid version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ pip-tools==5.1.2
 pre-commit==1.17.0
 psycopg2-binary==2.8.5
 pycodestyle==2.5.0
-pydruid==0.6.0
+pydruid==0.6.1
 pyhive==0.6.2
 pylint==1.9.2
 redis==3.5.1

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "postgres": ["psycopg2-binary==2.8.5"],
         "presto": ["pyhive[presto]>=0.4.0"],
         "elasticsearch": ["elasticsearch-dbapi>=0.1.0, <0.2.0"],
-        "druid": ["pydruid==0.6.0", "requests==2.22.0"],
+        "druid": ["pydruid>=0.6.1,<0.7"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "dremio": ["sqlalchemy_dremio>=1.1.0"],
         "cockroachdb": ["cockroachdb==0.3.3"],


### PR DESCRIPTION
### SUMMARY
`pydruid==0.6.0` was broken, and fixed in `0.6.1` per https://github.com/druid-io/pydruid/pull/221 . The new version has been tested by connecting Superset to an Imply cluster on Python versions `3.6.10`, `3.7.7` and `3.8.3`.

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
