### PR TITLE
feat: support nulls in the csv uploads

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 [pytest]
-addopts = -ra -q
 testpaths =
     tests
 python_files = *_test.py test_*.py *_tests.py

--- a/superset/config.py
+++ b/superset/config.py
@@ -35,6 +35,7 @@ from celery.schedules import crontab
 from dateutil import tz
 from flask import Blueprint
 from flask_appbuilder.security.manager import AUTH_DB
+from pandas.io.parsers import STR_NA_VALUES
 
 from superset.jinja_context import (  # pylint: disable=unused-import
     BaseTemplateProcessor,
@@ -621,6 +622,9 @@ ALLOWED_USER_CSV_SCHEMA_FUNC: Callable[
 ] = lambda database, user: [
     UPLOADED_CSV_HIVE_NAMESPACE
 ] if UPLOADED_CSV_HIVE_NAMESPACE else []
+
+# Values that should be treated as nulls for the csv uploads.
+CSV_DEFAULT_NA_NAMES = list(STR_NA_VALUES)
 
 # A dictionary of items that gets merged into the Jinja context for
 # SQL Lab. The existing context gets updated with this dictionary,

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -107,29 +107,43 @@ class HiveEngineSpec(PrestoEngineSpec):
             return []
 
     @classmethod
-    def get_create_table_stmt(
+    def get_create_table_stmt(  # pylint: disable=too-many-arguments
         cls,
         table: Table,
         schema_definition: str,
-        header_line_count: int,
+        location: str,
+        delim: str,
+        header_line_count: Optional[int],
         null_values: Optional[List[str]],
     ) -> text:
         tblproperties = []
         # available options:
         # https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL
-        if header_line_count > 0:
-            tblproperties.append(f"'skip.header.line.count'='{header_line_count}'")
+        # TODO(bkyryliuk): figure out what to do with the skip rows field.
+        params: Dict[str, str] = {
+            "delim": delim,
+            "location": location,
+        }
+        if header_line_count is not None and header_line_count >= 0:
+            header_line_count += 1
+            tblproperties.append("'skip.header.line.count'=':header_line_count'")
+            params["header_line_count"] = str(header_line_count)
         if null_values:
             # hive only supports 1 value for the null format
-            tblproperties.append(f"'serialization.null.format'='{null_values[0]}'")
-        tblproperties_stmt = ""
+            tblproperties.append("'serialization.null.format'=':null_value'")
+            params["null_value"] = null_values[0]
+
         if tblproperties:
             tblproperties_stmt = f"tblproperties ({', '.join(tblproperties)})"
-
-        return f"""CREATE TABLE {str(table)} ( {schema_definition} )
-            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
-            STORED AS TEXTFILE LOCATION :location
-            {tblproperties_stmt}""".strip()
+            sql = f"""CREATE TABLE {str(table)} ( {schema_definition} )
+                ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+                STORED AS TEXTFILE LOCATION :location
+                {tblproperties_stmt}"""
+        else:
+            sql = f"""CREATE TABLE {str(table)} ( {schema_definition} )
+                ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+                STORED AS TEXTFILE LOCATION :location"""
+        return sql, params
 
     @classmethod
     def create_table_from_csv(  # pylint: disable=too-many-arguments, too-many-locals
@@ -208,20 +222,16 @@ class HiveEngineSpec(PrestoEngineSpec):
             os.path.join(upload_prefix, table.table, os.path.basename(filename)),
         )
 
-        sql = text(
-            cls.get_create_table_stmt(
-                table,
-                schema_definition,
-                int(csv_to_df_kwargs.get("header", 0)),
-                csv_to_df_kwargs.get("na_values"),
-            )
+        sql, params = cls.get_create_table_stmt(
+            table,
+            schema_definition,
+            location,
+            csv_to_df_kwargs["sep"].encode().decode("unicode_escape"),
+            int(csv_to_df_kwargs.get("header", 0)),
+            csv_to_df_kwargs.get("na_values"),
         )
         engine = cls.get_engine(database)
-        engine.execute(
-            sql,
-            delim=csv_to_df_kwargs["sep"].encode().decode("unicode_escape"),
-            location=location,
-        )
+        engine.execute(text(sql), **params)
 
     @classmethod
     def convert_dttm(cls, target_type: str, dttm: datetime) -> Optional[str]:

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -15,10 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 """Contains the logic to create cohesive forms on the explore view"""
+import json
 from typing import Any, List, Optional
 
 from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
 from wtforms import Field
+
+
+class JsonListField(Field):
+    widget = BS3TextFieldWidget()
+    data: List[str] = []
+
+    def _value(self) -> str:
+        return json.dumps(self.data)
+
+    def process_formdata(self, valuelist: List[str]) -> None:
+        if valuelist and valuelist[0]:
+            self.data = json.loads(valuelist[0])
+        else:
+            self.data = []
 
 
 class CommaSeparatedListField(Field):

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -26,7 +26,11 @@ from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms.validators import DataRequired, Length, NumberRange, Optional
 
 from superset import app, db, security_manager
-from superset.forms import CommaSeparatedListField, filter_not_empty_values
+from superset.forms import (
+    CommaSeparatedListField,
+    filter_not_empty_values,
+    JsonListField,
+)
 from superset.models.core import Database
 
 config = app.config
@@ -210,6 +214,16 @@ class CsvToDatabaseForm(DynamicForm):
         validators=[Optional()],
         widget=BS3TextFieldWidget(),
     )
+    null_values = JsonListField(
+        _("Null values"),
+        default=config["CSV_DEFAULT_NA_NAMES"],
+        description=_(
+            "Json list of the values that should be treated as null. "
+            'Examples: [""], ["None", "N/A"], ["nan", "null"]. '
+            "Warning: Hive database supports only single value. "
+            'Use [""] for empty string.'
+        ),
+    )
 
 
 class ExcelToDatabaseForm(DynamicForm):
@@ -375,4 +389,14 @@ class ExcelToDatabaseForm(DynamicForm):
         ),
         validators=[Optional()],
         widget=BS3TextFieldWidget(),
+    )
+    null_values = JsonListField(
+        _("Null values"),
+        default=config["CSV_DEFAULT_NA_NAMES"],
+        description=_(
+            "Json list of the values that should be treated as null. "
+            'Examples: [""], ["None", "N/A"], ["nan", "null"]. '
+            "Warning: Hive database supports only single value. "
+            'Use [""] for empty string.'
+        ),
     )

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -149,6 +149,9 @@ class CsvToDatabaseView(SimpleFormView):
             database = (
                 db.session.query(models.Database).filter_by(id=con.data.get("id")).one()
             )
+
+            # More can be found here:
+            # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
             csv_to_df_kwargs = {
                 "sep": form.sep.data,
                 "header": form.header.data if form.header.data else 0,
@@ -162,6 +165,12 @@ class CsvToDatabaseView(SimpleFormView):
                 "infer_datetime_format": form.infer_datetime_format.data,
                 "chunksize": 1000,
             }
+            if form.null_values.data:
+                csv_to_df_kwargs["na_values"] = form.null_values.data
+                csv_to_df_kwargs["keep_default_na"] = False
+
+            # More can be found here:
+            # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html
             df_to_sql_kwargs = {
                 "name": csv_table.table,
                 "if_exists": form.if_exists.data,

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -27,8 +27,8 @@ from flask_appbuilder.security.sqla import models as ab_models
 from flask_testing import TestCase
 from sqlalchemy.orm import Session
 
+from tests.test_app import app
 from superset.sql_parse import CtasMethod
-from tests.test_app import app  # isort:skip
 from superset import db, security_manager
 from superset.connectors.base.models import BaseDatasource
 from superset.connectors.druid.models import DruidCluster, DruidDatasource

--- a/tests/db_engine_specs/base_tests.py
+++ b/tests/db_engine_specs/base_tests.py
@@ -14,13 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
 from datetime import datetime
 
+from tests.test_app import app
+from tests.base_tests import SupersetTestCase
 from superset.db_engine_specs.mysql import MySQLEngineSpec
 from superset.models.core import Database
-from tests.base_tests import SupersetTestCase
-
-from tests.test_app import app  # isort:skip
 
 
 class TestDbEngineSpec(SupersetTestCase):

--- a/tests/db_engine_specs/hive_tests.py
+++ b/tests/db_engine_specs/hive_tests.py
@@ -14,164 +14,189 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# isort:skip_file
+from datetime import datetime
 from unittest import mock
 
+import pytest
+
+from tests.test_app import app
 from superset.db_engine_specs.hive import HiveEngineSpec
 from superset.exceptions import SupersetException
 from superset.sql_parse import Table
-from tests.db_engine_specs.base_tests import TestDbEngineSpec
 
 
-class TestHiveDbEngineSpec(TestDbEngineSpec):
-    def test_0_progress(self):
-        log = """
-            17/02/07 18:26:27 INFO log.PerfLogger: <PERFLOG method=compile from=org.apache.hadoop.hive.ql.Driver>
-            17/02/07 18:26:27 INFO log.PerfLogger: <PERFLOG method=parse from=org.apache.hadoop.hive.ql.Driver>
-        """.split(
-            "\n"
-        )
-        self.assertEqual(0, HiveEngineSpec.progress(log))
+def test_0_progress():
+    log = """
+        17/02/07 18:26:27 INFO log.PerfLogger: <PERFLOG method=compile from=org.apache.hadoop.hive.ql.Driver>
+        17/02/07 18:26:27 INFO log.PerfLogger: <PERFLOG method=parse from=org.apache.hadoop.hive.ql.Driver>
+    """.split(
+        "\n"
+    )
+    assert HiveEngineSpec.progress(log) == 0
 
-    def test_number_of_jobs_progress(self):
-        log = """
-            17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
-        """.split(
-            "\n"
-        )
-        self.assertEqual(0, HiveEngineSpec.progress(log))
 
-    def test_job_1_launched_progress(self):
-        log = """
-            17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
-            17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
-        """.split(
-            "\n"
-        )
-        self.assertEqual(0, HiveEngineSpec.progress(log))
+def test_number_of_jobs_progress():
+    log = """
+        17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
+    """.split(
+        "\n"
+    )
+    assert HiveEngineSpec.progress(log) == 0
 
-    def test_job_1_launched_stage_1(self):
-        log = """
-            17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
-            17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
-        """.split(
-            "\n"
-        )
-        self.assertEqual(0, HiveEngineSpec.progress(log))
 
-    def test_job_1_launched_stage_1_map_40_progress(
-        self,
-    ):  # pylint: disable=invalid-name
-        log = """
-            17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
-            17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
-        """.split(
-            "\n"
-        )
-        self.assertEqual(10, HiveEngineSpec.progress(log))
+def test_job_1_launched_progress():
+    log = """
+        17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
+        17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
+    """.split(
+        "\n"
+    )
+    assert HiveEngineSpec.progress(log) == 0
 
-    def test_job_1_launched_stage_1_map_80_reduce_40_progress(
-        self,
-    ):  # pylint: disable=invalid-name
-        log = """
-            17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
-            17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 80%,  reduce = 40%
-        """.split(
-            "\n"
-        )
-        self.assertEqual(30, HiveEngineSpec.progress(log))
 
-    def test_job_1_launched_stage_2_stages_progress(
-        self,
-    ):  # pylint: disable=invalid-name
-        log = """
-            17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
-            17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 80%,  reduce = 40%
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-2 map = 0%,  reduce = 0%
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 100%,  reduce = 0%
-        """.split(
-            "\n"
-        )
-        self.assertEqual(12, HiveEngineSpec.progress(log))
+def test_job_1_launched_stage_1():
+    log = """
+        17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
+        17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
+    """.split(
+        "\n"
+    )
+    assert HiveEngineSpec.progress(log) == 0
 
-    def test_job_2_launched_stage_2_stages_progress(
-        self,
-    ):  # pylint: disable=invalid-name
-        log = """
-            17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
-            17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 100%,  reduce = 0%
-            17/02/07 19:15:55 INFO ql.Driver: Launching Job 2 out of 2
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
-            17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
-        """.split(
-            "\n"
-        )
-        self.assertEqual(60, HiveEngineSpec.progress(log))
 
-    def test_hive_error_msg(self):
-        msg = (
-            '{...} errorMessage="Error while compiling statement: FAILED: '
-            "SemanticException [Error 10001]: Line 4"
-            ":5 Table not found 'fact_ridesfdslakj'\", statusCode=3, "
-            "sqlState='42S02', errorCode=10001)){...}"
-        )
-        self.assertEqual(
-            (
-                "hive error: Error while compiling statement: FAILED: "
-                "SemanticException [Error 10001]: Line 4:5 "
-                "Table not found 'fact_ridesfdslakj'"
-            ),
-            HiveEngineSpec.extract_error_message(Exception(msg)),
-        )
+def test_job_1_launched_stage_1_map_40_progress():  # pylint: disable=invalid-name
+    log = """
+        17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
+        17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
+    """.split(
+        "\n"
+    )
+    assert HiveEngineSpec.progress(log) == 10
 
-        e = Exception("Some string that doesn't match the regex")
-        self.assertEqual(f"hive error: {e}", HiveEngineSpec.extract_error_message(e))
 
-        msg = (
-            "errorCode=10001, "
-            'errorMessage="Error while compiling statement"), operationHandle'
-            '=None)"'
-        )
-        self.assertEqual(
-            ("hive error: Error while compiling statement"),
-            HiveEngineSpec.extract_error_message(Exception(msg)),
-        )
+def test_job_1_launched_stage_1_map_80_reduce_40_progress():  # pylint: disable=invalid-name
+    log = """
+        17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
+        17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 80%,  reduce = 40%
+    """.split(
+        "\n"
+    )
+    assert HiveEngineSpec.progress(log) == 30
 
-    def test_hive_get_view_names_return_empty_list(
-        self,
-    ):  # pylint: disable=invalid-name
-        self.assertEqual(
-            [], HiveEngineSpec.get_view_names(mock.ANY, mock.ANY, mock.ANY)
-        )
 
-    def test_convert_dttm(self):
-        dttm = self.get_dttm()
+def test_job_1_launched_stage_2_stages_progress():  # pylint: disable=invalid-name
+    log = """
+        17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
+        17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 80%,  reduce = 40%
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-2 map = 0%,  reduce = 0%
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 100%,  reduce = 0%
+    """.split(
+        "\n"
+    )
+    assert HiveEngineSpec.progress(log) == 12
 
-        self.assertEqual(
-            HiveEngineSpec.convert_dttm("DATE", dttm), "CAST('2019-01-02' AS DATE)"
-        )
 
-        self.assertEqual(
-            HiveEngineSpec.convert_dttm("TIMESTAMP", dttm),
-            "CAST('2019-01-02 03:04:05.678900' AS TIMESTAMP)",
+def test_job_2_launched_stage_2_stages_progress():  # pylint: disable=invalid-name
+    log = """
+        17/02/07 19:15:55 INFO ql.Driver: Total jobs = 2
+        17/02/07 19:15:55 INFO ql.Driver: Launching Job 1 out of 2
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 100%,  reduce = 0%
+        17/02/07 19:15:55 INFO ql.Driver: Launching Job 2 out of 2
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 0%,  reduce = 0%
+        17/02/07 19:16:09 INFO exec.Task: 2017-02-07 19:16:09,173 Stage-1 map = 40%,  reduce = 0%
+    """.split(
+        "\n"
+    )
+    assert HiveEngineSpec.progress(log) == 60
+
+
+def test_hive_error_msg():
+    msg = (
+        '{...} errorMessage="Error while compiling statement: FAILED: '
+        "SemanticException [Error 10001]: Line 4"
+        ":5 Table not found 'fact_ridesfdslakj'\", statusCode=3, "
+        "sqlState='42S02', errorCode=10001)){...}"
+    )
+    assert HiveEngineSpec.extract_error_message(Exception(msg)) == (
+        "hive error: Error while compiling statement: FAILED: "
+        "SemanticException [Error 10001]: Line 4:5 "
+        "Table not found 'fact_ridesfdslakj'"
+    )
+
+    e = Exception("Some string that doesn't match the regex")
+    assert HiveEngineSpec.extract_error_message(e) == f"hive error: {e}"
+
+    msg = (
+        "errorCode=10001, "
+        'errorMessage="Error while compiling statement"), operationHandle'
+        '=None)"'
+    )
+    assert (
+        HiveEngineSpec.extract_error_message(Exception(msg))
+        == "hive error: Error while compiling statement"
+    )
+
+
+def test_hive_get_view_names_return_empty_list():  # pylint: disable=invalid-name
+    assert HiveEngineSpec.get_view_names(mock.ANY, mock.ANY, mock.ANY) == []
+
+
+def test_convert_dttm():
+    dttm = datetime.strptime("2019-01-02 03:04:05.678900", "%Y-%m-%d %H:%M:%S.%f")
+    assert HiveEngineSpec.convert_dttm("DATE", dttm) == "CAST('2019-01-02' AS DATE)"
+    assert (
+        HiveEngineSpec.convert_dttm("TIMESTAMP", dttm)
+        == "CAST('2019-01-02 03:04:05.678900' AS TIMESTAMP)"
+    )
+
+
+def test_create_table_from_csv_append() -> None:
+
+    with pytest.raises(SupersetException):
+        HiveEngineSpec.create_table_from_csv(
+            "foo.csv", Table("foobar"), mock.MagicMock(), {}, {"if_exists": "append"}
         )
 
-    def test_create_table_from_csv_append(self) -> None:
-        self.assertRaises(
-            SupersetException,
-            HiveEngineSpec.create_table_from_csv,
-            "foo.csv",
-            Table("foobar"),
-            None,
-            {},
-            {"if_exists": "append"},
-        )
+
+def test_get_create_table_stmt() -> None:
+    table = Table("employee")
+    schema_def = """eid int, name String, salary String, destination String"""
+    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 0, [""]) == (
+        """CREATE TABLE employee ( eid int, name String, salary String, destination String )
+            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+            STORED AS TEXTFILE LOCATION :location
+            tblproperties ('serialization.null.format'='')"""
+    )
+    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 1, ["1", "2"]) == (
+        """CREATE TABLE employee ( eid int, name String, salary String, destination String )
+            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+            STORED AS TEXTFILE LOCATION :location
+            tblproperties ('skip.header.line.count'='1', 'serialization.null.format'='1')"""
+    )
+    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 100, ["NaN"]) == (
+        """CREATE TABLE employee ( eid int, name String, salary String, destination String )
+            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+            STORED AS TEXTFILE LOCATION :location
+            tblproperties ('skip.header.line.count'='100', 'serialization.null.format'='NaN')"""
+    )
+    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 0, None) == (
+        """CREATE TABLE employee ( eid int, name String, salary String, destination String )
+            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+            STORED AS TEXTFILE LOCATION :location"""
+    )
+    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 100, []) == (
+        """CREATE TABLE employee ( eid int, name String, salary String, destination String )
+            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+            STORED AS TEXTFILE LOCATION :location
+            tblproperties ('skip.header.line.count'='100')"""
+    )

--- a/tests/db_engine_specs/hive_tests.py
+++ b/tests/db_engine_specs/hive_tests.py
@@ -171,32 +171,66 @@ def test_create_table_from_csv_append() -> None:
 def test_get_create_table_stmt() -> None:
     table = Table("employee")
     schema_def = """eid int, name String, salary String, destination String"""
-    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 0, [""]) == (
+    location = "s3a://directory/table"
+    from unittest import TestCase
+
+    TestCase.maxDiff = None
+    assert HiveEngineSpec.get_create_table_stmt(
+        table, schema_def, location, ",", 0, [""]
+    ) == (
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
-            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
-            STORED AS TEXTFILE LOCATION :location
-            tblproperties ('serialization.null.format'='')"""
+                ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+                STORED AS TEXTFILE LOCATION :location
+                tblproperties ('skip.header.line.count'=':header_line_count', 'serialization.null.format'=':null_value')""",
+        {
+            "delim": ",",
+            "location": "s3a://directory/table",
+            "header_line_count": "1",
+            "null_value": "",
+        },
     )
-    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 1, ["1", "2"]) == (
+    assert HiveEngineSpec.get_create_table_stmt(
+        table, schema_def, location, ",", 1, ["1", "2"]
+    ) == (
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
-            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
-            STORED AS TEXTFILE LOCATION :location
-            tblproperties ('skip.header.line.count'='1', 'serialization.null.format'='1')"""
+                ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+                STORED AS TEXTFILE LOCATION :location
+                tblproperties ('skip.header.line.count'=':header_line_count', 'serialization.null.format'=':null_value')""",
+        {
+            "delim": ",",
+            "location": "s3a://directory/table",
+            "header_line_count": "2",
+            "null_value": "1",
+        },
     )
-    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 100, ["NaN"]) == (
+    assert HiveEngineSpec.get_create_table_stmt(
+        table, schema_def, location, ",", 100, ["NaN"]
+    ) == (
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
-            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
-            STORED AS TEXTFILE LOCATION :location
-            tblproperties ('skip.header.line.count'='100', 'serialization.null.format'='NaN')"""
+                ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+                STORED AS TEXTFILE LOCATION :location
+                tblproperties ('skip.header.line.count'=':header_line_count', 'serialization.null.format'=':null_value')""",
+        {
+            "delim": ",",
+            "location": "s3a://directory/table",
+            "header_line_count": "101",
+            "null_value": "NaN",
+        },
     )
-    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 0, None) == (
+    assert HiveEngineSpec.get_create_table_stmt(
+        table, schema_def, location, ",", None, None
+    ) == (
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
-            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
-            STORED AS TEXTFILE LOCATION :location"""
+                ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+                STORED AS TEXTFILE LOCATION :location""",
+        {"delim": ",", "location": "s3a://directory/table"},
     )
-    assert HiveEngineSpec.get_create_table_stmt(table, schema_def, 100, []) == (
+    assert HiveEngineSpec.get_create_table_stmt(
+        table, schema_def, location, ",", 100, []
+    ) == (
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
-            ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
-            STORED AS TEXTFILE LOCATION :location
-            tblproperties ('skip.header.line.count'='100')"""
+                ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
+                STORED AS TEXTFILE LOCATION :location
+                tblproperties ('skip.header.line.count'=':header_line_count')""",
+        {"delim": ",", "location": "s3a://directory/table", "header_line_count": "101"},
     )


### PR DESCRIPTION
### SUMMARY
There are use cases when users would prefer to treat empty strings in the csv as nulls in the database.
This PR makes the field to be configurable and bring more transparency to how it is handled.
A default value is set to be the same as pandas, it doesn't look pretty and probably has too many values, that's why I also made it configurable.

Default values:
![image](https://user-images.githubusercontent.com/5727938/86205273-49375f00-bb1e-11ea-97f9-19eee5811821.png)

In addition to the feature, I've refactored hive_tests.py to follow pytest standards, now they can be run directly via pytest command.

### TEST PLAN
* pytest -s tests/db_engine_specs/hive_tests.py - for hive changes
* tox -e py36 -- tests/core_tests.py::TestCore::test_import_csv - for general changes
* tested locally for different uses case on mysql 
* tested on our staging env for hive changes

### Hive testing screenshots
![image](https://user-images.githubusercontent.com/5727938/86204789-31aba680-bb1d-11ea-8d7d-1720d951167d.png)
![image](https://user-images.githubusercontent.com/5727938/86204799-3bcda500-bb1d-11ea-9dd9-239becd8ce7e.png)


### ADDITIONAL INFORMATION
