### PR TITLE
style(sqllab): fixed button width as label changes

### DIFF
--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
@@ -32,6 +32,9 @@ interface Props {
   stopQuery: () => void;
   sql: string;
 }
+const commonBtnStyle = {
+  width: '80px',
+};
 
 const RunQueryActionButton = ({
   allowAsync = false,
@@ -51,6 +54,7 @@ const RunQueryActionButton = ({
     bsSize: 'small',
     bsStyle: btnStyle,
     disabled: !dbId,
+    style: commonBtnStyle,
   };
 
   if (shouldShowStopBtn) {


### PR DESCRIPTION
As the label change from RUN to STOP, the row of button shifts
left/right. This fixes the width so that it doesn't jitter.

<img width="364" alt="Screen Shot 2020-07-22 at 5 47 52 PM" src="https://user-images.githubusercontent.com/487433/88242899-85547000-cc43-11ea-94aa-d368aff7ad2f.png">
