### PR TITLE
fix: group by with timestamp granularity

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -854,6 +854,18 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                 select_exprs += [timestamp]
                 groupby_exprs_with_timestamp[timestamp.name] = timestamp
 
+            if granularity in groupby:
+                timestamp = dttm_col.get_timestamp_expression(time_grain)
+                for i, select_expr in enumerate(select_exprs):
+                    if select_expr.name == granularity:
+                        timestamp.name = select_expr.name
+                        timestamp.key = select_expr.name
+                        timestamp._df_label_expected = select_expr._df_label_expected
+                        select_exprs[i] = timestamp
+                        groupby_exprs_sans_timestamp[timestamp.name] = timestamp
+                        groupby_exprs_with_timestamp[timestamp.name] = timestamp
+                        break
+
             # Use main dttm column to support index with secondary dttm columns.
             if (
                 db_engine_spec.time_secondary_columns

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -854,7 +854,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                 select_exprs += [timestamp]
                 groupby_exprs_with_timestamp[timestamp.name] = timestamp
 
-            if granularity in groupby:
+            if groupby and granularity in groupby:
                 timestamp = dttm_col.get_timestamp_expression(time_grain)
                 for i, select_expr in enumerate(select_exprs):
                     if select_expr.name == granularity:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -860,10 +860,11 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                     if select_expr.name == granularity:
                         timestamp.name = select_expr.name
                         timestamp.key = select_expr.name
-                        timestamp._df_label_expected = select_expr._df_label_expected
+                        timestamp._df_label_expected = (  # pylint: disable=protected-access
+                            select_expr._df_label_expected  # pylint: disable=protected-access
+                        )
                         select_exprs[i] = timestamp
                         groupby_exprs_sans_timestamp[timestamp.name] = timestamp
-                        groupby_exprs_with_timestamp[timestamp.name] = timestamp
                         break
 
             # Use main dttm column to support index with secondary dttm columns.

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -817,6 +817,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         select_exprs: List[Column] = []
         groupby_exprs_sans_timestamp = OrderedDict()
 
+        assert extras is not None
         if (is_sip_38 and metrics and columns) or (not is_sip_38 and groupby):
             # dedup columns while preserving order
             columns_ = columns if is_sip_38 else groupby
@@ -825,10 +826,12 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
 
             select_exprs = []
             for selected in groupby:
+                # if groupby field/expr equals granularity field/expr
                 if selected == granularity:
                     time_grain = extras.get("time_grain_sqla")
                     sqla_col = columns_by_name[selected]
                     outer = sqla_col.get_timestamp_expression(time_grain, selected)
+                # if groupby field equals a selected column
                 elif selected in columns_by_name:
                     outer = columns_by_name[selected].get_sqla_col()
                 else:
@@ -846,7 +849,6 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                 )
             metrics_exprs = []
 
-        assert extras is not None
         time_range_endpoints = extras.get("time_range_endpoints")
         groupby_exprs_with_timestamp = OrderedDict(groupby_exprs_sans_timestamp.items())
         if granularity:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -854,6 +854,8 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                 select_exprs += [timestamp]
                 groupby_exprs_with_timestamp[timestamp.name] = timestamp
 
+            # if granularity is a fields on group by also, apply the same time grain
+            # on the group by field
             if groupby and granularity in groupby:
                 timestamp = dttm_col.get_timestamp_expression(time_grain)
                 for i, select_expr in enumerate(select_exprs):


### PR DESCRIPTION
### SUMMARY
When creating a chart for example on a pivot table and choosing a time grain and a group by with the same time column. It's expected that the time grain is still applied. This PR applies the time grain when one of the group by fields is the datetime column also 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="792" alt="Screenshot 2020-07-17 at 10 26 30" src="https://user-images.githubusercontent.com/4025227/87771256-03fe7700-c818-11ea-8121-57e5b79b2c66.png">

<img width="909" alt="Screenshot 2020-07-17 at 10 27 31" src="https://user-images.githubusercontent.com/4025227/87771343-24c6cc80-c818-11ea-87e9-49a7b495f568.png">


After:
<img width="867" alt="Screenshot 2020-07-17 at 10 15 57" src="https://user-images.githubusercontent.com/4025227/87770158-8d14ae80-c816-11ea-9f71-d4a4b2540053.png">

<img width="913" alt="Screenshot 2020-07-17 at 10 21 37" src="https://user-images.githubusercontent.com/4025227/87770775-5e4b0800-c817-11ea-99fe-e1bb26babd37.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
