### PR TITLE
fix(#10479): dashboard slug is cleared on import

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -313,9 +313,6 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         # and will remove the existing dashboard - slice association
         slices = copy(dashboard_to_import.slices)
 
-        # Clearing the slug to avoid conflicts
-        dashboard_to_import.slug = None
-
         old_json_metadata = json.loads(dashboard_to_import.json_metadata or "{}")
         old_to_new_slc_id_dict: Dict[int, int] = {}
         new_timed_refresh_immune_slices = []


### PR DESCRIPTION
### SUMMARY
Do not clear slug on dashboard import

### TEST PLAN
export then import a dashboard, the dashboard should be overwritten, not creating a new one.

### ADDITIONAL INFORMATION
Fixes #10479 
- [X] Has associated issue: #10479
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
