### PR TITLE
style: update +NEW button to use Button component, add dropdownItems prop to Button

### DIFF
--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -82,8 +82,13 @@ export default function Button(props: ButtonProps) {
   };
   const tooltip = props.tooltip;
   const placement = props.placement;
+  const dropdownItems = props.dropdownItems;
   delete buttonProps.tooltip;
   delete buttonProps.placement;
+
+  if ( dropdownItems ) {
+    console.log( 'dropdown items', dropdownItems );
+  }
 
   let button = (
     <SupersetButton {...buttonProps}>{props.children}</SupersetButton>

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -39,6 +39,7 @@ export interface ButtonProps {
   bsSize?: BootstrapButton.ButtonProps['bsSize'];
   style?: BootstrapButton.ButtonProps['style'];
   children?: React.ReactNode;
+  dropdownItems?: Array;
 }
 
 const BUTTON_WRAPPER_STYLE = { display: 'inline-block', cursor: 'not-allowed' };
@@ -87,6 +88,12 @@ export default function Button(props: ButtonProps) {
   delete buttonProps.tooltip;
   delete buttonProps.placement;
 
+  if (tooltip && props.disabled) {
+    // Working around the fact that tooltips don't get triggered when buttons are disabled
+    // https://github.com/react-bootstrap/react-bootstrap/issues/1588
+    buttonProps.style = { pointerEvents: 'none' };
+  }
+
   let button = (
     <SupersetButton {...buttonProps}>{props.children}</SupersetButton>
   );
@@ -94,7 +101,10 @@ export default function Button(props: ButtonProps) {
   if (dropdownItems) {
     button = (
       <div style={BUTTON_WRAPPER_STYLE}>
-        <SupersetButton {...buttonProps}>{props.children}</SupersetButton>
+        <SupersetButton {...buttonProps} data-toggle="dropdown"
+        >
+          {props.children}
+        </SupersetButton>
         <ul className="dropdown-menu">
           {dropdownItems.map((dropdownItem, index1) => (
             <MenuItem key={`${dropdownItem.label}`} href={dropdownItem.url}>
@@ -108,16 +118,6 @@ export default function Button(props: ButtonProps) {
   }
 
   if (tooltip) {
-    if (props.disabled) {
-      // Working around the fact that tooltips don't get triggered when buttons are disabled
-      // https://github.com/react-bootstrap/react-bootstrap/issues/1588
-      buttonProps.style = { pointerEvents: 'none' };
-      button = (
-        <div style={BUTTON_WRAPPER_STYLE}>
-          <SupersetButton {...buttonProps}>{props.children}</SupersetButton>
-        </div>
-      );
-    }
     return (
       <OverlayTrigger
         placement={placement}

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -28,6 +28,12 @@ import styled from '@superset-ui/style';
 
 export type OnClickHandler = React.MouseEventHandler<BootstrapButton>;
 
+export interface DropdownItemProps {
+  label: string;
+  url: string;
+  icon?: string;
+}
+
 export interface ButtonProps {
   className?: string;
   tooltip?: string;
@@ -39,7 +45,7 @@ export interface ButtonProps {
   bsSize?: BootstrapButton.ButtonProps['bsSize'];
   style?: BootstrapButton.ButtonProps['style'];
   children?: React.ReactNode;
-  dropdownItems?: Array;
+  dropdownItems?: DropdownItemProps[];
 }
 
 const BUTTON_WRAPPER_STYLE = { display: 'inline-block', cursor: 'not-allowed' };
@@ -101,17 +107,18 @@ export default function Button(props: ButtonProps) {
   if (dropdownItems) {
     button = (
       <div style={BUTTON_WRAPPER_STYLE}>
-        <SupersetButton {...buttonProps} data-toggle="dropdown"
-        >
+        <SupersetButton {...buttonProps} data-toggle="dropdown">
           {props.children}
         </SupersetButton>
         <ul className="dropdown-menu">
-          {dropdownItems.map((dropdownItem, index1) => (
-            <MenuItem key={`${dropdownItem.label}`} href={dropdownItem.url}>
-              <i className={`fa ${dropdownItem.icon}`} />
-              &nbsp; {dropdownItem.label}
-            </MenuItem>
-          ))}
+          {dropdownItems.map(
+            (dropdownItem: DropdownItemProps, index1: number) => (
+              <MenuItem key={`${dropdownItem.label}`} href={dropdownItem.url}>
+                <i className={`fa ${dropdownItem.icon}`} />
+                &nbsp; {dropdownItem.label}
+              </MenuItem>
+            ),
+          )}
         </ul>
       </div>
     );

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -22,6 +22,7 @@ import {
   Button as BootstrapButton,
   Tooltip,
   OverlayTrigger,
+  MenuItem,
 } from 'react-bootstrap';
 import styled from '@superset-ui/style';
 
@@ -86,13 +87,26 @@ export default function Button(props: ButtonProps) {
   delete buttonProps.tooltip;
   delete buttonProps.placement;
 
-  if ( dropdownItems ) {
-    console.log( 'dropdown items', dropdownItems );
-  }
-
   let button = (
     <SupersetButton {...buttonProps}>{props.children}</SupersetButton>
   );
+
+  if (dropdownItems) {
+    button = (
+      <div style={BUTTON_WRAPPER_STYLE}>
+        <SupersetButton {...buttonProps}>{props.children}</SupersetButton>
+        <ul className="dropdown-menu">
+          {dropdownItems.map((dropdownItem, index1) => (
+            <MenuItem key={`${dropdownItem.label}`} href={dropdownItem.url}>
+              <i className={`fa ${dropdownItem.icon}`} />
+              &nbsp; {dropdownItem.label}
+            </MenuItem>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
   if (tooltip) {
     if (props.disabled) {
       // Working around the fact that tooltips don't get triggered when buttons are disabled
@@ -115,5 +129,6 @@ export default function Button(props: ButtonProps) {
       </OverlayTrigger>
     );
   }
+
   return button;
 }

--- a/superset-frontend/src/components/Menu/NewMenu.tsx
+++ b/superset-frontend/src/components/Menu/NewMenu.tsx
@@ -41,45 +41,37 @@ const StyledButton = styled(Button)`
 `;
 
 const dropdownItems = [
-	'SQL Query',
-	'Chart',
-	'Dashboard',
+  {
+    label: t('SQL Query'),
+    url: '/superset/sqllab',
+    icon: 'fa-fw fa-search', // Might not need all of this, see what component already has
+  },
+  {
+    label: t('Chart'),
+    url: '/chart/add',
+    icon: 'fa-fw fa-bar-chart',
+  },
+  {
+    label: t('Dashboard'),
+    url: '/dashboard/new',
+    icon: 'fa-fw fa-dashboard',
+  },
 ];
 
 export default function NewMenu() {
   return (
     <li className="dropdown">
-	  <StyledButton
+      <StyledButton
         type="button"
         data-toggle="dropdown"
         className="dropdown-toggle btn btn-sm btn-primary"
-		dropdownItems={dropdownItems}
+        dropdownItems={dropdownItems}
       >
-		New
+        New
         <span className="caret-container">
-	      <span className="caret" />
-		</span>
+          <span className="caret" />
+        </span>
       </StyledButton>
-      <ul className="dropdown-menu">
-        <li>
-          <a href="/superset/sqllab">
-            <span className="fa fa-fw fa-search" />
-            {t('SQL Query')}
-          </a>
-        </li>
-        <li>
-          <a href="/chart/add">
-            <span className="fa fa-fw fa-bar-chart" />
-            {t('Chart')}
-          </a>
-        </li>
-        <li>
-          <a href="/dashboard/new/">
-            <span className="fa fa-fw fa-dashboard" />
-            {t('Dashboard')}
-          </a>
-        </li>
-      </ul>
     </li>
   );
 }

--- a/superset-frontend/src/components/Menu/NewMenu.tsx
+++ b/superset-frontend/src/components/Menu/NewMenu.tsx
@@ -17,21 +17,16 @@
  * under the License.
  */
 import React from 'react';
-import Button from '../Button';
 import styled from '@superset-ui/style';
 import { t } from '@superset-ui/translation';
-
-const buttonStyle = {
-  marginTop: '12px',
-  marginRight: '30px',
-};
+import Button, { DropdownItemProps } from '../Button';
 
 const StyledButton = styled(Button)`
   margin-top: 12px;
   margin-right: 30px;
 `;
 
-const dropdownItems = [
+const dropdownItems: DropdownItemProps[] = [
   {
     label: t('SQL Query'),
     url: '/superset/sqllab',
@@ -53,7 +48,6 @@ export default function NewMenu() {
   return (
     <li className="dropdown">
       <StyledButton
-        type="button"
         className="dropdown-toggle btn btn-sm btn-primary"
         dropdownItems={dropdownItems}
       >

--- a/superset-frontend/src/components/Menu/NewMenu.tsx
+++ b/superset-frontend/src/components/Menu/NewMenu.tsx
@@ -29,22 +29,13 @@ const buttonStyle = {
 const StyledButton = styled(Button)`
   margin-top: 12px;
   margin-right: 30px;
-  padding: 5px 80px 5px 50px;
-
-  i:before {
-    content: ' ';
-  }
-
-  .caret {
-    color: ${({ theme }) => theme.colors.grayscale.light5};
-  }
 `;
 
 const dropdownItems = [
   {
     label: t('SQL Query'),
     url: '/superset/sqllab',
-    icon: 'fa-fw fa-search', // Might not need all of this, see what component already has
+    icon: 'fa-fw fa-search',
   },
   {
     label: t('Chart'),
@@ -63,14 +54,10 @@ export default function NewMenu() {
     <li className="dropdown">
       <StyledButton
         type="button"
-        data-toggle="dropdown"
         className="dropdown-toggle btn btn-sm btn-primary"
         dropdownItems={dropdownItems}
       >
-        New
-        <span className="caret-container">
-          <span className="caret" />
-        </span>
+        <i className="fa fa-plus" /> New
       </StyledButton>
     </li>
   );

--- a/superset-frontend/src/components/Menu/NewMenu.tsx
+++ b/superset-frontend/src/components/Menu/NewMenu.tsx
@@ -17,6 +17,8 @@
  * under the License.
  */
 import React from 'react';
+import Button from '../Button';
+import styled from '@superset-ui/style';
 import { t } from '@superset-ui/translation';
 
 const buttonStyle = {
@@ -24,17 +26,40 @@ const buttonStyle = {
   marginRight: '30px',
 };
 
+const StyledButton = styled(Button)`
+  margin-top: 12px;
+  margin-right: 30px;
+  padding: 5px 80px 5px 50px;
+
+  i:before {
+    content: ' ';
+  }
+
+  .caret {
+    color: ${({ theme }) => theme.colors.grayscale.light5};
+  }
+`;
+
+const dropdownItems = [
+	'SQL Query',
+	'Chart',
+	'Dashboard',
+];
+
 export default function NewMenu() {
   return (
     <li className="dropdown">
-      <button
+	  <StyledButton
         type="button"
-        style={buttonStyle}
         data-toggle="dropdown"
         className="dropdown-toggle btn btn-sm btn-primary"
+		dropdownItems={dropdownItems}
       >
-        <i className="fa fa-plus" /> New
-      </button>
+		New
+        <span className="caret-container">
+	      <span className="caret" />
+		</span>
+      </StyledButton>
       <ul className="dropdown-menu">
         <li>
           <a href="/superset/sqllab">

--- a/superset-frontend/stylesheets/less/cosmo/bootswatch.less
+++ b/superset-frontend/stylesheets/less/cosmo/bootswatch.less
@@ -70,11 +70,6 @@
   text-transform: uppercase;
 }
 
-.btn-default:hover {
-  color: @gray-dark;
-  background-color: @gray-bg;
-}
-
 .nav-tabs {
   .dropdown-toggle.btn,
   .btn-group.open .dropdown-toggle.btn {


### PR DESCRIPTION
### SUMMARY
- [x] Updates `NewMenu` button to use `Button` component instead of simple `button` tag
- [x] Updates `Button` to allow for new `dropdownItems` prop, automatically turning a button into a dropdown when included
- [x] Removes an extra hover style in bootswatch that was overriding primary button hover styling

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
