### PR TITLE
fix: show error if rolling window returns empty df

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -216,6 +216,14 @@ class BaseViz:
             df = df.cumsum()
         if min_periods:
             df = df[min_periods:]
+        if df.empty:
+            raise QueryObjectValidationError(
+                _(
+                    "Applied rolling window did not return any data. Please make sure "
+                    "the source query satisfies the minimum periods defined in the "
+                    "rolling window."
+                )
+            )
         return df
 
     def get_samples(self) -> List[Dict[str, Any]]:

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -24,12 +24,13 @@ from typing import Any, Dict, List, Set
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import tests.test_app
 import superset.viz as viz
 from superset import app
 from superset.constants import NULL_STRING
-from superset.exceptions import SpatialException
+from superset.exceptions import QueryObjectValidationError, SpatialException
 from superset.utils.core import DTTM_ALIAS
 
 from .base_tests import SupersetTestCase
@@ -1265,6 +1266,26 @@ class TestTimeSeriesViz(SupersetTestCase):
             .tolist(),
             [1.0, 1.5, 2.0, 2.5],
         )
+
+    def test_apply_rolling_without_data(self):
+        datasource = self.get_datasource_mock()
+        df = pd.DataFrame(
+            index=pd.to_datetime(
+                ["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]
+            ),
+            data={"y": [1.0, 2.0, 3.0, 4.0]},
+        )
+        test_viz = viz.BigNumberViz(
+            datasource,
+            {
+                "metrics": ["y"],
+                "rolling_type": "cumsum",
+                "rolling_periods": 4,
+                "min_periods": 4,
+            },
+        )
+        with pytest.raises(QueryObjectValidationError):
+            test_viz.apply_rolling(df)
 
 
 class TestBigNumberViz(SupersetTestCase):


### PR DESCRIPTION
### SUMMARY
Currently applying a rolling function with a minimum period count that exceeds the input data causes a "No Results" error which is usually displayed when the original query doesn't return any data. This can be confusing to the end user, as clicking on "View Results" will display the data from the original query, which is not empty. This PR changes the flow to return a `QueryObjectValidationException` if the rolling period returns an empty `DataFrame` for a non-empty source `DataFrame`. If the original source data is empty the regular "No Results" message is displayed.

In the long term we should probably add the possibility to customize the "No Results" error to distinguish between no data being returned by the input query vs the post transformation operations. Until then this seems like a sensible compromise.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/89872897-48d0c000-dbc2-11ea-94ed-ba7901db07d0.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/89872946-5d14bd00-dbc2-11ea-824d-20c02be13f5d.png)

### TEST PLAN
Local testing + new test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
