### PR TITLE
fix: FilterBox JS errors when no results

### DIFF
--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -143,7 +143,7 @@ class FilterBox extends React.Component {
     let vals = null;
     if (options !== null) {
       if (Array.isArray(options)) {
-        vals = options.map(opt => opt.value);
+        vals = options.map(opt => (typeof opt === 'string' ? opt : opt.value));
       } else if (options.value) {
         vals = options.value;
       } else {
@@ -254,7 +254,7 @@ class FilterBox extends React.Component {
           });
       });
     const { key, label } = filterConfig;
-    const data = this.props.filtersChoices[key];
+    const data = filtersChoices[key] || [];
     const max = Math.max(...data.map(d => d.metric));
     let value = selectedValues[key] || null;
 


### PR DESCRIPTION
### SUMMARY

This fixes two small bugs for FilterBox

1. When query results has zero records, instead of throwing a JS error, we allow the select control to render:

   Before:

   ![Snip20200623_2](https://user-images.githubusercontent.com/335541/85488581-68187d00-b583-11ea-841a-d9ef4481aa13.png)

   After:

   ![Snip20200623_3](https://user-images.githubusercontent.com/335541/85488617-7797c600-b583-11ea-8df6-de68767c2c41.png)

2. Make it possible to create multiple freeform options: 

   <img src="https://user-images.githubusercontent.com/335541/85488839-d78e6c80-b583-11ea-9312-c1c9092417b2.png" width="300" />

  Previously new options will just replace old freeform option.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See above

### TEST PLAN

Manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
