### PR TITLE
feat: Typeahead searchable filter_box for dashboard

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/FilterBoxItemControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/FilterBoxItemControl_spec.jsx
@@ -50,7 +50,7 @@ describe('FilterBoxItemControl', () => {
 
   it('renderForms does the job', () => {
     const popover = shallow(inst.renderForm());
-    expect(popover.find(FormRow)).toHaveLength(7);
+    expect(popover.find(FormRow)).toHaveLength(8);
   });
 
   it('convert type for single value filter_box', () => {

--- a/superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx
@@ -53,6 +53,7 @@ const propTypes = {
   multiple: PropTypes.bool,
   column: PropTypes.string,
   metric: PropTypes.string,
+  fixedOptions: PropTypes.bool,
   defaultValue: PropTypes.string,
 };
 
@@ -61,6 +62,7 @@ const defaultProps = {
   asc: true,
   clearable: true,
   multiple: true,
+  fixedOptions: true,
 };
 
 const STYLE_WIDTH = { width: 350 };
@@ -68,8 +70,24 @@ const STYLE_WIDTH = { width: 350 };
 export default class FilterBoxItemControl extends React.Component {
   constructor(props) {
     super(props);
-    const { column, metric, asc, clearable, multiple, defaultValue } = props;
-    const state = { column, metric, asc, clearable, multiple, defaultValue };
+    const {
+      column,
+      metric,
+      asc,
+      clearable,
+      multiple,
+      fixedOptions,
+      defaultValue,
+    } = props;
+    const state = {
+      column,
+      metric,
+      asc,
+      clearable,
+      multiple,
+      fixedOptions,
+      defaultValue,
+    };
     this.state = state;
     this.onChange = this.onChange.bind(this);
     this.onControlChange = this.onControlChange.bind(this);
@@ -199,6 +217,21 @@ export default class FilterBoxItemControl extends React.Component {
               onChange={v =>
                 this.onControlChange(FILTER_CONFIG_ATTRIBUTES.MULTIPLE, v)
               }
+            />
+          }
+        />
+        <FormRow
+          label={t('Fixed Filter Options')}
+          tooltip={t(
+            'By default, filter box will only load top 1000 filter options once. ' +
+              'When disabled, filter box will load options from a remote source as the user types, ' +
+              'with 1000 options per load.',
+          )}
+          isCheckbox
+          control={
+            <CheckboxControl
+              value={this.state.fixedOptions}
+              onChange={v => this.onControlChange('fixedOptions', v)}
             />
           }
         />

--- a/superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx
@@ -53,7 +53,7 @@ const propTypes = {
   multiple: PropTypes.bool,
   column: PropTypes.string,
   metric: PropTypes.string,
-  fixedOptions: PropTypes.bool,
+  searchAllOptions: PropTypes.bool,
   defaultValue: PropTypes.string,
 };
 
@@ -62,7 +62,7 @@ const defaultProps = {
   asc: true,
   clearable: true,
   multiple: true,
-  fixedOptions: true,
+  searchAllOptions: true,
 };
 
 const STYLE_WIDTH = { width: 350 };
@@ -76,7 +76,7 @@ export default class FilterBoxItemControl extends React.Component {
       asc,
       clearable,
       multiple,
-      fixedOptions,
+      searchAllOptions,
       defaultValue,
     } = props;
     const state = {
@@ -85,7 +85,7 @@ export default class FilterBoxItemControl extends React.Component {
       asc,
       clearable,
       multiple,
-      fixedOptions,
+      searchAllOptions,
       defaultValue,
     };
     this.state = state;
@@ -221,17 +221,22 @@ export default class FilterBoxItemControl extends React.Component {
           }
         />
         <FormRow
-          label={t('Fixed Filter Options')}
+          label={t('Search All Filter Options')}
           tooltip={t(
-            'By default, filter box will only load top 1000 filter options once. ' +
-              'When disabled, filter box will load options from a remote source as the user types, ' +
-              'with 1000 options per load.',
+            'By default, each filter loads at most 1000 choices at the initial page load. ' +
+              'Check this box if you have more than 1000 filter values and want to enable dynamically ' +
+              'searching that loads filter values as users type (may add stress to your database).',
           )}
           isCheckbox
           control={
             <CheckboxControl
-              value={this.state.fixedOptions}
-              onChange={v => this.onControlChange('fixedOptions', v)}
+              value={this.state.searchAllOptions}
+              onChange={v =>
+                this.onControlChange(
+                  FILTER_CONFIG_ATTRIBUTES.SEARCH_ALL_OPTIONS,
+                  v,
+                )
+              }
             />
           }
         />

--- a/superset-frontend/src/explore/constants.js
+++ b/superset-frontend/src/explore/constants.js
@@ -84,6 +84,8 @@ export const TIME_FILTER_LABELS = {
 export const FILTER_CONFIG_ATTRIBUTES = {
   DEFAULT_VALUE: 'defaultValue',
   MULTIPLE: 'multiple',
-  FIXED_OPTIONS: 'fixedOptions',
+  SEARCH_ALL_OPTIONS: 'searchAllOptions',
   CLEARABLE: 'clearable',
 };
+
+export const FILTER_OPTIONS_LIMIT = 1000;

--- a/superset-frontend/src/explore/constants.js
+++ b/superset-frontend/src/explore/constants.js
@@ -84,4 +84,6 @@ export const TIME_FILTER_LABELS = {
 export const FILTER_CONFIG_ATTRIBUTES = {
   DEFAULT_VALUE: 'defaultValue',
   MULTIPLE: 'multiple',
+  FIXED_OPTIONS: 'fixedOptions',
+  CLEARABLE: 'clearable',
 };

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -35,6 +35,7 @@ import { getDashboardFilterKey } from '../../dashboard/util/getDashboardFilterKe
 import { getFilterColorMap } from '../../dashboard/util/dashboardFiltersColorMap';
 import {
   FILTER_CONFIG_ATTRIBUTES,
+  FILTER_OPTIONS_LIMIT,
   TIME_FILTER_LABELS,
 } from '../../explore/constants';
 import FilterBadgeIcon from '../../components/FilterBadgeIcon';
@@ -340,8 +341,7 @@ class FilterBox extends React.Component {
             });
           });
       });
-    // if fixedOptions is undefined, use fixed_options
-    const { key, label, fixedOptions = true } = filterConfig;
+    const { key, label } = filterConfig;
     const data = filtersChoices[key] || [];
     let value = selectedValues[key] || null;
 
@@ -379,7 +379,12 @@ class FilterBox extends React.Component {
         onMenuOpen={() => this.onFilterMenuOpen(key)}
         onBlur={this.onFilterMenuClose}
         onMenuClose={this.onFilterMenuClose}
-        selectWrap={fixedOptions ? CreatableSelect : AsyncCreatableSelect}
+        selectWrap={
+          [FILTER_CONFIG_ATTRIBUTES.SEARCH_ALL_OPTIONS] &&
+          data.length >= FILTER_OPTIONS_LIMIT
+            ? AsyncCreatableSelect
+            : CreatableSelect
+        }
         noResultsText={t('No results found')}
       />
     );

--- a/superset-frontend/src/visualizations/FilterBox/transformProps.js
+++ b/superset-frontend/src/visualizations/FilterBox/transformProps.js
@@ -26,6 +26,7 @@ export default function transformProps(chartProps) {
     initialValues,
     queryData,
     rawDatasource,
+    rawFormData,
   } = chartProps;
   const {
     onAddFilter = NOOP,
@@ -65,5 +66,7 @@ export default function transformProps(chartProps) {
     showDruidTimeOrigin,
     showSqlaTimeColumn,
     showSqlaTimeGrain: showSqlaTimeGranularity,
+    // the original form data, needed for async select options
+    rawFormData,
   };
 }

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1913,7 +1913,7 @@ class FilterBoxViz(BaseViz):
     is_timeseries = False
     credits = 'a <a href="https://github.com/airbnb/superset">Superset</a> original'
     cache_type = "get_data"
-    filter_row_limit = 25
+    filter_row_limit = 1000
 
     def query_obj(self) -> QueryObjectDict:
         return {}

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1913,7 +1913,7 @@ class FilterBoxViz(BaseViz):
     is_timeseries = False
     credits = 'a <a href="https://github.com/airbnb/superset">Superset</a> original'
     cache_type = "get_data"
-    filter_row_limit = 1000
+    filter_row_limit = 25
 
     def query_obj(self) -> QueryObjectDict:
         return {}


### PR DESCRIPTION
### SUMMARY
Currently Superset only show top 1000 options for a dropdown list in filter_box component. If a filter has > 1000 options, user won't see all the options. When user type-in with correct value (space, capital letter etc), the filter value can still get applied. But this experience confused many users. When they didn't see the option from the list, they thought it was not an option.

This PR is to enable async searchable options for filter_box in Superset dashboard:
- by default, filter_box only fetch top 1000 options (like right now).
- if enable `Search All Filter Options` and this filter key has >= 1000 options, filter box will load options from a remote source as the user types, with 1000 options per load.
- when user typing in, filter_box is actually sending out a new query with extra sql expression ` WHERE lower(_column_key_) like '_input_value_'`

<img width="422" alt="Screen Shot 2020-07-07 at 9 29 35 AM" src="https://user-images.githubusercontent.com/27990562/86813010-8460f300-c034-11ea-9864-b8e8c1e176cd.png">



For example: Malibu is not in the top 1000 destination.
**Before: user cannot see Malibu is an option** 

![42cSlzWfZb-2](https://user-images.githubusercontent.com/27990562/86308599-970ba000-bbce-11ea-94a0-650d5f5b59b0.gif)

**After: Malibu will show up while user typing**
![PIvGCagMOq](https://user-images.githubusercontent.com/27990562/86308565-85c29380-bbce-11ea-9a11-218d1bf815b9.gif)





### TEST PLAN
Manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Changes UI

