### PR TITLE
fix: datasets related objects, apply filter and openapi spec

### DIFF
--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -87,3 +87,35 @@ class DatasetPutSchema(Schema):
     owners = fields.List(fields.Integer())
     columns = fields.List(fields.Nested(DatasetColumnsPutSchema))
     metrics = fields.List(fields.Nested(DatasetMetricsPutSchema))
+
+
+class DatasetRelatedChart(Schema):
+    id = fields.Integer()
+    slice_name = fields.String()
+    viz_type = fields.String()
+
+
+class DatasetRelatedDashboard(Schema):
+    id = fields.Integer()
+    json_metadata = fields.Dict()
+    slug = fields.String()
+    title = fields.String()
+
+
+class DatasetRelatedCharts(Schema):
+    count = fields.Integer(description="Chart count")
+    result = fields.List(
+        fields.Nested(DatasetRelatedChart), description="A list of dashboards"
+    )
+
+
+class DatasetRelatedDashboards(Schema):
+    count = fields.Integer(description="Dashboard count")
+    result = fields.List(
+        fields.Nested(DatasetRelatedDashboard), description="A list of dashboards"
+    )
+
+
+class DatasetRelatedObjectsResponse(Schema):
+    charts = fields.Nested(DatasetRelatedCharts)
+    dashboards = fields.Nested(DatasetRelatedDashboards)

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -777,7 +777,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         max_id = db.session.query(func.max(SqlaTable.id)).scalar()
         # id does not exist and we get 404
-        invalid_id = [max_id + 1, 1]
+        invalid_id = max_id + 1
         uri = f"api/v1/dataset/{invalid_id}/related_objects/"
         self.login(username="admin")
         rv = self.client.get(uri)

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -703,7 +703,6 @@ class TestDatasetApi(SupersetTestCase):
     def test_export_dataset(self):
         """
         Dataset API: Test export dataset
-        :return:
         """
         birth_names_dataset = self.get_birth_names_dataset()
 
@@ -736,7 +735,6 @@ class TestDatasetApi(SupersetTestCase):
     def test_export_dataset_not_found(self):
         """
         Dataset API: Test export dataset not found
-        :return:
         """
         max_id = db.session.query(func.max(SqlaTable.id)).scalar()
         # Just one does not exist and we get 404
@@ -749,7 +747,6 @@ class TestDatasetApi(SupersetTestCase):
     def test_export_dataset_gamma(self):
         """
         Dataset API: Test export dataset has gamma
-        :return:
         """
         birth_names_dataset = self.get_birth_names_dataset()
 
@@ -773,3 +770,21 @@ class TestDatasetApi(SupersetTestCase):
         response = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(response["charts"]["count"], 18)
         self.assertEqual(response["dashboards"]["count"], 2)
+
+    def test_get_dataset_related_objects_not_found(self):
+        """
+        Dataset API: Test related objects not found
+        """
+        max_id = db.session.query(func.max(SqlaTable.id)).scalar()
+        # id does not exist and we get 404
+        invalid_id = [max_id + 1, 1]
+        uri = f"api/v1/dataset/{invalid_id}/related_objects/"
+        self.login(username="admin")
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 404)
+
+        self.login(username="gamma")
+        table = self.get_birth_names_dataset()
+        uri = f"api/v1/dataset/{table.id}/related_objects"
+        rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 404)

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -782,7 +782,7 @@ class TestDatasetApi(SupersetTestCase):
         self.login(username="admin")
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 404)
-
+        self.logout()
         self.login(username="gamma")
         table = self.get_birth_names_dataset()
         uri = f"api/v1/dataset/{table.id}/related_objects"


### PR DESCRIPTION
### SUMMARY
Applies filter on datasets related object and simplifies OpenApi spec using mashmallow schemas 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
