### PR TITLE
fix: table viz query mode switch not working

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
@@ -167,8 +167,18 @@ describe('Visualization > Table', () => {
     };
     cy.visitChartByParams(JSON.stringify(formData));
 
+    // should display in raw records mode
     cy.get('div[data-test="query_mode"] .btn.active').contains('Raw Records');
+    cy.get('div[data-test="all_columns"]').should('be.visible');
+    cy.get('div[data-test="groupby"]').should('not.be.visible');
+
     cy.verifySliceSuccess({ waitAlias: '@getJson', chartSelector: 'table' });
+
+    // should allow switch to aggregate mode
+    cy.get('div[data-test="query_mode"] .btn').contains('Aggregate').click();
+    cy.get('div[data-test="query_mode"] .btn.active').contains('Aggregate');
+    cy.get('div[data-test="all_columns"]').should('not.be.visible');
+    cy.get('div[data-test="groupby"]').should('be.visible');
   });
 
   it('Test table with columns, ordering, and row limit', () => {

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -111,11 +111,14 @@ function handleMissingChoice(control) {
 export function applyMapStateToPropsToControl(controlState, controlPanelState) {
   const { mapStateToProps } = controlState;
   let state = { ...controlState };
+  let { value } = state; // value is current user-input value
   if (mapStateToProps && controlPanelState) {
     state = {
       ...controlState,
       ...mapStateToProps(controlPanelState, controlState),
     };
+    // `mapStateToProps` may also provide a value
+    value = value || state.value;
   }
   // If default is a function, evaluate it
   if (typeof state.default === 'function') {
@@ -125,7 +128,6 @@ export function applyMapStateToPropsToControl(controlState, controlPanelState) {
       delete state.default;
     }
   }
-  let { value } = state;
   // If no current value, set it as default
   if (state.default && value === undefined) {
     value = state.default;


### PR DESCRIPTION
### SUMMARY

Fix a bug introduced by #10544 where users are not able to switch query mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Added a Cypress test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
