### PR TITLE
Revert "chore: add logging for "dashboard" action"

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1584,7 +1584,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         session.commit()
         return json_success(json.dumps({"published": dash.published}))
 
-    @event_logger.log_this
     @has_access
     @expose("/dashboard/<dashboard_id_or_slug>/")
     def dashboard(  # pylint: disable=too-many-locals


### PR DESCRIPTION
Reverts apache/incubator-superset#10744

I just found dashboard had a logger:
https://github.com/apache/incubator-superset/blob/77a31674125143ab6a84bae2ccf2d2db62a6874e/superset/views/core.py#L1650
but this logger can’t record the duration of whole dashboard action. Will try to fix the duration problem in a new PR.

@etr2460 @john-bodley 