### PR TITLE
fix: support non-string groupbys for pie chart

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1559,12 +1559,25 @@ class DistributionPieViz(NVD3Viz):
             '1'
             >>> _label_aggfunc(pd.Series(["abc", "def"]))
             'abc, def'
+            >>> # note: integer floats are stripped of decimal digits
+            >>> _label_aggfunc(pd.Series([0.1, 2.0, 0.3]))
+            '0.1, 2, 0.3'
             >>> _label_aggfunc(pd.Series([1, None, "abc", 0.8], dtype="object"))
             '1, <NULL>, abc, 0.8'
             """
-            return ", ".join(
-                [NULL_STRING if label is None else str(label) for label in labels]
-            )
+            label_list: List[str] = []
+            for label in labels:
+                if isinstance(label, str):
+                    label_recast = label
+                elif label is None or isinstance(label, float) and math.isnan(label):
+                    label_recast = NULL_STRING
+                elif isinstance(label, float) and label.is_integer():
+                    label_recast = str(int(label))
+                else:
+                    label_recast = str(label)
+                label_list.append(label_recast)
+
+            return ", ".join(label_list)
 
         if df.empty:
             return None

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -20,6 +20,7 @@ from datetime import datetime
 import logging
 from math import nan
 from unittest.mock import Mock, patch
+from typing import Any, Dict, List, Set
 
 import numpy as np
 import pandas as pd
@@ -1330,3 +1331,43 @@ class TestPivotTableViz(SupersetTestCase):
             viz.PivotTableViz.get_aggfunc("strcol", self.df, {"pandas_aggfunc": "min"})
             == "min"
         )
+
+
+class TestDistributionPieViz(SupersetTestCase):
+    base_df = pd.DataFrame(
+        data={
+            "intcol": [1, 2, 3, 4],
+            "floatcol": [0.1, 0.2, 0.3, 0.4],
+            "strcol_a": ["a", "a", "a", "a"],
+            "strcol_nulls": ["a", "b", "c", None],
+        }
+    )
+
+    @staticmethod
+    def get_cols(data: List[Dict[str, Any]]) -> Set[str]:
+        return set([row["x"] for row in data])
+
+    def test_string_groupby(self):
+        datasource = self.get_datasource_mock()
+        pie_viz = viz.DistributionPieViz(
+            datasource, {"metrics": ["floatcol"], "groupby": ["strcol_nulls"]},
+        )
+        data = pie_viz.get_data(self.base_df)
+        assert self.get_cols(data) == {"<NULL>", "a", "b", "c"}
+
+    def test_int_groupby(self):
+        datasource = self.get_datasource_mock()
+        pie_viz = viz.DistributionPieViz(
+            datasource, {"metrics": ["floatcol"], "groupby": ["intcol"]},
+        )
+        data = pie_viz.get_data(self.base_df)
+        assert self.get_cols(data) == {"1", "2", "3", "4"}
+
+    def test_multi_groupby(self):
+        datasource = self.get_datasource_mock()
+        pie_viz = viz.DistributionPieViz(
+            datasource,
+            {"metrics": ["floatcol"], "groupby": ["intcol", "strcol_nulls"]},
+        )
+        data = pie_viz.get_data(self.base_df)
+        assert self.get_cols(data) == {"1, a", "2, b", "3, c", "4, <NULL>"}

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -1336,10 +1336,10 @@ class TestPivotTableViz(SupersetTestCase):
 class TestDistributionPieViz(SupersetTestCase):
     base_df = pd.DataFrame(
         data={
-            "intcol": [1, 2, 3, 4],
-            "floatcol": [0.1, 0.2, 0.3, 0.4],
-            "strcol_a": ["a", "a", "a", "a"],
-            "strcol_nulls": ["a", "b", "c", None],
+            "intcol": [1, 2, 3, 4, None],
+            "floatcol": [1.0, 0.2, 0.3, 0.4, None],
+            "strcol_a": ["a", "a", "a", "a", None],
+            "strcol": ["a", "b", "c", None, "d"],
         }
     )
 
@@ -1347,13 +1347,23 @@ class TestDistributionPieViz(SupersetTestCase):
     def get_cols(data: List[Dict[str, Any]]) -> Set[str]:
         return set([row["x"] for row in data])
 
+    def test_bool_groupby(self):
+        datasource = self.get_datasource_mock()
+        df = pd.DataFrame(data={"intcol": [1, 2, None], "boolcol": [True, None, False]})
+
+        pie_viz = viz.DistributionPieViz(
+            datasource, {"metrics": ["intcol"], "groupby": ["boolcol"]},
+        )
+        data = pie_viz.get_data(df)
+        assert self.get_cols(data) == {"True", "False", "<NULL>"}
+
     def test_string_groupby(self):
         datasource = self.get_datasource_mock()
         pie_viz = viz.DistributionPieViz(
-            datasource, {"metrics": ["floatcol"], "groupby": ["strcol_nulls"]},
+            datasource, {"metrics": ["floatcol"], "groupby": ["strcol"]},
         )
         data = pie_viz.get_data(self.base_df)
-        assert self.get_cols(data) == {"<NULL>", "a", "b", "c"}
+        assert self.get_cols(data) == {"<NULL>", "a", "b", "c", "d"}
 
     def test_int_groupby(self):
         datasource = self.get_datasource_mock()
@@ -1361,13 +1371,20 @@ class TestDistributionPieViz(SupersetTestCase):
             datasource, {"metrics": ["floatcol"], "groupby": ["intcol"]},
         )
         data = pie_viz.get_data(self.base_df)
-        assert self.get_cols(data) == {"1", "2", "3", "4"}
+        assert self.get_cols(data) == {"<NULL>", "1", "2", "3", "4"}
+
+    def test_float_groupby(self):
+        datasource = self.get_datasource_mock()
+        pie_viz = viz.DistributionPieViz(
+            datasource, {"metrics": ["intcol"], "groupby": ["floatcol"]},
+        )
+        data = pie_viz.get_data(self.base_df)
+        assert self.get_cols(data) == {"<NULL>", "1", "0.2", "0.3", "0.4"}
 
     def test_multi_groupby(self):
         datasource = self.get_datasource_mock()
         pie_viz = viz.DistributionPieViz(
-            datasource,
-            {"metrics": ["floatcol"], "groupby": ["intcol", "strcol_nulls"]},
+            datasource, {"metrics": ["floatcol"], "groupby": ["intcol", "strcol"]},
         )
         data = pie_viz.get_data(self.base_df)
-        assert self.get_cols(data) == {"1, a", "2, b", "3, c", "4, <NULL>"}
+        assert self.get_cols(data) == {"1, a", "2, b", "3, c", "4, <NULL>", "<NULL>, d"}


### PR DESCRIPTION
### SUMMARY
This adds support for non-string labels to the Pie Chart Viz and uses `NULL_STRING` if a pie label is `None`. Also removes decimals for float groupbys that satisfy `is_integer()`. This is needed, as all `int` columns become `float` if they contain `NULL`s (Pandas limitation).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/33317356/89009803-0e3f6b80-d316-11ea-982e-b6e7160409a2.png)

### TEST PLAN
CI + new tests + local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #10490 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
