### PR TITLE
chore: move load examples to the fixture

### DIFF
--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -23,5 +23,6 @@ echo "Superset config module: $SUPERSET_CONFIG"
 
 superset db upgrade
 superset init
-pytest --maxfail=1 tests/load_examples_test.py
-pytest --maxfail=1 --cov=superset --ignore=load_examples_test tests/*
+
+echo "Running tests"
+pytest --maxfail=1 --cov=superset tests/*

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -25,4 +25,4 @@ superset db upgrade
 superset init
 
 echo "Running tests"
-pytest --maxfail=1 --cov=superset tests/*
+pytest --maxfail=1 --cov=superset

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -220,7 +220,7 @@ class TestCelery(SupersetTestCase):
         self.assertEqual(QueryStatus.SUCCESS, query3.status)
 
     def drop_table_if_exists(
-        self, table_name, table_type: CtasMethod, database=None
+        self, table_name: str, table_type: CtasMethod, database: Optional[Database] = None
     ) -> None:
         """Drop table if it exists, works on any DB"""
         sql = f"DROP {table_type} IF EXISTS  {table_name}"

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -18,6 +18,7 @@
 """Unit tests for Superset Celery worker"""
 import datetime
 import json
+from typing import Optional
 
 from parameterized import parameterized
 import time
@@ -26,13 +27,13 @@ import unittest.mock as mock
 
 import flask
 from flask import current_app
-from sqlalchemy.engine import Engine
 
 from tests.test_app import app
 from superset import db, sql_lab
 from superset.result_set import SupersetResultSet
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.extensions import celery_app
+from superset.models.core import Database
 from superset.models.helpers import QueryStatus
 from superset.models.sql_lab import Query
 from superset.sql_parse import ParsedQuery, CtasMethod
@@ -220,7 +221,7 @@ class TestCelery(SupersetTestCase):
         self.assertEqual(QueryStatus.SUCCESS, query3.status)
 
     def drop_table_if_exists(
-        self, table_name: str, table_type: CtasMethod, database: Optional[Database] = None
+        self, table_name: str, table_type: CtasMethod, database: Database,
     ) -> None:
         """Drop table if it exists, works on any DB"""
         sql = f"DROP {table_type} IF EXISTS  {table_name}"

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -366,14 +366,15 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         gamma = self.get_user("gamma")
 
         chart_id = self.insert_chart("title", [admin.id], 1).id
+        birth_names_table_id = SupersetTestCase.get_table_by_name("birth_names").id
         chart_data = {
             "slice_name": "title1_changed",
             "description": "description1",
             "owners": [gamma.id],
             "viz_type": "viz_type1",
-            "params": "{'a': 1}",
+            "params": """{"a": 1}""",
             "cache_timeout": 1000,
-            "datasource_id": 1,
+            "datasource_id": birth_names_table_id,
             "datasource_type": "table",
             "dashboards": [1],
         }
@@ -388,9 +389,9 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         self.assertIn(admin, model.owners)
         self.assertIn(gamma, model.owners)
         self.assertEqual(model.viz_type, "viz_type1")
-        self.assertEqual(model.params, "{'a': 1}")
+        self.assertEqual(model.params, """{"a": 1}""")
         self.assertEqual(model.cache_timeout, 1000)
-        self.assertEqual(model.datasource_id, 1)
+        self.assertEqual(model.datasource_id, birth_names_table_id)
         self.assertEqual(model.datasource_type, "table")
         self.assertEqual(model.datasource_name, "birth_names")
         self.assertIn(related_dashboard, model.dashboards)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -361,8 +361,8 @@ class TestCore(SupersetTestCase):
         self.assertEqual(resp.status_code, 200)
 
     def test_get_user_slices_for_owners(self):
-        self.login(username="admin")
-        user = security_manager.find_user("admin")
+        self.login(username="alpha")
+        user = security_manager.find_user("alpha")
         slice_name = "Girls"
 
         # ensure user is not owner of any slices

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -69,6 +69,15 @@ class TestDatasetApi(SupersetTestCase):
             .one()
         )
 
+    @staticmethod
+    def get_energy_usage_dataset():
+        example_db = get_example_database()
+        return (
+            db.session.query(SqlaTable)
+            .filter_by(database=example_db, table_name="energy_usage")
+            .one()
+        )
+
     def test_get_dataset_list(self):
         """
         Dataset API: Test get dataset list
@@ -133,7 +142,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test get dataset item
         """
-        table = self.get_birth_names_dataset()
+        table = self.get_energy_usage_dataset()
         self.login(username="admin")
         uri = f"api/v1/dataset/{table.id}"
         rv = self.get_assert_metric(uri, "get")
@@ -143,21 +152,22 @@ class TestDatasetApi(SupersetTestCase):
             "cache_timeout": None,
             "database": {"database_name": "examples", "id": 1},
             "default_endpoint": None,
-            "description": None,
+            "description": "Energy consumption",
             "fetch_values_predicate": None,
-            "filter_select_enabled": True,
+            "filter_select_enabled": False,
             "is_sqllab_view": False,
-            "main_dttm_col": "ds",
+            "main_dttm_col": None,
             "offset": 0,
             "owners": [],
             "schema": None,
             "sql": None,
-            "table_name": "birth_names",
+            "table_name": "energy_usage",
             "template_params": None,
         }
-        for key, value in expected_result.items():
-            self.assertEqual(response["result"][key], expected_result[key])
-        self.assertEqual(len(response["result"]["columns"]), 8)
+        assert {
+            k: v for k, v in response["result"].items() if k in expected_result
+        } == expected_result
+        self.assertEqual(len(response["result"]["columns"]), 3)
         self.assertEqual(len(response["result"]["metrics"]), 2)
 
     def test_get_dataset_info(self):

--- a/tests/schedules_test.py
+++ b/tests/schedules_test.py
@@ -65,7 +65,7 @@ class TestSchedules(SupersetTestCase):
             slce = db.session.query(Slice).filter_by(slice_name="Participants").one()
             dashboard = (
                 db.session.query(Dashboard)
-                .filter_by(dashboard_title="USA Births Names")
+                .filter_by(dashboard_title="World Bank's Data")
                 .one()
             )
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,10 +21,9 @@
 commands =
     superset db upgrade
     superset init
-    pytest -ra -q tests/load_examples_test.py
     # use -s to be able to use break pointers.
     # no args or tests/* can be passed as an argument to run all tests
-    pytest --ignore=load_examples_test {posargs}
+    pytest {posargs}
 deps =
     -rrequirements/testing.txt
 setenv =


### PR DESCRIPTION
Moves load_examples execution into the pytest test fixture that runs only 1ce for the whole test suite.
More on this topic: https://docs.pytest.org/en/stable/fixture.html

This PR exposed and cleans up couple small things:
1. there were tests that relied on the certain order of other test execution, had to modify them slightly
2. celery had leftover views & tables created

Next steps:
1. continue moving test setup logic into the fixtures
2. move db specific logic in tests to the separate class / module
