### PR TITLE
chore: Silencing unused thumbnail cache config

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -333,7 +333,10 @@ GET_FEATURE_FLAGS_FUNC: Optional[Callable[[Dict[str, bool]], Dict[str, bool]]] =
 # Thumbnail config (behind feature flag)
 # ---------------------------------------------------
 THUMBNAIL_SELENIUM_USER = "Admin"
-THUMBNAIL_CACHE_CONFIG: CacheConfig = {"CACHE_TYPE": "null"}
+THUMBNAIL_CACHE_CONFIG: CacheConfig = {
+    "CACHE_TYPE": "null",
+    "CACHE_NO_NULL_WARNING": True,
+}
 
 # ---------------------------------------------------
 # Image and file configuration


### PR DESCRIPTION
### SUMMARY

Whenever one uses the `superset` CLI with the thumbnail feature disabled (which is behind a feature flag), one would see the following warning, 

```
INFO:superset.utils.logging_configurator:logging was configured successfully
/usr/local/lib/python3.6/dist-packages/flask_caching/__init__.py:189: UserWarning: Flask-Caching: CACHE_TYPE is set to null, caching is effectively disabled.
```

This was in related to the `THUMBNAIL_CACHE_CONFIG` which is unused but has a default configuration of 

```python
THUMBNAIL_CACHE_CONFIG = {"CACHE_TYPE": "null"}
```

The fix is merely to disable the warning for said cache.

Note that the `CACHE_CONFIG` and `TABLE_NAMES_CACHE_CONFIG` are initialized as `{"CACHE_TYPE": "null"}` however the difference is the intent is for them to for these to by overridden as they are critical for non-feature flag aspects of the application.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
