### PR TITLE
fix: Making the database/cluster read-only

### DIFF
--- a/superset-frontend/src/components/TableSelector.jsx
+++ b/superset-frontend/src/components/TableSelector.jsx
@@ -53,6 +53,7 @@ const propTypes = {
   onChange: PropTypes.func,
   clearable: PropTypes.bool,
   handleError: PropTypes.func.isRequired,
+  isDatabaseSelectEnabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -67,6 +68,7 @@ const defaultProps = {
   sqlLabMode: true,
   formMode: false,
   clearable: true,
+  isDatabaseSelectEnabled: true,
 };
 
 export default class TableSelector extends React.PureComponent {
@@ -313,6 +315,7 @@ export default class TableSelector extends React.PureComponent {
         optionRenderer={this.renderDatabaseOption}
         mutator={this.dbMutator}
         placeholder={t('Select a database')}
+        isDisabled={!this.props.isDatabaseSelectEnabled}
         autoSelect
       />,
     );

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -457,15 +457,13 @@ export class DatasourceEditor extends React.PureComponent {
                 onSchemaChange={schema =>
                   this.onDatasourcePropChange('schema', schema)
                 }
-                onDbChange={database =>
-                  this.onDatasourcePropChange('database', database)
-                }
                 onTableChange={table =>
                   this.onDatasourcePropChange('datasource_name', table)
                 }
                 sqlLabMode={false}
                 clearable={false}
                 handleError={this.props.addDangerToast}
+                isDatabaseSelectEnabled={false}
               />
             }
             description={t(
@@ -748,6 +746,14 @@ export class DatasourceEditor extends React.PureComponent {
     return (
       <DatasourceContainer>
         {this.renderErrors()}
+        <div className="m-t-10">
+          <Alert bsStyle="warning">
+            <strong>{t('Be careful.')} </strong>
+            {t(
+              'Changing these settings will affect all charts using this dataset, including charts owned by other people.',
+            )}
+          </Alert>
+        </div>
         <Tabs
           id="table-tabs"
           onSelect={this.handleTabSelect}
@@ -830,14 +836,6 @@ export class DatasourceEditor extends React.PureComponent {
           <Tab eventKey={4} title={t('Settings')}>
             {activeTabKey === 4 && (
               <div>
-                <div className="m-t-10">
-                  <Alert bsStyle="warning">
-                    <strong>{t('Be careful.')} </strong>
-                    {t(
-                      'Changing these settings will affect all charts using this dataset, including charts owned by other people.',
-                    )}
-                  </Alert>
-                </div>
                 <Col md={6}>
                   <FormContainer>{this.renderSettingsFieldset()}</FormContainer>
                 </Col>

--- a/superset/connectors/base/views.py
+++ b/superset/connectors/base/views.py
@@ -14,11 +14,26 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any
+
 from flask import Markup
+from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
 
 from superset.connectors.base.models import BaseDatasource
 from superset.exceptions import SupersetException
 from superset.views.base import SupersetModelView
+
+
+class BS3TextFieldROWidget(  # pylint: disable=too-few-public-methods
+    BS3TextFieldWidget
+):
+    """
+    Custom read only text field widget.
+    """
+
+    def __call__(self, field: Any, **kwargs: Any) -> Markup:
+        kwargs["readonly"] = "true"
+        return super().__call__(field, **kwargs)
 
 
 class DatasourceModelView(SupersetModelView):

--- a/superset/connectors/druid/views.py
+++ b/superset/connectors/druid/views.py
@@ -25,10 +25,11 @@ from flask_appbuilder.fieldwidgets import Select2Widget
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
 from flask_babel import lazy_gettext as _
+from wtforms import StringField
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 
 from superset import db, security_manager
-from superset.connectors.base.views import DatasourceModelView
+from superset.connectors.base.views import BS3TextFieldROWidget, DatasourceModelView
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.connectors.druid import models
 from superset.constants import RouteMethod
@@ -98,7 +99,7 @@ class DruidColumnInlineView(CompactCRUDMixin, SupersetModelView):
     add_form_extra_fields = {
         "datasource": QuerySelectField(
             "Datasource",
-            query_factory=lambda: db.session().query(models.DruidDatasource),
+            query_factory=lambda: db.session.query(models.DruidDatasource),
             allow_blank=True,
             widget=Select2Widget(extra_classes="readonly"),
         )
@@ -179,7 +180,7 @@ class DruidMetricInlineView(CompactCRUDMixin, SupersetModelView):
     add_form_extra_fields = {
         "datasource": QuerySelectField(
             "Datasource",
-            query_factory=lambda: db.session().query(models.DruidDatasource),
+            query_factory=lambda: db.session.query(models.DruidDatasource),
             allow_blank=True,
             widget=Select2Widget(extra_classes="readonly"),
         )
@@ -332,6 +333,16 @@ class DruidDatasourceModelView(DatasourceModelView, DeleteMixin, YamlExportMixin
         "fetch_values_from": _("Fetch Values From"),
         "changed_by_": _("Changed By"),
         "modified": _("Modified"),
+    }
+    edit_form_extra_fields = {
+        "cluster": QuerySelectField(
+            "Cluster",
+            query_factory=lambda: db.session.query(models.DruidCluster),
+            widget=Select2Widget(extra_classes="readonly"),
+        ),
+        "datasource_name": StringField(
+            "Datasource Name", widget=BS3TextFieldROWidget()
+        ),
     }
 
     def pre_add(self, item: "DruidDatasourceModelView") -> None:

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -160,7 +160,7 @@ class TableColumnInlineView(  # pylint: disable=too-many-ancestors
     add_form_extra_fields = {
         "table": QuerySelectField(
             "Table",
-            query_factory=lambda: db.session().query(models.SqlaTable),
+            query_factory=lambda: db.session.query(models.SqlaTable),
             allow_blank=True,
             widget=Select2Widget(extra_classes="readonly"),
         )
@@ -232,7 +232,7 @@ class SqlMetricInlineView(  # pylint: disable=too-many-ancestors
     add_form_extra_fields = {
         "table": QuerySelectField(
             "Table",
-            query_factory=lambda: db.session().query(models.SqlaTable),
+            query_factory=lambda: db.session.query(models.SqlaTable),
             allow_blank=True,
             widget=Select2Widget(extra_classes="readonly"),
         )
@@ -393,7 +393,7 @@ class TableModelView(  # pylint: disable=too-many-ancestors
     edit_form_extra_fields = {
         "database": QuerySelectField(
             "Database",
-            query_factory=lambda: db.session().query(models.Database),
+            query_factory=lambda: db.session.query(models.Database),
             widget=Select2Widget(extra_classes="readonly"),
         )
     }


### PR DESCRIPTION
### SUMMARY

This PR makes a few related consistency updates to ensure that the database/cluster et al. is read-only either in the FAB CRUD or React data editor. Note one could reason that you could potential make the schema, table, etc. read-only, though my sense is that is that could be somewhat controversial. 

Specially this PR: 

1. For the React data editor makes the database read-only which is consistent with the FAB CRUD views.
2. Moves the React data editor warning above the tabs, i.e., users should be aware that changing any fields (metrics, columns, etc.) will impact all charts using said datasource.
3. For the Druid datasource CRUD view makes the cluster and datasource name read only. The cluster is akin to the database and thus this ensures consistency. Additionally the Druid datasource name is fixed hence this was also defined as read-only.  

@dpgaspar I noticed that there seems to have been a regression in FAB and the read-only selector logic which we are using (per the [documentation](https://flask-appbuilder.readthedocs.io/en/latest/advanced.html#forms-readonly-fields)) no longer works. I've also verified this using the FAB examples and was wondering whether you could look into it?

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="805" alt="Screen Shot 2020-09-09 at 4 43 44 PM" src="https://user-images.githubusercontent.com/4567245/92665525-ab010b80-f2bb-11ea-8a76-7c234f041cc4.png">

#### AFTER

<img width="803" alt="Screen Shot 2020-09-09 at 4 28 33 PM" src="https://user-images.githubusercontent.com/4567245/92665391-4b0a6500-f2bb-11ea-991f-2726b3f04417.png">

### TEST PLAN

Tested locally. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
