### PR TITLE
fix: allow numeric groupbys for pie chart

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1551,7 +1551,12 @@ class DistributionPieViz(NVD3Viz):
             return None
         metric = self.metric_labels[0]
         df = pd.DataFrame(
-            {"x": df[self.groupby].agg(func=lambda x: ", ".join(map(str, x)), axis=1), "y": df[metric]}
+            {
+                "x": df[self.groupby].agg(
+                    func=lambda x: ", ".join(map(str, x)), axis=1
+                ),
+                "y": df[metric],
+            }
         )
         df.sort_values(by="y", ascending=False, inplace=True)
         return df.to_dict(orient="records")

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1551,7 +1551,7 @@ class DistributionPieViz(NVD3Viz):
             return None
         metric = self.metric_labels[0]
         df = pd.DataFrame(
-            {"x": df[self.groupby].agg(func=", ".join, axis=1), "y": df[metric]}
+            {"x": df[self.groupby].agg(func=lambda x: ", ".join(map(str, x)), axis=1), "y": df[metric]}
         )
         df.sort_values(by="y", ascending=False, inplace=True)
         return df.to_dict(orient="records")


### PR DESCRIPTION
### SUMMARY

Make sure pie chart can handle numeric columns in group by.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

![image](https://user-images.githubusercontent.com/335541/88994379-10b1af00-d29d-11ea-80e7-2ff7a0af0edd.png)

#### After

![image](https://user-images.githubusercontent.com/335541/88994294-e102a700-d29c-11ea-9c0a-6a59943dd8bc.png)


### TEST PLAN

Manual 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #10391
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
