### PR TITLE
fix(filter-box): don't add empty filter to filtersChoices

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/FilterBox_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/FilterBox_spec.jsx
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import FilterBox from 'src/visualizations/FilterBox/FilterBox';
+
+describe('FilterBox', () => {
+  it('should only add defined non-predefined options to filtersChoices', () => {
+    const wrapper = shallow(
+      <FilterBox
+        chartId={1001}
+        datasource={{ id: 1 }}
+        filtersChoices={{
+          name: [
+            { id: 'John', text: 'John', metric: 1234 },
+            { id: 'Jane', text: 'Jane', metric: 345678 },
+          ],
+        }}
+        filtersFields={[
+          {
+            asc: false,
+            clearable: true,
+            column: 'name',
+            key: 'name',
+            label: 'name',
+            metric: 'sum__COUNT',
+            multiple: true,
+          },
+        ]}
+        origSelectedValues={{}}
+      />,
+    );
+    const inst = wrapper.instance();
+    // choose a predefined value
+    inst.setState({ selectedValues: { name: ['John'] } });
+    expect(inst.props.filtersChoices.name.length).toEqual(2);
+    // reset selection
+    inst.setState({ selectedValues: { name: null } });
+    expect(inst.props.filtersChoices.name.length).toEqual(2);
+    // Add a new name
+    inst.setState({ selectedValues: { name: 'James' } });
+    expect(inst.props.filtersChoices.name.length).toEqual(3);
+  });
+});

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -341,7 +341,7 @@ class FilterBox extends React.Component {
           ? selectedValues[key]
           : [selectedValues[key]];
         selectedValuesForKey
-          .filter(value => !choiceIds.has(value))
+          .filter(value => value !== null && !choiceIds.has(value))
           .forEach(value => {
             choices.unshift({
               filter: key,


### PR DESCRIPTION
### SUMMARY
When a FilterBox is cleared out, a null filter is added to the list of filter choices. This ensures that null valued selections are not added to `filtersChoices`. I think this regression was caused by #10210

### SCREENSHOTS
See linked issue for steps to reproduce.

### TEST PLAN
CI + new test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Closes #10672
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
