### PR TITLE
fix: better backward compatibility for table viz

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.js
@@ -103,7 +103,8 @@ describe('Visualization > Table', () => {
   it('Test table with columns and row limit', () => {
     const formData = {
       ...VIZ_DEFAULTS,
-      query_mode: 'raw',
+      // should still work when query_mode is not-set/invalid
+      query_mode: undefined,
       all_columns: ['name'],
       metrics: [],
       row_limit: 10,

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -6159,9 +6159,9 @@
       }
     },
     "@superset-ui/plugin-chart-table": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-table/-/plugin-chart-table-0.14.2.tgz",
-      "integrity": "sha512-1LnYQMdYqLPPcASPLQlLZtLTEmx8THibnRnUw/h7DIy2vG2ye70P/Bv/9BbFU32nkr6jokL3GQdwy4eAIdXE/A==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-table/-/plugin-chart-table-0.14.5.tgz",
+      "integrity": "sha512-H189jqOP0svrbh3VlJWufzN8hRxqQ5l2LtYpAZiwegGKqH9BlkJid61M99xjdTp5Zyzj+n4JA8ksesTe5HlfrQ==",
       "requires": {
         "@emotion/core": "^10.0.28",
         "@types/d3-array": "^2.0.0",
@@ -6173,7 +6173,7 @@
         "match-sorter": "^4.1.0",
         "memoize-one": "^5.1.1",
         "react-icons": "^3.10.0",
-        "react-table": "^7.2.0",
+        "react-table": "^7.2.1",
         "regenerator-runtime": "^0.13.5",
         "xss": "^1.0.6"
       },
@@ -19781,9 +19781,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
-          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+          "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -85,7 +85,7 @@
     "@superset-ui/legacy-plugin-chart-sankey": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-sankey-loop": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-sunburst": "^0.14.1",
-    "@superset-ui/plugin-chart-table": "^0.14.2",
+    "@superset-ui/plugin-chart-table": "^0.14.5",
     "@superset-ui/legacy-plugin-chart-treemap": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.14.1",
     "@superset-ui/legacy-preset-chart-big-number": "^0.14.1",


### PR DESCRIPTION
### SUMMARY

Bump table viz to v0.14.5 (not released yet) to change default query mode from `aggregate` to `null` so it can have better backward compatibility. Currently existing tables in the old `NOT GROUP BY` mode will not open the `Query Mode: Raw` tab by default.

Accompanying superset-ui PR: https://github.com/apache-superset/superset-ui/pull/659

This bug was actually captured by #10206, but I was lazy and went with an easier fix.

Update: also fixes #10215 .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Open an existing table chart querying raw columns:

Currently received:
<img src="https://user-images.githubusercontent.com/335541/86273903-c4802b80-bb85-11ea-9037-3163817ab073.png" width="300">

Expected:

<img src="https://user-images.githubusercontent.com/335541/86273789-9dc1f500-bb85-11ea-94cb-efb8dd8b7d0d.png" width="300">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: apache-superset/superset-ui#659 #10113 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
