### PR TITLE
fix: row limit in filter box

### DIFF
--- a/superset-frontend/src/visualizations/FilterBox/controlPanel.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/controlPanel.jsx
@@ -105,6 +105,11 @@ export default {
         ['adhoc_filters'],
       ],
     },
+    {
+      label: t('Query'),
+      expanded: true,
+      controlSetRows: [['row_limit']],
+    },
   ],
   controlOverrides: {
     adhoc_filters: {

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2031,7 +2031,6 @@ class FilterBoxViz(BaseViz):
     is_timeseries = False
     credits = 'a <a href="https://github.com/airbnb/superset">Superset</a> original'
     cache_type = "get_data"
-    filter_row_limit = 1000
 
     def query_obj(self) -> QueryObjectDict:
         return {}
@@ -2039,7 +2038,7 @@ class FilterBoxViz(BaseViz):
     def run_extra_queries(self) -> None:
         qry = super().query_obj()
         filters = self.form_data.get("filter_configs") or []
-        qry["row_limit"] = self.filter_row_limit
+        qry["row_limit"] = self.form_data.get("row_limit")
         self.dataframes = {}
         for flt in filters:
             col = flt.get("column")


### PR DESCRIPTION
### SUMMARY
Currently there is a hard coded row limit on FilterBox.
I added the row limit control to the filter box visualization control panel so the user can customize this limit.
However the new default limit is 50000, imposed by the control itself.

There was another pull request (#8101) that fixed this but placed the row limit within each field being filtered, but this leads to having several row limit selects.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![filterbox_before](https://user-images.githubusercontent.com/23409890/88283673-ca2fe380-cce3-11ea-8f62-0ca9dea83e80.png)

After:
![filterbox_after](https://user-images.githubusercontent.com/23409890/88283692-d2881e80-cce3-11ea-85ea-839e916459cc.png)

### TEST PLAN
Suppose that the rendering of controls cover this :thinking:

### ADDITIONAL INFORMATION
- [x] Has associated issue: #7971
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
