### PR TITLE
fix: deckgl dimension select missing options

### DIFF
--- a/superset-frontend/src/explore/controlPanels/DeckArc.js
+++ b/superset-frontend/src/explore/controlPanels/DeckArc.js
@@ -99,15 +99,17 @@ export default {
         ],
         [
           {
-            ...dimension,
-            label: t('Categorical Color'),
-            description: t(
-              'Pick a dimension from which categorical colors are defined',
-            ),
+            name: 'dimension',
+            config: {
+              ...dimension.config,
+              label: t('Categorical Color'),
+              description: t(
+                'Pick a dimension from which categorical colors are defined',
+              ),
+            },
           },
-          'color_scheme',
-          'label_colors',
         ],
+        ['color_scheme', 'label_colors'],
         [
           {
             name: 'stroke_width',

--- a/superset-frontend/src/explore/controlPanels/DeckScatter.js
+++ b/superset-frontend/src/explore/controlPanels/DeckScatter.js
@@ -134,15 +134,17 @@ export default {
         [null, legendFormat],
         [
           {
-            ...dimension,
-            label: t('Categorical Color'),
-            description: t(
-              'Pick a dimension from which categorical colors are defined',
-            ),
+            name: 'dimension',
+            config: {
+              ...dimension.config,
+              label: t('Categorical Color'),
+              description: t(
+                'Pick a dimension from which categorical colors are defined',
+              ),
+            },
           },
-          'color_scheme',
-          'label_colors',
         ],
+        ['color_scheme', 'label_colors'],
       ],
     },
     {

--- a/superset-frontend/src/explore/controlPanels/Shared_DeckGL.jsx
+++ b/superset-frontend/src/explore/controlPanels/Shared_DeckGL.jsx
@@ -22,7 +22,7 @@
 import React from 'react';
 import { t } from '@superset-ui/translation';
 import { validateNonEmpty } from '@superset-ui/validator';
-import { ColumnOption } from '@superset-ui/chart-controls';
+import { ColumnOption, sharedControls } from '@superset-ui/chart-controls';
 import { D3_FORMAT_OPTIONS, columnChoices, PRIMARY_COLOR } from '../controls';
 import { DEFAULT_VIEWPORT } from '../../explore/components/controls/ViewportControl';
 
@@ -33,37 +33,6 @@ const timeColumnOption = {
     'A reference to the [Time] configuration, taking granularity into ' +
       'account',
   ),
-};
-
-const groupByControl = {
-  type: 'SelectControl',
-  multi: true,
-  freeForm: true,
-  label: t('Group by'),
-  default: [],
-  includeTime: false,
-  description: t('One or many controls to group by'),
-  optionRenderer: c => <ColumnOption column={c} showType />,
-  valueRenderer: c => <ColumnOption column={c} />,
-  valueKey: 'column_name',
-  allowAll: true,
-  filterOption: (opt, text) =>
-    (opt.column_name &&
-      opt.column_name.toLowerCase().indexOf(text.toLowerCase()) >= 0) ||
-    (opt.verbose_name &&
-      opt.verbose_name.toLowerCase().indexOf(text.toLowerCase()) >= 0),
-  promptTextCreator: label => label,
-  mapStateToProps: (state, control) => {
-    const newState = {};
-    if (state.datasource) {
-      newState.options = state.datasource.columns.filter(c => c.groupby);
-      if (control && control.includeTime) {
-        newState.options.push(timeColumnOption);
-      }
-    }
-    return newState;
-  },
-  commaChoosesOption: false,
 };
 
 const sandboxUrl =
@@ -137,7 +106,7 @@ export const autozoom = {
 export const dimension = {
   name: 'dimension',
   config: {
-    ...groupByControl,
+    ...sharedControls.groupby,
     label: t('Dimension'),
     description: t('Select a dimension'),
     multi: false,
@@ -148,7 +117,7 @@ export const dimension = {
 export const jsColumns = {
   name: 'js_columns',
   config: {
-    ...groupByControl,
+    ...sharedControls.groupby,
     label: t('Extra data for JS'),
     default: [],
     description: t(


### PR DESCRIPTION
### SUMMARY

Fix Bug #10246 introduced by #9455 and #9628 .

Also moved color picker to its own row so to give more space for dimension select.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img src="https://user-images.githubusercontent.com/335541/87100467-5b418d80-c201-11ea-84f8-28e846d728f3.png" width="300" />


After: 

<img src="https://user-images.githubusercontent.com/335541/87100474-5ed51480-c201-11ea-82f1-387866a66621.png" width="300" />


### TEST PLAN

- Manual testing
- Go create a _Deck.gl Arc_ or _Deck.gl Scatter_ chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
