### PR TITLE
fix: add validator information to email/slack alerts

### DIFF
--- a/superset/models/alerts.py
+++ b/superset/models/alerts.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Models for scheduled execution of jobs"""
+import json
 import textwrap
 from datetime import datetime
 from typing import Any, Optional
@@ -201,3 +202,15 @@ class Validator(Model, AuditMixinNullable):
             foreign_keys=[self.alert_id],
             backref=backref("validators", cascade="all, delete-orphan"),
         )
+
+    def __str__(self) -> str:
+        """ String representing the comparison that will trigger a validator """
+        config = json.loads(self.config)
+
+        if self.validator_type.lower() == "operator":
+            return f"{config['op']} {config['threshold']}"
+
+        if self.validator_type.lower() == "not null":
+            return "!= Null or 0"
+
+        return ""

--- a/superset/models/alerts.py
+++ b/superset/models/alerts.py
@@ -203,7 +203,7 @@ class Validator(Model, AuditMixinNullable):
             backref=backref("validators", cascade="all, delete-orphan"),
         )
 
-    def __str__(self) -> str:
+    def pretty_print(self) -> str:
         """ String representing the comparison that will trigger a validator """
         config = json.loads(self.config)
 

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -105,7 +105,7 @@ class AlertContent(NamedTuple):
     label: str  # alert name
     sql: str  # sql statement for alert
     observation_value: str  # value from observation that triggered the alert
-    validation_str: str  # a string of the comparison that triggered an alert
+    validation_error_message: str  # a string of the comparison that triggered an alert
     alert_url: str  # url to alert details
     image_data: Optional[ScreenshotData]  # data for the alert screenshot
 
@@ -575,8 +575,8 @@ def deliver_alert(
     # where an alert might not have a validator
     recipients = recipients or alert.recipients
     slack_channel = slack_channel or alert.slack_channel
-    validation_str = (
-        str(alert.observations[-1].value) + " " + str(alert.validators[0])
+    validation_error_message = (
+        str(alert.observations[-1].value) + " " + alert.validators[0].pretty_print()
         if alert.validators
         else ""
     )
@@ -586,7 +586,7 @@ def deliver_alert(
             alert.label,
             alert.sql_observer[0].sql,
             str(alert.observations[-1].value),
-            validation_str,
+            validation_error_message,
             _get_url_path("AlertModelView.show", user_friendly=True, pk=alert_id),
             _get_slice_screenshot(alert.slice.id),
         )
@@ -596,7 +596,7 @@ def deliver_alert(
             alert.label,
             alert.sql_observer[0].sql,
             str(alert.observations[-1].value),
-            validation_str,
+            validation_error_message,
             _get_url_path("AlertModelView.show", user_friendly=True, pk=alert_id),
             None,
         )
@@ -626,7 +626,7 @@ def deliver_email_alert(alert_content: AlertContent, recipients: str) -> None:
         label=alert_content.label,
         sql=alert_content.sql,
         observation_value=alert_content.observation_value,
-        validation_str=alert_content.validation_str,
+        validation_error_message=alert_content.validation_error_message,
         image_url=image_url,
     )
 
@@ -645,7 +645,7 @@ def deliver_slack_alert(alert_content: AlertContent, slack_channel: str) -> None
             label=alert_content.label,
             sql=alert_content.sql,
             observation_value=alert_content.observation_value,
-            validation_str=alert_content.validation_str,
+            validation_error_message=alert_content.validation_error_message,
             url=alert_content.image_data.url,
             alert_url=alert_content.alert_url,
         )
@@ -656,7 +656,7 @@ def deliver_slack_alert(alert_content: AlertContent, slack_channel: str) -> None
             label=alert_content.label,
             sql=alert_content.sql,
             observation_value=alert_content.observation_value,
-            validation_str=alert_content.validation_str,
+            validation_error_message=alert_content.validation_error_message,
             alert_url=alert_content.alert_url,
         )
 

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -105,6 +105,7 @@ class AlertContent(NamedTuple):
     label: str  # alert name
     sql: str  # sql statement for alert
     observation_value: str  # value from observation that triggered the alert
+    validation_str: str  # a string of the comparison that triggered an alert
     alert_url: str  # url to alert details
     image_data: Optional[ScreenshotData]  # data for the alert screenshot
 
@@ -571,20 +572,21 @@ def deliver_alert(
 
     # Set all the values for the alert report
     # Alternate values are used in the case of a test alert
-    # where an alert has no observations yet
+    # where an alert might not have a validator
     recipients = recipients or alert.recipients
     slack_channel = slack_channel or alert.slack_channel
-    sql = alert.sql_observer[0].sql if alert.sql_observer else ""
-    observation_value = (
-        str(alert.observations[-1].value) if alert.observations else "Value"
+    validation_str = (
+        str(alert.observations[-1].value) + " " + str(alert.validators[0])
+        if alert.validators
+        else ""
     )
 
-    # TODO: add sql query results and validator information to alert content
     if alert.slice:
         alert_content = AlertContent(
             alert.label,
-            sql,
-            observation_value,
+            alert.sql_observer[0].sql,
+            str(alert.observations[-1].value),
+            validation_str,
             _get_url_path("AlertModelView.show", user_friendly=True, pk=alert_id),
             _get_slice_screenshot(alert.slice.id),
         )
@@ -592,8 +594,9 @@ def deliver_alert(
         # TODO: dashboard delivery!
         alert_content = AlertContent(
             alert.label,
-            sql,
-            observation_value,
+            alert.sql_observer[0].sql,
+            str(alert.observations[-1].value),
+            validation_str,
             _get_url_path("AlertModelView.show", user_friendly=True, pk=alert_id),
             None,
         )
@@ -623,6 +626,7 @@ def deliver_email_alert(alert_content: AlertContent, recipients: str) -> None:
         label=alert_content.label,
         sql=alert_content.sql,
         observation_value=alert_content.observation_value,
+        validation_str=alert_content.validation_str,
         image_url=image_url,
     )
 
@@ -641,6 +645,7 @@ def deliver_slack_alert(alert_content: AlertContent, slack_channel: str) -> None
             label=alert_content.label,
             sql=alert_content.sql,
             observation_value=alert_content.observation_value,
+            validation_str=alert_content.validation_str,
             url=alert_content.image_data.url,
             alert_url=alert_content.alert_url,
         )
@@ -651,6 +656,7 @@ def deliver_slack_alert(alert_content: AlertContent, slack_channel: str) -> None
             label=alert_content.label,
             sql=alert_content.sql,
             observation_value=alert_content.observation_value,
+            validation_str=alert_content.validation_str,
             alert_url=alert_content.alert_url,
         )
 

--- a/superset/templates/email/alert.txt
+++ b/superset/templates/email/alert.txt
@@ -17,10 +17,10 @@
  under the License.
 -->
 <h2 style="color: red;">Alert: {{label}} &#x26A0;</h2>
-<p><b>SQL Statement:</b></p>
+<p><b>Query:</b></p>
 <code><mark style="background-color: LightGrey; font-size: 1.1em">{{sql}}</mark></code></p>
-<p><b>SQL Result</b>: {{observation_value}}</p>
-<p><b>Reason For Alert</b>: {{validation_str}}</p>
+<p><b>Result</b>: {{observation_value}}</p>
+<p><b>Reason</b>: {{validation_str}}</p>
 <p><a href="{{alert_url}}">View Alert Details</a></p>
 <p>Click <a href="{{image_url}}">here</a> or the image below to view the chart related to this alert.</p>
 <a href="{{image_url}}">

--- a/superset/templates/email/alert.txt
+++ b/superset/templates/email/alert.txt
@@ -20,7 +20,7 @@
 <p><b>Query:</b></p>
 <code><mark style="background-color: LightGrey; font-size: 1.1em">{{sql}}</mark></code></p>
 <p><b>Result</b>: {{observation_value}}</p>
-<p><b>Reason</b>: {{validation_str}}</p>
+<p><b>Reason</b>: {{validation_error_message}}</p>
 <p><a href="{{alert_url}}">View Alert Details</a></p>
 <p>Click <a href="{{image_url}}">here</a> or the image below to view the chart related to this alert.</p>
 <a href="{{image_url}}">

--- a/superset/templates/email/alert.txt
+++ b/superset/templates/email/alert.txt
@@ -20,6 +20,7 @@
 <p><b>SQL Statement:</b></p>
 <code><mark style="background-color: LightGrey; font-size: 1.1em">{{sql}}</mark></code></p>
 <p><b>SQL Result</b>: {{observation_value}}</p>
+<p><b>Reason For Alert</b>: {{validation_str}}</p>
 <p><a href="{{alert_url}}">View Alert Details</a></p>
 <p>Click <a href="{{image_url}}">here</a> or the image below to view the chart related to this alert.</p>
 <a href="{{image_url}}">

--- a/superset/templates/slack/alert.txt
+++ b/superset/templates/slack/alert.txt
@@ -19,6 +19,6 @@
 *Triggered Alert: {{label}} :redalert:*
 *Query*:```{{sql}}```
 *Result*: {{observation_value}}
-*Reason*: {{validation_str}}
+*Reason*: {{validation_error_message}}
 <{{alert_url}}|View Alert Details>
 <{{url}}|*Explore in Superset*>

--- a/superset/templates/slack/alert.txt
+++ b/superset/templates/slack/alert.txt
@@ -17,8 +17,8 @@
   under the License.
 #}
 *Triggered Alert: {{label}} :redalert:*
-*SQL* *Statement*:```{{sql}}```
-*SQL* *Result*: {{observation_value}}
-*Reason* *For* *Alert*: {{validation_str}}
+*Query*:```{{sql}}```
+*Result*: {{observation_value}}
+*Reason*: {{validation_str}}
 <{{alert_url}}|View Alert Details>
 <{{url}}|*Explore in Superset*>

--- a/superset/templates/slack/alert.txt
+++ b/superset/templates/slack/alert.txt
@@ -19,5 +19,6 @@
 *Triggered Alert: {{label}} :redalert:*
 *SQL* *Statement*:```{{sql}}```
 *SQL* *Result*: {{observation_value}}
+*Reason* *For* *Alert*: {{validation_str}}
 <{{alert_url}}|View Alert Details>
 <{{url}}|*Explore in Superset*>

--- a/superset/templates/slack/alert_no_screenshot.txt
+++ b/superset/templates/slack/alert_no_screenshot.txt
@@ -19,5 +19,5 @@
 *Triggered Alert: {{label}} :redalert:*
 *Query*:```{{sql}}```
 *Result*: {{observation_value}}
-*Reason*: {{validation_str}}
+*Reason*: {{validation_error_message}}
 <{{alert_url}}|View Alert Details>

--- a/superset/templates/slack/alert_no_screenshot.txt
+++ b/superset/templates/slack/alert_no_screenshot.txt
@@ -19,4 +19,5 @@
 *Triggered Alert: {{label}} :redalert:*
 *SQL* *Statement*:```{{sql}}```
 *SQL* *Result*: {{observation_value}}
+*Reason* *For* *Alert*: {{validation_str}}
 <{{alert_url}}|View Alert Details>

--- a/superset/templates/slack/alert_no_screenshot.txt
+++ b/superset/templates/slack/alert_no_screenshot.txt
@@ -17,7 +17,7 @@
   under the License.
 #}
 *Triggered Alert: {{label}} :redalert:*
-*SQL* *Statement*:```{{sql}}```
-*SQL* *Result*: {{observation_value}}
-*Reason* *For* *Alert*: {{validation_str}}
+*Query*:```{{sql}}```
+*Result*: {{observation_value}}
+*Reason*: {{validation_str}}
 <{{alert_url}}|View Alert Details>

--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -310,7 +310,7 @@ def test_deliver_alert_screenshot(
     screenshot_mock, url_mock, email_mock, file_upload_mock, setup_database
 ):
     dbsession = setup_database
-    alert = create_alert(dbsession, "SELECT 55")
+    alert = create_alert(dbsession, "SELECT 55", "not null", "{}")
     observe(alert.id)
 
     screenshot = read_fixture("sample.png")
@@ -329,8 +329,9 @@ def test_deliver_alert_screenshot(
         "file": screenshot,
         "initial_comment": f"\n*Triggered Alert: {alert.label} :redalert:*\n"
         f"*SQL* *Statement*:```{alert.sql_observer[0].sql}```\n"
-        f"*SQL* *Result*: {alert.observations[-1].value}"
-        f"\n<http://0.0.0.0:8080/alert/show/{alert.id}"
+        f"*SQL* *Result*: {alert.observations[-1].value}\n"
+        f"*Reason* *For* *Alert*: {alert.observations[-1].value} {str(alert.validators[0])}\n"
+        f"<http://0.0.0.0:8080/alert/show/{alert.id}"
         f"|View Alert Details>\n<http://0.0.0.0:8080/superset/slice/{alert.slice_id}/"
         "|*Explore in Superset*>",
         "title": f"[Alert] {alert.label}",

--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -330,7 +330,7 @@ def test_deliver_alert_screenshot(
         "initial_comment": f"\n*Triggered Alert: {alert.label} :redalert:*\n"
         f"*Query*:```{alert.sql_observer[0].sql}```\n"
         f"*Result*: {alert.observations[-1].value}\n"
-        f"*Reason*: {alert.observations[-1].value} {str(alert.validators[0])}\n"
+        f"*Reason*: {alert.observations[-1].value} {alert.validators[0].pretty_print()}\n"
         f"<http://0.0.0.0:8080/alert/show/{alert.id}"
         f"|View Alert Details>\n<http://0.0.0.0:8080/superset/slice/{alert.slice_id}/"
         "|*Explore in Superset*>",

--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -328,9 +328,9 @@ def test_deliver_alert_screenshot(
         "channels": alert.slack_channel,
         "file": screenshot,
         "initial_comment": f"\n*Triggered Alert: {alert.label} :redalert:*\n"
-        f"*SQL* *Statement*:```{alert.sql_observer[0].sql}```\n"
-        f"*SQL* *Result*: {alert.observations[-1].value}\n"
-        f"*Reason* *For* *Alert*: {alert.observations[-1].value} {str(alert.validators[0])}\n"
+        f"*Query*:```{alert.sql_observer[0].sql}```\n"
+        f"*Result*: {alert.observations[-1].value}\n"
+        f"*Reason*: {alert.observations[-1].value} {str(alert.validators[0])}\n"
         f"<http://0.0.0.0:8080/alert/show/{alert.id}"
         f"|View Alert Details>\n<http://0.0.0.0:8080/superset/slice/{alert.slice_id}/"
         "|*Explore in Superset*>",


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR updates alert messages by adding the reason why a SQL-based alert was triggered. Information is taken from the alert's validator string.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Email:
![Screen Shot 2020-09-02 at 12 19 34 PM](https://user-images.githubusercontent.com/32852580/92026895-93071600-ed16-11ea-84e9-7af101840a6d.png)
Slack:
<img width="568" alt="Screen Shot 2020-09-02 at 12 20 10 PM" src="https://user-images.githubusercontent.com/32852580/92026931-a7e3a980-ed16-11ea-816e-3153275bec0d.png">



### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- [x] local
- [x] unit test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

