### PR TITLE
feat: add optional prophet forecasting functionality to chart data api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ setup(
         "cockroachdb": ["cockroachdb==0.3.3"],
         "thumbnails": ["Pillow>=7.0.0, <8.0.0"],
         "excel": ["xlrd>=1.2.0, <1.3"],
+        "prophet": ["fbprophet>=0.6,,0.7"],
     },
     python_requires="~=3.6",
     author="Apache Software Foundation",

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         "cockroachdb": ["cockroachdb==0.3.3"],
         "thumbnails": ["Pillow>=7.0.0, <8.0.0"],
         "excel": ["xlrd>=1.2.0, <1.3"],
-        "prophet": ["fbprophet>=0.6,,0.7"],
+        "prophet": ["fbprophet>=0.6,<0.7"],
     },
     python_requires="~=3.6",
     author="Apache Software Foundation",

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -72,6 +72,25 @@ WHITELIST_CUMULATIVE_FUNCTIONS = (
     "cumsum",
 )
 
+PROPHET_TIME_GRAIN_MAP = {
+    "PT1S": "S",
+    "PT1M": "min",
+    "PT5M": "5min",
+    "PT10M": "10min",
+    "PT15M": "15min",
+    "PT0.5H": "30min",
+    "PT1H": "H",
+    "P1D": "D",
+    "P1W": "W",
+    "P1M": "M",
+    "P0.25Y": "Q",
+    "P1Y": "A",
+    "1969-12-28T00:00:00Z/P1W": "W",
+    "1969-12-29T00:00:00Z/P1W": "W",
+    "P1W/1970-01-03T00:00:00Z": "W",
+    "P1W/1970-01-04T00:00:00Z": "W",
+}
+
 
 def _flatten_column_after_pivot(
     column: Union[str, Tuple[str, ...]], aggregates: Dict[str, Dict[str, Any]]
@@ -544,3 +563,103 @@ def contribution(
     if temporal_series is not None:
         contribution_df.insert(0, DTTM_ALIAS, temporal_series)
     return contribution_df
+
+
+def prophet(
+    df: DataFrame,
+    time_grain: str,
+    periods: int,
+    confidence_interval: float,
+    yearly_seasonality: Optional[Union[bool, int]] = None,
+    weekly_seasonality: Optional[Union[bool, int]] = None,
+    daily_seasonality: Optional[Union[bool, int]] = None,
+):
+    """
+    Add forecasts to each series in a timeseries dataframe, along with confidence
+    intervals for the prediction. For each series, the operation creates three
+    new columns with the column name suffixed with the following values:
+
+    - `__yhat`: the forecast for the given date
+    - `__yhat_lower`: the lower bound of the forecast for the given date
+    - `__yhat_upper`: the upper bound of the forecast for the given date
+    - `__yhat_upper`: the upper bound of the forecast for the given date
+
+
+    :param df: DataFrame containing all-numeric data (temporal column ignored)
+    :param time_grain: Time grain used to specify time period increments in prediction
+    :param periods: Time periods (in units of `time_grain`) to predict into the future
+    :param confidence_interval: Width of predicted confidence interval
+    :param yearly_seasonality: Should yearly seasonality be applied.
+           An integer value will specify Fourier order of seasonality.
+    :param weekly_seasonality: Should weekly seasonality be applied.
+           An integer value will specify Fourier order of seasonality, `None` will
+           automatically detect seasonality.
+    :param daily_seasonality: Should daily seasonality be applied.
+           An integer value will specify Fourier order of seasonality, `None` will
+           automatically detect seasonality.
+    :return: DataFrame with contributions, with temporal column at beginning if present
+    """
+    # validate inputs
+    if not time_grain:
+        raise QueryObjectValidationError(_("Time grain missing"))
+    freq = PROPHET_TIME_GRAIN_MAP.get(time_grain)
+    if not freq:
+        raise QueryObjectValidationError(
+            _("Unsupported time grain: %(time_grain)s", time_grain=time_grain,)
+        )
+    if not periods or periods < 0:
+        raise QueryObjectValidationError(_("Periods must be a positive integer value"))
+    if not confidence_interval or confidence_interval <= 0 or confidence_interval >= 1:
+        raise QueryObjectValidationError(
+            _("Confidence interval must be between 0 and 1 (exclusive)")
+        )
+    if DTTM_ALIAS not in df.columns:
+        raise QueryObjectValidationError(_("DataFrame must include temporal column"))
+    if len(df.columns) < 2:
+        raise QueryObjectValidationError(_("DataFrame include at least one series"))
+
+    try:
+        from fbprophet import Prophet
+    except ModuleNotFoundError:
+        raise QueryObjectValidationError(_("`fbprophet` package not installed"))
+
+    def _parse_seasonality(
+        input_value: Optional[Union[bool, int]]
+    ) -> Union[bool, str, int]:
+        if input_value is None:
+            return "auto"
+        if isinstance(input_value, bool):
+            return input_value
+        try:
+            return int(input_value)
+        except ValueError:
+            return input_value
+
+    target_df: Optional[DataFrame] = None
+    for column in [column for column in df.columns if column != DTTM_ALIAS]:
+        df_fit = df[[DTTM_ALIAS, column]]
+        df_fit.columns = ["ds", "y"]
+        model = Prophet(
+            interval_width=confidence_interval,
+            yearly_seasonality=_parse_seasonality(yearly_seasonality),
+            weekly_seasonality=_parse_seasonality(weekly_seasonality),
+            daily_seasonality=_parse_seasonality(daily_seasonality),
+        )
+        model.fit(df_fit)
+        future = model.make_future_dataframe(periods=periods, freq=freq)
+        forecast = model.predict(future)[["ds", "yhat", "yhat_lower", "yhat_upper"]]
+        joined = forecast.join(df_fit.set_index("ds"), on="ds").set_index(["ds"])
+        new_columns = [
+            f"{column}__yhat",
+            f"{column}__yhat_lower",
+            f"{column}__yhat_upper",
+            f"{column}",
+        ]
+        joined.columns = new_columns
+        if target_df is None:
+            target_df = joined
+        else:
+            for new_column in new_columns:
+                target_df = target_df.assign(**{new_column: joined[new_column]})
+    target_df.reset_index(level=0, inplace=True)
+    return target_df.rename(columns={"ds": DTTM_ALIAS})

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -607,7 +607,9 @@ def prophet(
         raise QueryObjectValidationError(
             _("Unsupported time grain: %(time_grain)s", time_grain=time_grain,)
         )
-    if not periods or periods < 0:
+    # check type at runtime due to marhsmallow schema not being able to handle
+    # union types
+    if not periods or periods < 0 or not isinstance(periods, int):
         raise QueryObjectValidationError(_("Periods must be a positive integer value"))
     if not confidence_interval or confidence_interval <= 0 or confidence_interval >= 1:
         raise QueryObjectValidationError(

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -21,6 +21,7 @@ from typing import List, Optional
 from unittest import mock
 
 import prison
+import pytest
 from sqlalchemy.sql import func
 
 from tests.test_app import app
@@ -765,6 +766,42 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]
         self.assertEqual(result["rowcount"], 10)
+
+    def test_chart_data_prophet(self):
+        """
+        Chart data API: Ensure prophet post transformation works
+        """
+        pytest.importorskip("fbprophet")
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        time_grain = "P1Y"
+        request_payload["queries"][0]["is_timeseries"] = True
+        request_payload["queries"][0]["groupby"] = []
+        request_payload["queries"][0]["extras"] = {"time_grain_sqla": time_grain}
+        request_payload["queries"][0]["granularity"] = "ds"
+        request_payload["queries"][0]["post_processing"] = [
+            {
+                "operation": "prophet",
+                "options": {
+                    "time_grain": time_grain,
+                    "periods": 3,
+                    "confidence_interval": 0.9,
+                },
+            }
+        ]
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        print(rv.data)
+        self.assertEqual(rv.status_code, 200)
+        response_payload = json.loads(rv.data.decode("utf-8"))
+        result = response_payload["result"][0]
+        row = result["data"][0]
+        self.assertIn("__timestamp", row)
+        self.assertIn("sum__num", row)
+        self.assertIn("sum__num__yhat", row)
+        self.assertIn("sum__num__yhat_upper", row)
+        self.assertIn("sum__num__yhat_lower", row)
+        self.assertEqual(result["rowcount"], 47)
 
     def test_chart_data_no_data(self):
         """

--- a/tests/pandas_postprocessing_tests.py
+++ b/tests/pandas_postprocessing_tests.py
@@ -20,6 +20,7 @@ import math
 from typing import Any, List, Optional
 
 from pandas import DataFrame, Series
+import pytest
 
 from superset.exceptions import QueryObjectValidationError
 from superset.utils import pandas_postprocessing as proc
@@ -508,3 +509,44 @@ class TestPostProcessing(SupersetTestCase):
         self.assertListEqual(df.columns.tolist(), ["a", "b"])
         self.assertListEqual(series_to_list(column_df["a"]), [0.25, 0.75])
         self.assertListEqual(series_to_list(column_df["b"]), [0.1, 0.9])
+
+    def test_prophet(self):
+        pytest.importorskip("fbprophet")
+        df_orig = DataFrame(
+            {
+                "__timestamp": [
+                    datetime(2018, 12, 31),
+                    datetime(2019, 12, 31),
+                    datetime(2020, 12, 31),
+                    datetime(2021, 12, 31),
+                ],
+                "a": [1.1, 1, 1.9, 3.15],
+                "b": [4, 3, 4.1, 3.95],
+            }
+        )
+
+        df = proc.prophet(
+            df=df_orig, time_grain="P1M", periods=3, confidence_interval=0.9
+        )
+        columns = {column for column in df.columns}
+        assert columns == {
+            "__timestamp",
+            "a__yhat",
+            "a__yhat_upper",
+            "a__yhat_lower",
+            "a",
+            "b__yhat",
+            "b__yhat_upper",
+            "b__yhat_lower",
+            "b",
+        }
+        assert df[DTTM_ALIAS].iloc[0].to_pydatetime() == datetime(2018, 3, 31)
+        assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2022, 3, 31)
+        assert len(df) == 7
+
+        df = proc.prophet(
+            df=df_orig, time_grain="P1M", periods=5, confidence_interval=0.9
+        )
+        assert df[DTTM_ALIAS].iloc[0].to_pydatetime() == datetime(2018, 3, 31)
+        assert df[DTTM_ALIAS].iloc[-1].to_pydatetime() == datetime(2026, 12, 31)
+        assert len(df) == 9


### PR DESCRIPTION
### SUMMARY
This PR adds [Facebook Prophet](https://facebook.github.io/prophet/) as an optional dependency to enable time series forecasting in viz plugins. For each series (=column), it will add three new columns with the following suffix:
- `__yhat`: forecast
- `__yhat_lower`: lower confidence level
- `__yhat_upper`: uper confidence level
In addition, it extrapolates as many time grain steps into the future as have been specified in the `periods` parameter. For instance, 52 periods with weekly time grains will create a forecast 52 weeks = 1 year into the future. The forecast along with confidence intervals will be made available for the whole time period, while the observations (without a suffix) will be null for the forecasted dates. For more details please refer to the [excellent tutorial](https://facebook.github.io/prophet/docs/quick_start.html#python-api) by the Prophet team.

This treats each series as an individual time series model, hence will be computationally very expensive in the case of multiple columns. However, since the new chart data endpoint caches the end result, only the first calculation will be slow.

I've tried to add as many different tests as possible (schema validation, post processing, e2e API test) to ensure functionality. The end-to-end tests require `fbprophet` to be installed, however I decided against adding it to `requirements-dev.txt`, as it will make CI much more sluggish. However, anyone interested in developing this feature further can install the dependency locally and activate the e2e tests that are otherwise skipped.

### TEST PLAN
CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
