### PR TITLE
fix: return slice owners for /user_slices ep

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1402,7 +1402,14 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 ),
                 isouter=True,
             )
-            .filter(or_(Slice.id.in_(owner_ids_query), FavStar.user_id == user_id,))
+            .filter(
+                or_(
+                    Slice.id.in_(owner_ids_query),
+                    Slice.created_by_fk == user_id,
+                    Slice.changed_by_fk == user_id,
+                    FavStar.user_id == user_id,
+                )
+            )
             .order_by(Slice.slice_name.asc())
         )
         payload = [

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1380,7 +1380,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     def user_slices(  # pylint: disable=no-self-use
         self, user_id: Optional[int] = None
     ) -> FlaskResponse:
-        """List of slices a user owns or faved"""
+        """List of slices a user owns, created, modified or faved"""
         if not user_id:
             user_id = g.user.id
         FavStar = models.FavStar

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -149,9 +149,12 @@ class SupersetTestCase(TestCase):
         resp = self.get_resp("/login/", data=dict(username=username, password=password))
         self.assertNotIn("User confirmation needed", resp)
 
-    def get_slice(self, slice_name: str, session: Session) -> Slice:
+    def get_slice(
+        self, slice_name: str, session: Session, expunge_from_session: bool = True
+    ) -> Slice:
         slc = session.query(Slice).filter_by(slice_name=slice_name).one()
-        session.expunge_all()
+        if expunge_from_session:
+            session.expunge_all()
         return slc
 
     @staticmethod

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -368,7 +368,9 @@ class CoreTests(SupersetTestCase):
         self.assertEqual(data, [])
 
         # make user owner of slice and verify that endpoint returns said slice
-        slc = db.session.query(Slice).filter_by(slice_name=slice_name).one()
+        slc = self.get_slice(
+            slice_name=slice_name, session=db.session, expunge_from_session=False
+        )
         slc.owners = [user]
         db.session.merge(slc)
         db.session.commit()
@@ -379,7 +381,9 @@ class CoreTests(SupersetTestCase):
         self.assertEqual(data[0]["title"], slice_name)
 
         # remove ownership and ensure user no longer gets slice
-        slc = db.session.query(Slice).filter_by(slice_name=slice_name).one()
+        slc = self.get_slice(
+            slice_name=slice_name, session=db.session, expunge_from_session=False
+        )
         slc.owners = []
         db.session.merge(slc)
         db.session.commit()

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -356,6 +356,38 @@ class CoreTests(SupersetTestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
 
+    def test_get_user_slices_for_owners(self):
+        self.login(username="admin")
+        user = security_manager.find_user("admin")
+        slice_name = "Girls"
+
+        # ensure user is not owner of any slices
+        url = f"/superset/user_slices/{user.id}/"
+        resp = self.client.get(url)
+        data = json.loads(resp.data)
+        self.assertEqual(data, [])
+
+        # make user owner of slice and verify that endpoint returns said slice
+        slc = db.session.query(Slice).filter_by(slice_name=slice_name).one()
+        slc.owners = [user]
+        db.session.merge(slc)
+        db.session.commit()
+        url = f"/superset/user_slices/{user.id}/"
+        resp = self.client.get(url)
+        data = json.loads(resp.data)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["title"], slice_name)
+
+        # remove ownership and ensure user no longer gets slice
+        slc = db.session.query(Slice).filter_by(slice_name=slice_name).one()
+        slc.owners = []
+        db.session.merge(slc)
+        db.session.commit()
+        url = f"/superset/user_slices/{user.id}/"
+        resp = self.client.get(url)
+        data = json.loads(resp.data)
+        self.assertEqual(data, [])
+
     def test_get_user_slices(self):
         self.login(username="admin")
         userid = security_manager.find_user("admin").id
@@ -736,31 +768,31 @@ class CoreTests(SupersetTestCase):
         slc = self.get_slice("Girls", db.session)
 
         # Setting some faves
-        url = "/superset/favstar/Slice/{}/select/".format(slc.id)
+        url = f"/superset/favstar/Slice/{slc.id}/select/"
         resp = self.get_json_resp(url)
         self.assertEqual(resp["count"], 1)
 
         dash = db.session.query(Dashboard).filter_by(slug="births").first()
-        url = "/superset/favstar/Dashboard/{}/select/".format(dash.id)
+        url = f"/superset/favstar/Dashboard/{dash.id}/select/"
         resp = self.get_json_resp(url)
         self.assertEqual(resp["count"], 1)
 
         userid = security_manager.find_user("admin").id
-        resp = self.get_resp("/superset/profile/admin/")
+        resp = self.get_resp(f"/superset/profile/{username}/")
         self.assertIn('"app"', resp)
-        data = self.get_json_resp("/superset/recent_activity/{}/".format(userid))
+        data = self.get_json_resp(f"/superset/recent_activity/{userid}/")
         self.assertNotIn("message", data)
-        data = self.get_json_resp("/superset/created_slices/{}/".format(userid))
+        data = self.get_json_resp(f"/superset/created_slices/{userid}/")
         self.assertNotIn("message", data)
-        data = self.get_json_resp("/superset/created_dashboards/{}/".format(userid))
+        data = self.get_json_resp(f"/superset/created_dashboards/{userid}/")
         self.assertNotIn("message", data)
-        data = self.get_json_resp("/superset/fave_slices/{}/".format(userid))
+        data = self.get_json_resp(f"/superset/fave_slices/{userid}/")
         self.assertNotIn("message", data)
-        data = self.get_json_resp("/superset/fave_dashboards/{}/".format(userid))
+        data = self.get_json_resp(f"/superset/fave_dashboards/{userid}/")
         self.assertNotIn("message", data)
-        data = self.get_json_resp(
-            "/superset/fave_dashboards_by_username/{}/".format(username)
-        )
+        data = self.get_json_resp(f"/superset/user_slices/{userid}/")
+        self.assertNotIn("message", data)
+        data = self.get_json_resp(f"/superset/fave_dashboards_by_username/{username}/")
         self.assertNotIn("message", data)
 
     def test_slice_id_is_always_logged_correctly_on_web_request(self):


### PR DESCRIPTION
### SUMMARY
Currently chart owners can't see their own charts when adding annotation layers, unless they have
- created,
- changed or
- favorited

the chart.

This PR adds owners to the filter on the `/superset/user_slices/` endpoint, which based on a quick search of the codebase is solely used by the `AnnotationLayer` component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
Local testing + CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
