### PR TITLE
style: replace inclusive/exclusive on DateFilterControl with </≤

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
@@ -19,7 +19,7 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { Button, Label } from 'react-bootstrap';
 
 import DateFilterControl from 'src/explore/components/controls/DateFilterControl';
@@ -37,7 +37,7 @@ describe('DateFilterControl', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<DateFilterControl {...defaultProps} />);
+    wrapper = mount(<DateFilterControl {...defaultProps} />);
   });
 
   it('renders a ControlHeader', () => {

--- a/superset-frontend/spec/javascripts/explore/utils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/utils_spec.jsx
@@ -25,6 +25,10 @@ import {
   getExploreLongUrl,
   shouldUseLegacyApi,
 } from 'src/explore/exploreUtils';
+import {
+  buildTimeRangeString,
+  formatTimeRange,
+} from 'src/explore/dateFilterUtils';
 import * as hostNamesConfig from 'src/utils/hostNamesConfig';
 import { getChartMetadataRegistry } from '@superset-ui/chart';
 
@@ -243,6 +247,40 @@ describe('exploreUtils', () => {
     it('returns false for formData without viz_type', () => {
       const useLegacyApi = shouldUseLegacyApi(formData);
       expect(useLegacyApi).toBe(false);
+    });
+  });
+
+  describe('buildTimeRangeString', () => {
+    it('generates proper time range string', () => {
+      expect(
+        buildTimeRangeString('2010-07-30T00:00:00', '2020-07-30T00:00:00'),
+      ).toBe('2010-07-30T00:00:00 : 2020-07-30T00:00:00');
+      expect(buildTimeRangeString('', '2020-07-30T00:00:00')).toBe(
+        ' : 2020-07-30T00:00:00',
+      );
+      expect(buildTimeRangeString('', '')).toBe(' : ');
+    });
+  });
+
+  describe('formatTimeRange', () => {
+    it('generates a readable time range', () => {
+      expect(formatTimeRange('Last 7 days')).toBe('Last 7 days');
+      expect(formatTimeRange('No filter')).toBe('No filter');
+      expect(formatTimeRange('Yesterday : Tomorrow')).toBe(
+        'Yesterday < col < Tomorrow',
+      );
+      expect(
+        formatTimeRange('2010-07-30T00:00:00 : 2020-07-30T00:00:00', [
+          'inclusive',
+          'exclusive',
+        ]),
+      ).toBe('2010-07-30 ≤ col < 2020-07-30');
+      expect(
+        formatTimeRange('2010-07-30T01:00:00 : ', ['exclusive', 'inclusive']),
+      ).toBe('2010-07-30T01:00:00 < col ≤ ∞');
+      expect(formatTimeRange(' : 2020-07-30T00:00:00')).toBe(
+        '-∞ < col < 2020-07-30',
+      );
     });
   });
 });

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -374,11 +374,6 @@ class DateFilterControl extends React.Component {
     );
   }
   renderPopover() {
-
-    const DeleteMe = styled.div`
-      background-color: ${({ theme }) => theme.colors.primary.base};
-    `;
-
     const grainOptions = TIME_GRAIN_OPTIONS.map(grain => (
       <MenuItem
         onSelect={value => this.setCustomRange('grain', value)}
@@ -604,7 +599,7 @@ class DateFilterControl extends React.Component {
   }
 }
 
-export default withTheme(DateFilterControl)
+export default withTheme(DateFilterControl);
 
 DateFilterControl.propTypes = propTypes;
 DateFilterControl.defaultProps = defaultProps;

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -394,7 +394,6 @@ export default class DateFilterControl extends React.Component {
         <Styles>
           <OverlayTrigger
             key={timeFrame}
-            alignLeft
             placement="right"
             overlay={
               <Tooltip id={`tooltip-${timeFrame}`}>
@@ -577,7 +576,7 @@ export default class DateFilterControl extends React.Component {
     );
   }
   render() {
-    let timeRange = this.props.value || defaultProps.value;
+    const timeRange = this.props.value || defaultProps.value;
     return (
       <div>
         <ControlHeader {...this.props} />

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -137,10 +137,10 @@ function getStateFromCommonTimeFrame(value) {
       value === 'No filter'
         ? ''
         : moment()
-      .utc()
-      .startOf('day')
-      .subtract(1, units)
-      .format(MOMENT_FORMAT),
+            .utc()
+            .startOf('day')
+            .subtract(1, units)
+            .format(MOMENT_FORMAT),
     until:
       value === 'No filter'
         ? ''

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -37,7 +37,7 @@ import Datetime from 'react-datetime';
 import 'react-datetime/css/react-datetime.css';
 import moment from 'moment';
 import { t } from '@superset-ui/translation';
-import { styled } from '@superset-ui/style';
+import { styled, withTheme } from '@superset-ui/style';
 
 import {
   buildTimeRangeString,
@@ -177,11 +177,11 @@ function getStateFromCustomRange(value) {
 
 const Styles = styled.div`
   .radio {
-    margin: 4px 0;
+    margin: ${({ theme }) => theme.gridUnit}px 0;
   }
 `;
 
-export default class DateFilterControl extends React.Component {
+class DateFilterControl extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -374,6 +374,11 @@ export default class DateFilterControl extends React.Component {
     );
   }
   renderPopover() {
+
+    const DeleteMe = styled.div`
+      background-color: ${({ theme }) => theme.colors.primary.base};
+    `;
+
     const grainOptions = TIME_GRAIN_OPTIONS.map(grain => (
       <MenuItem
         onSelect={value => this.setCustomRange('grain', value)}
@@ -391,7 +396,7 @@ export default class DateFilterControl extends React.Component {
       const timeRange = buildTimeRangeString(nextState.since, nextState.until);
 
       return (
-        <Styles>
+        <Styles theme={this.props.theme}>
           <OverlayTrigger
             key={timeFrame}
             placement="right"
@@ -598,6 +603,8 @@ export default class DateFilterControl extends React.Component {
     );
   }
 }
+
+export default withTheme(DateFilterControl)
 
 DateFilterControl.propTypes = propTypes;
 DateFilterControl.defaultProps = defaultProps;

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -37,6 +37,7 @@ import Datetime from 'react-datetime';
 import 'react-datetime/css/react-datetime.css';
 import moment from 'moment';
 import { t } from '@superset-ui/translation';
+import { styled } from '@superset-ui/style';
 
 import './DateFilterControl.less';
 import ControlHeader from '../ControlHeader';
@@ -163,6 +164,12 @@ function getStateFromCustomRange(value) {
     until,
   };
 }
+
+const Styles = styled.div`
+  .radio {
+    margin: 4px 0;
+  }
+`;
 
 export default class DateFilterControl extends React.Component {
   constructor(props) {
@@ -373,7 +380,7 @@ export default class DateFilterControl extends React.Component {
       const endpoints = this.props.endpoints.map(endpoint => endpoint === 'inclusive' ? '≤' : '<');
 
       return (
-        <div style={{ padding: '0' }}>
+        <Styles>
           <OverlayTrigger
             key={timeFrame}
             alignLeft
@@ -387,7 +394,7 @@ export default class DateFilterControl extends React.Component {
               </Tooltip>
             }
           >
-            <div className={'inlineBlock'}>
+            <div style={{ display: 'inline-block' }}>
               <Radio
                 key={timeFrame.replace(' ', '').toLowerCase()}
                 checked={this.state.common === timeFrame}
@@ -397,7 +404,7 @@ export default class DateFilterControl extends React.Component {
               </Radio>
             </div>
           </OverlayTrigger>
-        </div>
+        </Styles>
       );
     });
     return (

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -363,35 +363,41 @@ export default class DateFilterControl extends React.Component {
         key={grain}
         eventKey={grain}
         active={grain === this.state.grain}
+        fullWidth={false}
       >
         {grain}
       </MenuItem>
     ));
     const timeFrames = COMMON_TIME_FRAMES.map(timeFrame => {
       const nextState = getStateFromCommonTimeFrame(timeFrame);
-      const endpoints = this.props.endpoints;
+      const endpoints = this.props.endpoints.map(endpoint => endpoint === 'inclusive' ? '≤' : '<');
+
       return (
-        <OverlayTrigger
-          key={timeFrame}
-          placement="left"
-          overlay={
-            <Tooltip id={`tooltip-${timeFrame}`}>
-              {nextState.since} {endpoints && `(${endpoints[0]})`}
-              <br />
-              {nextState.until} {endpoints && `(${endpoints[1]})`}
-            </Tooltip>
-          }
-        >
-          <div>
-            <Radio
-              key={timeFrame.replace(' ', '').toLowerCase()}
-              checked={this.state.common === timeFrame}
-              onChange={() => this.setState(nextState)}
-            >
-              {timeFrame}
-            </Radio>
-          </div>
-        </OverlayTrigger>
+        <div style={{ padding: '0' }}>
+          <OverlayTrigger
+            key={timeFrame}
+            alignLeft
+            placement="right"
+            overlay={
+              <Tooltip id={`tooltip-${timeFrame}`}>
+                {nextState.since.replace('T00:00:00', '')}{' '}
+                {endpoints && `${endpoints[0]}`} col{' '}
+                {endpoints && `${endpoints[1]}`}{' '}
+                {nextState.until.replace('T00:00:00', '')}
+              </Tooltip>
+            }
+          >
+            <div className={'inlineBlock'}>
+              <Radio
+                key={timeFrame.replace(' ', '').toLowerCase()}
+                checked={this.state.common === timeFrame}
+                onChange={() => this.setState(nextState)}
+              >
+                {timeFrame}
+              </Radio>
+            </div>
+          </OverlayTrigger>
+        </div>
       );
     });
     return (
@@ -558,6 +564,7 @@ export default class DateFilterControl extends React.Component {
   render() {
     let value = this.props.value || defaultProps.value;
     const endpoints = this.props.endpoints;
+    console.log('!!!', endpoints, value);
     value = value
       .split(SEPARATOR)
       .map(

--- a/superset-frontend/src/explore/dateFilterUtils.ts
+++ b/superset-frontend/src/explore/dateFilterUtils.ts
@@ -1,0 +1,24 @@
+import { TimeRangeEndpoints } from '@superset-ui/query';
+
+const SEPARATOR = ' : ';
+
+export const buildTimeRangeString = (since: string, until: string): string =>
+  `${since}${SEPARATOR}${until}`;
+
+const formatDateEndpoint = (dttm: string, isStart?: boolean): string =>
+  dttm.replace('T00:00:00', '') || (isStart ? '-∞' : '∞');
+
+export const formatTimeRange = (
+  timeRange: string,
+  endpoints?: TimeRangeEndpoints,
+) => {
+  const splitDateRange = timeRange.split(SEPARATOR);
+  if (splitDateRange.length === 1) return timeRange;
+  const formattedEndpoints = (
+    endpoints || ['unknown', 'unknown']
+  ).map((endpoint: string) => (endpoint === 'inclusive' ? '≤' : '<'));
+
+  return `${formatDateEndpoint(splitDateRange[0], true)} ${
+    formattedEndpoints[0]
+  } col ${formattedEndpoints[1]} ${formatDateEndpoint(splitDateRange[1])}`;
+};

--- a/superset-frontend/src/explore/dateFilterUtils.ts
+++ b/superset-frontend/src/explore/dateFilterUtils.ts
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import { TimeRangeEndpoints } from '@superset-ui/query';
 
 const SEPARATOR = ' : ';


### PR DESCRIPTION
### SUMMARY
Small modifications to `DateFilterControl`:
- move tooltip from left to right to avoid tooltip falling outside screen.
- Replace `inclusive` and `exclusive` with `≤` and `<` respectively.
- created new `dateFilterUtils.ts` file to make it easier to migrate utils to TypeScript.

### AFTER
![captured (16)](https://user-images.githubusercontent.com/33317356/88381715-96ba8b00-cdaf-11ea-8457-54b5912fa703.gif)

### BEFORE
![captured (17)](https://user-images.githubusercontent.com/33317356/88381689-873b4200-cdaf-11ea-9563-c15749086188.gif)

### TEST PLAN
CI + new tests = local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
