### PR TITLE
fix(chart-data-api): improve chart data endpoint errors

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -143,7 +143,7 @@ class Chart extends React.PureComponent {
     return (
       <ErrorMessageWithStackTrace
         error={queryResponse?.errors?.[0]}
-        message={chartAlert}
+        message={chartAlert || queryResponse?.message}
         link={queryResponse ? queryResponse.link : null}
         stackTrace={chartStackTrace}
       />

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -474,7 +474,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         payload = query_context.get_payload()
         for query in payload:
             if query["error"]:
-                raise self.response_500(message=f"Error: {query['error']}")
+                return self.response_500(message=f"Error: {query['error']}")
         result_format = query_context.result_format
         if result_format == ChartDataResultFormat.CSV:
             # return the first result

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -465,13 +465,16 @@ class ChartRestApi(BaseSupersetModelRestApi):
             return self.response_400(message="Request is incorrect")
         except ValidationError as error:
             return self.response_400(
-                _("Request is incorrect: %(error)s", error=error.messages)
+                message=_("Request is incorrect: %(error)s", error=error.messages)
             )
         try:
             query_context.raise_for_access()
         except SupersetSecurityException:
             return self.response_401()
         payload = query_context.get_payload()
+        for query in payload:
+            if query["error"]:
+                raise self.response_500(message=f"Error: {query['error']}")
         result_format = query_context.result_format
         if result_format == ChartDataResultFormat.CSV:
             # return the first result

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -422,7 +422,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     @statsd_metrics
-    def data(self) -> Response:
+    def data(self) -> Response:  # pylint: disable=too-many-return-statements
         """
         Takes a query context constructed in the client and returns payload
         data response for the given query.
@@ -494,7 +494,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             resp.headers["Content-Type"] = "application/json; charset=utf-8"
             return resp
 
-        raise self.response_400(message=f"Unsupported result_format: {result_format}")
+        return self.response_400(message=f"Unsupported result_format: {result_format}")
 
     @expose("/<pk>/cache_screenshot/", methods=["GET"])
     @protect()

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -474,7 +474,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         payload = query_context.get_payload()
         for query in payload:
             if query["error"]:
-                return self.response_500(message=f"Error: {query['error']}")
+                return self.response_400(message=f"Error: {query['error']}")
         result_format = query_context.result_format
         if result_format == ChartDataResultFormat.CSV:
             # return the first result

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -111,8 +111,7 @@ class QueryContext:
                 self.df_metrics_to_num(df, query_object)
 
             df.replace([np.inf, -np.inf], np.nan)
-
-        df = query_object.exec_post_processing(df)
+            df = query_object.exec_post_processing(df)
 
         return {
             "query": result.query,
@@ -160,10 +159,7 @@ class QueryContext:
         df = payload["df"]
         status = payload["status"]
         if status != utils.QueryStatus.FAILED:
-            if df.empty:
-                payload["error"] = "No data"
-            else:
-                payload["data"] = self.get_data(df)
+            payload["data"] = self.get_data(df)
         del payload["df"]
         if self.result_type == utils.ChartDataResultType.RESULTS:
             return {"data": payload["data"]}

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1133,6 +1133,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         sql = query_str_ext.sql
         status = utils.QueryStatus.SUCCESS
         errors = None
+        error_message = None
 
         def mutator(df: pd.DataFrame) -> None:
             """
@@ -1163,6 +1164,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             )
             db_engine_spec = self.database.db_engine_spec
             errors = db_engine_spec.extract_errors(ex)
+            error_message = utils.error_msg_from_exception(ex)
 
         return QueryResult(
             status=status,
@@ -1170,6 +1172,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             duration=datetime.now() - qry_start_dttm,
             query=sql,
             errors=errors,
+            error_message=error_message,
         )
 
     def get_sqla_table_object(self) -> Table:

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -722,6 +722,36 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 10)
 
+    def test_chart_data_no_data(self):
+        """
+        Chart data API: Test chart data with empty result
+        """
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        request_payload["queries"][0]["filters"] = [
+            {"col": "gender", "op": "==", "val": "foo"}
+        ]
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        self.assertEqual(rv.status_code, 200)
+        response_payload = json.loads(rv.data.decode("utf-8"))
+        result = response_payload["result"][0]
+        self.assertEqual(result["rowcount"], 0)
+        self.assertEqual(result["data"], [])
+
+    def test_chart_data_incorrect_request(self):
+        """
+        Chart data API: Test chart data with invalid SQL
+        """
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        request_payload["queries"][0]["filters"] = []
+        # erroneus WHERE-clause
+        request_payload["queries"][0]["extras"]["where"] = "(gender abc def)"
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        self.assertEqual(rv.status_code, 400)
+
     def test_chart_data_with_invalid_datasource(self):
         """Chart data API: Test chart data query with invalid schema
         """

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -708,6 +708,28 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 5)
 
+    def test_chart_data_incorrect_result_type(self):
+        """
+        Chart data API: Test chart data with unsupported result type
+        """
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        request_payload["result_type"] = "qwerty"
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        self.assertEqual(rv.status_code, 400)
+
+    def test_chart_data_incorrect_result_format(self):
+        """
+        Chart data API: Test chart data with unsupported result format
+        """
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        request_payload["result_format"] = "qwerty"
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        self.assertEqual(rv.status_code, 400)
+
     def test_chart_data_mixed_case_filter_op(self):
         """
         Chart data API: Ensure mixed case filter operator generates valid result


### PR DESCRIPTION
### SUMMARY

TL;DR: this makes viz plugins behave in the same way as legacy viz plugins when the request fails or returns no data.

This fixes the following problems in the chart data endpoint:
- if no data was returned, the chart would not render, leaving the old chart on screen, potentially even an incorrect chart type. This was due to the legacy endpoint returning a 200 with empty data, as opposed to the new endpoint returning a 200 response with an error field but without a data field. To harmonize behavior, `QueryContext` was updated to return a non-error response with an empty data field for empty result sets.
- The `error_message` property of `QueryResult` was not being populated for failed requests in SQLA model, leading to the `error` field on `QueryObject` always being `None`.
- Errors were not picked up from `QueryObject`s when calling the chart data endpoint. This meant that erroneous requests were returned as 200s with an error-field that was not handled in any way, causing the chart to render in unexpected ways. Now the `error` field is is checked for each response dataset; if a single one is defined, a 400 is returned (these are mostly expected to be incorrect SQL).
- The error message from erroneous requests (=incorrect request schema) were not displayed, making it difficult to see in the frontend what the problem was.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### AFTER
When no data is returned, the chart data endpoint returns a response that the `Chart` component can properly identify as an empty response. Previously this left the previous rendered state visible.
![image](https://user-images.githubusercontent.com/33317356/87297393-05c2f480-c511-11ea-95a4-148254a09090.png)

When an incorrect request is performed, the error message is displayed, making debugging easier. Previously only "An error occurred." was displayed (please note that the error in this screenshot has been fixed by #10299).
![image](https://user-images.githubusercontent.com/33317356/87297616-681bf500-c511-11ea-939b-e05f48b2c193.png)

When an a query is incorrect, the error is displayed in the warning (previously this would print "An error occurred while rendering the visualization: TypeError: Cannot read property 'map' of undefined") 
![image](https://user-images.githubusercontent.com/33317356/87398566-b6d39880-c5be-11ea-9a6c-b728c57e4059.png)

### TEST PLAN
Local testing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
