### PR TITLE
feat(datasource): remove deleted columns and update column type on metadata refresh

### DIFF
--- a/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/DatasourceEditor_spec.jsx
@@ -34,17 +34,6 @@ const props = {
   onChange: () => {},
 };
 
-const extraColumn = {
-  column_name: 'new_column',
-  type: 'VARCHAR(10)',
-  description: null,
-  filterable: true,
-  verbose_name: null,
-  is_dttm: false,
-  expression: '',
-  groupby: true,
-};
-
 const DATASOURCE_ENDPOINT = 'glob:*/datasource/external_metadata/*';
 
 describe('DatasourceEditor', () => {
@@ -85,11 +74,65 @@ describe('DatasourceEditor', () => {
     });
   });
 
-  it('merges columns', () => {
+  it('to add, remove and modify columns accordingly', () => {
+    const columns = [
+      {
+        name: 'ds',
+        type: 'DATETIME',
+        nullable: true,
+        default: '',
+        primary_key: false,
+      },
+      {
+        name: 'gender',
+        type: 'VARCHAR(32)',
+        nullable: true,
+        default: '',
+        primary_key: false,
+      },
+      {
+        name: 'new_column',
+        type: 'VARCHAR(10)',
+        nullable: true,
+        default: '',
+        primary_key: false,
+      },
+    ];
+
     const numCols = props.datasource.columns.length;
     expect(inst.state.databaseColumns).toHaveLength(numCols);
-    inst.mergeColumns([extraColumn]);
-    expect(inst.state.databaseColumns).toHaveLength(numCols + 1);
+    inst.updateColumns(columns);
+    expect(inst.state.databaseColumns).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'DATETIME',
+          description: null,
+          filterable: false,
+          verbose_name: null,
+          is_dttm: true,
+          expression: '',
+          groupby: false,
+          column_name: 'ds',
+        },
+        {
+          type: 'VARCHAR(32)',
+          description: null,
+          filterable: true,
+          verbose_name: null,
+          is_dttm: false,
+          expression: '',
+          groupby: true,
+          column_name: 'gender',
+        },
+        expect.objectContaining({
+          column_name: 'new_column',
+          type: 'VARCHAR(10)',
+        }),
+      ]),
+    );
+    expect(inst.state.databaseColumns).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'name' })]),
+    );
   });
 
   it('renders isSqla fields', () => {

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -289,7 +289,7 @@ export class DatasourceEditor extends React.PureComponent {
     this.validate(this.onChange);
   }
 
-  mergeColumns(cols) {
+  updateColumns(cols) {
     const { databaseColumns } = this.state;
     const databaseColumnNames = cols.map(col => col.name);
     const currentCols = databaseColumns.reduce(
@@ -349,7 +349,7 @@ export class DatasourceEditor extends React.PureComponent {
 
     SupersetClient.get({ endpoint })
       .then(({ json }) => {
-        const [addedCols, removedCols, modifiedCols] = this.mergeColumns(json);
+        const [addedCols, removedCols, modifiedCols] = this.updateColumns(json);
         if (modifiedCols.length)
           this.props.addSuccessToast(
             t('Modified columns: %s', modifiedCols.join(', ')),

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -172,7 +172,7 @@ function ColumnCollectionTable({
           ) : (
             v
           ),
-        type: d => <Label bsStyle="s">{d}</Label>,
+        type: d => <Label>{d}</Label>,
         is_dttm: checkboxGenerator,
         filterable: checkboxGenerator,
         groupby: checkboxGenerator,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Hashable, List, NamedTuple, Optional, Tuple, Union
 import pandas as pd
 import sqlalchemy as sa
 import sqlparse
-from flask import escape, flash, Markup
+from flask import escape, Markup
 from flask_appbuilder import Model
 from flask_babel import lazy_gettext as _
 from jinja2.exceptions import TemplateError

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -440,13 +440,13 @@ class TableModelView(  # pylint: disable=too-many-ancestors
 
         for table_ in tables:
             try:
-                added, removed, modified = table_.fetch_metadata()
-                if added:
-                    results.added[table_.table_name] = added
-                if removed:
-                    results.removed[table_.table_name] = removed
-                if modified:
-                    results.modified[table_.table_name] = modified
+                metadata_results = table_.fetch_metadata()
+                if metadata_results.added:
+                    results.added[table_.table_name] = metadata_results.added
+                if metadata_results.removed:
+                    results.removed[table_.table_name] = metadata_results.removed
+                if metadata_results.modified:
+                    results.modified[table_.table_name] = metadata_results.modified
                 results.successes.append(table_)
             except Exception:  # pylint: disable=broad-except
                 results.failures.append(table_)

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -422,7 +422,7 @@ class TableModelView(  # pylint: disable=too-many-ancestors
     @action(
         "refresh", __("Refresh Metadata"), __("Refresh column metadata"), "fa-refresh"
     )
-    def refresh(  # pylint: disable=no-self-use
+    def refresh(  # pylint: disable=no-self-use, too-many-branches
         self, tables: Union["TableModelView", List["TableModelView"]]
     ) -> FlaskResponse:
         if not isinstance(tables, list):


### PR DESCRIPTION
### SUMMARY
Currently refreshing table metadata doesn't remove columns that aren't available on the table any longer. In addition, the React Table view doesn't update column types if they've changed. This PR:
- removes columns that are not present on table schema (both legacy and React).
- updates column type if changed (React; already working on legacy view).
- adds toasts for added, removed and update columns to (both legacy and React).
- Updates unit tests on React Jest specs to correspond to the new logic (skipped legacy view as I assume it's going to be deprecated).
- fix broken style on type pills on the table metadata column on React views (see screenshots).

### AFTER
![image](https://user-images.githubusercontent.com/33317356/90391701-3b21ab80-e096-11ea-80b2-bf50d9bad68e.png)
![image](https://user-images.githubusercontent.com/33317356/90424055-2b21c000-e0c6-11ea-9b72-2fc4106629bd.png)

### BEFORE
The type pills on the column tab were using an incorrect style, causing white foreground on white background.
![image](https://user-images.githubusercontent.com/33317356/90424134-4ab8e880-e0c6-11ea-8c28-06e8d484bdb4.png)


### TEST PLAN
Local testing + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
