### PR TITLE
feat: add linear color scale to sunburst chart

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -8422,9 +8422,9 @@
       }
     },
     "@superset-ui/legacy-plugin-chart-sunburst": {
-      "version": "0.14.9",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-plugin-chart-sunburst/-/legacy-plugin-chart-sunburst-0.14.9.tgz",
-      "integrity": "sha512-/dXLC8n7AsRqicdiK5UfqEjKvx5mWd75nWNgFkOpzB7nJAa4B+X0ykH1ORBk4+PUIK69QDMkD/8hoalm50YxJw==",
+      "version": "0.14.18",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-plugin-chart-sunburst/-/legacy-plugin-chart-sunburst-0.14.18.tgz",
+      "integrity": "sha512-fGIDg18oedPofWf6sJ56SYmxgz+ycNUUAFBgV8mPfaGPZsK/OMYcrde5GXVKqqHm0g06np4D0fEDN78upt31uQ==",
       "requires": {
         "d3": "^3.5.17",
         "prop-types": "^15.6.2"

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -88,7 +88,7 @@
     "@superset-ui/legacy-plugin-chart-rose": "^0.14.14",
     "@superset-ui/legacy-plugin-chart-sankey": "^0.14.9",
     "@superset-ui/legacy-plugin-chart-sankey-loop": "^0.14.9",
-    "@superset-ui/legacy-plugin-chart-sunburst": "^0.14.9",
+    "@superset-ui/legacy-plugin-chart-sunburst": "^0.14.18",
     "@superset-ui/legacy-plugin-chart-treemap": "^0.14.13",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.14.16",
     "@superset-ui/legacy-preset-chart-big-number": "^0.14.9",


### PR DESCRIPTION
### SUMMARY
Currently there is no way of changing the linear color scale on Sunburst chart when using a secondary metric. This adds a control for the linear scale. Actual work done in https://github.com/apache-superset/superset-ui/pull/714

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![captured (18)](https://user-images.githubusercontent.com/33317356/88842082-9ecb5e00-d1e7-11ea-9821-21667b01c615.gif)

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
