### PR TITLE
chore: deactive flaky filter test

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -63,8 +63,8 @@ describe('Dashboard filter', () => {
       cy.wait(aliases);
     });
   });
-
-  it('should apply filter', () => {
+  // TODO fix and reactivate this flaky test
+  xit('should apply filter', () => {
     cy.get('.Select__control input[type=text]').first().focus();
 
     // should open the filter indicator


### PR DESCRIPTION
Flaky tests hurt everyone's cognitive load. Let's deactivate for now and
revisit.

Tagging @ktmud who appears on the `git blame` (not blaming! just tagging!). 

Added a TODO. 