### PR TITLE
fix: change "add new slice" page title copy to "add new chart"

### DIFF
--- a/superset/templates/superset/add_slice.html
+++ b/superset/templates/superset/add_slice.html
@@ -19,7 +19,7 @@
 {% extends "superset/basic.html" %}
 
 {% block title %}
-  Add new slice
+  Add new chart
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
### SUMMARY
Pretty much what the title says. Updates page title for adding a chart to better match its content.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
<img width="504" alt="Screen Shot 2020-07-28 at 2 35 43 PM" src="https://user-images.githubusercontent.com/8216382/88724881-12824380-d0e0-11ea-8317-acf2ece0dfb4.png">

After
<img width="610" alt="Screen Shot 2020-07-28 at 2 35 27 PM" src="https://user-images.githubusercontent.com/8216382/88724914-1ada7e80-d0e0-11ea-8d8c-185dd3649ee8.png">

### TEST PLAN

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
