### PR TITLE
feat: add configuration for Presto cursor poll interval

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -51,6 +51,9 @@ QueryStatus = utils.QueryStatus
 config = app.config
 logger = logging.getLogger(__name__)
 
+# See here: https://github.com/dropbox/PyHive/blob/8eb0aeab8ca300f3024655419b93dad926c1a351/pyhive/presto.py#L93  # pylint: disable=line-too-long
+DEFAULT_PYHIVE_POLL_INTERVAL = 1
+
 
 def get_children(column: Dict[str, str]) -> List[Dict[str, str]]:
     """
@@ -729,6 +732,9 @@ class PrestoEngineSpec(BaseEngineSpec):
     def handle_cursor(cls, cursor: Any, query: Query, session: Session) -> None:
         """Updates progress information"""
         query_id = query.id
+        poll_interval = query.database.connect_args.get(
+            "poll_interval", DEFAULT_PYHIVE_POLL_INTERVAL
+        )
         logger.info("Query %i: Polling the cursor for progress", query_id)
         polled = cursor.poll()
         # poll returns dict -- JSON status information or ``None``
@@ -762,7 +768,7 @@ class PrestoEngineSpec(BaseEngineSpec):
                     if progress > query.progress:
                         query.progress = progress
                     session.commit()
-            time.sleep(1)
+            time.sleep(poll_interval)
             logger.info("Query %i: Polling the cursor for progress", query_id)
             polled = cursor.poll()
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -244,6 +244,10 @@ class Database(
     def default_schemas(self) -> List[str]:
         return self.get_extra().get("default_schemas", [])
 
+    @property
+    def connect_args(self) -> Dict[str, Any]:
+        return self.get_extra().get("engine_params", {}).get("connect_args", {})
+
     @classmethod
     def get_password_masked_url_from_uri(  # pylint: disable=invalid-name
         cls, uri: str


### PR DESCRIPTION
### SUMMARY
Uses the poll interval defined in the database's `connect_args` (if there) to set the polling interval for Presto's cursor. This will align the polling between Superset and PyHive, hopefully resulting in less downtime on shorter/synchronous queries (if the admin chooses)

### TEST PLAN
CI, unfortunately this is pretty hard to write a unit test for :/

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #10139
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @john-bodley @villebro @bkyryliuk @tooptoop4 