### PR TITLE
fix: shorten url with extra request parameters

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
@@ -59,12 +59,12 @@ describe('EmbedCodeButton', () => {
     wrapper.setState({
       height: '1000',
       width: '2000',
-      shortUrl: 'http://localhostendpoint_url&height=1000',
+      shortUrlId: 100,
     });
 
     const trigger = wrapper.find(OverlayTrigger);
     trigger.simulate('click');
-    expect(spy1.args[0][1]).toBe('standalone');
+    expect(spy1.callCount).toBe(1);
     expect(spy2.callCount).toBe(1);
 
     spy1.restore();
@@ -72,11 +72,14 @@ describe('EmbedCodeButton', () => {
   });
 
   it('returns correct embed code', () => {
+    const stub = sinon
+      .stub(exploreUtils, 'getURIDirectory')
+      .callsFake(() => 'endpoint_url');
     const wrapper = mount(<EmbedCodeButton {...defaultProps} />);
     wrapper.setState({
       height: '1000',
       width: '2000',
-      shortUrl: 'http://localhostendpoint_url&height=1000',
+      shortUrlId: 100,
     });
     const embedHTML =
       '<iframe\n' +
@@ -85,9 +88,10 @@ describe('EmbedCodeButton', () => {
       '  seamless\n' +
       '  frameBorder="0"\n' +
       '  scrolling="no"\n' +
-      '  src="http://localhostendpoint_url&height=1000"\n' +
+      '  src="http://localhostendpoint_url?r=100&standalone=true&height=1000"\n' +
       '>\n' +
       '</iframe>';
     expect(wrapper.instance().generateEmbedHTML()).toBe(embedHTML);
+    stub.restore();
   });
 });

--- a/superset-frontend/src/explore/components/EmbedCodeButton.jsx
+++ b/superset-frontend/src/explore/components/EmbedCodeButton.jsx
@@ -23,7 +23,7 @@ import { t } from '@superset-ui/translation';
 
 import FormLabel from 'src/components/FormLabel';
 import CopyToClipboard from 'src/components/CopyToClipboard';
-import { getExploreLongUrl } from '../exploreUtils';
+import { getExploreLongUrl, getURIDirectory } from '../exploreUtils';
 import { getShortUrl } from '../../utils/common';
 
 const propTypes = {
@@ -36,7 +36,7 @@ export default class EmbedCodeButton extends React.Component {
     this.state = {
       height: '400',
       width: '600',
-      shortUrl: '',
+      shortUrlId: 0,
     };
     this.handleInputChange = this.handleInputChange.bind(this);
     this.getCopyUrl = this.getCopyUrl.bind(this);
@@ -44,18 +44,14 @@ export default class EmbedCodeButton extends React.Component {
   }
 
   onShortUrlSuccess(shortUrl) {
+    const shortUrlId = shortUrl.substring(shortUrl.indexOf('/r/') + 3);
     this.setState(() => ({
-      shortUrl,
+      shortUrlId,
     }));
   }
 
   getCopyUrl() {
-    const srcLink = `${
-      window.location.origin +
-      getExploreLongUrl(this.props.latestQueryFormData, 'standalone')
-    }&height=${this.state.height}`;
-
-    return getShortUrl(srcLink)
+    return getShortUrl(getExploreLongUrl(this.props.latestQueryFormData))
       .then(this.onShortUrlSuccess)
       .catch(this.props.addDangerToast);
   }
@@ -69,6 +65,9 @@ export default class EmbedCodeButton extends React.Component {
   }
 
   generateEmbedHTML() {
+    const srcLink = `${window.location.origin + getURIDirectory()}?r=${
+      this.state.shortUrlId
+    }&standalone=true&height=${this.state.height}`;
     return (
       '<iframe\n' +
       `  width="${this.state.width}"\n` +
@@ -76,7 +75,7 @@ export default class EmbedCodeButton extends React.Component {
       '  seamless\n' +
       '  frameBorder="0"\n' +
       '  scrolling="no"\n' +
-      `  src="${this.state.shortUrl}"\n` +
+      `  src="${srcLink}"\n` +
       '>\n' +
       '</iframe>'
     );


### PR DESCRIPTION
### SUMMARY
In #10651 I added a feature that standalone iframe can use shorten url.
But later I found there is issue for the existed solution: we store full url in `url` tbl, which supposed to be content for `form_data` parameter only. For standalone chart, its full url is like: `form_data={key1:value1, key2: value2}&standalone=true&height=400`. 

This PR is to fix this issue:
- remove extra parameters standalone and height from shorten url request, request shorten url with only form_data parameter.
- create standalone url from frontend, with shorten url id and attach standalone=true and height parameter. So the shorten url for standalone chart will be like `http://localhost:8080/superset/explore/?r=8015&standalone=true&height=600`

### TEST PLAN
CI and manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #10651
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@mistercrunch @michellethomas 