### PR TITLE
fix: disable search all options by default

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx
@@ -62,7 +62,7 @@ const defaultProps = {
   asc: true,
   clearable: true,
   multiple: true,
-  searchAllOptions: true,
+  searchAllOptions: false,
 };
 
 const STYLE_WIDTH = { width: 350 };


### PR DESCRIPTION
### SUMMARY
this PR is to fix a mistake in PR #10210. According discussion here: https://github.com/apache/incubator-superset/pull/10210#discussion_r449391782 this feature should be disabled by default.

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #10210 
