### PR TITLE
chore: deprecate python 3.6 support

### DIFF
--- a/.github/workflows/superset-python.yml
+++ b/.github/workflows/superset-python.yml
@@ -213,8 +213,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        # run unit tests in multiple version just for fun
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.superset_test_config

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ######################################################################
 # PY stage that simply does a pip install on our requirements
 ######################################################################
-ARG PY_VER=3.6.9
+ARG PY_VER=3.7.9
 FROM python:${PY_VER} AS superset-py
 
 RUN mkdir /app \

--- a/RELEASING/Dockerfile.from_local_tarball
+++ b/RELEASING/Dockerfile.from_local_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.6-jessie
+FROM python:3.7-jessie
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 

--- a/RELEASING/Dockerfile.from_svn_tarball
+++ b/RELEASING/Dockerfile.from_svn_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.6-jessie
+FROM python:3.7-jessie
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 

--- a/RELEASING/Dockerfile.make_docs
+++ b/RELEASING/Dockerfile.make_docs
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.6-jessie
+FROM python:3.7-jessie
 ARG VERSION
 
 RUN git clone --depth 1 --branch ${VERSION} https://github.com/apache/incubator-superset.git /superset

--- a/RELEASING/Dockerfile.make_tarball
+++ b/RELEASING/Dockerfile.make_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.6-jessie
+FROM python:3.7-jessie
 
 RUN apt-get update -y
 RUN apt-get install -y jq

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,11 +21,10 @@ Installation & Configuration
 Getting Started
 ---------------
 
-Superset has deprecated support for Python ``2.*`` and supports
-only ``~=3.6`` to take advantage of the newer Python features and reduce
-the burden of supporting previous versions. We run our test suite
-against ``3.7``, with a subset of tests additionally being run against
-``3.6`` and ``3.8``.
+Superset supports Python versions ``>3.7`` to take advantage of the
+newer Python features and reduce the burden of supporting previous versions.
+We run our test suite against ``3.7``, with a subset of tests additionally
+also being run against ``3.8``.
 
 Cloud-native!
 -------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,13 +11,13 @@ alembic==1.4.2            # via flask-migrate
 amqp==2.6.1               # via kombu
 apispec[yaml]==3.3.2      # via flask-appbuilder
 async-timeout==3.0.1      # via aiohttp
-attrs==20.1.0             # via aiohttp, jsonschema
+attrs==20.2.0             # via aiohttp, jsonschema
 babel==2.8.0              # via flask-babel
 backoff==1.10.0           # via apache-superset
 billiard==3.6.3.0         # via celery
 bleach==3.1.5             # via apache-superset
-boto3==1.14.51            # via tabulator
-botocore==1.17.51         # via boto3, s3transfer
+boto3==1.14.56            # via tabulator
+botocore==1.17.56         # via boto3, s3transfer
 brotli==1.0.9             # via flask-compress
 cached-property==1.5.1    # via tableschema
 cachelib==0.1.1           # via apache-superset
@@ -30,7 +30,6 @@ colorama==0.4.3           # via apache-superset, flask-appbuilder
 contextlib2==0.6.0.post1  # via apache-superset
 croniter==0.3.34          # via apache-superset
 cryptography==3.1         # via apache-superset
-dataclasses==0.6          # via apache-superset
 decorator==4.4.2          # via retry
 defusedxml==0.6.0         # via python3-openid
 dnspython==2.0.0          # via email-validator

--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -10,7 +10,7 @@ cfgv==3.2.0               # via pre-commit
 click==7.1.2              # via pip-compile-multi, pip-tools
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-identify==1.4.29          # via pre-commit
+identify==1.5.0           # via pre-commit
 importlib-metadata==1.7.0  # via pluggy, pre-commit, tox, virtualenv
 nodeenv==1.5.0            # via pre-commit
 packaging==20.4           # via tox
@@ -24,7 +24,7 @@ pyyaml==5.3.1             # via pre-commit
 six==1.15.0               # via packaging, pip-tools, tox, virtualenv
 toml==0.10.1              # via pre-commit, tox
 toposort==1.5             # via pip-compile-multi
-tox==3.19.0               # via -r requirements/integration.in
+tox==3.20.0               # via -r requirements/integration.in
 virtualenv==20.0.31       # via pre-commit, tox
 zipp==3.1.0               # via importlib-metadata
 

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -18,7 +18,7 @@ iniconfig==1.0.1          # via pytest
 ipdb==0.13.3              # via -r requirements/testing.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.16.1           # via -r requirements/testing.in, ipdb
-isort==5.4.2              # via pylint
+isort==5.5.1              # via pylint
 jedi==0.17.2              # via ipython
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
@@ -37,7 +37,7 @@ pytest-cov==2.10.1        # via -r requirements/testing.in
 pytest==6.0.1             # via -r requirements/testing.in, pytest-cov
 redis==3.5.3              # via -r requirements/testing.in
 statsd==3.3.0             # via -r requirements/testing.in
-traitlets==4.3.3          # via ipython
+traitlets==5.0.3          # via ipython
 typed-ast==1.4.1          # via astroid
 wcwidth==0.2.5            # via prompt-toolkit
 websocket-client==0.57.0  # via docker

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         "contextlib2",
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
-        "dataclasses<0.7",
         "flask>=1.1.0, <2.0.0",
         "flask-appbuilder>=3.0.1, <4.0.0",
         "flask-caching",
@@ -145,7 +144,6 @@ setup(
     url="https://superset.apache.org/",
     download_url="https://www.apache.org/dist/incubator/superset/" + version_string,
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],


### PR DESCRIPTION
### SUMMARY
With Python 3.7 having been released over 2 years ago and recently [entered 'security fix'](https://www.python.org/downloads/release/python-379/) mode, along with the [`dataclasses`](https://pypi.org/project/dataclasses/) backport package no longer supporting Python 3.7 as of version 0.7, it's time to deprecate support for python 3.6 to be able to take full advantage of [new features in 3.7](https://realpython.com/python37-new-features/), and prepare for moving to Python 3.8 and onwards.

Changes introduced by this PR:
- removes 3.6 from the CI build matrix
- removes `dataclasses` dependency from `setup.py
- replaces Python 3.6 with 3.7 in all `Dockerfile`s

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
CI + local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
