### PR TITLE
chore(mypy): Fixing can_access_database types

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -50,6 +50,7 @@ from superset.utils.core import DatasourceName
 if TYPE_CHECKING:
     from superset.common.query_context import QueryContext
     from superset.connectors.base.models import BaseDatasource
+    from superset.connectors.druid.models import DruidCluster
     from superset.models.core import Database
     from superset.sql_parse import Table
     from superset.viz import BaseViz
@@ -230,13 +231,16 @@ class SupersetSecurityManager(SecurityManager):
 
         return self.can_access("all_database_access", "all_database_access")
 
-    def can_access_database(self, database: "Database") -> bool:
+    def can_access_database(self, database: Union["Database", "DruidCluster"]) -> bool:
         """
         Return True if the user can access the Superset database, False otherwise.
+
+        Note for Druid the database is akin to the Druid cluster.
 
         :param database: The Superset database
         :returns: Whether the user can access the Superset database
         """
+
         return (
             self.can_access_all_datasources()
             or self.can_access_all_databases()


### PR DESCRIPTION
### SUMMARY

This PR updates the typing for the `can_access_database` method as per [here](https://github.com/apache/incubator-superset/blob/9532bff48fd2a5c01f3e5e69d3bce166822951b5/superset/security/manager.py#L260) for Druid datasources the `database` is a `DruidCluster` per [here](https://github.com/apache/incubator-superset/blob/961b55cfbaa31723daf56d27b20cd4a074e0adc5/superset/connectors/druid/models.py#L522).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
