### PR TITLE
Fix local docker deployment

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -20,7 +20,7 @@
 ######################################################################
 FROM preset/superset:dev
 
-COPY ./requirements/*.txt ./docker/requirements-*.txt/ /app/requirements/
+COPY ./requirements/*.txt ./docker/requirements-*.txt /app/requirements/
 
 USER root
 # Cache everything for dev purposes...


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue where dependencies listed in ./docker/requirements-local.txt are not installed

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. Create ./docker/requirements-local.txt with this content
```
pybigquery>=0.4.10
```
2. Start the docker containers: `docker-compose up --build --force-recreate`. It doesn't actually install the pybigquery library. When you try to create a database connection to BigQuery from the UI, it'll throw the error.
3. After applying this fix, stop and start the containers: `docker-compose up --build --force-recreate`. This time, it'll install the library and you'll be able to create the database connection to BigQuery.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
