### PR TITLE
style: Move security/manage navigation tabs into a settings dropdown

### DIFF
--- a/superset-frontend/spec/javascripts/components/Menu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/Menu_spec.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Nav } from 'react-bootstrap';
+import { Nav, NavDropdown, NavItem } from 'react-bootstrap';
 import { supersetTheme, ThemeProvider } from '@superset-ui/style';
 
 import Menu from 'src/components/Menu/Menu';
@@ -26,19 +26,6 @@ import Menu from 'src/components/Menu/Menu';
 const defaultProps = {
   data: {
     menu: [
-      {
-        name: 'Security',
-        icon: 'fa-cogs',
-        label: 'Security',
-        childs: [
-          {
-            name: 'List Users',
-            icon: 'fa-user',
-            label: 'List Users',
-            url: '/users/list/',
-          },
-        ],
-      },
       {
         name: 'Sources',
         icon: 'fa-table',
@@ -100,6 +87,21 @@ const defaultProps = {
       user_login_url: '/login/',
       locale: 'en',
     },
+    settings: [
+      {
+        name: 'Security',
+        icon: 'fa-cogs',
+        label: 'Security',
+        childs: [
+          {
+            name: 'List Users',
+            icon: 'fa-user',
+            label: 'List Users',
+            url: '/users/list/',
+          },
+        ],
+      },
+    ],
   },
 };
 
@@ -163,5 +165,13 @@ describe('Menu', () => {
     });
 
     expect(versionedWrapper.find('.version-info div')).toHaveLength(2);
+  });
+
+  it('renders a NavDropdown (settings)', () => {
+    expect(wrapper.find(NavDropdown)).toHaveLength(1);
+  });
+
+  it('renders NavItems in NavDropdown (settings)', () => {
+    expect(wrapper.find(NavDropdown).find(NavItem)).toHaveLength(2);
   });
 });

--- a/superset-frontend/spec/javascripts/components/Menu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/Menu_spec.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Nav, NavDropdown, NavItem } from 'react-bootstrap';
+import { Nav, NavDropdown, MenuItem } from 'react-bootstrap';
 import { supersetTheme, ThemeProvider } from '@superset-ui/style';
 
 import Menu from 'src/components/Menu/Menu';
@@ -171,7 +171,7 @@ describe('Menu', () => {
     expect(wrapper.find(NavDropdown)).toHaveLength(1);
   });
 
-  it('renders NavItems in NavDropdown (settings)', () => {
-    expect(wrapper.find(NavDropdown).find(NavItem)).toHaveLength(2);
+  it('renders MenuItems in NavDropdown (settings)', () => {
+    expect(wrapper.find(NavDropdown).find(MenuItem)).toHaveLength(2);
   });
 });

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -129,15 +129,18 @@ export default function Menu({
   // Flatten settings
   const flatSettings: any[] = [];
 
-  settings.map((section: object, index: number) => {
-    // Top Section
-    section.isHeader = true;
+  settings.forEach((section: object, index: number) => {
+    const newSection: MenuObjectProps = {
+      ...section,
+      index,
+      isHeader: true,
+    };
 
-    flatSettings.push(section);
+    flatSettings.push(newSection);
 
     // Filter out '-'
-    if (section.childs) {
-      section.childs.forEach((child: any) => {
+    if (newSection.childs) {
+      newSection.childs.forEach((child: any) => {
         if (child !== '-') {
           flatSettings.push(child);
         }
@@ -169,19 +172,25 @@ export default function Menu({
           {!navbarRight.user_is_anonymous && <NewMenu />}
           {settings && settings.length && (
             <NavDropdown id={`settings-dropdown`} title="Settings">
-              {flatSettings.map((section, index) =>
-                section === '-' ? (
-                  <MenuItem
-                    key={`$${index}`}
-                    divider
-                    disabled
-                    className="settings-divider"
-                  />
-                ) : section.isHeader ? (
-                  <MenuItem key={`${section.label}`} disabled>
-                    {section.label}
-                  </MenuItem>
-                ) : (
+              {flatSettings.map((section, index) => {
+                if (section === '-') {
+                  return (
+                    <MenuItem
+                      key={`$${index}`}
+                      divider
+                      disabled
+                      className="settings-divider"
+                    />
+                  );
+                } else if (section.isHeader) {
+                  return (
+                    <MenuItem key={`${section.label}`} disabled>
+                      {section.label}
+                    </MenuItem>
+                  );
+                }
+
+                return (
                   <MenuItem
                     key={`${section.label}`}
                     href={section.url}
@@ -189,8 +198,8 @@ export default function Menu({
                   >
                     {section.label}
                   </MenuItem>
-                ),
-              )}
+                );
+              })}
             </NavDropdown>
           )}
           {navbarRight.documentation_url && (

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -129,28 +129,30 @@ export default function Menu({
   // Flatten settings
   const flatSettings: any[] = [];
 
-  settings.forEach((section: object, index: number) => {
-    const newSection: MenuObjectProps = {
-      ...section,
-      index,
-      isHeader: true,
-    };
+  if (settings) {
+    settings.forEach((section: object, index: number) => {
+      const newSection: MenuObjectProps = {
+        ...section,
+        index,
+        isHeader: true,
+      };
 
-    flatSettings.push(newSection);
+      flatSettings.push(newSection);
 
-    // Filter out '-'
-    if (newSection.childs) {
-      newSection.childs.forEach((child: any) => {
-        if (child !== '-') {
-          flatSettings.push(child);
-        }
-      });
-    }
+      // Filter out '-'
+      if (newSection.childs) {
+        newSection.childs.forEach((child: any) => {
+          if (child !== '-') {
+            flatSettings.push(child);
+          }
+        });
+      }
 
-    if (index !== settings.length - 1) {
-      flatSettings.push('-');
-    }
-  });
+      if (index !== settings.length - 1) {
+        flatSettings.push('-');
+      }
+    });
+  }
 
   return (
     <StyledHeader className="top" id="main-menu">

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import { t } from '@superset-ui/translation';
-import { Nav, Navbar, NavItem } from 'react-bootstrap';
+import { Nav, Navbar, NavDropdown, NavItem, MenuItem } from 'react-bootstrap';
 import styled from '@superset-ui/style';
 import MenuObject, { MenuObjectProps } from './MenuObject';
 import NewMenu from './NewMenu';
@@ -115,11 +115,39 @@ const StyledHeader = styled.header`
       margin: 0;
     }
   }
+
+  .settings-divider {
+    margin-bottom: 8px;
+    border-bottom: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+  }
 `;
 
 export default function Menu({
-  data: { menu, brand, navbar_right: navbarRight },
+  data: { menu, brand, navbar_right: navbarRight, settings },
 }: MenuProps) {
+  // Flatten settings
+  const flatSettings = [];
+
+  settings.map((section, index) => {
+    // Top Section
+    section.isHeader = true;
+
+    flatSettings.push(section);
+
+    // Filter out '-'
+    if (section.childs) {
+      section.childs.forEach(child => {
+        if (child !== '-') {
+          flatSettings.push(child);
+        }
+      });
+    }
+
+    if (index !== settings.length - 1) {
+      flatSettings.push('-');
+    }
+  });
+
   return (
     <StyledHeader className="top" id="main-menu">
       <Navbar inverse fluid staticTop role="navigation">
@@ -138,6 +166,32 @@ export default function Menu({
         </Nav>
         <Nav className="navbar-right">
           {!navbarRight.user_is_anonymous && <NewMenu />}
+          {settings && settings.length && (
+            <NavDropdown id={`settings-dropdown`} title="Settings">
+              {flatSettings.map((section, index) =>
+                section === '-' ? (
+                  <NavItem
+                    key={`$${index}`}
+                    divider
+                    disabled
+                    className="settings-divider"
+                  />
+                ) : section.isHeader ? (
+                  <NavItem key={`${section.label}`} disabled>
+                    {section.label}
+                  </NavItem>
+                ) : (
+                  <NavItem
+                    key={`${section.label}`}
+                    href={section.url}
+                    eventKey={index}
+                  >
+                    {section.label}
+                  </NavItem>
+                ),
+              )}
+            </NavDropdown>
+          )}
           {navbarRight.documentation_url && (
             <NavItem
               href={navbarRight.documentation_url}

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -51,6 +51,7 @@ export interface MenuProps {
     menu: MenuObjectProps[];
     brand: BrandProps;
     navbar_right: NavBarProps;
+    settings: MenuObjectProps[];
   };
 }
 
@@ -126,9 +127,9 @@ export default function Menu({
   data: { menu, brand, navbar_right: navbarRight, settings },
 }: MenuProps) {
   // Flatten settings
-  const flatSettings = [];
+  const flatSettings: any[] = [];
 
-  settings.map((section, index) => {
+  settings.map((section: object, index: number) => {
     // Top Section
     section.isHeader = true;
 
@@ -136,7 +137,7 @@ export default function Menu({
 
     // Filter out '-'
     if (section.childs) {
-      section.childs.forEach(child => {
+      section.childs.forEach((child: any) => {
         if (child !== '-') {
           flatSettings.push(child);
         }
@@ -170,24 +171,24 @@ export default function Menu({
             <NavDropdown id={`settings-dropdown`} title="Settings">
               {flatSettings.map((section, index) =>
                 section === '-' ? (
-                  <NavItem
+                  <MenuItem
                     key={`$${index}`}
                     divider
                     disabled
                     className="settings-divider"
                   />
                 ) : section.isHeader ? (
-                  <NavItem key={`${section.label}`} disabled>
+                  <MenuItem key={`${section.label}`} disabled>
                     {section.label}
-                  </NavItem>
+                  </MenuItem>
                 ) : (
-                  <NavItem
+                  <MenuItem
                     key={`${section.label}`}
                     href={section.url}
                     eventKey={index}
                   >
                     {section.label}
-                  </NavItem>
+                  </MenuItem>
                 ),
               )}
             </NavDropdown>

--- a/superset-frontend/src/components/Menu/MenuObject.tsx
+++ b/superset-frontend/src/components/Menu/MenuObject.tsx
@@ -20,8 +20,9 @@ import React from 'react';
 import { NavItem, MenuItem } from 'react-bootstrap';
 import NavDropdown from '../NavDropdown';
 
-interface MenuObjectChildProps {
+export interface MenuObjectChildProps {
   label: string;
+  name?: string;
   icon: string;
   index: number;
   url?: string;
@@ -33,6 +34,7 @@ export interface MenuObjectProps {
   index: number;
   url?: string;
   childs?: (MenuObjectChildProps | string)[];
+  isHeader?: boolean;
 }
 
 export default function MenuObject({

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -90,7 +90,12 @@ menu.menu.forEach((item: any) => {
   // Filter childs
   if (item.childs) {
     item.childs.forEach((child: MenuObjectChildProps | string) => {
-      if (child === '-' || !ignore.hasOwnProperty(child.name)) {
+      if (typeof child === 'string') {
+        children.push(child);
+      } else if (
+        (child as MenuObjectChildProps).label &&
+        !ignore.hasOwnProperty(child.label)
+      ) {
         children.push(child);
       }
     });

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -70,19 +70,19 @@ const ignore = {
 };
 
 // Cycle through menu.menu to build out cleanedMenu and settings
-const cleanedMenu = [];
-const settings = [];
+const cleanedMenu: object[] = [];
+const settings: object[] = [];
 
-menu.menu.forEach(item => {
+menu.menu.forEach((item: any) => {
   if (!item) {
     return;
   }
 
-  const children = [];
+  const children: object[] = [];
 
   // Filter childs
   if (item.childs) {
-    item.childs.forEach(child => {
+    item.childs.forEach((child: object) => {
       if (!ignore.hasOwnProperty(child.name)) {
         children.push(child);
       }

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -33,12 +33,16 @@ import ChartList from 'src/views/CRUD/chart/ChartList';
 import DatasetList from 'src/views/CRUD/data/dataset/DatasetList';
 import DatasourceList from 'src/views/CRUD/data/database/DatabaseList';
 
-import messageToastReducer from 'src/messageToasts/reducers';
-import { initEnhancer } from 'src/reduxUtils';
-import setupApp from 'src/setup/setupApp';
-import setupPlugins from 'src/setup/setupPlugins';
-import Welcome from 'src/views/CRUD/welcome/Welcome';
-import ToastPresenter from 'src/messageToasts/containers/ToastPresenter';
+import messageToastReducer from '../messageToasts/reducers';
+import { initEnhancer } from '../reduxUtils';
+import setupApp from '../setup/setupApp';
+import setupPlugins from '../setup/setupPlugins';
+import Welcome from './Welcome';
+import ToastPresenter from '../messageToasts/containers/ToastPresenter';
+import {
+  MenuObjectProps,
+  MenuObjectChildProps,
+} from '../components/Menu/MenuObject';
 
 setupApp();
 setupPlugins();
@@ -78,23 +82,26 @@ menu.menu.forEach((item: any) => {
     return;
   }
 
-  const children: object[] = [];
+  const children: (MenuObjectProps | string)[] = [];
+  const newItem = {
+    ...item,
+  };
 
   // Filter childs
   if (item.childs) {
-    item.childs.forEach((child: object) => {
-      if (!ignore.hasOwnProperty(child.name)) {
+    item.childs.forEach((child: MenuObjectChildProps | string) => {
+      if (child === '-' || !ignore.hasOwnProperty(child.name)) {
         children.push(child);
       }
     });
 
-    item.childs = children;
+    newItem.childs = children;
   }
 
   if (!settingsMenus.hasOwnProperty(item.name)) {
-    cleanedMenu.push(item);
+    cleanedMenu.push(newItem);
   } else {
-    settings.push(item);
+    settings.push(newItem);
   }
 });
 

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -37,7 +37,7 @@ import messageToastReducer from '../messageToasts/reducers';
 import { initEnhancer } from '../reduxUtils';
 import setupApp from '../setup/setupApp';
 import setupPlugins from '../setup/setupPlugins';
-import Welcome from './Welcome';
+import Welcome from './CRUD/welcome/Welcome';
 import ToastPresenter from '../messageToasts/containers/ToastPresenter';
 import {
   MenuObjectProps,

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -58,6 +58,49 @@ const store = createStore(
   compose(applyMiddleware(thunk), initEnhancer(false)),
 );
 
+// Menu items that should go into settings dropdown
+const settingsMenus = {
+  Security: true,
+  Manage: true,
+};
+
+// Menu items that should be ignored
+const ignore = {
+  'Import Dashboards': true,
+};
+
+// Cycle through menu.menu to build out cleanedMenu and settings
+const cleanedMenu = [];
+const settings = [];
+
+menu.menu.forEach(item => {
+  if (!item) {
+    return;
+  }
+
+  const children = [];
+
+  // Filter childs
+  if (item.childs) {
+    item.childs.forEach(child => {
+      if (!ignore.hasOwnProperty(child.name)) {
+        children.push(child);
+      }
+    });
+
+    item.childs = children;
+  }
+
+  if (!settingsMenus.hasOwnProperty(item.name)) {
+    cleanedMenu.push(item);
+  } else {
+    settings.push(item);
+  }
+});
+
+menu.menu = cleanedMenu;
+menu.settings = settings;
+
 const App = () => (
   <Provider store={store}>
     <ThemeProvider theme={supersetTheme}>


### PR DESCRIPTION
### SUMMARY
- [x] Adds settings dropdown in top-right corner
- [x] Move Security/Manage menu options into settings dropdown
- [x] Move 'Import Dashboard(s)' to a button next to Bulk Select on Dashboards page

Note: This update is currently waiting on Superset to use the React navbar exclusively (which is not currently the case). See PR #10401 for the required change this depends on.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (Also applies to FAB pages):
<img width="1162" alt="Screen Shot 2020-07-27 at 12 35 31 PM" src="https://user-images.githubusercontent.com/8216382/88584235-31aca280-d006-11ea-924d-1ddc88bc16d0.png">

After:
<img width="1163" alt="Screen Shot 2020-07-27 at 12 37 32 PM" src="https://user-images.githubusercontent.com/8216382/88584269-3ec99180-d006-11ea-96e6-832b9f4ede61.png">

<img width="1162" alt="Screen Shot 2020-07-27 at 12 55 19 PM" src="https://user-images.githubusercontent.com/8216382/88728013-9ee33500-d0e5-11ea-8db5-b5e0afba15d2.png">

### TEST PLAN
- [x] Added settings dropdown check to `Menu_spec.jsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
