### PR TITLE
ci: bump Python tests to 3.7 and add support for 3.8

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2.1.1
       with:
-        python-version: '3.6'
+        python-version: '3.7'
     - name: Install dependencies
       uses: apache-superset/cached-dependencies@b90713b
       with:

--- a/.github/workflows/superset-python.yml
+++ b/.github/workflows/superset-python.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.superset_test_config
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.superset_test_config

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,8 @@ Getting Started
 Superset has deprecated support for Python ``2.*`` and supports
 only ``~=3.6`` to take advantage of the newer Python features and reduce
 the burden of supporting previous versions. We run our test suite
-against ``3.6``, but ``3.7`` is fully supported as well.
+against ``3.7``, with a subset of tests additionally being run against
+``3.6`` and ``3.8``.
 
 Cloud-native!
 -------------

--- a/setup.py
+++ b/setup.py
@@ -146,5 +146,6 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )


### PR DESCRIPTION
### SUMMARY
With the bump of `pylint` to version 2.5.3 per #10101, the Superset build env should now be fully 3.7+ compatible.

### TEST PLAN
Run all python tests on 3.7 and ensure CI passes smoothly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
