### PR TITLE
fix(sql-lab): relax column name restrictions

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/ExploreResultsButton_spec.jsx
@@ -94,13 +94,7 @@ describe('ExploreResultsButton', () => {
     });
 
     const badCols = wrapper.instance().getInvalidColumns();
-    expect(badCols).toEqual([
-      'COUNT(*)',
-      '1',
-      '123',
-      'CASE WHEN 1=1 THEN 1 ELSE 0 END',
-      '__TIMESTAMP',
-    ]);
+    expect(badCols).toEqual(['my_dupe_col__2', '__timestamp', '__TIMESTAMP']);
 
     const msgWrapper = shallow(wrapper.instance().renderInvalidColumnMessage());
     expect(msgWrapper.find('div')).toHaveLength(1);

--- a/superset-frontend/spec/javascripts/sqllab/fixtures.ts
+++ b/superset-frontend/spec/javascripts/sqllab/fixtures.ts
@@ -327,6 +327,16 @@ export const queryWithBadColumns = {
         type: 'TIMESTAMP',
       },
       {
+        is_date: false,
+        name: 'my_dupe_col__2',
+        type: 'STRING',
+      },
+      {
+        is_date: true,
+        name: '__timestamp',
+        type: 'TIMESTAMP',
+      },
+      {
         is_date: true,
         name: '__TIMESTAMP',
         type: 'TIMESTAMP',

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -102,13 +102,12 @@ class ExploreResultsButton extends React.PureComponent {
       .asSeconds();
   }
   getInvalidColumns() {
-    const re1 = /^[A-Za-z_]\w*$/; // starts with char or _, then only alphanum
-    const re2 = /__\d+$/; // does not finish with __ and then a number which screams dup col name
-    const re3 = /^__timestamp/i; // is not a reserved temporal column alias
+    const re1 = /__\d+$/; // duplicate column name pattern
+    const re2 = /^__timestamp/i; // reserved temporal column alias
 
     return this.props.query.results.selected_columns
       .map(col => col.name)
-      .filter(col => !re1.test(col) || re2.test(col) || re3.test(col));
+      .filter(col => re1.test(col) || re2.test(col));
   }
   datasourceName() {
     const { query } = this.props;
@@ -193,17 +192,11 @@ class ExploreResultsButton extends React.PureComponent {
         <code>
           <strong>{invalidColumns.join(', ')} </strong>
         </code>
-        {t('cannot be used as a column name. Please use aliases (as in ')}
-        <code>
-          SELECT count(*)&nbsp;
-          <strong>AS my_alias</strong>
-        </code>
-        ){' '}
-        {t(`limited to alphanumeric characters and underscores. The alias "__timestamp"
-          used as for the temporal expression and column aliases ending with
-          double underscores followed by a numeric value are not allowed for reasons
-          discussed in Github issue #5739.
-          `)}
+        {t(`cannot be used as a column name. The column name/alias "__timestamp"
+          is reserved for the main temporal expression, and column aliases ending with
+          double underscores followed by a numeric value (e.g. "my_col__1") are reserved
+          for deduplicating duplicate column names. Please use aliases to rename the
+          invalid column names.`)}
       </div>
     );
   }


### PR DESCRIPTION
### SUMMARY
Currently virtual datasources (=SQL queries) are required to consist of columns that start with a non-numeric character and don't contain special characters, including whitespace. This is unnecessary, as the majority of databases support special characters as long as they are quoted. For instance, querying the example dataset `birth_france_by_region` produces an error due to the numeric columns 2003-2014, despite the datasource working just fine on the majority of databases.

This PR relaxes the column name restrictions to only two rules:
- `__timestamp` is reserved for the temporal column
- anything ending in `__\d`, e.g. `my_col__1`, as that pattern is used to deduplicate column names.

### BEFORE
Trying to use `SELECT * FROM birth_france_by_region` as a datasource:
![image](https://user-images.githubusercontent.com/33317356/92594490-8309ac00-f2ab-11ea-913c-4144999fef4a.png)

### AFTER
Nema problema!
![image](https://user-images.githubusercontent.com/33317356/92594314-48077880-f2ab-11ea-89e4-42d1ce967f39.png)

### TEST PLAN
Adjusted existing unit test

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
