### PR TITLE
fix: Pivot Table can't display Null value

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -782,7 +782,7 @@ class PivotTableViz(BaseViz):
         if self.form_data.get("transpose_pivot"):
             groupby, columns = columns, groupby
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
-        df = df.pivot_table(
+        df = df.fillna(value=NULL_STRING).pivot_table(
             index=groupby,
             columns=columns,
             values=metrics,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -777,14 +777,13 @@ class PivotTableViz(BaseViz):
         if aggfunc == "sum":
             aggfunc = lambda x: x.sum(min_count=1)
 
-        groupby = self.form_data.get("groupby")
-        columns = self.form_data.get("columns")
+        groupby = self.form_data.get("groupby") or []
+        columns = self.form_data.get("columns") or []
         if self.form_data.get("transpose_pivot"):
             groupby, columns = columns, groupby
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
-
-        df[columns] = df[columns].fillna(value=NULL_STRING)
-        df[groupby] = df[groupby].fillna(value=NULL_STRING)
+        filled_cols = groupby + columns
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
         df = df.pivot_table(
             index=groupby,
             columns=columns,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -782,7 +782,7 @@ class PivotTableViz(BaseViz):
         if self.form_data.get("transpose_pivot"):
             groupby, columns = columns, groupby
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
-        
+
         df[columns] = df[columns].fillna(value=NULL_STRING)
         df[groupby] = df[groupby].fillna(value=NULL_STRING)
         df = df.pivot_table(

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -777,16 +777,14 @@ class PivotTableViz(BaseViz):
         if aggfunc == "sum":
             aggfunc = lambda x: x.sum(min_count=1)
 
-        groupby = self.form_data.get("groupby") or []
-        columns = self.form_data.get("columns") or []
+        groupby = self.form_data.get("groupby")
+        columns = self.form_data.get("columns")
         if self.form_data.get("transpose_pivot"):
             groupby, columns = columns, groupby
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
         
-        # pandas will throw away nulls when grouping/pivoting,
-        # so we substitute NULL_STRING for any nulls in the necessary columns
-        filled_cols = columns + groupby
-        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+        df[columns] = df[columns].fillna(value=NULL_STRING)
+        df[groupby] = df[groupby].fillna(value=NULL_STRING)
         df = df.pivot_table(
             index=groupby,
             columns=columns,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -777,12 +777,17 @@ class PivotTableViz(BaseViz):
         if aggfunc == "sum":
             aggfunc = lambda x: x.sum(min_count=1)
 
-        groupby = self.form_data.get("groupby")
-        columns = self.form_data.get("columns")
+        groupby = self.form_data.get("groupby") or []
+        columns = self.form_data.get("columns") or []
         if self.form_data.get("transpose_pivot"):
             groupby, columns = columns, groupby
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
-        df = df.fillna(value=NULL_STRING).pivot_table(
+        
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = columns + groupby
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+        df = df.pivot_table(
             index=groupby,
             columns=columns,
             values=metrics,


### PR DESCRIPTION
substitute NULL_STRING in PivotTableViz Class for any nulls in the necessary columns

### SUMMARY
substitute NULL_STRING in PivotTableViz Class for any nulls in the necessary columns

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x ] Changes UI
- [x ] Requires DB Migration.
- [ x] Confirm DB Migration upgrade and downgrade tested.
- [ x] Introduces new feature or API
- [ x] Removes existing feature or API
