### PR TITLE
fix(listview): use disableSortBy to disable sorting in table columns

### DIFF
--- a/superset-frontend/src/views/chartList/ChartList.tsx
+++ b/superset-frontend/src/views/chartList/ChartList.tsx
@@ -119,7 +119,6 @@ class ChartList extends React.PureComponent<Props, State> {
       }: any) => <a href={url}>{sliceName}</a>,
       Header: t('Chart'),
       accessor: 'slice_name',
-      canSort: true,
     },
     {
       Cell: ({
@@ -129,7 +128,6 @@ class ChartList extends React.PureComponent<Props, State> {
       }: any) => vizType,
       Header: t('Visualization Type'),
       accessor: 'viz_type',
-      canSort: true,
     },
     {
       Cell: ({
@@ -139,7 +137,6 @@ class ChartList extends React.PureComponent<Props, State> {
       }: any) => <a href={dsUrl}>{dsNameTxt}</a>,
       Header: t('Datasource'),
       accessor: 'datasource_name',
-      canSort: true,
     },
     {
       Cell: ({
@@ -152,7 +149,6 @@ class ChartList extends React.PureComponent<Props, State> {
       }: any) => <a href={changedByUrl}>{changedByName}</a>,
       Header: t('Creator'),
       accessor: 'changed_by_fk',
-      canSort: true,
     },
     {
       Cell: ({
@@ -162,19 +158,21 @@ class ChartList extends React.PureComponent<Props, State> {
       }: any) => <span className="no-wrap">{moment(changedOn).fromNow()}</span>,
       Header: t('Last Modified'),
       accessor: 'changed_on',
-      canSort: true,
     },
     {
       accessor: 'description',
       hidden: true,
+      disableSortBy: true,
     },
     {
       accessor: 'owners',
       hidden: true,
+      disableSortBy: true,
     },
     {
       accessor: 'datasource',
       hidden: true,
+      disableSortBy: true,
     },
     {
       Cell: ({ row: { state, original } }: any) => {
@@ -226,6 +224,7 @@ class ChartList extends React.PureComponent<Props, State> {
       },
       Header: t('Actions'),
       id: 'actions',
+      disableSortBy: true,
     },
   ];
 

--- a/superset-frontend/src/views/dashboardList/DashboardList.tsx
+++ b/superset-frontend/src/views/dashboardList/DashboardList.tsx
@@ -134,7 +134,6 @@ class DashboardList extends React.PureComponent<Props, State> {
       }: any) => <a href={url}>{dashboardTitle}</a>,
       Header: t('Title'),
       accessor: 'dashboard_title',
-      sortable: true,
     },
     {
       Cell: ({
@@ -152,6 +151,7 @@ class DashboardList extends React.PureComponent<Props, State> {
       ),
       Header: t('Owners'),
       accessor: 'owners',
+      disableSortBy: true,
     },
     {
       Cell: ({
@@ -164,7 +164,6 @@ class DashboardList extends React.PureComponent<Props, State> {
       }: any) => <a href={changedByUrl}>{changedByName}</a>,
       Header: t('Creator'),
       accessor: 'changed_by_fk',
-      sortable: true,
     },
     {
       Cell: ({
@@ -178,7 +177,6 @@ class DashboardList extends React.PureComponent<Props, State> {
       ),
       Header: t('Published'),
       accessor: 'published',
-      sortable: true,
     },
     {
       Cell: ({
@@ -188,11 +186,11 @@ class DashboardList extends React.PureComponent<Props, State> {
       }: any) => <span className="no-wrap">{moment(changedOn).fromNow()}</span>,
       Header: t('Modified'),
       accessor: 'changed_on',
-      sortable: true,
     },
     {
       accessor: 'slug',
       hidden: true,
+      disableSortBy: true,
     },
     {
       Cell: ({ row: { state, original } }: any) => {
@@ -254,6 +252,7 @@ class DashboardList extends React.PureComponent<Props, State> {
       },
       Header: t('Actions'),
       id: 'actions',
+      disableSortBy: true,
     },
   ];
 

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -176,6 +176,7 @@ class DatasetList extends React.PureComponent<Props, State> {
         );
       },
       accessor: 'kind_icon',
+      disableSortBy: true,
       size: 'xs',
     },
     {
@@ -186,7 +187,6 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => datasetTitle,
       Header: t('Name'),
       accessor: 'table_name',
-      sortable: true,
     },
     {
       Cell: ({
@@ -196,16 +196,19 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => kind[0]?.toUpperCase() + kind.slice(1),
       Header: t('Type'),
       accessor: 'kind',
+      disableSortBy: true,
       size: 'md',
     },
     {
       Header: t('Source'),
       accessor: 'database_name',
+      disableSortBy: true,
       size: 'lg',
     },
     {
       Header: t('Schema'),
       accessor: 'schema',
+      disableSortBy: true,
       size: 'lg',
     },
     {
@@ -229,7 +232,6 @@ class DatasetList extends React.PureComponent<Props, State> {
       },
       Header: t('Last Modified'),
       accessor: 'changed_on',
-      sortable: true,
       size: 'xl',
     },
     {
@@ -240,10 +242,12 @@ class DatasetList extends React.PureComponent<Props, State> {
       }: any) => changedByName,
       Header: t('Modified By'),
       accessor: 'changed_by_fk',
+      disableSortBy: true,
       size: 'xl',
     },
     {
       accessor: 'database',
+      disableSortBy: true,
       hidden: true,
     },
     {
@@ -271,11 +275,13 @@ class DatasetList extends React.PureComponent<Props, State> {
       },
       Header: t('Owners'),
       id: 'owners',
+      disableSortBy: true,
       size: 'lg',
     },
     {
       accessor: 'is_sqllab_view',
       hidden: true,
+      disableSortBy: true,
     },
     {
       Cell: ({ row: { state, original } }: any) => {
@@ -352,6 +358,7 @@ class DatasetList extends React.PureComponent<Props, State> {
       },
       Header: t('Actions'),
       id: 'actions',
+      disableSortBy: true,
     },
   ];
 

--- a/superset-frontend/src/welcome/DashboardTable.jsx
+++ b/superset-frontend/src/welcome/DashboardTable.jsx
@@ -54,7 +54,6 @@ class DashboardTable extends React.PureComponent {
     {
       accessor: 'dashboard_title',
       Header: 'Dashboard',
-      canSort: true,
       Cell: ({
         row: {
           original: { url, dashboard_title: dashboardTitle },
@@ -64,7 +63,6 @@ class DashboardTable extends React.PureComponent {
     {
       accessor: 'changed_by_fk',
       Header: 'Creator',
-      canSort: true,
       Cell: ({
         row: {
           original: { changed_by_name: changedByName, changedByUrl },
@@ -74,7 +72,6 @@ class DashboardTable extends React.PureComponent {
     {
       accessor: 'changed_on',
       Header: 'Modified',
-      canSort: true,
       Cell: ({
         row: {
           original: { changed_on: changedOn },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent upgrade to react-table https://github.com/apache/incubator-superset/pull/10113#issuecomment-649855683 changed some of the sorting config used by the listviews (welcome, dashboards, charts, tables/datasets). As a result some columns became sortable that should not have been (eg, in datasets: the type of dataset icon, owners, and type). This PR updates the props to be more in line with what react-table expects which is that any column with an `accessor` property is sortable by default and columns with `disableSortBy` are not sortable. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- in datasets: only "Name" and "Last Modified" are sortable
- in charts: All columns except "Actions" is sortable
- in dashboards: "Title", "Creator", "Published", and "Modified" are sortable
- in welcome (`/superset/welcome`): "Dashboard", "Creator", and "Modified" are sortable.  

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
