### PR TITLE
fix: make test slice deterministic for schedules_test

### DIFF
--- a/tests/schedules_test.py
+++ b/tests/schedules_test.py
@@ -62,7 +62,7 @@ class TestSchedules(SupersetTestCase):
             )
 
             # Pick up a random slice and dashboard
-            slce = db.session.query(Slice).all()[0]
+            slce = db.session.query(Slice).filter_by(slice_name="Participants").all()[0]
             dashboard = db.session.query(Dashboard).all()[0]
 
             dashboard_schedule = DashboardEmailSchedule(**cls.common_data)


### PR DESCRIPTION
### SUMMARY

`tests/schedules_test.py` hardcoded `Participants` as the test slice in expected results, but the setup query in `setUpClass` is not deterministic.

This sometimes makes the CI [fail unexpectedly](https://github.com/apache/incubator-superset/runs/929681343?check_suite_focus=true).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
