### PR TITLE
fix: re-installing local superset in cache image

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -21,10 +21,12 @@
 FROM preset/superset:dev
 
 COPY ./requirements/*.txt ./docker/requirements-*.txt /app/requirements/
+COPY ./setup.py ./MANIFEST.in /app/
 
 USER root
 # Cache everything for dev purposes...
 RUN cd /app \
-    && pip install --no-cache -r requirements/docker.txt \
-    && pip install --no-cache -r requirements/requirements-local.txt || true
+    && pip install -e . \
+    && pip install -r requirements/docker.txt \
+    && pip install -r requirements/requirements-local.txt || true
 USER superset

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,9 +71,9 @@ services:
     volumes: *superset-volumes
 
   superset-node:
-    image: node:10-jessie
+    image: node:12
     container_name: superset_node
-    command: ["bash", "-c", "cd /app/superset-frontend && npm install --global webpack webpack-cli && npm install && npm run dev"]
+    command: ["bash", "-c", "cd /app/superset-frontend && npm install -f --no-optional --global webpack webpack-cli && npm install -f --no-optional && npm run dev"]
     env_file: docker/.env
     depends_on: *superset-depends-on
     volumes: *superset-volumes


### PR DESCRIPTION
### SUMMARY
Fixes issue with differing dependency versions in cache image vs requirements found in local install. Basically, the local `superset` package will always be re-installed on top of the cache image's superset in order to ensure that the deps align.

Fixes #10765

@hyunjong-lee - FYI