### PR TITLE
update port that cypress runs on for local vs test

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -181,6 +181,7 @@ cypress-run-all() {
   # so errors can print to stderr.
   local flasklog="${HOME}/flask.log"
   local port=8081
+  export CYPRESS_BASE_URL="http://localhost:${port}"
 
   nohup flask run --no-debugger -p $port >"$flasklog" 2>&1 </dev/null &
   local flaskProcessId=$!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -706,6 +706,10 @@ npm run cypress run -- --spec cypress/integration/dashboard/index.test.js --conf
 
 # to open the cypress ui
 npm run cypress open
+
+# to point cypress to a url other than the default (http://localhost:8088) set the environment variable before running the script
+# e.g., CYPRESS_BASE_URL="http://localhost:9000"
+CYPRESS_BASE_URL=<your url> npm run cypress open
 ```
 
 See [`superset-frontend/cypress_build.sh`](https://github.com/apache/incubator-superset/blob/master/superset-frontend/cypress_build.sh).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -680,6 +680,7 @@ We use [Cypress](https://www.cypress.io/) for integration tests. Tests can be ru
 
 ```bash
 export SUPERSET_CONFIG=tests.superset_test_config
+export CYPRESS_BASE_URL="http://localhost:8081"
 superset db upgrade
 superset init
 superset load_test_users

--- a/superset-frontend/cypress-base/cypress.json
+++ b/superset-frontend/cypress-base/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:8081",
+  "baseUrl": "http://localhost:8088",
   "chromeWebSecurity": false,
   "defaultCommandTimeout": 5000,
   "experimentalFetchPolyfill": true,

--- a/superset-frontend/cypress-base/package.json
+++ b/superset-frontend/cypress-base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "run cypress against superset",
   "scripts": {
-    "cypress": "CYPRESS_BASE_URL=\"http://localhost:${npm_config_port:-8088}\" cypress",
+    "cypress": "cypress",
     "cypress-debug": "cypress open --config watchForFileChanges=true"
   },
   "author": "Apcahe",

--- a/superset-frontend/cypress-base/package.json
+++ b/superset-frontend/cypress-base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "run cypress against superset",
   "scripts": {
-    "cypress": "cypress",
+    "cypress": "CYPRESS_BASE_URL=\"http://localhost:${npm_config_port:-8088}\" cypress",
     "cypress-debug": "cypress open --config watchForFileChanges=true"
   },
   "author": "Apcahe",

--- a/superset-frontend/cypress_build.sh
+++ b/superset-frontend/cypress_build.sh
@@ -25,7 +25,8 @@ time superset load_test_users
 time superset load_examples --load-test-data
 time superset init
 echo "[completed python build steps]"
-flask run -p 8081 --with-threads --reload --debugger &
+PORT='8081'
+flask run -p $PORT --with-threads --reload --debugger &
 
 #block on the longer running javascript process
 time npm ci
@@ -35,6 +36,7 @@ echo "[completed js build steps]"
 #setup cypress
 cd cypress-base
 time npm ci
+export CYPRESS_BASE_URL="http://localhost:${PORT}"
 CYPRESS_PATH='cypress/integration/'${1}'/*'
 time npm run cypress run -- --spec "$CYPRESS_PATH" --record false --config video=false
 


### PR DESCRIPTION
### SUMMARY
Docker and the local python virtual env (if you follow the instructions) are both set up to run on port 8088, whereas tox and github both run the app on port 8081. Cypress has a built in env variable that can be used to set the base url: `CYPRESS_BASE_URL`. The goal is to make it easier for developers to run Cypress locally without having to add an extra layer of configuration. The default port has been set in the cypess.json file to point to the host used by docker and local development, and tox and github uses the env var to overwrite the base in the scripts that run these tests. 

### TEST PLAN
Cypress should pass in github, tox should pass locally, and running `npm run cypress run` should work when running locally or on docker on port 8088. I also want to make sure that this doesn't break any configs that developers may have already set up in their local environments or IDEs, etc.  

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
