### PR TITLE
fix: made BaseScreenshot driver_type configurable

### DIFF
--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -181,7 +181,7 @@ class AuthWebDriverProxy:
 
 
 class BaseScreenshot:
-    driver_type = "chrome"
+    driver_type = current_app.config.get("EMAIL_REPORTS_WEBDRIVER", "chrome")
     thumbnail_type: str = ""
     element: str = ""
     window_size: WindowSize = (800, 600)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The webdriver for the BaseScreenshot class was set as a constant to use chromedriver. This PR changes the BaseScreenshot driver_type to default to chrome, but use EMAIL_REPORTS_WEBDRIVER in the config file if it exists.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
