### PR TITLE
feat: add extra column to tables and sql_metrics

### DIFF
--- a/superset/migrations/versions/f120347acb39_add_extra_column_to_tables_and_metrics.py
+++ b/superset/migrations/versions/f120347acb39_add_extra_column_to_tables_and_metrics.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add extra column to tables and metrics
+
+Revision ID: f120347acb39
+Revises: f2672aa8350a
+Create Date: 2020-08-12 10:01:43.531845
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "f120347acb39"
+down_revision = "f2672aa8350a"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    op.add_column("tables", sa.Column("extra", sa.Text(), nullable=True))
+    op.add_column("sql_metrics", sa.Column("extra", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("tables", "extra")
+    op.drop_column("sql_metrics", "extra")

--- a/superset/tasks/slack_util.py
+++ b/superset/tasks/slack_util.py
@@ -26,7 +26,7 @@ from slack.web.slack_response import SlackResponse
 from superset import app
 
 # Globals
-config = app.config  # type: ignore
+config = app.config
 logger = logging.getLogger("tasks.slack_util")
 
 


### PR DESCRIPTION
### SUMMARY
Adds the columns mentioned in https://github.com/apache/incubator-superset/issues/10591 for extra metadata around tables and metrics (with certification being the first use case)

I'm PRing out only the migration first to ensure push safety with future code that references these columns.

### TEST PLAN
CI, run the migration and see it succeed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @john-bodley @graceguo-supercat @ktmud 