### PR TITLE
feat: add dashboard support to SQL-based alerts

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -596,7 +596,8 @@ def deliver_alert(
     elif alert.dashboard:
         alert_content = AlertContent(
             alert.label,
-            alert.sql,
+            sql,
+            observation_value,
             _get_url_path("AlertModelView.show", user_friendly=True, pk=alert_id),
             _get_dashboard_screenshot(alert.dashboard_id),
         )
@@ -633,7 +634,8 @@ def deliver_email_alert(alert_content: AlertContent, recipients: str) -> None:
             alert_url=alert_content.alert_url,
             label=alert_content.label,
             sql=alert_content.sql,
-            image_url=alert_content.image_data.url,
+            observation_value=alert_content.observation_value,
+            image_url=image_url,
         )
     else:
         body = render_template(
@@ -641,8 +643,8 @@ def deliver_email_alert(alert_content: AlertContent, recipients: str) -> None:
             alert_url=alert_content.alert_url,
             label=alert_content.label,
             sql=alert_content.sql,
+            observation_value=alert_content.observation_value,
         )
-
 
     _deliver_email(recipients, deliver_as_group, subject, body, data, images)
 

--- a/superset/templates/email/alert_no_screenshot.txt
+++ b/superset/templates/email/alert_no_screenshot.txt
@@ -1,0 +1,22 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<h2 style="color: red;">Alert: {{label}} &#x26A0;</h2>
+<p><b>SQL Statement:</b></p>
+<code><mark style="background-color: LightGrey; font-size: 1.1em">{{sql}}</mark></code>
+<p><a href="{{alert_url}}">View Alert Details</a></p>

--- a/superset/templates/email/alert_no_screenshot.txt
+++ b/superset/templates/email/alert_no_screenshot.txt
@@ -18,5 +18,6 @@
 -->
 <h2 style="color: red;">Alert: {{label}} &#x26A0;</h2>
 <p><b>SQL Statement:</b></p>
-<code><mark style="background-color: LightGrey; font-size: 1.1em">{{sql}}</mark></code>
+<code><mark style="background-color: LightGrey; font-size: 1.1em">{{sql}}</mark></code></p>
+<p><b>SQL Result</b>: {{observation_value}}</p>
 <p><a href="{{alert_url}}">View Alert Details</a></p>

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -202,8 +202,7 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
         "recipients",
         "slack_channel",
         "slice",
-        # TODO: implement dashboard screenshots with alerts
-        # "dashboard",
+        "dashboard",
         "log_retention",
         "grace_period",
         "test_alert",
@@ -221,6 +220,10 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
             True,
         ),
         "recipients": _("A semicolon ';' delimited list of email addresses"),
+        "dashboard": _(
+            "If a slice is chosen, the alert will contain slice info"
+            " instead of dashboard info."
+        ),
         "log_retention": _("How long to keep the logs around for this alert"),
         "grace_period": _(
             "Once an alert is triggered, how long, in seconds, before "


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Used scheduled report implementation of dashboard screenshots to add support for dashboards on SQL-based alerting. Also updated email alerts to support emails with no screenshot.

Form:
![Screen Shot 2020-08-11 at 11 23 54 AM](https://user-images.githubusercontent.com/32852580/89934975-42dcde00-dbc6-11ea-9489-12fba0854fa3.png)
Slack:
<img width="536" alt="Screen Shot 2020-09-02 at 5 55 56 PM" src="https://user-images.githubusercontent.com/32852580/92059228-8ea62180-ed45-11ea-83db-8211cb3cfb7b.png">

Email:
![Screen Shot 2020-09-02 at 5 55 25 PM](https://user-images.githubusercontent.com/32852580/92059208-7cc47e80-ed45-11ea-8f13-9f8b4d7f8281.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [x] local test
- [ ] dropbox staging
- [ ] dropbox prob

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
