### PR TITLE
fix: chart export fails when buildQuery not present

### DIFF
--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -198,7 +198,12 @@ export const shouldUseLegacyApi = formData => {
   return useLegacyApi || false;
 };
 
-export const buildV1ChartDataPayload = ({ formData, force }) => {
+export const buildV1ChartDataPayload = ({
+  formData,
+  force,
+  resultFormat,
+  resultType,
+}) => {
   const buildQuery =
     getChartBuildQueryRegistry().get(formData.viz_type) ??
     (buildQueryformData =>
@@ -210,6 +215,8 @@ export const buildV1ChartDataPayload = ({ formData, force }) => {
   return buildQuery({
     ...formData,
     force,
+    result_format: resultFormat,
+    result_type: resultType,
   });
 };
 
@@ -260,13 +267,12 @@ export const exportChart = ({
     payload = formData;
   } else {
     url = '/api/v1/chart/data';
-    const buildQuery = getChartBuildQueryRegistry().get(formData.viz_type);
-    payload = buildQuery({
-      ...formData,
+    payload = buildV1ChartDataPayload({
+      formData,
       force,
+      resultFormat,
+      resultType,
     });
-    payload.result_type = resultType;
-    payload.result_format = resultFormat;
   }
   postForm(url, payload);
 };


### PR DESCRIPTION
### SUMMARY
If a viz plugin doesn't provide a `buildQuery` function, exporting charts (JSON, CSV) fails.

(FYI: this code will soon be replaced with `ChartClient` from `@superset-ui/chart`, hence not adding tests for this).

### TEST PLAN
CI + local testing by verifying that old+new charts render properly on dashboards and Explore mode, and that all export options still work (CSV, JSON, Samples, Query).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
