### PR TITLE
fix: Bump FAB to 3.0.1 fix superset init

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ decorator==4.4.2          # via retry
 defusedxml==0.6.0         # via python3-openid
 dnspython==1.16.0         # via email-validator
 email-validator==1.1.0    # via flask-appbuilder
-flask-appbuilder==3.0.0   # via apache-superset (setup.py)
+flask-appbuilder==3.0.1   # via apache-superset (setup.py)
 flask-babel==1.0.0        # via flask-appbuilder
 flask-caching==1.8.0      # via apache-superset (setup.py)
 flask-compress==1.5.0     # via apache-superset (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "cryptography>=2.4.2",
         "dataclasses<0.7",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=3.0.0, <4.0.0",
+        "flask-appbuilder>=3.0.1, <4.0.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",


### PR DESCRIPTION
### SUMMARY
3.0.1 fixes a regression that was causing `superset init` to fail on some cases with:

```
sqlalchemy.orm.exc.MultipleResultsFound: Multiple rows were found for one_or_none()
```


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
