### PR TITLE
chore: Removing explicit scoped session

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -487,8 +487,7 @@ def check_ownership(obj: Any, raise_if_false: bool = True) -> bool:
     roles = [r.name for r in get_user_roles()]
     if "Admin" in roles:
         return True
-    scoped_session = db.create_scoped_session()
-    orig_obj = scoped_session.query(obj.__class__).filter_by(id=obj.id).first()
+    orig_obj = db.session.query(obj.__class__).filter_by(id=obj.id).first()
 
     # Making a list of owners that works across ORM models
     owners: List[User] = []


### PR DESCRIPTION
### SUMMARY

Whilst looking into scoped SQLAlchemy session (the TL;DR is Airbnb is running into a thread issue when using the PyMySQL driver with MySQL 5.7) I did a grep for `scoped_sessions` and the only hit was here, yet per [Flask-SQLAlchemy](https://github.com/pallets/flask-sqlalchemy/blob/95328245ab03ddae97136877e88f18d6bd3cdbee/src/flask_sqlalchemy/__init__.py#L727) the `session` attribute represents a scoped session and thus it's unclear why we are recreating a scoped session.

Note there are a [handful of places](https://github.com/apache/incubator-superset/search?q=sessionmaker&unscoped_q=sessionmaker) where we're creating our own sessions which aren't scoped (and possibly not managed correctly) and I'm not sure why we aren't leveraging the session from Flask-SQLAlchemy here, i.e., I think in most of those cases, san SQL Lab, we should be using `db.session` rather than the session created from the connection which is passed by the event listener.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
