### PR TITLE
feat: add deafult buildQuery for V1 chart data requests

### DIFF
--- a/superset-frontend/spec/javascripts/chart/chartActions_spec.js
+++ b/superset-frontend/spec/javascripts/chart/chartActions_spec.js
@@ -77,7 +77,7 @@ describe('chart actions', () => {
 
   describe('v1 API', () => {
     beforeEach(() => {
-      fakeMetadata = { useLegacyApi: false };
+      fakeMetadata = { viz_type: 'my_viz', useLegacyApi: false };
     });
 
     it('should query with the built query', async () => {

--- a/superset-frontend/spec/javascripts/explore/utils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/utils_spec.jsx
@@ -19,7 +19,11 @@
 import sinon from 'sinon';
 
 import URI from 'urijs';
-import { getExploreUrl, getExploreLongUrl } from 'src/explore/exploreUtils';
+import {
+  buildV1ChartDataPayload,
+  getExploreUrl,
+  getExploreLongUrl,
+} from 'src/explore/exploreUtils';
 import * as hostNamesConfig from 'src/utils/hostNamesConfig';
 
 describe('exploreUtils', () => {
@@ -187,6 +191,15 @@ describe('exploreUtils', () => {
         URI(getExploreLongUrl(formData, 'base')),
         URI('/superset/explore/').search({ form_data: sFormData }),
       );
+    });
+  });
+
+  describe('buildV1ChartDataPayload', () => {
+    it('generate valid request payload despite no registered buildQuery', () => {
+      const v1RequestPayload = buildV1ChartDataPayload({
+        formData: { ...formData, viz_type: 'my_custom_viz' },
+      });
+      expect(v1RequestPayload).hasOwnProperty('queries');
     });
   });
 });

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -19,7 +19,8 @@
 /* eslint camelcase: 0 */
 import URI from 'urijs';
 import { SupersetClient } from '@superset-ui/connection';
-import { allowCrossDomain, availableDomains } from 'src/utils/hostNamesConfig';
+import { buildQueryContext } from '@superset-ui/query';
+import { availableDomains } from 'src/utils/hostNamesConfig';
 import { safeStringify } from 'src/utils/safeStringify';
 import {
   getChartBuildQueryRegistry,
@@ -198,7 +199,14 @@ export const shouldUseLegacyApi = formData => {
 };
 
 export const buildV1ChartDataPayload = ({ formData, force }) => {
-  const buildQuery = getChartBuildQueryRegistry().get(formData.viz_type);
+  const buildQuery =
+    getChartBuildQueryRegistry().get(formData.viz_type) ??
+    (buildQueryformData =>
+      buildQueryContext(buildQueryformData, baseQueryObject => [
+        {
+          ...baseQueryObject,
+        },
+      ]));
   return buildQuery({
     ...formData,
     force,


### PR DESCRIPTION
### SUMMARY
Currently registering a `buildQuery` function with the `ChartBuildQueryRegistry` is mandatory for all V1 viz plugins. While a custom `buildQuery` is needed for advanced post processing operations, in the majority of cases this is not needed, as control values can be automatically grouped using the `queryField` control property. Using a default callback will make it easier to get started with viz plugin development, and reduce plugin boilerplate.

### TEST PLAN
CI + new test with current pinned `superset-ui` dependencies. Also tested to work properly with the new word cloud plugin with and without a `buildQuery` callback.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
