### PR TITLE
fix: chart list api endpoint

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -119,12 +119,11 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "table.table_name",
         "thumbnail_url",
         "url",
-        "params",
-        "cache_timeout",
         "owners.id",
         "owners.username",
         "owners.first_name",
         "owners.last_name",
+        "viz_type",
     ]
     list_select_columns = list_columns + ["changed_by_fk", "changed_on"]
     order_columns = [


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- chart list CRUD view can't load because `viz_type` is missing 
- remove duplicated `params` and `cache_timeout` from list_columns; add `viz_type` to list_columns

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before**
![Screen Shot 2020-08-19 at 11 24 10 AM](https://user-images.githubusercontent.com/5705598/90674861-94ace600-e20e-11ea-9087-65b6c2ce88fa.png)
**After**
![Screen Shot 2020-08-19 at 11 24 29 AM](https://user-images.githubusercontent.com/5705598/90674895-a1c9d500-e20e-11ea-8832-83071d711647.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
