### PR TITLE
Eslint error cleanup

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/link.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/link.test.js
@@ -90,7 +90,7 @@ describe('Test explore links', () => {
 
     cy.visitChartByParams(JSON.stringify(formData));
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
-    cy.url().then(url => {
+    cy.url().then(() => {
       cy.get('button[data-target="#save_modal"]').click();
       cy.get('.modal-content').within(() => {
         cy.get('#saveas-radio').check();

--- a/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
@@ -20,12 +20,17 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { OverlayTrigger } from 'react-bootstrap';
 import sinon from 'sinon';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 
 import EmbedCodeButton from 'src/explore/components/EmbedCodeButton';
 import * as exploreUtils from 'src/explore/exploreUtils';
 import * as common from 'src/utils/common';
 
 describe('EmbedCodeButton', () => {
+  const mockStore = configureStore([]);
+  const store = mockStore({});
+
   const defaultProps = {
     latestQueryFormData: { datasource: '107__table' },
   };
@@ -41,11 +46,16 @@ describe('EmbedCodeButton', () => {
     expect(wrapper.find(OverlayTrigger)).toExist();
   });
 
-  it('should create shorten, standalone, explore url', () => {
+  it('should create short, standalone, explore url', () => {
     const spy1 = sinon.spy(exploreUtils, 'getExploreLongUrl');
     const spy2 = sinon.spy(common, 'getShortUrl');
 
-    const wrapper = mount(<EmbedCodeButton {...defaultProps} />);
+    const wrapper = mount(<EmbedCodeButton {...defaultProps} />, {
+      wrappingComponent: Provider,
+      wrappingComponentProps: {
+        store: store,
+      },
+    });
     wrapper.setState({
       height: '1000',
       width: '2000',

--- a/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
@@ -46,7 +46,7 @@ describe('EmbedCodeButton', () => {
     expect(wrapper.find(OverlayTrigger)).toExist();
   });
 
-  it('should create short, standalone, explore url', () => {
+  it('should create a short, standalone, explore url', () => {
     const spy1 = sinon.spy(exploreUtils, 'getExploreLongUrl');
     const spy2 = sinon.spy(common, 'getShortUrl');
 

--- a/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
@@ -53,7 +53,7 @@ describe('EmbedCodeButton', () => {
     const wrapper = mount(<EmbedCodeButton {...defaultProps} />, {
       wrappingComponent: Provider,
       wrappingComponentProps: {
-        store: store,
+        store,
       },
     });
     wrapper.setState({

--- a/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -18,13 +18,18 @@
  */
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 
 import Link from 'src/components/Link';
 import TableElement from 'src/SqlLab/components/TableElement';
 import ColumnElement from 'src/SqlLab/components/ColumnElement';
+
 import { mockedActions, table } from './fixtures';
 
 describe('TableElement', () => {
+  const mockStore = configureStore([]);
+  const store = mockStore({});
   const mockedProps = {
     actions: mockedActions,
     table,
@@ -45,7 +50,11 @@ describe('TableElement', () => {
     expect(wrapper.find(ColumnElement)).toHaveLength(14);
   });
   it('mounts', () => {
-    mount(<TableElement {...mockedProps} />);
+    mount(
+      <Provider store={store}>
+        <TableElement {...mockedProps} />
+      </Provider>,
+    );
   });
   it('sorts columns', () => {
     const wrapper = shallow(<TableElement {...mockedProps} />);
@@ -58,7 +67,11 @@ describe('TableElement', () => {
     );
   });
   it('calls the collapseTable action', () => {
-    const wrapper = mount(<TableElement {...mockedProps} />);
+    const wrapper = mount(
+      <Provider store={store}>
+        <TableElement {...mockedProps} />
+      </Provider>,
+    );
     expect(mockedActions.collapseTable.called).toBe(false);
     wrapper.find('.table-name').simulate('click');
     expect(mockedActions.collapseTable.called).toBe(true);

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -114,14 +114,12 @@ export default function Button(props: ButtonProps) {
           {props.children}
         </SupersetButton>
         <ul className="dropdown-menu">
-          {dropdownItems.map(
-            (dropdownItem: DropdownItemProps) => (
-              <MenuItem key={`${dropdownItem.label}`} href={dropdownItem.url}>
-                <i className={`fa ${dropdownItem.icon}`} />
-                &nbsp; {dropdownItem.label}
-              </MenuItem>
-            ),
-          )}
+          {dropdownItems.map((dropdownItem: DropdownItemProps) => (
+            <MenuItem key={`${dropdownItem.label}`} href={dropdownItem.url}>
+              <i className={`fa ${dropdownItem.icon}`} />
+              &nbsp; {dropdownItem.label}
+            </MenuItem>
+          ))}
         </ul>
       </div>
     );

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -115,7 +115,7 @@ export default function Button(props: ButtonProps) {
         </SupersetButton>
         <ul className="dropdown-menu">
           {dropdownItems.map(
-            (dropdownItem: DropdownItemProps, index1: number) => (
+            (dropdownItem: DropdownItemProps) => (
               <MenuItem key={`${dropdownItem.label}`} href={dropdownItem.url}>
                 <i className={`fa ${dropdownItem.icon}`} />
                 &nbsp; {dropdownItem.label}

--- a/superset-frontend/src/components/CopyToClipboard.jsx
+++ b/superset-frontend/src/components/CopyToClipboard.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip, OverlayTrigger, MenuItem } from 'react-bootstrap';
 import { t } from '@superset-ui/translation';
-import withToasts from '../messageToasts/enhancers/withToasts';
+import withToasts from 'src/messageToasts/enhancers/withToasts';
 
 const propTypes = {
   copyNode: PropTypes.node,

--- a/superset-frontend/src/components/CopyToClipboard.jsx
+++ b/superset-frontend/src/components/CopyToClipboard.jsx
@@ -20,6 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip, OverlayTrigger, MenuItem } from 'react-bootstrap';
 import { t } from '@superset-ui/translation';
+import withToasts from '../messageToasts/enhancers/withToasts';
 
 const propTypes = {
   copyNode: PropTypes.node,
@@ -30,6 +31,7 @@ const propTypes = {
   inMenu: PropTypes.bool,
   wrapped: PropTypes.bool,
   tooltipText: PropTypes.string,
+  addDangerToast: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -41,7 +43,7 @@ const defaultProps = {
   tooltipText: t('Copy to clipboard'),
 };
 
-export default class CopyToClipboard extends React.Component {
+class CopyToClipboard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -95,9 +97,9 @@ export default class CopyToClipboard extends React.Component {
         throw new Error(t('Not successful'));
       }
     } catch (err) {
-      window.alert(
+      this.props.addDangerToast(
         t('Sorry, your browser does not support copying. Use Ctrl / Cmd + C!'),
-      ); // eslint-disable-line
+      );
     }
 
     document.body.removeChild(span);
@@ -193,6 +195,8 @@ export default class CopyToClipboard extends React.Component {
     return inMenu ? this.renderInMenu() : this.renderLink();
   }
 }
+
+export default withToasts(CopyToClipboard);
 
 CopyToClipboard.propTypes = propTypes;
 CopyToClipboard.defaultProps = defaultProps;

--- a/superset-frontend/src/components/ListViewCard/ImageLoader.tsx
+++ b/superset-frontend/src/components/ListViewCard/ImageLoader.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { useEffect } from 'react';
+import { logging } from '@superset-ui/core';
 
 interface ImageLoaderProps
   extends React.DetailedHTMLProps<
@@ -48,7 +49,7 @@ export default function ImageLoader({
           }
         })
         .catch(e => {
-          console.error(e); // eslint-disable-line no-console
+          logging.error(e);
           setImgSrc(fallback);
         });
     }

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -23,6 +23,7 @@ import {
 import { t } from '@superset-ui/translation';
 import rison from 'rison';
 import getClientErrorObject from 'src/utils/getClientErrorObject';
+import { logging } from '@superset-ui/core';
 
 export const createFetchRelated = (
   resource: string,
@@ -56,7 +57,7 @@ export const createFetchRelated = (
 export function createErrorHandler(handleErrorFunc: (errMsg?: string) => void) {
   return async (e: SupersetClientResponse | string) => {
     const parsedError = await getClientErrorObject(e);
-    console.error(e);
+    logging.error(e);
     handleErrorFunc(parsedError.message);
   };
 }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Tweaks a few things that were causing eslint warnings. Just trying to thin the herd. Notes in inline comments below. The most significant one is getting rid of an `alert()` in favor of a Toast, which required some tweaks to tests and whatnot.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Fixes existing tests, doesn't seem to require any new ones.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
