### PR TITLE
fix(presto): Handle ROW data stored as string

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -664,7 +664,7 @@ class PrestoEngineSpec(BaseEngineSpec):
                 for row in data:
                     values = row.get(name) or []
                     if isinstance(values, str):
-                        row[name] = values = destringify(values)
+                        row[name] = values = cast(List[Any], destringify(values))
                     for value, col in zip(values, expanded):
                         row[col["name"]] = value
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -569,7 +569,7 @@ class PrestoEngineSpec(BaseEngineSpec):
         return datasource_names
 
     @classmethod
-    def expand_data(  # pylint: disable=too-many-locals
+    def expand_data(  # pylint: disable=too-many-locals,too-many-branches
         cls, columns: List[Dict[Any, Any]], data: List[Dict[Any, Any]]
     ) -> Tuple[List[Dict[Any, Any]], List[Dict[Any, Any]], List[Dict[Any, Any]]]:
         """

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -617,6 +617,7 @@ class PrestoEngineSpec(BaseEngineSpec):
                 current_array_level = level
 
             name = column["name"]
+            values: Optional[Union[str, List[Any]]]
 
             if column["type"].startswith("ARRAY("):
                 # keep processing array children; we append to the right so that
@@ -627,7 +628,7 @@ class PrestoEngineSpec(BaseEngineSpec):
                 i = 0
                 while i < len(data):
                     row = data[i]
-                    values: Union[str, List] = row.get(name)
+                    values = row.get(name)
                     if isinstance(values, str):
                         row[name] = values = destringify(values)
                     if values:
@@ -661,7 +662,7 @@ class PrestoEngineSpec(BaseEngineSpec):
 
                 # expand row objects into new columns
                 for row in data:
-                    values: Union[str, List] = row.get(name) or []
+                    values = row.get(name) or []
                     if isinstance(values, str):
                         row[name] = values = destringify(values)
                     for value, col in zip(values, expanded):

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -67,6 +67,10 @@ def stringify_values(array: np.ndarray) -> np.ndarray:
     return vstringify(array)
 
 
+def destringify(obj: str) -> Any:
+    return json.loads(obj)
+
+
 class SupersetResultSet:
     def __init__(  # pylint: disable=too-many-locals,too-many-branches
         self,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When [serializing nested types we convert them to string](https://github.com/apache/incubator-superset/blob/0017b61f51b83a19c03b698f83bdeeeb0ec5685d/superset/result_set.py#L119-L124), which breaks the `expand_data` in Presto.

I added a check in `expand_data` so that when the data associated with a nested column (types `ARRAY` and `ROW`) is a string, it gets deserialized back into the original data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

A Presto query selecting an `ARRAY` and a `ROW` without the `PRESTO_EXPAND_DATA` feature flag:

![Screen Shot 2020-07-28 at 12 41 30 PM](https://user-images.githubusercontent.com/1534870/88713305-f080c500-d0cf-11ea-83f6-767b59977c4e.png)

With the feature enabled, data should be displayed similar to how BigQuery does, with arrays expanded into multiple lines, and rows expanded into multiple columns. This is currently broken:

![Screen Shot 2020-07-28 at 12 41 33 PM](https://user-images.githubusercontent.com/1534870/88713375-10b08400-d0d0-11ea-92be-067ed2ba129d.png)

This PR fixes the problem, and the data gets expanded correctly:

![Screen Shot 2020-07-28 at 12 41 36 PM](https://user-images.githubusercontent.com/1534870/88713424-21f99080-d0d0-11ea-809d-cc84fa6e356d.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested with a simple query (see above), and added a unit test covering the problem.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
