### PR TITLE
style: Let explore toolbar header wrap when screen gets narrow

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -60,6 +60,7 @@ const StyledHeader = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  flex-wrap: wrap;
 
   span[role='button'] {
     display: flex;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Tiny PR; I _think_ the title and the screenshots below say it all :)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/91623206-52428200-e94f-11ea-8011-045acec7f9f9.png)

After:
![image](https://user-images.githubusercontent.com/812905/91623186-3dfe8500-e94f-11ea-9d0d-afb9913d013c.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
