### PR TITLE
fix: add None checking to cast_to_num

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -222,8 +222,8 @@ def cast_to_num(value: Optional[Union[float, int, str]]) -> Optional[Union[float
     10
     >>> cast_to_num(10.1)
     10.1
-    >>> cast_to_num(None)
-    None
+    >>> cast_to_num(None) is None
+    True
     >>> cast_to_num('this is not a string') is None
     True
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -211,7 +211,7 @@ def parse_js_uri_path_item(
     return unquote_plus(item) if unquote and item else item
 
 
-def cast_to_num(value: Union[float, int, str]) -> Optional[Union[float, int]]:
+def cast_to_num(value: Optional[Union[float, int, str]]) -> Optional[Union[float, int]]:
     """Casts a value to an int/float
 
     >>> cast_to_num('5')
@@ -222,6 +222,8 @@ def cast_to_num(value: Union[float, int, str]) -> Optional[Union[float, int]]:
     10
     >>> cast_to_num(10.1)
     10.1
+    >>> cast_to_num(None)
+    None
     >>> cast_to_num('this is not a string') is None
     True
 
@@ -229,6 +231,8 @@ def cast_to_num(value: Union[float, int, str]) -> Optional[Union[float, int]]:
     :returns: value cast to `int` if value is all digits, `float` if `value` is
               decimal value and `None`` if it can't be converted
     """
+    if value is None:
+        return None
     if isinstance(value, (int, float)):
         return value
     if value.isdigit():

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -38,6 +38,7 @@ from superset.models.core import Database, Log
 from superset.utils.cache_manager import CacheManager
 from superset.utils.core import (
     base_json_conv,
+    cast_to_num,
     convert_legacy_filters_into_adhoc,
     create_ssl_cert_file,
     format_timedelta,
@@ -1367,6 +1368,14 @@ class TestUtils(SupersetTestCase):
         self.assertEqual("BaZ", validator("BaZ"))
         self.assertRaises(marshmallow.ValidationError, validator, "qwerty")
         self.assertRaises(marshmallow.ValidationError, validator, 4)
+
+    def test_cast_to_num(self) -> None:
+        assert cast_to_num("5") == 5
+        assert cast_to_num("5.2") == 5.2
+        assert cast_to_num(10) == 10
+        assert cast_to_num(10.1) == 10.1
+        assert cast_to_num(None) is None
+        assert cast_to_num("this is not a string") is None
 
     def test_get_form_data_token(self):
         assert get_form_data_token({"token": "token_abcdefg1"}) == "token_abcdefg1"


### PR DESCRIPTION
### SUMMARY
`cast_to_num` can be called with `None`, which causes an exception (`'NoneType' object has no attribute 'isdigit'`). 

### TEST PLAN
CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
