### PR TITLE
feat: make screenshot timeout configurable

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -799,9 +799,9 @@ WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 # and render for the email report.
 EMAIL_PAGE_RENDER_WAIT = 30
 
-# Time in seconds before selenium times out after trying to
-# locate an element on the page and wait for that element to
-# load for an alert screenshot.
+# Used for alerting functionality: Time in seconds before selenium
+# times out after trying to locate an element on the page and wait
+# for that element to load for an alert screenshot.
 SCREENSHOT_LOCATE_WAIT = 10
 SCREENSHOT_LOAD_WAIT = 60
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -799,6 +799,12 @@ WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 # and render for the email report.
 EMAIL_PAGE_RENDER_WAIT = 30
 
+# Time in seconds before selenium times out after trying to
+# locate an element on the page and wait for that element to
+# load for an alert screenshot.
+SCREENSHOT_LOCATE_WAIT = 10
+SCREENSHOT_LOAD_WAIT = 60
+
 # Send user to a link where they can report bugs
 BUG_REPORT_URL = None
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -337,6 +337,12 @@ THUMBNAIL_CACHE_CONFIG: CacheConfig = {
     "CACHE_NO_NULL_WARNING": True,
 }
 
+# Used for thumbnails and other api: Time in seconds before selenium
+# times out after trying to locate an element on the page and wait
+# for that element to load for an alert screenshot.
+SCREENSHOT_LOCATE_WAIT = 10
+SCREENSHOT_LOAD_WAIT = 60
+
 # ---------------------------------------------------
 # Image and file configuration
 # ---------------------------------------------------
@@ -798,12 +804,6 @@ WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 # Time in seconds, selenium will wait for the page to load
 # and render for the email report.
 EMAIL_PAGE_RENDER_WAIT = 30
-
-# Used for alerting functionality: Time in seconds before selenium
-# times out after trying to locate an element on the page and wait
-# for that element to load for an alert screenshot.
-SCREENSHOT_LOCATE_WAIT = 10
-SCREENSHOT_LOAD_WAIT = 60
 
 # Send user to a link where they can report bugs
 BUG_REPORT_URL = None

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -102,8 +102,6 @@ class AuthWebDriverProxy:
         self._window: WindowSize = window or (800, 600)
         config_auth_func = current_app.config.get("WEBDRIVER_AUTH_FUNC", auth_driver)
         self._auth_func = auth_func or config_auth_func
-        self._element_locate_wait = current_app.config.get("SCREENSHOT_LOCATE_WAIT", 10)
-        self._element_load_wait = current_app.config.get("SCREENSHOT_LOAD_WAIT", 60)
 
     def create(self) -> WebDriver:
         if self._driver_type == "firefox":
@@ -161,11 +159,11 @@ class AuthWebDriverProxy:
         time.sleep(SELENIUM_HEADSTART)
         try:
             logger.debug("Wait for the presence of %s", element_name)
-            element = WebDriverWait(driver, self._element_locate_wait).until(
+            element = WebDriverWait(driver, current_app.config["SCREENSHOT_LOCATE_WAIT"]).until(
                 EC.presence_of_element_located((By.CLASS_NAME, element_name))
             )
             logger.debug("Wait for .loading to be done")
-            WebDriverWait(driver, self._element_load_wait).until_not(
+            WebDriverWait(driver, current_app.config["SCREENSHOT_LOAD_WAIT"]).until_not(
                 EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))
             )
             logger.info("Taking a PNG screenshot")

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -159,9 +159,9 @@ class AuthWebDriverProxy:
         time.sleep(SELENIUM_HEADSTART)
         try:
             logger.debug("Wait for the presence of %s", element_name)
-            element = WebDriverWait(driver, current_app.config["SCREENSHOT_LOCATE_WAIT"]).until(
-                EC.presence_of_element_located((By.CLASS_NAME, element_name))
-            )
+            element = WebDriverWait(
+                driver, current_app.config["SCREENSHOT_LOCATE_WAIT"]
+            ).until(EC.presence_of_element_located((By.CLASS_NAME, element_name)))
             logger.debug("Wait for .loading to be done")
             WebDriverWait(driver, current_app.config["SCREENSHOT_LOAD_WAIT"]).until_not(
                 EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -102,6 +102,8 @@ class AuthWebDriverProxy:
         self._window: WindowSize = window or (800, 600)
         config_auth_func = current_app.config.get("WEBDRIVER_AUTH_FUNC", auth_driver)
         self._auth_func = auth_func or config_auth_func
+        self._element_locate_wait = current_app.config.get("SCREENSHOT_LOCATE_WAIT", 10)
+        self._element_load_wait = current_app.config.get("SCREENSHOT_LOAD_WAIT", 60)
 
     def create(self) -> WebDriver:
         if self._driver_type == "firefox":
@@ -159,11 +161,11 @@ class AuthWebDriverProxy:
         time.sleep(SELENIUM_HEADSTART)
         try:
             logger.debug("Wait for the presence of %s", element_name)
-            element = WebDriverWait(driver, 10).until(
+            element = WebDriverWait(driver, self._element_locate_wait).until(
                 EC.presence_of_element_located((By.CLASS_NAME, element_name))
             )
             logger.debug("Wait for .loading to be done")
-            WebDriverWait(driver, 60).until_not(
+            WebDriverWait(driver, self._element_load_wait).until_not(
                 EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))
             )
             logger.info("Taking a PNG screenshot")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Selenium used to timeout after 10 seconds of trying to locate an element in DOM and after 60 seconds of waiting for the element to load after located. This PR makes those two values configurable in the config.py

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
