### PR TITLE
ESLint: Re-enable no-useless-path-segments rule

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -79,7 +79,6 @@ module.exports = {
         ],
         'import/no-named-as-default': 0,
         'import/no-named-as-default-member': 0,
-        'import/no-useless-path-segments': 0, // disabled temporarily
         'import/prefer-default-export': 0,
         indent: 0,
         'jsx-a11y/anchor-has-content': 0,
@@ -202,7 +201,6 @@ module.exports = {
     ],
     'import/no-cycle': 0, // re-enable up for discussion, might require some major refactors
     'import/no-named-as-default': 0,
-    'import/no-useless-path-segments': 0, // disabled temporarily
     'import/prefer-default-export': 0,
     indent: 0,
     'jsx-a11y/anchor-has-content': 0,

--- a/superset-frontend/src/components/Icon/icon.stories.jsx
+++ b/superset-frontend/src/components/Icon/icon.stories.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { withKnobs, select } from '@storybook/addon-knobs';
 import { styled, supersetTheme } from '@superset-ui/core';
-import Icon, { iconsRegistry } from './';
+import Icon, { iconsRegistry } from '.';
 
 export default {
   title: 'Icon',

--- a/superset-frontend/src/components/ListViewCard/ListViewCard.stories.tsx
+++ b/superset-frontend/src/components/ListViewCard/ListViewCard.stories.tsx
@@ -24,7 +24,7 @@ import ChartImg from 'images/chart-card-fallback.png';
 import { Dropdown, Menu } from 'src/common/components';
 import Icon from 'src/components/Icon';
 import FaveStar from 'src/components/FaveStar';
-import ListViewCard from './';
+import ListViewCard from '.';
 
 export default {
   title: 'ListViewCard',

--- a/superset-frontend/src/components/TableLoader.jsx
+++ b/superset-frontend/src/components/TableLoader.jsx
@@ -22,7 +22,7 @@ import { Table, Tr, Td } from 'reactable-arc';
 import { t, SupersetClient } from '@superset-ui/core';
 
 import withToasts from '../messageToasts/enhancers/withToasts';
-import Loading from '../components/Loading';
+import Loading from './Loading';
 import '../../stylesheets/reactable-pagination.less';
 
 const propTypes = {

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -22,12 +22,12 @@ import { t, SupersetClient } from '@superset-ui/core';
 
 import { addChart, removeChart, refreshChart } from '../../chart/chartAction';
 import { chart as initChart } from '../../chart/chartReducer';
-import { fetchDatasourceMetadata } from '../../dashboard/actions/datasources';
+import { fetchDatasourceMetadata } from './datasources';
 import {
   addFilter,
   removeFilter,
   updateDirectPathToFilter,
-} from '../../dashboard/actions/dashboardFilters';
+} from './dashboardFilters';
 import { applyDefaultFormData } from '../../explore/store';
 import getClientErrorObject from '../../utils/getClientErrorObject';
 import { SAVE_TYPE_OVERWRITE } from '../util/constants';
@@ -36,7 +36,7 @@ import {
   addWarningToast,
   addDangerToast,
 } from '../../messageToasts/actions';
-import { UPDATE_COMPONENTS_PARENTS_LIST } from '../actions/dashboardLayout';
+import { UPDATE_COMPONENTS_PARENTS_LIST } from './dashboardLayout';
 import serializeActiveFilterValues from '../util/serializeActiveFilterValues';
 import serializeFilterScopes from '../util/serializeFilterScopes';
 import { getActiveFilters } from '../util/activeDashboardFilters';

--- a/superset-frontend/src/dashboard/reducers/index.js
+++ b/superset-frontend/src/dashboard/reducers/index.js
@@ -24,7 +24,7 @@ import dashboardState from './dashboardState';
 import dashboardFilters from './dashboardFilters';
 import datasources from './datasources';
 import sliceEntities from './sliceEntities';
-import dashboardLayout from '../reducers/undoableDashboardLayout';
+import dashboardLayout from './undoableDashboardLayout';
 import messageToasts from '../../messageToasts/reducers';
 
 const impressionId = (state = '') => state;

--- a/superset-frontend/src/dashboard/util/activeDashboardFilters.js
+++ b/superset-frontend/src/dashboard/util/activeDashboardFilters.js
@@ -23,7 +23,7 @@ import {
   getChartIdAndColumnFromFilterKey,
   getDashboardFilterKey,
 } from './getDashboardFilterKey';
-import { CHART_TYPE } from '../util/componentTypes';
+import { CHART_TYPE } from './componentTypes';
 import { DASHBOARD_FILTER_SCOPE_GLOBAL } from '../reducers/dashboardFilters';
 
 let allFilterBoxChartIds = [];

--- a/superset-frontend/src/dashboard/util/getFilterScopeNodesTree.js
+++ b/superset-frontend/src/dashboard/util/getFilterScopeNodesTree.js
@@ -20,11 +20,7 @@ import { isEmpty } from 'lodash';
 import { t } from '@superset-ui/core';
 
 import { DASHBOARD_ROOT_ID } from './constants';
-import {
-  CHART_TYPE,
-  DASHBOARD_ROOT_TYPE,
-  TAB_TYPE,
-} from '../util/componentTypes';
+import { CHART_TYPE, DASHBOARD_ROOT_TYPE, TAB_TYPE } from './componentTypes';
 
 const FILTER_SCOPE_CONTAINER_TYPES = [TAB_TYPE, DASHBOARD_ROOT_TYPE];
 

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -40,11 +40,11 @@ import { t } from '@superset-ui/core';
 
 import Button from 'src/components/Button';
 import getClientErrorObject from '../../utils/getClientErrorObject';
-import CopyToClipboard from './../../components/CopyToClipboard';
+import CopyToClipboard from '../../components/CopyToClipboard';
 import { getChartDataRequest } from '../../chart/chartAction';
 import downloadAsImage from '../../utils/downloadAsImage';
 import Loading from '../../components/Loading';
-import ModalTrigger from './../../components/ModalTrigger';
+import ModalTrigger from '../../components/ModalTrigger';
 import RowCountLabel from './RowCountLabel';
 import {
   applyFormattingToTabularData,

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -35,7 +35,7 @@ import * as exploreActions from '../actions/exploreActions';
 import * as saveModalActions from '../actions/saveModalActions';
 import * as chartActions from '../../chart/chartAction';
 import { fetchDatasourceMetadata } from '../../dashboard/actions/datasources';
-import * as logActions from '../../logger/actions/';
+import * as logActions from '../../logger/actions';
 import {
   LOG_ACTIONS_MOUNT_EXPLORER,
   LOG_ACTIONS_CHANGE_EXPLORE_CONTROLS,

--- a/superset-frontend/src/explore/components/controls/CollectionControl.jsx
+++ b/superset-frontend/src/explore/components/controls/CollectionControl.jsx
@@ -29,7 +29,7 @@ import {
 
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import ControlHeader from '../ControlHeader';
-import controlMap from './';
+import controlMap from '.';
 import './CollectionControl.less';
 
 const propTypes = {

--- a/superset-frontend/src/explore/controlPanels/Shared_DeckGL.jsx
+++ b/superset-frontend/src/explore/controlPanels/Shared_DeckGL.jsx
@@ -27,7 +27,7 @@ import {
   columnChoices,
 } from '@superset-ui/chart-controls';
 import { PRIMARY_COLOR } from '../controls';
-import { DEFAULT_VIEWPORT } from '../../explore/components/controls/ViewportControl';
+import { DEFAULT_VIEWPORT } from '../components/controls/ViewportControl';
 
 const sandboxUrl =
   'https://github.com/apache/incubator-superset/' +


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `no-useless-path-segments`, which was disabled in PR https://github.com/apache/incubator-superset/pull/10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
