### PR TITLE
style: listviews closer to SIP-34

### DIFF
--- a/superset-frontend/spec/javascripts/components/ListView/ListView_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/ListView/ListView_spec.jsx
@@ -19,13 +19,14 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { MenuItem, Pagination } from 'react-bootstrap';
+import { MenuItem } from 'react-bootstrap';
 import Select from 'src/components/Select';
 import { QueryParamProvider } from 'use-query-params';
 
 import ListView from 'src/components/ListView/ListView';
 import ListViewFilters from 'src/components/ListView/Filters';
 import ListViewPagination from 'src/components/ListView/Pagination';
+import Pagination from 'src/components/Pagination';
 import { areArraysShallowEqual } from 'src/reduxUtils';
 import { ThemeProvider } from 'emotion-theming';
 import { supersetTheme } from '@superset-ui/style';

--- a/superset-frontend/spec/javascripts/views/chartList/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/chartList/ChartList_spec.jsx
@@ -21,6 +21,8 @@ import { mount } from 'enzyme';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
+import { ThemeProvider } from 'emotion-theming';
+import { supersetTheme } from '@superset-ui/style';
 
 import ChartList from 'src/views/chartList/ChartList';
 import ListView from 'src/components/ListView/ListView';
@@ -77,6 +79,8 @@ describe('ChartList', () => {
   const mockedProps = {};
   const wrapper = mount(<ChartList {...mockedProps} />, {
     context: { store },
+    wrappingComponent: ThemeProvider,
+    wrappingComponentProps: { theme: supersetTheme },
   });
 
   it('renders', () => {

--- a/superset-frontend/spec/javascripts/views/dashboardList/DashboardList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/dashboardList/DashboardList_spec.jsx
@@ -21,6 +21,8 @@ import { mount } from 'enzyme';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
+import { ThemeProvider } from 'emotion-theming';
+import { supersetTheme } from '@superset-ui/style';
 
 import DashboardList from 'src/views/dashboardList/DashboardList';
 import ListView from 'src/components/ListView/ListView';
@@ -67,6 +69,8 @@ describe('DashboardList', () => {
   const mockedProps = {};
   const wrapper = mount(<DashboardList {...mockedProps} />, {
     context: { store },
+    wrappingComponent: ThemeProvider,
+    wrappingComponentProps: { theme: supersetTheme },
   });
 
   it('renders', () => {

--- a/superset-frontend/spec/javascripts/welcome/DashboardTable_spec.jsx
+++ b/superset-frontend/spec/javascripts/welcome/DashboardTable_spec.jsx
@@ -21,6 +21,8 @@ import { mount } from 'enzyme';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
+import { ThemeProvider } from 'emotion-theming';
+import { supersetTheme } from '@superset-ui/style';
 
 import ListView from 'src/components/ListView/ListView';
 import DashboardTable from 'src/welcome/DashboardTable';
@@ -36,7 +38,11 @@ fetchMock.get(dashboardsEndpoint, { result: mockDashboards });
 
 function setup() {
   // use mount because data fetching is triggered on mount
-  return mount(<DashboardTable />, { context: { store } });
+  return mount(<DashboardTable />, {
+    context: { store },
+    wrappingComponent: ThemeProvider,
+    wrappingComponentProps: { theme: supersetTheme },
+  });
 }
 
 describe('DashboardTable', () => {

--- a/superset-frontend/src/components/AvatarIcon.tsx
+++ b/superset-frontend/src/components/AvatarIcon.tsx
@@ -55,7 +55,13 @@ export default function AvatarIcon({
       tooltip={fullName}
     >
       <ConfigProvider colors={colorList && colorList.colors}>
-        <StyledAvatar key={uniqueKey} name={fullName} size={String(iconSize)} textSizeRatio={Number(iconSize) / textSize} round />
+        <StyledAvatar
+          key={uniqueKey}
+          name={fullName}
+          size={String(iconSize)}
+          textSizeRatio={Number(iconSize) / textSize}
+          round
+        />
       </ConfigProvider>
     </TooltipWrapper>
   );

--- a/superset-frontend/src/components/AvatarIcon.tsx
+++ b/superset-frontend/src/components/AvatarIcon.tsx
@@ -59,7 +59,7 @@ export default function AvatarIcon({
           key={uniqueKey}
           name={fullName}
           size={String(iconSize)}
-          textSizeRatio={Number(iconSize) / textSize}
+          textSizeRatio={iconSize / textSize}
           round
         />
       </ConfigProvider>

--- a/superset-frontend/src/components/AvatarIcon.tsx
+++ b/superset-frontend/src/components/AvatarIcon.tsx
@@ -19,8 +19,8 @@
 import React from 'react';
 import styled from '@superset-ui/style';
 import { getCategoricalSchemeRegistry } from '@superset-ui/color';
-import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 import Avatar, { ConfigProvider } from 'react-avatar';
+import TooltipWrapper from 'src/components/TooltipWrapper';
 
 interface Props {
   firstName: string;
@@ -47,13 +47,14 @@ export default function AvatarIcon({
   const fullName = `${firstName} ${lastName}`;
 
   return (
-    <ConfigProvider colors={colorList && colorList.colors}>
-      <OverlayTrigger
-        placement="right"
-        overlay={<Tooltip id={`${uniqueKey}-tooltip`}>{fullName}</Tooltip>}
-      >
+    <TooltipWrapper
+      placement="bottom"
+      label={`${uniqueKey}-tooltip`}
+      tooltip={fullName}
+    >
+      <ConfigProvider colors={colorList && colorList.colors}>
         <StyledAvatar key={uniqueKey} name={fullName} size={iconSize} round />
-      </OverlayTrigger>
-    </ConfigProvider>
+      </ConfigProvider>
+    </TooltipWrapper>
   );
 }

--- a/superset-frontend/src/components/AvatarIcon.tsx
+++ b/superset-frontend/src/components/AvatarIcon.tsx
@@ -24,10 +24,11 @@ import TooltipWrapper from 'src/components/TooltipWrapper';
 
 interface Props {
   firstName: string;
-  iconSize: string;
   lastName: string;
   tableName: string;
   userName: string;
+  iconSize: number;
+  textSize: number;
 }
 
 const colorList = getCategoricalSchemeRegistry().get();
@@ -42,6 +43,7 @@ export default function AvatarIcon({
   lastName,
   userName,
   iconSize,
+  textSize,
 }: Props) {
   const uniqueKey = `${tableName}-${userName}`;
   const fullName = `${firstName} ${lastName}`;
@@ -53,7 +55,7 @@ export default function AvatarIcon({
       tooltip={fullName}
     >
       <ConfigProvider colors={colorList && colorList.colors}>
-        <StyledAvatar key={uniqueKey} name={fullName} size={iconSize} round />
+        <StyledAvatar key={uniqueKey} name={fullName} size={String(iconSize)} textSizeRatio={Number(iconSize) / textSize} round />
       </ConfigProvider>
     </TooltipWrapper>
   );

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -146,7 +146,7 @@ const ListView: FunctionComponent<Props> = ({
               />
             </>
           )}
-          {useNewUIFilters && (
+          {useNewUIFilters && filterable && (
             <FilterControls
               filters={filters}
               internalFilters={internalFilters}
@@ -204,12 +204,12 @@ const ListView: FunctionComponent<Props> = ({
 
             <Col>
               <span className="row-count-container">
-                {t('showing')}{' '}
+                showing {' '}
                 <strong>
                   {pageSize * pageIndex + (rows.length && 1)}-
                   {pageSize * pageIndex + rows.length}
                 </strong>{' '}
-                {t('of')} <strong>{count}</strong>
+                of <strong>{count}</strong>
               </span>
             </Col>
           </Row>

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -38,7 +38,6 @@ interface Props {
   fetchData: (conf: FetchDataConfig) => any;
   loading: boolean;
   className?: string;
-  title?: string;
   initialSort?: SortColumn[];
   filters?: Filters;
   bulkActions?: Array<{
@@ -72,7 +71,6 @@ const ListView: FunctionComponent<Props> = ({
   loading,
   initialSort = [],
   className = '',
-  title = '',
   filters = [],
   bulkActions = [],
   useNewUIFilters = false,
@@ -125,33 +123,27 @@ const ListView: FunctionComponent<Props> = ({
     <div className="superset-list-view-container">
       <div className={`superset-list-view ${className}`}>
         <div className="header">
-          {!useNewUIFilters && (
+          {!useNewUIFilters && filterable && (
             <>
-              {title && filterable && (
-                <>
-                  <Row>
-                    <Col md={10} />
-                    {filterable && (
-                      <Col md={2}>
-                        <FilterMenu
-                          filters={filters}
-                          internalFilters={internalFilters}
-                          setInternalFilters={setInternalFilters}
-                        />
-                      </Col>
-                    )}
-                  </Row>
-                  <hr />
-                  <FilterInputs
-                    internalFilters={internalFilters}
+              <Row>
+                <Col md={10} />
+                <Col md={2}>
+                  <FilterMenu
                     filters={filters}
-                    updateInternalFilter={updateInternalFilter}
-                    removeFilterAndApply={removeFilterAndApply}
-                    filtersApplied={filtersApplied}
-                    applyFilters={applyFilters}
+                    internalFilters={internalFilters}
+                    setInternalFilters={setInternalFilters}
                   />
-                </>
-              )}
+                </Col>
+              </Row>
+              <hr />
+              <FilterInputs
+                internalFilters={internalFilters}
+                filters={filters}
+                updateInternalFilter={updateInternalFilter}
+                removeFilterAndApply={removeFilterAndApply}
+                filtersApplied={filtersApplied}
+                applyFilters={applyFilters}
+              />
             </>
           )}
           {useNewUIFilters && (

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -118,122 +118,116 @@ const ListView: FunctionComponent<Props> = ({
   }
 
   return (
-    <div className={`superset-list-view ${className}`}>
-      <div className="header">
-        {!useNewUIFilters && (
-          <>
-            {title && filterable && (
-              <>
-                <Row>
-                  <Col md={11}>
-                    <h2>{t(title)}</h2>
-                  </Col>
-                  {filterable && (
-                    <Col md={1}>
-                      <FilterMenu
-                        filters={filters}
-                        internalFilters={internalFilters}
-                        setInternalFilters={setInternalFilters}
-                      />
+    <div className="superset-list-view-container">
+      <div className={`superset-list-view ${className}`}>
+        <div className="header">
+          {!useNewUIFilters && (
+            <>
+              {title && filterable && (
+                <>
+                  <Row>
+                    <Col md={10}>
                     </Col>
-                  )}
-                </Row>
-                <hr />
-                <FilterInputs
-                  internalFilters={internalFilters}
-                  filters={filters}
-                  updateInternalFilter={updateInternalFilter}
-                  removeFilterAndApply={removeFilterAndApply}
-                  filtersApplied={filtersApplied}
-                  applyFilters={applyFilters}
-                />
-              </>
-            )}
-          </>
-        )}
-        {useNewUIFilters && (
-          <>
-            <Row>
-              <Col md={10}>
-                <h2>{t(title)}</h2>
-              </Col>
-            </Row>
-            <hr />
-            <FilterControls
-              filters={filters}
-              internalFilters={internalFilters}
-              updateFilterValue={applyFilterValue}
-            />
-          </>
-        )}
-      </div>
-      <div className="body">
-        <TableCollection
-          getTableProps={getTableProps}
-          getTableBodyProps={getTableBodyProps}
-          prepareRow={prepareRow}
-          headerGroups={headerGroups}
-          rows={rows}
-          loading={loading}
-        />
-      </div>
-      <div className="footer">
-        <Row>
-          <Col md={2}>
-            <div className="form-actions-container">
-              <div className="btn-group">
-                {bulkActions.length > 0 && (
-                  <DropdownButton
-                    id="bulk-actions"
-                    bsSize="small"
-                    bsStyle="default"
-                    noCaret
-                    title={
-                      <>
-                        {t('Actions')} <span className="caret" />
-                      </>
-                    }
-                  >
-                    {bulkActions.map(action => (
-                      // @ts-ignore
-                      <MenuItem
-                        key={action.key}
-                        eventKey={selectedFlatRows}
+                    {filterable && (
+                      <Col md={2}>
+                        <FilterMenu
+                          filters={filters}
+                          internalFilters={internalFilters}
+                          setInternalFilters={setInternalFilters}
+                        />
+                      </Col>
+                    )}
+                  </Row>
+                  <hr />
+                  <FilterInputs
+                    internalFilters={internalFilters}
+                    filters={filters}
+                    updateInternalFilter={updateInternalFilter}
+                    removeFilterAndApply={removeFilterAndApply}
+                    filtersApplied={filtersApplied}
+                    applyFilters={applyFilters}
+                  />
+                </>
+              )}
+            </>
+          )}
+          {useNewUIFilters && (
+            <>
+              <FilterControls
+                filters={filters}
+                internalFilters={internalFilters}
+                updateFilterValue={applyFilterValue}
+              />
+            </>
+          )}
+        </div>
+        <div className="body">
+          <TableCollection
+            getTableProps={getTableProps}
+            getTableBodyProps={getTableBodyProps}
+            prepareRow={prepareRow}
+            headerGroups={headerGroups}
+            rows={rows}
+            loading={loading}
+          />
+        </div>
+        <div className="footer">
+          <Row>
+            <Col>
+              <div className="form-actions-container">
+                <div className="btn-group">
+                  {bulkActions.length > 0 && (
+                    <DropdownButton
+                      id="bulk-actions"
+                      bsSize="small"
+                      bsStyle="default"
+                      noCaret
+                      title={
+                        <>
+                          {t('Actions')} <span className="caret" />
+                        </>
+                      }
+                    >
+                      {bulkActions.map(action => (
                         // @ts-ignore
-                        onSelect={(selectedRows: typeof selectedFlatRows) => {
-                          action.onSelect(
-                            selectedRows.map((r: any) => r.original),
-                          );
-                        }}
-                      >
-                        {action.name}
-                      </MenuItem>
-                    ))}
-                  </DropdownButton>
-                )}
+                        <MenuItem
+                          key={action.key}
+                          eventKey={selectedFlatRows}
+                          // @ts-ignore
+                          onSelect={(selectedRows: typeof selectedFlatRows) => {
+                            action.onSelect(
+                              selectedRows.map((r: any) => r.original),
+                            );
+                          }}
+                        >
+                          {action.name}
+                        </MenuItem>
+                      ))}
+                    </DropdownButton>
+                  )}
+                </div>
               </div>
-            </div>
-          </Col>
-          <Col md={8} className="text-center">
-            <Pagination
-              totalPages={pageCount || 0}
-              currentPage={pageCount ? pageIndex + 1 : 0}
-              onChange={(p: number) => gotoPage(p - 1)}
-              hideFirstAndLastPageLinks
-            />
-          </Col>
-          <Col md={2}>
-            <span className="pull-right">
-              {t('showing')}{' '}
-              <strong>
-                {pageSize * pageIndex + (rows.length && 1)}-
-                {pageSize * pageIndex + rows.length}
-              </strong>{' '}
-              {t('of')} <strong>{count}</strong>
-            </span>
-          </Col>
-        </Row>
+            </Col>
+
+            <Col>
+              <span className="row-count-container">
+                {t('showing')}{' '}
+                <strong>
+                  {pageSize * pageIndex + (rows.length && 1)}-
+                  {pageSize * pageIndex + rows.length}
+                </strong>{' '}
+                {t('of')} <strong>{count}</strong>
+              </span>
+            </Col>
+          </Row>
+        </div>
       </div>
+      <Pagination
+        totalPages={pageCount || 0}
+        currentPage={pageCount ? pageIndex + 1 : 0}
+        onChange={(p: number) => gotoPage(p - 1)}
+        hideFirstAndLastPageLinks
+      />
     </div>
   );
 };

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -60,7 +60,7 @@ const bulkSelectColumnConfig = {
     />
   ),
   id: 'selection',
-  size: 's',
+  size: 'sm',
 };
 
 const ListView: FunctionComponent<Props> = ({

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -19,7 +19,8 @@
 import { t } from '@superset-ui/translation';
 import React, { FunctionComponent } from 'react';
 import { Col, DropdownButton, MenuItem, Row } from 'react-bootstrap';
-import IndeterminateCheckbox from '../IndeterminateCheckbox';
+import Loading from 'src/components/Loading';
+import IndeterminateCheckbox from 'src/components/IndeterminateCheckbox';
 import TableCollection from './TableCollection';
 import Pagination from './Pagination';
 import { FilterMenu, FilterInputs } from './LegacyFilters';
@@ -116,7 +117,9 @@ const ListView: FunctionComponent<Props> = ({
       }
     });
   }
-
+  if (loading && !data.length) {
+    return <Loading />;
+  }
   return (
     <div className="superset-list-view-container">
       <div className={`superset-list-view ${className}`}>
@@ -126,8 +129,7 @@ const ListView: FunctionComponent<Props> = ({
               {title && filterable && (
                 <>
                   <Row>
-                    <Col md={10}>
-                    </Col>
+                    <Col md={10} />
                     {filterable && (
                       <Col md={2}>
                         <FilterMenu
@@ -152,13 +154,11 @@ const ListView: FunctionComponent<Props> = ({
             </>
           )}
           {useNewUIFilters && (
-            <>
-              <FilterControls
-                filters={filters}
-                internalFilters={internalFilters}
-                updateFilterValue={applyFilterValue}
-              />
-            </>
+            <FilterControls
+              filters={filters}
+              internalFilters={internalFilters}
+              updateFilterValue={applyFilterValue}
+            />
           )}
         </div>
         <div className="body">

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -204,7 +204,7 @@ const ListView: FunctionComponent<Props> = ({
 
             <Col>
               <span className="row-count-container">
-                showing {' '}
+                showing{' '}
                 <strong>
                   {pageSize * pageIndex + (rows.length && 1)}-
                   {pageSize * pageIndex + rows.length}

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -60,6 +60,7 @@ const bulkSelectColumnConfig = {
     />
   ),
   id: 'selection',
+  size: 's',
 };
 
 const ListView: FunctionComponent<Props> = ({

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -69,12 +69,14 @@
         content: '';
         display: block;
         width: 100%;
-        height: 24px;
-        background-image: linear-gradient(100deg,
-            rgba(255, 255, 255, 0),
-            rgba(255, 255, 255, 0.5) 60%,
-            rgba(255, 255, 255, 0) 80%);
-        background-size: 200px 24px;
+        height: 48px;
+        background-image: linear-gradient(
+          100deg,
+          rgba(255, 255, 255, 0),
+          rgba(255, 255, 255, 0.5) 60%,
+          rgba(255, 255, 255, 0) 80%
+        );
+        background-size: 200px 48px;
         background-position: -100px 0;
         background-repeat: no-repeat;
         animation: loading-shimmer 1s infinite;

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -19,85 +19,99 @@
 
 @import '~stylesheets/less/variables.less';
 
-.superset-list-view {
-  background-color: white;
-  border-radius: 4px 0;
-  overflow: scroll;
-  margin: 0 16px;
+.superset-list-view-container {
+  text-align: center;
 
-  .filter-dropdown {
-    margin-top: 20px;
-  }
+  .superset-list-view {
+    text-align: left;
+    background-color: white;
+    border-radius: 4px 0;
+    overflow: scroll;
+    margin: 0 16px;
+    padding-bottom: 48px;
 
-  .filter-column {
-    height: 30px;
-    padding: 5px;
-    font-size: 16px;
-  }
+    .filter-dropdown {
+      margin-top: 20px;
+    }
 
-  .filter-close {
-    height: 30px;
-    padding: 5px;
+    .filter-column {
+      height: 30px;
+      padding: 5px;
+      font-size: 16px;
+    }
 
-    i {
+    .filter-close {
+      height: 30px;
+      padding: 5px;
+
+      i {
+        font-size: 20px;
+      }
+    }
+
+    .table-row-loader {
+      animation: shimmer 2s infinite;
+      background: linear-gradient(to right,
+          #f6f7f8 0%,
+          #edeef1 20%,
+          #f6f7f8 40%,
+          #f6f7f8 100%);
+      background-size: 1000px 100%;
+
+      span {
+        visibility: hidden;
+      }
+    }
+
+    .actions {
+      display: flex;
+      justify-content: space-between;
       font-size: 20px;
-    }
-  }
+      white-space: nowrap;
+      width: 100px;
 
-  .table-row-loader {
-    animation: shimmer 2s infinite;
-    background: linear-gradient(
-      to right,
-      #f6f7f8 0%,
-      #edeef1 20%,
-      #f6f7f8 40%,
-      #f6f7f8 100%
-    );
-    background-size: 1000px 100%;
-
-    span {
-      visibility: hidden;
-    }
-  }
-
-  .actions {
-    display: flex;
-    justify-content: space-between;
-    font-size: 20px;
-    white-space: nowrap;
-    width: 100px;
-
-    svg {
-      &:hover {
-        path {
-          fill: @primary-color;
+      svg {
+        &:hover {
+          path {
+            fill: @primary-color;
+          }
         }
       }
     }
-  }
 
-  .table-row {
-    &:hover {
-      background-color: @table-hover;
+    .table-row {
+      &:hover {
+        background-color: @table-hover;
+      }
     }
-  }
 
-  .table-row-selected {
-    background-color: @table-selected;
-
-    &:hover {
+    .table-row-selected {
       background-color: @table-selected;
+
+      &:hover {
+        background-color: @table-selected;
+      }
     }
-  }
 
-  .table-cell {
-    max-width: 200px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-  }
+    .table-cell {
+      max-width: 200px;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
 
-  .sort-icon {
-    position: absolute;
+    .sort-icon {
+      position: absolute;
+    }
+
+    .form-actions-container {
+      position: absolute;
+      left: 28px;
+    }
+
+    .row-count-container {
+      position: absolute;
+      right: 28px;
+    }
   }
 }
 

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -58,7 +58,10 @@
       .loading-bar {
         background-color: #e7e7e7;
         border-radius: 7px;
-        visibility: hidden;
+
+        span {
+          visibility: hidden;
+        }
       }
 
       &:after {

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -26,7 +26,7 @@
     text-align: left;
     background-color: white;
     border-radius: 4px 0;
-    overflow: hidden;
+    overflow: scroll;
     margin: 0 16px;
     padding-bottom: 48px;
 
@@ -88,7 +88,6 @@
       justify-content: space-between;
       font-size: 20px;
       white-space: nowrap;
-      width: 100px;
 
       svg {
         &:hover {

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -55,10 +55,7 @@
       .loading-bar {
         background-color: #e7e7e7;
         border-radius: 7px;
-
-        span {
-          visibility: hidden;
-        }
+        visibility: hidden;
       }
 
       &:after {
@@ -84,12 +81,11 @@
     }
 
     .actions {
-      display: flex;
-      justify-content: space-between;
-      font-size: 20px;
       white-space: nowrap;
 
       svg {
+        margin-right: 8px;
+
         &:hover {
           path {
             fill: @primary-color;
@@ -116,6 +112,7 @@
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
+      max-width: 300px;
     }
 
     .sort-icon {
@@ -132,14 +129,14 @@
       right: 28px;
     }
   }
-}
 
-@keyframes loading-shimmer {
-  40% {
-    background-position: 100% 0;
-  }
+  @keyframes loading-shimmer {
+    40% {
+      background-position: 100% 0;
+    }
 
-  100% {
-    background-position: 100% 0;
+    100% {
+      background-position: 100% 0;
+    }
   }
 }

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -56,7 +56,7 @@
       position: relative;
 
       .loading-bar {
-        background-color: #e7e7e7;
+        background-color: @brand-secondary-light4;
         border-radius: 7px;
 
         span {

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -70,12 +70,10 @@
         display: block;
         width: 100%;
         height: 48px;
-        background-image: linear-gradient(
-          100deg,
-          rgba(255, 255, 255, 0),
-          rgba(255, 255, 255, 0.5) 60%,
-          rgba(255, 255, 255, 0) 80%
-        );
+        background-image: linear-gradient(100deg,
+            rgba(255, 255, 255, 0),
+            rgba(255, 255, 255, 0.5) 60%,
+            rgba(255, 255, 255, 0) 80%);
         background-size: 200px 48px;
         background-position: -100px 0;
         background-repeat: no-repeat;
@@ -101,15 +99,15 @@
 
     .table-row {
       &:hover {
-        background-color: @table-hover;
+        background-color: @brand-secondary-light5;
       }
     }
 
     .table-row-selected {
-      background-color: @table-selected;
+      background-color: @brand-secondary-light4;
 
       &:hover {
-        background-color: @table-selected;
+        background-color: @brand-secondary-light4;
       }
     }
 

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -46,11 +46,13 @@
 
   .table-row-loader {
     animation: shimmer 2s infinite;
-    background: linear-gradient(to right,
-        #f6f7f8 0%,
-        #edeef1 20%,
-        #f6f7f8 40%,
-        #f6f7f8 100%);
+    background: linear-gradient(
+      to right,
+      #f6f7f8 0%,
+      #edeef1 20%,
+      #f6f7f8 40%,
+      #f6f7f8 100%
+    );
     background-size: 1000px 100%;
 
     span {

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -70,10 +70,12 @@
         display: block;
         width: 100%;
         height: 48px;
-        background-image: linear-gradient(100deg,
-            rgba(255, 255, 255, 0),
-            rgba(255, 255, 255, 0.5) 60%,
-            rgba(255, 255, 255, 0) 80%);
+        background-image: linear-gradient(
+          100deg,
+          rgba(255, 255, 255, 0),
+          rgba(255, 255, 255, 0.5) 60%,
+          rgba(255, 255, 255, 0) 80%
+        );
         background-size: 200px 48px;
         background-position: -100px 0;
         background-repeat: no-repeat;

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -49,17 +49,35 @@
       }
     }
 
-    .table-row-loader {
-      animation: shimmer 2s infinite;
-      background: linear-gradient(to right,
-          #f6f7f8 0%,
-          #edeef1 20%,
-          #f6f7f8 40%,
-          #f6f7f8 100%);
-      background-size: 1000px 100%;
+    .table-cell-loader {
+      position: relative;
 
-      span {
-        visibility: hidden;
+      .loading-bar {
+        background-color: #e7e7e7;
+        border-radius: 7px;
+
+        span {
+          visibility: hidden;
+        }
+      }
+
+      &:after {
+        position: absolute;
+        transform: translateY(-50%);
+        top: 50%;
+        left: 0;
+        content: '';
+        display: block;
+        width: 100%;
+        height: 24px;
+        background-image: linear-gradient(100deg,
+            rgba(255, 255, 255, 0),
+            rgba(255, 255, 255, 0.5) 60%,
+            rgba(255, 255, 255, 0) 80%);
+        background-size: 200px 24px;
+        background-position: -100px 0;
+        background-repeat: no-repeat;
+        animation: loading-shimmer 1s infinite;
       }
     }
 
@@ -115,12 +133,12 @@
   }
 }
 
-@keyframes shimmer {
-  0% {
-    background-position: -1000px 0;
+@keyframes loading-shimmer {
+  40% {
+    background-position: 100% 0;
   }
 
   100% {
-    background-position: 1000px 0;
+    background-position: 100% 0;
   }
 }

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -20,6 +20,11 @@
 @import '~stylesheets/less/variables.less';
 
 .superset-list-view {
+  background-color: white;
+  border-radius: 4px 0;
+  overflow: scroll;
+  margin: 0 16px;
+
   .filter-dropdown {
     margin-top: 20px;
   }
@@ -41,13 +46,11 @@
 
   .table-row-loader {
     animation: shimmer 2s infinite;
-    background: linear-gradient(
-      to right,
-      #f6f7f8 0%,
-      #edeef1 20%,
-      #f6f7f8 40%,
-      #f6f7f8 100%
-    );
+    background: linear-gradient(to right,
+        #f6f7f8 0%,
+        #edeef1 20%,
+        #f6f7f8 40%,
+        #f6f7f8 100%);
     background-size: 1000px 100%;
 
     span {
@@ -56,9 +59,10 @@
   }
 
   .actions {
+    display: flex;
+    justify-content: space-between;
     font-size: 20px;
     white-space: nowrap;
-
     width: 100px;
 
     svg {
@@ -68,10 +72,6 @@
         }
       }
     }
-  }
-
-  .action-button {
-    margin: 0 8px;
   }
 
   .table-row {

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -26,7 +26,7 @@
     text-align: left;
     background-color: white;
     border-radius: 4px 0;
-    overflow: scroll;
+    overflow: hidden;
     margin: 0 16px;
     padding-bottom: 48px;
 
@@ -114,9 +114,9 @@
     }
 
     .table-cell {
-      max-width: 200px;
       text-overflow: ellipsis;
       overflow: hidden;
+      white-space: nowrap;
     }
 
     .sort-icon {

--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -26,9 +26,12 @@
     text-align: left;
     background-color: white;
     border-radius: 4px 0;
-    overflow: scroll;
     margin: 0 16px;
     padding-bottom: 48px;
+
+    .body {
+      overflow: scroll;
+    }
 
     .filter-dropdown {
       margin-top: 20px;
@@ -67,12 +70,10 @@
         display: block;
         width: 100%;
         height: 48px;
-        background-image: linear-gradient(
-          100deg,
-          rgba(255, 255, 255, 0),
-          rgba(255, 255, 255, 0.5) 60%,
-          rgba(255, 255, 255, 0) 80%
-        );
+        background-image: linear-gradient(100deg,
+            rgba(255, 255, 255, 0),
+            rgba(255, 255, 255, 0.5) 60%,
+            rgba(255, 255, 255, 0) 80%);
         background-size: 200px 48px;
         background-position: -100px 0;
         background-repeat: no-repeat;
@@ -82,8 +83,11 @@
 
     .actions {
       white-space: nowrap;
+      font-size: 24px;
+      min-width: 100px;
 
-      svg {
+      svg,
+      i {
         margin-right: 8px;
 
         &:hover {

--- a/superset-frontend/src/components/ListView/Pagination.tsx
+++ b/superset-frontend/src/components/ListView/Pagination.tsx
@@ -17,8 +17,7 @@
  * under the License.
  */
 import React from 'react';
-// @ts-ignore
-import { Pagination } from 'react-bootstrap';
+import Pagination from 'src/components/Pagination';
 import {
   createUltimatePagination,
   ITEM_TYPES,
@@ -35,18 +34,14 @@ const ListViewPagination = createUltimatePagination({
     [ITEM_TYPES.ELLIPSIS]: ({ isActive, onClick }) => (
       <Pagination.Ellipsis disabled={isActive} onClick={onClick} />
     ),
-    [ITEM_TYPES.FIRST_PAGE_LINK]: ({ isActive, onClick }) => (
-      <Pagination.First disabled={isActive} onClick={onClick} />
-    ),
     [ITEM_TYPES.PREVIOUS_PAGE_LINK]: ({ isActive, onClick }) => (
       <Pagination.Prev disabled={isActive} onClick={onClick} />
     ),
     [ITEM_TYPES.NEXT_PAGE_LINK]: ({ isActive, onClick }) => (
       <Pagination.Next disabled={isActive} onClick={onClick} />
     ),
-    [ITEM_TYPES.LAST_PAGE_LINK]: ({ isActive, onClick }) => (
-      <Pagination.Last disabled={isActive} onClick={onClick} />
-    ),
+    [ITEM_TYPES.FIRST_PAGE_LINK]: () => null,
+    [ITEM_TYPES.LAST_PAGE_LINK]: () => null,
   },
 });
 

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -107,9 +107,9 @@ export default function TableCollection({
                     {...columnCellProps}
                     size={cell.column.size}
                   >
-                    <div className={cx({ 'loading-bar': loading })}>
-                      <span>{cell.render('Cell')}</span>
-                    </div>
+                    <span className={cx({ 'loading-bar': loading })}>
+                      {cell.render('Cell')}
+                    </span>
                   </TableCell>
                 );
               })}

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -141,14 +141,14 @@ export default function TableCollection({
                 return (
                   <td
                     className={cx('table-cell', {
-                      'table-cell-loader': true || loading,
+                      'table-cell-loader': loading,
                       [cell.column.size || '']: cell.column.size,
                     })}
                     {...cell.getCellProps()}
                     {...columnCellProps}
                   >
-                    <span className={cx({ 'loading-bar': true || loading })}>
-                      {cell.render('Cell')}
+                    <span className={cx({ 'loading-bar': loading })}>
+                      <span>{cell.render('Cell')}</span>
                     </span>
                   </td>
                 );

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import cx from 'classnames';
-import { TableInstance, Column } from 'react-table';
+import { TableInstance } from 'react-table';
 import styled from '@superset-ui/style';
 import Icon from 'src/components/Icon';
 
@@ -31,17 +31,31 @@ interface Props {
   loading: boolean;
 }
 
-const TableCell = styled.td`
-  width: ${(props: { size?: Column['size'] }) => {
-    if (props.size === 'xs') return '25px';
-    if (props.size === 'sm') return '50px';
-    if (props.size === 'md') return '75px';
-    if (props.size === 'lg') return '100px';
-    if (props.size === 'xl') return '150px';
-    if (props.size === 'xxl') return '200px';
-    return '';
-  }};
+const Table = styled.table`
+  th {
+    &.xs { min-width: 25px; }
+    &.sm { min-width: 50px; }
+    &.md { min-width: 75px; }
+    &.lg { min-width: 100px; }
+    &.xl { min-width: 150px; }
+    &.xxl { min-width: 200px; }
+
+    svg {
+      display: inline-block;
+      top: 6px;
+      position: relative;
+    }
+  }
+  td {
+    &.xs { width: 25px; }
+    &.sm { width: 50px; }
+    &.md { width: 75px; }
+    &.lg { width: 100px; }
+    &.xl { width: 150px; }
+    &.xxl { width: 200px; }
+  }
 `;
+
 export default function TableCollection({
   getTableProps,
   getTableBodyProps,
@@ -51,7 +65,7 @@ export default function TableCollection({
   loading,
 }: Props) {
   return (
-    <table {...getTableProps()} className="table table-hover">
+    <Table {...getTableProps()} className="table table-hover">
       <thead>
         {headerGroups.map(headerGroup => (
           <tr {...headerGroup.getHeaderGroupProps()}>
@@ -62,18 +76,23 @@ export default function TableCollection({
               } else if (column.isSorted && !column.isSortedDesc) {
                 sortIcon = <Icon name="sort-asc" />;
               }
-
               return column.hidden ? null : (
                 <th
                   {...column.getHeaderProps(
-                    column.sortable ? column.getSortByToggleProps() : {},
+                    column.sortable ? column.getSortByToggleProps() : {}
                   )}
                   data-test="sort-header"
+                  className={
+                    cx({
+                      [column.size || '']: column.size,
+                    })
+                  }
                 >
-                  <span>{column.render('Header')}</span>
-                  {column.sortable && (
-                    <span className="sort-icon">{sortIcon}</span>
-                  )}
+                  <span>{column.render('Header')}
+                    {column.sortable && (
+                      sortIcon
+                    )}
+                  </span>
                 </th>
               );
             })}
@@ -99,24 +118,24 @@ export default function TableCollection({
 
                 const columnCellProps = cell.column.cellProps || {};
                 return (
-                  <TableCell
+                  <td
                     className={cx('table-cell', {
                       'table-cell-loader': loading,
+                      [cell.column.size || '']: cell.column.size
                     })}
                     {...cell.getCellProps()}
                     {...columnCellProps}
-                    size={cell.column.size}
                   >
                     <span className={cx({ 'loading-bar': loading })}>
                       {cell.render('Cell')}
                     </span>
-                  </TableCell>
+                  </td>
                 );
               })}
             </tr>
           );
         })}
       </tbody>
-    </table>
+    </Table >
   );
 }

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -45,9 +45,9 @@ export default function TableCollection({
           <tr {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map(column => {
               let sortIcon = <Icon name="sort" />;
-              if (column.isSortedDesc) {
+              if (column.isSorted && column.isSortedDesc) {
                 sortIcon = <Icon name="sort-desc" />;
-              } else if (!column.isSortedDesc) {
+              } else if (column.isSorted && !column.isSortedDesc) {
                 sortIcon = <Icon name="sort-asc" />;
               }
 

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -29,6 +29,7 @@ interface Props {
   rows: TableInstance['rows'];
   loading: boolean;
 }
+
 export default function TableCollection({
   getTableProps,
   getTableBodyProps,
@@ -74,7 +75,6 @@ export default function TableCollection({
             <tr
               {...row.getRowProps()}
               className={cx({
-                'table-row-loader': loading,
                 'table-row-selected': row.isSelected,
               })}
               onMouseEnter={() => row.setState && row.setState({ hover: true })}
@@ -89,11 +89,15 @@ export default function TableCollection({
 
                 return (
                   <td
-                    className="table-cell"
+                    className={cx('table-cell', {
+                      'table-cell-loader': loading,
+                    })}
                     {...cell.getCellProps()}
                     {...columnCellProps}
                   >
-                    <span>{cell.render('Cell')}</span>
+                    <div className={cx({ 'loading-bar': loading })}>
+                      <span>{cell.render('Cell')}</span>
+                    </div>
                   </td>
                 );
               })}

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -18,7 +18,8 @@
  */
 import React from 'react';
 import cx from 'classnames';
-import { TableInstance } from 'react-table';
+import { TableInstance, Column } from 'react-table';
+import styled from '@superset-ui/style';
 import Icon from 'src/components/Icon';
 
 interface Props {
@@ -30,6 +31,17 @@ interface Props {
   loading: boolean;
 }
 
+const TableCell = styled.td`
+  width: ${(props: { size?: Column['size'] }) => {
+    if (props.size === 'xs') return '25px';
+    if (props.size === 's') return '50px';
+    if (props.size === 'md') return '75px';
+    if (props.size === 'l') return '100px';
+    if (props.size === 'xl') return '150px';
+    if (props.size === 'xxl') return '200px';
+    return '';
+  }};
+`;
 export default function TableCollection({
   getTableProps,
   getTableBodyProps,
@@ -86,19 +98,19 @@ export default function TableCollection({
                 if (cell.column.hidden) return null;
 
                 const columnCellProps = cell.column.cellProps || {};
-
                 return (
-                  <td
+                  <TableCell
                     className={cx('table-cell', {
                       'table-cell-loader': loading,
                     })}
                     {...cell.getCellProps()}
                     {...columnCellProps}
+                    size={cell.column.size}
                   >
                     <div className={cx({ 'loading-bar': loading })}>
                       <span>{cell.render('Cell')}</span>
                     </div>
-                  </td>
+                  </TableCell>
                 );
               })}
             </tr>

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -34,9 +34,9 @@ interface Props {
 const TableCell = styled.td`
   width: ${(props: { size?: Column['size'] }) => {
     if (props.size === 'xs') return '25px';
-    if (props.size === 's') return '50px';
+    if (props.size === 'sm') return '50px';
     if (props.size === 'md') return '75px';
-    if (props.size === 'l') return '100px';
+    if (props.size === 'lg') return '100px';
     if (props.size === 'xl') return '150px';
     if (props.size === 'xxl') return '200px';
     return '';

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -33,12 +33,24 @@ interface Props {
 
 const Table = styled.table`
   th {
-    &.xs { min-width: 25px; }
-    &.sm { min-width: 50px; }
-    &.md { min-width: 75px; }
-    &.lg { min-width: 100px; }
-    &.xl { min-width: 150px; }
-    &.xxl { min-width: 200px; }
+    &.xs {
+      min-width: 25px;
+    }
+    &.sm {
+      min-width: 50px;
+    }
+    &.md {
+      min-width: 75px;
+    }
+    &.lg {
+      min-width: 100px;
+    }
+    &.xl {
+      min-width: 150px;
+    }
+    &.xxl {
+      min-width: 200px;
+    }
 
     svg {
       display: inline-block;
@@ -47,12 +59,24 @@ const Table = styled.table`
     }
   }
   td {
-    &.xs { width: 25px; }
-    &.sm { width: 50px; }
-    &.md { width: 75px; }
-    &.lg { width: 100px; }
-    &.xl { width: 150px; }
-    &.xxl { width: 200px; }
+    &.xs {
+      width: 25px;
+    }
+    &.sm {
+      width: 50px;
+    }
+    &.md {
+      width: 75px;
+    }
+    &.lg {
+      width: 100px;
+    }
+    &.xl {
+      width: 150px;
+    }
+    &.xxl {
+      width: 200px;
+    }
   }
 `;
 
@@ -79,19 +103,16 @@ export default function TableCollection({
               return column.hidden ? null : (
                 <th
                   {...column.getHeaderProps(
-                    column.sortable ? column.getSortByToggleProps() : {}
+                    column.sortable ? column.getSortByToggleProps() : {},
                   )}
                   data-test="sort-header"
-                  className={
-                    cx({
-                      [column.size || '']: column.size,
-                    })
-                  }
+                  className={cx({
+                    [column.size || '']: column.size,
+                  })}
                 >
-                  <span>{column.render('Header')}
-                    {column.sortable && (
-                      sortIcon
-                    )}
+                  <span>
+                    {column.render('Header')}
+                    {column.sortable && sortIcon}
                   </span>
                 </th>
               );
@@ -120,13 +141,13 @@ export default function TableCollection({
                 return (
                   <td
                     className={cx('table-cell', {
-                      'table-cell-loader': loading,
-                      [cell.column.size || '']: cell.column.size
+                      'table-cell-loader': true || loading,
+                      [cell.column.size || '']: cell.column.size,
                     })}
                     {...cell.getCellProps()}
                     {...columnCellProps}
                   >
-                    <span className={cx({ 'loading-bar': loading })}>
+                    <span className={cx({ 'loading-bar': true || loading })}>
                       {cell.render('Cell')}
                     </span>
                   </td>
@@ -136,6 +157,6 @@ export default function TableCollection({
           );
         })}
       </tbody>
-    </Table >
+    </Table>
   );
 }

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -77,9 +77,12 @@ interface SubMenuState {
 
 class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
   state: SubMenuState = {
-    selectedMenu: this.props.childs && this.props.childs[0] ? this.props.childs[0].label : '',
+    selectedMenu:
+      this.props.childs && this.props.childs[0]
+        ? this.props.childs[0].label
+        : '',
     isModalOpen: false,
-  };
+  }
 
   onOpen = () => {
     this.setState({ isModalOpen: true });

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -64,11 +64,10 @@ const StyledHeader = styled.header`
 `;
 
 interface SubMenuProps {
-  createButton: { name: string; url: string | null };
-  canCreate: boolean;
-  label: string;
+  createButton?: { name: string; url: string | null };
+  canCreate?: boolean;
   name: string;
-  childs: Array<{ label: string; name: string; url: string }>;
+  childs?: Array<{ label: string; name: string; url: string }>;
 }
 
 interface SubMenuState {
@@ -78,7 +77,7 @@ interface SubMenuState {
 
 class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
   state: SubMenuState = {
-    selectedMenu: this.props.childs[0] && this.props.childs[0].label,
+    selectedMenu: this.props.childs && this.props.childs[0] ? this.props.childs[0].label : '',
     isModalOpen: false,
   };
 
@@ -88,7 +87,7 @@ class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
 
   onClose = () => {
     this.setState({ isModalOpen: false });
-  };
+  }
 
   handleClick = (item: string) => () => {
     this.setState({ selectedMenu: item });
@@ -99,7 +98,7 @@ class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
       <StyledHeader>
         <Navbar inverse fluid role="navigation">
           <Navbar.Header>
-            <Navbar.Brand>{this.props.label}</Navbar.Brand>
+            <Navbar.Brand>{this.props.name}</Navbar.Brand>
           </Navbar.Header>
           <DatasetModal show={this.state.isModalOpen} onHide={this.onClose} />
           <Nav>
@@ -116,7 +115,7 @@ class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
                 </MenuItem>
               ))}
           </Nav>
-          {this.props.canCreate && (
+          {this.props.canCreate && this.props.createButton && (
             <Nav className="navbar-right">
               <Button onClick={this.onOpen}>
                 <i className="fa fa-plus" /> {this.props.createButton.name}
@@ -124,7 +123,7 @@ class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
             </Nav>
           )}
         </Navbar>
-      </StyledHeader>
+      </StyledHeader >
     );
   }
 }

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -82,7 +82,7 @@ class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
         ? this.props.childs[0].label
         : '',
     isModalOpen: false,
-  }
+  };
 
   onOpen = () => {
     this.setState({ isModalOpen: true });
@@ -90,7 +90,7 @@ class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
 
   onClose = () => {
     this.setState({ isModalOpen: false });
-  }
+  };
 
   handleClick = (item: string) => () => {
     this.setState({ selectedMenu: item });
@@ -126,7 +126,7 @@ class SubMenu extends React.PureComponent<SubMenuProps, SubMenuState> {
             </Nav>
           )}
         </Navbar>
-      </StyledHeader >
+      </StyledHeader>
     );
   }
 }

--- a/superset-frontend/src/components/Pagination.tsx
+++ b/superset-frontend/src/components/Pagination.tsx
@@ -85,15 +85,14 @@ const PaginationList = styled.ul`
     span {
       padding: 8px 12px;
       text-decoration: none;
-      background-color: #fff;
-      border-radius: 4px;
+      background-color: ${({ theme }) => theme.colors.grayscale.light5};
+      border-radius: ${({ theme }) => theme.borderRadius}px;
 
       &:hover,
       &:focus {
         z-index: 2;
-        color: #00403b;
-        background-color: #f2f2f2;
-        border-color: #cfd8dc;
+        color: ${({ theme }) => theme.colors.grayscale.dark1};
+        background-color: ${({ theme }) => theme.colors.grayscale.light3};
       }
     }
 
@@ -110,7 +109,7 @@ const PaginationList = styled.ul`
     &.active {
       span {
         z-index: 3;
-        color: #fff;
+        color: ${({ theme }) => theme.colors.grayscale.light5};
         cursor: default;
         background-color: ${({ theme }) => theme.colors.primary.base};
 

--- a/superset-frontend/src/components/Pagination.tsx
+++ b/superset-frontend/src/components/Pagination.tsx
@@ -33,7 +33,7 @@ interface PaginationItemButton extends PaginationButton {
 function Prev({ disabled, onClick }: PaginationButton) {
   return (
     <li className={cx({ disabled })}>
-      <span role="button" tabIndex={0} onClick={onClick}>
+      <span role="button" tabIndex={disabled ? -1 : 0} onClick={onClick}>
         «
       </span>
     </li>
@@ -43,7 +43,7 @@ function Prev({ disabled, onClick }: PaginationButton) {
 function Next({ disabled, onClick }: PaginationButton) {
   return (
     <li className={cx({ disabled })}>
-      <span role="button" tabIndex={0} onClick={onClick}>
+      <span role="button" tabIndex={disabled ? -1 : 0} onClick={onClick}>
         »
       </span>
     </li>
@@ -53,7 +53,7 @@ function Next({ disabled, onClick }: PaginationButton) {
 function Item({ active, children, onClick }: PaginationItemButton) {
   return (
     <li className={cx({ active })}>
-      <span role="button" tabIndex={0} onClick={onClick}>
+      <span role="button" tabIndex={active ? -1 : 0} onClick={onClick}>
         {children}
       </span>
     </li>
@@ -63,7 +63,7 @@ function Item({ active, children, onClick }: PaginationItemButton) {
 function Ellipsis({ disabled, onClick }: PaginationButton) {
   return (
     <li className={cx({ disabled })}>
-      <span role="button" tabIndex={0} onClick={onClick}>
+      <span role="button" tabIndex={disabled ? -1 : 0} onClick={onClick}>
         ...
       </span>
     </li>
@@ -101,6 +101,10 @@ const PaginationList = styled.ul`
       span {
         background-color: transparent;
         cursor: default;
+
+        &:focus {
+          outline: none;
+        }
       }
     }
     &.active {
@@ -109,6 +113,10 @@ const PaginationList = styled.ul`
         color: #fff;
         cursor: default;
         background-color: ${({ theme }) => theme.colors.primary.base};
+
+        &:focus {
+          outline: none;
+        }
       }
     }
   }

--- a/superset-frontend/src/components/Pagination.tsx
+++ b/superset-frontend/src/components/Pagination.tsx
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { PureComponent } from 'react';
+import cx from 'classnames';
+import styled from '@superset-ui/style';
+
+interface PaginationButton {
+  disabled?: boolean;
+  onClick: React.EventHandler<React.SyntheticEvent<HTMLElement>>;
+}
+
+interface PaginationItemButton extends PaginationButton {
+  active: boolean;
+  children: React.ReactNode;
+}
+
+function Prev({ disabled, onClick }: PaginationButton) {
+  return (
+    <li className={cx({ disabled })}>
+      <span role="button" tabIndex={0} onClick={onClick}>
+        «
+      </span>
+    </li>
+  );
+}
+
+function Next({ disabled, onClick }: PaginationButton) {
+  return (
+    <li className={cx({ disabled })}>
+      <span role="button" tabIndex={0} onClick={onClick}>
+        »
+      </span>
+    </li>
+  );
+}
+
+function Item({ active, children, onClick }: PaginationItemButton) {
+  return (
+    <li className={cx({ active })}>
+      <span role="button" tabIndex={0} onClick={onClick}>
+        {children}
+      </span>
+    </li>
+  );
+}
+
+function Ellipsis({ disabled, onClick }: PaginationButton) {
+  return (
+    <li className={cx({ disabled })}>
+      <span role="button" tabIndex={0} onClick={onClick}>
+        ...
+      </span>
+    </li>
+  );
+}
+
+interface PaginationProps {
+  children: React.ReactNode;
+}
+
+const PaginationList = styled.ul`
+  display: inline-block;
+  margin: 16px 0;
+
+  li {
+    display: inline;
+    margin: 0 4px;
+
+    span {
+      padding: 8px 12px;
+      text-decoration: none;
+      background-color: #fff;
+      border-radius: 4px;
+
+      &:hover,
+      &:focus {
+        z-index: 2;
+        color: #00403b;
+        background-color: #f2f2f2;
+        border-color: #cfd8dc;
+      }
+    }
+
+    &.disabled {
+      span {
+        background-color: transparent;
+        cursor: default;
+      }
+    }
+    &.active {
+      span {
+        z-index: 3;
+        color: #fff;
+        cursor: default;
+        background-color: ${({ theme }) => theme.colors.primary.base};
+      }
+    }
+  }
+`;
+
+export default class Pagination extends PureComponent<PaginationProps> {
+  static Next = Next;
+  static Prev = Prev;
+  static Item = Item;
+  static Ellipsis = Ellipsis;
+  render() {
+    return <PaginationList> {this.props.children}</PaginationList>;
+  }
+}

--- a/superset-frontend/src/components/Pagination.tsx
+++ b/superset-frontend/src/components/Pagination.tsx
@@ -64,7 +64,7 @@ function Ellipsis({ disabled, onClick }: PaginationButton) {
   return (
     <li className={cx({ disabled })}>
       <span role="button" tabIndex={disabled ? -1 : 0} onClick={onClick}>
-        ...
+        …
       </span>
     </li>
   );

--- a/superset-frontend/src/types/react-table-config.d.ts
+++ b/superset-frontend/src/types/react-table-config.d.ts
@@ -118,7 +118,7 @@ declare module 'react-table' {
     hidden?: boolean;
     sortable?: boolean;
     cellProps?: any;
-    size?: 'xs' | 's' | 'md' | 'l' | 'xl';
+    size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   }
 
   export interface ColumnInstance<D extends object = {}>
@@ -129,7 +129,7 @@ declare module 'react-table' {
     hidden?: boolean;
     sortable?: boolean;
     cellProps?: any;
-    size?: 'xs' | 's' | 'md' | 'l' | 'xl';
+    size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   }
 
   export interface Cell<D extends object = {}>

--- a/superset-frontend/src/types/react-table-config.d.ts
+++ b/superset-frontend/src/types/react-table-config.d.ts
@@ -118,13 +118,19 @@ declare module 'react-table' {
     hidden?: boolean;
     sortable?: boolean;
     cellProps?: any;
+    size?: 'xs' | 's' | 'md' | 'l' | 'xl';
   }
 
   export interface ColumnInstance<D extends object = {}>
     extends UseFiltersColumnProps<D>,
       UseGroupByColumnProps<D>,
       UseResizeColumnsColumnProps<D>,
-      UseSortByColumnProps<D> {}
+      UseSortByColumnProps<D> {
+    hidden?: boolean;
+    sortable?: boolean;
+    cellProps?: any;
+    size?: 'xs' | 's' | 'md' | 'l' | 'xl';
+  }
 
   export interface Cell<D extends object = {}>
     extends UseGroupByCellProps<D>,

--- a/superset-frontend/src/types/react-table-config.d.ts
+++ b/superset-frontend/src/types/react-table-config.d.ts
@@ -67,7 +67,7 @@ import {
 import { ColumnSizer } from 'react-virtualized';
 
 declare module 'react-table' {
-  type columnSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  type ColumnSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   export interface TableOptions<D extends object>
     extends UseExpandedOptions<D>,
       UseFiltersOptions<D>,
@@ -120,7 +120,7 @@ declare module 'react-table' {
     hidden?: boolean;
     sortable?: boolean;
     cellProps?: any;
-    size?: columnSize;
+    size?: ColumnSize;
   }
 
   export interface ColumnInstance<D extends object = {}>

--- a/superset-frontend/src/types/react-table-config.d.ts
+++ b/superset-frontend/src/types/react-table-config.d.ts
@@ -64,8 +64,10 @@ import {
   UseSortByOptions,
   UseSortByState,
 } from 'react-table';
+import { ColumnSizer } from 'react-virtualized';
 
 declare module 'react-table' {
+  type columnSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   export interface TableOptions<D extends object>
     extends UseExpandedOptions<D>,
       UseFiltersOptions<D>,
@@ -118,7 +120,7 @@ declare module 'react-table' {
     hidden?: boolean;
     sortable?: boolean;
     cellProps?: any;
-    size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+    size?: columnSize;
   }
 
   export interface ColumnInstance<D extends object = {}>
@@ -129,7 +131,7 @@ declare module 'react-table' {
     hidden?: boolean;
     sortable?: boolean;
     cellProps?: any;
-    size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+    size?: ColumnSize;
   }
 
   export interface Cell<D extends object = {}>

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -23,6 +23,10 @@ import getClientErrorObject from './getClientErrorObject';
 
 export const NULL_STRING = '<NULL>';
 
+// moment time format strings
+export const SHORT_DATE = 'MMM D, YYYY';
+export const SHORT_TIME = 'h:m a';
+
 export function getParamFromQuery(query, param) {
   const vars = query.split('&');
   for (let i = 0; i < vars.length; i += 1) {

--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -519,7 +519,7 @@ class ChartList extends React.PureComponent<Props, State> {
     } = this.state;
     return (
       <>
-        <SubMenu name="Charts" />
+        <SubMenu name={t('Charts')} />
         {sliceCurrentlyEditing && (
           <PropertiesModal
             show
@@ -542,7 +542,7 @@ class ChartList extends React.PureComponent<Props, State> {
                 key: 'delete',
                 name: (
                   <>
-                    <i className="fa fa-trash" /> Delete
+                    <i className="fa fa-trash" /> {t('Delete')}
                   </>
                 ),
                 onSelect: confirmDelete,
@@ -551,7 +551,6 @@ class ChartList extends React.PureComponent<Props, State> {
             return (
               <ListView
                 className="chart-list-view"
-                title={'Charts'}
                 columns={this.columns}
                 data={charts}
                 count={chartCount}

--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -69,7 +69,7 @@ class ChartList extends React.PureComponent<Props, State> {
     filterOperators: {},
     filters: [],
     lastFetchDataConfig: null,
-    loading: false,
+    loading: true,
     permissions: [],
     sliceCurrentlyEditing: null,
   };

--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -519,7 +519,7 @@ class ChartList extends React.PureComponent<Props, State> {
     } = this.state;
     return (
       <>
-        <SubMenu label="Dashboards" />
+        <SubMenu name="Dashboards" />
         {sliceCurrentlyEditing && (
           <PropertiesModal
             show

--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -224,9 +224,8 @@ class ChartList extends React.PureComponent<Props, State> {
           </span>
         );
       },
-      Header: 'Actions',
+      Header: t('Actions'),
       id: 'actions',
-      size: 'md',
     },
   ];
 

--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -26,6 +26,7 @@ import rison from 'rison';
 // @ts-ignore
 import { Panel } from 'react-bootstrap';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
+import SubMenu from 'src/components/Menu/SubMenu';
 import ListView from 'src/components/ListView/ListView';
 import {
   FetchDataConfig,
@@ -517,58 +518,55 @@ class ChartList extends React.PureComponent<Props, State> {
       sliceCurrentlyEditing,
     } = this.state;
     return (
-      <div className="container welcome">
-        <Panel>
-          <Panel.Body>
-            {sliceCurrentlyEditing && (
-              <PropertiesModal
-                show
-                onHide={this.closeChartEditModal}
-                onSave={this.handleChartUpdated}
-                slice={sliceCurrentlyEditing}
-              />
-            )}
-            <ConfirmStatusChange
-              title={t('Please confirm')}
-              description={t(
-                'Are you sure you want to delete the selected charts?',
-              )}
-              onConfirm={this.handleBulkChartDelete}
-            >
-              {confirmDelete => {
-                const bulkActions = [];
-                if (this.canDelete) {
-                  bulkActions.push({
-                    key: 'delete',
-                    name: (
-                      <>
-                        <i className="fa fa-trash" /> Delete
+      <>
+        <SubMenu label="Dashboards" />
+        {sliceCurrentlyEditing && (
+          <PropertiesModal
+            show
+            onHide={this.closeChartEditModal}
+            onSave={this.handleChartUpdated}
+            slice={sliceCurrentlyEditing}
+          />
+        )}
+        <ConfirmStatusChange
+          title={t('Please confirm')}
+          description={t(
+            'Are you sure you want to delete the selected charts?',
+          )}
+          onConfirm={this.handleBulkChartDelete}
+        >
+          {confirmDelete => {
+            const bulkActions = [];
+            if (this.canDelete) {
+              bulkActions.push({
+                key: 'delete',
+                name: (
+                  <>
+                    <i className="fa fa-trash" /> Delete
                       </>
-                    ),
-                    onSelect: confirmDelete,
-                  });
-                }
-                return (
-                  <ListView
-                    className="chart-list-view"
-                    title={'Charts'}
-                    columns={this.columns}
-                    data={charts}
-                    count={chartCount}
-                    pageSize={PAGE_SIZE}
-                    fetchData={this.fetchData}
-                    loading={loading}
-                    initialSort={this.initialSort}
-                    filters={filters}
-                    bulkActions={bulkActions}
-                    useNewUIFilters={this.isNewUIEnabled}
-                  />
-                );
-              }}
-            </ConfirmStatusChange>
-          </Panel.Body>
-        </Panel>
-      </div>
+                ),
+                onSelect: confirmDelete,
+              });
+            }
+            return (
+              <ListView
+                className="chart-list-view"
+                title={'Charts'}
+                columns={this.columns}
+                data={charts}
+                count={chartCount}
+                pageSize={PAGE_SIZE}
+                fetchData={this.fetchData}
+                loading={loading}
+                initialSort={this.initialSort}
+                filters={filters}
+                bulkActions={bulkActions}
+                useNewUIFilters={this.isNewUIEnabled}
+              />
+            );
+          }}
+        </ConfirmStatusChange>
+      </>
     );
   }
 }

--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -543,7 +543,7 @@ class ChartList extends React.PureComponent<Props, State> {
                 name: (
                   <>
                     <i className="fa fa-trash" /> Delete
-                      </>
+                  </>
                 ),
                 onSelect: confirmDelete,
               });

--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -226,6 +226,7 @@ class ChartList extends React.PureComponent<Props, State> {
       },
       Header: 'Actions',
       id: 'actions',
+      size: 'md',
     },
   ];
 
@@ -519,7 +520,7 @@ class ChartList extends React.PureComponent<Props, State> {
     } = this.state;
     return (
       <>
-        <SubMenu name="Dashboards" />
+        <SubMenu name="Charts" />
         {sliceCurrentlyEditing && (
           <PropertiesModal
             show

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -142,14 +142,14 @@ class DashboardList extends React.PureComponent<Props, State> {
           original: { owners },
         },
       }: any) => (
-          <ExpandableList
-            items={owners.map(
-              ({ first_name: firstName, last_name: lastName }: any) =>
-                `${firstName} ${lastName}`,
-            )}
-            display={2}
-          />
-        ),
+        <ExpandableList
+          items={owners.map(
+            ({ first_name: firstName, last_name: lastName }: any) =>
+              `${firstName} ${lastName}`,
+          )}
+          display={2}
+        />
+      ),
       Header: t('Owners'),
       accessor: 'owners',
     },
@@ -172,10 +172,10 @@ class DashboardList extends React.PureComponent<Props, State> {
           original: { published },
         },
       }: any) => (
-          <span className="no-wrap">
-            {published ? <i className="fa fa-check" /> : ''}
-          </span>
-        ),
+        <span className="no-wrap">
+          {published ? <i className="fa fa-check" /> : ''}
+        </span>
+      ),
       Header: t('Published'),
       accessor: 'published',
       sortable: true,
@@ -510,7 +510,7 @@ class DashboardList extends React.PureComponent<Props, State> {
     } = this.state;
     return (
       <>
-        <SubMenu name="Dashboards" />
+        <SubMenu name={t('Dashboards')} />
         <ConfirmStatusChange
           title={t('Please confirm')}
           description={t(
@@ -525,7 +525,7 @@ class DashboardList extends React.PureComponent<Props, State> {
                 key: 'delete',
                 name: (
                   <>
-                    <i className="fa fa-trash" /> Delete
+                    <i className="fa fa-trash" /> {t('Delete')}
                   </>
                 ),
                 onSelect: confirmDelete,
@@ -536,7 +536,7 @@ class DashboardList extends React.PureComponent<Props, State> {
                 key: 'export',
                 name: (
                   <>
-                    <i className="fa fa-database" /> Export
+                    <i className="fa fa-database" /> {t('Export')}
                   </>
                 ),
                 onSelect: this.handleBulkDashboardExport,
@@ -554,7 +554,6 @@ class DashboardList extends React.PureComponent<Props, State> {
                 )}
                 <ListView
                   className="dashboard-list-view"
-                  title={'Dashboards'}
                   columns={this.columns}
                   data={dashboards}
                   count={dashboardCount}

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -254,6 +254,7 @@ class DashboardList extends React.PureComponent<Props, State> {
       },
       Header: t('Actions'),
       id: 'actions',
+      size: 'lg',
     },
   ];
 

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -142,14 +142,14 @@ class DashboardList extends React.PureComponent<Props, State> {
           original: { owners },
         },
       }: any) => (
-          <ExpandableList
-            items={owners.map(
-              ({ first_name: firstName, last_name: lastName }: any) =>
-                `${firstName} ${lastName}`,
-            )}
-            display={2}
-          />
-        ),
+        <ExpandableList
+          items={owners.map(
+            ({ first_name: firstName, last_name: lastName }: any) =>
+              `${firstName} ${lastName}`,
+          )}
+          display={2}
+        />
+      ),
       Header: t('Owners'),
       accessor: 'owners',
     },
@@ -172,10 +172,10 @@ class DashboardList extends React.PureComponent<Props, State> {
           original: { published },
         },
       }: any) => (
-          <span className="no-wrap">
-            {published ? <i className="fa fa-check" /> : ''}
-          </span>
-        ),
+        <span className="no-wrap">
+          {published ? <i className="fa fa-check" /> : ''}
+        </span>
+      ),
       Header: t('Published'),
       accessor: 'published',
       sortable: true,
@@ -526,7 +526,7 @@ class DashboardList extends React.PureComponent<Props, State> {
                 name: (
                   <>
                     <i className="fa fa-trash" /> Delete
-                      </>
+                  </>
                 ),
                 onSelect: confirmDelete,
               });
@@ -537,7 +537,7 @@ class DashboardList extends React.PureComponent<Props, State> {
                 name: (
                   <>
                     <i className="fa fa-database" /> Export
-                      </>
+                  </>
                 ),
                 onSelect: this.handleBulkDashboardExport,
               });

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -510,7 +510,7 @@ class DashboardList extends React.PureComponent<Props, State> {
     } = this.state;
     return (
       <>
-        <SubMenu label="Dashboards" />
+        <SubMenu name="Dashboards" />
         <ConfirmStatusChange
           title={t('Please confirm')}
           description={t(

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -77,7 +77,7 @@ class DashboardList extends React.PureComponent<Props, State> {
     filterOperators: {},
     filters: [],
     lastFetchDataConfig: null,
-    loading: false,
+    loading: true,
     permissions: [],
     dashboardToEdit: null,
   };

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -25,6 +25,7 @@ import rison from 'rison';
 // @ts-ignore
 import { Panel } from 'react-bootstrap';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
+import SubMenu from 'src/components/Menu/SubMenu';
 import ListView from 'src/components/ListView/ListView';
 import ExpandableList from 'src/components/ExpandableList';
 import {
@@ -141,14 +142,14 @@ class DashboardList extends React.PureComponent<Props, State> {
           original: { owners },
         },
       }: any) => (
-        <ExpandableList
-          items={owners.map(
-            ({ first_name: firstName, last_name: lastName }: any) =>
-              `${firstName} ${lastName}`,
-          )}
-          display={2}
-        />
-      ),
+          <ExpandableList
+            items={owners.map(
+              ({ first_name: firstName, last_name: lastName }: any) =>
+                `${firstName} ${lastName}`,
+            )}
+            display={2}
+          />
+        ),
       Header: t('Owners'),
       accessor: 'owners',
     },
@@ -171,10 +172,10 @@ class DashboardList extends React.PureComponent<Props, State> {
           original: { published },
         },
       }: any) => (
-        <span className="no-wrap">
-          {published ? <i className="fa fa-check" /> : ''}
-        </span>
-      ),
+          <span className="no-wrap">
+            {published ? <i className="fa fa-check" /> : ''}
+          </span>
+        ),
       Header: t('Published'),
       accessor: 'published',
       sortable: true,
@@ -508,71 +509,68 @@ class DashboardList extends React.PureComponent<Props, State> {
       dashboardToEdit,
     } = this.state;
     return (
-      <div className="container welcome">
-        <Panel>
-          <Panel.Body>
-            <ConfirmStatusChange
-              title={t('Please confirm')}
-              description={t(
-                'Are you sure you want to delete the selected dashboards?',
-              )}
-              onConfirm={this.handleBulkDashboardDelete}
-            >
-              {confirmDelete => {
-                const bulkActions = [];
-                if (this.canDelete) {
-                  bulkActions.push({
-                    key: 'delete',
-                    name: (
-                      <>
-                        <i className="fa fa-trash" /> Delete
-                      </>
-                    ),
-                    onSelect: confirmDelete,
-                  });
-                }
-                if (this.canExport) {
-                  bulkActions.push({
-                    key: 'export',
-                    name: (
-                      <>
-                        <i className="fa fa-database" /> Export
-                      </>
-                    ),
-                    onSelect: this.handleBulkDashboardExport,
-                  });
-                }
-                return (
+      <>
+        <SubMenu label="Dashboards" />
+        <ConfirmStatusChange
+          title={t('Please confirm')}
+          description={t(
+            'Are you sure you want to delete the selected dashboards?',
+          )}
+          onConfirm={this.handleBulkDashboardDelete}
+        >
+          {confirmDelete => {
+            const bulkActions = [];
+            if (this.canDelete) {
+              bulkActions.push({
+                key: 'delete',
+                name: (
                   <>
-                    {dashboardToEdit && (
-                      <PropertiesModal
-                        show
-                        dashboardId={dashboardToEdit.id}
-                        onHide={() => this.setState({ dashboardToEdit: null })}
-                        onDashboardSave={this.handleDashboardEdit}
-                      />
-                    )}
-                    <ListView
-                      className="dashboard-list-view"
-                      title={'Dashboards'}
-                      columns={this.columns}
-                      data={dashboards}
-                      count={dashboardCount}
-                      pageSize={PAGE_SIZE}
-                      fetchData={this.fetchData}
-                      loading={loading}
-                      initialSort={this.initialSort}
-                      filters={filters}
-                      bulkActions={bulkActions}
-                      useNewUIFilters={this.isNewUIEnabled}
-                    />
-                  </>
-                );
-              }}
-            </ConfirmStatusChange>
-          </Panel.Body>
-        </Panel>
-      </div>
+                    <i className="fa fa-trash" /> Delete
+                      </>
+                ),
+                onSelect: confirmDelete,
+              });
+            }
+            if (this.canExport) {
+              bulkActions.push({
+                key: 'export',
+                name: (
+                  <>
+                    <i className="fa fa-database" /> Export
+                      </>
+                ),
+                onSelect: this.handleBulkDashboardExport,
+              });
+            }
+            return (
+              <>
+                {dashboardToEdit && (
+                  <PropertiesModal
+                    show
+                    dashboardId={dashboardToEdit.id}
+                    onHide={() => this.setState({ dashboardToEdit: null })}
+                    onDashboardSave={this.handleDashboardEdit}
+                  />
+                )}
+                <ListView
+                  className="dashboard-list-view"
+                  title={'Dashboards'}
+                  columns={this.columns}
+                  data={dashboards}
+                  count={dashboardCount}
+                  pageSize={PAGE_SIZE}
+                  fetchData={this.fetchData}
+                  loading={loading}
+                  initialSort={this.initialSort}
+                  filters={filters}
+                  bulkActions={bulkActions}
+                  useNewUIFilters={this.isNewUIEnabled}
+                />
+              </>
+            );
+          }}
+        </ConfirmStatusChange>
+      </>
     );
   }
 }

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -142,14 +142,14 @@ class DashboardList extends React.PureComponent<Props, State> {
           original: { owners },
         },
       }: any) => (
-        <ExpandableList
-          items={owners.map(
-            ({ first_name: firstName, last_name: lastName }: any) =>
-              `${firstName} ${lastName}`,
-          )}
-          display={2}
-        />
-      ),
+          <ExpandableList
+            items={owners.map(
+              ({ first_name: firstName, last_name: lastName }: any) =>
+                `${firstName} ${lastName}`,
+            )}
+            display={2}
+          />
+        ),
       Header: t('Owners'),
       accessor: 'owners',
     },
@@ -172,10 +172,10 @@ class DashboardList extends React.PureComponent<Props, State> {
           original: { published },
         },
       }: any) => (
-        <span className="no-wrap">
-          {published ? <i className="fa fa-check" /> : ''}
-        </span>
-      ),
+          <span className="no-wrap">
+            {published ? <i className="fa fa-check" /> : ''}
+          </span>
+        ),
       Header: t('Published'),
       accessor: 'published',
       sortable: true,
@@ -254,7 +254,6 @@ class DashboardList extends React.PureComponent<Props, State> {
       },
       Header: t('Actions'),
       id: 'actions',
-      size: 'lg',
     },
   ];
 

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -487,9 +487,6 @@ class DatasetList extends React.PureComponent<Props, State> {
     return (
       <>
         <SubMenu {...this.menu} canCreate={this.canCreate} />
-        {/* <div className="container welcome">
-          <Panel>
-            <Panel.Body> */}
         <ConfirmStatusChange
           title={t('Please confirm')}
           description={t(
@@ -527,9 +524,6 @@ class DatasetList extends React.PureComponent<Props, State> {
             );
           }}
         </ConfirmStatusChange>
-        {/* </Panel.Body>
-          </Panel>
-        </div> */}
       </>
     );
   }

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -195,17 +195,17 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => kind[0]?.toUpperCase() + kind.slice(1),
       Header: t('Type'),
       accessor: 'kind',
-      size: 'l',
+      size: 'lg',
     },
     {
       Header: t('Source'),
       accessor: 'database_name',
-      size: 'l',
+      size: 'lg',
     },
     {
       Header: t('Schema'),
       accessor: 'schema',
-      size: 'l',
+      size: 'lg',
     },
     {
       Cell: ({
@@ -229,7 +229,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       Header: t('Last Modified'),
       accessor: 'changed_on',
       sortable: true,
-      size: 'l',
+      size: 'lg',
     },
     {
       Cell: ({
@@ -239,7 +239,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => changedByName,
       Header: t('Modified By'),
       accessor: 'changed_by_fk',
-      size: 'l',
+      size: 'lg',
     },
     {
       accessor: 'database',
@@ -269,7 +269,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       },
       Header: t('Owners'),
       id: 'owners',
-      size: 'l',
+      size: 'lg',
     },
     {
       accessor: 'is_sqllab_view',
@@ -350,7 +350,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       },
       Header: t('Actions'),
       id: 'actions',
-      size: 'm',
+      size: 'lg',
     },
   ];
 

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -487,49 +487,49 @@ class DatasetList extends React.PureComponent<Props, State> {
     return (
       <>
         <SubMenu {...this.menu} canCreate={this.canCreate} />
-        <div className="container welcome">
+        {/* <div className="container welcome">
           <Panel>
-            <Panel.Body>
-              <ConfirmStatusChange
-                title={t('Please confirm')}
-                description={t(
-                  'Are you sure you want to delete the selected datasets?',
-                )}
-                onConfirm={this.handleBulkDatasetDelete}
-              >
-                {confirmDelete => {
-                  const bulkActions = [];
-                  if (this.canDelete) {
-                    bulkActions.push({
-                      key: 'delete',
-                      name: (
-                        <>
-                          <i className="fa fa-trash" /> Delete
+            <Panel.Body> */}
+        <ConfirmStatusChange
+          title={t('Please confirm')}
+          description={t(
+            'Are you sure you want to delete the selected datasets?',
+          )}
+          onConfirm={this.handleBulkDatasetDelete}
+        >
+          {confirmDelete => {
+            const bulkActions = [];
+            if (this.canDelete) {
+              bulkActions.push({
+                key: 'delete',
+                name: (
+                  <>
+                    <i className="fa fa-trash" /> Delete
                         </>
-                      ),
-                      onSelect: confirmDelete,
-                    });
-                  }
-                  return (
-                    <ListView
-                      className="dataset-list-view"
-                      title={'Datasets'}
-                      columns={this.columns}
-                      data={datasets}
-                      count={datasetCount}
-                      pageSize={PAGE_SIZE}
-                      fetchData={this.fetchData}
-                      loading={loading}
-                      initialSort={this.initialSort}
-                      filters={filters}
-                      bulkActions={bulkActions}
-                    />
-                  );
-                }}
-              </ConfirmStatusChange>
-            </Panel.Body>
+                ),
+                onSelect: confirmDelete,
+              });
+            }
+            return (
+              <ListView
+                className="dataset-list-view"
+                title={'Datasets'}
+                columns={this.columns}
+                data={datasets}
+                count={datasetCount}
+                pageSize={PAGE_SIZE}
+                fetchData={this.fetchData}
+                loading={loading}
+                initialSort={this.initialSort}
+                filters={filters}
+                bulkActions={bulkActions}
+              />
+            );
+          }}
+        </ConfirmStatusChange>
+        {/* </Panel.Body>
           </Panel>
-        </div>
+        </div> */}
       </>
     );
   }

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -184,6 +184,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => datasetTitle,
       Header: t('Name'),
       accessor: 'table_name',
+      sortable: true,
     },
     {
       Cell: ({
@@ -207,7 +208,20 @@ class DatasetList extends React.PureComponent<Props, State> {
         row: {
           original: { changed_on: changedOn },
         },
-      }: any) => <span className="no-wrap">{moment(changedOn).fromNow()}</span>,
+      }: any) => {
+        const momentTime = moment(changedOn);
+        const time = momentTime.format('h:m a');
+        const date = momentTime.format('MMM D, YYYY');
+        return (
+          <TooltipWrapper
+            label="last-modified"
+            tooltip={time}
+            placement="right"
+          >
+            <span>{date}</span>
+          </TooltipWrapper>
+        );
+      },
       Header: t('Last Modified'),
       accessor: 'changed_on',
       sortable: true,
@@ -215,12 +229,9 @@ class DatasetList extends React.PureComponent<Props, State> {
     {
       Cell: ({
         row: {
-          original: {
-            changed_by_name: changedByName,
-            changed_by_url: changedByUrl,
-          },
+          original: { changed_by_name: changedByName },
         },
-      }: any) => <a href={changedByUrl}>{changedByName}</a>,
+      }: any) => changedByName,
       Header: t('Modified By'),
       accessor: 'changed_by_fk',
     },
@@ -268,14 +279,20 @@ class DatasetList extends React.PureComponent<Props, State> {
           <span
             className={`actions ${state && state.hover ? '' : 'invisible'}`}
           >
-            <a
-              role="button"
-              tabIndex={0}
-              className="action-button"
-              href={original.explore_url}
+            <TooltipWrapper
+              label="explore-action"
+              tooltip={t('Explore')}
+              placement="bottom"
             >
-              <Icon name="compass" />
-            </a>
+              <a
+                role="button"
+                tabIndex={0}
+                className="action-button"
+                href={original.explore_url}
+              >
+                <Icon name="compass" />
+              </a>
+            </TooltipWrapper>
             {this.canDelete && (
               <ConfirmStatusChange
                 title={t('Please Confirm')}
@@ -288,26 +305,38 @@ class DatasetList extends React.PureComponent<Props, State> {
                 onConfirm={handleDelete}
               >
                 {confirmDelete => (
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className="action-button"
-                    onClick={confirmDelete}
+                  <TooltipWrapper
+                    label="delete-action"
+                    tooltip={t('Delete')}
+                    placement="bottom"
                   >
-                    <Icon name="trash" />
-                  </span>
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      className="action-button"
+                      onClick={confirmDelete}
+                    >
+                      <Icon name="trash" />
+                    </span>
+                  </TooltipWrapper>
                 )}
               </ConfirmStatusChange>
             )}
             {this.canEdit && (
-              <span
-                role="button"
-                tabIndex={0}
-                className="action-button"
-                onClick={handleEdit}
+              <TooltipWrapper
+                label="edit-action"
+                tooltip={t('Edit')}
+                placement="bottom"
               >
-                <Icon name="pencil" />
-              </span>
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="action-button"
+                  onClick={handleEdit}
+                >
+                  <Icon name="pencil" />
+                </span>
+              </TooltipWrapper>
             )}
           </span>
         );

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -318,7 +318,6 @@ class DatasetList extends React.PureComponent<Props, State> {
   ];
 
   menu = {
-    label: 'Data',
     name: 'Data',
     createButton: {
       name: t('Dataset'),

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -87,7 +87,7 @@ class DatasetList extends React.PureComponent<Props, State> {
     filterOperators: {},
     filters: [],
     lastFetchDataConfig: null,
-    loading: false,
+    loading: true,
     owners: [],
     databases: [],
     permissions: [],
@@ -241,6 +241,7 @@ class DatasetList extends React.PureComponent<Props, State> {
           .slice(0, 5)
           .map((owner: Owner) => (
             <AvatarIcon
+              key={owner.id}
               tableName={tableName}
               firstName={owner.first_name}
               lastName={owner.last_name}

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -24,6 +24,7 @@ import React from 'react';
 import rison from 'rison';
 // @ts-ignore
 import { Panel } from 'react-bootstrap';
+import { SHORT_DATE, SHORT_TIME } from 'src/utils/common';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import ListView from 'src/components/ListView/ListView';
 import SubMenu from 'src/components/Menu/SubMenu';
@@ -214,8 +215,8 @@ class DatasetList extends React.PureComponent<Props, State> {
         },
       }: any) => {
         const momentTime = moment(changedOn);
-        const time = momentTime.format('h:m a');
-        const date = momentTime.format('MMM D, YYYY');
+        const time = momentTime.format(SHORT_DATE);
+        const date = momentTime.format(SHORT_TIME);
         return (
           <TooltipWrapper
             label="last-modified"
@@ -355,7 +356,7 @@ class DatasetList extends React.PureComponent<Props, State> {
   ];
 
   menu = {
-    name: 'Data',
+    name: t('Data'),
     createButton: {
       name: t('Dataset'),
       url: '/tablemodelview/add',
@@ -538,7 +539,7 @@ class DatasetList extends React.PureComponent<Props, State> {
                 key: 'delete',
                 name: (
                   <>
-                    <i className="fa fa-trash" /> Delete
+                    <i className="fa fa-trash" /> {t('Delete')}
                   </>
                 ),
                 onSelect: confirmDelete,
@@ -547,7 +548,6 @@ class DatasetList extends React.PureComponent<Props, State> {
             return (
               <ListView
                 className="dataset-list-view"
-                title={'Datasets'}
                 columns={this.columns}
                 data={datasets}
                 count={datasetCount}

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -195,7 +195,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => kind[0]?.toUpperCase() + kind.slice(1),
       Header: t('Type'),
       accessor: 'kind',
-      size: 'lg',
+      size: 'md',
     },
     {
       Header: t('Source'),
@@ -229,7 +229,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       Header: t('Last Modified'),
       accessor: 'changed_on',
       sortable: true,
-      size: 'lg',
+      size: 'xl',
     },
     {
       Cell: ({
@@ -239,7 +239,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => changedByName,
       Header: t('Modified By'),
       accessor: 'changed_by_fk',
-      size: 'lg',
+      size: 'xl',
     },
     {
       accessor: 'database',
@@ -263,7 +263,7 @@ class DatasetList extends React.PureComponent<Props, State> {
               firstName={owner.first_name}
               lastName={owner.last_name}
               userName={owner.username}
-              iconSize="20"
+              iconSize="24"
             />
           ));
       },
@@ -350,7 +350,6 @@ class DatasetList extends React.PureComponent<Props, State> {
       },
       Header: t('Actions'),
       id: 'actions',
-      size: 'lg',
     },
   ];
 

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -263,7 +263,8 @@ class DatasetList extends React.PureComponent<Props, State> {
               firstName={owner.first_name}
               lastName={owner.last_name}
               userName={owner.username}
-              iconSize="24"
+              iconSize={24}
+              textSize={9}
             />
           ));
       },

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -175,6 +175,7 @@ class DatasetList extends React.PureComponent<Props, State> {
         );
       },
       accessor: 'kind_icon',
+      size: 'xs',
     },
     {
       Cell: ({
@@ -194,14 +195,17 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => kind[0]?.toUpperCase() + kind.slice(1),
       Header: t('Type'),
       accessor: 'kind',
+      size: 'l',
     },
     {
       Header: t('Source'),
       accessor: 'database_name',
+      size: 'l',
     },
     {
       Header: t('Schema'),
       accessor: 'schema',
+      size: 'l',
     },
     {
       Cell: ({
@@ -225,6 +229,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       Header: t('Last Modified'),
       accessor: 'changed_on',
       sortable: true,
+      size: 'l',
     },
     {
       Cell: ({
@@ -234,6 +239,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => changedByName,
       Header: t('Modified By'),
       accessor: 'changed_by_fk',
+      size: 'l',
     },
     {
       accessor: 'database',
@@ -263,6 +269,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       },
       Header: t('Owners'),
       id: 'owners',
+      size: 'l',
     },
     {
       accessor: 'is_sqllab_view',
@@ -343,6 +350,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       },
       Header: t('Actions'),
       id: 'actions',
+      size: 'm',
     },
   ];
 

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -505,7 +505,7 @@ class DatasetList extends React.PureComponent<Props, State> {
                 name: (
                   <>
                     <i className="fa fa-trash" /> Delete
-                        </>
+                  </>
                 ),
                 onSelect: confirmDelete,
               });

--- a/superset-frontend/stylesheets/less/variables.less
+++ b/superset-frontend/stylesheets/less/variables.less
@@ -209,8 +209,4 @@
 /* in favor of custom/reusable CSS wherever possible                    */
 /************************************************************************/
 
-// ***************************** SIP 34 UI *******************************
-@table-hover: rgba(236, 238, 242, 0.5);
-@table-selected: #eceef2;
-
 @import '../less/cosmo/variables.less';


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- changes styles and pagination to match SIP-34. Datasets was the target but made a few changes to chartList and dashboardList since changes needed to be made to the underlying listview component. 
- Improves loading of the listview. The listview doesn't render until data is fetched and fetching new data uses a skeleton shimmer loading effect. 
- adds tooltips (dataset type, last modified, actions, owners)
- adds column option for fixed size.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="3008" alt="Screen Shot 2020-06-18 at 3 23 21 PM" src="https://user-images.githubusercontent.com/10255196/85077667-aecb3900-b177-11ea-8748-932d33c80c3f.png">
<img width="1672" alt="Screen Shot 2020-06-17 at 7 34 45 PM" src="https://user-images.githubusercontent.com/10255196/84971915-a10fa800-b0d2-11ea-83b6-3c092bddfb5a.png">
Dashboards and Charts
<img width="3008" alt="Screen Shot 2020-06-17 at 5 43 33 PM" src="https://user-images.githubusercontent.com/10255196/84971864-863d3380-b0d2-11ea-9b97-eda7be1c5ef5.png">
<img width="3006" alt="Screen Shot 2020-06-17 at 5 43 44 PM" src="https://user-images.githubusercontent.com/10255196/84971879-8c331480-b0d2-11ea-89b2-010d066283d2.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- toggle `ENABLE_REACT_CRUD_VIEWS` config flag, see changes in datasets/tables view

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI (behind config flag `ENABLE_REACT_CRUD_VIEWS`)
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
