### PR TITLE
fix: leave null timestamp unformatted in view results table

### DIFF
--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -72,12 +72,16 @@ describe('utils/common', () => {
     });
     it('changes formatting of temporal column', () => {
       const originalData = [
-        { __timestamp: 1594285437771, column1: 'lorem' },
-        { __timestamp: 1594285441675, column1: 'ipsum' },
+        { __timestamp: null, column1: 'lorem' },
+        { __timestamp: 0, column1: 'ipsum' },
+        { __timestamp: 1594285437771, column1: 'dolor' },
+        { __timestamp: 1594285441675, column1: 'sit' },
       ];
       const expectedData = [
-        { __timestamp: '2020-07-09 09:03:57', column1: 'lorem' },
-        { __timestamp: '2020-07-09 09:04:01', column1: 'ipsum' },
+        { __timestamp: null, column1: 'lorem' },
+        { __timestamp: '1970-01-01 00:00:00', column1: 'ipsum' },
+        { __timestamp: '2020-07-09 09:03:57', column1: 'dolor' },
+        { __timestamp: '2020-07-09 09:04:01', column1: 'sit' },
       ];
       expect(applyFormattingToTabularData(originalData)).toEqual(expectedData);
     });

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -128,7 +128,11 @@ export function applyFormattingToTabularData(data) {
   }
   return data.map(row => ({
     ...row,
-    // eslint-disable-next-line no-underscore-dangle
-    __timestamp: DATETIME_FORMATTER(new Date(row.__timestamp)),
+    /* eslint-disable no-underscore-dangle */
+    __timestamp:
+      row.__timestamp === 0 || row.__timestamp
+        ? DATETIME_FORMATTER(new Date(row.__timestamp))
+        : row.__timestamp,
+    /* eslint-enable no-underscore-dangle */
   }));
 }


### PR DESCRIPTION
### SUMMARY
A recent PR  #10268 introduced a regression, where null timestamps would show up as `1970-01-01 00:00:00` in the View Results table in Explore View.

### TEST PLAN
CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
