### PR TITLE
feat(row-level-security): add hook for customizing form dropdowns

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -869,6 +869,16 @@ TALISMAN_CONFIG = {
 # a custom security config could potentially give access to setting filters on
 # tables that users do not have access to.
 ENABLE_ROW_LEVEL_SECURITY = False
+# It is possible to customize which tables and roles are featured in the RLS
+# dropdown. When set, this dict is assigned to `add_form_query_rel_fields` and
+# `edit_form_query_rel_fields` on `RowLevelSecurityFiltersModelView`. Example:
+#
+# from flask_appbuilder.models.sqla import filters
+# RLS_FORM_QUERY_REL_FIELDS = {
+#     "roles": [["name", filters.FilterStartsWith, "RlsRole"]]
+#     "tables": [["table_name", filters.FilterContains, "rls"]]
+# }
+RLS_FORM_QUERY_REL_FIELDS: Optional[Dict[str, List[List[Any]]]] = None
 
 #
 # Flask session cookie options

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -274,6 +274,9 @@ class RowLevelSecurityFiltersModelView(  # pylint: disable=too-many-ancestors
         "creator": _("Creator"),
         "modified": _("Modified"),
     }
+    if app.config["RLS_FORM_QUERY_REL_FIELDS"]:
+        add_form_query_rel_fields = app.config["RLS_FORM_QUERY_REL_FIELDS"]
+        edit_form_query_rel_fields = add_form_query_rel_fields
 
 
 class TableModelView(  # pylint: disable=too-many-ancestors


### PR DESCRIPTION
### SUMMARY
Add a hook to `config.py` to be able to customize to which tables and roles RLS can be applied.

### TEST PLAN
Local testing

### SCREENSHOT
An example with the following config: 
```python
from flask_appbuilder.models.sqla import filters
RLS_FORM_QUERY_REL_FIELDS = {
    "roles": [["name", filters.FilterStartsWith, "A"]],
}
```
![image](https://user-images.githubusercontent.com/33317356/91282989-b835da80-e792-11ea-9abf-c361b4fc1451.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
