### PR TITLE
fix: broken glyphicons used in react-json-schema

### DIFF
--- a/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
@@ -25,6 +25,7 @@ import { t } from '@superset-ui/translation';
 
 import Button from '../../components/Button';
 import ModalTrigger from '../../components/ModalTrigger';
+import './ScheduleQueryButton.less';
 
 const validators = {
   greater: (a, b) => a > b,
@@ -159,12 +160,14 @@ class ScheduleQueryButton extends React.PureComponent {
         </Row>
         <Row>
           <Col md={12}>
-            <Form
-              schema={getJSONSchema()}
-              uiSchema={getUISchema()}
-              onSubmit={this.onSchedule}
-              validate={getValidator()}
-            />
+            <div className="json-schema">
+              <Form
+                schema={getJSONSchema()}
+                uiSchema={getUISchema()}
+                onSubmit={this.onSchedule}
+                validate={getValidator()}
+              />
+            </div>
           </Col>
         </Row>
         {this.props.scheduleQueryWarning && (
@@ -194,7 +197,7 @@ class ScheduleQueryButton extends React.PureComponent {
               disabled={this.props.disabled}
               tooltip={this.props.tooltip}
             >
-              <i className="fa fa-calendar" /> {t('Schedule Query')}
+              <i className="fa fa-calendar" /> {t('Schedule')}
             </Button>
           }
           bsSize="medium"

--- a/superset-frontend/src/SqlLab/components/ScheduleQueryButton.less
+++ b/superset-frontend/src/SqlLab/components/ScheduleQueryButton.less
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// -------------------------------------------------------------
+// Glyphicons are not supported and used by react-json-schema
+// -------------------------------------------------------------
+.json-schema {
+  i.glyphicon {
+    display: none;
+  }
+  .btn-add::after {
+    content: '+';
+  }
+  .array-item-move-up::after {
+    content: '↑';
+  }
+  .array-item-move-down::after {
+    content: '↓';
+  }
+  .array-item-remove::after {
+    content: '-';
+  }
+}
+// -------------------------------------------------------------

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -162,6 +162,7 @@ class SavedQueryViewApi(SavedQueryView):  # pylint: disable=too-many-ancestors
         "description",
         "sql",
         "extra_json",
+        "extra",
     ]
     add_columns = ["label", "db_id", "schema", "description", "sql", "extra_json"]
     edit_columns = add_columns


### PR DESCRIPTION
I'm working on a talk for the Airflow Summit
"Advanced Apache Superset for Data Engineers" and showing the "Schedule
Query" feature that Beto contributed a while back (behind a feature flag).

I found that the glyphicons used in `react-json-schema` are broken and
came up with an easy fix.

Also other minor tweaks on the feature.

## before
<img width="883" alt="Screen Shot 2020-07-08 at 10 34 34 PM" src="https://user-images.githubusercontent.com/487433/87000989-38649a00-c16b-11ea-99a4-b19f13ddc264.png">


## after

<img width="693" alt="Screen Shot 2020-07-08 at 10 28 44 PM" src="https://user-images.githubusercontent.com/487433/87000926-166b1780-c16b-11ea-810e-2e8c3c080f0c.png">
<img width="403" alt="Screen Shot 2020-07-08 at 10 28 32 PM" src="https://user-images.githubusercontent.com/487433/87000928-1703ae00-c16b-11ea-9c5e-01a2e0811489.png">

