### PR TITLE
fix: make time grain nullable in chart data endpoint

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -596,10 +596,12 @@ class ChartDataExtrasSchema(Schema):
             ),
         ),
         example="P1D",
+        allow_none=True,
     )
     druid_time_origin = fields.String(
         description="Starting point for time grain counting on legacy Druid "
         "datasources. Used to change e.g. Monday/Sunday first-day-of-week.",
+        allow_none=True,
     )
 
 

--- a/tests/charts/schema_tests.py
+++ b/tests/charts/schema_tests.py
@@ -17,11 +17,11 @@
 """Unit tests for Superset"""
 from typing import Any, Dict, Tuple
 
+from tests.test_app import app
 from superset.charts.schemas import ChartDataQueryContextSchema
 from superset.common.query_context import QueryContext
 from tests.base_tests import SupersetTestCase
 from tests.fixtures.query_context import get_query_context
-from tests.test_app import app
 
 
 def load_query_context(payload: Dict[str, Any]) -> Tuple[QueryContext, Dict[str, Any]]:
@@ -59,3 +59,13 @@ class SchemaTestCase(SupersetTestCase):
         query_context, errors = ChartDataQueryContextSchema().load(payload)
         self.assertIn("row_limit", errors["queries"][0])
         self.assertIn("row_offset", errors["queries"][0])
+
+    def test_query_context_null_timegrain(self):
+        self.login(username="admin")
+        table_name = "birth_names"
+        table = self.get_table_by_name(table_name)
+        payload = get_query_context(table.name, table.id, table.type)
+
+        payload["queries"][0]["extras"]["time_grain_sqla"] = None
+        _, errors = ChartDataQueryContextSchema().load(payload)
+        self.assertEqual(errors, {})

--- a/tests/charts/schema_tests.py
+++ b/tests/charts/schema_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 """Unit tests for Superset"""
 from typing import Any, Dict, Tuple
 


### PR DESCRIPTION
### SUMMARY
Currently the chart data endpoint errors out if called with a `NULL` time grain. This makes it nullable to properly support time series charts.

### TEST PLAN
CI + new test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
