### PR TITLE
fix: controls scroll issue

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -42,6 +42,7 @@ const propTypes = {
 };
 
 const Styles = styled.div`
+  height: 100%;
   max-height: 100%;
   .remove-alert {
     cursor: 'pointer';
@@ -49,6 +50,7 @@ const Styles = styled.div`
   #controlSections {
     display: flex;
     flex-direction: column;
+    height: 100%;
     max-height: 100%;
   }
   .nav-tabs {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes css glitch with some controls being cut off. This props open the wrapping container(s) to full height, but still lets them scroll if things go long.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![before](https://user-images.githubusercontent.com/812905/90678528-a6dd5300-e213-11ea-9cc5-20f98a087242.gif)

After:
![after](https://user-images.githubusercontent.com/812905/90678582-b8bef600-e213-11ea-9a35-fe78904aef8d.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
