### PR TITLE
Change pyarrow version for docker-compose up

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -88,7 +88,7 @@ polyline==1.4.0           # via apache-superset
 prison==0.1.3             # via flask-appbuilder
 psycopg2-binary==2.8.5    # via apache-superset
 py==1.9.0                 # via retry
-pyarrow==1.0.1            # via apache-superset
+pyarrow==0.17.0           # via apache-superset
 pycparser==2.20           # via cffi
 pydruid==0.6.1            # via apache-superset
 pyhive[hive]==0.6.3       # via apache-superset


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- `docker-compose up` does not work with the `pyarrow` version

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- no tests required

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
