### PR TITLE
docs: update upgrading for FAB3 OAuth change

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,7 +23,7 @@ assists people when migrating to a new version.
 
 ## Next
 
-* [9964](https://github.com/apache/incubator-superset/pull/9964): Breaking change on Flask-AppBuilder 3, if your using OAuth, checkout what needs to change [here](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/README.rst#change-log).
+* [9964](https://github.com/apache/incubator-superset/pull/9964): Breaking change on Flask-AppBuilder 3. If you're using OAuth, find out what needs to be changed [here](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/README.rst#change-log).
 
 * [10233](https://github.com/apache/incubator-superset/pull/10233): a change which deprecates the `ENABLE_FLASK_COMPRESS` config option in favor of the Flask-Compress `COMPRESS_REGISTER` config option which serves the same purpose.
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,8 @@ assists people when migrating to a new version.
 
 ## Next
 
+* [9964](https://github.com/apache/incubator-superset/pull/9964): Breaking change on Flask-AppBuilder 3, if your using OAuth, checkout what needs to change [here](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/README.rst#change-log).
+
 * [10233](https://github.com/apache/incubator-superset/pull/10233): a change which deprecates the `ENABLE_FLASK_COMPRESS` config option in favor of the Flask-Compress `COMPRESS_REGISTER` config option which serves the same purpose.
 
 * [10222](https://github.com/apache/incubator-superset/pull/10222): a change which changes how payloads are cached. Previous cached objects cannot be decoded and thus will be reloaded from source.


### PR DESCRIPTION
### SUMMARY
Configuration and dependency for OAuth changed on Flask-AppBuilder 3. This PR updates `UPGRADING`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
