### PR TITLE
fix: make SQL-based alert email links user friendly

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -580,13 +580,12 @@ def deliver_alert(alert_id: int, recipients: Optional[str] = None) -> None:
             "Superset.slice", slice_id=alert.slice.id, standalone="true"
         )
         screenshot = ChartScreenshot(chart_url, alert.slice.digest)
-        cache_key = screenshot.cache_key()
-        image_url = get_url_path(
-            "ChartRestApi.screenshot", pk=alert.slice.id, digest=cache_key
+        image_url = _get_url_path(
+            "Superset.slice", user_friendly=True, slice_id=alert.slice.id, standalone="true"
         )
-        standalone_index = chart_url.find("/?standalone=true")
+        standalone_index = image_url.find("/?standalone=true")
         if standalone_index != -1:
-            image_url = chart_url[:standalone_index]
+            image_url = image_url[:standalone_index]
 
         user = security_manager.find_user(current_app.config["THUMBNAIL_SELENIUM_USER"])
         img_data = screenshot.compute_and_cache(
@@ -605,7 +604,7 @@ def deliver_alert(alert_id: int, recipients: Optional[str] = None) -> None:
         images = {"screenshot": img_data}
     body = render_template(
         "email/alert.txt",
-        alert_url=get_url_path("AlertModelView.show", pk=alert.id),
+        alert_url=_get_url_path("AlertModelView.show", user_friendly=True, pk=alert.id),
         label=alert.label,
         sql=alert.sql,
         image_url=image_url,

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -581,7 +581,10 @@ def deliver_alert(alert_id: int, recipients: Optional[str] = None) -> None:
         )
         screenshot = ChartScreenshot(chart_url, alert.slice.digest)
         image_url = _get_url_path(
-            "Superset.slice", user_friendly=True, slice_id=alert.slice.id, standalone="true"
+            "Superset.slice",
+            user_friendly=True,
+            slice_id=alert.slice.id,
+            standalone="true",
         )
         standalone_index = image_url.find("/?standalone=true")
         if standalone_index != -1:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The links in SQL-based alert emails were not user friendly, i.e. `local:####/superset`. This PR makes the links user friendly based on `WEBDRIVER_BASEURL_USER_FRIENDLY` in config.py

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [x] local test
- [x] dropbox staging
- [ ] dropbox production

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI