### PR TITLE
fix: fix CTAS explore flow

### DIFF
--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx
@@ -24,7 +24,7 @@ import Dialog from 'react-bootstrap-dialog';
 import { t } from '@superset-ui/translation';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 
-import { exportChart } from '../../explore/exploreUtils';
+import { exploreChart } from '../../explore/exploreUtils';
 import * as actions from '../actions/sqlLab';
 import Button from '../../components/Button';
 
@@ -77,7 +77,7 @@ class ExploreCtasResultsButton extends React.PureComponent {
         );
 
         // open new window for data visualization
-        exportChart({ formData });
+        exploreChart(formData);
       })
       .catch(() => {
         this.props.actions.addDangerToast(


### PR DESCRIPTION
Fixes the mistyped exploreChart function for the create table as explore view

To repro:
1. Create a table using CTAS button
![image](https://user-images.githubusercontent.com/5727938/85503941-be93b480-b59f-11ea-9b01-a967bb2a2007.png)

2. Click on the explore button 
![image](https://user-images.githubusercontent.com/5727938/85503965-cf442a80-b59f-11ea-9561-338c7e3b06fb.png)

Actual behavior: nothing happens on the click
Expected behavior: opens an explore page in the new tab
