### PR TITLE
fix: embedded chart height

### DIFF
--- a/superset-frontend/src/explore/App.jsx
+++ b/superset-frontend/src/explore/App.jsx
@@ -33,10 +33,10 @@ setupPlugins();
 const App = ({ store }) => (
   <Provider store={store}>
     <ThemeProvider theme={supersetTheme}>
-      <div>
+      <>
         <ExploreViewContainer />
         <ToastPresenter />
-      </div>
+      </>
     </ThemeProvider>
   </Provider>
 );


### PR DESCRIPTION
### SUMMARY
When this empty div was added, it broke `ParentSize` a few components down the stack, resulting in embedded charts rendering with 0 height. This fixes the issue.

I was trying to figure out a good way to write a unit test for this, but couldn't since it involves so many layers of components. Perhaps a snapshot test would be valuable in the future though

### TEST PLAN
CI, test an embedded chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @rusackas @graceguo-supercat @ktmud 