### PR TITLE
fix: make auth for hive optional

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -439,7 +439,7 @@ class HiveEngineSpec(PrestoEngineSpec):
 
         # Must be Hive connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
-        if backend_name == "hive" and impersonate_user is True and username is not None:
+        if backend_name == "hive" and impersonate_user and username is not None:
             configuration["hive.server2.proxy.user"] = username
         return configuration
 

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -439,11 +439,7 @@ class HiveEngineSpec(PrestoEngineSpec):
 
         # Must be Hive connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
-        if (
-            backend_name == "hive"
-            and impersonate_user is True
-            and username is not None
-        ):
+        if backend_name == "hive" and impersonate_user is True and username is not None:
             configuration["hive.server2.proxy.user"] = username
         return configuration
 

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -437,11 +437,10 @@ class HiveEngineSpec(PrestoEngineSpec):
         url = make_url(uri)
         backend_name = url.get_backend_name()
 
-        # Must be Hive connection, enable impersonation, and set param
+        # Must be Hive connection, enable impersonation, and set optional param
         # auth=LDAP|KERBEROS
         if (
             backend_name == "hive"
-            and "auth" in url.query.keys()
             and impersonate_user is True
             and username is not None
         ):


### PR DESCRIPTION
This will make allow the admin to set up a root connection that can be impersonated.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If a root Hive connection is used liked in Hue, we want to simply impersonate that single connection to allow Apache Sentry/Ranger to manage user rights regarding databases/tables. If we enforce the auth param, we also are forced to set credentials on that connection, although we want to use a dedicated hive-server and connection in combination with Apache Sentry/Range, similar to Hue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Set up an unprotected Hive server and add that connection.
```
hive://myhive01.example:10000
```
Select impersonation.
Without the auth flags (eG the submitted fix) Superset is able to impersonate the connection properly.
If the auth setting is set (eG to LDAP or Kerberos) Superset expects username:password in the connection string, although it is not required.

To verify the correct behavior, set the connection, check impersonation, and do not modify the `Extra` settings.
An open connection should still be able to impersonate the connection.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
  https://github.com/apache/incubator-superset/issues/8406 (unsolved)
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
