### PR TITLE
fix: removing unsupported modal sizes

### DIFF
--- a/superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx
+++ b/superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx
@@ -95,7 +95,7 @@ class EstimateQueryCostButton extends React.PureComponent {
               <i className="fa fa-clock-o" /> {btnText}
             </Button>
           }
-          bsSize="medium"
+          bsSize="sm"
         />
       </span>
     );

--- a/superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx
+++ b/superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx
@@ -95,7 +95,6 @@ class EstimateQueryCostButton extends React.PureComponent {
               <i className="fa fa-clock-o" /> {btnText}
             </Button>
           }
-          bsSize="sm"
         />
       </span>
     );

--- a/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
@@ -201,7 +201,7 @@ class ScheduleQueryButton extends React.PureComponent {
               <i className="fa fa-calendar" /> {t('Schedule')}
             </Button>
           }
-          bsSize="medium"
+          bsSize="sm"
         />
       </span>
     );

--- a/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
@@ -201,7 +201,6 @@ class ScheduleQueryButton extends React.PureComponent {
               <i className="fa fa-calendar" /> {t('Schedule')}
             </Button>
           }
-          bsSize="sm"
         />
       </span>
     );

--- a/superset-frontend/src/components/DeleteModal.tsx
+++ b/superset-frontend/src/components/DeleteModal.tsx
@@ -63,7 +63,7 @@ export default function DeleteModal({
       primaryButtonType="danger"
       show={open}
       title={title}
-      bsSize="medium"
+      bsSize="sm"
     >
       <DescriptionContainer>{description}</DescriptionContainer>
       <StyleFormGroup>

--- a/superset-frontend/src/components/DeleteModal.tsx
+++ b/superset-frontend/src/components/DeleteModal.tsx
@@ -63,7 +63,6 @@ export default function DeleteModal({
       primaryButtonType="danger"
       show={open}
       title={title}
-      bsSize="sm"
     >
       <DescriptionContainer>{description}</DescriptionContainer>
       <StyleFormGroup>

--- a/superset-frontend/src/components/Modal.tsx
+++ b/superset-frontend/src/components/Modal.tsx
@@ -31,7 +31,7 @@ interface ModalProps {
   primaryButtonType?: 'primary' | 'danger';
   show: boolean;
   title: React.ReactNode;
-  bsSize?: 'sm' | 'small' | 'lg' | 'large';
+  bsSize?: 'small' | 'large'; // react-bootstrap also supports 'sm', 'lg' but we're keeping it simple.
 }
 
 const StyledModal = styled(BaseModal)`

--- a/superset-frontend/src/components/Modal.tsx
+++ b/superset-frontend/src/components/Modal.tsx
@@ -31,7 +31,7 @@ interface ModalProps {
   primaryButtonType?: 'primary' | 'danger';
   show: boolean;
   title: React.ReactNode;
-  bsSize?: 'xs' | 'xsmall' | 'sm' | 'small' | 'medium' | 'lg' | 'large';
+  bsSize?:  'sm' | 'small' | 'lg' | 'large';
 }
 
 const StyledModal = styled(BaseModal)`

--- a/superset-frontend/src/components/Modal.tsx
+++ b/superset-frontend/src/components/Modal.tsx
@@ -31,7 +31,7 @@ interface ModalProps {
   primaryButtonType?: 'primary' | 'danger';
   show: boolean;
   title: React.ReactNode;
-  bsSize?:  'sm' | 'small' | 'lg' | 'large';
+  bsSize?: 'sm' | 'small' | 'lg' | 'large';
 }
 
 const StyledModal = styled(BaseModal)`

--- a/superset-frontend/src/components/Modal.tsx
+++ b/superset-frontend/src/components/Modal.tsx
@@ -75,10 +75,9 @@ export default function Modal({
   primaryButtonType = 'primary',
   show,
   title,
-  bsSize = 'lg',
 }: ModalProps) {
   return (
-    <StyledModal show={show} onHide={onHide} bsSize={bsSize}>
+    <StyledModal show={show} onHide={onHide}>
       <BaseModal.Header closeButton>
         <BaseModal.Title>
           <Title>{title}</Title>

--- a/superset-frontend/src/components/ModalTrigger.jsx
+++ b/superset-frontend/src/components/ModalTrigger.jsx
@@ -34,7 +34,7 @@ const propTypes = {
   onExit: PropTypes.func,
   isButton: PropTypes.bool,
   isMenuItem: PropTypes.bool,
-  bsSize: PropTypes.oneOf(["lg", "large", "sm", "small"]),
+  bsSize: PropTypes.oneOf(['lg', 'large', 'sm', 'small']),
   className: PropTypes.string,
   tooltip: PropTypes.string,
   backdrop: PropTypes.oneOf(['static', true, false]),

--- a/superset-frontend/src/components/ModalTrigger.jsx
+++ b/superset-frontend/src/components/ModalTrigger.jsx
@@ -34,7 +34,7 @@ const propTypes = {
   onExit: PropTypes.func,
   isButton: PropTypes.bool,
   isMenuItem: PropTypes.bool,
-  bsSize: PropTypes.oneOf(['lg', 'large', 'sm', 'small']),
+  bsSize: PropTypes.oneOf(['large', 'small']), // react-bootstrap also supports 'sm', 'lg' but we're keeping it simple.
   className: PropTypes.string,
   tooltip: PropTypes.string,
   backdrop: PropTypes.oneOf(['static', true, false]),

--- a/superset-frontend/src/components/ModalTrigger.jsx
+++ b/superset-frontend/src/components/ModalTrigger.jsx
@@ -34,7 +34,7 @@ const propTypes = {
   onExit: PropTypes.func,
   isButton: PropTypes.bool,
   isMenuItem: PropTypes.bool,
-  bsSize: PropTypes.string,
+  bsSize: PropTypes.oneOf(["lg", "large", "sm", "small"]),
   className: PropTypes.string,
   tooltip: PropTypes.string,
   backdrop: PropTypes.oneOf(['static', true, false]),

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -120,7 +120,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
   };
 
   return (
-    <Modal show={show} onHide={onHide} onEnter={onEnterModal} bsSize="lg">
+    <Modal show={show} onHide={onHide} onEnter={onEnterModal} bsSize="large">
       <Modal.Header closeButton>
         <Modal.Title>{t('Select a datasource')}</Modal.Title>
       </Modal.Header>

--- a/superset-frontend/src/datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/datasource/DatasourceModal.tsx
@@ -110,7 +110,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   };
 
   return (
-    <Modal show={show} onHide={onHide} bsSize="lg">
+    <Modal show={show} onHide={onHide} bsSize="large">
       <Modal.Header closeButton>
         <Modal.Title>
           <div>

--- a/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
@@ -213,7 +213,7 @@ export default class VizTypeControl extends React.PureComponent {
           onHide={this.toggleModal}
           onEnter={this.focusSearch}
           onExit={this.setSearchRef}
-          bsSize="lg"
+          bsSize="large"
         >
           <Modal.Header closeButton>
             <Modal.Title>{t('Select a visualization type')}</Modal.Title>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There were a few instances of react-bootstrap using bsSize of `medium` which isn't actually supported by React Bootstrap. This sets those to `sm` and locks down TS/PropTypes accordingly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
