### PR TITLE
feat: SIP-34 explore save modal

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/link.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/link.test.js
@@ -20,7 +20,13 @@
 // Tests for links in the explore UI
 // ***********************************************
 
+import rison from 'rison';
+import shortid from 'shortid';
 import { HEALTH_POP_FORM_DATA_DEFAULTS } from './visualizations/shared.helper';
+
+const apiURL = (endpoint, queryObject) => {
+  return `${endpoint}?q=${rison.encode(queryObject)}`;
+};
 
 describe('Test explore links', () => {
   beforeEach(() => {
@@ -73,97 +79,120 @@ describe('Test explore links', () => {
     });
   });
 
-  xit('Test chart save as', () => {
+  it('Test chart save as AND overwrite', () => {
     const formData = {
       ...HEALTH_POP_FORM_DATA_DEFAULTS,
       viz_type: 'table',
       metrics: ['sum__SP_POP_TOTL'],
       groupby: ['country_name'],
     };
-    const newChartName = 'Test chart';
+    const newChartName = `Test chart [${shortid.generate()}]`;
 
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
     cy.url().then(url => {
       cy.get('button[data-target="#save_modal"]').click();
       cy.get('.modal-content').within(() => {
-        cy.get('#saveas-radio').click();
+        cy.get('#saveas-radio').check();
         cy.get('input[name=new_slice_name]').type(newChartName);
         cy.get('button#btn_modal_save').click();
       });
-      cy.url().should('eq', url);
-
-      cy.visitChartByName(newChartName);
       cy.verifySliceSuccess({ waitAlias: '@postJson' });
-    });
-  });
+      cy.visitChartByName(newChartName);
 
-  xit('Test chart save', () => {
-    const chartName = 'Test chart';
-    cy.visitChartByName(chartName);
-    cy.verifySliceSuccess({ waitAlias: '@postJson' });
-
-    cy.get('[data-test=groupby]').within(() => {
-      cy.get('.Select__clear-indicator').click();
+      // Overwriting!
+      cy.get('button[data-target="#save_modal"]').click();
+      cy.get('.modal-content').within(() => {
+        cy.get('#overwrite-radio').check();
+        cy.get('button#btn_modal_save').click();
+      });
+      cy.verifySliceSuccess({ waitAlias: '@postJson' });
+      const query = {
+        filters: [
+          {
+            col: 'slice_name',
+            opr: 'eq',
+            value: newChartName,
+          },
+        ],
+      };
+      cy.request(apiURL('/api/v1/chart/', query)).then(response => {
+        expect(response.body.count).equals(1);
+        cy.request('DELETE', `/api/v1/chart/${response.body.ids[0]}`);
+      });
     });
-    cy.get('button[data-target="#save_modal"]').click();
-    cy.get('.modal-content').within(() => {
-      cy.get('button#btn_modal_save').click();
-    });
-    cy.verifySliceSuccess({ waitAlias: '@postJson' });
-    cy.request(`/chart/api/read?_flt_3_slice_name=${chartName}`).then(
-      response => {
-        cy.request('DELETE', `/chart/api/delete/${response.body.pks[0]}`);
-      },
-    );
   });
 
   it('Test chart save as and add to new dashboard', () => {
-    cy.visitChartByName('Growth Rate');
-    cy.verifySliceSuccess({ waitAlias: '@postJson' });
+    const chartName = 'Growth Rate';
+    const newChartName = `${chartName} [${shortid.generate()}]`;
+    const dashboardTitle = `Test dashboard [${shortid.generate()}]`;
 
-    const dashboardTitle = 'Test dashboard [new]';
-    cy.get('button[data-target="#save_modal"]').click();
-    cy.get('.modal-content').within(() => {
-      cy.get('#saveas-radio').click();
-      cy.get('input[name=new_slice_name]').type('New Growth Rate');
-      cy.get('button#btn_modal_save').click();
-    });
+    cy.visitChartByName(chartName);
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
-    cy.request(
-      `/dashboard/api/read?_flt_3_dashboard_title=${dashboardTitle}`,
-    ).then(response => {
-      expect(response.body.pks[0]).not.equals(null);
-    });
-  });
-
-  it('Test chart save as and add to existing dashboard', () => {
-    cy.visitChartByName('Most Populated Countries');
-    cy.verifySliceSuccess({ waitAlias: '@postJson' });
-    const chartName = 'Most Populated Countries [new]';
-    const dashboardTitle = 'Test dashboard [existing]';
 
     cy.get('button[data-target="#save_modal"]').click();
     cy.get('.modal-content').within(() => {
-      cy.get('input[name=new_slice_name]').type(chartName);
-      cy.get('.save-modal-selector')
-        .click()
-        .within(() => {
-          cy.get('input').type(dashboardTitle);
-          cy.get('.Select__option--is-focused').trigger('mousedown');
-        });
+      cy.get('#saveas-radio').check();
+      cy.get('input[name=new_slice_name]').click().clear().type(newChartName);
+      // Add a new option using the "CreatableSelect" feature
+      cy.get('#dashboard-creatable-select').type(
+        `${dashboardTitle}{enter}{enter}`,
+      );
       cy.get('button#btn_modal_save').click();
     });
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
-    cy.request(`/chart/api/read?_flt_3_slice_name=${chartName}`).then(
-      response => {
-        cy.request('DELETE', `/chart/api/delete/${response.body.pks[0]}`);
-      },
-    );
-    cy.request(
-      `/dashboard/api/read?_flt_3_dashboard_title=${dashboardTitle}`,
-    ).then(response => {
-      cy.request('DELETE', `/dashboard/api/delete/${response.body.pks[0]}`);
+    let query = {
+      filters: [
+        {
+          col: 'dashboard_title',
+          opr: 'eq',
+          value: dashboardTitle,
+        },
+      ],
+    };
+    cy.request(apiURL('/api/v1/dashboard/', query)).then(response => {
+      expect(response.body.count).equals(1);
+    });
+
+    cy.visitChartByName(newChartName);
+    cy.verifySliceSuccess({ waitAlias: '@postJson' });
+
+    cy.get('button[data-target="#save_modal"]').click();
+    cy.get('.modal-content').within(() => {
+      cy.get('#overwrite-radio').check();
+      cy.get('input[name=new_slice_name]').click().clear().type(newChartName);
+      // This time around, typing the same dashboard name
+      // will select the existing one
+      cy.get('#dashboard-creatable-select').type(
+        `${dashboardTitle}{enter}{enter}`,
+      );
+      cy.get('button#btn_modal_save').click();
+    });
+    cy.verifySliceSuccess({ waitAlias: '@postJson' });
+    query = {
+      filters: [
+        {
+          col: 'slice_name',
+          opr: 'eq',
+          value: chartName,
+        },
+      ],
+    };
+    cy.request(apiURL('/api/v1/chart/', query)).then(response => {
+      expect(response.body.count).equals(1);
+    });
+    query = {
+      filters: [
+        {
+          col: 'dashboard_title',
+          opr: 'eq',
+          value: dashboardTitle,
+        },
+      ],
+    };
+    cy.request(apiURL('/api/v1/dashboard/', query)).then(response => {
+      expect(response.body.count).equals(1);
     });
   });
 });

--- a/superset-frontend/cypress-base/cypress/integration/explore/link.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/link.test.js
@@ -125,8 +125,7 @@ describe('Test explore links', () => {
     cy.get('button[data-target="#save_modal"]').click();
     cy.get('.modal-content').within(() => {
       cy.get('input[name=new_slice_name]').type('New Growth Rate');
-      cy.get('input[data-test=add-to-new-dashboard]').check();
-      cy.get('input[placeholder="[dashboard name]"]').type(dashboardTitle);
+      cy.get('input[data-test=add-to-existing-dashboard]').click();
       cy.get('button#btn_modal_save').click();
     });
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
@@ -146,7 +145,7 @@ describe('Test explore links', () => {
     cy.get('button[data-target="#save_modal"]').click();
     cy.get('.modal-content').within(() => {
       cy.get('input[name=new_slice_name]').type(chartName);
-      cy.get('input[data-test=add-to-existing-dashboard]').check();
+      cy.get('input[data-test=add-to-existing-dashboard]').click();
       cy.get('.save-modal-selector')
         .click()
         .within(() => {

--- a/superset-frontend/cypress-base/cypress/integration/explore/link.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/link.test.js
@@ -87,6 +87,7 @@ describe('Test explore links', () => {
     cy.url().then(url => {
       cy.get('button[data-target="#save_modal"]').click();
       cy.get('.modal-content').within(() => {
+        cy.get('#saveas-radio').click();
         cy.get('input[name=new_slice_name]').type(newChartName);
         cy.get('button#btn_modal_save').click();
       });
@@ -121,11 +122,11 @@ describe('Test explore links', () => {
     cy.visitChartByName('Growth Rate');
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
 
-    const dashboardTitle = 'Test dashboard';
+    const dashboardTitle = 'Test dashboard [new]';
     cy.get('button[data-target="#save_modal"]').click();
     cy.get('.modal-content').within(() => {
+      cy.get('#saveas-radio').click();
       cy.get('input[name=new_slice_name]').type('New Growth Rate');
-      cy.get('input[data-test=add-to-existing-dashboard]').click();
       cy.get('button#btn_modal_save').click();
     });
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
@@ -139,13 +140,12 @@ describe('Test explore links', () => {
   it('Test chart save as and add to existing dashboard', () => {
     cy.visitChartByName('Most Populated Countries');
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
-    const chartName = 'New Most Populated Countries';
-    const dashboardTitle = 'Test dashboard';
+    const chartName = 'Most Populated Countries [new]';
+    const dashboardTitle = 'Test dashboard [existing]';
 
     cy.get('button[data-target="#save_modal"]').click();
     cy.get('.modal-content').within(() => {
       cy.get('input[name=new_slice_name]').type(chartName);
-      cy.get('input[data-test=add-to-existing-dashboard]').click();
       cy.get('.save-modal-selector')
         .click()
         .within(() => {

--- a/superset-frontend/cypress-base/package-lock.json
+++ b/superset-frontend/cypress-base/package-lock.json
@@ -5005,6 +5005,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "rison": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/rison/-/rison-0.1.1.tgz",
+      "integrity": "sha1-TcwFV7JBr/YOdheOd5ITVxPzMSA="
+    },
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",

--- a/superset-frontend/cypress-base/package.json
+++ b/superset-frontend/cypress-base/package.json
@@ -9,8 +9,9 @@
   "author": "Apcahe",
   "license": "Apache-2.0",
   "dependencies": {
-    "shortid": "^2.2.15",
-    "@cypress/code-coverage": "^3.8.1"
+    "@cypress/code-coverage": "^3.8.1",
+    "rison": "^0.1.1",
+    "shortid": "^2.2.15"
   },
   "devDependencies": {
     "cypress": "4.9.0",

--- a/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -203,7 +203,6 @@ describe('SaveModal', () => {
           wrapper.instance().saveOrOverwrite(true);
           defaultProps.actions.saveSlice().then(() => {
             expect(window.location.assign.callCount).toEqual(1);
-            console.log(window.location.assign.getCall(0).args);
             expect(window.location.assign.getCall(0).args[0]).toEqual(
               'http://localhost/mock_dashboard/',
             );

--- a/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -22,7 +22,7 @@ import thunk from 'redux-thunk';
 import { bindActionCreators } from 'redux';
 
 import { shallow, mount } from 'enzyme';
-import { Modal, Button, Radio } from 'react-bootstrap';
+import { FormControl, Modal, Button, Radio } from 'react-bootstrap';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
 
@@ -65,7 +65,7 @@ describe('SaveModal', () => {
     target: {
       value: 'mock event target',
     },
-    value: 'mock value',
+    value: 10,
   };
 
   const getWrapper = () =>
@@ -73,19 +73,18 @@ describe('SaveModal', () => {
       context: { store },
     }).dive();
 
-  it('renders a Modal with 7 inputs and 2 buttons', () => {
+  it('renders a Modal with the right set of components', () => {
     const wrapper = getWrapper();
     expect(wrapper.find(Modal)).toHaveLength(1);
-    expect(wrapper.find('input')).toHaveLength(2);
-    expect(wrapper.find(Button)).toHaveLength(2);
-    expect(wrapper.find(Radio)).toHaveLength(5);
+    expect(wrapper.find(FormControl)).toHaveLength(1);
+    expect(wrapper.find(Button)).toHaveLength(3);
+    expect(wrapper.find(Radio)).toHaveLength(2);
   });
 
-  it('does not show overwrite option for new slice', () => {
-    const wrapperNewSlice = getWrapper();
-    wrapperNewSlice.setProps({ slice: null });
-    expect(wrapperNewSlice.find('#overwrite-radio')).toHaveLength(0);
-    expect(wrapperNewSlice.find('#saveas-radio')).toHaveLength(1);
+  it('overwrite radio button is disabled for new slice', () => {
+    const wrapper = getWrapper();
+    wrapper.setProps({ slice: null });
+    expect(wrapper.find('#overwrite-radio').prop('disabled')).toBe(true);
   });
 
   it('disable overwrite option for non-owner', () => {
@@ -128,14 +127,11 @@ describe('SaveModal', () => {
   it('onChange', () => {
     const wrapper = getWrapper();
 
-    wrapper.instance().onChange('newSliceName', mockEvent);
+    wrapper.instance().onSliceNameChange(mockEvent);
     expect(wrapper.state().newSliceName).toBe(mockEvent.target.value);
 
-    wrapper.instance().onChange('saveToDashboardId', mockEvent);
+    wrapper.instance().onDashboardSelectChange(mockEvent);
     expect(wrapper.state().saveToDashboardId).toBe(mockEvent.value);
-
-    wrapper.instance().onChange('newDashboardName', mockEvent);
-    expect(wrapper.state().newDashboardName).toBe(mockEvent.target.value);
   });
 
   describe('saveOrOverwrite', () => {
@@ -145,7 +141,7 @@ describe('SaveModal', () => {
       sinon.stub(defaultProps.actions, 'saveSlice').callsFake(() =>
         Promise.resolve({
           data: {
-            dashboard: '/mock_dashboard/',
+            dashboard_url: 'http://localhost/mock_dashboard/',
             slice: { slice_url: '/mock_slice/' },
           },
         }),
@@ -168,10 +164,6 @@ describe('SaveModal', () => {
       const wrapper = getWrapper();
       const saveToDashboardId = 100;
 
-      wrapper.setState({ addToDash: 'existing' });
-      wrapper.instance().saveOrOverwrite(true);
-      expect(wrapper.state().alert).toBe('Please select a dashboard');
-
       wrapper.setState({ saveToDashboardId });
       wrapper.instance().saveOrOverwrite(true);
       const args = defaultProps.actions.saveSlice.getCall(0).args;
@@ -181,10 +173,6 @@ describe('SaveModal', () => {
     it('new dashboard', () => {
       const wrapper = getWrapper();
       const newDashboardName = 'new dashboard name';
-
-      wrapper.setState({ addToDash: 'new' });
-      wrapper.instance().saveOrOverwrite(true);
-      expect(wrapper.state().alert).toBe('Please enter a dashboard name');
 
       wrapper.setState({ newDashboardName });
       wrapper.instance().saveOrOverwrite(true);
@@ -215,6 +203,7 @@ describe('SaveModal', () => {
           wrapper.instance().saveOrOverwrite(true);
           defaultProps.actions.saveSlice().then(() => {
             expect(window.location.assign.callCount).toEqual(1);
+            console.log(window.location.assign.getCall(0).args);
             expect(window.location.assign.getCall(0).args[0]).toEqual(
               'http://localhost/mock_dashboard/',
             );

--- a/superset-frontend/src/components/Checkbox.jsx
+++ b/superset-frontend/src/components/Checkbox.jsx
@@ -23,11 +23,12 @@ const propTypes = {
   checked: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   style: PropTypes.object,
+  style: PropTypes.string,
 };
 
-export default function Checkbox({ checked, onChange, style }) {
+export default function Checkbox({ checked, onChange, style, className }) {
   return (
-    <span style={style}>
+    <span style={style} className={className}>
       <i
         role="button"
         tabIndex={0}

--- a/superset-frontend/src/components/Checkbox.jsx
+++ b/superset-frontend/src/components/Checkbox.jsx
@@ -23,29 +23,17 @@ const propTypes = {
   checked: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   style: PropTypes.object,
-  label: PropTypes.node,
-  dataTest: PropTypes.string,
 };
 
-export default function Checkbox({
-  label,
-  checked,
-  onChange,
-  style,
-  className,
-  dataTest,
-}) {
+export default function Checkbox({ checked, onChange, style }) {
   return (
-    <span style={style} className={className}>
+    <span style={style}>
       <i
         role="button"
         tabIndex={0}
         className={`fa fa-check ${
           checked ? 'text-primary' : 'text-transparent'
         }`}
-        role="button"
-        dataTest={dataTest}
-        tabIndex={0}
         onClick={() => {
           onChange(!checked);
         }}
@@ -55,17 +43,6 @@ export default function Checkbox({
           cursor: 'pointer',
         }}
       />
-      {label && (
-        <span
-          className="m-l-5"
-          role="button"
-          tabIndex={0}
-          onClick={() => onChange(!checked)}
-          style={{ cursor: 'pointer' }}
-        >
-          {label}
-        </span>
-      )}
     </span>
   );
 }

--- a/superset-frontend/src/components/Checkbox.jsx
+++ b/superset-frontend/src/components/Checkbox.jsx
@@ -23,10 +23,10 @@ const propTypes = {
   checked: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   style: PropTypes.object,
-  style: PropTypes.string,
+  label: PropTypes.node,
 };
 
-export default function Checkbox({ checked, onChange, style, className }) {
+export default function Checkbox({ label, checked, onChange, style, className }) {
   return (
     <span style={style} className={className}>
       <i
@@ -44,6 +44,15 @@ export default function Checkbox({ checked, onChange, style, className }) {
           cursor: 'pointer',
         }}
       />
+      {label &&
+        <span
+          className="m-l-5"
+          onClick={() => onChange(!checked)}
+          style={{ cursor: 'pointer' }}
+        >
+          {label}
+        </span>
+      }
     </span>
   );
 }

--- a/superset-frontend/src/components/Checkbox.jsx
+++ b/superset-frontend/src/components/Checkbox.jsx
@@ -51,13 +51,13 @@ export default function Checkbox({
         }}
       />
       {label && (
-        <span
+        <label
           className="m-l-5"
           onClick={() => onChange(!checked)}
           style={{ cursor: 'pointer' }}
         >
           {label}
-        </span>
+        </label>
       )}
     </span>
   );

--- a/superset-frontend/src/components/Checkbox.jsx
+++ b/superset-frontend/src/components/Checkbox.jsx
@@ -24,6 +24,7 @@ const propTypes = {
   onChange: PropTypes.func.isRequired,
   style: PropTypes.object,
   label: PropTypes.node,
+  dataTest: PropTypes.string,
 };
 
 export default function Checkbox({
@@ -32,6 +33,7 @@ export default function Checkbox({
   onChange,
   style,
   className,
+  dataTest,
 }) {
   return (
     <span style={style} className={className}>
@@ -41,6 +43,9 @@ export default function Checkbox({
         className={`fa fa-check ${
           checked ? 'text-primary' : 'text-transparent'
         }`}
+        role="button"
+        dataTest={dataTest}
+        tabIndex={0}
         onClick={() => {
           onChange(!checked);
         }}
@@ -51,13 +56,15 @@ export default function Checkbox({
         }}
       />
       {label && (
-        <label
+        <span
           className="m-l-5"
+          role="button"
+          tabIndex={0}
           onClick={() => onChange(!checked)}
           style={{ cursor: 'pointer' }}
         >
           {label}
-        </label>
+        </span>
       )}
     </span>
   );

--- a/superset-frontend/src/components/Checkbox.jsx
+++ b/superset-frontend/src/components/Checkbox.jsx
@@ -26,7 +26,13 @@ const propTypes = {
   label: PropTypes.node,
 };
 
-export default function Checkbox({ label, checked, onChange, style, className }) {
+export default function Checkbox({
+  label,
+  checked,
+  onChange,
+  style,
+  className,
+}) {
   return (
     <span style={style} className={className}>
       <i
@@ -44,7 +50,7 @@ export default function Checkbox({ label, checked, onChange, style, className })
           cursor: 'pointer',
         }}
       />
-      {label &&
+      {label && (
         <span
           className="m-l-5"
           onClick={() => onChange(!checked)}
@@ -52,7 +58,7 @@ export default function Checkbox({ label, checked, onChange, style, className })
         >
           {label}
         </span>
-      }
+      )}
     </span>
   );
 }

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -81,7 +81,7 @@ class SaveModal extends React.Component {
         this.setState({ newSliceName: event.target.value });
         break;
       case 'saveToDashboardId':
-        this.setState({ saveToDashboardId: event.value });
+        this.setState({ saveToDashboardId: event ? event.value : null });
         this.toggleDash(true);
         break;
       default:
@@ -113,21 +113,19 @@ class SaveModal extends React.Component {
     sliceParams.slice_name = this.state.newSliceName;
 
     const { addToDash } = this.state;
-    sliceParams.add_to_dash = addToDash;
     if (addToDash) {
+      sliceParams.add_to_dash = addToDash;
       if (this.state.saveToDashboardId) {
         sliceParams.save_to_dashboard_id = this.state.saveToDashboardId;
       } else {
         sliceParams.new_dashboard_name = '[new dashboard]';
       }
-    } else {
     }
     sliceParams.goto_dash = gotodash;
 
     this.props.actions
       .saveSlice(this.props.form_data, sliceParams)
       .then(({ data }) => {
-        console.log(data);
         if (data.dashboard_id === null) {
           sessionStorage.removeItem(SK_DASHBOARD_ID);
         } else {
@@ -135,9 +133,9 @@ class SaveModal extends React.Component {
         }
         // Go to new slice url or dashboard url
         if (gotodash) {
-          //window.location.assign(supersetURL(data.dashboard));
+          window.location.assign(supersetURL(data.dashboard));
         } else {
-          //window.location.assign(data.slice.slice_url);
+          window.location.assign(data.slice.slice_url);
         }
       });
     this.props.onHide();
@@ -152,7 +150,7 @@ class SaveModal extends React.Component {
     const canNotSaveToDash =
       EXPLORE_ONLY_VIZ_TYPE.indexOf(this.state.vizType) > -1;
     return (
-      <Modal show onHide={this.props.onHide} bsStyle="large">
+      <Modal show onHide={this.props.onHide}>
         <Modal.Header closeButton>
           <Modal.Title>{t('Save A Chart')}</Modal.Title>
         </Modal.Header>
@@ -198,22 +196,21 @@ class SaveModal extends React.Component {
 
           <br />
           <hr />
-          <>
-            <Checkbox
-              inline
-              className="m-r-5"
-              disabled={canNotSaveToDash}
-              checked={this.state.addToDash}
-              onChange={this.toggleDash}
-              data-test="add-to-existing-dashboard"
-            />
-            {t('Add to dashboard')}
-          </>
+          <Checkbox
+            inline
+            className="m-r-5"
+            disabled={canNotSaveToDash}
+            checked={this.state.addToDash}
+            label={t('Add to dashboard')}
+            onChange={this.toggleDash}
+            data-test="add-to-existing-dashboard"
+          />
           <Select
             className="save-modal-selector"
-            disabled={canNotSaveToDash}
             options={this.props.dashboards}
+            clearable
             onChange={this.onChange.bind(this, 'saveToDashboardId')}
+            isDisabled={!this.state.addToDash}
             autoSize={false}
             value={this.state.saveToDashboardId}
             placeholder="Select a dashboard or leave empty to create a new one"

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -28,10 +28,10 @@ import {
   Modal,
   Radio,
 } from 'react-bootstrap';
-import Checkbox from '../../components/Checkbox';
 import Select from 'src/components/Select';
 import { t } from '@superset-ui/translation';
 
+import Checkbox from '../../components/Checkbox';
 import { supersetURL } from '../../utils/common';
 import { EXPLORE_ONLY_VIZ_TYPE } from '../constants';
 
@@ -206,13 +206,12 @@ class SaveModal extends React.Component {
           </FormGroup>
           <hr />
           <Checkbox
-            inline
             className="m-r-5"
             disabled={canNotSaveToDash}
             checked={this.state.addToDash}
             label={t('Add to dashboard')}
             onChange={this.toggleDash}
-            data-test="add-to-existing-dashboard"
+            dataTest="add-to-existing-dashboard"
           />
           <Select
             className="save-modal-selector"

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -20,7 +20,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Modal, Alert, Button, Radio } from 'react-bootstrap';
+import { FormGroup, Modal, Alert, Button, Radio } from 'react-bootstrap';
 import Checkbox from '../../components/Checkbox';
 import Select from 'src/components/Select';
 import { t } from '@superset-ui/translation';
@@ -167,33 +167,32 @@ class SaveModal extends React.Component {
               />
             </Alert>
           )}
-          {this.props.slice && (
+          <FormGroup>
             <Radio
               id="overwrite-radio"
-              disabled={!this.props.can_overwrite}
+              inline
+              disabled={!(this.props.can_overwrite && this.props.slice)}
               checked={this.state.action === 'overwrite'}
               onChange={this.changeAction.bind(this, 'overwrite')}
             >
-              {t('Overwrite chart %s', this.props.slice.slice_name)}
+              {t('Save (Overwrite)')}
             </Radio>
-          )}
-
-          <Radio
-            id="saveas-radio"
-            inline
-            checked={this.state.action === 'saveas'}
-            onChange={this.changeAction.bind(this, 'saveas')}
-          >
-            {' '}
-            {t('Save as')} &nbsp;
-          </Radio>
+            <Radio
+              id="saveas-radio"
+              inline
+              checked={this.state.action === 'saveas'}
+              onChange={this.changeAction.bind(this, 'saveas')}
+            >
+              {' '}
+              {t('Save as')} &nbsp;
+            </Radio>
+          </FormGroup>
           <input
             name="new_slice_name"
             placeholder={this.state.newSliceName || t('[chart name]')}
             onChange={this.onChange.bind(this, 'newSliceName')}
             onFocus={this.changeAction.bind(this, 'saveas')}
           />
-
           <br />
           <hr />
           <Checkbox

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -40,6 +40,9 @@ const propTypes = {
   datasource: PropTypes.object,
 };
 
+// Session storage key for recent dashboard
+const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
+
 class SaveModal extends React.Component {
   constructor(props) {
     super(props);
@@ -59,9 +62,7 @@ class SaveModal extends React.Component {
       const dashboardIds = this.props.dashboards.map(
         dashboard => dashboard.value,
       );
-      let recentDashboard = sessionStorage.getItem(
-        'save_chart_recent_dashboard',
-      );
+      let recentDashboard = sessionStorage.getItem(SK_DASHBOARD_ID);
       recentDashboard = recentDashboard && parseInt(recentDashboard, 10);
       if (
         recentDashboard !== null &&
@@ -128,12 +129,9 @@ class SaveModal extends React.Component {
       .then(({ data }) => {
         console.log(data);
         if (data.dashboard_id === null) {
-          sessionStorage.removeItem('save_chart_recent_dashboard');
+          sessionStorage.removeItem(SK_DASHBOARD_ID);
         } else {
-          sessionStorage.setItem(
-            'save_chart_recent_dashboard',
-            data.dashboard_id,
-          );
+          sessionStorage.setItem(SK_DASHBOARD_ID, data.dashboard_id);
         }
         // Go to new slice url or dashboard url
         if (gotodash) {

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -20,7 +20,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { FormGroup, Modal, Alert, Button, Radio } from 'react-bootstrap';
+import {
+  Alert,
+  Button,
+  FormControl,
+  FormGroup,
+  Modal,
+  Radio,
+} from 'react-bootstrap';
 import Checkbox from '../../components/Checkbox';
 import Select from 'src/components/Select';
 import { t } from '@superset-ui/translation';
@@ -184,16 +191,19 @@ class SaveModal extends React.Component {
               onChange={this.changeAction.bind(this, 'saveas')}
             >
               {' '}
-              {t('Save as')} &nbsp;
+              {t('Save as ...')} &nbsp;
             </Radio>
           </FormGroup>
-          <input
-            name="new_slice_name"
-            placeholder={this.state.newSliceName || t('[chart name]')}
-            onChange={this.onChange.bind(this, 'newSliceName')}
-            onFocus={this.changeAction.bind(this, 'saveas')}
-          />
-          <br />
+          <FormGroup>
+            <FormControl
+              name="new_slice_name"
+              type="text"
+              bsSize="sm"
+              placeholder="Name"
+              value={this.state.newSliceName}
+              onChange={this.onChange.bind(this, 'newSliceName')}
+            />
+          </FormGroup>
           <hr />
           <Checkbox
             inline

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -184,6 +184,7 @@ class SaveModal extends React.Component {
           <hr />
           {t('Add to dashboard')}
           <CreatableSelect
+            id="dashboard-creatable-select"
             className="save-modal-selector"
             options={this.props.dashboards}
             clearable

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -118,7 +118,7 @@ class SaveModal extends React.Component {
       if (this.state.saveToDashboardId) {
         sliceParams.save_to_dashboard_id = this.state.saveToDashboardId;
       } else {
-        sliceParams.new_dashboard_name = '[new dashboard]';
+        sliceParams.new_dashboard_name = t('Untitled dashboard');
       }
     }
     sliceParams.goto_dash = gotodash;
@@ -150,7 +150,7 @@ class SaveModal extends React.Component {
     const canNotSaveToDash =
       EXPLORE_ONLY_VIZ_TYPE.indexOf(this.state.vizType) > -1;
     return (
-      <Modal show onHide={this.props.onHide}>
+      <Modal show onHide={this.props.onHide} bsSize="medium">
         <Modal.Header closeButton>
           <Modal.Title>{t('Save A Chart')}</Modal.Title>
         </Modal.Header>
@@ -218,25 +218,34 @@ class SaveModal extends React.Component {
         </Modal.Body>
 
         <Modal.Footer>
-          <Button
-            type="button"
-            id="btn_modal_save"
-            bsSize="sm"
-            className="btn pull-left"
-            onClick={this.saveOrOverwrite.bind(this, false)}
-          >
-            {t('Save')}
-          </Button>
-          <Button
-            type="button"
-            id="btn_modal_save_goto_dash"
-            bsSize="sm"
-            className="btn btn-primary pull-left gotodash"
-            disabled={!this.state.addToDash || canNotSaveToDash}
-            onClick={this.saveOrOverwrite.bind(this, true)}
-          >
-            {t('Save & go to dashboard')}
-          </Button>
+          <div className="float-right">
+            <Button
+              type="button"
+              id="btn_cancel"
+              bsSize="sm"
+              onClick={this.props.onHide}
+            >
+              {t('Cancel')}
+            </Button>
+            <Button
+              type="button"
+              id="btn_modal_save_goto_dash"
+              bsSize="sm"
+              disabled={!this.state.addToDash || canNotSaveToDash}
+              onClick={this.saveOrOverwrite.bind(this, true)}
+            >
+              {t('Save & go to dashboard')}
+            </Button>
+            <Button
+              type="button"
+              id="btn_modal_save"
+              bsSize="sm"
+              bsStyle="primary"
+              onClick={this.saveOrOverwrite.bind(this, false)}
+            >
+              {t('Save')}
+            </Button>
+          </div>
         </Modal.Footer>
       </Modal>
     );

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -49,7 +49,7 @@ const propTypes = {
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
-const SELECT_PLACEHOLDER = t('**Select** a dashboard OR **create** a new one')
+const SELECT_PLACEHOLDER = t('**Select** a dashboard OR **create** a new one');
 
 class SaveModal extends React.Component {
   constructor(props) {
@@ -187,9 +187,7 @@ class SaveModal extends React.Component {
             />
           </FormGroup>
           <FormGroup>
-            <ControlLabel>
-              {t('Add to dashboard')}
-            </ControlLabel>
+            <ControlLabel>{t('Add to dashboard')}</ControlLabel>
             <CreatableSelect
               id="dashboard-creatable-select"
               className="save-modal-selector"
@@ -198,7 +196,9 @@ class SaveModal extends React.Component {
               creatable
               onChange={this.onDashboardSelectChange}
               autoSize={false}
-              value={this.state.saveToDashboardId || this.state.newDashboardName}
+              value={
+                this.state.saveToDashboardId || this.state.newDashboardName
+              }
               placeholder={
                 // Using markdown to allow for good i18n
                 <ReactMarkdown

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -25,11 +25,13 @@ import {
   Button,
   FormControl,
   FormGroup,
+  ControlLabel,
   Modal,
   Radio,
 } from 'react-bootstrap';
 import { CreatableSelect } from 'src/components/Select/SupersetStyledSelect';
 import { t } from '@superset-ui/translation';
+import ReactMarkdown from 'react-markdown';
 
 import { EXPLORE_ONLY_VIZ_TYPE } from '../constants';
 
@@ -47,6 +49,7 @@ const propTypes = {
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
+const SELECT_PLACEHOLDER = t('**Select** a dashboard OR **create** a new one')
 
 class SaveModal extends React.Component {
   constructor(props) {
@@ -136,7 +139,7 @@ class SaveModal extends React.Component {
     return (
       <Modal show onHide={this.props.onHide}>
         <Modal.Header closeButton>
-          <Modal.Title>{t('Save A Chart')}</Modal.Title>
+          <Modal.Title>{t('Save Chart')}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {(this.state.alert || this.props.alert) && (
@@ -171,7 +174,9 @@ class SaveModal extends React.Component {
               {t('Save as ...')} &nbsp;
             </Radio>
           </FormGroup>
+          <hr />
           <FormGroup>
+            <ControlLabel>{t('Chart name')}</ControlLabel>
             <FormControl
               name="new_slice_name"
               type="text"
@@ -181,19 +186,28 @@ class SaveModal extends React.Component {
               onChange={this.onSliceNameChange}
             />
           </FormGroup>
-          <hr />
-          {t('Add to dashboard')}
-          <CreatableSelect
-            id="dashboard-creatable-select"
-            className="save-modal-selector"
-            options={this.props.dashboards}
-            clearable
-            creatable
-            onChange={this.onDashboardSelectChange}
-            autoSize={false}
-            value={this.state.saveToDashboardId || this.state.newDashboardName}
-            placeholder={t('Select a dashboard OR create a new one')}
-          />
+          <FormGroup>
+            <ControlLabel>
+              {t('Add to dashboard')}
+            </ControlLabel>
+            <CreatableSelect
+              id="dashboard-creatable-select"
+              className="save-modal-selector"
+              options={this.props.dashboards}
+              clearable
+              creatable
+              onChange={this.onDashboardSelectChange}
+              autoSize={false}
+              value={this.state.saveToDashboardId || this.state.newDashboardName}
+              placeholder={
+                // Using markdown to allow for good i18n
+                <ReactMarkdown
+                  source={SELECT_PLACEHOLDER}
+                  renderers={{ paragraph: 'span' }}
+                />
+              }
+            />
+          </FormGroup>
         </Modal.Body>
 
         <Modal.Footer>

--- a/superset-frontend/src/explore/main.less
+++ b/superset-frontend/src/explore/main.less
@@ -112,10 +112,6 @@
   }
 }
 
-.save-modal-selector {
-  margin: 10px 0;
-}
-
 .list-group {
   margin-bottom: 10px;
 }

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -563,29 +563,32 @@ td.filtered {
 
 // Making native radio buttons use brand color
 input[type='radio']:after {
-	width: 15px;
-	height: 15px;
-	border-radius: 15px;
-	top: -2px;
-	left: -1px;
-	position: relative;
-	background-color: #fff;
-	content: '';
-	display: inline-block;
-	visibility: visible;
-	border: 2px solid @gray;
+  width: 15px;
+  height: 15px;
+  border-radius: 15px;
+  top: -2px;
+  left: -1px;
+  position: relative;
+  background-color: #fff;
+  content: '';
+  display: inline-block;
+  visibility: visible;
+  border: 2px solid @gray;
 }
 
 input[type='radio']:checked:after {
-	width: 15px;
-	height: 15px;
-	border-radius: 15px;
-	top: -2px;
-	left: -1px;
-	position: relative;
-	background-color: #fff;
-	content: '';
-	display: inline-block;
-	visibility: visible;
-	border: 5px solid @brand-primary;
+  width: 15px;
+  height: 15px;
+  border-radius: 15px;
+  top: -2px;
+  left: -1px;
+  position: relative;
+  background-color: #fff;
+  content: '';
+  display: inline-block;
+  visibility: visible;
+  border: 5px solid @brand-primary;
+}
+hr {
+  border-top: 1px solid @gray-light;
 }

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -560,3 +560,32 @@ td.filtered {
   flex-direction: column;
   justify-content: center;
 }
+
+// Making native radio buttons use brand color
+input[type='radio']:after {
+	width: 15px;
+	height: 15px;
+	border-radius: 15px;
+	top: -2px;
+	left: -1px;
+	position: relative;
+	background-color: #fff;
+	content: '';
+	display: inline-block;
+	visibility: visible;
+	border: 2px solid @gray;
+}
+
+input[type='radio']:checked:after {
+	width: 15px;
+	height: 15px;
+	border-radius: 15px;
+	top: -2px;
+	left: -1px;
+	position: relative;
+	background-color: #fff;
+	content: '';
+	display: inline-block;
+	visibility: visible;
+	border: 5px solid @brand-primary;
+}

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -813,7 +813,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         # Adding slice to a dashboard if requested
         dash: Optional[Dashboard] = None
 
-        add_to_dash = request.args.get("add_to_dash")
+        add_to_dash = request.args.get("add_to_dash") == "true"
         save_to_dashboard_id = request.args.get("save_to_dashboard_id")
         if add_to_dash and save_to_dashboard_id:
             # Adding the chart to an existing dashboard

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -813,9 +813,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         # Adding slice to a dashboard if requested
         dash: Optional[Dashboard] = None
 
-        add_to_dash = request.args.get("add_to_dash") == "true"
         save_to_dashboard_id = request.args.get("save_to_dashboard_id")
-        if add_to_dash and save_to_dashboard_id:
+        new_dashboard_name = request.args.get("new_dashboard_name")
+        if save_to_dashboard_id:
             # Adding the chart to an existing dashboard
             dash = cast(
                 Dashboard,
@@ -839,7 +839,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 ),
                 "info",
             )
-        elif add_to_dash and not save_to_dashboard_id:
+        elif new_dashboard_name:
+            # Creating and adding to a new dashboard
             # check create dashboard permissions
             dash_add_perm = security_manager.can_access("can_add", "DashboardModelView")
             if not dash_add_perm:
@@ -871,7 +872,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "can_overwrite": is_owner(slc, g.user),
             "form_data": slc.form_data,
             "slice": slc.data,
-            "dashboard_id": dash.id if dash else None,
+            "dashboard_url": dash.url if dash else None,
         }
 
         if dash and request.args.get("goto_dash") == "true":

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -813,11 +813,14 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         # Adding slice to a dashboard if requested
         dash: Optional[Dashboard] = None
 
-        if request.args.get("add_to_dash") == "existing":
+        add_to_dash = request.args.get("add_to_dash")
+        save_to_dashboard_id = request.args.get("save_to_dashboard_id")
+        if add_to_dash and save_to_dashboard_id:
+            # Adding the chart to an existing dashboard
             dash = cast(
                 Dashboard,
                 db.session.query(Dashboard)
-                .filter_by(id=int(request.args["save_to_dashboard_id"]))
+                .filter_by(id=int(save_to_dashboard_id))
                 .one(),
             )
             # check edit dashboard permissions
@@ -836,7 +839,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 ),
                 "info",
             )
-        elif request.args.get("add_to_dash") == "new":
+        elif add_to_dash and not save_to_dashboard_id:
             # check create dashboard permissions
             dash_add_perm = security_manager.can_access("can_add", "DashboardModelView")
             if not dash_add_perm:


### PR DESCRIPTION
Getting the explore save modal closer to SIP-34

RFC: SIP-34 doesn't really offer the "Create a new dashboard and add this chart into it" option and I wanted to preserve that. I did it with a checkbox + leaving the select empty, but unclear what the best way would be.


## After (updated to latest commit)
<img width="674" alt="Screen Shot 2020-07-22 at 2 23 15 PM" src="https://user-images.githubusercontent.com/487433/88230249-e7eb4300-cc26-11ea-9022-828aaa42e768.png">


## Before
<img width="682" alt="Screen Shot 2020-07-16 at 10 50 24 PM" src="https://user-images.githubusercontent.com/487433/87753127-c1f11900-c7b6-11ea-8845-a4b5472fc794.png">


## SIP-34
<img width="821" alt="Screen Shot 2020-07-16 at 10 49 23 PM" src="https://user-images.githubusercontent.com/487433/87753066-9e2dd300-c7b6-11ea-8ceb-913c87a686ff.png">

