### PR TITLE
fix(presto): default unknown types to string type

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -902,16 +902,18 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return label_mutated
 
     @classmethod
-    def get_sqla_column_type(cls, type_: str) -> Optional[TypeEngine]:
+    def get_sqla_column_type(cls, type_: Optional[str]) -> Optional[TypeEngine]:
         """
         Return a sqlalchemy native column type that corresponds to the column type
         defined in the data source (return None to use default type inferred by
-        SQLAlchemy). Override `_column_type_mappings` for specific needs
+        SQLAlchemy). Override `column_type_mappings` for specific needs
         (see MSSQL for example of NCHAR/NVARCHAR handling).
 
         :param type_: Column type returned by inspector
         :return: SqlAlchemy column type
         """
+        if not type_:
+            return None
         for regex, sqla_type in cls.column_type_mappings:
             match = regex.match(type_)
             if match:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -269,11 +269,9 @@ class PrestoEngineSpec(BaseEngineSpec):
                         if column_type is None:
                             column_type = types.String()
                             logger.info(
-                                "Did not recognize type {} of column {}".format(
-                                    # pylint: disable=logging-format-interpolation
-                                    field_info[1],
-                                    field_info[0],
-                                )
+                                "Did not recognize type %s of column %s",
+                                field_info[1],
+                                field_info[0],
                             )
                         if field_info[1] == "array" or field_info[1] == "row":
                             stack.append((field_info[0], field_info[1]))
@@ -390,11 +388,9 @@ class PrestoEngineSpec(BaseEngineSpec):
             if column_type is None:
                 column_type = types.String()
                 logger.info(
-                    "Did not recognize type {} of column {}".format(
-                        # pylint: disable=logging-format-interpolation
-                        column.Type,
-                        column.Column,
-                    )
+                    "Did not recognize type %s of column %s",
+                    str(column.Type),
+                    str(column.Column),
                 )
             column_info = cls._create_column_info(column.Column, column_type)
             column_info["nullable"] = getattr(column, "Null", True)

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -174,7 +174,9 @@ class PrestoEngineSpec(BaseEngineSpec):
         return [row[0] for row in results]
 
     @classmethod
-    def _create_column_info(cls, name: str, data_type: str) -> Dict[str, Any]:
+    def _create_column_info(
+        cls, name: str, data_type: types.TypeEngine
+    ) -> Dict[str, Any]:
         """
         Create column info object
         :param name: column name
@@ -265,8 +267,13 @@ class PrestoEngineSpec(BaseEngineSpec):
                         # overall structural data type
                         column_type = cls.get_sqla_column_type(field_info[1])
                         if column_type is None:
-                            raise NotImplementedError(
-                                _("Unknown column type: %(col)s", col=field_info[1])
+                            column_type = types.String()
+                            logger.info(
+                                "Did not recognize type {} of column {}".format(
+                                    # pylint: disable=logging-format-interpolation
+                                    field_info[1],
+                                    field_info[0],
+                                )
                             )
                         if field_info[1] == "array" or field_info[1] == "row":
                             stack.append((field_info[0], field_info[1]))
@@ -381,8 +388,13 @@ class PrestoEngineSpec(BaseEngineSpec):
             # otherwise column is a basic data type
             column_type = cls.get_sqla_column_type(column.Type)
             if column_type is None:
-                raise NotImplementedError(
-                    _("Unknown column type: %(col)s", col=column_type)
+                column_type = types.String()
+                logger.info(
+                    "Did not recognize type {} of column {}".format(
+                        # pylint: disable=logging-format-interpolation
+                        column.Type,
+                        column.Column,
+                    )
                 )
             column_info = cls._create_column_info(column.Column, column_type)
             column_info["nullable"] = getattr(column, "Null", True)

--- a/tests/db_engine_specs/presto_tests.py
+++ b/tests/db_engine_specs/presto_tests.py
@@ -511,3 +511,6 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
 
         sqla_type = PrestoEngineSpec.get_sqla_column_type("integer")
         assert isinstance(sqla_type, types.Integer)
+
+        sqla_type = PrestoEngineSpec.get_sqla_column_type(None)
+        assert sqla_type is None


### PR DESCRIPTION
### SUMMARY
A recent PR #10658 introduced a regression on Presto for undefined column types. The regression was caused due to one of the methods calling the `get_sqla_column_type` method with `None` which is contradictory with the method signature. This reverts exception raising for unknown types and defaults those to `sqlalchemy.types.String()`, while at the same time logging the discrepancy.

Going forward the associated methods need to be broken up and properly unit tested, as they are currently very difficult to follow.

### TEST PLAN
CI + added test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #10743
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
