### PR TITLE
fix: table chart query mode initial value

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
@@ -165,8 +165,9 @@ describe('Visualization > Table', () => {
       metrics: [],
       row_limit: 10,
     };
-
     cy.visitChartByParams(JSON.stringify(formData));
+
+    cy.get('div[data-test="query_mode"] .btn.active').contains('Raw Records');
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'table' });
   });
 

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -110,7 +110,6 @@ function handleMissingChoice(control) {
 
 export function applyMapStateToPropsToControl(controlState, controlPanelState) {
   const { mapStateToProps } = controlState;
-  let { value } = controlState;
   let state = { ...controlState };
   if (mapStateToProps && controlPanelState) {
     state = {
@@ -126,6 +125,7 @@ export function applyMapStateToPropsToControl(controlState, controlPanelState) {
       delete state.default;
     }
   }
+  let { value } = state;
   // If no current value, set it as default
   if (state.default && value === undefined) {
     value = state.default;


### PR DESCRIPTION
### SUMMARY

Fix a backward compatibility issue for table charts: when opening an existing table chart before #10113 , whose `query_mode` is not persisted in `form_data`, if the chart is in `Raw Records` mode, the Query Mode control will incorrectly display as "Aggregate".

This is because we calculate the control value in `mapPropsToState` but the mapped value was latter overridden by defaults---a bug introduced by #10264 .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### After

"Raw Records" should be correctly selected for existing charts having only "Columns" control:

<img src="https://user-images.githubusercontent.com/335541/89595053-67246d80-d808-11ea-9f7e-d02fe29e71c7.png" width="300">


### TEST PLAN

Add a Cypress test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
