### PR TITLE
fix: dataset delete and perm delete

### DIFF
--- a/superset/datasets/commands/delete.py
+++ b/superset/datasets/commands/delete.py
@@ -52,7 +52,7 @@ class DeleteDatasetCommand(BaseCommand):
                 else None
             )
             permission_views = (
-                security_manager.get_session.query(
+                db.session.query(
                     security_manager.permissionview_model
                 )
                 .filter_by(view_menu=view_menu)

--- a/superset/datasets/commands/delete.py
+++ b/superset/datasets/commands/delete.py
@@ -46,7 +46,11 @@ class DeleteDatasetCommand(BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
-            view_menu = security_manager.find_view_menu(self._model.get_perm())
+            view_menu = (
+                security_manager.find_view_menu(self._model.get_perm())
+                if self._model
+                else None
+            )
             permission_views = (
                 security_manager.get_session.query(
                     security_manager.permissionview_model

--- a/superset/datasets/commands/delete.py
+++ b/superset/datasets/commands/delete.py
@@ -52,9 +52,7 @@ class DeleteDatasetCommand(BaseCommand):
                 else None
             )
             permission_views = (
-                db.session.query(
-                    security_manager.permissionview_model
-                )
+                db.session.query(security_manager.permissionview_model)
                 .filter_by(view_menu=view_menu)
                 .all()
             )

--- a/superset/datasets/commands/delete.py
+++ b/superset/datasets/commands/delete.py
@@ -51,6 +51,11 @@ class DeleteDatasetCommand(BaseCommand):
                 if self._model
                 else None
             )
+            if not view_menu:
+                logger.error(
+                    "Could not find the data access permission for the dataset"
+                )
+                raise DatasetDeleteFailedError()
             permission_views = (
                 db.session.query(security_manager.permissionview_model)
                 .filter_by(view_menu=view_menu)

--- a/superset/tasks/slack_util.py
+++ b/superset/tasks/slack_util.py
@@ -26,7 +26,7 @@ from slack.web.slack_response import SlackResponse
 from superset import app
 
 # Globals
-config = app.config
+config = app.config  # type: ignore
 logger = logging.getLogger("tasks.slack_util")
 
 

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -615,10 +615,17 @@ class TestDatasetApi(SupersetTestCase):
         Dataset API: Test delete dataset item
         """
         dataset = self.insert_default_dataset()
+        view_menu = security_manager.find_view_menu(dataset.get_perm())
+        self.assertIsNotNone(view_menu)
+        view_menu_id = view_menu.id
         self.login(username="admin")
         uri = f"api/v1/dataset/{dataset.id}"
         rv = self.client.delete(uri)
         self.assertEqual(rv.status_code, 200)
+        non_view_menu = db.session.query(security_manager.viewmenu_model).get(
+            view_menu_id
+        )
+        self.assertIsNone(non_view_menu)
 
     def test_delete_item_dataset_not_owned(self):
         """


### PR DESCRIPTION
### SUMMARY

When deleting a dataset the permission cleanup was issuing `Remove Permission from View Error: Parent instance` is not bound to a Session. This PR fixes it and adds a test to assert the deletion is complete and correct

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
