### PR TITLE
fix: refine shouldUseLegacyApi and add tests

### DIFF
--- a/superset-frontend/spec/javascripts/explore/utils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/utils_spec.jsx
@@ -216,7 +216,7 @@ describe('exploreUtils', () => {
       getChartMetadataRegistry().remove('my_legacy_viz').remove('my_v1_viz');
     });
 
-    it('return true for legacy viz', () => {
+    it('returns true for legacy viz', () => {
       const useLegacyApi = shouldUseLegacyApi({
         ...formData,
         viz_type: 'my_legacy_viz',
@@ -224,7 +224,7 @@ describe('exploreUtils', () => {
       expect(useLegacyApi).toBe(true);
     });
 
-    it('return false for v1 viz', () => {
+    it('returns false for v1 viz', () => {
       const useLegacyApi = shouldUseLegacyApi({
         ...formData,
         viz_type: 'my_v1_viz',
@@ -232,7 +232,7 @@ describe('exploreUtils', () => {
       expect(useLegacyApi).toBe(false);
     });
 
-    it('return false for formData with unregistered viz_type', () => {
+    it('returns false for formData with unregistered viz_type', () => {
       const useLegacyApi = shouldUseLegacyApi({
         ...formData,
         viz_type: 'undefined_viz',
@@ -240,7 +240,7 @@ describe('exploreUtils', () => {
       expect(useLegacyApi).toBe(false);
     });
 
-    it('return false for formData without viz_type', () => {
+    it('returns false for formData without viz_type', () => {
       const useLegacyApi = shouldUseLegacyApi(formData);
       expect(useLegacyApi).toBe(false);
     });

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -194,8 +194,8 @@ export function getExploreUrl({
 }
 
 export const shouldUseLegacyApi = formData => {
-  const { useLegacyApi } = getChartMetadataRegistry().get(formData.viz_type);
-  return useLegacyApi || false;
+  const vizMetadata = getChartMetadataRegistry().get(formData.viz_type);
+  return vizMetadata ? vizMetadata.useLegacyApi : false;
 };
 
 export const buildV1ChartDataPayload = ({


### PR DESCRIPTION
### SUMMARY
The bug that #10147 fixes exposed a shortcoming in the `shouldUseLegacyApi` function in `exploreUtils`. This fixes the bug and adds unit tests to catch all possible cases I could think of.

### TEST PLAN
CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
