### PR TITLE
fix: disable domain sharding on explore view

### DIFF
--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -40,7 +40,7 @@ import { addDangerToast } from '../messageToasts/actions';
 import { logEvent } from '../logger/actions';
 import { Logger, LOG_ACTIONS_LOAD_CHART } from '../logger/LogUtils';
 import getClientErrorObject from '../utils/getClientErrorObject';
-import { allowCrossDomain as allowDomainSharding } from '../utils/hostNamesConfig';
+import { allowCrossDomain as domainShardingEnabled } from '../utils/hostNamesConfig';
 
 export const CHART_UPDATE_STARTED = 'CHART_UPDATE_STARTED';
 export function chartUpdateStarted(queryController, latestQueryFormData, key) {
@@ -106,6 +106,9 @@ const legacyChartDataRequest = async (
   requestParams = {},
 ) => {
   const endpointType = getLegacyEndpointType({ resultFormat, resultType });
+  const allowDomainSharding =
+    // eslint-disable-next-line camelcase
+    domainShardingEnabled && requestParams?.dashboard_id;
   const url = getExploreUrl({
     formData,
     endpointType,
@@ -153,6 +156,9 @@ const v1ChartDataRequest = async (
   const qs = requestParams.dashboard_id
     ? { dashboard_id: requestParams.dashboard_id }
     : {};
+  const allowDomainSharding =
+    // eslint-disable-next-line camelcase
+    domainShardingEnabled && requestParams?.dashboard_id;
   const url = getChartDataUri({
     path: '/api/v1/chart/data',
     qs,
@@ -182,7 +188,7 @@ export async function getChartDataRequest({
     ...requestParams,
   };
 
-  if (allowDomainSharding) {
+  if (domainShardingEnabled) {
     querySettings = {
       ...querySettings,
       mode: 'cors',


### PR DESCRIPTION
### SUMMARY
In airbnb we use [domain sharding](https://www.keycdn.com/support/domain-sharding#:~:text=Domain%20sharding%20is%20a%20technique,before%20beginning%20the%20next%20set.) for dashboard, so that Dashboard can send > 6 chart requests at a time, and improve dashboard load time.

For explore view, since there is only 1 chart request at at time, we should not use domain sharding, so that other internal services that have very strict iframe limitation, can still embed Superset charts (but not dashboard) as iframe.

@etr2460 

### TEST PLAN
CI and manual test.

