### PR TITLE
fix(explore): edit datasource does not update control states

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
@@ -41,6 +41,9 @@ const defaultProps = {
       name: 'main',
     },
   },
+  actions: {
+    setDatasource: sinon.spy(),
+  },
   onChange: sinon.spy(),
 };
 
@@ -71,15 +74,15 @@ describe('DatasourceControl', () => {
     let wrapper = setup();
     expect(wrapper.find('#datasource_menu')).toHaveLength(1);
     expect(wrapper.find('#datasource_menu').dive().find(MenuItem)).toHaveLength(
-      2,
+      3,
     );
 
     wrapper = setup({
-      onDatasourceSave: () => {},
+      isEditable: false,
     });
     expect(wrapper.find('#datasource_menu')).toHaveLength(1);
     expect(wrapper.find('#datasource_menu').dive().find(MenuItem)).toHaveLength(
-      3,
+      2,
     );
   });
 });

--- a/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
@@ -27,7 +27,6 @@ import {
   getFormDataFromControls,
   applyMapStateToPropsToControl,
   getAllControlsState,
-  getControlsState,
 } from 'src/explore/controlUtils';
 
 describe('controlUtils', () => {

--- a/superset-frontend/src/components/TooltipWrapper.jsx
+++ b/superset-frontend/src/components/TooltipWrapper.jsx
@@ -26,6 +26,10 @@ const propTypes = {
   tooltip: PropTypes.node.isRequired,
   children: PropTypes.node.isRequired,
   placement: PropTypes.string,
+  trigger: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
 };
 
 const defaultProps = {
@@ -37,11 +41,13 @@ export default function TooltipWrapper({
   tooltip,
   children,
   placement,
+  trigger,
 }) {
   return (
     <OverlayTrigger
       placement={placement}
       overlay={<Tooltip id={`${kebabCase(label)}-tooltip`}>{tooltip}</Tooltip>}
+      trigger={trigger}
     >
       {children}
     </OverlayTrigger>

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -389,6 +389,7 @@ function mapStateToProps(state) {
   const form_data = getFormDataFromControls(explore.controls);
   const chartKey = Object.keys(charts)[0];
   const chart = charts[chartKey];
+
   return {
     isDatasourceMetaLoading: explore.isDatasourceMetaLoading,
     datasource: explore.datasource,

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -160,11 +160,11 @@ class DatasourceControl extends React.PureComponent {
                   {t('Explore in SQL Lab')}
                 </MenuItem>
               )}
-              {this.props.isEditable ? (
+              {this.props.isEditable && (
                 <MenuItem eventKey="3" onClick={this.toggleEditDatasourceModal}>
                   {t('Edit Datasource')}
                 </MenuItem>
-              ) : null}
+              )}
             </DropdownButton>
           </TooltipWrapper>
           <OverlayTrigger

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -38,9 +38,11 @@ import TooltipWrapper from '../../../components/TooltipWrapper';
 import './DatasourceControl.less';
 
 const propTypes = {
+  actions: PropTypes.object.isRequired,
   onChange: PropTypes.func,
   value: PropTypes.string,
   datasource: PropTypes.object.isRequired,
+  isEditable: PropTypes.bool,
   onDatasourceSave: PropTypes.func,
 };
 
@@ -48,6 +50,7 @@ const defaultProps = {
   onChange: () => {},
   onDatasourceSave: null,
   value: null,
+  isEditable: true,
 };
 
 class DatasourceControl extends React.PureComponent {
@@ -58,12 +61,20 @@ class DatasourceControl extends React.PureComponent {
       showChangeDatasourceModal: false,
       menuExpanded: false,
     };
+    this.onDatasourceSave = this.onDatasourceSave.bind(this);
     this.toggleChangeDatasourceModal = this.toggleChangeDatasourceModal.bind(
       this,
     );
     this.toggleEditDatasourceModal = this.toggleEditDatasourceModal.bind(this);
     this.toggleShowDatasource = this.toggleShowDatasource.bind(this);
     this.renderDatasource = this.renderDatasource.bind(this);
+  }
+
+  onDatasourceSave(datasource) {
+    this.props.actions.setDatasource(datasource);
+    if (this.props.onDatasourceSave) {
+      this.props.onDatasourceSave(datasource);
+    }
   }
 
   toggleShowDatasource() {
@@ -120,7 +131,7 @@ class DatasourceControl extends React.PureComponent {
 
   render() {
     const { showChangeDatasourceModal, showEditDatasourceModal } = this.state;
-    const { datasource, onChange, onDatasourceSave, value } = this.props;
+    const { datasource, onChange, value } = this.props;
     return (
       <div>
         <ControlHeader {...this.props} />
@@ -128,6 +139,7 @@ class DatasourceControl extends React.PureComponent {
           <TooltipWrapper
             label="change-datasource"
             tooltip={t('Click to change the datasource')}
+            trigger={['hover']}
           >
             <DropdownButton
               title={datasource.name}
@@ -148,11 +160,11 @@ class DatasourceControl extends React.PureComponent {
                   {t('Explore in SQL Lab')}
                 </MenuItem>
               )}
-              {!!this.props.onDatasourceSave && (
+              {this.props.isEditable ? (
                 <MenuItem eventKey="3" onClick={this.toggleEditDatasourceModal}>
                   {t('Edit Datasource')}
                 </MenuItem>
-              )}
+              ) : null}
             </DropdownButton>
           </TooltipWrapper>
           <OverlayTrigger
@@ -179,11 +191,11 @@ class DatasourceControl extends React.PureComponent {
         <DatasourceModal
           datasource={datasource}
           show={showEditDatasourceModal}
-          onDatasourceSave={onDatasourceSave}
+          onDatasourceSave={this.onDatasourceSave}
           onHide={this.toggleEditDatasourceModal}
         />
         <ChangeDatasourceModal
-          onDatasourceSave={onDatasourceSave}
+          onDatasourceSave={this.onDatasourceSave}
           onHide={this.toggleChangeDatasourceModal}
           show={showChangeDatasourceModal}
           onChange={onChange}

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -20,7 +20,6 @@ import memoizeOne from 'memoize-one';
 import { getChartControlPanelRegistry } from '@superset-ui/chart';
 import { expandControlConfig } from '@superset-ui/chart-controls';
 import { controls as SHARED_CONTROLS } from './controls';
-import * as exploreActions from './actions/exploreActions';
 import * as SECTIONS from './controlPanels/sections';
 
 export function getFormDataFromControls(controlsState) {
@@ -94,7 +93,7 @@ export function applyMapStateToPropsToControl(controlState, controlPanelState) {
   if (mapStateToProps && controlPanelState) {
     return {
       ...controlState,
-      ...mapStateToProps(controlPanelState, controlState, exploreActions),
+      ...mapStateToProps(controlPanelState, controlState),
     };
   }
   return controlState;

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -204,9 +204,9 @@ export const controls = {
     label: t('Datasource'),
     default: null,
     description: null,
-    mapStateToProps: (state, control, actions) => ({
-      datasource: state.datasource,
-      onDatasourceSave: actions ? actions.setDatasource : () => {},
+    mapStateToProps: ({ datasource }) => ({
+      datasource,
+      isEditable: !!datasource,
     }),
   },
 


### PR DESCRIPTION
### SUMMARY

Follow up for #10283 .

Even after re-enable the "Edit datasource" menu item, the datasource edit modal doesn't actually update current control state---users have to refresh the page to see their datasource updated. This is because the `actions` object passed to `mapStateToProps` is not the actual reducer dispatch function, but the methods to generate dispatch payload.

The functionality was broken because #10224 and #10264 simplified how `mapStateToProps` is called and removed `actions` from `mapStateToProps`'s signature. Since `DatasourceControl` is the only place where `actions` dispatchers are needed for `mapStateToProps`, and all controls actually [already accepts `actions` as props](https://github.com/apache/incubator-superset/blob/700429f431d20b624e886cf554b2b493793448be/superset-frontend/src/explore/components/ControlPanelsContainer.jsx#L95), it makes sense to keep the function simple and refactor `DatasourceControl` instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

1. Edit a datasource. We recommend start from a table chart.
2. After saving the datasource, you should be able to see the changes to datasource columns, metrics, etc in the controls without refreshing the page.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
