### PR TITLE
fix: update time range select tooltip

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -82,8 +82,8 @@ const DEFAULT_SINCE = moment()
 const DEFAULT_UNTIL = moment().utc().startOf('day').format(MOMENT_FORMAT);
 const SEPARATOR = ' : ';
 const FREEFORM_TOOLTIP = t(
-  'Superset supports smart date parsing. Strings like `last sunday` or ' +
-    '`last october` can be used.',
+  'Superset supports smart date parsing. Strings like `3 weeks ago`, `last sunday` or ' +
+    '`2 weeks from now` can be used.',
 );
 
 const DATE_FILTER_POPOVER_STYLE = { width: '250px' };

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -82,7 +82,7 @@ const DEFAULT_SINCE = moment()
 const DEFAULT_UNTIL = moment().utc().startOf('day').format(MOMENT_FORMAT);
 const SEPARATOR = ' : ';
 const FREEFORM_TOOLTIP = t(
-  'Superset supports smart date parsing. Strings like `3 weeks ago`, `last sunday` or ' +
+  'Superset supports smart date parsing. Strings like `3 weeks ago`, `last sunday`, or ' +
     '`2 weeks from now` can be used.',
 );
 

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -4329,8 +4329,8 @@ msgstr ""
 
 #: superset-frontend/src/explore/components/controls/DateFilterControl.jsx:85
 msgid ""
-"Superset supports smart date parsing. Strings like `last sunday` or `last"
-" october` can be used."
+"Superset supports smart date parsing. Strings like `3 weeks ago`, `last sunday`"
+" or `2 weeks from now` can be used."
 msgstr ""
 
 #: superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx:142


### PR DESCRIPTION
### SUMMARY
Updates time range select tooltip in Explore to provide more clear examples of smart date parsing

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
<img width="353" alt="Screen Shot 2020-07-28 at 3 16 08 PM" src="https://user-images.githubusercontent.com/8216382/88727851-4a3fba00-d0e5-11ea-8f9b-406ce8c1bc3c.png">

After
<img width="365" alt="Screen Shot 2020-07-28 at 3 07 06 PM" src="https://user-images.githubusercontent.com/8216382/88727826-385e1700-d0e5-11ea-848f-b4c560232f24.png">

### TEST PLAN

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
