### PR TITLE
Fix: Include RLS filters for cache keys

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1454,6 +1454,11 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             templatable_statements.append(extras["where"])
         if "having" in extras:
             templatable_statements.append(extras["having"])
+        # make sure the RLS filters are included
+        if config["ENABLE_ROW_LEVEL_SECURITY"] and self.is_rls_supported:
+            templatable_statements += [
+                f.clause
+                for f in security_manager.get_rls_filters(self) ]
         for statement in templatable_statements:
             if ExtraCache.regex.search(statement):
                 return True

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1454,11 +1454,10 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             templatable_statements.append(extras["where"])
         if "having" in extras:
             templatable_statements.append(extras["having"])
-        # make sure the RLS filters are included
         if config["ENABLE_ROW_LEVEL_SECURITY"] and self.is_rls_supported:
             templatable_statements += [
-                f.clause
-                for f in security_manager.get_rls_filters(self) ]
+                f.clause for f in security_manager.get_rls_filters(self)
+            ]
         for statement in templatable_statements:
             if ExtraCache.regex.search(statement):
                 return True


### PR DESCRIPTION
This fix makes sure that RLS filters are searched for templatable jinja content, ensuring cached visualizations aren't shown to the wrong user.

### SUMMARY
I added a check to see if there are any RLS filters that are templated

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
I haven't tried it with multiple layers of RLS (eg, a user has multiple roles, and each role has different RLS filters), so that may need to be tested.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #10804 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
