### PR TITLE
feat: add test email functionality to SQL-based email alerts

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -540,6 +540,7 @@ def schedule_alert_query(  # pylint: disable=unused-argument
     report_type: ScheduleType,
     schedule_id: int,
     recipients: Optional[str] = None,
+    is_test_alert: Optional[bool] = False,
 ) -> None:
     model_cls = get_scheduler_model(report_type)
     dbsession = db.create_scoped_session()
@@ -551,12 +552,11 @@ def schedule_alert_query(  # pylint: disable=unused-argument
         return
 
     if report_type == ScheduleType.alert:
-        # recipients is only specified when task is called from view for a test email
-        if recipients:
+        if is_test_alert and recipients:
             deliver_alert(schedule, recipients)
             return
 
-        elif run_alert_query(schedule, dbsession):
+        if run_alert_query(schedule, dbsession):
             # deliver_dashboard OR deliver_slice
             return
     else:

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -551,7 +551,12 @@ def schedule_alert_query(  # pylint: disable=unused-argument
         return
 
     if report_type == ScheduleType.alert:
-        if run_alert_query(schedule, dbsession):
+        # recipients is only specified when task is called from view for a test email
+        if recipients:
+            deliver_alert(schedule, recipients)
+            return
+
+        elif run_alert_query(schedule, dbsession):
             # deliver_dashboard OR deliver_slice
             return
     else:
@@ -564,10 +569,12 @@ class AlertState:
     PASS = "pass"
 
 
-def deliver_alert(alert: Alert) -> None:
+def deliver_alert(alert: Alert, recipients: Optional[str] = None) -> None:
     logging.info("Triggering alert: %s", alert)
     img_data = None
     images = {}
+    recipients = recipients or alert.recipients
+
     if alert.slice:
 
         chart_url = get_url_path(
@@ -604,7 +611,7 @@ def deliver_alert(alert: Alert) -> None:
         image_url=image_url,
     )
 
-    _deliver_email(alert.recipients, deliver_as_group, subject, body, data, images)
+    _deliver_email(recipients, deliver_as_group, subject, body, data, images)
 
 
 def run_alert_query(alert: Alert, dbsession: Session) -> Optional[bool]:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -832,6 +832,13 @@ def get_email_address_list(address_string: str) -> List[str]:
     return [x.strip() for x in address_string_list if x.strip()]
 
 
+def get_email_address_str(address_string: str) -> str:
+    address_list = get_email_address_list(address_string)
+    address_list_str = ", ".join(address_list)
+
+    return address_list_str
+
+
 def choicify(values: Iterable[Any]) -> List[Tuple[Any, Any]]:
     """Takes an iterable and makes an iterable of tuples with it"""
     return [(v, v) for v in values]

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Dict, Optional, Union
 
 from croniter import croniter
 from flask_appbuilder import CompactCRUDMixin
@@ -50,7 +51,10 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
     datamodel = SQLAInterface(Alert)
     route_base = "/alert"
     include_route_methods = RouteMethod.CRUD_SET
-    _extra_data = {"test_alert": False, "test_email_recipients": None}
+    _extra_data: Dict[str, Union[bool, Optional[str]]] = {
+        "test_alert": False,
+        "test_email_recipients": None,
+    }
 
     list_columns = (
         "label",
@@ -130,7 +134,7 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
             email_recipients = get_email_address_str(form.test_email_recipients.data)
 
         self._extra_data["test_alert"] = form.test_alert.data
-        self._extra_data["test_email_recipients"] = email_recipients  # type: ignore
+        self._extra_data["test_email_recipients"] = email_recipients
 
     def pre_add(self, item: "AlertModelView") -> None:
         item.recipients = get_email_address_str(item.recipients)

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -112,7 +112,7 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
             "Test Email Recipients",
             default=None,
             description="List of recipients to send test email to. "
-                        "If empty, email will be sent to original recipients.",
+            "If empty, email will be sent to original recipients.",
         ),
     }
     edit_form_extra_fields = add_form_extra_fields
@@ -132,7 +132,9 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
         if self._extra_data["test_alert"]:
             recipients = self._extra_data["test_email_recipients"] or item.recipients
             args = (ScheduleType.alert, item.id)
-            schedule_alert_query.apply_async(args=args, kwargs=dict(recipients=recipients))
+            schedule_alert_query.apply_async(
+                args=args, kwargs=dict(recipients=recipients)
+            )
 
     def post_update(self, item: "AlertModelView") -> None:
         self.post_add(item)

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -106,13 +106,13 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
         "test_alert": BooleanField(
             "Send Test Alert",
             default=False,
-            description="If enabled, a test alert will be sent on creation / update of active alerts",
+            description="If enabled, a test alert will be sent on the creation / update of active alerts.",
         ),
         "test_email_recipients": StringField(
             "Test Email Recipients",
             default=None,
             description="List of recipients to send test email to. "
-            "If empty, email will be sent to original recipients.",
+            "If empty, an email will be sent to the original recipients.",
         ),
     }
     edit_form_extra_fields = add_form_extra_fields

--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -22,8 +22,9 @@ import pytest
 
 from superset import db
 from superset.models.alerts import Alert, AlertLog
+from superset.models.schedules import ScheduleType
 from superset.models.slice import Slice
-from superset.tasks.schedules import run_alert_query
+from superset.tasks.schedules import run_alert_query, schedule_alert_query
 from superset.utils import core as utils
 from tests.test_app import app
 
@@ -112,3 +113,30 @@ def test_run_alert_query(mock_error, mock_deliver, setup_database):
     run_alert_query(database.query(Alert).filter_by(id=5).one(), database)
     assert mock_deliver.call_count == 1
     assert mock_error.call_count == 4
+
+
+@patch("superset.tasks.schedules.deliver_alert")
+@patch("superset.tasks.schedules.run_alert_query")
+def test_schedule_alert_query(mock_run_alert, mock_deliver_alert, setup_database):
+    database = setup_database
+    active_alert = database.query(Alert).filter_by(id=1).one()
+    inactive_alert = database.query(Alert).filter_by(id=3).one()
+
+    # Test that inactive alerts are no processed
+    schedule_alert_query(report_type=ScheduleType.alert, schedule_id=inactive_alert.id)
+    assert mock_run_alert.call_count == 0
+    assert mock_deliver_alert.call_count == 0
+
+    # Test that active alerts with no recipients passed in are processed regularly
+    schedule_alert_query(report_type=ScheduleType.alert, schedule_id=active_alert.id)
+    assert mock_run_alert.call_count == 1
+    assert mock_deliver_alert.call_count == 0
+
+    # Test that active alerts with recipients passed in are delivered immediately
+    schedule_alert_query(
+        report_type=ScheduleType.alert,
+        schedule_id=active_alert.id,
+        recipients="testing@email.com",
+    )
+    assert mock_run_alert.call_count == 1
+    assert mock_deliver_alert.call_count == 1

--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -132,11 +132,12 @@ def test_schedule_alert_query(mock_run_alert, mock_deliver_alert, setup_database
     assert mock_run_alert.call_count == 1
     assert mock_deliver_alert.call_count == 0
 
-    # Test that active alerts with recipients passed in are delivered immediately
+    # Test that active alerts sent as a test are delivered immediately
     schedule_alert_query(
         report_type=ScheduleType.alert,
         schedule_id=active_alert.id,
         recipients="testing@email.com",
+        is_test_alert=True,
     )
     assert mock_run_alert.call_count == 1
     assert mock_deliver_alert.call_count == 1


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added functionality for users to request a test email to be sent whenever an active SQL-based alert is created or updated. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
In AlertModelView
Before:
![Screen Shot 2020-07-29 at 1 11 09 PM](https://user-images.githubusercontent.com/32852580/88848929-f9d86300-d19d-11ea-8640-7896d39d7b12.png)

After:
![Screen Shot 2020-07-29 at 1 17 28 PM](https://user-images.githubusercontent.com/32852580/88848859-e3caa280-d19d-11ea-9dea-70384837d78a.png)



### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [x] unit test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
