### PR TITLE
fix(table-viz): table chart time column should use default

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/line.test.ts
@@ -45,6 +45,13 @@ describe('Visualization > Line', () => {
     cy.get('.alert-warning').should('not.exist');
   });
 
+  it('should allow negative values in Y bounds', () => {
+    cy.get('#controlSections-tab-display').click();
+    cy.get('span').contains('Y Axis Bounds').scrollIntoView();
+    cy.get('input[placeholder="Min"]').type('-0.1', { delay: 100 });
+    cy.get('.alert-warning').should('not.exist');
+  });
+
   it('should work with adhoc metric', () => {
     const formData = { ...LINE_CHART_DEFAULTS, metrics: [NUM_METRIC] };
     cy.visitChartByParams(JSON.stringify(formData));
@@ -54,9 +61,7 @@ describe('Visualization > Line', () => {
   it('should work with groupby', () => {
     const metrics = ['count'];
     const groupby = ['gender'];
-
     const formData = { ...LINE_CHART_DEFAULTS, metrics, groupby };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
@@ -64,13 +69,11 @@ describe('Visualization > Line', () => {
   it('should work with simple filter', () => {
     const metrics = ['count'];
     const filters = [SIMPLE_FILTER];
-
     const formData = {
       ...LINE_CHART_DEFAULTS,
       metrics,
       adhoc_filters: filters,
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
@@ -83,7 +86,6 @@ describe('Visualization > Line', () => {
       groupby: ['name'],
       timeseries_limit_metric: NUM_METRIC,
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
@@ -97,28 +99,24 @@ describe('Visualization > Line', () => {
       timeseries_limit_metric: NUM_METRIC,
       order_desc: true,
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
   it('should work with rolling avg', () => {
     const metrics = [NUM_METRIC];
-
     const formData = {
       ...LINE_CHART_DEFAULTS,
       metrics,
       rolling_type: 'mean',
       rolling_periods: 10,
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
   it('should work with time shift 1 year', () => {
     const metrics = [NUM_METRIC];
-
     const formData = {
       ...LINE_CHART_DEFAULTS,
       metrics,
@@ -162,28 +160,24 @@ describe('Visualization > Line', () => {
 
   it('should work with time shift yoy', () => {
     const metrics = [NUM_METRIC];
-
     const formData = {
       ...LINE_CHART_DEFAULTS,
       metrics,
       time_compare: ['1+year'],
       comparison_type: 'ratio',
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
 
   it('should work with time shift percentage change', () => {
     const metrics = [NUM_METRIC];
-
     const formData = {
       ...LINE_CHART_DEFAULTS,
       metrics,
       time_compare: ['1+year'],
       comparison_type: 'percentage',
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
   });
@@ -193,7 +187,6 @@ describe('Visualization > Line', () => {
       ...LINE_CHART_DEFAULTS,
       metrics: ['count'],
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
     cy.get('text.nv-legend-text').contains('COUNT(*)');
@@ -224,7 +217,6 @@ describe('Visualization > Line', () => {
         },
       ],
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
     cy.get('.slice_container').within(() => {
@@ -263,7 +255,6 @@ describe('Visualization > Line', () => {
         cy.visitChartByParams(JSON.stringify(formData));
       },
     );
-
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'svg' });
     cy.get('.slice_container').within(() => {
       cy.get('.nv-event-annotation-layer-0')

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
@@ -35,6 +35,15 @@ describe('Visualization > Table', () => {
     cy.route('POST', '/superset/explore_json/**').as('getJson');
   });
 
+  it('Use default time column', () => {
+    cy.visitChartByParams({
+      ...VIZ_DEFAULTS,
+      granularity_sqla: undefined,
+      metrics: ['count'],
+    });
+    cy.get('input[name="select-granularity_sqla"]').should('have.value', 'ds');
+  });
+
   it('Format non-numeric metrics correctly', () => {
     cy.visitChartByParams({
       ...VIZ_DEFAULTS,

--- a/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
@@ -263,6 +263,15 @@ describe('controlUtils', () => {
       const control = getControlState('metric', 'table', state, null);
       expect(control.validationErrors).toEqual(['cannot be empty']);
     });
+    it('should not validate if control panel is initializing', () => {
+      const control = getControlState(
+        'metric',
+        'table',
+        { ...state, controls: undefined },
+        undefined,
+      );
+      expect(control.validationErrors).toBeUndefined();
+    });
   });
 
   describe('queryFields', () => {

--- a/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/controlUtils_spec.jsx
@@ -35,6 +35,7 @@ describe('controlUtils', () => {
       columns: ['a', 'b', 'c'],
       metrics: [{ metric_name: 'first' }, { metric_name: 'second' }],
     },
+    controls: {},
   };
 
   beforeAll(() => {
@@ -250,9 +251,10 @@ describe('controlUtils', () => {
     it('should not apply mapStateToProps when initializing', () => {
       const control = getControlState('metrics', 'table', {
         ...state,
-        isInitializing: true,
+        controls: undefined,
       });
-      expect(control.default).toEqual(null);
+      expect(typeof control.default).toBe('function');
+      expect(control.value).toBe(undefined);
     });
   });
 

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -78,8 +78,6 @@ class ControlPanelsContainer extends React.Component {
     const {
       validationErrors,
       provideFormDataToProps,
-      value,
-      default: defaultValue,
       ...restProps
     } = controlData;
 
@@ -91,7 +89,6 @@ class ControlPanelsContainer extends React.Component {
     return (
       <Control
         name={name}
-        value={value === undefined ? defaultValue : value}
         key={`control-${name}`}
         validationErrors={validationErrors}
         actions={actions}

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -66,19 +66,20 @@ class ControlPanelsContainer extends React.Component {
   renderControl({ name, config }) {
     const { actions, controls, exploreState, form_data: formData } = this.props;
     const { visibility } = config;
+
     // If the control item is not an object, we have to look up the control data from
     // the centralized controls file.
     // When it is an object we read control data straight from `config` instead
     const controlData = {
-      ...controls[name],
       ...config,
+      ...controls[name],
       name,
-      // apply current value in formData
-      value: formData[name],
     };
     const {
       validationErrors,
       provideFormDataToProps,
+      value,
+      default: defaultValue,
       ...restProps
     } = controlData;
 
@@ -90,6 +91,7 @@ class ControlPanelsContainer extends React.Component {
     return (
       <Control
         name={name}
+        value={value === undefined ? defaultValue : value}
         key={`control-${name}`}
         validationErrors={validationErrors}
         actions={actions}

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -151,7 +151,10 @@ export function getControlStateFromControlConfig(
   }
   let controlState = { ...controlConfig, value };
   // only apply mapStateToProps when control states have been initialized
-  if (controlPanelState && controlPanelState.controls) {
+  if (
+    (controlPanelState && controlPanelState.controls) ||
+    controlPanelState === null
+  ) {
     controlState = applyMapStateToPropsToControl(
       controlState,
       controlPanelState,

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -151,6 +151,7 @@ export function getControlStateFromControlConfig(
   }
   let controlState = { ...controlConfig, value };
   // only apply mapStateToProps when control states have been initialized
+  // or when explicitly didn't provide control panel state (mostly for testing)
   if (
     (controlPanelState && controlPanelState.controls) ||
     controlPanelState === null
@@ -159,8 +160,9 @@ export function getControlStateFromControlConfig(
       controlState,
       controlPanelState,
     );
+    return validateControl(handleMissingChoice(controlState), controlState);
   }
-  return validateControl(handleMissingChoice(controlState), controlState);
+  return controlState;
 }
 
 export function getControlState(controlKey, vizType, state, value) {

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -36,18 +36,17 @@ export function getFormDataFromControls(controlsState) {
 
 export function validateControl(control, processedState) {
   const validators = control.validators;
+  const validationErrors = [];
   if (validators && validators.length > 0) {
-    const validatedControl = { ...control };
-    const validationErrors = [];
     validators.forEach(f => {
       const v = f.call(control, control.value, processedState);
       if (v) {
         validationErrors.push(v);
       }
     });
-    return { ...validatedControl, validationErrors };
   }
-  return control;
+  // always reset validation errors even when there is no validator
+  return { ...control, validationErrors };
 }
 
 /**

--- a/superset-frontend/src/explore/reducers/getInitialState.js
+++ b/superset-frontend/src/explore/reducers/getInitialState.js
@@ -41,7 +41,6 @@ export default function getInitialState(bootstrapData) {
     filterColumnOpts: [],
     isDatasourceMetaLoading: false,
     isStarred: false,
-    isInitializing: true,
   };
   const controls = getControlsState(bootstrappedState, rawFormData);
   bootstrappedState.controls = controls;
@@ -55,7 +54,6 @@ export default function getInitialState(bootstrapData) {
       bootstrappedState,
     );
   });
-  bootstrappedState.isInitializing = false;
 
   const sliceFormData = slice
     ? getFormDataFromControls(getControlsState(bootstrapData, slice.form_data))


### PR DESCRIPTION
### SUMMARY

Table chart has stopped using the default time column due to recent refactor to control utils (#10224, #10264, #10284). Other charts somehow weren't impacted.

The root cause is that `mapStateToProps` for the Time Column control will update `control.default` that wasn't picked by the re-run of `mapStateToProps` in `getInitialState`.

Refactored `applyMapStateToPropsToControl` so that everything the map function updates `default` or `value`, it will always be picked up by `getControlState`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Go create a new table chart with a datasource that has a time column.

Before: default time column (the first temporal column) is not populated

<img src="https://user-images.githubusercontent.com/335541/87255810-cded7b80-c442-11ea-8ef3-bb8188296114.png" width="400">


After: default time column should be automatically populated

<img src="https://user-images.githubusercontent.com/335541/87255778-97affc00-c442-11ea-8c93-f4e2c4d31b80.png" width="400">

### TEST PLAN

Added an integration test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
