### PR TITLE
fix: optimize mapStateToProps for chart controls

### DIFF
--- a/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
@@ -27,6 +27,7 @@ import {
   getFormDataFromControls,
   applyMapStateToPropsToControl,
   getAllControlsState,
+  getControlsState,
 } from 'src/explore/controlUtils';
 
 describe('controlUtils', () => {
@@ -185,8 +186,8 @@ describe('controlUtils', () => {
     });
 
     it('removes the mapStateToProps key from the object', () => {
-      let control = getControlConfig('all_columns', 'table');
-      control = applyMapStateToPropsToControl(control, state);
+      const control = getControlConfig('all_columns', 'table');
+      applyMapStateToPropsToControl(control, state);
       expect(control.mapStateToProps[0]).toBe(undefined);
     });
   });
@@ -245,6 +246,14 @@ describe('controlUtils', () => {
       };
       const control = getControlState('metrics', 'table', stateWithCount);
       expect(control.default).toEqual(['count']);
+    });
+
+    it('should not apply mapStateToProps when initializing', () => {
+      const control = getControlState('metrics', 'table', {
+        ...state,
+        isInitializing: true,
+      });
+      expect(control.default).toEqual(null);
     });
   });
 

--- a/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
@@ -186,8 +186,8 @@ describe('controlUtils', () => {
     });
 
     it('removes the mapStateToProps key from the object', () => {
-      const control = getControlConfig('all_columns', 'table');
-      applyMapStateToPropsToControl(control, state);
+      let control = getControlConfig('all_columns', 'table');
+      control = applyMapStateToPropsToControl(control, state);
       expect(control.mapStateToProps[0]).toBe(undefined);
     });
   });

--- a/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
@@ -199,7 +199,6 @@ describe('ExploreResultsButton', () => {
           const calls = fetchMock.calls(visualizeEndpoint);
           expect(calls).toHaveLength(1);
           const formData = calls[0][1].body;
-
           Object.keys(mockOptions).forEach(key => {
             // eslint-disable-next-line no-unused-expressions
             expect(formData.get(key)).toBeDefined();

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -88,15 +88,17 @@ export const getControlConfig = memoizeOne(function getControlConfig(
   return control?.config || control;
 });
 
-export function applyMapStateToPropsToControl(control, state) {
-  if (control.mapStateToProps) {
-    const appliedControl = { ...control };
-    if (state) {
-      Object.assign(appliedControl, control.mapStateToProps(state, control));
-    }
-    return appliedControl;
+/**
+ * Call `mapStateToProps` from controlState and update it in place.
+ */
+export function applyMapStateToPropsToControl(controlState, controlPanelState) {
+  if (controlState.mapStateToProps && controlPanelState) {
+    Object.assign(
+      controlState,
+      controlState.mapStateToProps(controlPanelState, controlState),
+    );
   }
-  return control;
+  return controlState;
 }
 
 function handleMissingChoice(control) {
@@ -121,15 +123,20 @@ function handleMissingChoice(control) {
   return control;
 }
 
-export function getControlStateFromControlConfig(controlConfig, state, value) {
+export function getControlStateFromControlConfig(
+  controlConfig,
+  controlPanelState,
+  value,
+) {
   // skip invalid config values
   if (!controlConfig) {
     return null;
   }
-  const controlState = applyMapStateToPropsToControl(
-    { ...controlConfig },
-    state,
-  );
+  const controlState = { ...controlConfig };
+  // only apply mapStateToProps when control states have been initialized
+  if ('controls' in controlPanelState) {
+    applyMapStateToPropsToControl(controlState, controlPanelState);
+  }
 
   // If default is a function, evaluate it
   if (typeof controlState.default === 'function') {

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -144,6 +144,10 @@ export function getControlStateFromControlConfig(
       controlState,
       controlPanelState,
     );
+    // if default is still a function, discard
+    if (typeof controlState.default === 'function') {
+      delete controlState.default;
+    }
   }
 
   // If a choice control went from multi=false to true, wrap value in array

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -134,13 +134,16 @@ export function getControlStateFromControlConfig(
   }
   const controlState = { ...controlConfig };
   // only apply mapStateToProps when control states have been initialized
-  if ('controls' in controlPanelState) {
+  if (controlPanelState.controls || !controlPanelState.isInitializing) {
     applyMapStateToPropsToControl(controlState, controlPanelState);
   }
 
   // If default is a function, evaluate it
   if (typeof controlState.default === 'function') {
-    controlState.default = controlState.default(controlState);
+    controlState.default = controlState.default(
+      controlState,
+      controlPanelState,
+    );
   }
 
   // If a choice control went from multi=false to true, wrap value in array

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -88,15 +88,13 @@ export const getControlConfig = memoizeOne(function getControlConfig(
   return control?.config || control;
 });
 
-/**
- * Call `mapStateToProps` from controlState and update it in place.
- */
 export function applyMapStateToPropsToControl(controlState, controlPanelState) {
-  if (controlState.mapStateToProps && controlPanelState) {
-    Object.assign(
-      controlState,
-      controlState.mapStateToProps(controlPanelState, controlState),
-    );
+  const { mapStateToProps } = controlState;
+  if (mapStateToProps && controlPanelState) {
+    return {
+      ...controlState,
+      ...mapStateToProps(controlPanelState, controlState),
+    };
   }
   return controlState;
 }
@@ -132,10 +130,16 @@ export function getControlStateFromControlConfig(
   if (!controlConfig) {
     return null;
   }
-  const controlState = { ...controlConfig };
+  let controlState = { ...controlConfig };
   // only apply mapStateToProps when control states have been initialized
-  if (controlPanelState.controls || !controlPanelState.isInitializing) {
-    applyMapStateToPropsToControl(controlState, controlPanelState);
+  if (
+    controlPanelState &&
+    (controlPanelState.controls || !controlPanelState.isInitializing)
+  ) {
+    controlState = applyMapStateToPropsToControl(
+      controlState,
+      controlPanelState,
+    );
   }
 
   // If default is a function, evaluate it

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -316,7 +316,6 @@ export const controls = {
         'filter below is applied against this column or ' +
         'expression',
     ),
-    default: control => control.default,
     clearable: false,
     optionRenderer: c => <ColumnOption column={c} showType />,
     valueRenderer: c => <ColumnOption column={c} />,

--- a/superset-frontend/src/explore/reducers/getInitialState.js
+++ b/superset-frontend/src/explore/reducers/getInitialState.js
@@ -46,10 +46,14 @@ export default function getInitialState(bootstrapData) {
   const controls = getControlsState(bootstrappedState, rawFormData);
   bootstrappedState.controls = controls;
 
-  // apply initial mapStateToProps for all controls, must be done after
-  // bootstrapState has initialized `controls`.
-  Object.values(controls).forEach(controlState => {
-    applyMapStateToPropsToControl(controlState, bootstrappedState);
+  // apply initial mapStateToProps for all controls, must execute AFTER
+  // bootstrappedState has initialized `controls`. Order of execution is not
+  // guaranteed, so controls shouldn't rely on the each other's mapped state.
+  Object.entries(controls).forEach(([key, controlState]) => {
+    controls[key] = applyMapStateToPropsToControl(
+      controlState,
+      bootstrappedState,
+    );
   });
   bootstrappedState.isInitializing = false;
 

--- a/superset-frontend/src/explore/reducers/getInitialState.js
+++ b/superset-frontend/src/explore/reducers/getInitialState.js
@@ -21,7 +21,10 @@ import shortid from 'shortid';
 import getToastsFromPyFlashMessages from '../../messageToasts/utils/getToastsFromPyFlashMessages';
 import { getChartKey } from '../exploreUtils';
 import { getControlsState } from '../store';
-import { getFormDataFromControls, applyMapStateToPropsToControl } from '../controlUtils';
+import {
+  getFormDataFromControls,
+  applyMapStateToPropsToControl,
+} from '../controlUtils';
 
 export default function getInitialState(bootstrapData) {
   const { form_data: rawFormData } = bootstrapData;
@@ -38,9 +41,9 @@ export default function getInitialState(bootstrapData) {
     filterColumnOpts: [],
     isDatasourceMetaLoading: false,
     isStarred: false,
+    isInitializing: true,
   };
   const controls = getControlsState(bootstrappedState, rawFormData);
-
   bootstrappedState.controls = controls;
 
   // apply initial mapStateToProps for all controls, must be done after
@@ -48,6 +51,7 @@ export default function getInitialState(bootstrapData) {
   Object.values(controls).forEach(controlState => {
     applyMapStateToPropsToControl(controlState, bootstrappedState);
   });
+  bootstrappedState.isInitializing = false;
 
   const sliceFormData = slice
     ? getFormDataFromControls(getControlsState(bootstrapData, slice.form_data))

--- a/superset-frontend/src/explore/store.js
+++ b/superset-frontend/src/explore/store.js
@@ -39,7 +39,6 @@ export function getControlsState(state, inputFormData) {
    * adds value keys coming from inputFormData passed here. This can't be an action creator
    * just yet because it's used in both the explore and dashboard views.
    * */
-
   // Getting a list of active control names for the current viz
   const formData = { ...inputFormData };
   const vizType = formData.viz_type || 'table';


### PR DESCRIPTION
### SUMMARY

This is a bug fix for "EXPLORE" button in SQL query results.

The query mode control for table chart relies on `controls` prop in control panel state to determine what's the actual query mode, so `controls` state mapping for chart controls must be initialized before `mapStateToProps` is called.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

When clicking on the "EXPLORE" button in SQL Lab:

<img src="https://user-images.githubusercontent.com/335541/86982480-30423580-c13e-11ea-9cb3-3b4687dfe607.png" width="400" />

#### Before: 

Query is successful, but query mode is incorrectly set to "Aggregate":

<img src="https://user-images.githubusercontent.com/335541/86982518-4cde6d80-c13e-11ea-8a39-cddc20db1380.png" width="600">

#### After:

Query successfully switches to "Raw" mode:

<img src="https://user-images.githubusercontent.com/335541/86984619-f116e300-c143-11ea-8f3d-9557032bfeb8.png" width="600">

### TEST PLAN

Updated unit test + manual testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #10113 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


cc @kristw @serenajiang 