### PR TITLE
fix(security): dbs/clusters perm

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -44,7 +44,9 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref, relationship, Session
+from sqlalchemy.sql import expression
 from sqlalchemy_utils import EncryptedType
 
 from superset import conf, db, is_feature_enabled, security_manager
@@ -280,12 +282,16 @@ class DruidCluster(Model, AuditMixinNullable, ImportMixin):
                 datasource.refresh_metrics()
         session.commit()
 
-    @property
+    @hybrid_property
     def perm(self) -> str:
-        return "[{obj.cluster_name}].(id:{obj.id})".format(obj=self)
+        return f"[{self.cluster_name}].(id:{self.id})"
+
+    @perm.expression  # type: ignore
+    def perm(cls) -> str:  # pylint: disable=no-self-argument
+        return "[" + cls.cluster_name + "].(id:" + expression.cast(cls.id, String) + ")"
 
     def get_perm(self) -> str:
-        return self.perm
+        return self.perm  # type: ignore
 
     @property
     def name(self) -> str:

--- a/superset/migrations/versions/a72cb0ebeb22_deprecate_dbs_perm_column.py
+++ b/superset/migrations/versions/a72cb0ebeb22_deprecate_dbs_perm_column.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""deprecate dbs.perm column
+
+Revision ID: a72cb0ebeb22
+Revises: 743a117f0d98
+Create Date: 2020-06-21 19:50:51.630917
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a72cb0ebeb22"
+down_revision = "743a117f0d98"
+
+
+def upgrade():
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.drop_column("perm")
+
+
+def downgrade():
+    with op.batch_alter_table("dbs") as batch_op:
+        batch_op.add_column(sa.Column("perm", sa.String(1000), nullable=True))

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -45,10 +45,11 @@ from sqlalchemy import (
 from sqlalchemy.engine import Dialect, Engine, url
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import make_url, URL
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.pool import NullPool
 from sqlalchemy.schema import UniqueConstraint
-from sqlalchemy.sql import Select
+from sqlalchemy.sql import expression, Select
 from sqlalchemy_utils import EncryptedType
 
 from superset import app, db_engine_specs, is_feature_enabled, security_manager
@@ -137,7 +138,6 @@ class Database(
         ),
     )
     encrypted_extra = Column(EncryptedType(Text, config["SECRET_KEY"]), nullable=True)
-    perm = Column(String(1000))
     impersonate_user = Column(Boolean, default=False)
     server_cert = Column(EncryptedType(Text, config["SECRET_KEY"]), nullable=True)
     export_fields = [
@@ -639,8 +639,18 @@ class Database(
     def sql_url(self) -> str:
         return f"/superset/sql/{self.id}/"
 
-    def get_perm(self) -> str:
+    @hybrid_property
+    def perm(self) -> str:
         return f"[{self.database_name}].(id:{self.id})"
+
+    @perm.expression  # type: ignore
+    def perm(cls) -> str:  # pylint: disable=no-self-argument
+        return (
+            "[" + cls.database_name + "].(id:" + expression.cast(cls.id, String) + ")"
+        )
+
+    def get_perm(self) -> str:
+        return self.perm  # type: ignore
 
     def has_table(self, table: Table) -> bool:
         engine = self.get_sqla_engine()

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -244,7 +244,7 @@ class SupersetSecurityManager(SecurityManager):
         return (
             self.can_access_all_datasources()
             or self.can_access_all_databases()
-            or self.can_access("database_access", database.perm)
+            or self.can_access("database_access", database.perm)  # type: ignore
         )
 
     def can_access_schema(self, datasource: "BaseDatasource") -> bool:

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -350,6 +350,53 @@ class RolePermissionTests(SupersetTestCase):
         session.delete(stored_db)
         session.commit()
 
+    def test_hybrid_perm_druid_cluster(self):
+        cluster = DruidCluster(cluster_name="tmp_druid_cluster3")
+        db.session.add(cluster)
+
+        id_ = (
+            db.session.query(DruidCluster.id)
+            .filter_by(cluster_name="tmp_druid_cluster3")
+            .scalar()
+        )
+
+        record = (
+            db.session.query(DruidCluster)
+            .filter_by(perm=f"[tmp_druid_cluster3].(id:{id_})")
+            .one()
+        )
+
+        self.assertEquals(record.get_perm(), record.perm)
+        self.assertEquals(record.id, id_)
+        self.assertEquals(record.cluster_name, "tmp_druid_cluster3")
+        db.session.delete(cluster)
+        db.session.commit()
+
+    def test_hybrid_perm_database(self):
+        database = Database(
+            database_name="tmp_database3", sqlalchemy_uri="sqlite://test"
+        )
+
+        db.session.add(database)
+
+        id_ = (
+            db.session.query(Database.id)
+            .filter_by(database_name="tmp_database3")
+            .scalar()
+        )
+
+        record = (
+            db.session.query(Database)
+            .filter_by(perm=f"[tmp_database3].(id:{id_})")
+            .one()
+        )
+
+        self.assertEquals(record.get_perm(), record.perm)
+        self.assertEquals(record.id, id_)
+        self.assertEquals(record.database_name, "tmp_database3")
+        db.session.delete(database)
+        db.session.commit()
+
     def test_set_perm_slice(self):
         session = db.session
         database = Database(


### PR DESCRIPTION
### SUMMARY

Though both the [`Database`](https://github.com/apache/incubator-superset/blob/8e23d4f369f35724b34b14def8a5a8bafb1d2ecb/superset/models/core.py#L99) and [`DruidCluster`](https://github.com/apache/incubator-superset/blob/8e23d4f369f35724b34b14def8a5a8bafb1d2ecb/superset/connectors/druid/models.py#L122) have a `perm` property (which is merely a concatenation of either the database or cluster name and record ID), the property only maps to a physical column for the `Database` model. 

The `perm` column exists is so various permission based queries can be executed to determine if a user can access said data entities. The reason it is not a physical column for the `DruidCluster` model is probably an oversight as this logic is rarely used. Note this PR addresses the inconsistency.

Rather than storing the `perm` in the database I thought there was merit in deprecating the `dbs.perm` column and replacing it with a SQLAlchemy [hybrid attribute](https://docs.sqlalchemy.org/en/13/orm/extensions/hybrid.html#defining-expression-behavior-distinct-from-attribute-behavior). These hybrid attributes act like virtual columns and function in both Python and SQL (a SQL expression has been provided to deal with the casting of the `id` column to a string). If people are ok with these hybrid attributes I wonder if there's merit in deprecating all of the physical `perm` columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI and added additional unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
