### PR TITLE
security: disallow uuid package on jinja2

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,7 +23,7 @@ assists people when migrating to a new version.
 
 ## Next
 
-* [10794](https://github.com/apache/incubator-superset/pull/10794): Breaking change: `uuid` python package is not supported on Jinja2 anymore, only uuid functions are expose eg: `uuid1`, `uuid3`, `uuid4`, `uuid5`.
+* [10794](https://github.com/apache/incubator-superset/pull/10794): Breaking change: `uuid` python package is not supported on Jinja2 anymore, only uuid functions are exposed eg: `uuid1`, `uuid3`, `uuid4`, `uuid5`.
 
 * [10674](https://github.com/apache/incubator-superset/pull/10674): Breaking change: PUBLIC_ROLE_LIKE_GAMMA was removed is favour of the new PUBLIC_ROLE_LIKE so it can be set it whatever role you want.
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,8 @@ assists people when migrating to a new version.
 
 ## Next
 
+* [10794](https://github.com/apache/incubator-superset/pull/10794): Breaking change: `uuid` python package is not supported on Jinja2 anymore, only uuid functions are expose eg: `uuid1`, `uuid3`, `uuid4`, `uuid5`.
+
 * [10674](https://github.com/apache/incubator-superset/pull/10674): Breaking change: PUBLIC_ROLE_LIKE_GAMMA was removed is favour of the new PUBLIC_ROLE_LIKE so it can be set it whatever role you want.
 
 * [10590](https://github.com/apache/incubator-superset/pull/10590): Breaking change: this PR will convert iframe chart into dashboard markdown component, and remove all `iframe`, `separator`, and `markup` slices (and support) from Superset. If you have important data in those slices, please backup manually.

--- a/docs/sqllab.rst
+++ b/docs/sqllab.rst
@@ -73,7 +73,10 @@ Superset's Jinja context:
 
 - ``time``: ``time``
 - ``datetime``: ``datetime.datetime``
-- ``uuid``: ``uuid``
+- ``uuid1``: ``uuid1``
+- ``uuid3``: ``uuid3``
+- ``uuid4``: ``uuid4``
+- ``uuid5``: ``uuid5``
 - ``random``: ``random``
 - ``relativedelta``: ``dateutil.relativedelta.relativedelta``
 

--- a/superset/extensions.py
+++ b/superset/extensions.py
@@ -50,7 +50,10 @@ class JinjaContextManager:
             "relativedelta": relativedelta,
             "time": time,
             "timedelta": timedelta,
-            "uuid": uuid,
+            "uuid1": uuid.uuid1,
+            "uuid3": uuid.uuid3,
+            "uuid4": uuid.uuid4,
+            "uuid5": uuid.uuid5,
         }
         self._template_processors: Dict[str, Type["BaseTemplateProcessor"]] = {}
 


### PR DESCRIPTION
### SUMMARY
Disallow the use of the entire `uuid` python package.

There is a case to be made if we should disallow all packages completely. Checked all the other packages (used `dir(datetime)` for example) and found nothing relevant.

Safer to remove all packages and just allow "flat" functions, but this would result in a big loss of default functionality, for example on `datetime`. User's can always reenable these using `JINJA_CONTEXT_ADDONS`

### ADDITIONAL INFORMATION
- [x] Has associated issue: #10785
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
