### PR TITLE
perf(datasets): improve datasets API performance for attr kind

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -84,6 +84,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "owners.first_name",
         "owners.last_name",
         "schema",
+        "sql",
         "table_name",
     ]
     show_columns = [

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -100,6 +100,7 @@ class DatasetApiTests(SupersetTestCase):
             "kind",
             "owners",
             "schema",
+            "sql",
             "table_name",
         ]
         self.assertEqual(sorted(list(response["result"][0].keys())), expected_columns)


### PR DESCRIPTION
### SUMMARY
Datasets API was issuing N+1 queries due to the `kind` property that uses `table.sql` column forcing a SQLAlchemy lazy_load

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@willbarrett 
