### PR TITLE
fix: can not type `0.05` in `TextControl` if isFloat

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl.tsx
@@ -49,7 +49,7 @@ export default class TextControl extends React.Component<TextControlProps> {
       if (error) {
         errors.push(error);
       } else {
-        value = value.match(/.*(\.)$/g) ? value : parseFloat(value);
+        value = value.match(/.*(\.|0)$/g) ? value : parseFloat(value);
       }
     }
     if (value !== '' && this.props.isInt) {


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix: can not type `0.05` in `TextControl` if isFloat

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/pull/9351
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
