### PR TITLE
feat: base tabbed modal for new database CRUD UI

### DIFF
--- a/superset-frontend/images/icons/databases.svg
+++ b/superset-frontend/images/icons/databases.svg
@@ -1,0 +1,21 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3 5C2.44772 5 2 5.44772 2 6V10C2 10.5523 2.44772 11 3 11H21C21.5523 11 22 10.5523 22 10V6C22 5.44772 21.5523 5 21 5H3ZM3 13C2.44772 13 2 13.4477 2 14V18C2 18.5523 2.44772 19 3 19H21C21.5523 19 22 18.5523 22 18V14C22 13.4477 21.5523 13 21 13H3Z" fill="#323232"/>
+</svg>

--- a/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseList_spec.jsx
@@ -22,6 +22,7 @@ import configureStore from 'redux-mock-store';
 import { styledMount as mount } from 'spec/helpers/theming';
 
 import DatabaseList from 'src/views/CRUD/data/database/DatabaseList';
+import DatabaseModal from 'src/views/CRUD/data/database/DatabaseModal';
 import SubMenu from 'src/components/Menu/SubMenu';
 
 // store needed for withToasts(DatabaseList)
@@ -37,5 +38,9 @@ describe('DatabaseList', () => {
 
   it('renders a SubMenu', () => {
     expect(wrapper.find(SubMenu)).toExist();
+  });
+
+  it('renders a DatabaseModal', () => {
+    expect(wrapper.find(DatabaseModal)).toExist();
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { styledMount as mount } from 'spec/helpers/theming';
+
+import DatabaseModal from 'src/views/CRUD/data/database/DatabaseModal';
+import Modal from 'src/common/components/Modal';
+// import Tabs from 'src/common/components/Tabs';
+// import BaseTabs from 'src/common/components';
+
+// store needed for withToasts(DatabaseModal)
+const mockStore = configureStore([thunk]);
+const store = mockStore({});
+
+describe('DatabaseModal', () => {
+  const wrapper = mount(<DatabaseModal />, { context: { store } });
+
+  it('renders', () => {
+    expect(wrapper.find(DatabaseModal)).toExist();
+  });
+
+  it('renders a Modal', () => {
+    expect(wrapper.find(Modal)).toExist();
+  });
+
+});

--- a/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
@@ -40,5 +40,4 @@ describe('DatabaseModal', () => {
   it('renders a Modal', () => {
     expect(wrapper.find(Modal)).toExist();
   });
-
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
@@ -23,8 +23,6 @@ import { styledMount as mount } from 'spec/helpers/theming';
 
 import DatabaseModal from 'src/views/CRUD/data/database/DatabaseModal';
 import Modal from 'src/common/components/Modal';
-// import Tabs from 'src/common/components/Tabs';
-// import BaseTabs from 'src/common/components';
 
 // store needed for withToasts(DatabaseModal)
 const mockStore = configureStore([thunk]);

--- a/superset-frontend/src/common/components/Modal.tsx
+++ b/superset-frontend/src/common/components/Modal.tsx
@@ -92,6 +92,7 @@ export default function Modal({
   title,
   width,
   centered,
+  ...rest
 }: ModalProps) {
   return (
     <StyledModal
@@ -118,6 +119,7 @@ export default function Modal({
           {primaryButtonName}
         </Button>,
       ]}
+      {...rest}
     >
       {children}
     </StyledModal>

--- a/superset-frontend/src/common/components/Modal.tsx
+++ b/superset-frontend/src/common/components/Modal.tsx
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import styled from '@superset-ui/style';
+import { Modal as BaseModal } from 'src/common/components';
+import { t } from '@superset-ui/translation';
+import Button from 'src/views/CRUD/data/dataset/Button';
+
+interface ModalProps {
+  className?: string;
+  children: React.ReactNode;
+  disablePrimaryButton?: boolean;
+  onHide: () => void;
+  onHandledPrimaryAction: () => void;
+  primaryButtonName: string;
+  primaryButtonType?: 'primary' | 'danger';
+  show: boolean;
+  title: React.ReactNode;
+  width?: string;
+  centered?: boolean;
+}
+
+const StyledModal = styled(BaseModal)`
+  .ant-modal-header {
+    background-color: ${({ theme }) => theme.colors.grayscale.light4};
+    border-radius: ${({ theme }) => theme.borderRadius}px
+      ${({ theme }) => theme.borderRadius}px 0 0;
+
+    .ant-modal-title h4 {
+      display: flex;
+      margin: 0;
+      align-items: center;
+    }
+  }
+
+  .ant-modal-close-x {
+    display: flex;
+    align-items: center;
+
+    .close {
+      flex: 1 1 auto;
+      margin-bottom: 3px;
+      color: ${({ theme }) => theme.colors.secondary.dark1};
+      font-size: 32px;
+      font-weight: ${({ theme }) => theme.typography.weights.light};
+    }
+  }
+
+  .ant-modal-body {
+    padding: 18px;
+  }
+
+  .ant-modal-footer {
+    border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+    padding: 16px;
+
+    .btn {
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    .btn + .btn {
+      margin-left: 8px;
+    }
+  }
+`;
+
+export default function Modal({
+  children,
+  disablePrimaryButton = false,
+  onHide,
+  onHandledPrimaryAction,
+  primaryButtonName,
+  primaryButtonType = 'primary',
+  show,
+  title,
+  width,
+  centered,
+}: ModalProps) {
+  return (
+    <StyledModal
+      centered={!!centered}
+      onOk={onHandledPrimaryAction}
+      onCancel={onHide}
+      width={width || '600px'}
+      visible={show}
+      title={title}
+      closeIcon={
+        <span className="close" aria-hidden="true">
+          ×
+        </span>
+      }
+      footer={[
+        <Button key="back" onClick={onHide}>
+          {t('Cancel')}
+        </Button>,
+        <Button
+          key="submit"
+          disabled={disablePrimaryButton}
+          onClick={onHandledPrimaryAction}
+        >
+          {primaryButtonName}
+        </Button>,
+      ]}
+    >
+      {children}
+    </StyledModal>
+  );
+}

--- a/superset-frontend/src/common/components/Tabs.tsx
+++ b/superset-frontend/src/common/components/Tabs.tsx
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import styled from '@superset-ui/style';
+import { Tabs as BaseTabs } from 'src/common/components';
+
+const Tabs = styled(BaseTabs)`
+  margin-top: -18px;
+
+  .ant-tabs-nav-list {
+    width: 100%;
+  }
+
+  .ant-tabs-tab {
+    flex: 1 1 auto;
+    width: 0;
+
+    &.ant-tabs-tab-active .ant-tabs-tab-btn {
+      color: inherit;
+    }
+  }
+
+  .ant-tabs-tab-btn {
+    flex: 1 1 auto;
+    font-size: ${({ theme }) => theme.typography.sizes.s}px;
+    text-align: center;
+    text-transform: uppercase;
+
+    .required {
+      margin-left: ${({ theme }) => theme.gridUnit / 2}px;
+      color: ${({ theme }) => theme.colors.error.base};
+    }
+  }
+
+  .ant-tabs-ink-bar {
+    background: ${({ theme }) => theme.colors.secondary.base};
+  }
+`;
+
+export default Tabs;

--- a/superset-frontend/src/components/Icon/index.tsx
+++ b/superset-frontend/src/components/Icon/index.tsx
@@ -28,6 +28,7 @@ import { ReactComponent as CircleCheckIcon } from 'images/icons/circle-check.svg
 import { ReactComponent as CircleCheckSolidIcon } from 'images/icons/circle-check-solid.svg';
 import { ReactComponent as CloseIcon } from 'images/icons/close.svg';
 import { ReactComponent as CompassIcon } from 'images/icons/compass.svg';
+import { ReactComponent as DatabasesIcon } from 'images/icons/databases.svg';
 import { ReactComponent as DatasetPhysicalIcon } from 'images/icons/dataset_physical.svg';
 import { ReactComponent as DatasetVirtualIcon } from 'images/icons/dataset_virtual.svg';
 import { ReactComponent as DropdownArrowIcon } from 'images/icons/dropdown-arrow.svg';
@@ -57,6 +58,7 @@ type IconName =
   | 'circle-check'
   | 'close'
   | 'compass'
+  | 'databases'
   | 'dataset-physical'
   | 'dataset-virtual'
   | 'dropdown-arrow'
@@ -85,6 +87,7 @@ export const iconsRegistry: Record<
   'checkbox-on': CheckboxOnIcon,
   'circle-check-solid': CircleCheckSolidIcon,
   'circle-check': CircleCheckIcon,
+  databases: DatabasesIcon,
   'dataset-physical': DatasetPhysicalIcon,
   'dataset-virtual': DatasetVirtualIcon,
   'favorite-selected': FavoriteSelectedIcon,

--- a/superset-frontend/src/components/Icon/index.tsx
+++ b/superset-frontend/src/components/Icon/index.tsx
@@ -109,6 +109,7 @@ export const iconsRegistry: Record<
   trash: TrashIcon,
   warning: WarningIcon,
 };
+
 interface IconProps extends SVGProps<SVGSVGElement> {
   name: IconName;
 }
@@ -120,6 +121,7 @@ const Icon = ({
   ...rest
 }: IconProps) => {
   const Component = iconsRegistry[name];
+
   return (
     <Component color={color} viewBox={viewBox} data-test={name} {...rest} />
   );

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -16,31 +16,91 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-
+import { SupersetClient } from '@superset-ui/connection';
+import { t } from '@superset-ui/translation';
+import React, { useEffect, useState } from 'react';
+import { createErrorHandler } from 'src/views/CRUD/utils';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import { commonMenuData } from 'src/views/CRUD/data/common';
+import DatabaseModal from './DatabaseModal';
 
-interface DatasourceListProps {
+type DatabaseObject = {
+  id: number;
+  // TODO: add more props
+};
+
+interface DatabaseListProps {
   addDangerToast: (msg: string) => void;
   addSuccessToast: (msg: string) => void;
 }
 
-function DatasourceList({
-  addDangerToast,
-  addSuccessToast,
-}: DatasourceListProps) {
+function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
+  const [databaseModalOpen, setDatabaseModalOpen] = useState<boolean>(false);
+  const [currentDatabase, setCurrentDatabase] = useState<DatabaseObject | null>(
+    null,
+  );
+  const [permissions, setPermissions] = useState<string[]>([]);
+
+  const fetchDatasetInfo = () => {
+    SupersetClient.get({
+      endpoint: `/api/v1/dataset/_info`,
+    }).then(
+      ({ json: infoJson = {} }) => {
+        setPermissions(infoJson.permissions);
+      },
+      createErrorHandler(errMsg =>
+        addDangerToast(t('An error occurred while fetching datasets', errMsg)),
+      ),
+    );
+  };
+
+  useEffect(() => {
+    fetchDatasetInfo();
+  }, []);
+
+  const hasPerm = (perm: string) => {
+    if (!permissions.length) {
+      return false;
+    }
+
+    return Boolean(permissions.find(p => p === perm));
+  };
+
+  const canCreate = hasPerm('can_add');
+
   const menuData: SubMenuProps = {
     activeChild: 'Databases',
     ...commonMenuData,
   };
 
+  if (canCreate) {
+    menuData.primaryButton = {
+      name: (
+        <>
+          {' '}
+          <i className="fa fa-plus" /> {t('Database')}{' '}
+        </>
+      ),
+      onClick: () => {
+        // Ensure modal will be opened in add mode
+        setCurrentDatabase(null);
+        setDatabaseModalOpen(true);
+      },
+    };
+  }
+
   return (
     <>
       <SubMenu {...menuData} />
+      <DatabaseModal
+        database={currentDatabase}
+        show={databaseModalOpen}
+        onHide={() => setDatabaseModalOpen(false)}
+        onDatabaseAdd={() => {}}
+      />
     </>
   );
 }
 
-export default withToasts(DatasourceList);
+export default withToasts(DatabaseList);

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -23,12 +23,7 @@ import { createErrorHandler } from 'src/views/CRUD/utils';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import { commonMenuData } from 'src/views/CRUD/data/common';
-import DatabaseModal from './DatabaseModal';
-
-type DatabaseObject = {
-  id: number;
-  // TODO: add more props
-};
+import DatabaseModal, { DatabaseObject } from './DatabaseModal';
 
 interface DatabaseListProps {
   addDangerToast: (msg: string) => void;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -97,7 +97,9 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
         database={currentDatabase}
         show={databaseModalOpen}
         onHide={() => setDatabaseModalOpen(false)}
-        onDatabaseAdd={() => {}}
+        onDatabaseAdd={() => {
+          /* TODO: add database logic here */
+        }}
       />
     </>
   );

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -69,6 +69,12 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
     ...commonMenuData,
   };
 
+  const testDB = {
+    id: 10,
+    name: 'test',
+    uri: 'test/test/',
+  };
+
   if (canCreate) {
     menuData.primaryButton = {
       name: (
@@ -79,7 +85,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
       ),
       onClick: () => {
         // Ensure modal will be opened in add mode
-        setCurrentDatabase(null);
+        setCurrentDatabase(testDB);
         setDatabaseModalOpen(true);
       },
     };

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -69,12 +69,6 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
     ...commonMenuData,
   };
 
-  const testDB = {
-    id: 10,
-    name: 'test',
-    uri: 'test/test/',
-  };
-
   if (canCreate) {
     menuData.primaryButton = {
       name: (
@@ -85,7 +79,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
       ),
       onClick: () => {
         // Ensure modal will be opened in add mode
-        setCurrentDatabase(testDB);
+        setCurrentDatabase(null);
         setDatabaseModalOpen(true);
       },
     };

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -26,7 +26,7 @@ import Tabs from 'src/common/components/Tabs';
 import { Tabs as BaseTabs } from 'src/common/components';
 
 export type DatabaseObject = {
-  id: number;
+  id?: number;
   name: string;
   uri: string;
   // TODO: add more props
@@ -47,32 +47,95 @@ const StyledIcon = styled(Icon)`
   margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
 `;
 
+const StyledInputContainer = styled.div`
+  .label {
+    display: block;
+    padding: ${({ theme }) => theme.gridUnit}px 0;
+    color: ${({ theme }) => theme.colors.grayscale.light1};
+    text-align: left;
+  }
+
+  input[type='text'] {
+    padding: ${({ theme }) => theme.gridUnit * 1.5}px
+      ${({ theme }) => theme.gridUnit * 2}px;
+    border-style: none;
+    border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+    border-radius: ${({ theme }) => theme.gridUnit}px;
+
+    &[name='name'] {
+      width: 40%;
+    }
+  }
+`;
+
 const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   addDangerToast,
   addSuccessToast,
   onDatabaseAdd,
   onHide,
   show,
-  database,
+  database = null,
 }) => {
   // const [disableSave, setDisableSave] = useState(true);
-  const [disableSave] = useState(true);
+  const [disableSave] = useState<boolean>(true);
+  const [db, setDB] = useState<DatabaseObject | null>(null);
+  const [isHidden, setIsHidden] = useState<boolean>(true);
+
+  console.log('db', db);
+
+  // Functions
+  const hide = () => {
+    setIsHidden(true);
+    onHide();
+  };
+
   const onSave = () => {
     if (onDatabaseAdd) {
       onDatabaseAdd();
     }
 
-    onHide();
+    hide();
+  };
+
+  const onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const target = event.target;
+    const data = {
+      name: db ? db.name : '',
+      uri: db ? db.uri : '',
+      ...db,
+    };
+
+    data[target.name] = target.value;
+
+    setDB(data);
   };
 
   const isEditMode = database !== null;
+
+  // Initialize
+  if (
+    isEditMode &&
+    (!db || !db.id || (database && database.id !== db.id) || (isHidden && show))
+  ) {
+    setDB(database);
+  } else if (!isEditMode && (!db || db.id)) {
+    setDB({
+      name: '',
+      uri: '',
+    });
+  }
+
+  // Show/hide
+  if (isHidden && show) {
+    setIsHidden(false);
+  }
 
   return (
     <Modal
       className="database-modal"
       disablePrimaryButton={disableSave}
       onHandledPrimaryAction={onSave}
-      onHide={onHide}
+      onHide={hide}
       primaryButtonName={isEditMode ? t('Save') : t('Add')}
       width="750px"
       show={show}
@@ -93,7 +156,19 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           }
           key="1"
         >
-          Connection Form Data
+          <StyledInputContainer>
+            <div className="label">
+              {t('Datasource Name')}
+              <span className="required">*</span>
+            </div>
+            <input
+              type="text"
+              name="name"
+              value={db ? db.name : ''}
+              placeholder={t('Name your datasource')}
+              onChange={onInputChange}
+            />
+          </StyledInputContainer>
         </TabPane>
         <TabPane tab={<span>{t('Performance')}</span>} key="2">
           Performance Form Data

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -48,10 +48,14 @@ const StyledIcon = styled(Icon)`
 `;
 
 const StyledInputContainer = styled.div`
-  .label {
+  margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
+
+  .label,
+  .helper {
     display: block;
     padding: ${({ theme }) => theme.gridUnit}px 0;
     color: ${({ theme }) => theme.colors.grayscale.light1};
+    font-size: ${({ theme }) => theme.typography.sizes.s}px;
     text-align: left;
 
     .required {
@@ -60,7 +64,12 @@ const StyledInputContainer = styled.div`
     }
   }
 
+  .input-container {
+    display: flex;
+  }
+
   input[type='text'] {
+    flex: 1 1 auto;
     padding: ${({ theme }) => theme.gridUnit * 1.5}px
       ${({ theme }) => theme.gridUnit * 2}px;
     border-style: none;
@@ -68,6 +77,7 @@ const StyledInputContainer = styled.div`
     border-radius: ${({ theme }) => theme.gridUnit}px;
 
     &[name='name'] {
+      flex: 0 1 auto;
       width: 40%;
     }
   }
@@ -121,7 +131,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     (!db || !db.id || (database && database.id !== db.id) || (isHidden && show))
   ) {
     setDB(database);
-  } else if (!isEditMode && (!db || db.id)) {
+  } else if (!isEditMode && (!db || db.id || (isHidden && show))) {
     setDB({
       name: '',
       uri: '',
@@ -164,13 +174,41 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
               {t('Datasource Name')}
               <span className="required">*</span>
             </div>
-            <input
-              type="text"
-              name="name"
-              value={db ? db.name : ''}
-              placeholder={t('Name your datasource')}
-              onChange={onInputChange}
-            />
+            <div className="input-container">
+              <input
+                type="text"
+                name="name"
+                value={db ? db.name : ''}
+                placeholder={t('Name your datasource')}
+                onChange={onInputChange}
+              />
+            </div>
+          </StyledInputContainer>
+          <StyledInputContainer>
+            <div className="label">
+              {t('SQLAlchemy URI')}
+              <span className="required">*</span>
+            </div>
+            <div className="input-container">
+              <input
+                type="text"
+                name="uri"
+                value={db ? db.uri : ''}
+                placeholder={t('SQLAlchemy URI')}
+                onChange={onInputChange}
+              />
+            </div>
+            <div className="helper">
+              {t('Refer to the ')}
+              <a
+                href="https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('SQLAlchemy docs')}
+              </a>
+              {t(' for more information on how to structure your URI.')}
+            </div>
           </StyledInputContainer>
         </TabPane>
         <TabPane tab={<span>{t('Performance')}</span>} key="2">

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { FunctionComponent, useState } from 'react';
+import styled from '@superset-ui/style';
+import { t } from '@superset-ui/translation';
+import withToasts from 'src/messageToasts/enhancers/withToasts';
+import Icon from 'src/components/Icon';
+import Button from 'src/views/CRUD/data/dataset/Button';
+import { Tabs, Modal } from 'src/common/components';
+
+type DatabaseObject = {
+  id: number;
+  // TODO: add more props
+};
+
+interface DatabaseModalProps {
+  addDangerToast: (msg: string) => void;
+  addSuccessToast: (msg: string) => void;
+  onDatabaseAdd?: (database?: DatabaseObject) => void; // TODO: should we add a separate function for edit?
+  onHide: () => void;
+  show: boolean;
+  database?: DatabaseObject | null; // If included, will go into edit mode
+}
+
+const { TabPane } = Tabs;
+
+const StyledIcon = styled(Icon)`
+  margin: auto 10px auto 0;
+`;
+
+const StyledTabs = styled(Tabs)`
+  margin-top: -18px;
+
+  .ant-tabs-nav-list {
+    width: 100%;
+  }
+
+  .ant-tabs-tab {
+    width: 20%;
+
+    &.ant-tabs-tab-active .ant-tabs-tab-btn {
+      color: inherit;
+    }
+  }
+
+  .ant-tabs-tab-btn {
+    flex: 1 1 auto;
+    font-size: 12px;
+    text-align: center;
+    text-transform: uppercase;
+
+    .required {
+      margin-left: 2px;
+      color: #e04355;
+    }
+  }
+
+  .ant-tabs-ink-bar {
+    background: ${({ theme }) => theme.colors.secondary.base};
+  }
+`;
+
+const StyledModal = styled(Modal)`
+  .ant-modal-header {
+    background-color: ${({ theme }) => theme.colors.grayscale.light4};
+    border-radius: ${({ theme }) => theme.borderRadius}px
+      ${({ theme }) => theme.borderRadius}px 0 0;
+
+    .ant-modal-title h4 {
+      display: flex;
+      margin: 0;
+      align-items: center;
+    }
+  }
+
+  .ant-modal-close-x {
+    display: flex;
+    align-items: center;
+
+    .close {
+      flex: 1 1 auto;
+      margin-bottom: 3px;
+      color: ${({ theme }) => theme.colors.secondary.dark1};
+      font-size: 32px;
+      font-weight: ${({ theme }) => theme.typography.weights.light};
+    }
+  }
+
+  .ant-modal-body {
+    padding: 18px;
+  }
+
+  .ant-modal-footer {
+    border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+    padding: 16px;
+
+    .btn {
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    .btn + .btn {
+      margin-left: 8px;
+    }
+  }
+`;
+
+const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
+  addDangerToast,
+  addSuccessToast,
+  onDatabaseAdd,
+  onHide,
+  show,
+  database,
+}) => {
+  // const [disableSave, setDisableSave] = useState(true);
+  const [disableSave] = useState(true);
+  const onSave = () => {
+    if (onDatabaseAdd) {
+      onDatabaseAdd();
+    }
+  };
+
+  return (
+    <StyledModal
+      className="database-modal"
+      centered
+      onOk={onSave}
+      onCancel={onHide}
+      width="750px"
+      visible={show}
+      closeIcon={
+        <span className="close" aria-hidden="true">
+          ×
+        </span>
+      }
+      title={
+        <h4>
+          <StyledIcon name="databases" />
+          {t('Add Database')}
+        </h4>
+      }
+      footer={[
+        <Button key="back" onClick={onHide}>
+          {t('Cancel')}
+        </Button>,
+        <Button key="submit" disabled={disableSave} onClick={onSave}>
+          {t('Add')}
+        </Button>,
+      ]}
+    >
+      <StyledTabs defaultActiveKey="1">
+        <TabPane
+          tab={
+            <span>
+              Connection<span className="required">*</span>
+            </span>
+          }
+          key="1"
+        >
+          Connection Form Data
+        </TabPane>
+        <TabPane tab="Performance" key="2">
+          Performance Form Data
+        </TabPane>
+        <TabPane tab="SQL Lab Settings" key="3">
+          SQL Lab Settings Form Data
+        </TabPane>
+        <TabPane tab="Security" key="4">
+          Security Form Data
+        </TabPane>
+        <TabPane tab="Extra" key="5">
+          Extra Form Data
+        </TabPane>
+      </StyledTabs>
+    </StyledModal>
+  );
+};
+
+export default withToasts(DatabaseModal);

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -43,7 +43,7 @@ interface DatabaseModalProps {
 const { TabPane } = Tabs;
 
 const StyledIcon = styled(Icon)`
-  margin: auto 10px auto 0;
+  margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
 `;
 
 const StyledTabs = styled(Tabs)`
@@ -54,7 +54,8 @@ const StyledTabs = styled(Tabs)`
   }
 
   .ant-tabs-tab {
-    width: 20%;
+    flex: 1 1 auto;
+    width: 0;
 
     &.ant-tabs-tab-active .ant-tabs-tab-btn {
       color: inherit;
@@ -63,13 +64,13 @@ const StyledTabs = styled(Tabs)`
 
   .ant-tabs-tab-btn {
     flex: 1 1 auto;
-    font-size: 12px;
+    font-size: ${({ theme }) => theme.typography.sizes.s}px;
     text-align: center;
     text-transform: uppercase;
 
     .required {
-      margin-left: 2px;
-      color: #e04355;
+      margin-left: ${({ theme }) => theme.gridUnit / 2}px;
+      color: ${({ theme }) => theme.colors.error.base};
     }
   }
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -53,6 +53,11 @@ const StyledInputContainer = styled.div`
     padding: ${({ theme }) => theme.gridUnit}px 0;
     color: ${({ theme }) => theme.colors.grayscale.light1};
     text-align: left;
+
+    .required {
+      margin-left: ${({ theme }) => theme.gridUnit / 2}px;
+      color: ${({ theme }) => theme.colors.error.base};
+    }
   }
 
   input[type='text'] {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -21,8 +21,8 @@ import styled from '@superset-ui/style';
 import { t } from '@superset-ui/translation';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import Icon from 'src/components/Icon';
-import Button from 'src/views/CRUD/data/dataset/Button';
-import { Tabs, Modal } from 'src/common/components';
+import Modal from 'src/common/components/Modal';
+import { Tabs } from 'src/common/components';
 
 type DatabaseObject = {
   id: number;
@@ -76,51 +76,6 @@ const StyledTabs = styled(Tabs)`
   }
 `;
 
-const StyledModal = styled(Modal)`
-  .ant-modal-header {
-    background-color: ${({ theme }) => theme.colors.grayscale.light4};
-    border-radius: ${({ theme }) => theme.borderRadius}px
-      ${({ theme }) => theme.borderRadius}px 0 0;
-
-    .ant-modal-title h4 {
-      display: flex;
-      margin: 0;
-      align-items: center;
-    }
-  }
-
-  .ant-modal-close-x {
-    display: flex;
-    align-items: center;
-
-    .close {
-      flex: 1 1 auto;
-      margin-bottom: 3px;
-      color: ${({ theme }) => theme.colors.secondary.dark1};
-      font-size: 32px;
-      font-weight: ${({ theme }) => theme.typography.weights.light};
-    }
-  }
-
-  .ant-modal-body {
-    padding: 18px;
-  }
-
-  .ant-modal-footer {
-    border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
-    padding: 16px;
-
-    .btn {
-      font-size: 12px;
-      text-transform: uppercase;
-    }
-
-    .btn + .btn {
-      margin-left: 8px;
-    }
-  }
-`;
-
 const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   addDangerToast,
   addSuccessToast,
@@ -135,35 +90,27 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     if (onDatabaseAdd) {
       onDatabaseAdd();
     }
+
+    onHide();
   };
 
+  const isEditMode = database !== null;
+
   return (
-    <StyledModal
+    <Modal
       className="database-modal"
-      centered
-      onOk={onSave}
-      onCancel={onHide}
+      disablePrimaryButton={disableSave}
+      onHandledPrimaryAction={onSave}
+      onHide={onHide}
+      primaryButtonName={isEditMode ? t('Save') : t('Add')}
       width="750px"
-      visible={show}
-      closeIcon={
-        <span className="close" aria-hidden="true">
-          ×
-        </span>
-      }
+      show={show}
       title={
         <h4>
           <StyledIcon name="databases" />
-          {t('Add Database')}
+          {isEditMode ? t('Edit Database') : t('Add Database')}
         </h4>
       }
-      footer={[
-        <Button key="back" onClick={onHide}>
-          {t('Cancel')}
-        </Button>,
-        <Button key="submit" disabled={disableSave} onClick={onSave}>
-          {t('Add')}
-        </Button>,
-      ]}
     >
       <StyledTabs defaultActiveKey="1">
         <TabPane
@@ -189,7 +136,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           Extra Form Data
         </TabPane>
       </StyledTabs>
-    </StyledModal>
+    </Modal>
   );
 };
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -86,8 +86,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const [db, setDB] = useState<DatabaseObject | null>(null);
   const [isHidden, setIsHidden] = useState<boolean>(true);
 
-  console.log('db', db);
-
   // Functions
   const hide = () => {
     setIsHidden(true);

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -118,23 +118,24 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         <TabPane
           tab={
             <span>
-              Connection<span className="required">*</span>
+              {t('Connection')}
+              <span className="required">*</span>
             </span>
           }
           key="1"
         >
           Connection Form Data
         </TabPane>
-        <TabPane tab="Performance" key="2">
+        <TabPane tab={<span>{t('Performance')}</span>} key="2">
           Performance Form Data
         </TabPane>
-        <TabPane tab="SQL Lab Settings" key="3">
+        <TabPane tab={<span>{t('SQL Lab Settings')}</span>} key="3">
           SQL Lab Settings Form Data
         </TabPane>
-        <TabPane tab="Security" key="4">
+        <TabPane tab={<span>{t('Security')}</span>} key="4">
           Security Form Data
         </TabPane>
-        <TabPane tab="Extra" key="5">
+        <TabPane tab={<span>{t('Extra')}</span>} key="5">
           Extra Form Data
         </TabPane>
       </StyledTabs>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -24,8 +24,10 @@ import Icon from 'src/components/Icon';
 import Modal from 'src/common/components/Modal';
 import { Tabs } from 'src/common/components';
 
-type DatabaseObject = {
+export type DatabaseObject = {
   id: number;
+  name: string;
+  uri: string;
   // TODO: add more props
 };
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -22,7 +22,8 @@ import { t } from '@superset-ui/translation';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import Icon from 'src/components/Icon';
 import Modal from 'src/common/components/Modal';
-import { Tabs } from 'src/common/components';
+import Tabs from 'src/common/components/Tabs';
+import { Tabs as BaseTabs } from 'src/common/components';
 
 export type DatabaseObject = {
   id: number;
@@ -40,43 +41,10 @@ interface DatabaseModalProps {
   database?: DatabaseObject | null; // If included, will go into edit mode
 }
 
-const { TabPane } = Tabs;
+const { TabPane } = BaseTabs;
 
 const StyledIcon = styled(Icon)`
   margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
-`;
-
-const StyledTabs = styled(Tabs)`
-  margin-top: -18px;
-
-  .ant-tabs-nav-list {
-    width: 100%;
-  }
-
-  .ant-tabs-tab {
-    flex: 1 1 auto;
-    width: 0;
-
-    &.ant-tabs-tab-active .ant-tabs-tab-btn {
-      color: inherit;
-    }
-  }
-
-  .ant-tabs-tab-btn {
-    flex: 1 1 auto;
-    font-size: ${({ theme }) => theme.typography.sizes.s}px;
-    text-align: center;
-    text-transform: uppercase;
-
-    .required {
-      margin-left: ${({ theme }) => theme.gridUnit / 2}px;
-      color: ${({ theme }) => theme.colors.error.base};
-    }
-  }
-
-  .ant-tabs-ink-bar {
-    background: ${({ theme }) => theme.colors.secondary.base};
-  }
 `;
 
 const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
@@ -115,7 +83,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         </h4>
       }
     >
-      <StyledTabs defaultActiveKey="1">
+      <Tabs defaultActiveKey="1">
         <TabPane
           tab={
             <span>
@@ -139,7 +107,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         <TabPane tab={<span>{t('Extra')}</span>} key="5">
           Extra Form Data
         </TabPane>
-      </StyledTabs>
+      </Tabs>
     </Modal>
   );
 };

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
@@ -42,7 +42,7 @@ interface DatasetModalProps {
 }
 
 const StyledIcon = styled(Icon)`
-  margin: auto 10px auto 0;
+  margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
 `;
 
 const TableSelectorContainer = styled.div`


### PR DESCRIPTION
### SUMMARY
- [x] Add `DatabaseModal` opened from new `DatabaseList` UI
- [x] Sections separated into sections based on relevance
- [x] Modal can accept a database object to trigger edit mode
- [x] Add styled ant-d `Modal` to `src/common/components`
- [x] As per #10642 new UI is only available when both `ENABLE_REACT_CRUD_VIEWS` and `SIP_34_DATABASE_UI` config flags are turned on

Tabbed sections will be built in later PRs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1395" alt="Screen Shot 2020-08-24 at 3 38 04 PM" src="https://user-images.githubusercontent.com/8216382/91107839-2069ac80-e62b-11ea-9cba-62351d970da8.png">
<img width="1392" alt="Screen Shot 2020-08-24 at 3 38 14 PM" src="https://user-images.githubusercontent.com/8216382/91107840-22337000-e62b-11ea-8458-2516f2df95d5.png">
<img width="1393" alt="Screen Shot 2020-08-24 at 4 55 21 PM" src="https://user-images.githubusercontent.com/8216382/91107841-23649d00-e62b-11ea-865a-13658638aede.png">

### TEST PLAN

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
