### PR TITLE
fix: Ensuring /queries/ route accepts float or int

### DIFF
--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -192,6 +192,8 @@ class SqlLabTests(SupersetTestCase):
         self.login("admin")
         data = self.get_json_resp("/superset/queries/0")
         self.assertEqual(2, len(data))
+        data = self.get_json_resp("/superset/queries/0.0")
+        self.assertEqual(2, len(data))
 
         # Run 2 more queries
         self.run_sql("SELECT * FROM birth_names LIMIT 1", client_id="client_id_4")


### PR DESCRIPTION
### SUMMARY

Apologies for the regression which was fixed in https://github.com/apache/incubator-superset/pull/10070. This PR updates the logic to ensure that Unix time provided is either a float or integer. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
