### PR TITLE
fix: added scoped session for SQL-based alerting

### DIFF
--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -86,21 +86,24 @@ def teardown_module():
 @patch("superset.tasks.schedules.logging.Logger.error")
 def test_run_alert_query(mock_error, mock_deliver_alert):
     with app.app_context():
-        run_alert_query(db.session.query(Alert).filter_by(id=1).one().id)
+        alert1 = db.session.query(Alert).filter_by(id=1).one()
+        run_alert_query(alert1.id, alert1.database_id, alert1.sql, alert1.label)
         alert1 = db.session.query(Alert).filter_by(id=1).one()
         assert mock_deliver_alert.call_count == 0
         assert len(alert1.logs) == 1
         assert alert1.logs[0].alert_id == 1
         assert alert1.logs[0].state == "pass"
 
-        run_alert_query(db.session.query(Alert).filter_by(id=2).one().id)
+        alert2 = db.session.query(Alert).filter_by(id=2).one()
+        run_alert_query(alert2.id, alert2.database_id, alert2.sql, alert2.label)
         alert2 = db.session.query(Alert).filter_by(id=2).one()
         assert mock_deliver_alert.call_count == 1
         assert len(alert2.logs) == 1
         assert alert2.logs[0].alert_id == 2
         assert alert2.logs[0].state == "trigger"
 
-        run_alert_query(db.session.query(Alert).filter_by(id=3).one().id)
+        alert3 = db.session.query(Alert).filter_by(id=3).one()
+        run_alert_query(alert3.id, alert3.database_id, alert3.sql, alert3.label)
         alert3 = db.session.query(Alert).filter_by(id=3).one()
         assert mock_deliver_alert.call_count == 1
         assert mock_error.call_count == 2
@@ -108,11 +111,13 @@ def test_run_alert_query(mock_error, mock_deliver_alert):
         assert alert3.logs[0].alert_id == 3
         assert alert3.logs[0].state == "error"
 
-        run_alert_query(db.session.query(Alert).filter_by(id=4).one().id)
+        alert4 = db.session.query(Alert).filter_by(id=4).one()
+        run_alert_query(alert4.id, alert4.database_id, alert4.sql, alert4.label)
         assert mock_deliver_alert.call_count == 1
         assert mock_error.call_count == 3
 
-        run_alert_query(db.session.query(Alert).filter_by(id=5).one().id)
+        alert5 = db.session.query(Alert).filter_by(id=5).one()
+        run_alert_query(alert5.id, alert5.database_id, alert5.sql, alert5.label)
         assert mock_deliver_alert.call_count == 1
         assert mock_error.call_count == 4
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Multiple errors such as `sqlalchemy.exc.NoSuchColumnError`, `sqlalchemy.exc.ResourceClosedError` and `MySQLdb._exceptions.OperationalError`  were being seen when multiple alert celery tasks were run concurrently. These errors occurred during the first few iterations of a celery beat schedule after initialization, however they would stop after after a few iterations of the beat schedule. This PR uses `db.create_scoped_session()` for alerting celery tasks to fix these errors. Retrying is implemented along with the celery task as a temporary fix for https://github.com/apache/incubator-superset/issues/10530

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [x] local test
- [x] dropbox staging
- [ ] dropbox prod

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/10530
