### PR TITLE
More Label touchups (margins)

### DIFF
--- a/superset-frontend/src/SqlLab/components/LimitControl.tsx
+++ b/superset-frontend/src/SqlLab/components/LimitControl.tsx
@@ -146,7 +146,7 @@ export default class LimitControl extends React.PureComponent<
   render() {
     return (
       <div>
-        <Label className="pointer" onClick={this.handleToggle}>
+        <Label onClick={this.handleToggle}>
           LIMIT {this.props.value || this.props.maxRow}
         </Label>
         <Overlay

--- a/superset-frontend/src/components/CachedLabel.jsx
+++ b/superset-frontend/src/components/CachedLabel.jsx
@@ -71,7 +71,7 @@ class CacheLabel extends React.PureComponent {
     return (
       <TooltipWrapper tooltip={this.state.tooltipContent} label="cache-desc">
         <Label
-          className={`${this.props.className} m-r-5 pointer`}
+          className={`${this.props.className}`}
           bsStyle={labelStyle}
           onClick={this.props.onClick}
           onMouseOver={this.mouseOver.bind(this)}

--- a/superset-frontend/src/components/Label/Label.stories.tsx
+++ b/superset-frontend/src/components/Label/Label.stories.tsx
@@ -48,7 +48,6 @@ export const LabelGallery = () => (
       <Label
         key={opt}
         bsStyle={opt}
-        style={{ marginRight: '10px' }}
         onClick={action('clicked')}
       >
         {`style: "${opt}"`}

--- a/superset-frontend/src/components/Label/Label.stories.tsx
+++ b/superset-frontend/src/components/Label/Label.stories.tsx
@@ -45,11 +45,7 @@ export const bsStyleKnob = {
 export const LabelGallery = () => (
   <>
     {Object.values(bsStyleKnob.options).map(opt => (
-      <Label
-        key={opt}
-        bsStyle={opt}
-        onClick={action('clicked')}
-      >
+      <Label key={opt} bsStyle={opt} onClick={action('clicked')}>
         {`style: "${opt}"`}
       </Label>
     ))}

--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -115,8 +115,10 @@ export default function Label(props: LabelProps) {
       ? props.bsStyle
       : 'default',
     className: cx({
-      [`${props.className}`]:props.className,
-      [`label-${props.bsStyle}`]: !officialBootstrapStyles.includes(props.bsStyle || ''),
+      [`${props.className}`]: props.className,
+      [`label-${props.bsStyle}`]: !officialBootstrapStyles.includes(
+        props.bsStyle || '',
+      ),
     }),
   };
   return <SupersetLabel {...labelProps}>{props.children}</SupersetLabel>;

--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -114,8 +114,7 @@ export default function Label(props: LabelProps) {
     bsStyle: officialBootstrapStyles.includes(props.bsStyle || '')
       ? props.bsStyle
       : 'default',
-    className: cx({
-      [`${props.className}`]: props.className,
+    className: cx(props.className, {
       [`label-${props.bsStyle}`]: !officialBootstrapStyles.includes(
         props.bsStyle || '',
       ),

--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -19,12 +19,14 @@
 import React from 'react';
 import { Label as BootstrapLabel } from 'react-bootstrap';
 import styled from '@superset-ui/style';
+import cx from 'classnames';
 
 export type OnClickHandler = React.MouseEventHandler<BootstrapLabel>;
 
 export interface LabelProps {
   key?: string;
   className?: string;
+  id?: string;
   tooltip?: string;
   placement?: string;
   onClick?: OnClickHandler;
@@ -34,6 +36,15 @@ export interface LabelProps {
 }
 
 const SupersetLabel = styled(BootstrapLabel)`
+  /* un-bunch them! */
+  margin-right: ${({ theme }) => theme.gridUnit}px;
+  &:first-of-type {
+    margin-left: 0;
+  }
+  &:last-of-type {
+    margin-right: 0;
+  }
+
   cursor: ${({ onClick }) => (onClick ? 'pointer' : 'default')};
   transition: background-color ${({ theme }) => theme.transitionTiming}s;
   &.label-warning {
@@ -103,9 +114,10 @@ export default function Label(props: LabelProps) {
     bsStyle: officialBootstrapStyles.includes(props.bsStyle || '')
       ? props.bsStyle
       : 'default',
-    className: officialBootstrapStyles.includes(props.bsStyle || '')
-      ? undefined
-      : `label-${props.bsStyle}`,
+    className: cx({
+      [`${props.className}`]:props.className,
+      [`label-${props.bsStyle}`]: !officialBootstrapStyles.includes(props.bsStyle || ''),
+    }),
   };
   return <SupersetLabel {...labelProps}>{props.children}</SupersetLabel>;
 }

--- a/superset-frontend/src/components/TableSelector.jsx
+++ b/superset-frontend/src/components/TableSelector.jsx
@@ -247,9 +247,7 @@ export default class TableSelector extends React.PureComponent {
   renderDatabaseOption(db) {
     return (
       <span title={db.database_name}>
-        <Label bsStyle="default">
-          {db.backend}
-        </Label>
+        <Label bsStyle="default">{db.backend}</Label>
         {db.database_name}
       </span>
     );

--- a/superset-frontend/src/components/TableSelector.jsx
+++ b/superset-frontend/src/components/TableSelector.jsx
@@ -247,7 +247,7 @@ export default class TableSelector extends React.PureComponent {
   renderDatabaseOption(db) {
     return (
       <span title={db.database_name}>
-        <Label bsStyle="default" className="m-r-5">
+        <Label bsStyle="default">
           {db.backend}
         </Label>
         {db.database_name}

--- a/superset-frontend/src/components/Timer.tsx
+++ b/superset-frontend/src/components/Timer.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { Label } from 'react-bootstrap';
+import Label from 'src/components/Label';
 
 import { now, fDuration } from '../modules/dates';
 
@@ -73,7 +73,7 @@ export default function Timer({
   });
 
   return (
-    <Label id="timer" className="m-r-5" bsStyle={status}>
+    <Label id="timer" bsStyle={status}>
       {clockStr}
     </Label>
   );

--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -72,8 +72,9 @@ const StyledHeader = styled.div`
     align-items: center;
     justify-content: flex-end;
 
-    .btn-group {
+    > .btn-group {
       flex: 0 0 auto;
+      margin-left: ${({ theme }) => theme.gridUnit}px;
     }
   }
 `;

--- a/superset-frontend/src/explore/components/RowCountLabel.jsx
+++ b/superset-frontend/src/explore/components/RowCountLabel.jsx
@@ -47,7 +47,7 @@ export default function RowCountLabel({ rowcount, limit, suffix }) {
   );
   return (
     <TooltipWrapper label="tt-rowcount" tooltip={tooltip}>
-      <Label bsStyle={bsStyle} className="m-r-5 pointer">
+      <Label bsStyle={bsStyle}>
         {formattedRowCount} {suffix}
       </Label>
     </TooltipWrapper>

--- a/superset-frontend/src/explore/components/controls/FixedOrMetricControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FixedOrMetricControl.jsx
@@ -104,7 +104,7 @@ export default class FixedOrMetricControl extends React.Component {
     return (
       <div>
         <ControlHeader {...this.props} />
-        <Label className="pointer" onClick={this.toggle}>
+        <Label onClick={this.toggle}>
           {this.state.type === controlTypes.fixed && (
             <span>{this.state.fixedValue}</span>
           )}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This makes some margins intrinsic to the Label component. These margins are NOT applied on the left side of the `first-of-type` or right side of `last-of-type`. This means we shouldn't need the `m-r-5` classes` in any Labels. We also don't really need the `pointer` class on labels with an `onClick` prop, so I killed that too. One example of a `last-of-type` that still DOES need margin on the right is in the screenshot below, but I added that margin to the context of the wrapping container, which is what we should _probably_ be doing where exceptions apply to the rule.

![image](https://user-images.githubusercontent.com/812905/91621482-0d671d00-e948-11ea-9c4d-a85ad98bc450.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Storybook, in-situ viewing, CI passing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
