### PR TITLE
fix: Removing node_modules volume in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ x-superset-volumes: &superset-volumes
   - ./docker/pythonpath_dev:/app/pythonpath
   - ./superset:/app/superset
   - ./superset-frontend:/app/superset-frontend
-  - node_modules:/app/superset-frontend/node_modules
   - superset_home:/app/superset_home
 
 version: "3.7"
@@ -105,8 +104,6 @@ services:
 
 volumes:
   superset_home:
-    external: false
-  node_modules:
     external: false
   db_home:
     external: false


### PR DESCRIPTION
### SUMMARY
The `node_modules` volume in docker-compose has been causing issues for several folks due to odd docker permissions when building the stack from scratch. As the actual `npm install` step doesn't really take long, it's not necessary to have this as a volume.
