### PR TITLE
fix: error message modal overflow

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -58,6 +58,7 @@ const ErrorAlertDiv = styled.div<{ level: ErrorLevel }>`
 
 const ErrorModal = styled(Modal)<{ level: ErrorLevel }>`
   color: ${({ level, theme }) => theme.colors[level].dark2};
+  overflow-wrap: break-word;
 
   .icon {
     margin-right: ${({ theme }) => 2 * theme.gridUnit}px;


### PR DESCRIPTION
### SUMMARY
The message overflows if there aren't spaces in the message. This fixes it

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1147" alt="Screen Shot 2020-08-11 at 12 14 47 PM" src="https://user-images.githubusercontent.com/7409244/89940340-32c8fc80-dbce-11ea-95aa-ffcbd387fe18.png">

After:
<img width="627" alt="Screen Shot 2020-08-11 at 12 21 00 PM" src="https://user-images.githubusercontent.com/7409244/89940354-378db080-dbce-11ea-8871-5400058ac6f1.png">


### TEST PLAN
CI, manual validation with the screenshots above

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @ktmud @graceguo-supercat 