### PR TITLE
fix: downgrade sqlparse and add unit test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ six==1.14.0               # via bleach, cryptography, flask-jwt-extended, flask-
 slackclient==2.6.2        # via apache-superset (setup.py)
 sqlalchemy-utils==0.36.6  # via apache-superset (setup.py), flask-appbuilder
 sqlalchemy==1.3.16        # via alembic, apache-superset (setup.py), flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-utils
-sqlparse==0.3.1           # via apache-superset (setup.py)
+sqlparse==0.3.0           # via apache-superset (setup.py)
 typing-extensions==3.7.4.2  # via aiohttp
 urllib3==1.25.9           # via selenium
 vine==1.3.0               # via amqp, celery

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         "slackclient>=2.6.2",
         "sqlalchemy>=1.3.16, <2.0",
         "sqlalchemy-utils>=0.36.6,<0.37",
-        "sqlparse==0.3.0",
+        "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562
         "wtforms-json",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         "slackclient>=2.6.2",
         "sqlalchemy>=1.3.16, <2.0",
         "sqlalchemy-utils>=0.36.6,<0.37",
-        "sqlparse>=0.3.0, <0.4",
+        "sqlparse==0.3.0",
         "wtforms-json",
     ],
     extras_require={


### PR DESCRIPTION
### SUMMARY
Downgrade sqlparse library to 0.3.0

Reported bug in sqlparse as well: https://github.com/andialbrecht/sqlparse/issues/562

0.3.1 has a bug and reindentation converts [removes the space]

```
extract(HOUR from from_unixtime(hour_ts) AT TIME ZONE 'America/Los_Angeles')
```
into
```
extract(HOUR **fromfrom_unixtime(hour_ts)** AT TIME ZONE 'America/Los_Angeles')
```

Partially reverts: https://github.com/apache/incubator-superset/pull/9786/files  (sqlparse bump and the test)

### TEST PLAN
unit tests and local deployment

### ADDITIONAL INFORMATION
[x] Bug Fix