### PR TITLE
fix(chart-data-api): fix csv and query result type and QueryObject schema

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -473,7 +473,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             return self.response_401()
         payload = query_context.get_payload()
         for query in payload:
-            if query["error"]:
+            if query.get("error"):
                 return self.response_400(message=f"Error: {query['error']}")
         result_format = query_context.result_format
         if result_format == ChartDataResultFormat.CSV:

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -702,7 +702,7 @@ class ChartDataQueryObjectSchema(Schema):
     timeseries_limit = fields.Integer(
         description="Maximum row count for timeseries queries. Default: `0`",
     )
-    timeseries_limit_metric = fields.Integer(
+    timeseries_limit_metric = fields.Raw(
         description="Metric used to limit timeseries queries by.", allow_none=True,
     )
     row_limit = fields.Integer(

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -730,6 +730,28 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 400)
 
+    def test_chart_data_query_result_type(self):
+        """
+        Chart data API: Test chart data with query result format
+        """
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        request_payload["result_type"] = "query"
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        self.assertEqual(rv.status_code, 200)
+
+    def test_chart_data_csv_result_format(self):
+        """
+        Chart data API: Test chart data with CSV result format
+        """
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        request_payload["result_format"] = "csv"
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        self.assertEqual(rv.status_code, 200)
+
     def test_chart_data_mixed_case_filter_op(self):
         """
         Chart data API: Ensure mixed case filter operator generates valid result


### PR DESCRIPTION
### SUMMARY
The recent PR #10300 introduced a regression due to the error property not being populated for all result types, namely CSV and Query export. In addition, the data type for `timeseries_limit_metric` in QueryObject` schema was incorrect, causing errors when limiting series in timeseries charts by a custom metric. 

### TEST PLAN
CI + new tests for all fixed errors

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
