### PR TITLE
build: dont prefer ts for cypress tests

### DIFF
--- a/.github/workflows/prefer_typescript.yml
+++ b/.github/workflows/prefer_typescript.yml
@@ -15,11 +15,17 @@ jobs:
         uses: trilom/file-changes-action@master
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Determine if a .js or .jsx file was added
         id: check
         run: |
-          echo ::set-output name=was_js_file_added::$(jq 'map(endswith(".js") or endswith(".jsx"))' ${HOME}/files_added.json | jq 'reduce .[] as $is_js (false; . or $is_js)')
-      - if: steps.check.outputs.was_js_file_added != 'false'
+          js_file_added() {
+            jq 'any((contains("cypress") | not) and (endswith(".js") or endswith(".jsx")))' \
+              ${HOME}/files_added.json
+          }
+          echo ::set-output name=was_js_file_added::$(js_file_added)
+
+      - if: steps.check.outputs.was_js_file_added == 'true'
         name: Comment about preferring TypeScript
         uses: unsplash/comment-on-pr@master
         env:
@@ -28,4 +34,7 @@ jobs:
           msg: |
             ## WARNING: Prefer TypeScript
             
-            It looks like your PR contains new `.js` or `.jsx` files. As decided in [SIP-36](https://github.com/apache/incubator-superset/issues/9101), all new files should be written in TypeScript. Please convert new JavaScript files to TypeScript and then re-request review.
+            It looks like your PR contains new `.js` or `.jsx` files. As decided in \
+            [SIP-36](https://github.com/apache/incubator-superset/issues/9101), \
+            all new files should be written in TypeScript. Please convert new JavaScript \
+            files to TypeScript and then re-request review.


### PR DESCRIPTION
### SUMMARY

Cypress tests don't need to be TypeScript

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Check CI.

Tested in https://github.com/ktmud/incubator-superset/pull/153