### PR TITLE
fix: Pivot Table can't display Null value

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -782,7 +782,10 @@ class PivotTableViz(BaseViz):
         if self.form_data.get("transpose_pivot"):
             groupby, columns = columns, groupby
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
-        df = df.pivot_table(
+
+        #pandas will throw away nulls when grouping/pivoting,
+        #so we substitute NULL_STRING for any nulls in the necessary columns.
+        df = df.fillna(value=NULL_STRING).pivot_table(
             index=groupby,
             columns=columns,
             values=metrics,


### PR DESCRIPTION
substitute NULL_STRING in PivotTableViz Class for any nulls in the necessary columns

### SUMMARY
substitute NULL_STRING in PivotTableViz Class

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x ] Changes UI
- [ x] Requires DB Migration.
- [x ] Confirm DB Migration upgrade and downgrade tested.
- [x ] Introduces new feature or API
- [ x] Removes existing feature or API
