### PR TITLE
fix(csv upload): hive params typo

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -126,11 +126,11 @@ class HiveEngineSpec(PrestoEngineSpec):
         }
         if header_line_count is not None and header_line_count >= 0:
             header_line_count += 1
-            tblproperties.append("'skip.header.line.count'=':header_line_count'")
+            tblproperties.append("'skip.header.line.count'=:header_line_count")
             params["header_line_count"] = str(header_line_count)
         if null_values:
             # hive only supports 1 value for the null format
-            tblproperties.append("'serialization.null.format'=':null_value'")
+            tblproperties.append("'serialization.null.format'=:null_value")
             params["null_value"] = null_values[0]
 
         if tblproperties:

--- a/tests/db_engine_specs/hive_tests.py
+++ b/tests/db_engine_specs/hive_tests.py
@@ -181,7 +181,7 @@ def test_get_create_table_stmt() -> None:
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
                 ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
                 STORED AS TEXTFILE LOCATION :location
-                tblproperties ('skip.header.line.count'=':header_line_count', 'serialization.null.format'=':null_value')""",
+                tblproperties ('skip.header.line.count'=:header_line_count, 'serialization.null.format'=:null_value)""",
         {
             "delim": ",",
             "location": "s3a://directory/table",
@@ -195,7 +195,7 @@ def test_get_create_table_stmt() -> None:
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
                 ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
                 STORED AS TEXTFILE LOCATION :location
-                tblproperties ('skip.header.line.count'=':header_line_count', 'serialization.null.format'=':null_value')""",
+                tblproperties ('skip.header.line.count'=:header_line_count, 'serialization.null.format'=:null_value)""",
         {
             "delim": ",",
             "location": "s3a://directory/table",
@@ -209,7 +209,7 @@ def test_get_create_table_stmt() -> None:
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
                 ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
                 STORED AS TEXTFILE LOCATION :location
-                tblproperties ('skip.header.line.count'=':header_line_count', 'serialization.null.format'=':null_value')""",
+                tblproperties ('skip.header.line.count'=:header_line_count, 'serialization.null.format'=:null_value)""",
         {
             "delim": ",",
             "location": "s3a://directory/table",
@@ -231,6 +231,6 @@ def test_get_create_table_stmt() -> None:
         """CREATE TABLE employee ( eid int, name String, salary String, destination String )
                 ROW FORMAT DELIMITED FIELDS TERMINATED BY :delim
                 STORED AS TEXTFILE LOCATION :location
-                tblproperties ('skip.header.line.count'=':header_line_count')""",
+                tblproperties ('skip.header.line.count'=:header_line_count)""",
         {"delim": ",", "location": "s3a://directory/table", "header_line_count": "101"},
     )


### PR DESCRIPTION
### SUMMARY
Missed this bug in #10208 😬 . This was causing hive csv upload to fail because of syntax errors.

`:param` will handle quotes where necessary - we don't need quotes around them.

### TEST PLAN
Tested in dev env.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@bkyryliuk @etr2460 
