### PR TITLE
feat: server side dashboard css for less repaint

### DIFF
--- a/superset/templates/superset/dashboard.html
+++ b/superset/templates/superset/dashboard.html
@@ -18,6 +18,15 @@
 #}
 {% extends "superset/basic.html" %}
 
+{% block head_css %}
+  {{ super() }}
+  {% if custom_css %}
+    <style class="CssEditor-css" type="text/css">
+      {{ custom_css }}
+    </style>
+  {% endif %}
+{% endblock %}
+
 {% block body %}
   <div id="app" data-bootstrap="{{ bootstrap_data }}" />
 {% endblock %}

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1700,6 +1700,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             entry="dashboard",
             standalone_mode=standalone_mode,
             title=dash.dashboard_title,
+            custom_css=dashboard_data.get("css"),
             bootstrap_data=json.dumps(
                 bootstrap_data, default=utils.pessimistic_json_iso_dttm_ser
             ),


### PR DESCRIPTION
### SUMMARY

Add custom dashboard css to server side rendering so the page doesn't have to repaint when refresh.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

Since custom CSS is added after dashboard is loaded, when loading a dashboard, you may see an annoying repaint:

![load-repaint](https://user-images.githubusercontent.com/335541/92984619-55199880-f460-11ea-89cd-fd79fd57c1f7.gif)

#### After

No repaint when refreshing the page:

![no-repaint](https://user-images.githubusercontent.com/335541/92984648-85f9cd80-f460-11ea-9b2c-e93f3cd10eb3.gif)


### TEST PLAN

Manual testing.

1. Go add some custom CSS to a dashboard. Following is used in the screenshots:
   ```css
   body {
     font-family: monospace;
   }
   #app-menu {
     display: none;
   }
   ```
2. Save and refresh the page.
3. Editing the CSS again, live edits should be able to delete previous CSS.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

