### PR TITLE
fix: row count container alignment

### DIFF
--- a/superset-frontend/src/components/ListView/ListViewStyles.less
+++ b/superset-frontend/src/components/ListView/ListViewStyles.less
@@ -134,8 +134,8 @@
     }
 
     .row-count-container {
-      position: absolute;
-      right: 28px;
+      float: right;
+      padding-right: 24px;
     }
   }
 


### PR DESCRIPTION
### SUMMARY
It looks like this change wasn't wasn't tested for both sides of this feature flag `LIST_VIEWS_NEW_UI` or the config `ENABLE_REACT_CRUD_VIEWS` (uncertain how these actually interact with each other)

hopefully we can reach feature parity soon so that we can all migrate to having it True, reducing the complexity of working around this

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1920" alt="Screen Shot 2020-06-26 at 3 15 29 PM" src="https://user-images.githubusercontent.com/7409244/85905297-e5303600-b7bf-11ea-99c1-de2748451daf.png">

After:
<img width="1920" alt="Screen Shot 2020-06-26 at 3 09 53 PM" src="https://user-images.githubusercontent.com/7409244/85905165-85d22600-b7bf-11ea-8c9e-9a19c5e98adc.png">

### TEST PLAN
Ensure the row count container is aligned properly

Even after following the instructions from your PR (enabling the feature flag) @nytai, I wasn't able to get the new UI to show up. Could you direct me how to test that this works with the new styling?

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @nytai @graceguo-supercat @ktmud 