### PR TITLE
fix: pie chart multiple groupbys

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1527,10 +1527,10 @@ class DistributionPieViz(NVD3Viz):
         if df.empty:
             return None
         metric = self.metric_labels[0]
-        df = df.pivot_table(index=self.groupby, values=[metric])
-        df.sort_values(by=metric, ascending=False, inplace=True)
-        df = df.reset_index()
-        df.columns = ["x", "y"]
+        df = pd.DataFrame(
+            {"x": df[self.groupby].agg(func=", ".join, axis=1), "y": df[metric]}
+        )
+        df.sort_values(by="y", ascending=False, inplace=True)
         return df.to_dict(orient="records")
 
 


### PR DESCRIPTION
### SUMMARY
Currently the Pie chart doesn't render if there are multiple groupbys in the query. This PR removes the unnecessary `pivot_table` operation (the data is already grouped) and concatenates the groupby columns into one column `x` joined by commas.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/88161776-16fab800-cc19-11ea-8efe-1fac36654fab.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/88161656-eca8fa80-cc18-11ea-92c4-23a4a24722fa.png)

### TEST PLAN
Test pie chart with single and multiple groupbys.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
