### PR TITLE
refactor: Using self.get_session in security manager

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -389,15 +389,15 @@ class SupersetSecurityManager(SecurityManager):
         if not conf.get("PUBLIC_ROLE_LIKE_GAMMA", False):
             return None
 
-        from superset import db
-
-        return db.session.query(self.role_model).filter_by(name="Public").first()
+        return (
+            self.get_session.query(self.role_model)
+            .filter_by(name="Public")
+            .one_or_none()
+        )
 
     def user_view_menu_names(self, permission_name: str) -> Set[str]:
-        from superset import db
-
         base_query = (
-            db.session.query(self.viewmenu_model.name)
+            self.get_session.query(self.viewmenu_model.name)
             .join(self.permissionview_model)
             .join(self.permission_model)
             .join(assoc_permissionview_role)
@@ -438,7 +438,6 @@ class SupersetSecurityManager(SecurityManager):
         :returns: The list of accessible SQL schemas
         """
 
-        from superset import db
         from superset.connectors.sqla.models import SqlaTable
 
         if hierarchical and self.can_access_database(database):
@@ -455,7 +454,7 @@ class SupersetSecurityManager(SecurityManager):
         perms = self.user_view_menu_names("datasource_access")
         if perms:
             tables = (
-                db.session.query(SqlaTable.schema)
+                self.get_session.query(SqlaTable.schema)
                 .filter(SqlaTable.database_id == database.id)
                 .filter(SqlaTable.schema.isnot(None))
                 .filter(SqlaTable.schema != "")
@@ -481,8 +480,6 @@ class SupersetSecurityManager(SecurityManager):
         :returns: The list of accessible SQL tables w/ schema
         """
 
-        from superset import db
-
         if self.can_access_database(database):
             return datasource_names
 
@@ -494,7 +491,7 @@ class SupersetSecurityManager(SecurityManager):
         user_perms = self.user_view_menu_names("datasource_access")
         schema_perms = self.user_view_menu_names("schema_access")
         user_datasources = ConnectorRegistry.query_datasources_by_permissions(
-            db.session, database, user_perms, schema_perms
+            self.get_session, database, user_perms, schema_perms
         )
         if schema:
             names = {d.table_name for d in user_datasources if d.schema == schema}
@@ -540,7 +537,6 @@ class SupersetSecurityManager(SecurityManager):
         Creates missing FAB permissions for datasources, schemas and metrics.
         """
 
-        from superset import db
         from superset.connectors.base.models import BaseMetric
         from superset.models import core as models
 
@@ -556,20 +552,20 @@ class SupersetSecurityManager(SecurityManager):
                 self.add_permission_view_menu(view_menu, perm)
 
         logger.info("Creating missing datasource permissions.")
-        datasources = ConnectorRegistry.get_all_datasources(db.session)
+        datasources = ConnectorRegistry.get_all_datasources(self.get_session)
         for datasource in datasources:
             merge_pv("datasource_access", datasource.get_perm())
             merge_pv("schema_access", datasource.get_schema_perm())
 
         logger.info("Creating missing database permissions.")
-        databases = db.session.query(models.Database).all()
+        databases = self.get_session.query(models.Database).all()
         for database in databases:
             merge_pv("database_access", database.perm)
 
         logger.info("Creating missing metrics permissions")
         metrics: List[BaseMetric] = []
         for datasource_class in ConnectorRegistry.sources.values():
-            metrics += list(db.session.query(datasource_class.metric_class).all())
+            metrics += list(self.get_session.query(datasource_class.metric_class).all())
 
     def clean_perms(self) -> None:
         """
@@ -767,7 +763,7 @@ class SupersetSecurityManager(SecurityManager):
         """
         Set the datasource permissions.
 
-        :param mapper: The table mappper
+        :param mapper: The table mapper
         :param connection: The DB-API connection
         :param target: The mapped instance being persisted
         """
@@ -922,7 +918,6 @@ class SupersetSecurityManager(SecurityManager):
         :returns: A list of filters
         """
         if hasattr(g, "user") and hasattr(g.user, "id"):
-            from superset import db
             from superset.connectors.sqla.models import (
                 RLSFilterRoles,
                 RLSFilterTables,
@@ -930,22 +925,22 @@ class SupersetSecurityManager(SecurityManager):
             )
 
             user_roles = (
-                db.session.query(assoc_user_role.c.role_id)
+                self.get_session.query(assoc_user_role.c.role_id)
                 .filter(assoc_user_role.c.user_id == g.user.id)
                 .subquery()
             )
             filter_roles = (
-                db.session.query(RLSFilterRoles.c.rls_filter_id)
+                self.get_session.query(RLSFilterRoles.c.rls_filter_id)
                 .filter(RLSFilterRoles.c.role_id.in_(user_roles))
                 .subquery()
             )
             filter_tables = (
-                db.session.query(RLSFilterTables.c.rls_filter_id)
+                self.get_session.query(RLSFilterTables.c.rls_filter_id)
                 .filter(RLSFilterTables.c.table_id == table.id)
                 .subquery()
             )
             query = (
-                db.session.query(
+                self.get_session.query(
                     RowLevelSecurityFilter.id, RowLevelSecurityFilter.clause
                 )
                 .filter(RowLevelSecurityFilter.id.in_(filter_tables))


### PR DESCRIPTION
### SUMMARY

@dpgaspar per your https://github.com/apache/incubator-superset/pull/10034#discussion_r443736809 I thought there was merit in replacing `db.session` with `self.get_session` throughout the entire security manager.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
