### PR TITLE
fix: caching on viz with relative time ranges and time compare

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -390,14 +390,15 @@ class BaseViz:
         "5 days ago" or "now").
 
         The `extra` arguments are currently used by time shift queries, since
-        different time shifts wil differ only in the `from_dttm` and `to_dttm`
-        values which are stripped.
+        different time shifts wil differ only in the `from_dttm`, `to_dttm`,
+        `inner_from_dttm`, and `inner_to_dttm` values which are stripped.
         """
         cache_dict = copy.copy(query_obj)
         cache_dict.update(extra)
 
-        for k in ["from_dttm", "to_dttm"]:
-            del cache_dict[k]
+        for k in ["from_dttm", "to_dttm", "inner_from_dttm", "inner_to_dttm"]:
+            if k in cache_dict:
+                del cache_dict[k]
 
         cache_dict["time_range"] = self.form_data.get("time_range")
         cache_dict["datasource"] = self.datasource.uid

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -122,7 +122,21 @@ class CoreTests(SupersetTestCase):
         cache_key = viz.cache_key(qobj)
 
         qobj["groupby"] = []
-        self.assertNotEqual(cache_key, viz.cache_key(qobj))
+        cache_key_with_groupby = viz.cache_key(qobj)
+        self.assertNotEqual(cache_key, cache_key_with_groupby)
+
+        self.assertNotEqual(
+            viz.cache_key(qobj), viz.cache_key(qobj, time_compare="12 weeks")
+        )
+
+        self.assertNotEqual(
+            viz.cache_key(qobj, time_compare="28 days"),
+            viz.cache_key(qobj, time_compare="12 weeks"),
+        )
+
+        qobj["inner_from_dttm"] = datetime.datetime(1901, 1, 1)
+
+        self.assertEquals(cache_key_with_groupby, viz.cache_key(qobj))
 
     def test_get_superset_tables_not_allowed(self):
         example_db = utils.get_example_database()


### PR DESCRIPTION
### SUMMARY
When loading a recently loaded chart with a relative time range and a time compare selected, the chart renders with the "cached" icons, but it clearly takes far too long to load (like a minute compared to the usual half a second for a cached chart. After investigation, it looks like the cache key isn't consistent for relative time range time compare extra queries. This fixes that issue

### TEST PLAN
CI + new unit tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @john-bodley @mistercrunch @villebro 