### PR TITLE
fix(table-vis): bump to v0.14.6 to fix missing anchor links

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -6159,9 +6159,9 @@
       }
     },
     "@superset-ui/plugin-chart-table": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-table/-/plugin-chart-table-0.14.5.tgz",
-      "integrity": "sha512-H189jqOP0svrbh3VlJWufzN8hRxqQ5l2LtYpAZiwegGKqH9BlkJid61M99xjdTp5Zyzj+n4JA8ksesTe5HlfrQ==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-table/-/plugin-chart-table-0.14.6.tgz",
+      "integrity": "sha512-UkFI+H6EYeRVEijT4XDyxoNVD0IGk2s2pYK2TkV45Fjp/ZX8eAumJGYaC66I1pGwWnkubmsGeNQuA2z9DcMruw==",
       "requires": {
         "@emotion/core": "^10.0.28",
         "@types/d3-array": "^2.0.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -85,7 +85,7 @@
     "@superset-ui/legacy-plugin-chart-sankey": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-sankey-loop": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-sunburst": "^0.14.1",
-    "@superset-ui/plugin-chart-table": "^0.14.5",
+    "@superset-ui/plugin-chart-table": "^0.14.6",
     "@superset-ui/legacy-plugin-chart-treemap": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.14.1",
     "@superset-ui/legacy-preset-chart-big-number": "^0.14.1",


### PR DESCRIPTION
### SUMMARY

Bump @superset-ui/plugin-chart-table to v0.14.6 to fix anchor elements' missing href attribute in HTML cell values (`<a href="...">`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Storybook in superset-ui: https://github.com/apache-superset/superset-ui/pull/661


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
