### PR TITLE
chore: s/assertEqual/assertEquals

### DIFF
--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -129,15 +129,15 @@ class ConfigTests(SupersetTestCase):
         self.createTable(table_defaults)
         id_col = [c for c in self._logs_table.columns if c.column_name == "id"][0]
         self.assertTrue(id_col.is_dttm)
-        self.assertEquals(id_col.python_date_format, "epoch_ms")
+        self.assertEqual(id_col.python_date_format, "epoch_ms")
         dttm_col = [c for c in self._logs_table.columns if c.column_name == "dttm"][0]
         self.assertTrue(dttm_col.is_dttm)
-        self.assertEquals(dttm_col.python_date_format, "epoch_s")
+        self.assertEqual(dttm_col.python_date_format, "epoch_s")
         dms_col = [
             c for c in self._logs_table.columns if c.column_name == "duration_ms"
         ][0]
         self.assertTrue(dms_col.is_dttm)
-        self.assertEquals(dms_col.python_date_format, "invalid")
+        self.assertEqual(dms_col.python_date_format, "invalid")
 
     def test_expression_by_column_name(self):
         table_defaults = {
@@ -163,12 +163,12 @@ class ConfigTests(SupersetTestCase):
 
         id_col = [c for c in self._logs_table.columns if c.column_name == "id"][0]
         self.assertTrue(id_col.is_dttm)
-        self.assertEquals(id_col.python_date_format, "epoch_ms")
+        self.assertEqual(id_col.python_date_format, "epoch_ms")
         self.assertIsNone(id_col.expression)
 
         dttm_col = [c for c in self._logs_table.columns if c.column_name == "dttm"][0]
         self.assertTrue(dttm_col.is_dttm)
-        self.assertEquals(dttm_col.python_date_format, "epoch_s")
+        self.assertEqual(dttm_col.python_date_format, "epoch_s")
         self.assertEqual(dttm_col.expression, "CAST(dttm as INTEGER)")
 
 

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -137,7 +137,7 @@ class CoreTests(SupersetTestCase):
 
         qobj["inner_from_dttm"] = datetime.datetime(1901, 1, 1)
 
-        self.assertEquals(cache_key_with_groupby, viz.cache_key(qobj))
+        self.assertEqual(cache_key_with_groupby, viz.cache_key(qobj))
 
     def test_get_superset_tables_not_allowed(self):
         example_db = utils.get_example_database()

--- a/tests/datasource_tests.py
+++ b/tests/datasource_tests.py
@@ -84,11 +84,11 @@ class DatasourceTests(SupersetTestCase):
 
         datasource_post["database"]["id"] = new_db.id
         resp = self.save_datasource_from_dict(datasource_post)
-        self.assertEquals(resp["database"]["id"], new_db.id)
+        self.assertEqual(resp["database"]["id"], new_db.id)
 
         datasource_post["database"]["id"] = db_id
         resp = self.save_datasource_from_dict(datasource_post)
-        self.assertEquals(resp["database"]["id"], db_id)
+        self.assertEqual(resp["database"]["id"], db_id)
 
         self.delete_fake_db()
 

--- a/tests/jinja_context_tests.py
+++ b/tests/jinja_context_tests.py
@@ -25,11 +25,11 @@ from tests.base_tests import SupersetTestCase
 class Jinja2ContextTests(SupersetTestCase):
     def test_filter_values_default(self) -> None:
         with app.test_request_context():
-            self.assertEquals(filter_values("name", "foo"), ["foo"])
+            self.assertEqual(filter_values("name", "foo"), ["foo"])
 
     def test_filter_values_no_default(self) -> None:
         with app.test_request_context():
-            self.assertEquals(filter_values("name"), [])
+            self.assertEqual(filter_values("name"), [])
 
     def test_filter_values_adhoc_filters(self) -> None:
         with app.test_request_context(
@@ -49,7 +49,7 @@ class Jinja2ContextTests(SupersetTestCase):
                 )
             }
         ):
-            self.assertEquals(filter_values("name"), ["foo"])
+            self.assertEqual(filter_values("name"), ["foo"])
 
         with app.test_request_context(
             data={
@@ -68,7 +68,7 @@ class Jinja2ContextTests(SupersetTestCase):
                 )
             }
         ):
-            self.assertEquals(filter_values("name"), ["foo", "bar"])
+            self.assertEqual(filter_values("name"), ["foo", "bar"])
 
     def test_filter_values_extra_filters(self) -> None:
         with app.test_request_context(
@@ -78,22 +78,22 @@ class Jinja2ContextTests(SupersetTestCase):
                 )
             }
         ):
-            self.assertEquals(filter_values("name"), ["foo"])
+            self.assertEqual(filter_values("name"), ["foo"])
 
     def test_url_param_default(self) -> None:
         with app.test_request_context():
-            self.assertEquals(ExtraCache().url_param("foo", "bar"), "bar")
+            self.assertEqual(ExtraCache().url_param("foo", "bar"), "bar")
 
     def test_url_param_no_default(self) -> None:
         with app.test_request_context():
-            self.assertEquals(ExtraCache().url_param("foo"), None)
+            self.assertEqual(ExtraCache().url_param("foo"), None)
 
     def test_url_param_query(self) -> None:
         with app.test_request_context(query_string={"foo": "bar"}):
-            self.assertEquals(ExtraCache().url_param("foo"), "bar")
+            self.assertEqual(ExtraCache().url_param("foo"), "bar")
 
     def test_url_param_form_data(self) -> None:
         with app.test_request_context(
             query_string={"form_data": json.dumps({"url_params": {"foo": "bar"}})}
         ):
-            self.assertEquals(ExtraCache().url_param("foo"), "bar")
+            self.assertEqual(ExtraCache().url_param("foo"), "bar")

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -329,6 +329,6 @@ class SqlaTableModelTestCase(SupersetTestCase):
         )
 
         data_for_slices = tbl.data_for_slices([slc])
-        self.assertEquals(len(data_for_slices["columns"]), 0)
-        self.assertEquals(len(data_for_slices["metrics"]), 1)
-        self.assertEquals(len(data_for_slices["verbose_map"].keys()), 2)
+        self.assertEqual(len(data_for_slices["columns"]), 0)
+        self.assertEqual(len(data_for_slices["metrics"]), 1)
+        self.assertEqual(len(data_for_slices["verbose_map"].keys()), 2)

--- a/tests/query_context_tests.py
+++ b/tests/query_context_tests.py
@@ -115,7 +115,7 @@ class QueryContextTests(SupersetTestCase):
         extras = query_object.to_dict()["extras"]
         self.assertTrue("time_range_endpoints" in extras)
 
-        self.assertEquals(
+        self.assertEqual(
             extras["time_range_endpoints"],
             (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.EXCLUSIVE),
         )

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -130,7 +130,7 @@ class RolePermissionTests(SupersetTestCase):
         stored_table = (
             session.query(SqlaTable).filter_by(table_name="tmp_perm_table").one()
         )
-        self.assertEquals(
+        self.assertEqual(
             stored_table.perm, f"[examples].[tmp_perm_table](id:{stored_table.id})"
         )
         self.assertIsNotNone(
@@ -138,7 +138,7 @@ class RolePermissionTests(SupersetTestCase):
                 "datasource_access", stored_table.perm
             )
         )
-        self.assertEquals(stored_table.schema_perm, "[examples].[tmp_schema]")
+        self.assertEqual(stored_table.schema_perm, "[examples].[tmp_schema]")
         self.assertIsNotNone(
             security_manager.find_permission_view_menu(
                 "schema_access", stored_table.schema_perm
@@ -151,7 +151,7 @@ class RolePermissionTests(SupersetTestCase):
         stored_table = (
             session.query(SqlaTable).filter_by(table_name="tmp_perm_table_v2").one()
         )
-        self.assertEquals(
+        self.assertEqual(
             stored_table.perm, f"[examples].[tmp_perm_table_v2](id:{stored_table.id})"
         )
         self.assertIsNotNone(
@@ -160,7 +160,7 @@ class RolePermissionTests(SupersetTestCase):
             )
         )
         # no changes in schema
-        self.assertEquals(stored_table.schema_perm, "[examples].[tmp_schema]")
+        self.assertEqual(stored_table.schema_perm, "[examples].[tmp_schema]")
         self.assertIsNotNone(
             security_manager.find_permission_view_menu(
                 "schema_access", stored_table.schema_perm
@@ -173,7 +173,7 @@ class RolePermissionTests(SupersetTestCase):
         stored_table = (
             session.query(SqlaTable).filter_by(table_name="tmp_perm_table_v2").one()
         )
-        self.assertEquals(
+        self.assertEqual(
             stored_table.perm, f"[examples].[tmp_perm_table_v2](id:{stored_table.id})"
         )
         self.assertIsNotNone(
@@ -182,7 +182,7 @@ class RolePermissionTests(SupersetTestCase):
             )
         )
         # no changes in schema
-        self.assertEquals(stored_table.schema_perm, "[examples].[tmp_schema_v2]")
+        self.assertEqual(stored_table.schema_perm, "[examples].[tmp_schema_v2]")
         self.assertIsNotNone(
             security_manager.find_permission_view_menu(
                 "schema_access", stored_table.schema_perm
@@ -199,7 +199,7 @@ class RolePermissionTests(SupersetTestCase):
         stored_table = (
             session.query(SqlaTable).filter_by(table_name="tmp_perm_table_v2").one()
         )
-        self.assertEquals(
+        self.assertEqual(
             stored_table.perm, f"[tmp_db].[tmp_perm_table_v2](id:{stored_table.id})"
         )
         self.assertIsNotNone(
@@ -208,7 +208,7 @@ class RolePermissionTests(SupersetTestCase):
             )
         )
         # no changes in schema
-        self.assertEquals(stored_table.schema_perm, "[tmp_db].[tmp_schema_v2]")
+        self.assertEqual(stored_table.schema_perm, "[tmp_db].[tmp_schema_v2]")
         self.assertIsNotNone(
             security_manager.find_permission_view_menu(
                 "schema_access", stored_table.schema_perm
@@ -221,7 +221,7 @@ class RolePermissionTests(SupersetTestCase):
         stored_table = (
             session.query(SqlaTable).filter_by(table_name="tmp_perm_table_v2").one()
         )
-        self.assertEquals(
+        self.assertEqual(
             stored_table.perm, f"[tmp_db].[tmp_perm_table_v2](id:{stored_table.id})"
         )
         self.assertIsNotNone(
@@ -254,7 +254,7 @@ class RolePermissionTests(SupersetTestCase):
             .filter_by(datasource_name="tmp_datasource")
             .one()
         )
-        self.assertEquals(
+        self.assertEqual(
             stored_datasource.perm,
             f"[druid_test].[tmp_datasource](id:{stored_datasource.id})",
         )
@@ -268,7 +268,7 @@ class RolePermissionTests(SupersetTestCase):
         # store with a schema
         stored_datasource.datasource_name = "tmp_schema.tmp_datasource"
         session.commit()
-        self.assertEquals(
+        self.assertEqual(
             stored_datasource.perm,
             f"[druid_test].[tmp_schema.tmp_datasource](id:{stored_datasource.id})",
         )
@@ -297,7 +297,7 @@ class RolePermissionTests(SupersetTestCase):
             .filter_by(cluster_name="tmp_druid_cluster")
             .one()
         )
-        self.assertEquals(
+        self.assertEqual(
             stored_cluster.perm, f"[tmp_druid_cluster].(id:{stored_cluster.id})"
         )
         self.assertIsNotNone(
@@ -308,7 +308,7 @@ class RolePermissionTests(SupersetTestCase):
 
         stored_cluster.cluster_name = "tmp_druid_cluster2"
         session.commit()
-        self.assertEquals(
+        self.assertEqual(
             stored_cluster.perm, f"[tmp_druid_cluster2].(id:{stored_cluster.id})"
         )
         self.assertIsNotNone(
@@ -330,7 +330,7 @@ class RolePermissionTests(SupersetTestCase):
         stored_db = (
             session.query(Database).filter_by(database_name="tmp_database").one()
         )
-        self.assertEquals(stored_db.perm, f"[tmp_database].(id:{stored_db.id})")
+        self.assertEqual(stored_db.perm, f"[tmp_database].(id:{stored_db.id})")
         self.assertIsNotNone(
             security_manager.find_permission_view_menu(
                 "database_access", stored_db.perm
@@ -342,7 +342,7 @@ class RolePermissionTests(SupersetTestCase):
         stored_db = (
             session.query(Database).filter_by(database_name="tmp_database2").one()
         )
-        self.assertEquals(stored_db.perm, f"[tmp_database2].(id:{stored_db.id})")
+        self.assertEqual(stored_db.perm, f"[tmp_database2].(id:{stored_db.id})")
         self.assertIsNotNone(
             security_manager.find_permission_view_menu(
                 "database_access", stored_db.perm
@@ -368,9 +368,9 @@ class RolePermissionTests(SupersetTestCase):
             .one()
         )
 
-        self.assertEquals(record.get_perm(), record.perm)
-        self.assertEquals(record.id, id_)
-        self.assertEquals(record.cluster_name, "tmp_druid_cluster3")
+        self.assertEqual(record.get_perm(), record.perm)
+        self.assertEqual(record.id, id_)
+        self.assertEqual(record.cluster_name, "tmp_druid_cluster3")
         db.session.delete(cluster)
         db.session.commit()
 
@@ -393,9 +393,9 @@ class RolePermissionTests(SupersetTestCase):
             .one()
         )
 
-        self.assertEquals(record.get_perm(), record.perm)
-        self.assertEquals(record.id, id_)
-        self.assertEquals(record.database_name, "tmp_database3")
+        self.assertEqual(record.get_perm(), record.perm)
+        self.assertEqual(record.id, id_)
+        self.assertEqual(record.database_name, "tmp_database3")
         db.session.delete(database)
         db.session.commit()
 
@@ -420,9 +420,9 @@ class RolePermissionTests(SupersetTestCase):
         session.commit()
 
         slice = session.query(Slice).filter_by(slice_name="slice_name").one()
-        self.assertEquals(slice.perm, table.perm)
-        self.assertEquals(slice.perm, f"[tmp_database].[tmp_perm_table](id:{table.id})")
-        self.assertEquals(slice.schema_perm, table.schema_perm)
+        self.assertEqual(slice.perm, table.perm)
+        self.assertEqual(slice.perm, f"[tmp_database].[tmp_perm_table](id:{table.id})")
+        self.assertEqual(slice.schema_perm, table.schema_perm)
         self.assertIsNone(slice.schema_perm)
 
         table.schema = "tmp_perm_schema"
@@ -430,8 +430,8 @@ class RolePermissionTests(SupersetTestCase):
         session.commit()
         # TODO(bogdan): modify slice permissions on the table update.
         self.assertNotEquals(slice.perm, table.perm)
-        self.assertEquals(slice.perm, f"[tmp_database].[tmp_perm_table](id:{table.id})")
-        self.assertEquals(
+        self.assertEqual(slice.perm, f"[tmp_database].[tmp_perm_table](id:{table.id})")
+        self.assertEqual(
             table.perm, f"[tmp_database].[tmp_perm_table_v2](id:{table.id})"
         )
         # TODO(bogdan): modify slice schema permissions on the table update.
@@ -441,12 +441,12 @@ class RolePermissionTests(SupersetTestCase):
         # updating slice refreshes the permissions
         slice.slice_name = "slice_name_v2"
         session.commit()
-        self.assertEquals(slice.perm, table.perm)
-        self.assertEquals(
+        self.assertEqual(slice.perm, table.perm)
+        self.assertEqual(
             slice.perm, f"[tmp_database].[tmp_perm_table_v2](id:{table.id})"
         )
-        self.assertEquals(slice.schema_perm, table.schema_perm)
-        self.assertEquals(slice.schema_perm, "[tmp_database].[tmp_perm_schema]")
+        self.assertEqual(slice.schema_perm, table.schema_perm)
+        self.assertEqual(slice.schema_perm, "[tmp_database].[tmp_perm_schema]")
 
         session.delete(slice)
         session.delete(table)
@@ -464,7 +464,7 @@ class RolePermissionTests(SupersetTestCase):
             schemas = security_manager.get_schemas_accessible_by_user(
                 database, ["1", "2", "3"]
             )
-            self.assertEquals(schemas, ["1", "2", "3"])  # no changes
+            self.assertEqual(schemas, ["1", "2", "3"])  # no changes
 
     @patch("superset.security.manager.g")
     def test_schemas_accessible_by_user_schema_access(self, mock_g):
@@ -477,7 +477,7 @@ class RolePermissionTests(SupersetTestCase):
                 database, ["1", "2", "3"]
             )
             # temp_schema is not passed in the params
-            self.assertEquals(schemas, ["1"])
+            self.assertEqual(schemas, ["1"])
         delete_schema_perm("[examples].[1]")
 
     @patch("superset.security.manager.g")
@@ -489,7 +489,7 @@ class RolePermissionTests(SupersetTestCase):
             schemas = security_manager.get_schemas_accessible_by_user(
                 database, ["temp_schema", "2", "3"]
             )
-            self.assertEquals(schemas, ["temp_schema"])
+            self.assertEqual(schemas, ["temp_schema"])
 
     @patch("superset.security.manager.g")
     def test_schemas_accessible_by_user_datasource_and_schema_access(self, mock_g):
@@ -501,7 +501,7 @@ class RolePermissionTests(SupersetTestCase):
             schemas = security_manager.get_schemas_accessible_by_user(
                 database, ["temp_schema", "2", "3"]
             )
-            self.assertEquals(schemas, ["temp_schema", "2"])
+            self.assertEqual(schemas, ["temp_schema", "2"])
         vm = security_manager.find_permission_view_menu(
             "schema_access", "[examples].[2]"
         )
@@ -549,7 +549,7 @@ class RolePermissionTests(SupersetTestCase):
         NEW_FLASK_GET_SQL_DBS_REQUEST = f"/api/v1/database/?q={prison.dumps(arguments)}"
         self.login(username="gamma")
         databases_json = self.client.get(NEW_FLASK_GET_SQL_DBS_REQUEST).json
-        self.assertEquals(databases_json["count"], 1)
+        self.assertEqual(databases_json["count"], 1)
         self.logout()
 
     def assert_can_read(self, view_menu, permissions_set):

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -555,7 +555,7 @@ class UtilsTestCase(SupersetTestCase):
         merge_request_params(form_data, url_params)
         self.assertIn("url_params", form_data.keys())
         self.assertIn("abc", form_data["url_params"])
-        self.assertEquals(
+        self.assertEqual(
             url_params["dashboard_ids"], form_data["url_params"]["dashboard_ids"]
         )
 


### PR DESCRIPTION
Cleanup assertEquals usage.

Example warning message:
```
tests/config_tests.py::TestConfig::test_python_date_format_by_column_name
  /Users/bogdankyryliuk/src/oss/incubator-superset/tests/config_tests.py:129: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(id_col.python_date_format, "epoch_ms")
```