### PR TITLE
fix: make __time an ok column name in SQL Lab

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/fixtures.ts
+++ b/superset-frontend/spec/javascripts/sqllab/fixtures.ts
@@ -323,6 +323,11 @@ export const queryWithBadColumns = {
       },
       {
         is_date: true,
+        name: '__TIME',
+        type: 'TIMESTAMP',
+      },
+      {
+        is_date: true,
         name: '__TIMESTAMP',
         type: 'TIMESTAMP',
       },

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -104,7 +104,7 @@ class ExploreResultsButton extends React.PureComponent {
   getInvalidColumns() {
     const re1 = /^[A-Za-z_]\w*$/; // starts with char or _, then only alphanum
     const re2 = /__\d+$/; // does not finish with __ and then a number which screams dup col name
-    const re3 = /^__/; // is not a reserved column name e.g. __timestamp
+    const re3 = /^__timestamp/i; // is not a reserved temporal column alias
 
     return this.props.query.results.selected_columns
       .map(col => col.name)
@@ -199,9 +199,10 @@ class ExploreResultsButton extends React.PureComponent {
           <strong>AS my_alias</strong>
         </code>
         ){' '}
-        {t(`limited to alphanumeric characters and underscores. Column aliases starting
-          with double underscores or ending with double underscores followed by a
-          numeric value are not allowed for reasons discussed in Github issue #5739.
+        {t(`limited to alphanumeric characters and underscores. The alias "__timestamp"
+          used as for the temporal expression and column aliases ending with
+          double underscores followed by a numeric value are not allowed for reasons
+          discussed in Github issue #5739.
           `)}
       </div>
     );


### PR DESCRIPTION
### SUMMARY
Currently all double underscore prefixed column names are considered reserved in SQL Lab, despite only `__timestamp` being truly reserved. This causes trouble when querying Druid SQL datasources, as it unnecessarily prohibits exploration of queries with the standard `__time` column found in Druid tables.

### TEST PLAN
CI + new test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
