### PR TITLE
chore: fix add datasource help string

### DIFF
--- a/superset-frontend/src/addSlice/AddSliceContainer.jsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.jsx
@@ -87,29 +87,33 @@ export default class AddSliceContainer extends React.PureComponent {
           <Panel.Body>
             <div>
               <p>{t('Choose a datasource')}</p>
-              <div style={styleSelectWidth}>
-                <Select
-                  clearable={false}
-                  ignoreAccents={false}
-                  name="select-datasource"
-                  onChange={this.changeDatasource}
-                  options={this.props.datasources}
-                  placeholder={t('Choose a datasource')}
-                  style={styleSelectWidth}
-                  value={this.state.datasourceValue}
-                  width={600}
-                />
-              </div>
-              <p className="text-muted">
-                {t(
-                  'If the datasource you are looking for is not ' +
-                    'available in the list, ' +
-                    'follow the instructions on the how to add it on the ',
-                )}
-                <a href="https://superset.apache.org/tutorial.html">
-                  {t('Superset tutorial')}
-                </a>
+              <p>
+                <div style={styleSelectWidth}>
+                  <Select
+                    clearable={false}
+                    ignoreAccents={false}
+                    name="select-datasource"
+                    onChange={this.changeDatasource}
+                    options={this.props.datasources}
+                    placeholder={t('Choose a datasource')}
+                    style={styleSelectWidth}
+                    value={this.state.datasourceValue}
+                    width={600}
+                  />
+                </div>
               </p>
+              <span className="text-muted">
+                {t(
+                  'If the datasource you are looking for is not available in the list, follow the instructions on how to add it in the Superset tutorial.',
+                )}{' '}
+                <a
+                  href="https://superset.apache.org/tutorial.html#adding-a-new-table"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <i className="fa fa-external-link" />
+                </a>
+              </span>
             </div>
             <br />
             <div>


### PR DESCRIPTION
### SUMMARY
Splitting sentences like this doesn't work for translations because not all languages follow the same sentence structure as English. I fixed the translation by moving the link to a link icon, improved the style of the page, and also put the full string on one line to make grepping easier

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1920" alt="Screen Shot 2020-06-21 at 9 42 05 PM" src="https://user-images.githubusercontent.com/7409244/85250038-3b8d2580-b40a-11ea-8f79-be9d599dddc0.png">

After:
<img width="1919" alt="Screen Shot 2020-06-21 at 9 51 40 PM" src="https://user-images.githubusercontent.com/7409244/85250029-3334ea80-b40a-11ea-9267-f217054084e8.png">

### TEST PLAN
CI, clicking on the link to make sure it works

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @suddjian @ktmud @graceguo-supercat 