### PR TITLE
fix: incorrect filter operator emitted by Filter Box

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -8694,9 +8694,9 @@
       }
     },
     "@superset-ui/query": {
-      "version": "0.14.12",
-      "resolved": "https://registry.npmjs.org/@superset-ui/query/-/query-0.14.12.tgz",
-      "integrity": "sha512-mCs9qg7z4GWlMuImrAfqEdVcwPFaSZ2EwbC8H4rdiiRy3duhJGO81Wnvk8J4S1+8L1PwXx+nLVPDjh/Mg7u65g=="
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/@superset-ui/query/-/query-0.14.15.tgz",
+      "integrity": "sha512-k89EuCkXp3LmbBSm8yYpmykeoJNy1HvMj3jNRwYS0kvV7nNd267oAdXl8UnFzl+htxqwLUIidcXN9vzydB4Whw=="
     },
     "@superset-ui/style": {
       "version": "0.14.9",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -98,7 +98,7 @@
     "@superset-ui/plugin-chart-table": "^0.14.11",
     "@superset-ui/plugin-chart-word-cloud": "^0.14.9",
     "@superset-ui/preset-chart-xy": "^0.14.9",
-    "@superset-ui/query": "^0.14.12",
+    "@superset-ui/query": "^0.14.15",
     "@superset-ui/style": "^0.14.9",
     "@superset-ui/superset-ui": "^0.14.9",
     "@superset-ui/time-format": "^0.14.9",

--- a/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/util/getEffectiveExtraFilters_spec.js
@@ -33,7 +33,7 @@ describe('getEffectiveExtraFilters', () => {
       },
       {
         col: '__time_range',
-        op: '=',
+        op: '==',
         val: ' : 2020-07-17T00:00:00',
       },
     ]);

--- a/superset-frontend/src/dashboard/util/charts/getEffectiveExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getEffectiveExtraFilters.ts
@@ -22,7 +22,7 @@ export default function getEffectiveExtraFilters(filters: DataRecordFilters) {
   return Object.entries(filters)
     .map(([column, values]) => ({
       col: column,
-      op: Array.isArray(values) ? 'in' : '=',
+      op: Array.isArray(values) ? 'in' : '==',
       val: values,
     }))
     .filter(filter => filter.val !== null);

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -659,7 +659,7 @@ class ChartDataExtrasSchema(Schema):
 
     time_range_endpoints = fields.List(
         fields.String(
-            validate=validate.OneOf(choices=("INCLUSIVE", "EXCLUSIVE")),
+            validate=validate.OneOf(choices=("unknown", "inclusive", "exclusive")),
             description="A list with two values, stating if start/end should be "
             "inclusive/exclusive.",
         )

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List
 
 QUERY_OBJECTS = {
     "birth_names": {
-        "extras": {"where": "", "time_range_endpoints": ["inclusive", "exclusive"],},
+        "extras": {"where": "", "time_range_endpoints": ["inclusive", "exclusive"]},
         "granularity": "ds",
         "groupby": ["name"],
         "is_timeseries": False,

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List
 
 QUERY_OBJECTS = {
     "birth_names": {
-        "extras": {"where": "", "time_range_endpoints": ["INCLUSIVE", "EXCLUSIVE"],},
+        "extras": {"where": "", "time_range_endpoints": ["inclusive", "exclusive"],},
         "granularity": "ds",
         "groupby": ["name"],
         "is_timeseries": False,


### PR DESCRIPTION
### SUMMARY
Fix error caused by incorrect filter operator type definitions and `time_range_endpoints` character case in OpenAPI spec. Dependent on https://github.com/apache-superset/superset-ui/pull/700 .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
CI + local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #10414
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
