### PR TITLE
style: add border between menu and submenu

### DIFF
--- a/superset-frontend/spec/javascripts/components/Menu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/Menu_spec.jsx
@@ -18,7 +18,8 @@
  */
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Nav, NavDropdown, MenuItem } from 'react-bootstrap';
+import { Nav, MenuItem } from 'react-bootstrap';
+import NavDropdown from 'src/components/NavDropdown';
 import { supersetTheme, ThemeProvider } from '@superset-ui/style';
 
 import Menu from 'src/components/Menu/Menu';

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -18,7 +18,8 @@
  */
 import React from 'react';
 import { t } from '@superset-ui/translation';
-import { Nav, Navbar, NavDropdown, NavItem, MenuItem } from 'react-bootstrap';
+import { Nav, Navbar, NavItem, MenuItem } from 'react-bootstrap';
+import NavDropdown from 'src/components/NavDropdown';
 import styled from '@superset-ui/style';
 import MenuObject, { MenuObjectProps } from './MenuObject';
 import NewMenu from './NewMenu';
@@ -56,6 +57,10 @@ export interface MenuProps {
 }
 
 const StyledHeader = styled.header`
+  &:nth-last-of-type(2) nav {
+    margin-bottom: 2px;
+  }
+
   .caret {
     display: none;
   }

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -23,7 +23,7 @@ import Button, { OnClickHandler } from 'src/components/Button';
 
 const StyledHeader = styled.header`
   position: relative;
-  top: -20px;
+  top: -18px;
   .navbar-header .navbar-brand {
     font-weight: ${({ theme }) => theme.typography.weights.bold};
   }

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -22,8 +22,6 @@ import { Nav, Navbar, MenuItem } from 'react-bootstrap';
 import Button, { OnClickHandler } from 'src/components/Button';
 
 const StyledHeader = styled.header`
-  position: relative;
-  top: -18px;
   .navbar-header .navbar-brand {
     font-weight: ${({ theme }) => theme.typography.weights.bold};
   }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Recent changes to the menu and submenu CSS resulted in the loss of a border between the 2. This pr should fix it. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="3008" alt="Screen Shot 2020-08-27 at 10 29 09 AM" src="https://user-images.githubusercontent.com/10255196/91475273-34dabe80-e850-11ea-851c-aaa4fe15c675.png">

After:
<img width="3006" alt="Screen Shot 2020-08-27 at 10 53 45 AM" src="https://user-images.githubusercontent.com/10255196/91477723-9e100100-e853-11ea-8ff8-593580038627.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
 👀 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
