### PR TITLE
chore: [logging] add selected tab name into perf logging

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -91,12 +91,15 @@ class Dashboard extends React.PureComponent {
   }
 
   componentDidMount() {
+    const appContainer = document.getElementById('app');
+    const bootstrapData = appContainer?.getAttribute('data-bootstrap') || '';
     const { dashboardState, layout } = this.props;
     const eventData = {
       is_edit_mode: dashboardState.editMode,
       mount_duration: Logger.getTimestamp(),
       is_empty: isDashboardEmpty(layout),
       is_published: dashboardState.isPublished,
+      bootstrap_data_length: bootstrapData.length,
     };
     const directLinkComponentId = getLocationHash();
     if (directLinkComponentId) {

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -150,12 +150,13 @@ class Tabs extends React.PureComponent {
         },
       });
     } else if (tabIndex !== this.state.tabIndex) {
+      const pathToTabIndex = getDirectPathToTabIndex(component, tabIndex);
+      const targetTabId = pathToTabIndex[pathToTabIndex.length - 1];
       this.props.logEvent(LOG_ACTIONS_SELECT_DASHBOARD_TAB, {
-        tab_id: component.id,
+        target_id: targetTabId,
         index: tabIndex,
       });
 
-      const pathToTabIndex = getDirectPathToTabIndex(component, tabIndex);
       this.props.onChangeTab({ pathToTabIndex });
     }
   }

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -68,7 +68,12 @@ const loggerMiddleware = store => next => action => {
     return next(action);
   }
 
-  const { dashboardInfo, explore, impressionId } = store.getState();
+  const {
+    dashboardInfo,
+    explore,
+    impressionId,
+    dashboardLayout,
+  } = store.getState();
   let logMetadata = {
     impression_id: impressionId,
     version: 'v2',
@@ -109,6 +114,12 @@ const loggerMiddleware = store => next => action => {
       event_id: lastEventId,
       visibility: document.visibilityState,
     };
+  }
+
+  if (eventData.target_id && dashboardLayout.present) {
+    const meta = dashboardLayout.present[eventData.target_id].meta;
+    // chart name or tab/header text
+    eventData.target_name = meta.chartId ? meta.sliceName : meta.text;
   }
 
   logMessageQueue.append(eventData);


### PR DESCRIPTION
### SUMMARY
Add extra data into dashboard perf logging:
- fix/add target tab name when user switch dashboard tab
- add dashboard initial bootstrap data length


### TEST PLAN
sample log data:
<img width="941" alt="Screen Shot 2020-06-16 at 11 59 13 PM" src="https://user-images.githubusercontent.com/27990562/84865681-7ae3fc80-b02d-11ea-9927-ac1bedd2b659.png">

@etr2460 @ktmud 
