### PR TITLE
refactor: remove slice level label_colors from dashboard init load

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -304,6 +304,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Exposes API endpoint to compute thumbnails
     "THUMBNAILS": False,
     "REDUCE_DASHBOARD_BOOTSTRAP_PAYLOAD": True,
+    "REMOVE_SLICE_LEVEL_LABEL_COLORS": False,
     "SHARE_QUERIES_VIA_KV_STORE": False,
     "SIP_38_VIZ_REARCHITECTURE": False,
     "TAGGING_SYSTEM": False,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1652,6 +1652,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
 
         dashboard_data = dash.data
+        if is_feature_enabled("REMOVE_SLICE_LEVEL_LABEL_COLORS"):
+            # dashboard metadata has dashboard-level label_colors,
+            # so remove slice-level label_colors from its form_data
+            for slc in dashboard_data.get("slices"):
+                form_data = slc.get("form_data")
+                form_data.pop("label_colors", None)
+
         dashboard_data.update(
             {
                 "standalone_mode": standalone_mode,


### PR DESCRIPTION
### SUMMARY
When dashboard is loaded, it loaded bootstrap data for render dashboard. it includes: datasources, slice metadata, and dashboard metadata.

When dashboard has set color_scheme, its metadata will have `color_labels` section and set color for each label in the dashboard. This attribute will overwrite slice level color_label in its form_data. So when used in dashboard, slice's own color_label has no use. But this section could be pretty big and repeated by all the slices in the dashboard, which make the dashboard initial bootstrap data size very big.

This PR is to remove slice level color_label attribute (in its form_data) in the dashboard bootstrap data. 

### TEST PLAN
CI and manually load some dashboards.

@etr2460 

