### PR TITLE
style: Tabs now support AntD compound components (+ basic stories)

### DIFF
--- a/superset-frontend/.storybook/main.js
+++ b/superset-frontend/.storybook/main.js
@@ -22,7 +22,7 @@ const path = require('path');
 const customConfig = require('../webpack.config.js');
 
 module.exports = {
-  stories: ['../src/components/**/*.stories.@(t|j)sx'],
+stories: ['../src/@(components|common)/**/*.stories.@(t|j)sx'],
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-links',

--- a/superset-frontend/src/common/components/Tabs.tsx
+++ b/superset-frontend/src/common/components/Tabs.tsx
@@ -17,9 +17,9 @@
  * under the License.
  */
 import styled from '@superset-ui/style';
-import { Tabs as BaseTabs } from 'src/common/components';
+import { Tabs as AntdTabs } from 'src/common/components';
 
-const Tabs = styled(BaseTabs)`
+const StyledTabs = styled(AntdTabs)`
   margin-top: -18px;
 
   .ant-tabs-nav-list {
@@ -51,5 +51,11 @@ const Tabs = styled(BaseTabs)`
     background: ${({ theme }) => theme.colors.secondary.base};
   }
 `;
+
+const StyledTabPane = styled(AntdTabs.TabPane)``;
+
+const Tabs = Object.assign(StyledTabs, {
+  TabPane: StyledTabPane,
+});
 
 export default Tabs;

--- a/superset-frontend/src/common/components/common.stories.tsx
+++ b/superset-frontend/src/common/components/common.stories.tsx
@@ -18,13 +18,13 @@
  */
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-// import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import Modal from './Modal';
 import Tabs from './Tabs';
 
 export default {
   title: 'Common Components',
-  // decorators: [withKnobs],
+  decorators: [withKnobs],
 };
 
 export const StyledModal = () => (
@@ -42,11 +42,19 @@ export const StyledModal = () => (
 );
 
 export const StyledTabs = () => (
-  <Tabs defaultActiveKey="1">
-    <Tabs.TabPane tab="Tab 1" key="1">
+  <Tabs defaultActiveKey="1" centered={boolean('Center tabs', false)}>
+    <Tabs.TabPane
+      tab="Tab 1"
+      key="1"
+      disabled={boolean('Tab 1 Disabled', false)}
+    >
       Tab 1 Content!
     </Tabs.TabPane>
-    <Tabs.TabPane tab="Tab 2" key="2">
+    <Tabs.TabPane
+      tab="Tab 2"
+      key="2"
+      disabled={boolean('Tab 2 Disabled', false)}
+    >
       Tab 2 Content!
     </Tabs.TabPane>
   </Tabs>

--- a/superset-frontend/src/common/components/common.stories.tsx
+++ b/superset-frontend/src/common/components/common.stories.tsx
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+// import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
+import Modal from './Modal';
+import Tabs from './Tabs';
+
+export default {
+  title: 'Common Components',
+  // decorators: [withKnobs],
+};
+
+export const StyledModal = () => (
+  <Modal
+    disablePrimaryButton={false}
+    onHandledPrimaryAction={action('Primary Action')}
+    primaryButtonName="Danger"
+    primaryButtonType="danger"
+    show
+    onHide={action('hidden')}
+    title="I'm a modal!"
+  >
+    <div>hi!</div>
+  </Modal>
+);
+
+export const StyledTabs = () => (
+  <Tabs defaultActiveKey="1">
+    <Tabs.TabPane tab="Tab 1" key="1">
+      Tab 1 Content!
+    </Tabs.TabPane>
+    <Tabs.TabPane tab="Tab 2" key="2">
+      Tab 2 Content!
+    </Tabs.TabPane>
+  </Tabs>
+);

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -23,7 +23,6 @@ import withToasts from 'src/messageToasts/enhancers/withToasts';
 import Icon from 'src/components/Icon';
 import Modal from 'src/common/components/Modal';
 import Tabs from 'src/common/components/Tabs';
-import { Tabs as BaseTabs } from 'src/common/components';
 
 export type DatabaseObject = {
   id?: number;
@@ -40,8 +39,6 @@ interface DatabaseModalProps {
   show: boolean;
   database?: DatabaseObject | null; // If included, will go into edit mode
 }
-
-const { TabPane } = BaseTabs;
 
 const StyledIcon = styled(Icon)`
   margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
@@ -160,7 +157,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       }
     >
       <Tabs defaultActiveKey="1">
-        <TabPane
+        <Tabs.TabPane
           tab={
             <span>
               {t('Connection')}
@@ -210,19 +207,19 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
               {t(' for more information on how to structure your URI.')}
             </div>
           </StyledInputContainer>
-        </TabPane>
-        <TabPane tab={<span>{t('Performance')}</span>} key="2">
+        </Tabs.TabPane>
+        <Tabs.TabPane tab={<span>{t('Performance')}</span>} key="2">
           Performance Form Data
-        </TabPane>
-        <TabPane tab={<span>{t('SQL Lab Settings')}</span>} key="3">
+        </Tabs.TabPane>
+        <Tabs.TabPane tab={<span>{t('SQL Lab Settings')}</span>} key="3">
           SQL Lab Settings Form Data
-        </TabPane>
-        <TabPane tab={<span>{t('Security')}</span>} key="4">
+        </Tabs.TabPane>
+        <Tabs.TabPane tab={<span>{t('Security')}</span>} key="4">
           Security Form Data
-        </TabPane>
-        <TabPane tab={<span>{t('Extra')}</span>} key="5">
+        </Tabs.TabPane>
+        <Tabs.TabPane tab={<span>{t('Extra')}</span>} key="5">
           Extra Form Data
-        </TabPane>
+        </Tabs.TabPane>
       </Tabs>
     </Modal>
   );


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR Rewires the styled Antd Tabs component a bit, so that it can be used with the same compound component API of the AntD component(s) it's derived from.

The PR also includes (admittedly lightweight) Storybook for the tabs component and the Modal component, plus the changes needed to load these stories from the `/common` folder

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
The storybook pretty much is the test. It _might_ be worth adding a test that simply mounts all the `/common/components/` components just to make sure they don't bomb out for whatever reason, but we can address that in another PR. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Could use review from @nytai / @riahk / @lilykuang 