### PR TITLE
feat: Added configuration to SQL Lab results "Explore" button

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ResultSet_spec.jsx
@@ -37,6 +37,7 @@ describe('ResultSet', () => {
     cache: true,
     query: queries[0],
     height: 0,
+    database: { allows_virtual_table_explore: true },
   };
   const stoppedQueryProps = { ...mockedProps, query: stoppedQuery };
   const runningQueryProps = { ...mockedProps, query: runningQuery };

--- a/superset-frontend/src/SqlLab/components/ResultSet.jsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.jsx
@@ -145,13 +145,15 @@ export default class ResultSet extends React.PureComponent {
       return (
         <div className="ResultSetControls">
           <div className="ResultSetButtons">
-            {this.props.visualize && (
-              <ExploreResultsButton
-                query={this.props.query}
-                database={this.props.database}
-                actions={this.props.actions}
-              />
-            )}
+            {this.props.visualize &&
+              this.props.database &&
+              this.props.database.allows_virtual_table_explore && (
+                <ExploreResultsButton
+                  query={this.props.query}
+                  database={this.props.database}
+                  actions={this.props.actions}
+                />
+              )}
             {this.props.csv && (
               <Button
                 bsSize="small"

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -193,7 +193,7 @@ class Database(
     def allows_virtual_table_explore(self) -> bool:
         extra = self.get_extra()
 
-        return bool(extra.get("virtual_table_explore_enabled", True))
+        return bool(extra.get("allows_virtual_table_explore", True))
 
     @property
     def data(self) -> Dict[str, Any]:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -190,6 +190,12 @@ class Database(
         )
 
     @property
+    def allows_virtual_table_explore(self) -> bool:
+        extra = self.get_extra()
+
+        return bool(extra.get("virtual_table_explore_enabled", True))
+
+    @property
     def data(self) -> Dict[str, Any]:
         return {
             "id": self.id,
@@ -198,6 +204,7 @@ class Database(
             "allow_multi_schema_metadata_fetch": self.allow_multi_schema_metadata_fetch,
             "allows_subquery": self.allows_subquery,
             "allows_cost_estimate": self.allows_cost_estimate,
+            "allows_virtual_table_explore": self.allows_virtual_table_explore,
         }
 
     @property

--- a/superset/views/database/api.py
+++ b/superset/views/database/api.py
@@ -136,6 +136,7 @@ class DatabaseRestApi(DatabaseMixin, BaseSupersetModelRestApi):
         "allow_csv_upload",
         "allows_subquery",
         "allows_cost_estimate",
+        "allows_virtual_table_explore",
         "backend",
         "function_names",
     ]

--- a/superset/views/database/mixins.py
+++ b/superset/views/database/mixins.py
@@ -144,7 +144,9 @@ class DatabaseMixin:
             "If database flavor does not support schema or any schema is allowed "
             "to be accessed, just leave the list empty<br/>"
             "4. the ``version`` field is a string specifying the this db's version. "
-            "This should be used with Presto DBs so that the syntax is correct",
+            "This should be used with Presto DBs so that the syntax is correct<br/>"
+            "5. The ``allows_virtual_table_explore`` field is a boolean specifying "
+            "whether or not the Explore button in SQL Lab results is shown.",
             True,
         ),
         "encrypted_extra": utils.markdown(

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1248,6 +1248,29 @@ class CoreTests(SupersetTestCase):
         payload = views.Superset._get_sqllab_tabs(user_id=user_id)
         self.assertEqual(len(payload["queries"]), 1)
 
+    def test_virtual_table_explore_visibility(self):
+        # test that default visibility it set to True
+        database = utils.get_example_database()
+        self.assertEqual(database.allows_virtual_table_explore, True)
+
+        # test that visibility is disabled when extra is set to False
+        extra = database.get_extra()
+        extra["virtual_table_explore_enabled"] = False
+        database.extra = json.dumps(extra)
+        self.assertEqual(database.allows_virtual_table_explore, False)
+
+        # test that visibility is enabled when extra is set to True
+        extra = database.get_extra()
+        extra["virtual_table_explore_enabled"] = True
+        database.extra = json.dumps(extra)
+        self.assertEqual(database.allows_virtual_table_explore, True)
+
+        # test that visibility is not broken with bad values
+        extra = database.get_extra()
+        extra["virtual_table_explore_enabled"] = "trash value"
+        database.extra = json.dumps(extra)
+        self.assertEqual(database.allows_virtual_table_explore, True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1255,19 +1255,19 @@ class CoreTests(SupersetTestCase):
 
         # test that visibility is disabled when extra is set to False
         extra = database.get_extra()
-        extra["virtual_table_explore_enabled"] = False
+        extra["allows_virtual_table_explore"] = False
         database.extra = json.dumps(extra)
         self.assertEqual(database.allows_virtual_table_explore, False)
 
         # test that visibility is enabled when extra is set to True
         extra = database.get_extra()
-        extra["virtual_table_explore_enabled"] = True
+        extra["allows_virtual_table_explore"] = True
         database.extra = json.dumps(extra)
         self.assertEqual(database.allows_virtual_table_explore, True)
 
         # test that visibility is not broken with bad values
         extra = database.get_extra()
-        extra["virtual_table_explore_enabled"] = "trash value"
+        extra["allows_virtual_table_explore"] = "trash value"
         database.extra = json.dumps(extra)
         self.assertEqual(database.allows_virtual_table_explore, True)
 

--- a/tests/database_api_tests.py
+++ b/tests/database_api_tests.py
@@ -49,6 +49,7 @@ class DatabaseApiTests(SupersetTestCase):
             "allow_run_async",
             "allows_cost_estimate",
             "allows_subquery",
+            "allows_virtual_table_explore",
             "backend",
             "database_name",
             "expose_in_sqllab",


### PR DESCRIPTION
## SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Introduces Database level configuration for the visibility of the "Explore" button seen in the query results section of SQL Lab. At large scale it may be hard to maintain charts that are built on virtual tables. This change allows users to disable the explore button on the SQL Lab.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before Configuration:
![Screen Shot 2020-06-25 at 9 25 52 AM](https://user-images.githubusercontent.com/32852580/85759257-e0875700-b6c5-11ea-8726-2a231f269d4f.png)

After visibility is set to false:
![Screen Shot 2020-06-25 at 4 51 58 PM](https://user-images.githubusercontent.com/32852580/85806636-793cc780-b704-11ea-9792-afa186319f6c.png)


![Screen Shot 2020-06-25 at 9 27 56 AM](https://user-images.githubusercontent.com/32852580/85759870-2b08d380-b6c6-11ea-8714-e9f15bee24f1.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [x] unit tests
- [x] tested locally
- [ ] dropbox staging
- [ ] dropbox production

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Changes UI
