### PR TITLE
fix(test): missing auth on tests

### DIFF
--- a/tests/base_api_tests.py
+++ b/tests/base_api_tests.py
@@ -31,6 +31,7 @@ from .base_tests import SupersetTestCase
 
 class Model1Api(BaseSupersetModelRestApi):
     datamodel = SQLAInterface(Dashboard)
+    allow_browser_login = True
     class_permission_name = "DashboardModelView"
     method_permission_name = {
         "get_list": "list",

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -191,7 +191,7 @@ class TestCore(SupersetTestCase):
         db.session.add(annotation)
         db.session.commit()
 
-        self.login(username="admin")
+        self.login()
         resp_annotations = json.loads(
             self.get_resp("annotationlayermodelview/api/read")
         )

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -92,6 +92,7 @@ class TestCore(SupersetTestCase):
         self.assertIn("User confirmation needed", resp)
 
     def test_dashboard_endpoint(self):
+        self.login()
         resp = self.client.get("/superset/dashboard/-1/")
         assert resp.status_code == 404
 
@@ -190,6 +191,7 @@ class TestCore(SupersetTestCase):
         db.session.add(annotation)
         db.session.commit()
 
+        self.login(username="admin")
         resp_annotations = json.loads(
             self.get_resp("annotationlayermodelview/api/read")
         )
@@ -562,6 +564,7 @@ class TestCore(SupersetTestCase):
         db.session.commit()
 
     def test_warm_up_cache(self):
+        self.login()
         slc = self.get_slice("Girls", db.session)
         data = self.get_json_resp("/superset/warm_up_cache?slice_id={}".format(slc.id))
         self.assertEqual(
@@ -629,7 +632,7 @@ class TestCore(SupersetTestCase):
         assert "Dashboards" in self.get_resp("/dashboard/list/")
 
     def test_csv_endpoint(self):
-        self.login("admin")
+        self.login()
         sql = """
             SELECT name
             FROM birth_names
@@ -654,7 +657,7 @@ class TestCore(SupersetTestCase):
         self.logout()
 
     def test_extra_table_metadata(self):
-        self.login("admin")
+        self.login()
         example_db = utils.get_example_database()
         schema = "default" if example_db.backend in {"presto", "hive"} else "superset"
         self.get_json_resp(
@@ -695,7 +698,7 @@ class TestCore(SupersetTestCase):
         if utils.get_example_database().backend == "presto":
             # TODO: make it work for presto
             return
-        self.login("admin")
+        self.login()
         sql = "SELECT '{{ datetime(2017, 1, 1).isoformat() }}' as test"
         data = self.run_sql(sql, "fdaklj3ws")
         self.assertEqual(data["data"][0]["test"], "2017-01-01T00:00:00")
@@ -764,7 +767,7 @@ class TestCore(SupersetTestCase):
     def test_custom_templated_sql_json(self, sql_lab_mock, mock_dt) -> None:
         """Test sqllab receives macros expanded query."""
         mock_dt.utcnow = mock.Mock(return_value=datetime.datetime(1970, 1, 1))
-        self.login("admin")
+        self.login()
         sql = "SELECT '$DATE()' as test"
         resp = {
             "status": utils.QueryStatus.SUCCESS,
@@ -976,6 +979,7 @@ class TestCore(SupersetTestCase):
         mock_results_backend.get.return_value = compressed
 
         # get all results
+        self.login()
         result = json.loads(self.get_resp("/superset/results/key/"))
         expected = {"status": "success", "query": {"rows": 100}, "data": data}
         self.assertEqual(result, expected)


### PR DESCRIPTION
### SUMMARY
Fixes some tests that were successful but were actually testing on a non authenticated user context (they were supposed to run with admin). This surfaced while cherry picking for 0.38. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
