### PR TITLE
feat: Implement explore functionality even if datasource doesn't exist

### DIFF
--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -52,6 +52,20 @@ class DatasetDAO(BaseDAO):
             return None
 
     @staticmethod
+    def get_table_or_none(
+        database_id: int, table_name: str, schema_name: Optional[str]
+    ) -> Optional[SqlaTable]:
+        return (
+            db.session.query(SqlaTable)
+            .filter(
+                SqlaTable.table_name == table_name,
+                SqlaTable.schema == schema_name,
+                SqlaTable.database_id == database_id,
+            )
+            .one_or_none()
+        )
+
+    @staticmethod
     def get_related_objects(database_id: int) -> Dict[str, Any]:
         charts = (
             db.session.query(Slice)
@@ -74,7 +88,9 @@ class DatasetDAO(BaseDAO):
         return dict(charts=charts, dashboards=dashboards)
 
     @staticmethod
-    def validate_table_exists(database: Database, table_name: str, schema: str) -> bool:
+    def validate_table_exists(
+        database: Database, table_name: str, schema: Optional[str]
+    ) -> bool:
         try:
             database.get_table(table_name, schema=schema)
             return True

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1484,4 +1484,21 @@ class PostProcessingContributionOrientation(str, Enum):
     """
 
     ROW = "row"
+
     COLUMN = "column"
+
+
+def parse_table_full_name(
+    full_table_name: str, schema: Optional[str] = None
+) -> Tuple[Optional[str], str]:
+    """Parses full table name into components like table name, schema name.
+    Note the table name conforms to the [[cluster.]schema.]table construct.
+    """
+    table_name_pieces = full_table_name.split(".")
+    if len(table_name_pieces) == 3:
+        return table_name_pieces[1], table_name_pieces[2]
+    if len(table_name_pieces) == 2:
+        return table_name_pieces[0], table_name_pieces[1]
+    if len(table_name_pieces) == 1:
+        return schema, table_name_pieces[0]
+    return schema, full_table_name

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -84,6 +84,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         "viz_types": "list",
         "datasources": "list",
         "related_objects": "list",
+        "explore": "add",
     }
 
     order_rel_fields: Dict[str, Tuple[str, str]] = {}

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -60,6 +60,7 @@ from superset.utils.core import (
     validate_json,
     zlib_compress,
     zlib_decompress,
+    parse_table_full_name,
 )
 from superset.utils import schema
 from superset.views.utils import (
@@ -1365,3 +1366,18 @@ class TestUtils(SupersetTestCase):
         self.assertEqual("BaZ", validator("BaZ"))
         self.assertRaises(marshmallow.ValidationError, validator, "qwerty")
         self.assertRaises(marshmallow.ValidationError, validator, 4)
+
+
+def test_parse_table_full_name():
+    assert parse_table_full_name("table") == (None, "table")
+    assert parse_table_full_name("table", schema="schema") == ("schema", "table")
+    assert parse_table_full_name("table_schema.table", schema="schema") == (
+        "table_schema",
+        "table",
+    )
+    assert parse_table_full_name("table_schema.table") == ("table_schema", "table")
+    assert parse_table_full_name("hive.table_schema.table") == ("table_schema", "table")
+    assert parse_table_full_name("nonsense.hive.table_schema.table") == (
+        None,
+        "nonsense.hive.table_schema.table",
+    )


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Reimplements: https://github.com/apache/incubator-superset/pull/9650
This PR implements and ability for external systems to integrate with superset, more specifically it implements a single endpoint that gets or creates a table for the given database and takes you to the explore view.

### TEST PLAN
Unit tests
Used in dropbox production for almost 2 quarters

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API