### PR TITLE
style: SIP-34 labels

### DIFF
--- a/superset-frontend/src/components/CachedLabel.jsx
+++ b/superset-frontend/src/components/CachedLabel.jsx
@@ -70,9 +70,8 @@ class CacheLabel extends React.PureComponent {
     return (
       <TooltipWrapper tooltip={this.state.tooltipContent} label="cache-desc">
         <Label
-          className={this.props.className}
+          className={`${this.props.className} m-r-5 pointer`}
           bsStyle={labelStyle}
-          style={{ fontSize: '10px', marginRight: '5px', cursor: 'pointer' }}
           onClick={this.props.onClick}
           onMouseOver={this.mouseOver.bind(this)}
           onMouseOut={this.mouseOut.bind(this)}

--- a/superset-frontend/src/components/Timer.jsx
+++ b/superset-frontend/src/components/Timer.jsx
@@ -18,8 +18,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { now, fDuration } from '../modules/dates';
 import { Label } from 'react-bootstrap';
+
+import { now, fDuration } from '../modules/dates';
 
 const propTypes = {
   endTime: PropTypes.number,

--- a/superset-frontend/src/components/Timer.jsx
+++ b/superset-frontend/src/components/Timer.jsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { now, fDuration } from '../modules/dates';
+import { Label } from 'react-bootstrap';
 
 const propTypes = {
   endTime: PropTypes.number,
@@ -76,12 +77,13 @@ export default class Timer extends React.PureComponent {
     let timerSpan = null;
     if (this.props) {
       timerSpan = (
-        <span
-          className={`inlineBlock m-r-5 label label-${this.props.status}`}
+        <Label
+          className="m-r-5"
           style={this.props.style}
+          bsStyle={this.props.status}
         >
           {this.state.clockStr}
-        </span>
+        </Label>
       );
     }
     return timerSpan;

--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -163,7 +163,6 @@ export class ExploreChartHeader extends React.PureComponent {
             endTime={chartUpdateEndTime}
             isRunning={chartStatus === 'loading'}
             status={CHART_STATUS_MAP[chartStatus]}
-            style={{ fontSize: '10px', marginRight: '5px' }}
           />
           <ExploreActionButtons
             actions={this.props.actions}

--- a/superset-frontend/src/explore/components/RowCountLabel.jsx
+++ b/superset-frontend/src/explore/components/RowCountLabel.jsx
@@ -47,10 +47,7 @@ export default function RowCountLabel({ rowcount, limit, suffix }) {
   );
   return (
     <TooltipWrapper label="tt-rowcount" tooltip={tooltip}>
-      <Label
-        bsStyle={bsStyle}
-        className="m-r-5 pointer"
-      >
+      <Label bsStyle={bsStyle} className="m-r-5 pointer">
         {formattedRowCount} {suffix}
       </Label>
     </TooltipWrapper>

--- a/superset-frontend/src/explore/components/RowCountLabel.jsx
+++ b/superset-frontend/src/explore/components/RowCountLabel.jsx
@@ -49,7 +49,7 @@ export default function RowCountLabel({ rowcount, limit, suffix }) {
     <TooltipWrapper label="tt-rowcount" tooltip={tooltip}>
       <Label
         bsStyle={bsStyle}
-        style={{ fontSize: '10px', marginRight: '5px', cursor: 'pointer' }}
+        className="m-r-5 pointer"
       >
         {formattedRowCount} {suffix}
       </Label>

--- a/superset-frontend/src/explore/main.less
+++ b/superset-frontend/src/explore/main.less
@@ -214,19 +214,6 @@
   border: @gray-light solid thin;
 }
 
-.label-default {
-  background-color: @gray;
-  font-weight: @font-weight-normal;
-}
-
-.btn.label-btn {
-  background-color: @gray;
-  font-weight: @font-weight-normal;
-  color: @lightest;
-  padding: 5px 4px 4px;
-  border: 0;
-}
-
 .label-dropdown ul.dropdown-menu {
   position: fixed;
   top: auto;
@@ -237,7 +224,6 @@
 .label-btn:hover,
 .label-btn-label:hover {
   background-color: @gray-dark;
-  color: @lightest;
 }
 
 .label-btn-label {

--- a/superset-frontend/stylesheets/less/cosmo/bootswatch.less
+++ b/superset-frontend/stylesheets/less/cosmo/bootswatch.less
@@ -280,9 +280,23 @@ table,
 }
 
 .label {
-  border-radius: @border-radius-normal;
-  padding: 0.3em 0.6em 0.2em;
+  border-radius: 21px;
+  padding: 0.35em 0.8em 0.35em;
   font-weight: @font-weight-normal;
+  text-transform: uppercase;
+  font-size: @font-size-s;
+}
+.label-default:hover {
+  background-color: darken(@label-default-bg, 5%);
+}
+.label-warning:hover {
+  background-color: darken(@label-warning-bg, 5%);
+}
+.label-danger:hover {
+  background-color: darken(@label-danger-bg, 5%);
+}
+.label-primary:hover {
+  background-color: darken(@label-primary-bg, 5%);
 }
 
 label {

--- a/superset-frontend/stylesheets/less/cosmo/variables.less
+++ b/superset-frontend/stylesheets/less/cosmo/variables.less
@@ -28,7 +28,7 @@
 @gray-darker: lighten(@gray-base, 13.5%);
 @gray-dark: lighten(@gray-base, 20%);
 @bs-gray: lighten(@gray-base, 33.5%);
-@bs-gray-light: lighten(@gray-base, 70%);
+@bs-gray-light: lighten(@gray-base, 60%);
 @gray-lighter: lighten(@gray-base, 95%);
 
 @brand-primary: @primary-color; // superset-var
@@ -568,7 +568,7 @@
 // ** Info label background color
 @label-info-bg: @brand-info;
 // ** Warning label background color
-@label-warning-bg: @brand-warning;
+@label-warning-bg: darken(@brand-warning, 6%);
 // ** Danger label background color
 @label-danger-bg: @brand-danger;
 

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -26,10 +26,6 @@
   color: @danger;
 }
 
-.label {
-  font-size: 100%;
-}
-
 .no-wrap {
   white-space: nowrap;
 }


### PR DESCRIPTION
Aligning with SIP-34 designs for labels/pills. Going uppercase fixes the
padding issues we had before, and the rounder pills look better.

Cleaning up some CSS in the process

# After
<img width="1786" alt="Screen Shot 2020-07-22 at 5 36 13 PM" src="https://user-images.githubusercontent.com/487433/88242397-e3805380-cc41-11ea-87d6-ac4a1ec86139.png">
<img width="1790" alt="Screen Shot 2020-07-22 at 5 34 58 PM" src="https://user-images.githubusercontent.com/487433/88242398-e4b18080-cc41-11ea-9134-a21b70857fbe.png">
