### PR TITLE
feat: dataset REST API for distinct values

### DIFF
--- a/superset/constants.py
+++ b/superset/constants.py
@@ -55,6 +55,7 @@ class RouteMethod:  # pylint: disable=too-few-public-methods
     POST = "post"
     PUT = "put"
     RELATED = "related"
+    DISTINCT = "distinct"
 
     # Commonly used sets
     API_SET = {API_CREATE, API_DELETE, API_GET, API_READ, API_UPDATE}

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -67,6 +67,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     include_route_methods = RouteMethod.REST_MODEL_VIEW_CRUD_SET | {
         RouteMethod.EXPORT,
         RouteMethod.RELATED,
+        RouteMethod.DISTINCT,
         "refresh",
         "related_objects",
     }
@@ -151,6 +152,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     }
     filter_rel_fields = {"database": [["id", DatabaseFilter, lambda: []]]}
     allowed_rel_fields = {"database", "owners"}
+    allowed_distinct_fields = {"schema"}
 
     openapi_spec_component_schemas = (DatasetRelatedObjectsResponse,)
 

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -356,7 +356,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
     @statsd_metrics
     @rison(get_related_schema)
     def distinct(self, column_name: str, **kwargs: Any) -> FlaskResponse:
-        """Get related fields data
+        """Get distinct values from field data
         ---
         get:
           parameters:
@@ -372,7 +372,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
                   $ref: '#/components/schemas/get_related_schema'
           responses:
             200:
-              description: Related column data
+              description: Distinct field data
               content:
                 application/json:
                   schema:

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -152,7 +152,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         # Setup statsd
         self.stats_logger = BaseStatsLogger()
         # Add base API spec base query parameter schemas
-        if self.apispec_parameter_schemas is None:
+        if self.apispec_parameter_schemas is None:  # type: ignore
             self.apispec_parameter_schemas = {}
         self.apispec_parameter_schemas["get_related_schema"] = get_related_schema
         if self.openapi_spec_component_schemas is None:

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -19,12 +19,16 @@ import logging
 from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, Type, Union
 
 from apispec import APISpec
+from apispec.exceptions import DuplicateComponentNameError
 from flask import Blueprint, Response
-from flask_appbuilder import AppBuilder, Model, ModelRestApi
+from flask_appbuilder import AppBuilder, ModelRestApi
 from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.models.filters import BaseFilter, Filters
 from flask_appbuilder.models.sqla.filters import FilterStartsWith
-from marshmallow import Schema
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+from marshmallow import Schema, fields
+from sqlalchemy import distinct
+from sqlalchemy import func
 
 from superset.stats_logger import BaseStatsLogger
 from superset.typing import FlaskResponse
@@ -39,6 +43,25 @@ get_related_schema = {
         "filter": {"type": "string"},
     },
 }
+
+
+class RelatedResultResponseSchema(Schema):
+    value = fields.Integer(description="The related item identifier")
+    text = fields.String(description="The related item string representation")
+
+
+class RelatedResponseSchema(Schema):
+    count = fields.Integer(description="The total number of related values")
+    result = fields.List(fields.Nested(RelatedResultResponseSchema))
+
+
+class DistinctResultResponseSchema(Schema):
+    text = fields.String(description="The distinct item")
+
+
+class DistincResponseSchema(Schema):
+    count = fields.Integer(description="The total number of distinct values")
+    result = fields.List(fields.Nested(DistinctResultResponseSchema))
 
 
 def statsd_metrics(f: Callable[..., Any]) -> Callable[..., Any]:
@@ -78,6 +101,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         "bulk_delete": "delete",
         "info": "list",
         "related": "list",
+        "distinct": "list",
         "thumbnail": "list",
         "refresh": "edit",
         "data": "list",
@@ -112,6 +136,8 @@ class BaseSupersetModelRestApi(ModelRestApi):
     """  # pylint: disable=pointless-string-statement
     allowed_rel_fields: Set[str] = set()
 
+    allowed_distinct_fields: Set[str] = set()
+
     openapi_spec_component_schemas: Tuple[Type[Schema], ...] = tuple()
     """
     Add extra schemas to the OpenAPI component schemas section
@@ -123,15 +149,29 @@ class BaseSupersetModelRestApi(ModelRestApi):
     show_columns: List[str]
 
     def __init__(self) -> None:
-        super().__init__()
+        # Setup statsd
         self.stats_logger = BaseStatsLogger()
+        # Add base API spec base query parameter schemas
+        if self.apispec_parameter_schemas is None:
+            self.apispec_parameter_schemas = {}
+        self.apispec_parameter_schemas["get_related_schema"] = get_related_schema
+        if self.openapi_spec_component_schemas is None:
+            self.openapi_spec_component_schemas = ()
+        self.openapi_spec_component_schemas = self.openapi_spec_component_schemas + (
+            RelatedResponseSchema,
+            DistincResponseSchema,
+        )
+        super().__init__()
 
     def add_apispec_components(self, api_spec: APISpec) -> None:
 
         for schema in self.openapi_spec_component_schemas:
-            api_spec.components.schema(
-                schema.__name__, schema=schema,
-            )
+            try:
+                api_spec.components.schema(
+                    schema.__name__, schema=schema,
+                )
+            except DuplicateComponentNameError:
+                pass
         super().add_apispec_components(api_spec)
 
     def create_blueprint(
@@ -153,7 +193,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         super()._init_properties()
 
     def _get_related_filter(
-        self, datamodel: Model, column_name: str, value: str
+        self, datamodel: SQLAInterface, column_name: str, value: str
     ) -> Filters:
         filter_field = self.related_field_filters.get(column_name)
         if isinstance(filter_field, str):
@@ -164,6 +204,18 @@ class BaseSupersetModelRestApi(ModelRestApi):
         base_filters = self.filter_rel_fields.get(column_name)
         if base_filters:
             filters.add_filter_list(base_filters)
+        if value and filter_field:
+            filters.add_filter(
+                filter_field.field_name, filter_field.filter_class, value
+            )
+        return filters
+
+    def _get_distinct_filter(self, column_name: str, value: str) -> Filters:
+        filter_field = RelatedFieldFilter(column_name, FilterStartsWith)
+        filter_field = cast(RelatedFieldFilter, filter_field)
+        search_columns = [filter_field.field_name] if filter_field else None
+        filters = self.datamodel.get_filters(search_columns)
+        filters.add_filter_list(self.base_filters)
         if value and filter_field:
             filters.add_filter(
                 filter_field.field_name, filter_field.filter_class, value
@@ -251,39 +303,21 @@ class BaseSupersetModelRestApi(ModelRestApi):
             content:
               application/json:
                 schema:
-                  type: object
-                  properties:
-                    page_size:
-                      type: integer
-                    page:
-                      type: integer
-                    filter:
-                      type: string
+                  $ref: '#/components/schemas/get_related_schema'
           responses:
             200:
               description: Related column data
               content:
                 application/json:
                   schema:
-                    type: object
-                    properties:
-                      count:
-                        type: integer
-                      result:
-                        type: object
-                        properties:
-                          value:
-                            type: integer
-                          text:
-                            type: string
+                  schema:
+                    $ref: "#/components/schemas/RelatedResponseSchema"
             400:
               $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
             404:
               $ref: '#/components/responses/404'
-            422:
-              $ref: '#/components/responses/422'
             500:
               $ref: '#/components/responses/500'
         """
@@ -315,4 +349,69 @@ class BaseSupersetModelRestApi(ModelRestApi):
             {"value": datamodel.get_pk_value(value), "text": str(value)}
             for value in values
         ]
+        return self.response(200, count=count, result=result)
+
+    @expose("/distinct/<column_name>", methods=["GET"])
+    @protect()
+    @safe
+    @statsd_metrics
+    @rison(get_related_schema)
+    def distinct(self, column_name: str, **kwargs: Any) -> FlaskResponse:
+        """Get related fields data
+        ---
+        get:
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: column_name
+          - in: query
+            name: q
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/get_related_schema'
+          responses:
+            200:
+              description: Related column data
+              content:
+                application/json:
+                  schema:
+                  schema:
+                    $ref: "#/components/schemas/DistincResponseSchema"
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            404:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        if column_name not in self.allowed_distinct_fields:
+            self.incr_stats("error", self.related.__name__)
+            return self.response_404()
+        args = kwargs.get("rison", {})
+        # handle pagination
+        page, page_size = self._sanitize_page_args(*self._handle_page_args(args))
+        # Create generic base filters with added request filter
+        filters = self._get_distinct_filter(column_name, args.get("filter"))
+        # Make the query
+        query_count = self.appbuilder.get_session.query(
+            func.count(distinct(getattr(self.datamodel.obj, column_name)))
+        )
+        count = self.datamodel.apply_filters(query_count, filters).scalar()
+        if count == 0:
+            return self.response(200, count=count, result=[])
+        query = self.appbuilder.get_session.query(
+            distinct(getattr(self.datamodel.obj, column_name))
+        )
+        # Apply generic base filters with added request filter
+        query = self.datamodel.apply_filters(query, filters)
+        # Apply sort
+        query = self.datamodel.apply_order_by(query, column_name, "asc")
+        # Apply pagination
+        result = self.datamodel.apply_pagination(query, page, page_size).all()
+        # produce response
+        result = [{"text": item[0]} for item in result if item[0] is not None]
         return self.response(200, count=count, result=result)

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -26,9 +26,8 @@ from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.models.filters import BaseFilter, Filters
 from flask_appbuilder.models.sqla.filters import FilterStartsWith
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from marshmallow import Schema, fields
-from sqlalchemy import distinct
-from sqlalchemy import func
+from marshmallow import fields, Schema
+from sqlalchemy import distinct, func
 
 from superset.stats_logger import BaseStatsLogger
 from superset.typing import FlaskResponse

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -221,7 +221,7 @@ class TestDatasetApi(SupersetTestCase):
 
         if example_db.backend == "postgresql":
             # Test filter
-            query_parameter = {"filter": "in"}
+            query_parameter = {"filter": "inf"}
             pg_test_query_parameter(
                 query_parameter,
                 {"count": 1, "result": [{"text": "information_schema"}]},
@@ -230,12 +230,12 @@ class TestDatasetApi(SupersetTestCase):
             query_parameter = {"page": 0, "page_size": 1}
             pg_test_query_parameter(
                 query_parameter,
-                {"count": 2, "result": [{"text": "information_schema"}]},
+                {"count": 5, "result": [{"text": ""}]},
             )
 
             query_parameter = {"page": 1, "page_size": 1}
             pg_test_query_parameter(
-                query_parameter, {"count": 2, "result": [{"text": "public"}]}
+                query_parameter, {"count": 5, "result": [{"text": "admin_database"}]}
             )
 
         for dataset in datasets:

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -229,8 +229,7 @@ class TestDatasetApi(SupersetTestCase):
 
             query_parameter = {"page": 0, "page_size": 1}
             pg_test_query_parameter(
-                query_parameter,
-                {"count": 5, "result": [{"text": ""}]},
+                query_parameter, {"count": 5, "result": [{"text": ""}]},
             )
 
             query_parameter = {"page": 1, "page_size": 1}

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -173,7 +173,6 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test get dataset distinct schema
         """
-        self.maxDiff = None
 
         def pg_test_query_parameter(query_parameter, expected_response):
             uri = f"api/v1/dataset/distinct/schema?q={prison.dumps(query_parameter)}"
@@ -203,23 +202,13 @@ class TestDatasetApi(SupersetTestCase):
                     {"text": "superset"},
                 ],
             }
-        else:
-            expected_response = {
-                "count": 5,
-                "result": [
-                    {"text": ""},
-                    {"text": "admin_database"},
-                    {"text": "superset"},
-                ],
-            }
-        self.login(username="admin")
-        uri = "api/v1/dataset/distinct/schema"
-        rv = self.client.get(uri)
-        response = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(rv.status_code, 200)
-        self.assertEqual(response, expected_response)
+            self.login(username="admin")
+            uri = "api/v1/dataset/distinct/schema"
+            rv = self.client.get(uri)
+            response = json.loads(rv.data.decode("utf-8"))
+            self.assertEqual(rv.status_code, 200)
+            self.assertEqual(response, expected_response)
 
-        if example_db.backend == "postgresql":
             # Test filter
             query_parameter = {"filter": "inf"}
             pg_test_query_parameter(

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -173,6 +173,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test get dataset distinct schema
         """
+        self.maxDiff = None
 
         def pg_test_query_parameter(query_parameter, expected_response):
             uri = f"api/v1/dataset/distinct/schema?q={prison.dumps(query_parameter)}"
@@ -193,12 +194,24 @@ class TestDatasetApi(SupersetTestCase):
                 )
             )
             expected_response = {
-                "count": 2,
-                "result": [{"text": "information_schema"}, {"text": "public"}],
+                "count": 5,
+                "result": [
+                    {"text": ""},
+                    {"text": "admin_database"},
+                    {"text": "information_schema"},
+                    {"text": "public"},
+                    {"text": "superset"},
+                ],
             }
         else:
-            datasets.append(self.insert_default_dataset())
-            expected_response = {"count": 1, "result": [{"text": ""}]}
+            expected_response = {
+                "count": 5,
+                "result": [
+                    {"text": ""},
+                    {"text": "admin_database"},
+                    {"text": "superset"},
+                ],
+            }
         self.login(username="admin")
         uri = "api/v1/dataset/distinct/schema"
         rv = self.client.get(uri)


### PR DESCRIPTION
### SUMMARY
Creates a new generic endpoint to query distinct values from a `ModelRestApi` useful for filter dropdowns

This endpoint behaves in a very similar way then `/api/v1/<resource>/related/<column_name>` on this case `/api/v1/<resource>/distinct/<column_name>`

Accepts also the same JSON/Rison query parameters:

``` json
{
  "filter": "string",
  "page": 0,
  "page_size": 0
}
```

To enable this generic endpoint on a `ModelRestApi` child class we need to:

```
include_route_methods = { ..., RouteMethod.DISTINCT, }
```

Enable the fields that we allow to be queried:

```
allowed_distinct_fields = {"schema"}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="501" alt="Screenshot 2020-08-13 at 16 48 27" src="https://user-images.githubusercontent.com/4025227/90156828-d9ef9480-dd84-11ea-8f23-c17e8e89e8c0.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
