### PR TITLE
chore: add logging for "dashboard" action

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1584,6 +1584,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         session.commit()
         return json_success(json.dumps({"published": dash.published}))
 
+    @event_logger.log_this
     @has_access
     @expose("/dashboard/<dashboard_id_or_slug>/")
     def dashboard(  # pylint: disable=too-many-locals


### PR DESCRIPTION
### SUMMARY
Add log decorator to `/dashboard/<id>` endpoint. This will help us tracking server-side processing time for dashboard requests.


### TEST PLAN
CI and manual test.


@john-bodley @etr2460 
