### PR TITLE
fix: extra filters for chart data endpoint

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -62,28 +62,28 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": "",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "resolved": "",
               "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
@@ -94,14 +94,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "resolved": "",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
@@ -112,42 +112,42 @@
             },
             "chownr": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+              "resolved": "",
               "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "resolved": "",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "resolved": "",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "resolved": "",
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "optional": true,
@@ -157,28 +157,28 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "resolved": "",
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "resolved": "",
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+              "resolved": "",
               "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
               "dev": true,
               "optional": true,
@@ -188,14 +188,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "resolved": "",
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
@@ -212,7 +212,7 @@
             },
             "glob": {
               "version": "7.1.6",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "resolved": "",
               "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
               "dev": true,
               "optional": true,
@@ -227,14 +227,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "resolved": "",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
@@ -244,7 +244,7 @@
             },
             "ignore-walk": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+              "resolved": "",
               "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
               "dev": true,
               "optional": true,
@@ -254,7 +254,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": "",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
@@ -265,21 +265,21 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "resolved": "",
               "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "resolved": "",
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
@@ -289,14 +289,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "resolved": "",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
@@ -306,14 +306,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true,
               "optional": true
             },
             "minipass": {
               "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "resolved": "",
               "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "optional": true,
@@ -324,7 +324,7 @@
             },
             "minizlib": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+              "resolved": "",
               "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
               "dev": true,
               "optional": true,
@@ -334,7 +334,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "optional": true,
@@ -344,14 +344,14 @@
             },
             "ms": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+              "resolved": "",
               "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
               "dev": true,
               "optional": true,
@@ -363,7 +363,7 @@
             },
             "node-pre-gyp": {
               "version": "0.14.0",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+              "resolved": "",
               "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
               "dev": true,
               "optional": true,
@@ -382,7 +382,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
@@ -393,7 +393,7 @@
             },
             "npm-bundled": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
               "dev": true,
               "optional": true,
@@ -403,14 +403,14 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+              "resolved": "",
               "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.7",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
+              "resolved": "",
               "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
               "dev": true,
               "optional": true,
@@ -421,7 +421,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
@@ -434,21 +434,21 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "resolved": "",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": "",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
@@ -458,21 +458,21 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "resolved": "",
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
@@ -483,21 +483,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+              "resolved": "",
               "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "resolved": "",
               "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
@@ -510,7 +510,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "resolved": "",
                   "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
@@ -519,7 +519,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
@@ -535,7 +535,7 @@
             },
             "rimraf": {
               "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "resolved": "",
               "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
               "dev": true,
               "optional": true,
@@ -545,49 +545,49 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "resolved": "",
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "resolved": "",
               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
@@ -599,7 +599,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
@@ -609,7 +609,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
@@ -619,14 +619,14 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.13",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+              "resolved": "",
               "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
               "dev": true,
               "optional": true,
@@ -642,14 +642,14 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "resolved": "",
               "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
@@ -659,14 +659,14 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
               "dev": true,
               "optional": true
@@ -6336,9 +6336,9 @@
       }
     },
     "@superset-ui/query": {
-      "version": "0.14.9",
-      "resolved": "https://registry.npmjs.org/@superset-ui/query/-/query-0.14.9.tgz",
-      "integrity": "sha512-tldCA8YzqG02oCz/mSY5xA2g3AAqdF5f2p755tPimUHCqtn5axnE38AaRDz+0PyKNyStx0JkYkOVgqvX2ggpzA=="
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/@superset-ui/query/-/query-0.14.12.tgz",
+      "integrity": "sha512-mCs9qg7z4GWlMuImrAfqEdVcwPFaSZ2EwbC8H4rdiiRy3duhJGO81Wnvk8J4S1+8L1PwXx+nLVPDjh/Mg7u65g=="
     },
     "@superset-ui/style": {
       "version": "0.14.9",
@@ -6368,6 +6368,13 @@
         "@superset-ui/time-format": "0.14.9",
         "@superset-ui/translation": "0.14.9",
         "@superset-ui/validator": "0.14.9"
+      },
+      "dependencies": {
+        "@superset-ui/query": {
+          "version": "0.14.9",
+          "resolved": "https://registry.npmjs.org/@superset-ui/query/-/query-0.14.9.tgz",
+          "integrity": "sha512-tldCA8YzqG02oCz/mSY5xA2g3AAqdF5f2p755tPimUHCqtn5axnE38AaRDz+0PyKNyStx0JkYkOVgqvX2ggpzA=="
+        }
       }
     },
     "@superset-ui/time-format": {
@@ -10199,28 +10206,28 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": "",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "resolved": "",
               "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
@@ -10231,14 +10238,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "resolved": "",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
@@ -10256,35 +10263,35 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "resolved": "",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "resolved": "",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "optional": true,
@@ -10294,21 +10301,21 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "resolved": "",
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "resolved": "",
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
@@ -10325,14 +10332,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "resolved": "",
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
@@ -10349,7 +10356,7 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "resolved": "",
               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "optional": true,
@@ -10364,14 +10371,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "resolved": "",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
@@ -10381,7 +10388,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "resolved": "",
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "optional": true,
@@ -10391,7 +10398,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": "",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
@@ -10402,21 +10409,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "resolved": "",
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
@@ -10426,14 +10433,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "resolved": "",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
@@ -10490,14 +10497,14 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+              "resolved": "",
               "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "dev": true,
               "optional": true,
@@ -10509,7 +10516,7 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+              "resolved": "",
               "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "dev": true,
               "optional": true,
@@ -10528,7 +10535,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
@@ -10539,14 +10546,14 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+              "resolved": "",
               "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+              "resolved": "",
               "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "dev": true,
               "optional": true,
@@ -10557,7 +10564,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
@@ -10570,21 +10577,21 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "resolved": "",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": "",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
@@ -10594,21 +10601,21 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "resolved": "",
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
@@ -10619,21 +10626,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "resolved": "",
               "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "resolved": "",
               "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
@@ -10646,7 +10653,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
@@ -10662,7 +10669,7 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+              "resolved": "",
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "optional": true,
@@ -10672,49 +10679,49 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "resolved": "",
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "resolved": "",
               "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
@@ -10726,7 +10733,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
@@ -10736,7 +10743,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
@@ -10746,7 +10753,7 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
@@ -10769,14 +10776,14 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "resolved": "",
               "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
@@ -10786,7 +10793,7 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
@@ -29571,28 +29578,28 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": "",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "resolved": "",
               "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
@@ -29603,14 +29610,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "resolved": "",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
@@ -29621,42 +29628,42 @@
             },
             "chownr": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+              "resolved": "",
               "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "resolved": "",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "resolved": "",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "resolved": "",
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "optional": true,
@@ -29666,28 +29673,28 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "resolved": "",
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "resolved": "",
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+              "resolved": "",
               "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
               "dev": true,
               "optional": true,
@@ -29697,14 +29704,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "resolved": "",
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
@@ -29721,7 +29728,7 @@
             },
             "glob": {
               "version": "7.1.6",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "resolved": "",
               "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
               "dev": true,
               "optional": true,
@@ -29736,14 +29743,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "resolved": "",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
@@ -29753,7 +29760,7 @@
             },
             "ignore-walk": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+              "resolved": "",
               "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
               "dev": true,
               "optional": true,
@@ -29763,7 +29770,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": "",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
@@ -29774,21 +29781,21 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "resolved": "",
               "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "resolved": "",
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
@@ -29798,14 +29805,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "resolved": "",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
@@ -29815,14 +29822,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true,
               "optional": true
             },
             "minipass": {
               "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "resolved": "",
               "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "optional": true,
@@ -29833,7 +29840,7 @@
             },
             "minizlib": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+              "resolved": "",
               "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
               "dev": true,
               "optional": true,
@@ -29843,7 +29850,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "optional": true,
@@ -29853,14 +29860,14 @@
             },
             "ms": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+              "resolved": "",
               "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
               "dev": true,
               "optional": true,
@@ -29872,7 +29879,7 @@
             },
             "node-pre-gyp": {
               "version": "0.14.0",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+              "resolved": "",
               "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
               "dev": true,
               "optional": true,
@@ -29891,7 +29898,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
@@ -29902,7 +29909,7 @@
             },
             "npm-bundled": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
               "dev": true,
               "optional": true,
@@ -29912,14 +29919,14 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+              "resolved": "",
               "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.7",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
+              "resolved": "",
               "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
               "dev": true,
               "optional": true,
@@ -29930,7 +29937,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
@@ -29943,21 +29950,21 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "resolved": "",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": "",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
@@ -29967,21 +29974,21 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "resolved": "",
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
@@ -29992,21 +29999,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+              "resolved": "",
               "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "resolved": "",
               "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
@@ -30019,7 +30026,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "resolved": "",
                   "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
@@ -30028,7 +30035,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
@@ -30044,7 +30051,7 @@
             },
             "rimraf": {
               "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "resolved": "",
               "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
               "dev": true,
               "optional": true,
@@ -30054,49 +30061,49 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "resolved": "",
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "resolved": "",
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "resolved": "",
               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
@@ -30108,7 +30115,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
@@ -30118,7 +30125,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
@@ -30128,14 +30135,14 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "resolved": "",
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.13",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+              "resolved": "",
               "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
               "dev": true,
               "optional": true,
@@ -30151,14 +30158,14 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "resolved": "",
               "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
@@ -30168,14 +30175,14 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "resolved": "",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "resolved": "",
               "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
               "dev": true,
               "optional": true

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -94,7 +94,7 @@
     "@superset-ui/plugin-chart-table": "^0.14.11",
     "@superset-ui/plugin-chart-word-cloud": "^0.14.9",
     "@superset-ui/preset-chart-xy": "^0.14.9",
-    "@superset-ui/query": "^0.14.9",
+    "@superset-ui/query": "^0.14.12",
     "@superset-ui/style": "^0.14.9",
     "@superset-ui/superset-ui": "^0.14.9",
     "@superset-ui/time-format": "^0.14.9",

--- a/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
@@ -16,12 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DataRecordFilters } from '@superset-ui/chart';
+import getEffectiveExtraFilters from 'src/dashboard/util/charts/getEffectiveExtraFilters';
 
-export default function getEffectiveExtraFilters(filters: DataRecordFilters) {
-  return Object.entries(filters).map(([column, values]) => ({
-    col: column,
-    op: Array.isArray(values) ? 'IN' : '=',
-    val: values,
-  }));
-}
+describe('getEffectiveExtraFilters', () => {
+  it('should create IN operator for arrays', () => {
+    const result = getEffectiveExtraFilters({
+      gender: ['girl'],
+      __time_range: ' : 2000-07-17T00:00:00',
+    });
+    expect(result).toMatchObject([
+      {
+        col: 'gender',
+        op: 'IN',
+        val: ['girl'],
+      },
+      {
+        col: '__time_range',
+        op: '=',
+        val: ' : 2020-07-17T00:00:00',
+      },
+    ]);
+  });
+});

--- a/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
@@ -22,7 +22,8 @@ describe('getEffectiveExtraFilters', () => {
   it('should create IN operator for arrays', () => {
     const result = getEffectiveExtraFilters({
       gender: ['girl'],
-      __time_range: ' : 2000-07-17T00:00:00',
+      name: null,
+      __time_range: ' : 2020-07-17T00:00:00',
     });
     expect(result).toMatchObject([
       {

--- a/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
@@ -28,7 +28,7 @@ describe('getEffectiveExtraFilters', () => {
     expect(result).toMatchObject([
       {
         col: 'gender',
-        op: 'IN',
+        op: 'in',
         val: ['girl'],
       },
       {

--- a/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
@@ -19,7 +19,7 @@
 import getEffectiveExtraFilters from 'src/dashboard/util/charts/getEffectiveExtraFilters';
 
 describe('getEffectiveExtraFilters', () => {
-  it('should create IN operator for arrays', () => {
+  it('should create valid filters', () => {
     const result = getEffectiveExtraFilters({
       gender: ['girl'],
       name: null,

--- a/superset-frontend/src/dashboard/util/charts/getEffectiveExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getEffectiveExtraFilters.ts
@@ -25,5 +25,5 @@ export default function getEffectiveExtraFilters(filters: DataRecordFilters) {
       op: Array.isArray(values) ? 'IN' : '=',
       val: values,
     }))
-    .filter(filter => filter !== null);
+    .filter(filter => filter.val !== null);
 }

--- a/superset-frontend/src/dashboard/util/charts/getEffectiveExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getEffectiveExtraFilters.ts
@@ -19,9 +19,11 @@
 import { DataRecordFilters } from '@superset-ui/chart';
 
 export default function getEffectiveExtraFilters(filters: DataRecordFilters) {
-  return Object.entries(filters).map(([column, values]) => ({
-    col: column,
-    op: Array.isArray(values) ? 'IN' : '=',
-    val: values,
-  }));
+  return Object.entries(filters)
+    .map(([column, values]) => ({
+      col: column,
+      op: Array.isArray(values) ? 'IN' : '=',
+      val: values,
+    }))
+    .filter(filter => filter !== null);
 }

--- a/superset-frontend/src/dashboard/util/charts/getEffectiveExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getEffectiveExtraFilters.ts
@@ -22,7 +22,7 @@ export default function getEffectiveExtraFilters(filters: DataRecordFilters) {
   return Object.entries(filters)
     .map(([column, values]) => ({
       col: column,
-      op: Array.isArray(values) ? 'IN' : '=',
+      op: Array.isArray(values) ? 'in' : '=',
       val: values,
     }))
     .filter(filter => filter.val !== null);

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -743,7 +743,7 @@ class ChartDataQueryObjectSchema(Schema):
         fields.Dict(),
         description="HAVING filters to be added to legacy Druid datasource queries. "
         "This field is deprecated and should be passed to `extras` "
-        "as `filters_druid`.",
+        "as `having_druid`.",
         deprecated=True,
     )
 


### PR DESCRIPTION
### SUMMARY
Currently Filter Box events aren't being properly reflected in the new chart data endpoint requests. This was because `extra_filters` weren't being properly merged with filters from the chart data payload. The bulk of the fix was done in `superset-ui` ( https://github.com/apache-superset/superset-ui/pull/688 ),  and updates `@superset-ui/chart` to the most recent released version.

### TEST PLAN
CI + new tests.

### SCREENSHOTS
Below are screenshots of a Filter Box with changing legacy charts (Name Line, Multiformat Line) and one new chart (Name Cloud, ECharts Multiformat).

#### BEFORE
Previously Filter Box changes (date range, time grain, gender selector) were NOT reflected in the viz' calling the new chart data endpoint (Name Cloud, ECharts Multiformat).
![captured (13)](https://user-images.githubusercontent.com/33317356/88011266-94da9880-cb1f-11ea-9950-4ba703462d31.gif)
![captured (14)](https://user-images.githubusercontent.com/33317356/88011291-a6bc3b80-cb1f-11ea-99ee-1332ebb0619b.gif)


#### AFTER
As can be seen, changes in the Filter Box are reflected properly in all charts.
![captured (12)](https://user-images.githubusercontent.com/33317356/88010806-6b6d3d00-cb1e-11ea-98a0-acf5fcd29edd.gif)
![captured (11)](https://user-images.githubusercontent.com/33317356/88010852-8344c100-cb1e-11ea-9b6e-6188fd11cc52.gif)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #10348
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
