### PR TITLE
fix(sqllab): button width isn't wide enough for 'Run Selection'

### DIFF
--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
@@ -33,7 +33,7 @@ interface Props {
   sql: string;
 }
 const commonBtnStyle = {
-  width: '80px',
+  width: '140px',
 };
 
 const RunQueryActionButton = ({
@@ -45,7 +45,7 @@ const RunQueryActionButton = ({
   stopQuery = NO_OP,
   sql = '',
 }: Props) => {
-  const runBtnText = selectedText ? t('Run Selected Query') : t('Run');
+  const runBtnText = selectedText ? t('Run Selection') : t('Run');
   const btnStyle = selectedText ? 'warning' : 'primary';
   const shouldShowStopBtn =
     !!queryState && ['running', 'pending'].indexOf(queryState) > -1;


### PR DESCRIPTION
closes https://github.com/apache/incubator-superset/issues/10440

<img width="477" alt="Screen Shot 2020-07-28 at 11 12 22 PM" src="https://user-images.githubusercontent.com/487433/88763502-189c1280-d128-11ea-8357-b6b63c015881.png">
<img width="402" alt="Screen Shot 2020-07-28 at 11 12 14 PM" src="https://user-images.githubusercontent.com/487433/88763503-1934a900-d128-11ea-82ca-8dfcb18c961a.png">
