### PR TITLE
chore: splitting button stories into separate stories

### DIFF
--- a/superset-frontend/src/components/Button/button.stories.jsx
+++ b/superset-frontend/src/components/Button/button.stories.jsx
@@ -124,7 +124,6 @@ export const ButtonGallery = () => (
   </div>
 );
 
-
 export const InteractiveButton = () => (
   <div style={{ padding: '10px', backgroundColor: 'white' }}>
     <Button

--- a/superset-frontend/src/components/Button/button.stories.jsx
+++ b/superset-frontend/src/components/Button/button.stories.jsx
@@ -99,9 +99,34 @@ const hrefKnob = {
   defaultValue: null,
 };
 
-export const SupersetButton = () => (
+export const ButtonGallery = () => (
   <div style={{ padding: '10px', backgroundColor: 'white' }}>
-    <h3>Interactive</h3>
+    {Object.values(bsSizeKnob.options)
+      .filter(a => a)
+      .map(size => (
+        <div>
+          <h4>{size}</h4>
+          {Object.values(bsStyleKnob.options)
+            .filter(o => o)
+            .map(style => (
+              <Button
+                disabled={boolean('Disabled', false)}
+                bsStyle={style}
+                bsSize={size}
+                onClick={action('clicked')}
+                style={{ marginRight: 5 }}
+              >
+                {style}
+              </Button>
+            ))}
+        </div>
+      ))}
+  </div>
+);
+
+
+export const InteractiveButton = () => (
+  <div style={{ padding: '10px', backgroundColor: 'white' }}>
     <Button
       disabled={boolean('Disabled', false)}
       bsStyle={select(
@@ -139,26 +164,5 @@ export const SupersetButton = () => (
     >
       {text('Label', 'Button!')}
     </Button>
-    <h3>Gallery</h3>
-    {Object.values(bsSizeKnob.options)
-      .filter(a => a)
-      .map(size => (
-        <div>
-          <h4>{size}</h4>
-          {Object.values(bsStyleKnob.options)
-            .filter(o => o)
-            .map(style => (
-              <Button
-                disabled={boolean('Disabled', false)}
-                bsStyle={style}
-                bsSize={size}
-                onClick={action('clicked')}
-                style={{ marginRight: 5 }}
-              >
-                {style}
-              </Button>
-            ))}
-        </div>
-      ))}
   </div>
 );


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Buttons had an "Interactive" secion and "Gallery" section within one story. This PR just splits them into two stories.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
![image](https://user-images.githubusercontent.com/812905/90573215-bd7b9f80-e16a-11ea-8982-6e4895b045bf.png)
![image](https://user-images.githubusercontent.com/812905/90573231-c9fff800-e16a-11ea-9002-0895fa15a904.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
