### PR TITLE
feat: update delete modal for dataset

### DIFF
--- a/superset-frontend/spec/javascripts/components/ConfirmStatusChange_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/ConfirmStatusChange_spec.jsx
@@ -18,8 +18,10 @@
  */
 import React from 'react';
 import { mount } from 'enzyme';
-import { Modal, Button } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
+import { supersetTheme, ThemeProvider } from '@superset-ui/style';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
+import Modal from 'src/components/Modal';
 
 describe('ConfirmStatusChange', () => {
   const mockedProps = {
@@ -35,6 +37,10 @@ describe('ConfirmStatusChange', () => {
         </>
       )}
     </ConfirmStatusChange>,
+    {
+      wrappingComponent: ThemeProvider,
+      wrappingComponentProps: { theme: supersetTheme },
+    },
   );
 
   it('opens a confirm modal', () => {

--- a/superset-frontend/src/components/ConfirmStatusChange.tsx
+++ b/superset-frontend/src/components/ConfirmStatusChange.tsx
@@ -16,63 +16,55 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t } from '@superset-ui/translation';
-import * as React from 'react';
-// @ts-ignore
-import { Button, Modal } from 'react-bootstrap';
+import React, { useState } from 'react';
+import DeleteModal from 'src/components/DeleteModal';
 
 type Callback = (...args: any[]) => void;
-interface Props {
-  title: string | React.ReactNode;
-  description: string | React.ReactNode;
+interface ConfirmStatusChangeProps {
+  title: React.ReactNode;
+  description: React.ReactNode;
   onConfirm: Callback;
   children: (showConfirm: Callback) => React.ReactNode;
 }
 
-interface State {
-  callbackArgs: any[];
-  open: boolean;
-}
-export default class ConfirmStatusChange extends React.Component<Props, State> {
-  public state = {
-    callbackArgs: [],
-    open: false,
-  };
+export default function ConfirmStatusChange({
+  title,
+  description,
+  onConfirm,
+  children,
+}: ConfirmStatusChangeProps) {
+  const [open, setOpen] = useState(false);
+  const [currentCallbackArgs, setCurrentCallbackArgs] = useState<any[]>([]);
 
-  public showConfirm = (...callbackArgs: any[]) => {
+  const showConfirm = (...callbackArgs: any[]) => {
     // check if any args are DOM events, if so, call persist
     callbackArgs.forEach(
       arg => arg && typeof arg.persist === 'function' && arg.persist(),
     );
-
-    this.setState({
-      callbackArgs,
-      open: true,
-    });
+    setOpen(true);
+    setCurrentCallbackArgs(callbackArgs);
   };
 
-  public hide = () => this.setState({ open: false, callbackArgs: [] });
-
-  public confirm = () => {
-    this.props.onConfirm(...this.state.callbackArgs);
-    this.hide();
+  const hide = () => {
+    setOpen(false);
+    setCurrentCallbackArgs([]);
   };
 
-  public render() {
-    return (
-      <>
-        {this.props.children && this.props.children(this.showConfirm)}
-        <Modal show={this.state.open} onHide={this.hide}>
-          <Modal.Header closeButton>{this.props.title}</Modal.Header>
-          <Modal.Body>{this.props.description}</Modal.Body>
-          <Modal.Footer>
-            <Button onClick={this.hide}>{t('Cancel')}</Button>
-            <Button bsStyle="danger" onClick={this.confirm}>
-              {t('OK')}
-            </Button>
-          </Modal.Footer>
-        </Modal>
-      </>
-    );
-  }
+  const confirm = () => {
+    onConfirm(...currentCallbackArgs);
+    hide();
+  };
+
+  return (
+    <>
+      {children && children(showConfirm)}
+      <DeleteModal
+        description={description}
+        onConfirm={confirm}
+        onHide={hide}
+        open={open}
+        title={title}
+      />
+    </>
+  );
 }

--- a/superset-frontend/src/components/DeleteModal.tsx
+++ b/superset-frontend/src/components/DeleteModal.tsx
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t } from '@superset-ui/translation';
+import React, { useState } from 'react';
+import styled from '@superset-ui/style';
+import { FormGroup, FormControl } from 'react-bootstrap';
+import Modal from 'src/components/Modal';
+
+const StyleFormGroup = styled(FormGroup)`
+  padding-top: 8px;
+  width: 50%;
+  label {
+    color: ${({ theme }) => theme.colors.grayscale.light1};
+    text-transform: uppercase;
+  }
+`;
+
+const DescriptionContainer = styled.div`
+  line-height: 40px;
+  padding-top: 16px;
+`;
+
+interface DeleteModalProps {
+  description: React.ReactNode;
+  onConfirm: () => void;
+  onHide: () => void;
+  open: boolean;
+  title: React.ReactNode;
+}
+
+export default function DeleteModal({
+  description,
+  onConfirm,
+  onHide,
+  open,
+  title,
+}: DeleteModalProps) {
+  const [disableChange, setDisableChange] = useState(true);
+
+  return (
+    <Modal
+      disablePrimaryButton={disableChange}
+      onHide={onHide}
+      onHandledPrimaryAction={onConfirm}
+      primaryButtonName={t('delete')}
+      primaryButtonType="danger"
+      show={open}
+      title={title}
+    >
+      <DescriptionContainer>{description}</DescriptionContainer>
+      <StyleFormGroup>
+        <label htmlFor="delete">{t('type delete to confirm')}</label>
+        <FormControl
+          id="delete"
+          type="text"
+          // @ts-ignore
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            setDisableChange(event.target.value !== 'DELETE')
+          }
+        />
+      </StyleFormGroup>
+    </Modal>
+  );
+}

--- a/superset-frontend/src/components/Modal.tsx
+++ b/superset-frontend/src/components/Modal.tsx
@@ -20,13 +20,15 @@ import React from 'react';
 import styled from '@superset-ui/style';
 import { Modal as BaseModal } from 'react-bootstrap';
 import { t } from '@superset-ui/translation';
-import Button from './Button';
+import Button from '../views/datasetList/Button';
 
 interface ModalProps {
   children: React.ReactNode;
-  disableSave: boolean;
+  disablePrimaryButton?: boolean;
   onHide: () => void;
-  onSave: () => void;
+  onHandledPrimaryAction: () => void;
+  primaryButtonName: string;
+  primaryButtonType?: 'primary' | 'danger';
   show: boolean;
   title: React.ReactNode;
 }
@@ -45,8 +47,7 @@ const StyledModal = styled(BaseModal)`
   }
 
   .modal-body {
-    padding: 18px 0 340px 18px;
-    width: 65%;
+    padding: 18px;
   }
 
   .modal-footer {
@@ -66,9 +67,11 @@ const Title = styled.div`
 
 export default function Modal({
   children,
-  disableSave,
+  disablePrimaryButton = false,
+  onHandledPrimaryAction,
   onHide,
-  onSave,
+  primaryButtonName,
+  primaryButtonType = 'primary',
   show,
   title,
 }: ModalProps) {
@@ -83,8 +86,12 @@ export default function Modal({
       <BaseModal.Footer>
         <span className="float-right">
           <Button onClick={onHide}>{t('Cancel')}</Button>
-          <Button bsStyle="primary" disabled={disableSave} onClick={onSave}>
-            {t('Add')}
+          <Button
+            bsStyle={primaryButtonType}
+            disabled={disablePrimaryButton}
+            onClick={onHandledPrimaryAction}
+          >
+            {primaryButtonName}
           </Button>
         </span>
       </BaseModal.Footer>

--- a/superset-frontend/src/views/datasetList/Button.tsx
+++ b/superset-frontend/src/views/datasetList/Button.tsx
@@ -25,7 +25,7 @@ interface ModalProps {
   disabled?: boolean;
   onClick: () => void;
   padding?: number;
-  bsStyle?: 'default' | 'primary';
+  bsStyle?: 'default' | 'primary' | 'danger';
   width?: number;
 }
 
@@ -49,6 +49,11 @@ const StyledButton = styled(BaseButton)`
   &.btn-primary,
   &.btn-primary:hover {
     background-color: ${({ theme }) => theme.colors.primary.base};
+    color: ${({ theme }) => theme.colors.grayscale.light5};
+  }
+  &.btn-danger,
+  &.btn-danger:hover {
+    background-color: ${({ theme }) => theme.colors.error.base};
     color: ${({ theme }) => theme.colors.grayscale.light5};
   }
 `;

--- a/superset-frontend/src/views/datasetList/DatasetList.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetList.tsx
@@ -545,10 +545,10 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
               {datasetCurrentlyDeleting && (
                 <DeleteModal
                   description={t(
-                    `The datasource ${datasetCurrentlyDeleting.table_name} is linked to 
+                    `The dataset ${datasetCurrentlyDeleting.table_name} is linked to 
                   ${datasetCurrentlyDeleting.chart_count} charts that appear on 
                   ${datasetCurrentlyDeleting.dashboard_count} dashboards. 
-                  Are you sure you want to continue? Deleting the datasource will break 
+                  Are you sure you want to continue? Deleting the dataset will break 
                   those objects.`,
                   )}
                   onConfirm={() =>
@@ -556,7 +556,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                   }
                   onHide={closeDatasetDeleteModal}
                   open
-                  title={t('Delete Datatset?')}
+                  title={t('Delete Dataset?')}
                 />
               )}
               <ListView

--- a/superset-frontend/src/views/datasetList/DatasetModal.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetModal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import styled from '@superset-ui/style';
 import { SupersetClient } from '@superset-ui/connection';
 import { t } from '@superset-ui/translation';

--- a/superset-frontend/src/views/datasetList/DatasetModal.tsx
+++ b/superset-frontend/src/views/datasetList/DatasetModal.tsx
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useState, FunctionComponent } from 'react';
 import styled from '@superset-ui/style';
 import { SupersetClient } from '@superset-ui/connection';
 import { t } from '@superset-ui/translation';
 import { isEmpty, isNil } from 'lodash';
 import Icon from 'src/components/Icon';
 import TableSelector from 'src/components/TableSelector';
-import Modal from './Modal';
+import Modal from 'src/components/Modal';
 import withToasts from '../../messageToasts/enhancers/withToasts';
 
 interface DatasetModalProps {
@@ -33,35 +33,29 @@ interface DatasetModalProps {
   show: boolean;
 }
 
-interface DatasetModalState {
-  datasourceId?: number;
-  disableSave: boolean;
-  schema: string;
-  tableName: string;
-}
-
 const StyledIcon = styled(Icon)`
   margin: auto 10px auto 0;
 `;
 
-class DatasetModal extends React.PureComponent<
-  DatasetModalProps,
-  DatasetModalState
-> {
-  constructor(props: DatasetModalProps) {
-    super(props);
-    this.onSave = this.onSave.bind(this);
-    this.onChange = this.onChange.bind(this);
+const TableSelectorContainer = styled.div`
+  .TableSelector {
+    padding-bottom: 340px;
+    width: 65%;
   }
+`;
 
-  state: DatasetModalState = {
-    datasourceId: undefined,
-    disableSave: true,
-    schema: '',
-    tableName: '',
-  };
+const DatasetModal: FunctionComponent<DatasetModalProps> = ({
+  addDangerToast,
+  addSuccessToast,
+  onHide,
+  show,
+}) => {
+  const [datasourceId, setDatasourceId] = useState<number | null>(null);
+  const [disableSave, setDisableSave] = useState(true);
+  const [currentSchema, setSchema] = useState('');
+  const [currentTableName, setTableName] = useState('');
 
-  onChange({
+  const onChange = ({
     dbId,
     schema,
     tableName,
@@ -69,61 +63,62 @@ class DatasetModal extends React.PureComponent<
     dbId: number;
     schema: string;
     tableName: string;
-  }) {
-    const disableSave = isNil(dbId) || isEmpty(schema) || isEmpty(tableName);
-    this.setState({
-      datasourceId: dbId,
-      disableSave,
-      schema,
-      tableName,
-    });
-  }
+  }) => {
+    setDatasourceId(dbId);
+    setDisableSave(isNil(dbId) || isEmpty(schema) || isEmpty(tableName));
+    setSchema(schema);
+    setTableName(tableName);
+  };
 
-  onSave() {
-    const { datasourceId, schema, tableName } = this.state;
-    const data = { database: datasourceId, schema, table_name: tableName };
+  const onSave = () => {
+    const data = {
+      database: datasourceId,
+      schema: currentSchema,
+      table_name: currentTableName,
+    };
     SupersetClient.post({
       endpoint: '/api/v1/dataset/',
       body: JSON.stringify(data),
       headers: { 'Content-Type': 'application/json' },
     })
       .then(() => {
-        this.props.addSuccessToast(t('The dataset has been saved'));
-        this.props.onHide();
+        addSuccessToast(t('The dataset has been saved'));
+        onHide();
       })
       .catch(e => {
-        this.props.addDangerToast(t('Error while saving dataset'));
+        addDangerToast(t('Error while saving dataset'));
         console.error(e);
       });
-  }
+  };
 
-  render() {
-    return (
-      <Modal
-        disableSave={this.state.disableSave}
-        onHide={this.props.onHide}
-        onSave={this.onSave}
-        show={this.props.show}
-        title={
-          <>
-            <StyledIcon name="warning" />
-            {t('Add Dataset')}
-          </>
-        }
-      >
+  return (
+    <Modal
+      disablePrimaryButton={disableSave}
+      onHandledPrimaryAction={onSave}
+      onHide={onHide}
+      primaryButtonName={t('Add')}
+      show={show}
+      title={
+        <>
+          <StyledIcon name="warning" />
+          {t('Add Dataset')}
+        </>
+      }
+    >
+      <TableSelectorContainer>
         <TableSelector
           clearable={false}
-          dbId={this.state.datasourceId}
+          dbId={datasourceId}
           formMode
-          handleError={this.props.addDangerToast}
-          onChange={this.onChange}
-          schema={this.state.schema}
+          handleError={addDangerToast}
+          onChange={onChange}
+          schema={currentSchema}
           sqlLabMode={false}
-          tableName={this.state.tableName}
+          tableName={currentTableName}
         />
-      </Modal>
-    );
-  }
-}
+      </TableSelectorContainer>
+    </Modal>
+  );
+};
 
 export default withToasts(DatasetModal);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- implement the Delete modal to match UI closer to SIP-34
- warns user about related charts and dashboard 
- user need to type 'DELETE' before being able to delete the dataset

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**AFTER**
https://www.loom.com/share/79bf03bccdea498ab6c0531494f29271

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
