### PR TITLE
fix: allow creating option in table select in dataset add modal

### DIFF
--- a/superset-frontend/src/components/TableSelector.jsx
+++ b/superset-frontend/src/components/TableSelector.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import styled from '@superset-ui/style';
 import PropTypes from 'prop-types';
 import rison from 'rison';
-import { Select, AsyncSelect } from 'src/components/Select';
+import { AsyncSelect, CreatableSelect, Select } from 'src/components/Select';
 import { Label } from 'react-bootstrap';
 import { t } from '@superset-ui/translation';
 import { SupersetClient } from '@superset-ui/connection';
@@ -358,31 +358,49 @@ export default class TableSelector extends React.PureComponent {
       tableSelectDisabled = true;
     }
     const options = this.state.tableOptions;
-    const select = this.props.schema ? (
-      <Select
-        name="select-table"
-        isLoading={this.state.tableLoading}
-        ignoreAccents={false}
-        placeholder={t('Select table or type table name')}
-        autosize={false}
-        onChange={this.changeTable}
-        options={options}
-        value={this.state.tableName}
-        optionRenderer={this.renderTableOption}
-      />
-    ) : (
-      <AsyncSelect
-        name="async-select-table"
-        placeholder={tableSelectPlaceholder}
-        disabled={tableSelectDisabled}
-        autosize={false}
-        onChange={this.changeTable}
-        value={this.state.tableName}
-        loadOptions={this.getTableNamesBySubStr}
-        optionRenderer={this.renderTableOption}
-        isDisabled={this.props.formMode}
-      />
-    );
+    let select = null;
+    if (this.props.schema && !this.props.formMode) {
+      select = (
+        <Select
+          name="select-table"
+          isLoading={this.state.tableLoading}
+          ignoreAccents={false}
+          placeholder={t('Select table or type table name')}
+          autosize={false}
+          onChange={this.changeTable}
+          options={options}
+          value={this.state.tableName}
+          optionRenderer={this.renderTableOption}
+        />
+      );
+    } else if (this.props.formMode) {
+      select = (
+        <CreatableSelect
+          name="select-table"
+          isLoading={this.state.tableLoading}
+          ignoreAccents={false}
+          placeholder={t('Select table or type table name')}
+          autosize={false}
+          onChange={this.changeTable}
+          options={options}
+          value={this.state.tableName}
+          optionRenderer={this.renderTableOption}
+        />
+      );
+    } else {
+      select = (
+        <AsyncSelect
+          name="async-select-table"
+          placeholder={tableSelectPlaceholder}
+          isDisabled={tableSelectDisabled}
+          autosize={false}
+          onChange={this.changeTable}
+          value={this.state.tableName}
+          loadOptions={this.getTableNamesBySubStr}
+          optionRenderer={this.renderTableOption}
+        />
+      );
+    }
     const refresh = !this.props.formMode && (
       <RefreshLabel
         onClick={() => this.changeSchema({ value: this.props.schema }, true)}

--- a/superset-frontend/src/views/datasetList/AddDatasetModal.tsx
+++ b/superset-frontend/src/views/datasetList/AddDatasetModal.tsx
@@ -73,7 +73,7 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
     tableName: string;
   }) => {
     setDatasourceId(dbId);
-    setDisableSave(isNil(dbId) || isEmpty(schema) || isEmpty(tableName));
+    setDisableSave(isNil(dbId) || isEmpty(tableName));
     setSchema(schema);
     setTableName(tableName);
   };
@@ -83,7 +83,7 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
       endpoint: '/api/v1/dataset/',
       body: JSON.stringify({
         database: datasourceId,
-        schema: currentSchema,
+        ...(currentSchema ? { schema: currentSchema } : {}),
         table_name: currentTableName,
       }),
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is currently an issue with adding google sheets as datasets. The dataset add modal expects there to be a schema selected before table select is enabled. Since google sheets don't have schemas there is no way to add a google sheet as a dataset. The fix is:
- Allow creating option in dataset add modal. Google sheets urls can now be pasted in the select field.
- schema is now optional. Simply leave it blank to add a google sheet. 

Trade Offs: there will now be a higher possibility for errors as users will be able to submit the form without shema and the table option now allows input so users can paste non-existent tables into the select field. Long term we should consider an api that can tell us if a database 1. supports schemas, 2. allows free-form table inputs 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1684" alt="Screen Shot 2020-07-20 at 5 34 40 PM" src="https://user-images.githubusercontent.com/10255196/87999377-6e7d1480-caaf-11ea-862c-046a67bc1f3d.png">
<img width="908" alt="Screen Shot 2020-07-20 at 5 35 00 PM" src="https://user-images.githubusercontent.com/10255196/87999380-6f15ab00-caaf-11ea-9817-60843a7e9b89.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- can add a google sheet as a dataset. 
- can add a regular table as a dataset
- unit tests pass.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI (behind `ENABLE_REACT_CRUD_VIEWS` flag)
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
