### PR TITLE
style: make database list less bloated

### DIFF
--- a/superset/views/database/mixins.py
+++ b/superset/views/database/mixins.py
@@ -37,10 +37,8 @@ class DatabaseMixin:
     list_columns = [
         "database_name",
         "backend",
-        "allow_run_async",
-        "allow_dml",
-        "allow_csv_upload",
         "expose_in_sqllab",
+        "allow_run_async",
         "creator",
         "modified",
     ]
@@ -197,7 +195,7 @@ class DatabaseMixin:
         "extra": _("Extra"),
         "encrypted_extra": _("Secure Extra"),
         "server_cert": _("Root certificate"),
-        "allow_run_async": _("Asynchronous Query Execution"),
+        "allow_run_async": _("Async Execution"),
         "impersonate_user": _("Impersonate the logged on user"),
         "allow_csv_upload": _("Allow Csv Upload"),
         "modified": _("Modified"),


### PR DESCRIPTION
Late arriving cosmetic bash item:

## After
<img width="1314" alt="Screen Shot 2020-07-28 at 11 19 06 PM" src="https://user-images.githubusercontent.com/487433/88763964-ef2fb680-d128-11ea-8c36-d26d35033f79.png">

## Before
<img width="1320" alt="Screen Shot 2020-07-28 at 11 16 56 PM" src="https://user-images.githubusercontent.com/487433/88763967-f060e380-d128-11ea-9f52-2bc950b87e1f.png">
