### PR TITLE
fix: add additional ui tweaks

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.test.js
@@ -45,7 +45,7 @@ describe('SqlLab query tabs', () => {
       });
 
       // first item is close
-      cy.get('.SqlEditorTabs .ddbtn-tab .close').first().click();
+      cy.get('.SqlEditorTabs .ddbtn-tab .fa-close').first().click();
 
       cy.get('.SqlEditorTabs > ul > li').should(
         'have.length',

--- a/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.test.js
@@ -45,7 +45,7 @@ describe('SqlLab query tabs', () => {
       });
 
       // first item is close
-      cy.get('.SqlEditorTabs .ddbtn-tab .fa-close').first().click();
+      cy.get('.SqlEditorTabs .ddbtn-tab svg').first().click();
 
       cy.get('.SqlEditorTabs > ul > li').should(
         'have.length',

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -289,9 +289,10 @@ class TabbedSqlEditors extends React.PureComponent {
       const title = (
         <>
           {qe.title} <TabStatusIcon tabState={state} />{' '}
-          <span className="close" onClick={() => this.removeQueryEditor(qe)}>
-            {'×'}
-          </span>
+          <i
+            className="fa fa-close"
+            onClick={() => this.removeQueryEditor(qe)}
+          />
         </>
       );
       const tabTitle = (

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -29,6 +29,7 @@ import * as Actions from '../actions/sqlLab';
 import SqlEditor from './SqlEditor';
 import { areArraysShallowEqual } from '../../reduxUtils';
 import TabStatusIcon from './TabStatusIcon';
+import Icon from '../../components/Icon';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -289,8 +290,11 @@ class TabbedSqlEditors extends React.PureComponent {
       const title = (
         <>
           {qe.title} <TabStatusIcon tabState={state} />{' '}
-          <i
-            className="fa fa-close"
+          <Icon
+            role="button"
+            tabIndex={0}
+            cursor="pointer"
+            name="cancel-x"
             onClick={() => this.removeQueryEditor(qe)}
           />
         </>

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -259,6 +259,14 @@ div.Workspace {
     &:active {
       background: none;
     }
+
+    .fa.fa-close {
+      color: @gray;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
   }
 
   .dropdown.btn-group.btn-group-sm {
@@ -302,15 +310,6 @@ div.Workspace {
 
   .dropdown-toggle {
     padding-top: 2px;
-  }
-
-  .close {
-    opacity: 1;
-    font-size: @font-size-l;
-    font-weight: @font-weight-light;
-    color: @almost-black;
-    position: relative;
-    right: -4px;
   }
 }
 

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -177,11 +177,9 @@ div.Workspace {
 
   display: inline-block;
   background-color: @gray-light;
-  line-height: 8px; // set specifically for closing 'x'
   text-align: center;
   vertical-align: middle;
   font-size: @font-size-m;
-  margin-top: -3px;
   font-weight: @font-weight-bold;
 }
 
@@ -260,12 +258,8 @@ div.Workspace {
       background: none;
     }
 
-    .fa.fa-close {
-      color: @gray;
-
-      &:hover {
-        cursor: pointer;
-      }
+    svg {
+      vertical-align: middle;
     }
   }
 

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -306,9 +306,10 @@ div.Workspace {
 
   .close {
     opacity: 1;
+    font-size: @font-size-l;
+    font-weight: @font-weight-light;
     color: @almost-black;
     position: relative;
-    top: -2px;
     right: -4px;
   }
 }


### PR DESCRIPTION
### SUMMARY
This PR is to finish extra UI tweaks based on the discussion on #10257 (which was merged without review approval accidentally)
- smaller and lighter `x`


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
<img width="776" alt="Screen Shot 2020-07-09 at 11 28 04 AM" src="https://user-images.githubusercontent.com/27990562/87077746-764bd780-c1d8-11ea-87f7-926542bda8f5.png">

**After:**
<img width="758" alt="Screen Shot 2020-07-14 at 4 16 07 PM" src="https://user-images.githubusercontent.com/27990562/87486754-d388c400-c5f0-11ea-8534-3ce0b554a90f.png">




### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #10257 
- [x] Changes UI

@kenchendesign @rusackas 

