### PR TITLE
fix: pandas will throw away nulls when pivoting

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -719,7 +719,10 @@ class TimeTableViz(BaseViz):
 
         # pandas will throw away nulls when grouping/pivoting,
         # so we substitute NULL_STRING for any nulls in the necessary columns
-        filled_cols = DTTM_ALIAS + columns
+        if columns:
+            filled_cols = [DTTM_ALIAS] + columns
+        else:
+            filled_cols = [DTTM_ALIAS]
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         pt = df.pivot_table(index=DTTM_ALIAS, columns=columns, values=values)
@@ -783,15 +786,16 @@ class PivotTableViz(BaseViz):
         if aggfunc == "sum":
             aggfunc = lambda x: x.sum(min_count=1)
 
-        groupby = self.form_data.get("groupby")
-        columns = self.form_data.get("columns")
+        groupby = self.form_data.get("groupby") or []
+        columns = self.form_data.get("columns") or []
         if self.form_data.get("transpose_pivot"):
             groupby, columns = columns, groupby
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
 
         # pandas will throw away nulls when grouping/pivoting,
         # so we substitute NULL_STRING for any nulls in the necessary columns
-        filled_cols = groupby + columns
+        filled_cols = columns + groupby
+
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         df = df.pivot_table(
@@ -1120,7 +1124,7 @@ class BigNumberViz(BaseViz):
 
         # pandas will throw away nulls when grouping/pivoting,
         # so we substitute NULL_STRING for any nulls in the necessary columns
-        filled_cols = DTTM_ALIAS
+        filled_cols = [DTTM_ALIAS]
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         df = df.pivot_table(
@@ -1240,7 +1244,9 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
         # pandas will throw away nulls when grouping/pivoting,
         # so we substitute NULL_STRING for any nulls in the necessary columns
-        filled_cols = DTTM_ALIAS + fd.get("groupby")
+        groups = fd.get("groupby") or []
+        filled_cols = [DTTM_ALIAS] + groups
+
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         if aggregate:
@@ -1459,7 +1465,7 @@ class NVD3DualLineViz(NVD3Viz):
 
         # pandas will throw away nulls when grouping/pivoting,
         # so we substitute NULL_STRING for any nulls in the necessary columns
-        filled_cols = DTTM_ALIAS
+        filled_cols = [DTTM_ALIAS]
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         df = df.pivot_table(index=DTTM_ALIAS, values=[metric, metric_2])
@@ -1516,7 +1522,7 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
 
         # pandas will throw away nulls when grouping/pivoting,
         # so we substitute NULL_STRING for any nulls in the necessary columns
-        filled_cols = DTTM_ALIAS + ["series"]
+        filled_cols = [DTTM_ALIAS, "series"]
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         df = df.pivot_table(
@@ -2749,12 +2755,13 @@ class PairedTTestViz(BaseViz):
             return None
 
         fd = self.form_data
-        groups = fd.get("groupby")
+        groups = fd.get("groupby") or []
         metrics = self.metric_labels
 
         # pandas will throw away nulls when grouping/pivoting,
         # so we substitute NULL_STRING for any nulls in the necessary columns
-        filled_cols = DTTM_ALIAS + groups
+        filled_cols = [DTTM_ALIAS] + groups
+
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         df = df.pivot_table(index=DTTM_ALIAS, columns=groups, values=metrics)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -716,6 +716,12 @@ class TimeTableViz(BaseViz):
         if fd.get("groupby"):
             values = self.metric_labels[0]
             columns = fd.get("groupby")
+
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = DTTM_ALIAS + columns
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+
         pt = df.pivot_table(index=DTTM_ALIAS, columns=columns, values=values)
         pt.index = pt.index.map(str)
         pt = pt.sort_index()
@@ -782,6 +788,12 @@ class PivotTableViz(BaseViz):
         if self.form_data.get("transpose_pivot"):
             groupby, columns = columns, groupby
         metrics = [utils.get_metric_name(m) for m in self.form_data["metrics"]]
+
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = groupby + columns
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+
         df = df.pivot_table(
             index=groupby,
             columns=columns,
@@ -1106,6 +1118,11 @@ class BigNumberViz(BaseViz):
         if df.empty:
             return None
 
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = DTTM_ALIAS
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+
         df = df.pivot_table(
             index=DTTM_ALIAS,
             columns=[],
@@ -1220,6 +1237,11 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
         if df.empty:
             return df
+
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = DTTM_ALIAS + fd.get("groupby")
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         if aggregate:
             df = df.pivot_table(
@@ -1434,6 +1456,12 @@ class NVD3DualLineViz(NVD3Viz):
 
         metric = utils.get_metric_name(fd["metric"])
         metric_2 = utils.get_metric_name(fd["metric_2"])
+
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = DTTM_ALIAS
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+
         df = df.pivot_table(index=DTTM_ALIAS, values=[metric, metric_2])
 
         chart_data = self.to_series(df)
@@ -1485,6 +1513,12 @@ class NVD3TimePivotViz(NVD3TimeSeriesViz):
         max_ts = df[DTTM_ALIAS].max()
         max_rank = df["ranked"].max()
         df[DTTM_ALIAS] = df.index + (max_ts - df[DTTM_ALIAS])
+
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = DTTM_ALIAS + ["series"]
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+
         df = df.pivot_table(
             index=DTTM_ALIAS,
             columns="series",
@@ -1527,6 +1561,12 @@ class DistributionPieViz(NVD3Viz):
         if df.empty:
             return None
         metric = self.metric_labels[0]
+
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = self.groupby
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+
         df = df.pivot_table(index=self.groupby, values=[metric])
         df.sort_values(by=metric, ascending=False, inplace=True)
         df = df.reset_index()
@@ -1628,6 +1668,7 @@ class DistributionBarViz(DistributionPieViz):
 
         row = df.groupby(self.groupby).sum()[metrics[0]].copy()
         row.sort_values(ascending=False, inplace=True)
+
         pt = df.pivot_table(index=self.groupby, columns=columns, values=metrics)
         if fd.get("contribution"):
             pt = pt.T
@@ -2710,6 +2751,12 @@ class PairedTTestViz(BaseViz):
         fd = self.form_data
         groups = fd.get("groupby")
         metrics = self.metric_labels
+
+        # pandas will throw away nulls when grouping/pivoting,
+        # so we substitute NULL_STRING for any nulls in the necessary columns
+        filled_cols = DTTM_ALIAS + groups
+        df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
+
         df = df.pivot_table(index=DTTM_ALIAS, columns=groups, values=metrics)
         cols = []
         # Be rid of falsey keys


### PR DESCRIPTION
pandas will throw away nulls when grouping/pivoting, so we substitute NULL_STRING for any nulls in the necessary columns

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ x] Changes UI
- [x ] Requires DB Migration.
- [x ] Confirm DB Migration upgrade and downgrade tested.
- [ x] Introduces new feature or API
- [x ] Removes existing feature or API
