### PR TITLE
refactor: Break some static methods out of superset.views.core.Superset

### DIFF
--- a/superset/charts/dao.py
+++ b/superset/charts/dao.py
@@ -60,3 +60,15 @@ class ChartDAO(BaseDAO):
     @staticmethod
     def fetch_all_datasources() -> List["BaseDatasource"]:
         return ConnectorRegistry.get_all_datasources(db.session)
+
+    @staticmethod
+    def save(slc: Slice, commit: bool = True) -> None:
+        db.session.add(slc)
+        if commit:
+            db.session.commit()
+
+    @staticmethod
+    def overwrite(slc: Slice, commit: bool = True) -> None:
+        db.session.merge(slc)
+        if commit:
+            db.session.commit()

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -16,7 +16,6 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset"""
-import copy
 import json
 import unittest
 from random import random
@@ -37,19 +36,6 @@ from .base_tests import SupersetTestCase
 
 
 class DashboardTests(SupersetTestCase):
-    def __init__(self, *args, **kwargs):
-        super(DashboardTests, self).__init__(*args, **kwargs)
-
-    @classmethod
-    def setUpClass(cls):
-        pass
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def get_mock_positions(self, dash):
         positions = {"DASHBOARD_VERSION_KEY": "v2"}
         for i, slc in enumerate(dash.slices):
@@ -237,57 +223,6 @@ class DashboardTests(SupersetTestCase):
             for key in slc:
                 if key not in ["modified", "changed_on", "changed_on_humanized"]:
                     self.assertEqual(slc[key], resp["slices"][index][key])
-
-    def test_set_dash_metadata(self, username="admin"):
-        self.login(username=username)
-        dash = db.session.query(Dashboard).filter_by(slug="world_health").first()
-        data = dash.data
-        positions = data["position_json"]
-        data.update({"positions": positions})
-        original_data = copy.deepcopy(data)
-
-        # add filter scopes
-        filter_slice = dash.slices[0]
-        immune_slices = dash.slices[2:]
-        filter_scopes = {
-            str(filter_slice.id): {
-                "region": {
-                    "scope": ["ROOT_ID"],
-                    "immune": [slc.id for slc in immune_slices],
-                }
-            }
-        }
-        data.update({"filter_scopes": json.dumps(filter_scopes)})
-        views.Superset._set_dash_metadata(dash, data)
-        updated_metadata = json.loads(dash.json_metadata)
-        self.assertEqual(updated_metadata["filter_scopes"], filter_scopes)
-
-        # remove a slice and change slice ids (as copy slices)
-        removed_slice = immune_slices.pop()
-        removed_component = [
-            key
-            for (key, value) in positions.items()
-            if isinstance(value, dict)
-            and value.get("type") == "CHART"
-            and value["meta"]["chartId"] == removed_slice.id
-        ]
-        positions.pop(removed_component[0], None)
-
-        data.update({"positions": positions})
-        views.Superset._set_dash_metadata(dash, data)
-        updated_metadata = json.loads(dash.json_metadata)
-        expected_filter_scopes = {
-            str(filter_slice.id): {
-                "region": {
-                    "scope": ["ROOT_ID"],
-                    "immune": [slc.id for slc in immune_slices],
-                }
-            }
-        }
-        self.assertEqual(updated_metadata["filter_scopes"], expected_filter_scopes)
-
-        # reset dash to original data
-        views.Superset._set_dash_metadata(dash, original_data)
 
     def test_add_slices(self, username="admin"):
         self.login(username=username)

--- a/tests/dashboards/dao_tests.py
+++ b/tests/dashboards/dao_tests.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file
+import copy
+import json
+
+import tests.test_app  # pylint: disable=unused-import
+from superset import db
+from superset.dashboards.dao import DashboardDAO
+from superset.models.dashboard import Dashboard
+from tests.base_tests import SupersetTestCase
+
+
+class DashboardDAOTests(SupersetTestCase):
+    def test_set_dash_metadata(self):
+        dash = db.session.query(Dashboard).filter_by(slug="world_health").first()
+        data = dash.data
+        positions = data["position_json"]
+        data.update({"positions": positions})
+        original_data = copy.deepcopy(data)
+
+        # add filter scopes
+        filter_slice = dash.slices[0]
+        immune_slices = dash.slices[2:]
+        filter_scopes = {
+            str(filter_slice.id): {
+                "region": {
+                    "scope": ["ROOT_ID"],
+                    "immune": [slc.id for slc in immune_slices],
+                }
+            }
+        }
+        data.update({"filter_scopes": json.dumps(filter_scopes)})
+        DashboardDAO.set_dash_metadata(dash, data)
+        updated_metadata = json.loads(dash.json_metadata)
+        self.assertEqual(updated_metadata["filter_scopes"], filter_scopes)
+
+        # remove a slice and change slice ids (as copy slices)
+        removed_slice = immune_slices.pop()
+        removed_component = [
+            key
+            for (key, value) in positions.items()
+            if isinstance(value, dict)
+            and value.get("type") == "CHART"
+            and value["meta"]["chartId"] == removed_slice.id
+        ]
+        positions.pop(removed_component[0], None)
+
+        data.update({"positions": positions})
+        DashboardDAO.set_dash_metadata(dash, data)
+        updated_metadata = json.loads(dash.json_metadata)
+        expected_filter_scopes = {
+            str(filter_slice.id): {
+                "region": {
+                    "scope": ["ROOT_ID"],
+                    "immune": [slc.id for slc in immune_slices],
+                }
+            }
+        }
+        self.assertEqual(updated_metadata["filter_scopes"], expected_filter_scopes)
+
+        # reset dash to original data
+        DashboardDAO.set_dash_metadata(dash, original_data)


### PR DESCRIPTION
### SUMMARY
This PR tackles some low-hanging fruit, moving some static methods out of `views/core.py` into more appropriate places and moving a related test function to a new test file. PR 1/n that will put this file into a better state. Tackling in small bits to allow for better reviews and cut down on merge conflicts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
