### PR TITLE
feat: support non-numeric columns in pivot table

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -779,7 +779,7 @@ class PivotTableViz(BaseViz):
     @staticmethod
     def get_aggfunc(
         metric: str, df: pd.DataFrame, form_data: Dict[str, Any]
-    ) -> Union[str, Callable]:
+    ) -> Union[str, Callable[[Any], Any]]:
         aggfunc = form_data.get("pandas_aggfunc") or "sum"
         if pd.api.types.is_numeric_dtype(df[metric]):
             # Ensure that Pandas's sum function mimics that of SQL.
@@ -796,7 +796,7 @@ class PivotTableViz(BaseViz):
             del df[DTTM_ALIAS]
 
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
-        aggfuncs: Dict[str, Union[str, Callable]] = {}
+        aggfuncs: Dict[str, Union[str, Callable[[Any], Any]]] = {}
         for metric in metrics:
             aggfuncs[metric] = self.get_aggfunc(metric, df, self.form_data)
 

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -1292,3 +1292,41 @@ class TestBigNumberViz(SupersetTestCase):
         )
         data = viz.BigNumberViz(datasource, {"metrics": ["y"]}).get_data(df)
         assert np.isnan(data[2]["y"])
+
+
+class TestPivotTableViz(SupersetTestCase):
+    df = pd.DataFrame(
+        data={
+            "intcol": [1, 2, 3, None],
+            "floatcol": [0.1, 0.2, 0.3, None],
+            "strcol": ["a", "b", "c", None],
+        }
+    )
+
+    def test_get_aggfunc_numeric(self):
+        # is a sum function
+        func = viz.PivotTableViz.get_aggfunc("intcol", self.df, {})
+        assert hasattr(func, "__call__")
+        assert func(self.df["intcol"]) == 6
+
+        assert (
+            viz.PivotTableViz.get_aggfunc("intcol", self.df, {"pandas_aggfunc": "min"})
+            == "min"
+        )
+        assert (
+            viz.PivotTableViz.get_aggfunc(
+                "floatcol", self.df, {"pandas_aggfunc": "max"}
+            )
+            == "max"
+        )
+
+    def test_get_aggfunc_non_numeric(self):
+        assert viz.PivotTableViz.get_aggfunc("strcol", self.df, {}) == "max"
+        assert (
+            viz.PivotTableViz.get_aggfunc("strcol", self.df, {"pandas_aggfunc": "sum"})
+            == "max"
+        )
+        assert (
+            viz.PivotTableViz.get_aggfunc("strcol", self.df, {"pandas_aggfunc": "min"})
+            == "min"
+        )


### PR DESCRIPTION
### SUMMARY
Adds support for non-numeric metrics in pivot table. Since only `min` and `max` aggregation works for non-numeric dtypes in Pandas, choosing any other aggregator will default to `max`.

Related PR: https://github.com/apache-superset/superset-ui/pull/695

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/88148193-ec076880-cc06-11ea-84de-abe58570be5d.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/88148109-ce3a0380-cc06-11ea-952c-8037ad3f0c3b.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
