### PR TITLE
fix: dashboard should not add extra_filters onto chart annotation

### DIFF
--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -221,6 +221,7 @@ export function runAnnotationQuery(
   timeout = 60,
   formData = null,
   key,
+  isDashboardRequest = false,
 ) {
   return function (dispatch, getState) {
     const sliceKey = key || Object.keys(getState().charts)[0];
@@ -251,7 +252,7 @@ export function runAnnotationQuery(
       {},
     );
 
-    if (fd !== null) {
+    if (!isDashboardRequest && fd) {
       const hasExtraFilters = fd.extra_filters && fd.extra_filters.length > 0;
       sliceFormData.extra_filters = hasExtraFilters
         ? fd.extra_filters
@@ -410,13 +411,16 @@ export function exploreJSON(
       });
 
     const annotationLayers = formData.annotation_layers || [];
+    const isDashboardRequest = dashboardId > 0;
 
     return Promise.all([
       chartDataRequestCaught,
       dispatch(triggerQuery(false, key)),
       dispatch(updateQueryFormData(formData, key)),
       ...annotationLayers.map(x =>
-        dispatch(runAnnotationQuery(x, timeout, formData, key)),
+        dispatch(
+          runAnnotationQuery(x, timeout, formData, key, isDashboardRequest),
+        ),
       ),
     ]);
   };


### PR DESCRIPTION
### SUMMARY
We used to be able to show filtered vs all data in the same chart by using annotation. See below is an example, region vs global.

But I recently found there was an issue introduced by #8057, where dashboard filter (**extra_filters** param) is applied to chart's annotation layer. This will cause chart and annotation layer both have same query, so we can't compare filtered data vs original annotation layer.

This PR is try to fix this issue, not passing dashboard filter parameters to chart's annotation layer.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**before:**
<img width="1264" alt="Screen Shot 2020-06-20 at 1 02 36 AM" src="https://user-images.githubusercontent.com/27990562/85197001-f397c280-b292-11ea-930c-eea241c01981.png">


**after:**
<img width="1263" alt="Screen Shot 2020-06-20 at 1 06 17 AM" src="https://user-images.githubusercontent.com/27990562/85197002-f692b300-b292-11ea-89d9-ccca267787f0.png">


### TEST PLAN
Manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #8057

@ktmud @etr2460 @mistercrunch 