### PR TITLE
fix(chart-data-api): case insensitive evaluation of filter op

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -14,15 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 from flask_babel import gettext as _
-from marshmallow import fields, post_load, Schema, validate, ValidationError
+from marshmallow import fields, post_load, Schema, validate
 from marshmallow.validate import Length, Range
 
 from superset.common.query_context import QueryContext
-from superset.exceptions import SupersetException
-from superset.utils import core as utils
+from superset.utils import schema as utils
+from superset.utils.core import FilterOperator
 
 #
 # RISON/JSON schemas for query parameters
@@ -100,13 +100,6 @@ openapi_spec_methods_override = {
 }
 
 
-def validate_json(value: Union[bytes, bytearray, str]) -> None:
-    try:
-        utils.validate_json(value)
-    except SupersetException:
-        raise ValidationError("JSON not valid")
-
-
 class ChartPostSchema(Schema):
     """
     Schema to add a new chart.
@@ -123,7 +116,7 @@ class ChartPostSchema(Schema):
     )
     owners = fields.List(fields.Integer(description=owners_description))
     params = fields.String(
-        description=params_description, allow_none=True, validate=validate_json
+        description=params_description, allow_none=True, validate=utils.validate_json
     )
     cache_timeout = fields.Integer(
         description=cache_timeout_description, allow_none=True
@@ -551,8 +544,8 @@ class ChartDataFilterSchema(Schema):
     )
     op = fields.String(  # pylint: disable=invalid-name
         description="The comparison operator.",
-        validate=validate.OneOf(
-            choices=[filter_op.value for filter_op in utils.FilterOperator]
+        validate=utils.OneOfCaseInsensitive(
+            choices=[filter_op.value for filter_op in FilterOperator]
         ),
         required=True,
         example="IN",

--- a/superset/utils/schema.py
+++ b/superset/utils/schema.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Union
+
+from marshmallow import validate, ValidationError
+
+from superset.exceptions import SupersetException
+from superset.utils import core as utils
+
+
+class OneOfCaseInsensitive(validate.OneOf):
+    """
+    Marshmallow validator that's based on the built-in `OneOf`, but performs
+    validation case insensitively.
+    """
+
+    def __call__(self, value) -> str:
+        try:
+            print(value)
+            if (value.lower() if isinstance(value, str) else value) not in [
+                choice.lower() if isinstance(choice, str) else choice
+                for choice in self.choices
+            ]:
+                raise ValidationError(self._format_error(value))
+        except TypeError as error:
+            raise ValidationError(self._format_error(value)) from error
+
+        return value
+
+
+def validate_json(value: Union[bytes, bytearray, str]) -> None:
+    """
+    JSON Validator that can be passed to a Marshmallow `Field`'s validate argument.
+
+    :raises ValidationError: if value is not serializable to JSON
+    :param value: an object that should be parseable to JSON
+    """
+    try:
+        utils.validate_json(value)
+    except SupersetException:
+        raise ValidationError("JSON not valid")

--- a/superset/utils/schema.py
+++ b/superset/utils/schema.py
@@ -30,7 +30,6 @@ class OneOfCaseInsensitive(validate.OneOf):
 
     def __call__(self, value: Any) -> str:
         try:
-            print(value)
             if (value.lower() if isinstance(value, str) else value) not in [
                 choice.lower() if isinstance(choice, str) else choice
                 for choice in self.choices

--- a/superset/utils/schema.py
+++ b/superset/utils/schema.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Union
+from typing import Any, Union
 
 from marshmallow import validate, ValidationError
 
@@ -28,7 +28,7 @@ class OneOfCaseInsensitive(validate.OneOf):
     validation case insensitively.
     """
 
-    def __call__(self, value) -> str:
+    def __call__(self, value: Any) -> str:
         try:
             print(value)
             if (value.lower() if isinstance(value, str) else value) not in [

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -708,6 +708,20 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 5)
 
+    def test_chart_data_mixed_case_filter_op(self):
+        """
+        Chart data API: Ensure mixed case filter operator generates valid result
+        """
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        request_payload["queries"][0]["filters"][0]["op"] = "In"
+        request_payload["queries"][0]["row_limit"] = 10
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        response_payload = json.loads(rv.data.decode("utf-8"))
+        result = response_payload["result"][0]
+        self.assertEqual(result["rowcount"], 10)
+
     def test_chart_data_with_invalid_datasource(self):
         """Chart data API: Test chart data query with invalid schema
         """


### PR DESCRIPTION
### SUMMARY
Introduce case insensitive validation of filter operators in chart data schemas, as filter operators are made uppercase in both Druid and SQLA connectors, hence case isn't a concern for queries. The custom validators are moved to `utils/schema.py` as they will likely be relevant in other endpoints, too.

Currently the cases of filter operators are inconsistent: some are all uppercase, others all lowercase. I considered unifying those, but it would have introduced risk of regression, so will save that for a separate PR after 0.37.0 has shipped.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/87283575-19189480-c4fe-11ea-993a-d3a58562d32c.png)
### AFTER
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/33317356/87283443-f8e8d580-c4fd-11ea-9891-7d009bca778d.png)

### TEST PLAN
CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #10296 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
