### PR TITLE
fix: only call signal if executing on the main thread

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -26,6 +26,7 @@ import re
 import signal
 import smtplib
 import tempfile
+import threading
 import traceback
 import uuid
 import zlib

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -631,8 +631,9 @@ class timeout:  # pylint: disable=invalid-name
 
     def __enter__(self) -> None:
         try:
-            signal.signal(signal.SIGALRM, self.handle_timeout)
-            signal.alarm(self.seconds)
+            if threading.current_thread() == threading.main_thread():
+                signal.signal(signal.SIGALRM, self.handle_timeout)
+                signal.alarm(self.seconds)
         except ValueError as ex:
             logger.warning("timeout can't be used in the current context")
             logger.exception(ex)


### PR DESCRIPTION
### SUMMARY
Fixing Signal  error that complains about signal only working in main thread.

ValueError: signal only works in main thread
  File "superset/utils/core.py", line 624, in __enter__
    signal.signal(signal.SIGALRM, self.handle_timeout)
  File "signal.py", line 47, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))

signal only works in main thread

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
