### PR TITLE
Adding editorconfig setting for IDE hints

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# 4 space indentation for Python files
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length=88
+
+# 2 space indentation for Frontend files
+[*.{js,jsx,ts,tsx,html,less,css}]
+indent_style = space
+indent_size = 2
+
+# 2 space indentation for json and yaml files
+[*.{json,yml}]
+indent_style = space
+indent_size = 2
+
+# Tab indentation
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file


### PR DESCRIPTION
### SUMMARY

- When editing Python files, always forget the longest character limit in CI, add editconfig configuration, can let IDE/Editor remind instead of wait until CI is executed.
- When editing frontend files, also need remind indentation is 2.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TEST PLAN
N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
