### PR TITLE
fix: Fixed Attribute Error when running core_tests.py

### DIFF
--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -37,8 +37,8 @@ from unittest import mock, skipUnless
 import pandas as pd
 import sqlalchemy as sqla
 
+from tests.test_app import app # isort:skip
 import superset.views.utils
-from tests.test_app import app
 from superset import (
     dataframe,
     db,

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -37,7 +37,7 @@ from unittest import mock, skipUnless
 import pandas as pd
 import sqlalchemy as sqla
 
-from tests.test_app import app # isort:skip
+from tests.test_app import app  # isort:skip
 import superset.views.utils
 from superset import (
     dataframe,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using tox to individually test core_tests.py (ie. tox -e py37 -- tests/core_tests.py) an Attribute Error occurs because superset.views.utils is imported before tests.test_app.app. I changed the import order of these in order to get rid of the error and allow core_tests.py to be run individually.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![Screen Shot 2020-06-24 at 10 38 13 AM](https://user-images.githubusercontent.com/32852580/85605206-d3eff980-b606-11ea-873f-029643ef3d6b.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
