### PR TITLE
feat(viz): export csv with frontend  the same name

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -617,10 +617,7 @@ class BaseViz:
         df = self.get_df()
         columns = list(df.columns)
         verbose_map = self.datasource.data.get("verbose_map", {})
-
-        if verbose_map:
-            df.columns = [verbose_map.get(column, column) for column in columns]
-
+        df.columns = [verbose_map.get(column, column) for column in columns]
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, **config["CSV_EXPORT"])
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -616,9 +616,11 @@ class BaseViz:
     def get_csv(self) -> Optional[str]:
         df = self.get_df()
         columns = list(df.columns)
-        verbose_map = self.datasource.data.get("verbose_map",{})
+        verbose_map = self.datasource.data.get("verbose_map", {})
+
         if verbose_map:
-            df.columns = [verbose_map.get(column,column) for column in columns]
+            df.columns = [verbose_map.get(column, column) for column in columns]
+
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, **config["CSV_EXPORT"])
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -21,6 +21,7 @@ These objects represent the backend of all the visualizations that
 Superset can render.
 """
 import copy
+import dataclasses
 import inspect
 import logging
 import math
@@ -41,7 +42,6 @@ from typing import (
     Union,
 )
 
-import dataclasses
 import geohash
 import numpy as np
 import pandas as pd
@@ -616,9 +616,9 @@ class BaseViz:
     def get_csv(self) -> Optional[str]:
         df = self.get_df()
         columns = list(df.columns)
-        verbose_map = self.datasource.data.get("verbose_map", {})
+        verbose_map = self.datasource.data.get("verbose_map",{})
         if verbose_map:
-            df.columns = [verbose_map.get(column, column) for column in columns]
+            df.columns = [verbose_map.get(column,column) for column in columns]
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, **config["CSV_EXPORT"])
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -21,7 +21,6 @@ These objects represent the backend of all the visualizations that
 Superset can render.
 """
 import copy
-import dataclasses
 import inspect
 import logging
 import math
@@ -42,6 +41,7 @@ from typing import (
     Union,
 )
 
+import dataclasses
 import geohash
 import numpy as np
 import pandas as pd
@@ -616,7 +616,7 @@ class BaseViz:
     def get_csv(self) -> Optional[str]:
         df = self.get_df()
         columns = list(df.columns)
-        verbose_map = self.datasource.data.get('verbose_map', {})
+        verbose_map = self.datasource.data.get("verbose_map", {})
         if verbose_map:
             df.columns = [verbose_map.get(column, column) for column in columns]
         include_index = not isinstance(df.index, pd.RangeIndex)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -615,6 +615,10 @@ class BaseViz:
 
     def get_csv(self) -> Optional[str]:
         df = self.get_df()
+        columns = list(df.columns)
+        verbose_map = self.datasource.data.get('verbose_map', {})
+        if verbose_map:
+            df.columns = [verbose_map.get(column, column) for column in columns]
         include_index = not isinstance(df.index, pd.RangeIndex)
         return df.to_csv(index=include_index, **config["CSV_EXPORT"])
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -614,12 +614,14 @@ class BaseViz:
         return content
 
     def get_csv(self) -> Optional[str]:
-        df = self.get_df()
+        df = self.get_df_payload()["df"]  # leverage caching logic
         columns = list(df.columns)
-        verbose_map = self.datasource.data.get("verbose_map", {})
-        df.columns = [verbose_map.get(column, column) for column in columns]
+        verbose_map = self.datasource.data.get('verbose_map', {})
+        
+        if verbose_map:
+            df.columns = [verbose_map.get(column, column) for column in columns]
         include_index = not isinstance(df.index, pd.RangeIndex)
-        return df.to_csv(index=include_index, **config["CSV_EXPORT"])
+        return csv.df_to_escaped_csv(df, index=include_index, **config["CSV_EXPORT"])
 
     def get_data(self, df: pd.DataFrame) -> VizData:
         return df.to_dict(orient="records")


### PR DESCRIPTION
The column names displayed on the report are inconsistent with the column names of the actual exported csv file, which can sometimes cause confusion. Therefore, I hope to add a feature to make the column names displayed on the report consistent with the column names of the exported csv file.

### SUMMARY
Use verbose_map to help the column names of csv export to be consistent with the front-end display


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
![image](https://user-images.githubusercontent.com/23111194/91929626-60a6ea00-ed11-11ea-9f49-047f86d61727.png)

AFTER 
![image](https://user-images.githubusercontent.com/23111194/91929725-a2379500-ed11-11ea-8b22-e4673a5b399b.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [] Has associated issue:
- [] Changes UI
- [] Requires DB Migration.
- [] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [] Removes existing feature or API
