### PR TITLE
feature: Adding extra_filters to warm_up_cache

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1431,12 +1431,16 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         """Warms up the cache for the slice or table.
 
         Note for slices a force refresh occurs.
+
+        In terms of the `extra_filters` these can be obtained from records in the JSON
+        encoded `logs.json` column associated with the `explore_json` action.
         """
         session = db.session()
         slice_id = request.args.get("slice_id")
         dashboard_id = request.args.get("dashboard_id")
         table_name = request.args.get("table_name")
         db_name = request.args.get("db_name")
+        extra_filters = request.args.get("extra_filters")
 
         if not slice_id and not (table_name and db_name):
             return json_error_response(
@@ -1482,8 +1486,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             try:
                 form_data = get_form_data(slc.id, use_slice_data=True)[0]
                 if dashboard_id:
-                    form_data["extra_filters"] = get_dashboard_extra_filters(
-                        slc.id, dashboard_id
+                    form_data["extra_filters"] = (
+                        json.loads(extra_filters)
+                        if extra_filters
+                        else get_dashboard_extra_filters(slc.id, dashboard_id)
                     )
 
                 obj = get_viz(

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -576,6 +576,17 @@ class TestCore(SupersetTestCase):
         )
         assert len(data) > 0
 
+        dashboard = self.get_dash_by_slug("births")
+
+        assert self.get_json_resp(
+            f"/superset/warm_up_cache?dashboard_id={dashboard.id}&slice_id={slc.id}"
+        ) == [{"slice_id": slc.id, "viz_error": None, "viz_status": "success"}]
+
+        assert self.get_json_resp(
+            f"/superset/warm_up_cache?dashboard_id={dashboard.id}&slice_id={slc.id}&extra_filters="
+            + quote(json.dumps([{"col": "name", "op": "in", "val": ["Jennifer"]}]))
+        ) == [{"slice_id": slc.id, "viz_error": None, "viz_status": "success"}]
+
     def test_shortner(self):
         self.login(username="admin")
         data = (


### PR DESCRIPTION
### SUMMARY

At Airbnb on a nightly basis we warm up recently consumed dashboard slices, which adheres to the default dashboard filters (if applicable). We carried out an analysis which modeled how various factored contributed to the cache hit rate and cache efficiency rate, i.e., what proportion of pre-warmed payloads were actually consumed.

A clear mechanism for increasing the cache hit rate seems to be to warm up dashboard slices with specified filters (and not simply rely on the default) based on event logs (which were fixed in https://github.com/apache/incubator-superset/pull/10197). This PR provides a mechanism for providing the dashboard filters (which materialize as `extra_filters` in the form-data). If not specified it falls back to using the default dashboard filters which is the current logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI and added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
