### PR TITLE
fix: pin slack client, breaking change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ retry==0.9.2              # via apache-superset (setup.py)
 selenium==3.141.0         # via apache-superset (setup.py)
 simplejson==3.17.0        # via apache-superset (setup.py)
 six==1.14.0               # via bleach, cryptography, flask-jwt-extended, flask-talisman, isodate, jsonschema, packaging, pathlib2, polyline, prison, pyrsistent, python-dateutil, sqlalchemy-utils, wtforms-json
-slackclient==2.6.2        # via apache-superset (setup.py)
+slackclient==2.5.0        # via apache-superset (setup.py)
 sqlalchemy-utils==0.36.6  # via apache-superset (setup.py), flask-appbuilder
 sqlalchemy==1.3.16        # via alembic, apache-superset (setup.py), flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-utils
 sqlparse==0.3.0           # via apache-superset (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "retry>=0.9.2",
         "selenium>=3.141.0",
         "simplejson>=3.15.0",
-        "slackclient>=2.6.2",
+        "slackclient==2.5.0",  # PINNED! slack changes file upload api in the future versions
         "sqlalchemy>=1.3.16, <2.0",
         "sqlalchemy-utils>=0.36.6,<0.37",
         "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562

--- a/tests/schedules_test.py
+++ b/tests/schedules_test.py
@@ -19,7 +19,9 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch, PropertyMock
 
 from flask_babel import gettext as __
+import pytest
 from selenium.common.exceptions import WebDriverException
+from slack import errors, WebClient
 
 from tests.test_app import app
 from superset import db
@@ -530,3 +532,11 @@ class TestSchedules(SupersetTestCase):
                 "title": "[Report]  Participants",
             },
         )
+
+
+def test_slack_client_compatibility():
+    c2 = WebClient()
+    # slackclient >2.5.0 raises TypeError: a bytes-like object is required, not 'str
+    # and requires to path a filepath instead of the bytes directly
+    with pytest.raises(errors.SlackApiError):
+        c2.files_upload(channels="#bogdan-test2", file=b"blabla", title="Test upload")


### PR DESCRIPTION
Slack client versions > 2.5.0 do not accept the file content anymore. It broke the slack integration.
Added test that would capture undesired upgrades.
Eventually we can fix via writing a tmp file and then uploading it.

### TEST PLAN
* ipython
* unit test
* dropbox staging
