### PR TITLE
fix: update to last pyathena >= 1.10.8, to fix athena CSV upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
         "wtforms-json",
     ],
     extras_require={
+        "athena": ["pyathena>=1.10.8,<1.11"],
         "bigquery": ["pybigquery>=0.4.10", "pandas_gbq>=0.10.0"],
         "cors": ["flask-cors>=2.0.0"],
         "gsheets": ["gsheetsdb>=0.1.9"],


### PR DESCRIPTION
### SUMMARY

It was not possible to upload CSV into Athena. (TEXT type error)

was related to PyAthena https://github.com/laughingman7743/PyAthena/issues/146
issue is closed in PyAthnea >= 1.10.8

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
![image](https://user-images.githubusercontent.com/4283686/86011023-7865a780-ba1c-11ea-97ca-4ebe03eed307.png)

AFTER
![image](https://user-images.githubusercontent.com/4283686/86010985-6dab1280-ba1c-11ea-9ef7-1813c4c0851a.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
import a csv into aws Athena if import is ok **without any error** it's ok.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/10054
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
