### PR TITLE
fix: enforce mandatory chart name on save and edit

### DIFF
--- a/superset-frontend/src/explore/components/PropertiesModal.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal.tsx
@@ -262,6 +262,9 @@ function PropertiesModal({ slice, onHide, onSave }: InternalProps) {
         </Row>
       </Modal.Body>
       <Modal.Footer>
+        <Button type="button" bsSize="sm" onClick={onHide}>
+          {t('Cancel')}
+        </Button>
         <Button
           type="submit"
           bsSize="sm"
@@ -270,9 +273,6 @@ function PropertiesModal({ slice, onHide, onSave }: InternalProps) {
           disabled={!owners || submitting || !name}
         >
           {t('Save')}
-        </Button>
-        <Button type="button" bsSize="sm" onClick={onHide}>
-          {t('Cancel')}
         </Button>
         <Dialog ref={errorDialog} />
       </Modal.Footer>

--- a/superset-frontend/src/explore/components/PropertiesModal.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal.tsx
@@ -267,7 +267,7 @@ function PropertiesModal({ slice, onHide, onSave }: InternalProps) {
           bsSize="sm"
           bsStyle="primary"
           className="m-r-5"
-          disabled={!owners || submitting}
+          disabled={!owners || submitting || !name}
         >
           {t('Save')}
         </Button>

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -25,10 +25,10 @@ import {
   Button,
   FormControl,
   FormGroup,
-  ControlLabel,
   Modal,
   Radio,
 } from 'react-bootstrap';
+import FormLabel from 'src/components/FormLabel';
 import { CreatableSelect } from 'src/components/Select/SupersetStyledSelect';
 import { t } from '@superset-ui/translation';
 import ReactMarkdown from 'react-markdown';
@@ -176,7 +176,9 @@ class SaveModal extends React.Component {
           </FormGroup>
           <hr />
           <FormGroup>
-            <ControlLabel>{t('Chart name')}</ControlLabel>
+            <FormLabel required>
+              {t('Chart name')}
+            </FormLabel>
             <FormControl
               name="new_slice_name"
               type="text"
@@ -187,7 +189,7 @@ class SaveModal extends React.Component {
             />
           </FormGroup>
           <FormGroup>
-            <ControlLabel>{t('Add to dashboard')}</ControlLabel>
+            <FormLabel required>{t('Add to dashboard')}</FormLabel>
             <CreatableSelect
               id="dashboard-creatable-select"
               className="save-modal-selector"
@@ -224,7 +226,11 @@ class SaveModal extends React.Component {
               type="button"
               id="btn_modal_save_goto_dash"
               bsSize="sm"
-              disabled={canNotSaveToDash || !this.state.newDashboardName}
+              disabled={
+                canNotSaveToDash ||
+                !this.state.newSliceName ||
+                !this.state.newDashboardName
+              }
               onClick={this.saveOrOverwrite.bind(this, true)}
             >
               {t('Save & go to dashboard')}
@@ -235,6 +241,7 @@ class SaveModal extends React.Component {
               bsSize="sm"
               bsStyle="primary"
               onClick={this.saveOrOverwrite.bind(this, false)}
+              disabled={!this.state.newSliceName}
             >
               {t('Save')}
             </Button>

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -176,9 +176,7 @@ class SaveModal extends React.Component {
           </FormGroup>
           <hr />
           <FormGroup>
-            <FormLabel required>
-              {t('Chart name')}
-            </FormLabel>
+            <FormLabel required>{t('Chart name')}</FormLabel>
             <FormControl
               name="new_slice_name"
               type="text"

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -407,12 +407,24 @@ class ChartList extends React.PureComponent<Props, State> {
       ...(filterExps.length ? { filters: filterExps } : {}),
     });
 
+    const replaceEmptyChartName = (data: Chart[]): Chart[] => {
+      return data.map(chart => {
+        return {
+          ...chart,
+          slice_name: chart.slice_name !== '' ? chart.slice_name : '<empty>',
+        };
+      });
+    };
+
     return SupersetClient.get({
       endpoint: `/api/v1/chart/?q=${queryParams}`,
     })
       .then(
         ({ json = {} }) => {
-          this.setState({ charts: json.result, chartCount: json.count });
+          this.setState({
+            charts: replaceEmptyChartName(json.result),
+            chartCount: json.count,
+          });
         },
         createErrorHandler(errMsg =>
           this.props.addDangerToast(

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -407,24 +407,12 @@ class ChartList extends React.PureComponent<Props, State> {
       ...(filterExps.length ? { filters: filterExps } : {}),
     });
 
-    const replaceEmptyChartName = (data: Chart[]): Chart[] => {
-      return data.map(chart => {
-        return {
-          ...chart,
-          slice_name: chart.slice_name !== '' ? chart.slice_name : '<empty>',
-        };
-      });
-    };
-
     return SupersetClient.get({
       endpoint: `/api/v1/chart/?q=${queryParams}`,
     })
       .then(
         ({ json = {} }) => {
-          this.setState({
-            charts: replaceEmptyChartName(json.result),
-            chartCount: json.count,
-          });
+          this.setState({ charts: json.result, chartCount: json.count });
         },
         createErrorHandler(errMsg =>
           this.props.addDangerToast(


### PR DESCRIPTION
### SUMMARY
Currently it is possible to save charts without names, causing confusion in the React CRUD list view. This PR changes the following:
- Enforce the required slice name field when editing a chart on the React CRUD view.
- Migrate the `ControlLabel` to `FormLabel` on `SaveModal.tsx` and add `required props to chart and dashboard and enforce required chart name on both "Save" and "Save & Go To Dashboard".

### BEFORE
![chart-react-before](https://user-images.githubusercontent.com/33317356/88912599-2b1d6580-d268-11ea-8933-a8d8ec6aaeea.gif)
![Jul-30-2020 13-34-30](https://user-images.githubusercontent.com/33317356/88913374-72582600-d269-11ea-9329-2c31d5a2d5e4.gif)

### AFTER
![Jul-30-2020 13-29-02](https://user-images.githubusercontent.com/33317356/88912923-b4cd3300-d268-11ea-82d7-f23610554be2.gif)
![Jul-30-2020 13-33-21](https://user-images.githubusercontent.com/33317356/88913393-797f3400-d269-11ea-9159-01b751a117e9.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
