### PR TITLE
refactor: convert DatasetList schema filter to use new distinct api

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/data/dataset/DatasetList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/dataset/DatasetList_spec.jsx
@@ -35,6 +35,7 @@ const store = mockStore({});
 
 const datasetsInfoEndpoint = 'glob:*/api/v1/dataset/_info*';
 const datasetsOwnersEndpoint = 'glob:*/api/v1/dataset/related/owners*';
+const datasetsSchemaEndpoint = 'glob:*/api/v1/dataset/distinct/schema*';
 const databaseEndpoint = 'glob:*/api/v1/dataset/related/database*';
 const datasetsEndpoint = 'glob:*/api/v1/dataset/?*';
 
@@ -55,6 +56,9 @@ fetchMock.get(datasetsInfoEndpoint, {
   permissions: ['can_list', 'can_edit', 'can_add', 'can_delete'],
 });
 fetchMock.get(datasetsOwnersEndpoint, {
+  result: [],
+});
+fetchMock.get(datasetsSchemaEndpoint, {
   result: [],
 });
 fetchMock.get(datasetsEndpoint, {
@@ -97,10 +101,18 @@ describe('DatasetList', () => {
 
   it('fetches data', () => {
     const callsD = fetchMock.calls(/dataset\/\?q/);
-    expect(callsD).toHaveLength(2);
-    expect(callsD[1][0]).toMatchInlineSnapshot(
+    expect(callsD).toHaveLength(1);
+    expect(callsD[0][0]).toMatchInlineSnapshot(
       `"http://localhost/api/v1/dataset/?q=(order_column:changed_on_delta_humanized,order_direction:desc,page:0,page_size:25)"`,
     );
+  });
+
+  it('fetches owner filter values', () => {
+    expect(fetchMock.calls(/dataset\/related\/owners/)).toHaveLength(1);
+  });
+
+  it('fetches schema filter values', () => {
+    expect(fetchMock.calls(/dataset\/distinct\/schema/)).toHaveLength(1);
   });
 
   it('shows/hides bulk actions when bulk actions is clicked', async () => {

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -24,12 +24,12 @@ import rison from 'rison';
 import getClientErrorObject from 'src/utils/getClientErrorObject';
 import { logging } from '@superset-ui/core';
 
-export const createFetchRelated = (
+const createFetchResourceMethod = (method: string) => (
   resource: string,
   relation: string,
   handleError: (error: Response) => void,
 ) => async (filterValue = '', pageIndex?: number, pageSize?: number) => {
-  const resourceEndpoint = `/api/v1/${resource}/related/${relation}`;
+  const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
 
   try {
     const queryParams = rison.encode({
@@ -52,6 +52,9 @@ export const createFetchRelated = (
   }
   return [];
 };
+
+export const createFetchRelated = createFetchResourceMethod('related');
+export const createFetchDistinct = createFetchResourceMethod('distinct');
 
 export function createErrorHandler(handleErrorFunc: (errMsg?: string) => void) {
   return async (e: SupersetClientResponse | string) => {

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -415,5 +415,9 @@ class BaseSupersetModelRestApi(ModelRestApi):
         # Apply pagination
         result = self.datamodel.apply_pagination(query, page, page_size).all()
         # produce response
-        result = [{"text": item[0]} for item in result if item[0] is not None]
+        result = [
+            {"text": item[0], "value": item[0]}
+            for item in result
+            if item[0] is not None
+        ]
         return self.response(200, count=count, result=result)

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -192,15 +192,16 @@ class TestDatasetApi(SupersetTestCase):
                     "columns", "information_schema", [], get_main_database()
                 )
             )
+            schema_values = [
+                "",
+                "admin_database",
+                "information_schema",
+                "public",
+                "superset",
+            ]
             expected_response = {
                 "count": 5,
-                "result": [
-                    {"text": ""},
-                    {"text": "admin_database"},
-                    {"text": "information_schema"},
-                    {"text": "public"},
-                    {"text": "superset"},
-                ],
+                "result": [{"text": val, "value": val} for val in schema_values],
             }
             self.login(username="admin")
             uri = "api/v1/dataset/distinct/schema"
@@ -213,17 +214,26 @@ class TestDatasetApi(SupersetTestCase):
             query_parameter = {"filter": "inf"}
             pg_test_query_parameter(
                 query_parameter,
-                {"count": 1, "result": [{"text": "information_schema"}]},
+                {
+                    "count": 1,
+                    "result": [
+                        {"text": "information_schema", "value": "information_schema"}
+                    ],
+                },
             )
 
             query_parameter = {"page": 0, "page_size": 1}
             pg_test_query_parameter(
-                query_parameter, {"count": 5, "result": [{"text": ""}]},
+                query_parameter, {"count": 5, "result": [{"text": "", "value": ""}]},
             )
 
             query_parameter = {"page": 1, "page_size": 1}
             pg_test_query_parameter(
-                query_parameter, {"count": 5, "result": [{"text": "admin_database"}]}
+                query_parameter,
+                {
+                    "count": 5,
+                    "result": [{"text": "admin_database", "value": "admin_database"}],
+                },
             )
 
         for dataset in datasets:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Recently, a new api for fetching distinct column values (used for select filter values) was merged: https://github.com/apache/incubator-superset/pull/10595. This PR updates the schemas filter for DatasetList to use the new api. It also creates a generic function for generating fetch functions, compliant with the react-select async api, for fetching distinct values on a resource. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
-CI, unit tests, manual testing. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
