### PR TITLE
fix(table-viz): format non-numeric metrics

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/shared.helper.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/shared.helper.js
@@ -63,6 +63,52 @@ export const NUM_METRIC = {
   optionName: 'metric_1de0s4viy5d_ly7y8k6ghvk',
 };
 
+export const MAX_DS = {
+  aggregate: 'MAX',
+  column: {
+    column_name: 'ds',
+    description: null,
+    expression: null,
+    filterable: true,
+    groupby: true,
+    id: 333,
+    is_dttm: true,
+    optionName: '_col_ds',
+    python_date_format: null,
+    type: 'TIMESTAMP WITHOUT TIME ZONE',
+    verbose_name: null,
+  },
+  expressionType: 'SIMPLE',
+  hasCustomLabel: false,
+  isNew: false,
+  label: 'MAX(ds)',
+  optionName: 'metric_pbib7j9m15a_js80vs9vca',
+  sqlExpression: null,
+};
+
+export const MAX_STATE = {
+  expressionType: 'SIMPLE',
+  column: {
+    id: 337,
+    column_name: 'state',
+    verbose_name: null,
+    description: null,
+    expression: null,
+    filterable: true,
+    groupby: true,
+    is_dttm: false,
+    type: 'VARCHAR(10)',
+    python_date_format: null,
+    optionName: '_col_state',
+  },
+  aggregate: 'MAX',
+  sqlExpression: null,
+  isNew: false,
+  hasCustomLabel: false,
+  label: 'MAX(state)',
+  optionName: 'metric_kvval50pvbo_hewj3pzacb',
+};
+
 export const SIMPLE_FILTER = {
   expressionType: 'SIMPLE',
   subject: 'name',

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -6159,9 +6159,9 @@
       }
     },
     "@superset-ui/plugin-chart-table": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-table/-/plugin-chart-table-0.14.6.tgz",
-      "integrity": "sha512-UkFI+H6EYeRVEijT4XDyxoNVD0IGk2s2pYK2TkV45Fjp/ZX8eAumJGYaC66I1pGwWnkubmsGeNQuA2z9DcMruw==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-chart-table/-/plugin-chart-table-0.14.8.tgz",
+      "integrity": "sha512-xfu1y/6Vo4DXtvaaXBjUOPGrEEKkbtgVKHXDEWrk3MATmODMlut11vrNs/UcllTkzHGOhTCdg3eHEPfAM2+crw==",
       "requires": {
         "@emotion/core": "^10.0.28",
         "@types/d3-array": "^2.0.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -85,7 +85,7 @@
     "@superset-ui/legacy-plugin-chart-sankey": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-sankey-loop": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-sunburst": "^0.14.1",
-    "@superset-ui/plugin-chart-table": "^0.14.6",
+    "@superset-ui/plugin-chart-table": "^0.14.8",
     "@superset-ui/legacy-plugin-chart-treemap": "^0.14.1",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.14.1",
     "@superset-ui/legacy-preset-chart-big-number": "^0.14.1",


### PR DESCRIPTION
### SUMMARY

This PR adds more robust formatting for non-numeric metrics (e.g., `MAX(ds)` and `arbitrary(state)`).

Also make sure all TIMESTAMP WITHOUT TIME ZONE columns are using UTC time (to be consistent with how time column works).

Related: https://github.com/apache-superset/superset-ui/pull/663

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

![image](https://user-images.githubusercontent.com/335541/86396688-43916480-bc57-11ea-8f18-8d84f93697cd.png)

#### After

![Snip20200702_17](https://user-images.githubusercontent.com/335541/86396719-5441da80-bc57-11ea-9028-1fa9793e4e35.png)

### TEST PLAN

New Cypress tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: bug introduced by #10113 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
