### PR TITLE
build: enable test coverage only for CI

### DIFF
--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -24,4 +24,4 @@ echo "Superset config module: $SUPERSET_CONFIG"
 superset db upgrade
 superset init
 nosetests --stop tests/load_examples_test.py
-nosetests --stop --exclude=load_examples_test tests
+nosetests --stop --exclude=load_examples_test --with-coverage tests

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -23,5 +23,5 @@ echo "Superset config module: $SUPERSET_CONFIG"
 
 superset db upgrade
 superset init
-nosetests --stop tests/load_examples_test.py
+nosetests --stop --with-coverage tests/load_examples_test.py
 nosetests --stop --exclude=load_examples_test --with-coverage tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ upload-dir = docs/_build/html
 [nosetests]
 verbosity = 3
 detailed-errors = 1
-with-coverage = 1
 nocapture = 1
 cover-package = superset
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@
 commands =
     {toxinidir}/superset/bin/superset db upgrade
     {toxinidir}/superset/bin/superset init
-    nosetests tests/load_examples_test.py
+    nosetests --with-coverage tests/load_examples_test.py
     nosetests --exclude=load_examples_test --with-coverage {posargs:tests}
 deps =
     -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     {toxinidir}/superset/bin/superset db upgrade
     {toxinidir}/superset/bin/superset init
     nosetests tests/load_examples_test.py
-    nosetests --exclude=load_examples_test {posargs:tests}
+    nosetests --exclude=load_examples_test --with-coverage {posargs:tests}
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt


### PR DESCRIPTION
# SUMMARY

Currently Python unit tests via `nosetests` always output test coverage, but there's no way to disable it. The very long coverage report is quite annoying and makes it more difficult to scan test errors, especially when you just want to run a single test.

<img src="https://user-images.githubusercontent.com/335541/85433684-a2f5c300-b539-11ea-880d-46210ee4dbb2.png" width="400" />

This PR disables test coverage by default, but reenables it for CI jobs that run the full test suite.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See SUMMARY

### TEST PLAN

Make sure test coverage still reported for GitHub PRs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
