### PR TITLE
fix: set optional imagePullSecrets for helm chart

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
   - name: Chuan-Yen Chiang
     email: cychiang0823@gmail.com
     url: https://github.com/cychiang
-version: 0.1.0
+version: 0.1.1

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
         app: {{ template "superset.name" . }}
         release: {{ .Release.Name }}
     spec:
+    {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       securityContext:
         runAsUser: 0 # Needed in order to allow pip install to work in bootstrap
       {{- if .Values.supersetNode.initContainers }}

--- a/helm/superset/templates/init-job.yaml
+++ b/helm/superset/templates/init-job.yaml
@@ -24,6 +24,10 @@ spec:
     metadata:
       name: {{ template "superset.name" . }}-init-db
     spec:
+    {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       securityContext:
         runAsUser: 0 # Needed in order to allow pip install to work in bootstrap
       {{- if .Values.init.initContainers }}

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -47,6 +47,8 @@ image:
   repository: preset/superset
   tag: latest
   pullPolicy: IfNotPresent
+  # imagePullSecrets:
+  #   - name: docker-registry
 
 service:
   type: NodePort


### PR DESCRIPTION
### SUMMARY
User will have to set `imagePullSecrets` in order to use a different base image than `preset/superset`. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
