### PR TITLE
feat: dataset api endpoint for charts and dashboards count

### DIFF
--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -52,25 +52,26 @@ class DatasetDAO(BaseDAO):
             return None
 
     @staticmethod
-    def get_related_counts(database_id: int) -> Dict[str, int]:
-        chart_result = (
-            db.session.query(Slice.id)
+    def get_related_objects(database_id: int) -> Dict[str, Any]:
+        charts = (
+            db.session.query(Slice)
             .filter(
                 Slice.datasource_id == database_id, Slice.datasource_type == "table"
             )
             .all()
         )
-        chart_ids = [result.id for result in chart_result]
-        dashboard_count = (
+        chart_ids = [chart.id for chart in charts]
+
+        dashboards = (
             (
-                db.session.query(Dashboard.id)
+                db.session.query(Dashboard)
                 .join(Dashboard.slices)
                 .filter(Slice.id.in_(chart_ids))
             )
             .distinct()
-            .count()
+            .all()
         )
-        return dict(chart_count=len(chart_result), dashboard_count=dashboard_count)
+        return dict(charts=charts, dashboards=dashboards)
 
     @staticmethod
     def validate_table_exists(database: Database, table_name: str, schema: str) -> bool:

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -83,7 +83,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         "data": "list",
         "viz_types": "list",
         "datasources": "list",
-        "related_counts": "list",
+        "related_objects": "list",
     }
 
     order_rel_fields: Dict[str, Tuple[str, str]] = {}

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -83,6 +83,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         "data": "list",
         "viz_types": "list",
         "datasources": "list",
+        "related_counts": "list",
     }
 
     order_rel_fields: Dict[str, Tuple[str, str]] = {}

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -750,3 +750,17 @@ class TestDatasetApi(SupersetTestCase):
         self.login(username="gamma")
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 401)
+
+    def test_get_dataset_related_objects(self):
+        """
+        Dataset API: Test get chart and dashboard count related to a dataset
+        :return:
+        """
+        self.login(username="admin")
+        table = self.get_birth_names_dataset()
+        uri = f"api/v1/dataset/{table.id}/related_objects"
+        rv = self.get_assert_metric(uri, "related_objects")
+        self.assertEqual(rv.status_code, 200)
+        response = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(response["charts"]["count"], 18)
+        self.assertEqual(response["dashboards"]["count"], 2)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- create new GET endpoint for charts and dashboards count associated to a dataset 
- when users try to delete a dataset, warning modal will show so that they know if a dataset is currently tied to charts and dashboards 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- add new endpoint to dataset warning modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
