### PR TITLE
style: add fade transition to bottom border on navbar menu items

### DIFF
--- a/superset-frontend/spec/javascripts/components/Menu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/Menu_spec.jsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { Nav } from 'react-bootstrap';
+import { supersetTheme, ThemeProvider } from '@superset-ui/style';
 
 import Menu from 'src/components/Menu/Menu';
 
@@ -156,7 +157,10 @@ describe('Menu', () => {
       ...overrideProps,
     };
 
-    const versionedWrapper = mount(<Menu {...props} />);
+    const versionedWrapper = mount(<Menu {...props} />, {
+      wrappingComponent: ThemeProvider,
+      wrappingComponentProps: { theme: supersetTheme },
+    });
 
     expect(versionedWrapper.find('.version-info div')).toHaveLength(2);
   });

--- a/superset-frontend/src/components/Menu/Menu.jsx
+++ b/superset-frontend/src/components/Menu/Menu.jsx
@@ -61,25 +61,25 @@ const StyledHeader = styled.header`
   }
 
   .navbar-nav > li > a {
-	&:after {
-		content: '';
-		position: absolute;
-		bottom: -3px;
-		left: 0;
-		width: 100%;
-		height: 3px;
-		background-color: #20a7c9;
-		opacity: 0;
-		transition: opacity 0.5s;
-	}
+    &:after {
+      content: '';
+      position: absolute;
+      bottom: -3px;
+      left: 0;
+      width: 100%;
+      height: 3px;
+      background-color: #20a7c9;
+      opacity: 0;
+      transition: opacity 0.5s;
+    }
 
-	&:hover {
-		border-bottom: none;
+    &:hover {
+      border-bottom: none;
 
-		&:after {
-			opacity: 1;
-		}
-	}
+      &:after {
+        opacity: 1;
+      }
+    }
   }
 `;
 

--- a/superset-frontend/src/components/Menu/Menu.jsx
+++ b/superset-frontend/src/components/Menu/Menu.jsx
@@ -68,9 +68,9 @@ const StyledHeader = styled.header`
       left: 0;
       width: 100%;
       height: 3px;
-      background-color: #20a7c9;
+      background-color: ${({ theme }) => theme.colors.primary.base};
       opacity: 0;
-      transition: opacity 0.5s;
+      transition: opacity ${({ theme }) => theme.transitionTiming * 2}s;
     }
 
     &:hover {

--- a/superset-frontend/src/components/Menu/Menu.jsx
+++ b/superset-frontend/src/components/Menu/Menu.jsx
@@ -59,6 +59,28 @@ const StyledHeader = styled.header`
     flex-direction: column;
     justify-content: center;
   }
+
+  .navbar-nav > li > a {
+	&:after {
+		content: '';
+		position: absolute;
+		bottom: -3px;
+		left: 0;
+		width: 100%;
+		height: 3px;
+		background-color: #20a7c9;
+		opacity: 0;
+		transition: opacity 0.5s;
+	}
+
+	&:hover {
+		border-bottom: none;
+
+		&:after {
+			opacity: 1;
+		}
+	}
+  }
 `;
 
 export default function Menu({


### PR DESCRIPTION
### SUMMARY
Update the navbar's current menu item hover state to fade in the bottom border

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![navbar hover before 7:22:2020](https://user-images.githubusercontent.com/8216382/88237674-9649b500-cc34-11ea-8dea-6a8c04ba7f05.gif)

After:
![navbar hover after 7:22:2020](https://user-images.githubusercontent.com/8216382/88237780-d4df6f80-cc34-11ea-85e8-77ed5c265584.gif)

### TEST PLAN

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
