### PR TITLE
fix: saving custom CSS correctly from dashboard editor

### DIFF
--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -267,7 +267,7 @@ class Header extends React.PureComponent {
       dashboardTitle,
       layout: positions,
       expandedSlices,
-      css,
+      customCss,
       colorNamespace,
       colorScheme,
       dashboardInfo,
@@ -288,7 +288,7 @@ class Header extends React.PureComponent {
     const data = {
       positions,
       expanded_slices: expandedSlices,
-      css,
+      css: customCss,
       color_namespace: colorNamespace,
       color_scheme: colorScheme,
       label_colors: labelColors,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A fix was made to the `save as` modal that wasn't applied to the method called by the `save as` button after editing the custom CSS. This fixes the parameter name (which was changed to avoid a collision with Emotion props).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #10102 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
