### PR TITLE
fix: datatable dependencies for pivot-table in dev

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -225,6 +225,10 @@ const config = {
     noParse: /(mapbox-gl)\.js$/,
     rules: [
       {
+        test: /datatables\.net.*/,
+        loader: 'imports-loader?define=>false',
+      },
+      {
         test: /\.tsx?$/,
         use: [
           'thread-loader',


### PR DESCRIPTION
### SUMMARY

#10113 removed `jquer.DataTables` and the webpack hack to make it work for dev servers (`npm run dev`). But it is still used by the Pivot Table chart.

This will throw a "can't access $ of undefined" error in a clean build.

This should have been catched by Cypress tests for visualizations, but they were not turned on.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![image](https://user-images.githubusercontent.com/335541/86161354-fe87f980-bac1-11ea-854a-ad8922efde7e.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #10113 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
