### PR TITLE
chore: remove QueryView (ModelView)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parameterized,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,slack,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dataclasses,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parameterized,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytest,pytz,retry,selenium,setuptools,simplejson,slack,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 known_first_party = superset
-known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dataclasses,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parameterized,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytest,pytz,retry,selenium,setuptools,simplejson,slack,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
+known_third_party =alembic,apispec,backoff,bleach,cachelib,celery,click,colorama,contextlib2,croniter,cryptography,dateutil,flask,flask_appbuilder,flask_babel,flask_caching,flask_compress,flask_login,flask_migrate,flask_sqlalchemy,flask_talisman,flask_testing,flask_wtf,geohash,geopy,humanize,isodate,jinja2,markdown,markupsafe,marshmallow,msgpack,numpy,pandas,parameterized,parsedatetime,pathlib2,polyline,prison,pyarrow,pyhive,pytz,retry,selenium,setuptools,simplejson,slack,sphinx_rtd_theme,sqlalchemy,sqlalchemy_utils,sqlparse,werkzeug,wtforms,wtforms_json,yaml
 multi_line_output = 3
 order_by_type = false
 

--- a/superset/app.py
+++ b/superset/app.py
@@ -176,7 +176,6 @@ class SupersetAppInitializer:
             AlertLogModelView,
         )
         from superset.views.sql_lab import (
-            QueryView,
             SavedQueryViewApi,
             SavedQueryView,
             TabStateView,
@@ -248,14 +247,6 @@ class SupersetAppInitializer:
             category="Manage",
             category_label=__("Manage"),
             category_icon="",
-        )
-        appbuilder.add_view(
-            QueryView,
-            "Queries",
-            label=__("Queries"),
-            category="Manage",
-            category_label=__("Manage"),
-            icon="fa-search",
         )
         if self.config["ENABLE_ROW_LEVEL_SECURITY"]:
             appbuilder.add_view(

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -14,29 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any
-
 import simplejson as json
 from flask import g, redirect, request, Response
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_babel import lazy_gettext as _
-from flask_sqlalchemy import BaseQuery
 
-from superset import db, get_feature_flags, security_manager
+from superset import db, get_feature_flags
 from superset.constants import RouteMethod
 from superset.models.sql_lab import Query, SavedQuery, TableSchema, TabState
 from superset.typing import FlaskResponse
 from superset.utils import core as utils
 
-from .base import (
-    BaseFilter,
-    BaseSupersetView,
-    DeleteMixin,
-    json_success,
-    SupersetModelView,
-)
+from .base import BaseSupersetView, DeleteMixin, json_success, SupersetModelView
 
 
 class SavedQueryView(

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -39,41 +39,6 @@ from .base import (
 )
 
 
-class QueryFilter(BaseFilter):  # pylint: disable=too-few-public-methods
-    def apply(self, query: BaseQuery, value: Any) -> BaseQuery:
-        """
-        Filter queries to only those owned by current user. If
-        can_access_all_queries permission is set a user can list all queries
-
-        :returns: query
-        """
-        if not security_manager.can_access_all_queries():
-            query = query.filter(Query.user_id == g.user.get_user_id())
-        return query
-
-
-class QueryView(SupersetModelView):
-    datamodel = SQLAInterface(Query)
-    include_route_methods = {RouteMethod.SHOW, RouteMethod.LIST, RouteMethod.API_READ}
-
-    list_title = _("List Query")
-    show_title = _("Show Query")
-    add_title = _("Add Query")
-    edit_title = _("Edit Query")
-
-    list_columns = ["username", "database_name", "status", "start_time", "end_time"]
-    order_columns = ["status", "start_time", "end_time"]
-    base_filters = [["id", QueryFilter, lambda: []]]
-    label_columns = {
-        "user": _("User"),
-        "username": _("User"),
-        "database_name": _("Database"),
-        "status": _("Status"),
-        "start_time": _("Start Time"),
-        "end_time": _("End Time"),
-    }
-
-
 class SavedQueryView(
     SupersetModelView, DeleteMixin
 ):  # pylint: disable=too-many-ancestors

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -411,26 +411,26 @@ class TestSqlLab(SupersetTestCase):
         )
         self.assertEqual(len(data["data"]), test_limit)
 
-    def test_queryview_filter(self) -> None:
+    def test_query_api_filter(self) -> None:
         """
-        Test queryview api without can_only_access_owned_queries perm added to
+        Test query api without can_only_access_owned_queries perm added to
         Admin and make sure all queries show up.
         """
         self.run_some_queries()
         self.login(username="admin")
 
-        url = "/queryview/api/read"
+        url = "/api/v1/query/"
         data = self.get_json_resp(url)
         admin = security_manager.find_user("admin")
         gamma_sqllab = security_manager.find_user("gamma_sqllab")
         self.assertEqual(3, len(data["result"]))
-        user_queries = [result.get("username") for result in data["result"]]
+        user_queries = [result.get("user").get("username") for result in data["result"]]
         assert admin.username in user_queries
         assert gamma_sqllab.username in user_queries
 
-    def test_queryview_can_access_all_queries(self) -> None:
+    def test_query_api_can_access_all_queries(self) -> None:
         """
-        Test queryview api with can_access_all_queries perm added to
+        Test query api with can_access_all_queries perm added to
         gamma and make sure all queries show up.
         """
         session = db.session
@@ -448,7 +448,7 @@ class TestSqlLab(SupersetTestCase):
         # Test search_queries for Admin user
         self.run_some_queries()
         self.login("gamma_sqllab")
-        url = "/queryview/api/read"
+        url = "/api/v1/query/"
         data = self.get_json_resp(url)
         self.assertEqual(3, len(data["result"]))
 
@@ -462,16 +462,16 @@ class TestSqlLab(SupersetTestCase):
 
         session.commit()
 
-    def test_queryview_admin_can_access_all_queries(self) -> None:
+    def test_query_admin_can_access_all_queries(self) -> None:
         """
-        Test queryview api with all_query_access perm added to
+        Test query api with all_query_access perm added to
         Admin and make sure only Admin queries show up. This is the default
         """
         # Test search_queries for Admin user
         self.run_some_queries()
         self.login("admin")
 
-        url = "/queryview/api/read"
+        url = "/api/v1/query/"
         data = self.get_json_resp(url)
         admin = security_manager.find_user("admin")
         self.assertEqual(3, len(data["result"]))


### PR DESCRIPTION
### SUMMARY
This is not needed anymore as we have the "Query Search" page, and the `/api/v1/query` REST endpoints.