### PR TITLE
fix: use custom int parsing over flask int parsing in sqllab queries endpoint

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2659,7 +2659,7 @@ class Superset(BaseSupersetView):
 
     @has_access_api
     @expose("/queries/<last_updated_ms>")
-    def queries(self, last_updated_ms) -> FlaskResponse:
+    def queries(self, last_updated_ms: str) -> FlaskResponse:
         """
         Get the updated queries.
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2658,14 +2658,15 @@ class Superset(BaseSupersetView):
         return json_success(json.dumps(datasource.data))
 
     @has_access_api
-    @expose("/queries/<int:last_updated_ms>")
-    def queries(self, last_updated_ms: int) -> FlaskResponse:
+    @expose("/queries/<last_updated_ms>")
+    def queries(self, last_updated_ms) -> FlaskResponse:
         """
         Get the updated queries.
 
         :param last_updated_ms: unix time, milliseconds
         """
-        return self.queries_exec(last_updated_ms)
+        last_updated_ms_int = int(float(last_updated_ms)) if last_updated_ms else 0
+        return self.queries_exec(last_updated_ms_int)
 
     def queries_exec(self, last_updated_ms: int) -> FlaskResponse:
         stats_logger.incr("queries")

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -210,7 +210,7 @@ class SqlLabTests(SupersetTestCase):
         db.session.commit()
 
         data = self.get_json_resp(
-            "/superset/queries/{}".format(int(datetime_to_epoch(now)) - 1000)
+            "/superset/queries/{}".format(float(datetime_to_epoch(now)) - 1000)
         )
         self.assertEqual(1, len(data))
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Flask returns a 404 when a route doesn't match it's signature. `/superset/queries/1588736634550.6` was returning 404 due to the `<int:last_updated_ms>` syntax since the requested endpoint contains a float. 

This PR reverts the typing logic introduced in https://github.com/apache/incubator-superset/pull/9939/files#diff-ac978615a4f22c4fad4d01f39e1d4595L2646 in favor of the custom int parsing logic that was in palce before. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- tested locally (`/superset/queries/1588736634550.6` does not 404)
- unit tested

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
