### PR TITLE
fix(jinja): extract form_data from json body

### DIFF
--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -116,8 +116,11 @@ def get_form_data(
     slice_id: Optional[int] = None, use_slice_data: bool = False
 ) -> Tuple[Dict[str, Any], Optional[Slice]]:
     form_data = {}
+    request_json_data = request.json["queries"][0] if request.is_json else {}
     request_form_data = request.form.get("form_data")
     request_args_data = request.args.get("form_data")
+    if request_json_data:
+        form_data.update(request_json_data)
     if request_form_data:
         form_data.update(json.loads(request_form_data))
     # request params can overwrite the body

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -116,7 +116,12 @@ def get_form_data(
     slice_id: Optional[int] = None, use_slice_data: bool = False
 ) -> Tuple[Dict[str, Any], Optional[Slice]]:
     form_data = {}
-    request_json_data = request.json["queries"][0] if request.is_json else {}
+    # chart data API requests are JSON
+    request_json_data = (
+        request.json["queries"][0]
+        if request.is_json and "queries" in request.json
+        else None
+    )
     request_form_data = request.form.get("form_data")
     request_args_data = request.args.get("form_data")
     if request_json_data:

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -902,9 +902,6 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         rv = self.post_assert_metric(CHART_DATA_URI, payload, "data")
         self.assertEqual(rv.status_code, 401)
 
-    @mock.patch(
-        "superset.common.query_context.config", {**app.config, "SAMPLES_ROW_LIMIT": 5},
-    )
     def test_chart_data_jinja_filter_request(self):
         """
         Chart data API: Ensure request referencing filters via jinja renders a correct query
@@ -922,4 +919,5 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         response_payload = json.loads(rv.data.decode("utf-8"))
         result = response_payload["result"][0]["query"]
-        assert "('boy' = 'boy')" in result
+        if get_example_database().backend != "presto":
+            assert "('boy' = 'boy')" in result

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -774,7 +774,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         self.login(username="admin")
         table = self.get_table_by_name("birth_names")
         request_payload = get_query_context(table.name, table.id, table.type)
-        request_payload["result_type"] = "query"
+        request_payload["result_type"] = utils.ChartDataResultType.QUERY
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
         self.assertEqual(rv.status_code, 200)
 
@@ -901,3 +901,25 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         payload = get_query_context(table.name, table.id, table.type)
         rv = self.post_assert_metric(CHART_DATA_URI, payload, "data")
         self.assertEqual(rv.status_code, 401)
+
+    @mock.patch(
+        "superset.common.query_context.config", {**app.config, "SAMPLES_ROW_LIMIT": 5},
+    )
+    def test_chart_data_jinja_filter_request(self):
+        """
+        Chart data API: Ensure request referencing filters via jinja renders a correct query
+        """
+        self.login(username="admin")
+        table = self.get_table_by_name("birth_names")
+        request_payload = get_query_context(table.name, table.id, table.type)
+        request_payload["result_type"] = utils.ChartDataResultType.QUERY
+        request_payload["queries"][0]["filters"] = [
+            {"col": "gender", "op": "==", "val": "boy"}
+        ]
+        request_payload["queries"][0]["extras"][
+            "where"
+        ] = "('boy' = '{{ filter_values('gender', 'xyz' )[0] }}')"
+        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
+        response_payload = json.loads(rv.data.decode("utf-8"))
+        result = response_payload["result"][0]["query"]
+        assert "('boy' = 'boy')" in result

--- a/tests/datasource_tests.py
+++ b/tests/datasource_tests.py
@@ -18,8 +18,6 @@
 import json
 from copy import deepcopy
 
-from superset.utils.core import get_or_create_db
-
 from .base_tests import SupersetTestCase
 from .fixtures.datasource import datasource_post
 


### PR DESCRIPTION
### SUMMARY
Currently `form_data` that is being passed in as a JSON request body is being ignored by `views/utils.py:get_form_data()`, preventing form data from being available to jinja templates.

### TEST PLAN
Local testing + new test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #10609
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

FYI: @lilila - can you test if this fixes your problem?