### PR TITLE
feat: add source tab to DatasourceEditor

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -37,6 +37,7 @@ describe('Datasource control', () => {
     cy.get('#datasource_menu').click();
     cy.get('a').contains('Edit Datasource').click();
     // create new metric
+    cy.get('a[role="tab"]').contains('Metrics').click();
     cy.get('button').contains('Add Item').click();
     cy.get('input[value="<new metric>"]').click();
     cy.get('input[value="<new metric>"]')
@@ -53,6 +54,7 @@ describe('Datasource control', () => {
     // delete metric
     cy.get('#datasource_menu').click();
     cy.get('a').contains('Edit Datasource').click();
+    cy.get('a[role="tab"]').contains('Metrics').click();
     cy.get(`input[value="${newMetricName}"]`)
       .closest('tr')
       .find('.fa-trash')

--- a/superset-frontend/spec/javascripts/datasource/DatasourceModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/DatasourceModal_spec.jsx
@@ -60,12 +60,10 @@ async function mountAndWait(props = mockedProps) {
 }
 
 describe('DatasourceModal', () => {
-  fetchMock.post(SAVE_ENDPOINT, SAVE_PAYLOAD);
-  const callsP = fetchMock.put(SAVE_ENDPOINT, SAVE_PAYLOAD);
-
   let wrapper;
 
   beforeEach(async () => {
+    fetchMock.reset();
     wrapper = await mountAndWait();
   });
 
@@ -82,6 +80,7 @@ describe('DatasourceModal', () => {
   });
 
   it('saves on confirm', async () => {
+    const callsP = fetchMock.post(SAVE_ENDPOINT, SAVE_PAYLOAD);
     act(() => {
       wrapper
         .find('button[data-test="datasource-modal-save"]')
@@ -94,6 +93,9 @@ describe('DatasourceModal', () => {
       okButton.simulate('click');
     });
     await waitForComponentToPaint(wrapper);
-    expect(callsP._calls).toHaveLength(2); /* eslint no-underscore-dangle: 0 */
+    const expected = ['http://localhost/datasource/save/'];
+    expect(callsP._calls.map(call => call[0])).toEqual(
+      expected,
+    ); /* eslint no-underscore-dangle: 0 */
   });
 });

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -323,6 +323,10 @@ table.table-no-hover tr:hover {
   margin-top: 10px;
 }
 
+.m-t-20 {
+  margin-top: 20px;
+}
+
 .m-b-10 {
   margin-bottom: 10px;
 }

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -835,10 +835,6 @@ class TestDatasetApi(SupersetTestCase):
         self.login(username="admin")
         rv = self.get_assert_metric(uri, "export")
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(
-            rv.headers["Content-Disposition"],
-            generate_download_headers("yaml")["Content-Disposition"],
-        )
 
         cli_export = export_to_dict(
             session=db.session,


### PR DESCRIPTION
### SUMMARY
Add a `Source` tab to the dataset editor

TODO: expose database/schema selector on virtual dataset, this will require some refactoring around `TableSelector`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="938" alt="Screen Shot 2020-08-29 at 4 50 28 PM" src="https://user-images.githubusercontent.com/487433/91648054-c8122080-ea17-11ea-9189-8df182370802.png">
<img width="1003" alt="Screen Shot 2020-08-29 at 4 50 21 PM" src="https://user-images.githubusercontent.com/487433/91648055-ca747a80-ea17-11ea-90bd-aa09a55674ea.png">
