### PR TITLE
fix: Database API missing allow none on fields

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -215,7 +215,9 @@ class DatabasePostSchema(Schema):
     database_name = fields.String(
         description=database_name_description, required=True, validate=Length(1, 250),
     )
-    cache_timeout = fields.Integer(description=cache_timeout_description)
+    cache_timeout = fields.Integer(
+        description=cache_timeout_description, allow_none=True
+    )
     expose_in_sqllab = fields.Boolean(description=expose_in_sqllab_description)
     allow_run_async = fields.Boolean(description=allow_run_async_description)
     allow_csv_upload = fields.Boolean(description=allow_csv_upload_description)
@@ -230,11 +232,15 @@ class DatabasePostSchema(Schema):
     )
     impersonate_user = fields.Boolean(description=impersonate_user_description)
     encrypted_extra = fields.String(
-        description=encrypted_extra_description, validate=encrypted_extra_validator
+        description=encrypted_extra_description,
+        validate=encrypted_extra_validator,
+        allow_none=True,
     )
     extra = fields.String(description=extra_description, validate=extra_validator)
     server_cert = fields.String(
-        description=server_cert_description, validate=server_cert_validator
+        description=server_cert_description,
+        allow_none=True,
+        validate=server_cert_validator,
     )
     sqlalchemy_uri = fields.String(
         description=sqlalchemy_uri_description,
@@ -247,7 +253,9 @@ class DatabasePutSchema(Schema):
     database_name = fields.String(
         description=database_name_description, allow_none=True, validate=Length(1, 250),
     )
-    cache_timeout = fields.Integer(description=cache_timeout_description)
+    cache_timeout = fields.Integer(
+        description=cache_timeout_description, allow_none=True
+    )
     expose_in_sqllab = fields.Boolean(description=expose_in_sqllab_description)
     allow_run_async = fields.Boolean(description=allow_run_async_description)
     allow_csv_upload = fields.Boolean(description=allow_csv_upload_description)
@@ -262,11 +270,15 @@ class DatabasePutSchema(Schema):
     )
     impersonate_user = fields.Boolean(description=impersonate_user_description)
     encrypted_extra = fields.String(
-        description=encrypted_extra_description, validate=encrypted_extra_validator
+        description=encrypted_extra_description,
+        allow_none=True,
+        validate=encrypted_extra_validator,
     )
     extra = fields.String(description=extra_description, validate=extra_validator)
     server_cert = fields.String(
-        description=server_cert_description, validate=server_cert_validator
+        description=server_cert_description,
+        allow_none=True,
+        validate=server_cert_validator,
     )
     sqlalchemy_uri = fields.String(
         description=sqlalchemy_uri_description,

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -225,7 +225,9 @@ class DatabasePostSchema(Schema):
     allow_cvas = fields.Boolean(description=allow_cvas_description)
     allow_dml = fields.Boolean(description=allow_dml_description)
     force_ctas_schema = fields.String(
-        description=force_ctas_schema_description, validate=Length(0, 250)
+        description=force_ctas_schema_description,
+        allow_none=True,
+        validate=Length(0, 250),
     )
     allow_multi_schema_metadata_fetch = fields.Boolean(
         description=allow_multi_schema_metadata_fetch_description,
@@ -263,7 +265,9 @@ class DatabasePutSchema(Schema):
     allow_cvas = fields.Boolean(description=allow_cvas_description)
     allow_dml = fields.Boolean(description=allow_dml_description)
     force_ctas_schema = fields.String(
-        description=force_ctas_schema_description, validate=Length(0, 250)
+        description=force_ctas_schema_description,
+        allow_none=True,
+        validate=Length(0, 250),
     )
     allow_multi_schema_metadata_fetch = fields.Boolean(
         description=allow_multi_schema_metadata_fetch_description


### PR DESCRIPTION
### SUMMARY
Some fields on the database model are allowed `None` and this was not properly reflected on the marshmallow schemas

ping: @riahk


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
