### PR TITLE
fix(db-engine-spec): execute oracle DML statement bug in sqllab

### DIFF
--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -74,5 +74,5 @@ class OracleEngineSpec(BaseEngineSpec):
         :return: Result of query
         """
         if not cursor.description:
-            return [()]
-        super().fetch_data(cursor, limit)
+            return []
+        return super().fetch_data(cursor, limit)

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -15,12 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import (
-    Any,
-    List,
-    Optional,
-    Tuple
-)
+from typing import Any, List, Optional, Tuple
 
 from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 from superset.utils import core as utils

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -15,7 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import Optional
+from typing import (
+    Any,
+    List,
+    Optional,
+    Tuple
+)
 
 from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 from superset.utils import core as utils
@@ -58,3 +63,18 @@ class OracleEngineSpec(BaseEngineSpec):
     @classmethod
     def epoch_ms_to_dttm(cls) -> str:
         return "TO_DATE('1970-01-01','YYYY-MM-DD')+(1/24/60/60/1000)*{col}"
+    
+    @classmethod
+    def fetch_data(cls, cursor: Any, limit: int) -> List[Tuple]:
+        """
+        :param cursor: Cursor instance
+        :param limit: Maximum number of rows to be returned by the cursor
+        :return: Result of query
+        """
+        if not cursor.description:
+            return []
+        if cls.arraysize:
+            cursor.arraysize = cls.arraysize
+        if cls.limit_method == LimitMethod.FETCH_MANY:
+            return cursor.fetchmany(limit)
+        return cursor.fetchall()

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -65,12 +65,14 @@ class OracleEngineSpec(BaseEngineSpec):
         return "TO_DATE('1970-01-01','YYYY-MM-DD')+(1/24/60/60/1000)*{col}"
     
     @classmethod
-    def fetch_data(cls, cursor: Any, limit: Optional[int] = None) -> List[Tuple[Any, ...]]:
+    def fetch_data(
+        cls, cursor: Any, limit: Optional[int] = None
+    ) -> List[Tuple[Any, ...]]:
         """
         :param cursor: Cursor instance
         :param limit: Maximum number of rows to be returned by the cursor
         :return: Result of query
         """
         if not cursor.description:
-            return []
+            return [()]
         super().fetch_data(cursor, limit)

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -73,8 +73,4 @@ class OracleEngineSpec(BaseEngineSpec):
         """
         if not cursor.description:
             return []
-        if cls.arraysize:
-            cursor.arraysize = cls.arraysize
-        if cls.limit_method == LimitMethod.FETCH_MANY:
-            return cursor.fetchmany(limit)
-        return cursor.fetchall()
+        super().fetch_data(cursor, limit)

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -65,7 +65,7 @@ class OracleEngineSpec(BaseEngineSpec):
         return "TO_DATE('1970-01-01','YYYY-MM-DD')+(1/24/60/60/1000)*{col}"
     
     @classmethod
-    def fetch_data(cls, cursor: Any, limit: Optional[int]) -> List[Tuple]:
+    def fetch_data(cls, cursor: Any, limit: Optional[int] = None) -> List[Tuple[Any, ...]]:
         """
         :param cursor: Cursor instance
         :param limit: Maximum number of rows to be returned by the cursor

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -63,7 +63,7 @@ class OracleEngineSpec(BaseEngineSpec):
     @classmethod
     def epoch_ms_to_dttm(cls) -> str:
         return "TO_DATE('1970-01-01','YYYY-MM-DD')+(1/24/60/60/1000)*{col}"
-    
+
     @classmethod
     def fetch_data(
         cls, cursor: Any, limit: Optional[int] = None

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -65,7 +65,7 @@ class OracleEngineSpec(BaseEngineSpec):
         return "TO_DATE('1970-01-01','YYYY-MM-DD')+(1/24/60/60/1000)*{col}"
     
     @classmethod
-    def fetch_data(cls, cursor: Any, limit: int) -> List[Tuple]:
+    def fetch_data(cls, cursor: Any, limit: Optional[int]) -> List[Tuple]:
         """
         :param cursor: Cursor instance
         :param limit: Maximum number of rows to be returned by the cursor


### PR DESCRIPTION
when i execute oracle sql statements like update in SQLLAB, get "oracle error: not a query" error. 

Refer https://www.python.org/dev/peps/pep-0249/, superset old version use
`cursor.description` ，because this attribute will be None for operations that do not return rows or if the cursor has not had an operation invoked via the .execute*() method yet.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
