### PR TITLE
fix: Remove incorrect comment indicating thumbnails are insecure

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -565,7 +565,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             }
             cache_chart_thumbnail.delay(**kwargs)
             return self.response(
-                202, cache_key=cache_key, chart_url=chart_url, image_url=image_url,
+                202, cache_key=cache_key, chart_url=chart_url, image_url=image_url
             )
 
         return trigger_celery()
@@ -613,8 +613,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
         # Making sure the chart still exists
         if not chart:
             return self.response_404()
-
-        # TODO make sure the user has access to the chart
 
         # fetch the chart screenshot using the current user and cache if set
         img = ChartScreenshot.get_from_cache_key(thumbnail_cache, digest)


### PR DESCRIPTION
### SUMMARY
The comment removed  by this PR indicates that access controls are not in place for thumbnails. In fact, the `@protect` decorator on the function acts as access control via the FAB permission system. This PR removes the comment to avoid further ambiguity.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TEST PLAN
Not necessary, it's a comment removal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
