### PR TITLE
style: push bootstrap theme towards SIP-34 styles

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,slack,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.js
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.js
@@ -43,12 +43,10 @@ export default () => {
         const initialTabCount = tabListA.length;
 
         // open the tab dropdown to remove
-        cy.get('#a11y-query-editor-tabs > ul > li.dropdown').click();
+        cy.get('#a11y-query-editor-tabs > ul > li .dropdown-toggle').click();
 
         // first item is close
-        cy.get('#a11y-query-editor-tabs > ul > li.dropdown ul li a')
-          .eq(0)
-          .click();
+        cy.get('#a11y-query-editor-tabs .close-btn a').click();
 
         cy.get('#a11y-query-editor-tabs > ul > li').should(
           'have.length',

--- a/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.js
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.js
@@ -43,12 +43,12 @@ export default () => {
         const initialTabCount = tabListA.length;
 
         // open the tab dropdown to remove
-        cy.get(
-          '#a11y-query-editor-tabs > ul > li:first button:nth-child(2)',
-        ).click();
+        cy.get('#a11y-query-editor-tabs > ul > li.dropdown').click();
 
         // first item is close
-        cy.get('#a11y-query-editor-tabs > ul > li:first ul li a').eq(0).click();
+        cy.get('#a11y-query-editor-tabs > ul > li.dropdown ul li a')
+          .eq(0)
+          .click();
 
         cy.get('#a11y-query-editor-tabs > ul > li').should(
           'have.length',

--- a/superset-frontend/spec/javascripts/explore/components/QueryAndSaveBtns_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/QueryAndSaveBtns_spec.jsx
@@ -49,7 +49,7 @@ describe('QueryAndSaveButtons', () => {
     });
 
     it('renders buttons with correct text', () => {
-      expect(wrapper.find(Button).contains(' Run Query')).toBe(true);
+      expect(wrapper.find(Button).contains('Run')).toBe(true);
       expect(wrapper.find(Button).contains(' Save')).toBe(true);
     });
 

--- a/superset-frontend/spec/javascripts/sqllab/SqlEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/SqlEditor_spec.jsx
@@ -109,7 +109,7 @@ describe('SqlEditor', () => {
   it('allows toggling autocomplete', () => {
     const wrapper = shallow(<SqlEditor {...mockedProps} />);
     expect(wrapper.find(AceEditorWrapper).props().autocomplete).toBe(true);
-    wrapper.find(Checkbox).props().onChange();
+    wrapper.find('.autocomplete').simulate('click');
     expect(wrapper.find(AceEditorWrapper).props().autocomplete).toBe(false);
   });
 });

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
@@ -42,7 +42,7 @@ const RunQueryActionButton = ({
   stopQuery = NO_OP,
   sql,
 }: Props) => {
-  const runBtnText = selectedText ? t('Run Selected Query') : t('Run Query');
+  const runBtnText = selectedText ? t('Run Selected Query') : t('Run');
   const btnStyle = selectedText ? 'warning' : 'primary';
   const shouldShowStopBtn =
     !!queryState && ['running', 'pending'].indexOf(queryState) > -1;
@@ -68,7 +68,7 @@ const RunQueryActionButton = ({
         tooltip={t('Run query asynchronously (Ctrl + ↵)')}
         disabled={!sql.trim()}
       >
-        <i className="fa fa-table" /> {runBtnText}
+        <i className="fa fa-bolt" /> {runBtnText}
       </Button>
     );
   }

--- a/superset-frontend/src/SqlLab/components/SaveQuery.jsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery.jsx
@@ -172,7 +172,7 @@ class SaveQuery extends React.PureComponent {
               className="toggleSave"
               onClick={this.toggleSave}
             >
-              <i className="fa fa-save" /> {t('Save Query')}
+              <i className="fa fa-save" /> {t('Save')}
             </Button>
           }
           bsSize="small"

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.jsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery.jsx
@@ -112,7 +112,7 @@ class ShareSqlLabQuery extends React.Component {
         overlay={this.renderPopover()}
       >
         <Button bsSize="small" className="toggleSave">
-          <i className="fa fa-clipboard" /> {t('Share Query')}
+          <i className="fa fa-share" /> {t('Share')}
         </Button>
       </OverlayTrigger>
     );

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -20,7 +20,6 @@ import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 import PropTypes from 'prop-types';
 import {
-  Checkbox,
   FormGroup,
   InputGroup,
   Form,
@@ -35,6 +34,7 @@ import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 
 import Button from '../../components/Button';
+import Checkbox from '../../components/Checkbox';
 import LimitControl from './LimitControl';
 import TemplateParamsEditor from './TemplateParamsEditor';
 import SouthPane from './SouthPane';
@@ -509,16 +509,14 @@ class SqlEditor extends React.PureComponent {
           </Form>
         </div>
         <div className="rightItems">
-          <span>
+          <Button className="p-r-5" onClick={this.handleToggleAutocompleteEnabled}>
             <Checkbox
               checked={this.state.autocompleteEnabled}
-              inline
-              title={t('Autocomplete')}
-              onChange={this.handleToggleAutocompleteEnabled}
-            >
-              {t('Autocomplete')}
-            </Checkbox>
-          </span>
+            />
+            {' '}
+            {t('Autocomplete')}
+          </Button>
+          {' '}
           <TemplateParamsEditor
             language="json"
             onChange={params => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -509,14 +509,13 @@ class SqlEditor extends React.PureComponent {
           </Form>
         </div>
         <div className="rightItems">
-          <Button className="p-r-5" onClick={this.handleToggleAutocompleteEnabled}>
-            <Checkbox
-              checked={this.state.autocompleteEnabled}
-            />
-            {' '}
+          <Button
+            className="p-r-5"
+            onClick={this.handleToggleAutocompleteEnabled}
+          >
+            <Checkbox checked={this.state.autocompleteEnabled} />{' '}
             {t('Autocomplete')}
-          </Button>
-          {' '}
+          </Button>{' '}
           <TemplateParamsEditor
             language="json"
             onChange={params => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -510,7 +510,7 @@ class SqlEditor extends React.PureComponent {
         </div>
         <div className="rightItems">
           <Button
-            className="p-r-5"
+            className="autocomplete"
             onClick={this.handleToggleAutocompleteEnabled}
           >
             <Checkbox checked={this.state.autocompleteEnabled} />{' '}

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -289,7 +289,7 @@ class TabbedSqlEditors extends React.PureComponent {
       );
       const tabTitle = (
         <>
-          {title}
+          <span className="ddbtn-tab">{title}</span>
           {isSelected && (
             <SplitButton
               bsSize="small"
@@ -297,7 +297,11 @@ class TabbedSqlEditors extends React.PureComponent {
               className="ddbtn-tab"
               title="&nbsp;"
             >
-              <MenuItem eventKey="1" onClick={() => this.removeQueryEditor(qe)}>
+              <MenuItem
+                className="close-btn"
+                eventKey="1"
+                onClick={() => this.removeQueryEditor(qe)}
+              >
                 <div className="icon-container">
                   <i className="fa fa-close" />
                 </div>

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -290,7 +290,7 @@ class TabbedSqlEditors extends React.PureComponent {
       const tabTitle = (
         <>
           {title}
-          {isSelected &&
+          {isSelected && (
             <SplitButton
               bsSize="small"
               id={'ddbtn-tab-' + i}
@@ -313,7 +313,9 @@ class TabbedSqlEditors extends React.PureComponent {
                 <div className="icon-container">
                   <i className="fa fa-cogs" />
                 </div>
-                {this.state.hideLeftBar ? t('Expand tool bar') : t('Hide tool bar')}
+                {this.state.hideLeftBar
+                  ? t('Expand tool bar')
+                  : t('Hide tool bar')}
               </MenuItem>
               <MenuItem
                 eventKey="4"
@@ -324,14 +326,17 @@ class TabbedSqlEditors extends React.PureComponent {
                 </div>
                 {t('Close all other tabs')}
               </MenuItem>
-              <MenuItem eventKey="5" onClick={() => this.duplicateQueryEditor(qe)}>
+              <MenuItem
+                eventKey="5"
+                onClick={() => this.duplicateQueryEditor(qe)}
+              >
                 <div className="icon-container">
                   <i className="fa fa-files-o" />
                 </div>
                 {t('Duplicate tab')}
               </MenuItem>
             </SplitButton>
-          }
+          )}
         </>
       );
       return (

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -288,46 +288,51 @@ class TabbedSqlEditors extends React.PureComponent {
         </>
       );
       const tabTitle = (
-        <SplitButton
-          bsSize="small"
-          id={'ddbtn-tab-' + i}
-          className="ddbtn-tab"
-          title={title}
-        >
-          <MenuItem eventKey="1" onClick={() => this.removeQueryEditor(qe)}>
-            <div className="icon-container">
-              <i className="fa fa-close" />
-            </div>
-            {t('Close tab')}
-          </MenuItem>
-          <MenuItem eventKey="2" onClick={() => this.renameTab(qe)}>
-            <div className="icon-container">
-              <i className="fa fa-i-cursor" />
-            </div>
-            {t('Rename tab')}
-          </MenuItem>
-          <MenuItem eventKey="3" onClick={this.toggleLeftBar}>
-            <div className="icon-container">
-              <i className="fa fa-cogs" />
-            </div>
-            {this.state.hideLeftBar ? t('Expand tool bar') : t('Hide tool bar')}
-          </MenuItem>
-          <MenuItem
-            eventKey="4"
-            onClick={() => this.removeAllOtherQueryEditors(qe)}
-          >
-            <div className="icon-container">
-              <i className="fa fa-times-circle-o" />
-            </div>
-            {t('Close all other tabs')}
-          </MenuItem>
-          <MenuItem eventKey="5" onClick={() => this.duplicateQueryEditor(qe)}>
-            <div className="icon-container">
-              <i className="fa fa-files-o" />
-            </div>
-            {t('Duplicate tab')}
-          </MenuItem>
-        </SplitButton>
+        <>
+          {title}
+          {isSelected &&
+            <SplitButton
+              bsSize="small"
+              id={'ddbtn-tab-' + i}
+              className="ddbtn-tab"
+              title="&nbsp;"
+            >
+              <MenuItem eventKey="1" onClick={() => this.removeQueryEditor(qe)}>
+                <div className="icon-container">
+                  <i className="fa fa-close" />
+                </div>
+                {t('Close tab')}
+              </MenuItem>
+              <MenuItem eventKey="2" onClick={() => this.renameTab(qe)}>
+                <div className="icon-container">
+                  <i className="fa fa-i-cursor" />
+                </div>
+                {t('Rename tab')}
+              </MenuItem>
+              <MenuItem eventKey="3" onClick={this.toggleLeftBar}>
+                <div className="icon-container">
+                  <i className="fa fa-cogs" />
+                </div>
+                {this.state.hideLeftBar ? t('Expand tool bar') : t('Hide tool bar')}
+              </MenuItem>
+              <MenuItem
+                eventKey="4"
+                onClick={() => this.removeAllOtherQueryEditors(qe)}
+              >
+                <div className="icon-container">
+                  <i className="fa fa-times-circle-o" />
+                </div>
+                {t('Close all other tabs')}
+              </MenuItem>
+              <MenuItem eventKey="5" onClick={() => this.duplicateQueryEditor(qe)}>
+                <div className="icon-container">
+                  <i className="fa fa-files-o" />
+                </div>
+                {t('Duplicate tab')}
+              </MenuItem>
+            </SplitButton>
+          }
+        </>
       );
       return (
         <Tab key={qe.id} title={tabTitle} eventKey={qe.id}>

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -259,7 +259,7 @@ div.Workspace {
 
   .ddbtn-tab {
     font-size: inherit;
-    font-weight: @font-weight-bold;
+    color: black;
 
     &:active {
       background: none;

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -259,7 +259,6 @@ div.Workspace {
 
   .ddbtn-tab {
     font-size: inherit;
-    font-weight: @font-weight-bold;
 
     &:active {
       background: none;

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -259,6 +259,7 @@ div.Workspace {
 
   .ddbtn-tab {
     font-size: inherit;
+    font-weight: @font-weight-bold;
 
     &:active {
       background: none;

--- a/superset-frontend/src/components/ListView/LegacyFilters.tsx
+++ b/superset-frontend/src/components/ListView/LegacyFilters.tsx
@@ -49,7 +49,7 @@ export const FilterMenu = ({
         <>
           <i className="fa fa-filter text-primary" />
           {'  '}
-          {t('Filter List')}
+          {t('Filter')}
         </>
       }
     >

--- a/superset-frontend/src/components/ListView/LegacyFilters.tsx
+++ b/superset-frontend/src/components/ListView/LegacyFilters.tsx
@@ -30,6 +30,8 @@ import { Select } from 'src/components/Select';
 import { Filters, InternalFilter, SelectOption } from './types';
 import { extractInputValue, getDefaultFilterOperator } from './utils';
 
+const styleWidth100p = { width: '100%' };
+
 export const FilterMenu = ({
   filters,
   internalFilters,
@@ -181,12 +183,13 @@ export const FilterInputs = ({
     {internalFilters.length > 0 && (
       <>
         <Row>
-          <Col md={10} />
-          <Col md={2}>
+          <Col md={11} />
+          <Col md={1}>
             <Button
               data-test="apply-filters"
               disabled={!!filtersApplied}
               bsStyle="primary"
+              style={styleWidth100p}
               onClick={applyFilters}
               bsSize="small"
             >

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -125,11 +125,11 @@ const ListView: FunctionComponent<Props> = ({
             {title && filterable && (
               <>
                 <Row>
-                  <Col md={10}>
+                  <Col md={11}>
                     <h2>{t(title)}</h2>
                   </Col>
                   {filterable && (
-                    <Col md={2}>
+                    <Col md={1}>
                       <FilterMenu
                         filters={filters}
                         internalFilters={internalFilters}

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.css
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.css
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 .save-btn {
   width: 100px;
 }

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.css
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.css
@@ -1,0 +1,3 @@
+.save-btn {
+  width: 100px;
+}

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -20,8 +20,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ButtonGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import classnames from 'classnames';
+import { t } from '@superset-ui/translation';
 
 import Button from '../../components/Button';
+import './QueryAndSaveBtns.css';
 
 const propTypes = {
   canAdd: PropTypes.bool.isRequired,
@@ -50,6 +52,7 @@ export default function QueryAndSaveBtns({
 }) {
   const saveClasses = classnames({
     'disabled disabledButton': !canAdd,
+    'save-btn': true,
   });
 
   let qryButtonStyle = 'default';
@@ -61,17 +64,17 @@ export default function QueryAndSaveBtns({
 
   const saveButtonDisabled = errorMessage ? true : loading;
   const qryOrStopButton = loading ? (
-    <Button onClick={onStop} bsStyle="warning">
+    <Button onClick={onStop} bsStyle="warning" className="save-btn">
       <i className="fa fa-stop-circle-o" /> Stop
     </Button>
   ) : (
     <Button
-      className="query"
+      className="query save-btn"
       onClick={onQuery}
       bsStyle={qryButtonStyle}
       disabled={!!errorMessage}
     >
-      <i className="fa fa-bolt" /> Run Query
+      <i className="fa fa-bolt" /> {t('Run')}
     </Button>
   );
 

--- a/superset-frontend/stylesheets/less/cosmo/bootswatch.less
+++ b/superset-frontend/stylesheets/less/cosmo/bootswatch.less
@@ -71,9 +71,8 @@
 }
 
 .btn-default:hover {
-  color: @brand-primary;
-  background-color: @brand-primary-light4;
-  border-color: @brand-primary-light1;
+  color: @gray-dark;
+  background-color: @gray-bg;
 }
 
 .nav-tabs {
@@ -423,6 +422,7 @@ a.list-group-item {
 
 .nav-tabs > li > a {
   border-top: 3px solid transparent;
+  color: @text-color;
 }
 
 .nav-tabs > li.active > a,

--- a/superset-frontend/stylesheets/less/cosmo/bootswatch.less
+++ b/superset-frontend/stylesheets/less/cosmo/bootswatch.less
@@ -66,6 +66,10 @@
 
 // Buttons ====================================================================
 
+.btn {
+  text-transform: uppercase;
+}
+
 .btn-default:hover {
   color: @gray-dark;
   background-color: @gray-bg;

--- a/superset-frontend/stylesheets/less/cosmo/bootswatch.less
+++ b/superset-frontend/stylesheets/less/cosmo/bootswatch.less
@@ -71,8 +71,9 @@
 }
 
 .btn-default:hover {
-  color: @gray-dark;
-  background-color: @gray-bg;
+  color: @brand-primary;
+  background-color: @brand-primary-light4;
+  border-color: @brand-primary-light1;
 }
 
 .nav-tabs {
@@ -281,10 +282,13 @@ table,
 
 .label {
   border-radius: @border-radius-normal;
+  padding: 0.3em 0.6em 0.2em;
+  font-weight: @font-weight-normal;
 }
 
 label {
   font-weight: @font-weight-normal;
+  font-size: @font-size-s;
 }
 
 // Progress bars ==============================================================
@@ -296,7 +300,7 @@ label {
   .progress-bar {
     font-size: @font-size-s;
     line-height: @line-height-tight;
-    padding-top: 1px;
+    padding-top: 2px;
   }
 }
 

--- a/superset-frontend/stylesheets/less/cosmo/variables.less
+++ b/superset-frontend/stylesheets/less/cosmo/variables.less
@@ -162,7 +162,7 @@
 @btn-info-bg: @brand-info;
 @btn-info-border: @btn-info-bg;
 
-@btn-warning-color: @btn-default-color;
+@btn-warning-color: @btn-primary-color;
 @btn-warning-bg: @brand-warning;
 @btn-warning-border: @btn-warning-bg;
 

--- a/superset-frontend/stylesheets/less/cosmo/variables.less
+++ b/superset-frontend/stylesheets/less/cosmo/variables.less
@@ -107,8 +107,8 @@
 @line-height-small: 1.5;
 
 @border-radius-base: @border-radius-normal;
-@border-radius-large: 2px;
-@border-radius-small: 2px;
+@border-radius-large: 4px;
+@border-radius-small: 4px;
 
 // ** Global color for active items (e.g., navs or dropdowns).
 @component-active-color: @lightest; // superset-var
@@ -151,8 +151,8 @@
 @btn-primary-border: @brand-primary;
 
 @btn-default-color: @brand-primary;
-@btn-default-bg: @brand-primary-light3;
-@btn-default-border: @brand-primary-light3;
+@btn-default-bg: @lightest;
+@btn-default-border: @brand-primary;
 
 @btn-success-color: @btn-primary-color;
 @btn-success-bg: @brand-success;

--- a/superset-frontend/stylesheets/less/cosmo/variables.less
+++ b/superset-frontend/stylesheets/less/cosmo/variables.less
@@ -150,9 +150,9 @@
 @btn-primary-bg: @brand-primary;
 @btn-primary-border: @brand-primary;
 
-@btn-default-color: @brand-primary;
+@btn-default-color: @bs-gray;
 @btn-default-bg: @lightest;
-@btn-default-border: @brand-primary;
+@btn-default-border: @bs-gray-light;
 
 @btn-success-color: @btn-primary-color;
 @btn-success-bg: @brand-success;

--- a/superset-frontend/stylesheets/less/cosmo/variables.less
+++ b/superset-frontend/stylesheets/less/cosmo/variables.less
@@ -146,13 +146,13 @@
 
 @btn-font-weight: normal;
 
-@btn-primary-color: @lightest; // superset-var
+@btn-primary-color: @lightest;
 @btn-primary-bg: @brand-primary;
 @btn-primary-border: @brand-primary;
 
-@btn-default-color: @bs-gray;
-@btn-default-bg: @lightest; // superset-var
-@btn-default-border: @bs-gray-light;
+@btn-default-color: @brand-primary;
+@btn-default-bg: @brand-primary-light3;
+@btn-default-border: @brand-primary-light3;
 
 @btn-success-color: @btn-primary-color;
 @btn-success-bg: @brand-success;

--- a/superset-frontend/stylesheets/less/variables.less
+++ b/superset-frontend/stylesheets/less/variables.less
@@ -24,9 +24,8 @@
 /* component styles. This will allow us to more easily adjust theming   */
 /************************************************************************/
 
-@primary-color: #20A7C9;
+@primary-color: #20a7c9;
 @indicator-color: @primary-color;
-
 
 @brand-primary-dark1: #1a85a0;
 @brand-primary-dark2: #156378;
@@ -61,10 +60,10 @@
 @link-hover: darken(@link, @colorstop-one);
 
 /***************************** status colors ****************************/
-@success: #5AC189;
-@info: #66BCFE;
-@warning: #FF7F44;
-@danger: #E04355;
+@success: #5ac189;
+@info: #66bcfe;
+@warning: #ff7f44;
+@danger: #e04355;
 
 /* general component effects */
 @shadow-highlight: @primary-color;

--- a/superset-frontend/stylesheets/less/variables.less
+++ b/superset-frontend/stylesheets/less/variables.less
@@ -24,8 +24,8 @@
 /* component styles. This will allow us to more easily adjust theming   */
 /************************************************************************/
 
-@primary-color: #00a699;
-@indicator-color: #44c0ff;
+@primary-color: #20A7C9;
+@indicator-color: @primary-color;
 
 @almost-black: #263238;
 @gray-dark: #484848;
@@ -42,14 +42,10 @@
 @link-hover: darken(@link, @colorstop-one);
 
 /***************************** status colors ****************************/
-@success: #4ac15f;
-@info: lighten(#2ab7ca, 15%);
-@warning: mix(
-  #fed766,
-  #ffab00,
-  50%
-); // mix of old superset warning color and cosmo warning color. Compromise!
-@danger: #fe4a49;
+@success: #5AC189;
+@info: #66BCFE;
+@warning: #FF7F44;
+@danger: #E04355;
 
 /* general component effects */
 @shadow-highlight: @primary-color;

--- a/superset-frontend/stylesheets/less/variables.less
+++ b/superset-frontend/stylesheets/less/variables.less
@@ -28,23 +28,23 @@
 @indicator-color: @primary-color;
 
 
-@brand-primary-dark1: '#1A85A0';
-@brand-primary-dark2: '#156378';
-@brand-primary-light1: '#79CADE';
-@brand-primary-light2: '#A5DAE9';
-@brand-primary-light3: '#D2EDF4';
-@brand-primary-light4: '#E9F6F9';
-@brand-primary-light5: '#F3F8FA';
+@brand-primary-dark1: #1a85a0;
+@brand-primary-dark2: #156378;
+@brand-primary-light1: #79cade;
+@brand-primary-light2: #a5dae9;
+@brand-primary-light3: #d2edf4;
+@brand-primary-light4: #e9f6f9;
+@brand-primary-light5: #f3f8fa;
 
-@brand-secondary: '#444E7C';
-@brand-secondary-dark1: '#363E63';
-@brand-secondary-dark2: '#282E4A';
-@brand-secondary-dark3: '#1B1F31';
-@brand-secondary-light1: '#8E94B0';
-@brand-secondary-light2: '#B4B8CA';
-@brand-secondary-light3: '#D9DBE4';
-@brand-secondary-light4: '#ECEEF2';
-@brand-secondary-light5: '#F5F5F8';
+@brand-secondary: #444e7c;
+@brand-secondary-dark1: #363e63;
+@brand-secondary-dark2: #282e4a;
+@brand-secondary-dark3: #1b1f31;
+@brand-secondary-light1: #8e94b0;
+@brand-secondary-light2: #b4b8ca;
+@brand-secondary-light3: #d9dbe4;
+@brand-secondary-light4: #eceef2;
+@brand-secondary-light5: #f5f5f8;
 
 @almost-black: #263238;
 @gray-dark: #484848;

--- a/superset-frontend/stylesheets/less/variables.less
+++ b/superset-frontend/stylesheets/less/variables.less
@@ -56,7 +56,7 @@
 @darkest: #000000;
 
 /**************************** text-specific *****************************/
-@link: @brand-primary;
+@link: #1985a0;
 @link-hover: darken(@link, @colorstop-one);
 
 /***************************** status colors ****************************/

--- a/superset-frontend/stylesheets/less/variables.less
+++ b/superset-frontend/stylesheets/less/variables.less
@@ -27,6 +27,25 @@
 @primary-color: #20A7C9;
 @indicator-color: @primary-color;
 
+
+@brand-primary-dark1: '#1A85A0';
+@brand-primary-dark2: '#156378';
+@brand-primary-light1: '#79CADE';
+@brand-primary-light2: '#A5DAE9';
+@brand-primary-light3: '#D2EDF4';
+@brand-primary-light4: '#E9F6F9';
+@brand-primary-light5: '#F3F8FA';
+
+@brand-secondary: '#444E7C';
+@brand-secondary-dark1: '#363E63';
+@brand-secondary-dark2: '#282E4A';
+@brand-secondary-dark3: '#1B1F31';
+@brand-secondary-light1: '#8E94B0';
+@brand-secondary-light2: '#B4B8CA';
+@brand-secondary-light3: '#D9DBE4';
+@brand-secondary-light4: '#ECEEF2';
+@brand-secondary-light5: '#F5F5F8';
+
 @almost-black: #263238;
 @gray-dark: #484848;
 @gray-light: #cfd8dc;
@@ -181,7 +200,7 @@
 /* BORDER RADII                                                         */
 /* Standard border-radius settings                                      */
 /************************************************************************/
-@border-radius-normal: 2px;
+@border-radius-normal: 4px;
 @border-radius-large: (@border-radius-normal * 2);
 
 /************************************************************************/

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -445,7 +445,7 @@ table.table-no-hover tr:hover {
 }
 
 .list-add-action .btn.btn-sm {
-  padding: 5px 6px;
+  padding: 6px 6px;
   font-size: @font-size-xs;
   line-height: 2px;
   border-radius: 50%;


### PR DESCRIPTION
Spent 1-2 hours playing around to get a sense of how much we can push towards `SIP-34`'s look & feel with limited effort.

## BEFORE
<img width="1258" alt="Screen Shot 2020-06-16 at 12 03 10 AM" src="https://user-images.githubusercontent.com/487433/84742086-d4ccbf80-af64-11ea-8d85-4a883da55eae.png">

## AFTER
<img width="1256" alt="Screen Shot 2020-06-16 at 12 02 40 AM" src="https://user-images.githubusercontent.com/487433/84742096-d72f1980-af64-11ea-87a6-08d320b4efd3.png">
<img width="1232" alt="Screen Shot 2020-06-16 at 9 49 46 PM" src="https://user-images.githubusercontent.com/487433/84856822-87ac2480-b01c-11ea-8ea5-47f567def2ea.png">
<img width="1235" alt="Screen Shot 2020-06-16 at 9 48 05 PM" src="https://user-images.githubusercontent.com/487433/84856824-8844bb00-b01c-11ea-9633-95aa9fc83b65.png">


## TODO
- [ ] colors went in smoothly, though we need a new Superset logo with the new `@brand-primary` color!
- [x] text on `btn-sm` isn't aligned, the new font we use isn't aligned with the pixels it reserves
- [ ] SIP-34 primary and secondary buttons don't look good in button groups where it's unclear where one button and the next starts. I think we'll be moving away from using `btn-group` and have buttons side by side (with a gap) and the extra buttons into dropdowns - but this requires touching layouts (not just CSS). Bootstrap offers `btn-primary` and `btn-default`, but no tierciary. For now I rolled with using what SIP-34 defines as tierciary on `btn-default` to work around the group issue 
- [x] SQL Lab tab headers are buttons but shouldn't be, as a result they got uppercased. We need to get them out of buttons