### PR TITLE
build: optimize webpack code split

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -43,6 +43,8 @@ const {
   devserverPort = 9000,
   measure = false,
   analyzeBundle = false,
+  analyzerPort = 8888,
+  nameChunks = false,
 } = parsedArgs;
 const isDevMode = mode !== 'production';
 
@@ -197,13 +199,61 @@ const config = {
     sideEffects: true,
     splitChunks: {
       chunks: 'all',
+      name: nameChunks,
       automaticNameDelimiter: '-',
       minChunks: 2,
       cacheGroups: {
-        default: false,
-        major: {
-          name: 'vendors-major',
-          test: /\/node_modules\/(brace|react|react-dom|@superset-ui\/translation|webpack.*|@babel.*)\//,
+        automaticNamePrefix: 'chunk',
+        // basic stable dependencies
+        vendors: {
+          priority: 50,
+          name: 'vendors',
+          test: new RegExp(
+            `/node_modules/(${[
+              'abortcontroller-polyfill',
+              'react',
+              'react-dom',
+              'prop-types',
+              'redux',
+              'react-redux',
+              'react-hot-loader',
+              'react-select',
+              'react-sortable-hoc',
+              'react-virtualized',
+              'react-table',
+              '@hot-loader.*',
+              'webpack.*',
+              '@?babel.*',
+              'lodash.*',
+              'antd',
+              '@ant-design.*',
+              '.*bootstrap',
+              'moment',
+              'jquery',
+              'core-js.*',
+              '@emotion.*',
+              'd3.*',
+            ].join('|')})/`,
+          ),
+        },
+        // bundle large libraries separately
+        brace: {
+          name: 'brace',
+          test: /\/node_modules\/(brace|react-ace)\//,
+          priority: 40,
+        },
+        mathjs: {
+          name: 'mathjs',
+          test: /\/node_modules\/mathjs\//,
+          priority: 30,
+          enforce: true,
+        },
+        // viz thumbnails are used in `addSlice` and `explore` page
+        thumbnail: {
+          name: 'thumbnail',
+          test: /thumbnail(Large)?\.png/i,
+          priority: 20,
+          enforce: true,
         },
       },
     },
@@ -299,7 +349,7 @@ const config = {
           },
         ],
       },
-      /* for css linking images */
+      /* for css linking images (and viz plugin thumbnails) */
       {
         test: /\.png$/,
         loader: 'url-loader',
@@ -404,7 +454,7 @@ if (isDevMode) {
 // Pass flag --analyzeBundle=true to enable
 // e.g. npm run build -- --analyzeBundle=true
 if (analyzeBundle) {
-  config.plugins.push(new BundleAnalyzerPlugin());
+  config.plugins.push(new BundleAnalyzerPlugin({ analyzerPort }));
 }
 
 // Speed measurement is disabled by default


### PR DESCRIPTION
### SUMMARY

Give more hints to webpack code split so that vendor scripts can be better extracted and cached. Reduced the overall bundle size from 7.05MB to 4.11MB.

Future plan would be to utilize more async module imports `import(...)` so that large chunks of code like `brace` and `mathjs` can be loaded on demand instead of on page load.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

Bundle sizes via `npm run build -- --analyzeBundle=true`:

![bundle-before](https://user-images.githubusercontent.com/335541/92795062-f1f70b80-f364-11ea-9eb5-233ead456dd4.png)

Visiting an example dashboard ("Tabbed Dashboard" from example testing data) with throttled network:

![dashboard-before](https://user-images.githubusercontent.com/335541/92795278-1ce15f80-f365-11ea-9652-704d32a90a8a.png)


#### After

![bundle-after](https://user-images.githubusercontent.com/335541/92795259-17841500-f365-11ea-9c48-66db0b417b9f.png)

![dashboard-after](https://user-images.githubusercontent.com/335541/92795082-f58a9280-f364-11ea-9699-b61f68b723df.png)

There are more JavaScript requests, but DOMContentLoaded time improved. Note this is also only the initial visit. We expect average load time to improve for future new releases as vendor scripts now have better cache.

### TEST PLAN

Make sure CI passes.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
