### PR TITLE
fix(dashboard): add animation state to fix tab switch re-renders

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Chart_spec.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import Chart from 'src/dashboard/components/gridComponents/Chart';
+import { ChartUnconnected as Chart } from 'src/dashboard/components/gridComponents/Chart';
 import SliceHeader from 'src/dashboard/components/SliceHeader';
 import ChartContainer from 'src/chart/ChartContainer';
 
@@ -44,6 +44,7 @@ describe('Chart', () => {
     slice: {
       ...sliceEntities.slices[queryId],
       description_markeddown: 'markdown',
+      owners: [],
     },
     sliceName: sliceEntities.slices[queryId].slice_name,
     timeout: 60,
@@ -52,6 +53,13 @@ describe('Chart', () => {
     toggleExpandSlice() {},
     addFilter() {},
     logEvent() {},
+    handleToggleFullSize() {},
+    changeFilter() {},
+    setFocusedFilterField() {},
+    unsetFocusedFilterField() {},
+    addDangerToast() {},
+    componentId: 'test',
+    dashboardId: 111,
     editMode: false,
     isExpanded: false,
     supersetCanExplore: false,

--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -63,7 +63,8 @@ const propTypes = {
   onQuery: PropTypes.func,
   onFilterMenuOpen: PropTypes.func,
   onFilterMenuClose: PropTypes.func,
-  isParentMounted: PropTypes.bool,
+  // id of the last mounted parent tab
+  mountedParent: PropTypes.string,
 };
 
 const BLANK = {};
@@ -75,7 +76,6 @@ const defaultProps = {
   initialValues: BLANK,
   setControlValue() {},
   triggerRender: false,
-  isParentMounted: true,
   dashboardId: null,
   chartStackTrace: null,
 };

--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -63,6 +63,7 @@ const propTypes = {
   onQuery: PropTypes.func,
   onFilterMenuOpen: PropTypes.func,
   onFilterMenuClose: PropTypes.func,
+  isParentMounted: PropTypes.bool,
 };
 
 const BLANK = {};
@@ -74,6 +75,7 @@ const defaultProps = {
   initialValues: BLANK,
   setControlValue() {},
   triggerRender: false,
+  isParentMounted: true,
   dashboardId: null,
   chartStackTrace: null,
 };

--- a/superset-frontend/src/chart/ChartContainer.jsx
+++ b/superset-frontend/src/chart/ChartContainer.jsx
@@ -23,14 +23,6 @@ import * as actions from './chartAction';
 import { logEvent } from '../logger/actions';
 import Chart from './Chart';
 
-function mapStateToProps({ dashboardState }) {
-  return {
-    // needed to prevent chart from rendering while tab switch animation in progress
-    // when undefined, default to have mounted the root tab
-    mountedParent: dashboardState?.mountedTab,
-  };
-}
-
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(
@@ -43,4 +35,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Chart);
+export default connect(null, mapDispatchToProps)(Chart);

--- a/superset-frontend/src/chart/ChartContainer.jsx
+++ b/superset-frontend/src/chart/ChartContainer.jsx
@@ -24,8 +24,11 @@ import { logEvent } from '../logger/actions';
 import Chart from './Chart';
 
 function mapStateToProps({ dashboardState }) {
-  // needed to prevent chart from rendering while animating
-  return { isParentMounted: dashboardState?.isTabMounted };
+  return {
+    // needed to prevent chart from rendering while tab switch animation in progress
+    // when undefined, default to have mounted the root tab
+    mountedParent: dashboardState?.mountedTab,
+  };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/superset-frontend/src/chart/ChartContainer.jsx
+++ b/superset-frontend/src/chart/ChartContainer.jsx
@@ -23,6 +23,11 @@ import * as actions from './chartAction';
 import { logEvent } from '../logger/actions';
 import Chart from './Chart';
 
+function mapStateToProps({ dashboardState }) {
+  // needed to prevent chart from rendering while animating
+  return { isParentMounted: dashboardState?.isTabMounted };
+}
+
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(
@@ -35,4 +40,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(null, mapDispatchToProps)(Chart);
+export default connect(mapStateToProps, mapDispatchToProps)(Chart);

--- a/superset-frontend/src/chart/ChartRenderer.jsx
+++ b/superset-frontend/src/chart/ChartRenderer.jsx
@@ -34,8 +34,8 @@ const propTypes = {
   setControlValue: PropTypes.func,
   vizType: PropTypes.string.isRequired,
   triggerRender: PropTypes.bool,
-  // whether the parent container is animating
-  isParentMounted: PropTypes.bool,
+  // last mounted parent tab
+  mountedParent: PropTypes.string,
   // state
   chartAlert: PropTypes.string,
   chartStatus: PropTypes.string,
@@ -57,9 +57,6 @@ const defaultProps = {
   initialValues: BLANK,
   setControlValue() {},
   triggerRender: false,
-  // whether the chart has REALLY been mounted to DOM
-  // (they may not because when placed in tabs, the tab might still be animating)
-  isParentMounted: true,
 };
 
 class ChartRenderer extends React.Component {
@@ -91,10 +88,11 @@ class ChartRenderer extends React.Component {
     if (resultsReady) {
       this.hasQueryResponseChange =
         nextProps.queryResponse !== this.props.queryResponse;
-      if (!nextProps.isParentMounted) return false;
+      // null mountedParent means animationg is still in progress
+      if (nextProps.mountedParent === null) return false;
       return (
         this.hasQueryResponseChange ||
-        nextProps.isParentMounted !== this.props.isParentMounted ||
+        nextProps.mountedParent !== this.props.mountedParent ||
         nextProps.annotationData !== this.props.annotationData ||
         nextProps.height !== this.props.height ||
         nextProps.width !== this.props.width ||

--- a/superset-frontend/src/chart/ChartRenderer.jsx
+++ b/superset-frontend/src/chart/ChartRenderer.jsx
@@ -34,8 +34,6 @@ const propTypes = {
   setControlValue: PropTypes.func,
   vizType: PropTypes.string.isRequired,
   triggerRender: PropTypes.bool,
-  // last mounted parent tab
-  mountedParent: PropTypes.string,
   // state
   chartAlert: PropTypes.string,
   chartStatus: PropTypes.string,
@@ -88,11 +86,8 @@ class ChartRenderer extends React.Component {
     if (resultsReady) {
       this.hasQueryResponseChange =
         nextProps.queryResponse !== this.props.queryResponse;
-      // null mountedParent means animationg is still in progress
-      if (nextProps.mountedParent === null) return false;
       return (
         this.hasQueryResponseChange ||
-        nextProps.mountedParent !== this.props.mountedParent ||
         nextProps.annotationData !== this.props.annotationData ||
         nextProps.height !== this.props.height ||
         nextProps.width !== this.props.width ||

--- a/superset-frontend/src/chart/ChartRenderer.jsx
+++ b/superset-frontend/src/chart/ChartRenderer.jsx
@@ -34,6 +34,8 @@ const propTypes = {
   setControlValue: PropTypes.func,
   vizType: PropTypes.string.isRequired,
   triggerRender: PropTypes.bool,
+  // whether the parent container is animating
+  isParentMounted: PropTypes.bool,
   // state
   chartAlert: PropTypes.string,
   chartStatus: PropTypes.string,
@@ -55,6 +57,9 @@ const defaultProps = {
   initialValues: BLANK,
   setControlValue() {},
   triggerRender: false,
+  // whether the chart has REALLY been mounted to DOM
+  // (they may not because when placed in tabs, the tab might still be animating)
+  isParentMounted: true,
 };
 
 class ChartRenderer extends React.Component {
@@ -86,18 +91,17 @@ class ChartRenderer extends React.Component {
     if (resultsReady) {
       this.hasQueryResponseChange =
         nextProps.queryResponse !== this.props.queryResponse;
-
-      if (
+      if (!nextProps.isParentMounted) return false;
+      return (
         this.hasQueryResponseChange ||
+        nextProps.isParentMounted !== this.props.isParentMounted ||
         nextProps.annotationData !== this.props.annotationData ||
         nextProps.height !== this.props.height ||
         nextProps.width !== this.props.width ||
         nextProps.triggerRender ||
         nextProps.formData.color_scheme !== this.props.formData.color_scheme ||
         nextProps.cacheBusterProp !== this.props.cacheBusterProp
-      ) {
-        return true;
-      }
+      );
     }
     return false;
   }

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -321,12 +321,12 @@ export function setDirectPathToChild(path) {
   return { type: SET_DIRECT_PATH, path };
 }
 
-export const SET_IS_TAB_MOUNTED = 'SET_IS_TAB_MOUNTED';
+export const SET_MOUNTED_TAB = 'SET_MOUNTED_TAB';
 /**
  * Set if tab switch animation is in progress
  */
-export function setIsTabMounted(isTabMounted) {
-  return { type: SET_IS_TAB_MOUNTED, isTabMounted };
+export function setMountedTab(mountedTab) {
+  return { type: SET_MOUNTED_TAB, mountedTab };
 }
 
 export const SET_FOCUSED_FILTER_FIELD = 'SET_FOCUSED_FILTER_FIELD';

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -321,6 +321,14 @@ export function setDirectPathToChild(path) {
   return { type: SET_DIRECT_PATH, path };
 }
 
+export const SET_IS_TAB_MOUNTED = 'SET_IS_TAB_MOUNTED';
+/**
+ * Set if tab switch animation is in progress
+ */
+export function setIsTabMounted(isTabMounted) {
+  return { type: SET_IS_TAB_MOUNTED, isTabMounted };
+}
+
 export const SET_FOCUSED_FILTER_FIELD = 'SET_FOCUSED_FILTER_FIELD';
 export function setFocusedFilterField(chartId, column) {
   return { type: SET_FOCUSED_FILTER_FIELD, chartId, column };

--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -249,10 +249,6 @@ class DashboardBuilder extends React.Component {
                         key={index === 0 ? DASHBOARD_GRID_ID : id}
                         eventKey={index}
                         mountOnEnter
-                        onExiting={() => {
-                          // Exiting previous tab, animating start
-                          this.props.setMountedTab(null);
-                        }}
                         onEntering={() => {
                           // Entering current tab, DOM is visible and has dimension
                           this.props.setMountedTab(id);

--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -249,6 +249,7 @@ class DashboardBuilder extends React.Component {
                         key={index === 0 ? DASHBOARD_GRID_ID : id}
                         eventKey={index}
                         mountOnEnter
+                        unmountOnExit={false}
                         onEntering={() => {
                           // Entering current tab, DOM is visible and has dimension
                           this.props.setMountedTab(id);

--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -60,6 +60,7 @@ const propTypes = {
   handleComponentDrop: PropTypes.func.isRequired,
   directPathToChild: PropTypes.arrayOf(PropTypes.string),
   setDirectPathToChild: PropTypes.func.isRequired,
+  setMountedTab: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -247,6 +248,15 @@ class DashboardBuilder extends React.Component {
                       <TabPane
                         key={index === 0 ? DASHBOARD_GRID_ID : id}
                         eventKey={index}
+                        mountOnEnter
+                        onExiting={() => {
+                          // Exiting previous tab, animating start
+                          this.props.setMountedTab(null);
+                        }}
+                        onEntering={() => {
+                          // Entering current tab, DOM is visible and has dimension
+                          this.props.setMountedTab(id);
+                        }}
                       >
                         <DashboardGrid
                           gridComponent={dashboardLayout[id]}

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -18,6 +18,7 @@
  */
 import cx from 'classnames';
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { exploreChart, exportChart } from '../../../explore/exploreUtils';
 import SliceHeader from '../SliceHeader';
@@ -41,6 +42,8 @@ const propTypes = {
   height: PropTypes.number.isRequired,
   updateSliceName: PropTypes.func.isRequired,
   isComponentVisible: PropTypes.bool,
+  // last switched tab
+  mountedParent: PropTypes.string,
   handleToggleFullSize: PropTypes.func.isRequired,
 
   // from redux
@@ -70,6 +73,7 @@ const propTypes = {
 const defaultProps = {
   isCached: false,
   isComponentVisible: true,
+  mountedParent: 'ROOT',
 };
 
 // we use state + shouldComponentUpdate() logic to prevent perf-wrecking
@@ -114,6 +118,9 @@ class Chart extends React.Component {
     // allow chart update/re-render only if visible:
     // under selected tab or no tab layout
     if (nextProps.isComponentVisible) {
+      if (nextProps.mountedParent === null) {
+        return false;
+      }
       if (nextProps.chart.triggerQuery) {
         return true;
       }
@@ -140,7 +147,7 @@ class Chart extends React.Component {
       }
     }
 
-    // `cacheBusterProp` is nnjected by react-hot-loader
+    // `cacheBusterProp` is jected by react-hot-loader
     return this.props.cacheBusterProp !== nextProps.cacheBusterProp;
   }
 
@@ -347,4 +354,20 @@ class Chart extends React.Component {
 Chart.propTypes = propTypes;
 Chart.defaultProps = defaultProps;
 
-export default Chart;
+function mapStateToProps({ dashboardState }) {
+  return {
+    // needed to prevent chart from rendering while tab switch animation in progress
+    // when undefined, default to have mounted the root tab
+    mountedParent: dashboardState?.mountedTab,
+  };
+}
+
+/**
+ * The original Chart component not connected to state.
+ */
+export const ChartUnconnected = Chart;
+
+/**
+ * Redux connected Chart component.
+ */
+export default connect(mapStateToProps, null)(Chart);

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -51,7 +51,7 @@ const propTypes = {
 
   // actions (from DashboardComponent.jsx)
   logEvent: PropTypes.func.isRequired,
-  setIsTabMounted: PropTypes.func.isRequired,
+  setMountedTab: PropTypes.func.isRequired,
 
   // grid related
   availableColumnCount: PropTypes.number,
@@ -264,12 +264,16 @@ class Tabs extends React.PureComponent {
                     />
                   }
                   onExiting={() => {
-                    // Exiting previous tab, animating start
-                    this.props.setIsTabMounted(false);
+                    if (renderTabContent) {
+                      // Exiting previous tab, animating start
+                      this.props.setMountedTab(null);
+                    }
                   }}
                   onEntering={() => {
                     // Entering current tab, DOM is visible and has dimension
-                    this.props.setIsTabMounted(true);
+                    if (renderTabContent) {
+                      this.props.setMountedTab(tabId);
+                    }
                   }}
                 >
                   {renderTabContent && (

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -47,8 +47,11 @@ const propTypes = {
   renderTabContent: PropTypes.bool, // whether to render tabs + content or just tabs
   editMode: PropTypes.bool.isRequired,
   renderHoverMenu: PropTypes.bool,
-  logEvent: PropTypes.func.isRequired,
   directPathToChild: PropTypes.arrayOf(PropTypes.string),
+
+  // actions (from DashboardComponent.jsx)
+  logEvent: PropTypes.func.isRequired,
+  setIsTabMounted: PropTypes.func.isRequired,
 
   // grid related
   availableColumnCount: PropTypes.number,
@@ -260,6 +263,14 @@ class Tabs extends React.PureComponent {
                       onDeleteTab={this.handleDeleteTab}
                     />
                   }
+                  onExiting={() => {
+                    // Exiting previous tab, animating start
+                    this.props.setIsTabMounted(false);
+                  }}
+                  onEntering={() => {
+                    // Entering current tab, DOM is visible and has dimension
+                    this.props.setIsTabMounted(true);
+                  }}
                 >
                   {renderTabContent && (
                     <DashboardComponent

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -263,12 +263,6 @@ class Tabs extends React.PureComponent {
                       onDeleteTab={this.handleDeleteTab}
                     />
                   }
-                  onExiting={() => {
-                    if (renderTabContent) {
-                      // Exiting previous tab, animating start
-                      this.props.setMountedTab(null);
-                    }
-                  }}
                   onEntering={() => {
                     // Entering current tab, DOM is visible and has dimension
                     if (renderTabContent) {

--- a/superset-frontend/src/dashboard/containers/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardBuilder.jsx
@@ -24,6 +24,7 @@ import {
   setColorSchemeAndUnsavedChanges,
   showBuilderPane,
   setDirectPathToChild,
+  setMountedTab,
 } from '../actions/dashboardState';
 import {
   deleteTopLevelTabs,
@@ -48,6 +49,7 @@ function mapDispatchToProps(dispatch) {
       showBuilderPane,
       setColorSchemeAndUnsavedChanges,
       setDirectPathToChild,
+      setMountedTab,
     },
     dispatch,
   );

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -33,7 +33,10 @@ import {
   updateComponents,
   handleComponentDrop,
 } from '../actions/dashboardLayout';
-import { setDirectPathToChild } from '../actions/dashboardState';
+import {
+  setDirectPathToChild,
+  setIsTabMounted,
+} from '../actions/dashboardState';
 import { logEvent } from '../../logger/actions';
 import { addDangerToast } from '../../messageToasts/actions';
 
@@ -106,6 +109,7 @@ function mapDispatchToProps(dispatch) {
       updateComponents,
       handleComponentDrop,
       setDirectPathToChild,
+      setIsTabMounted,
       logEvent,
     },
     dispatch,

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -33,10 +33,7 @@ import {
   updateComponents,
   handleComponentDrop,
 } from '../actions/dashboardLayout';
-import {
-  setDirectPathToChild,
-  setIsTabMounted,
-} from '../actions/dashboardState';
+import { setDirectPathToChild, setMountedTab } from '../actions/dashboardState';
 import { logEvent } from '../../logger/actions';
 import { addDangerToast } from '../../messageToasts/actions';
 
@@ -109,7 +106,7 @@ function mapDispatchToProps(dispatch) {
       updateComponents,
       handleComponentDrop,
       setDirectPathToChild,
-      setIsTabMounted,
+      setMountedTab,
       logEvent,
     },
     dispatch,

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -33,7 +33,7 @@ import {
   UPDATE_CSS,
   SET_REFRESH_FREQUENCY,
   SET_DIRECT_PATH,
-  SET_IS_TAB_MOUNTED,
+  SET_MOUNTED_TAB,
   SET_FOCUSED_FILTER_FIELD,
 } from '../actions/dashboardState';
 
@@ -127,10 +127,10 @@ export default function dashboardStateReducer(state = {}, action) {
         directPathLastUpdated: Date.now(),
       };
     },
-    [SET_IS_TAB_MOUNTED]() {
+    [SET_MOUNTED_TAB]() {
       return {
         ...state,
-        isTabMounted: action.isTabMounted,
+        mountedTab: action.mountedTab,
       };
     },
     [SET_FOCUSED_FILTER_FIELD]() {

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -33,6 +33,7 @@ import {
   UPDATE_CSS,
   SET_REFRESH_FREQUENCY,
   SET_DIRECT_PATH,
+  SET_IS_TAB_MOUNTED,
   SET_FOCUSED_FILTER_FIELD,
 } from '../actions/dashboardState';
 
@@ -124,6 +125,12 @@ export default function dashboardStateReducer(state = {}, action) {
         ...state,
         directPathToChild: action.path,
         directPathLastUpdated: Date.now(),
+      };
+    },
+    [SET_IS_TAB_MOUNTED]() {
+      return {
+        ...state,
+        isTabMounted: action.isTabMounted,
       };
     },
     [SET_FOCUSED_FILTER_FIELD]() {

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -123,11 +123,14 @@ export default function dashboardStateReducer(state = {}, action) {
     [SET_DIRECT_PATH]() {
       return {
         ...state,
+        // change of direct path (tabs) will reset current mounted tab
+        mountedTab: null,
         directPathToChild: action.path,
         directPathLastUpdated: Date.now(),
       };
     },
     [SET_MOUNTED_TAB]() {
+      // set current mounted tab after tab is really mounted to DOM
       return {
         ...state,
         mountedTab: action.mountedTab,


### PR DESCRIPTION
### SUMMARY

A more robust fix for #10349 and #10432 .

This should fix all similar problems related using DOM dimensions in charts before dashboard tab switch completes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

Table chart was not able to expand height when applying filters gave it more rows:

![bug-before](https://user-images.githubusercontent.com/335541/88845539-2e95eb80-d199-11ea-93c8-57b58b4e3726.gif)


#### After

Table chart correctly expand height:

![bug-after](https://user-images.githubusercontent.com/335541/88845560-36559000-d199-11ea-8521-40d6f285200a.gif)


### TEST PLAN

Manual testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
