### PR TITLE
fix: move menu reorg logic from crud app into Menu component

### DIFF
--- a/superset-frontend/spec/javascripts/components/Menu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/Menu_spec.jsx
@@ -22,7 +22,7 @@ import { Nav, MenuItem } from 'react-bootstrap';
 import NavDropdown from 'src/components/NavDropdown';
 import { supersetTheme, ThemeProvider } from '@superset-ui/style';
 
-import Menu from 'src/components/Menu/Menu';
+import { Menu } from 'src/components/Menu/Menu';
 
 const defaultProps = {
   data: {

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -39,10 +39,6 @@ import setupApp from '../setup/setupApp';
 import setupPlugins from '../setup/setupPlugins';
 import Welcome from './CRUD/welcome/Welcome';
 import ToastPresenter from '../messageToasts/containers/ToastPresenter';
-import {
-  MenuObjectProps,
-  MenuObjectChildProps,
-} from '../components/Menu/MenuObject';
 
 setupApp();
 setupPlugins();
@@ -61,57 +57,6 @@ const store = createStore(
   {},
   compose(applyMiddleware(thunk), initEnhancer(false)),
 );
-
-// Menu items that should go into settings dropdown
-const settingsMenus = {
-  Security: true,
-  Manage: true,
-};
-
-// Menu items that should be ignored
-const ignore = {
-  'Import Dashboards': true,
-};
-
-// Cycle through menu.menu to build out cleanedMenu and settings
-const cleanedMenu: object[] = [];
-const settings: object[] = [];
-
-menu.menu.forEach((item: any) => {
-  if (!item) {
-    return;
-  }
-
-  const children: (MenuObjectProps | string)[] = [];
-  const newItem = {
-    ...item,
-  };
-
-  // Filter childs
-  if (item.childs) {
-    item.childs.forEach((child: MenuObjectChildProps | string) => {
-      if (typeof child === 'string') {
-        children.push(child);
-      } else if (
-        (child as MenuObjectChildProps).label &&
-        !ignore.hasOwnProperty(child.label)
-      ) {
-        children.push(child);
-      }
-    });
-
-    newItem.childs = children;
-  }
-
-  if (!settingsMenus.hasOwnProperty(item.name)) {
-    cleanedMenu.push(newItem);
-  } else {
-    settings.push(newItem);
-  }
-});
-
-menu.menu = cleanedMenu;
-menu.settings = settings;
 
 const App = () => (
   <Provider store={store}>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Recently a PR was merged that reorganized some of the menu options into a settings dropdown. That logic was only applied to one of the react "apps" https://github.com/preset-io/incubator-superset/blob/3e374dab076ae8baeab6148203ed1a74d1627a59/superset-frontend/src/views/App.tsx#L66

This PR moves that logic into the menu component so that all instances of the menu have the same reorg applied. 
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="3007" alt="Screen Shot 2020-08-28 at 10 55 50 AM" src="https://user-images.githubusercontent.com/10255196/91601141-fdd2de80-e91d-11ea-8b60-2e069a786b47.png">

After:
<img width="3008" alt="Screen Shot 2020-08-28 at 10 56 13 AM" src="https://user-images.githubusercontent.com/10255196/91601146-fe6b7500-e91d-11ea-9257-3ec1d287f9f4.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- 👀  (this changes can be seen in sqllab, on master there's a Security and Manage dropdown, on this branch, those options live under the settings dropdown) 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
