### PR TITLE
ESLint: Re-enable rule no-else-return

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -90,7 +90,6 @@ module.exports = {
         'new-cap': 0,
         'no-bitwise': 0,
         'no-continue': 0,
-        'no-else-return': 0, // disabled temporarily
         'no-mixed-operators': 0,
         'no-multi-assign': 0,
         'no-multi-spaces': 0,
@@ -208,8 +207,7 @@ module.exports = {
     'jsx-a11y/mouse-events-have-key-events': 0, // re-enable up for discussion
     'lines-between-class-members': 0, // disabled temporarily
     'new-cap': 0,
-    'no-restricted-globals': 0, // disabled temporarily
-    'no-else-return': 0, // disabled temporarily
+    'no-restricted-globals': 0,
     'no-bitwise': 0,
     'no-continue': 0,
     'no-mixed-operators': 0,

--- a/superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx
+++ b/superset-frontend/src/SqlLab/components/EstimateQueryCostButton.jsx
@@ -61,7 +61,8 @@ class EstimateQueryCostButton extends React.PureComponent {
           {this.props.queryCostEstimate.error}
         </Alert>
       );
-    } else if (this.props.queryCostEstimate.completed) {
+    }
+    if (this.props.queryCostEstimate.completed) {
       return (
         <Table
           className="table cost-estimate"

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -216,7 +216,8 @@ export default class ResultSet extends React.PureComponent<
 
     if (query.state === 'stopped') {
       return <Alert bsStyle="warning">Query was stopped</Alert>;
-    } else if (query.state === 'failed') {
+    }
+    if (query.state === 'failed') {
       return (
         <div className="result-set-error-message">
           <ErrorMessageWithStackTrace
@@ -227,7 +228,8 @@ export default class ResultSet extends React.PureComponent<
           />
         </div>
       );
-    } else if (query.state === 'success' && query.ctas) {
+    }
+    if (query.state === 'success' && query.ctas) {
       const { tempSchema, tempTable } = query;
       let object = 'Table';
       if (query.ctas_method === CtasEnum.VIEW) {
@@ -262,7 +264,8 @@ export default class ResultSet extends React.PureComponent<
           </Alert>
         </div>
       );
-    } else if (query.state === 'success' && query.results) {
+    }
+    if (query.state === 'success' && query.results) {
       const { results } = query;
       let data;
       if (this.props.cache && query.cached) {
@@ -287,7 +290,8 @@ export default class ResultSet extends React.PureComponent<
             />
           </>
         );
-      } else if (data && data.length === 0) {
+      }
+      if (data && data.length === 0) {
         return (
           <Alert bsStyle="warning">{t('The query returned no data')}</Alert>
         );
@@ -310,7 +314,8 @@ export default class ResultSet extends React.PureComponent<
             {t('Fetch data preview')}
           </Button>
         );
-      } else if (query.resultsKey) {
+      }
+      if (query.resultsKey) {
         return (
           <Button
             buttonSize="sm"

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
@@ -59,7 +59,8 @@ const RunQueryActionButton = ({
         <i className="fa fa-stop" /> {t('Stop')}
       </Button>
     );
-  } else if (allowAsync) {
+  }
+  if (allowAsync) {
     return (
       <Button
         {...commonBtnProps}

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -238,7 +238,8 @@ class TableElement extends React.PureComponent {
           const colB = b.name.toUpperCase();
           if (colA < colB) {
             return -1;
-          } else if (colA > colB) {
+          }
+          if (colA > colB) {
             return 1;
           }
           return 0;

--- a/superset-frontend/src/chart/chartReducer.js
+++ b/superset-frontend/src/chart/chartReducer.js
@@ -168,7 +168,8 @@ export default function chartReducer(charts = {}, action) {
   if (action.type === actions.REMOVE_CHART) {
     delete charts[action.key];
     return charts;
-  } else if (action.type === actions.UPDATE_CHART_ID) {
+  }
+  if (action.type === actions.UPDATE_CHART_ID) {
     const { newId, key } = action;
     charts[newId] = {
       ...charts[key],

--- a/superset-frontend/src/components/AlteredSliceTag.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag.jsx
@@ -36,7 +36,8 @@ function alterForComparison(value) {
   // for this purpose
   if (value === undefined || value === null || value === '') {
     return null;
-  } else if (typeof value === 'object') {
+  }
+  if (typeof value === 'object') {
     if (Array.isArray(value) && value.length === 0) {
       return null;
     }
@@ -100,9 +101,11 @@ export default class AlteredSliceTag extends React.Component {
     // or the value type
     if (value === undefined) {
       return 'N/A';
-    } else if (value === null) {
+    }
+    if (value === null) {
       return 'null';
-    } else if (
+    }
+    if (
       this.state.controlsMap[key] &&
       this.state.controlsMap[key].type === 'AdhocFilterControl'
     ) {
@@ -118,21 +121,26 @@ export default class AlteredSliceTag extends React.Component {
           return `${v.subject} ${v.operator} ${filterVal}`;
         })
         .join(', ');
-    } else if (
+    }
+    if (
       this.state.controlsMap[key] &&
       this.state.controlsMap[key].type === 'BoundsControl'
     ) {
       return `Min: ${value[0]}, Max: ${value[1]}`;
-    } else if (
+    }
+    if (
       this.state.controlsMap[key] &&
       this.state.controlsMap[key].type === 'CollectionControl'
     ) {
       return value.map(v => safeStringify(v)).join(', ');
-    } else if (typeof value === 'boolean') {
+    }
+    if (typeof value === 'boolean') {
       return value ? 'true' : 'false';
-    } else if (value.constructor === Array) {
+    }
+    if (value.constructor === Array) {
       return value.length ? value.join(', ') : '[]';
-    } else if (typeof value === 'string' || typeof value === 'number') {
+    }
+    if (typeof value === 'string' || typeof value === 'number') {
       return value;
     }
     return safeStringify(value);

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -323,12 +323,15 @@ export default class FilterableTable extends PureComponent<
       if (aValue === bValue) {
         // equal items sort equally
         return 0;
-      } else if (aValue === null) {
+      }
+      if (aValue === null) {
         // nulls sort after anything else
         return 1;
-      } else if (bValue === null) {
+      }
+      if (bValue === null) {
         return -1;
-      } else if (descending) {
+      }
+      if (descending) {
         return aValue < bValue ? 1 : -1;
       }
       return aValue < bValue ? -1 : 1;

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -199,7 +199,8 @@ export function Menu({
                       className="settings-divider"
                     />
                   );
-                } else if (section.isHeader) {
+                }
+                if (section.isHeader) {
                   return (
                     <MenuItem key={`${section.label}`} disabled>
                       {section.label}

--- a/superset-frontend/src/components/Menu/MenuObject.tsx
+++ b/superset-frontend/src/components/Menu/MenuObject.tsx
@@ -57,7 +57,8 @@ export default function MenuObject({
       {childs?.map((child: MenuObjectChildProps | string, index1: number) => {
         if (typeof child === 'string' && child === '-') {
           return <MenuItem key={`$${index1}`} divider />;
-        } else if (typeof child !== 'string') {
+        }
+        if (typeof child !== 'string') {
           return (
             <MenuItem
               key={`${child.label}`}

--- a/superset-frontend/src/components/ModalTrigger.jsx
+++ b/superset-frontend/src/components/ModalTrigger.jsx
@@ -108,7 +108,8 @@ export default class ModalTrigger extends React.Component {
           {this.renderModal()}
         </>
       );
-    } else if (this.props.isMenuItem) {
+    }
+    if (this.props.isMenuItem) {
       return (
         <>
           <MenuItem onClick={this.open}>{this.props.triggerNode}</MenuItem>

--- a/superset-frontend/src/dashboard/components/FilterIndicatorsContainer.jsx
+++ b/superset-frontend/src/dashboard/components/FilterIndicatorsContainer.jsx
@@ -54,7 +54,8 @@ function sortByIndicatorLabel(indicator1, indicator2) {
   const s2 = (indicator2.label || indicator2.name).toLowerCase();
   if (s1 < s2) {
     return -1;
-  } else if (s1 > s2) {
+  }
+  if (s1 > s2) {
     return 1;
   }
   return 0;

--- a/superset-frontend/src/dashboard/components/PublishedStatus.jsx
+++ b/superset-frontend/src/dashboard/components/PublishedStatus.jsx
@@ -86,7 +86,7 @@ export default class PublishedStatus extends React.Component {
     }
 
     // Show the published badge for the owner of the dashboard to toggle
-    else if (this.props.canEdit && this.props.canSave) {
+    if (this.props.canEdit && this.props.canSave) {
       return (
         <TooltipWrapper
           label="Published Dashboard"

--- a/superset-frontend/src/dashboard/components/SliceAdder.jsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.jsx
@@ -71,7 +71,8 @@ class SliceAdder extends React.Component {
     return (a, b) => {
       if (a[attr] < b[attr]) {
         return -1 * desc;
-      } else if (a[attr] > b[attr]) {
+      }
+      if (a[attr] > b[attr]) {
         return 1 * desc;
       }
       return 0;

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
@@ -137,7 +137,8 @@ class Markdown extends React.PureComponent {
         markdownSource: nextComponent.meta.code,
         hasError: false,
       };
-    } else if (
+    }
+    if (
       !hasError &&
       editorMode === 'preview' &&
       nextComponent.meta.code !== markdownSource

--- a/superset-frontend/src/dashboard/reducers/dashboardFilters.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardFilters.js
@@ -126,7 +126,8 @@ export default function dashboardFiltersReducer(dashboardFilters = {}, action) {
       components: action.components,
     });
     return dashboardFilters;
-  } else if (action.type === UPDATE_DASHBOARD_FILTERS_SCOPE) {
+  }
+  if (action.type === UPDATE_DASHBOARD_FILTERS_SCOPE) {
     const allDashboardFiltersScope = action.scopes;
     // update filter scope for each filter field
     const updatedFilters = Object.entries(allDashboardFiltersScope).reduce(
@@ -153,14 +154,16 @@ export default function dashboardFiltersReducer(dashboardFilters = {}, action) {
 
     buildActiveFilters({ dashboardFilters: updatedFilters });
     return updatedFilters;
-  } else if (action.type === REMOVE_FILTER) {
+  }
+  if (action.type === REMOVE_FILTER) {
     const { chartId } = action;
     const { [chartId]: deletedFilter, ...updatedFilters } = dashboardFilters;
     buildActiveFilters({ dashboardFilters: updatedFilters });
     buildFilterColorMap(updatedFilters);
 
     return updatedFilters;
-  } else if (action.type in actionHandlers) {
+  }
+  if (action.type in actionHandlers) {
     const updatedFilters = {
       ...dashboardFilters,
       [action.chartId]: actionHandlers[action.type](

--- a/superset-frontend/src/dashboard/util/getComponentWidthFromDrop.js
+++ b/superset-frontend/src/dashboard/util/getComponentWidthFromDrop.js
@@ -65,9 +65,11 @@ export default function getComponentWidthFromDrop({
 
   if (isNaN(destinationCapacity) || isNaN(draggingWidth.width)) {
     return draggingWidth.width;
-  } else if (destinationCapacity >= draggingWidth.width) {
+  }
+  if (destinationCapacity >= draggingWidth.width) {
     return draggingWidth.width;
-  } else if (destinationCapacity >= draggingWidth.minimumWidth) {
+  }
+  if (destinationCapacity >= draggingWidth.minimumWidth) {
     return destinationCapacity;
   }
 

--- a/superset-frontend/src/dashboard/util/logging/findNonTabChildChartIds.js
+++ b/superset-frontend/src/dashboard/util/logging/findNonTabChildChartIds.js
@@ -54,7 +54,8 @@ let cachedIdsLookup = {};
 export default function findNonTabChildChartIdsWithCache({ id, layout }) {
   if (cachedLayout === layout && cachedIdsLookup[id]) {
     return cachedIdsLookup[id];
-  } else if (layout !== cachedLayout) {
+  }
+  if (layout !== cachedLayout) {
     cachedLayout = layout;
     cachedIdsLookup = {};
   }

--- a/superset-frontend/src/explore/AdhocFilter.js
+++ b/superset-frontend/src/explore/AdhocFilter.js
@@ -60,7 +60,8 @@ function translateToSql(adhocMetric, { useSimple } = {}) {
     return `${subject} ${operator} ${isMulti ? "('" : ''}${comparator}${
       isMulti ? "')" : ''
     }`;
-  } else if (adhocMetric.expressionType === EXPRESSION_TYPES.SQL) {
+  }
+  if (adhocMetric.expressionType === EXPRESSION_TYPES.SQL) {
     return adhocMetric.sqlExpression;
   }
   return '';

--- a/superset-frontend/src/explore/AdhocMetric.js
+++ b/superset-frontend/src/explore/AdhocMetric.js
@@ -95,7 +95,8 @@ export default class AdhocMetric {
       return `${this.aggregate || ''}(${
         (this.column && this.column.column_name) || ''
       })`;
-    } else if (this.expressionType === EXPRESSION_TYPES.SQL) {
+    }
+    if (this.expressionType === EXPRESSION_TYPES.SQL) {
       return this.sqlExpression;
     }
     return '';
@@ -125,7 +126,8 @@ export default class AdhocMetric {
   isValid() {
     if (this.expressionType === EXPRESSION_TYPES.SIMPLE) {
       return !!(this.column && this.aggregate);
-    } else if (this.expressionType === EXPRESSION_TYPES.SQL) {
+    }
+    if (this.expressionType === EXPRESSION_TYPES.SQL) {
       return !!this.sqlExpression;
     }
     return false;

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -60,11 +60,14 @@ const defaultProps = {
 function translateOperator(operator) {
   if (operator === OPERATORS['==']) {
     return 'equals';
-  } else if (operator === OPERATORS['!=']) {
+  }
+  if (operator === OPERATORS['!=']) {
     return 'not equal to';
-  } else if (operator === OPERATORS.LIKE) {
+  }
+  if (operator === OPERATORS.LIKE) {
     return 'like';
-  } else if (operator === OPERATORS['LATEST PARTITION']) {
+  }
+  if (operator === OPERATORS['LATEST PARTITION']) {
     return 'use latest_partition template';
   }
   return operator;

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -142,10 +142,12 @@ class ControlPanelsContainer extends React.Component {
               if (!controlItem) {
                 // When the item is invalid
                 return null;
-              } else if (React.isValidElement(controlItem)) {
+              }
+              if (React.isValidElement(controlItem)) {
                 // When the item is a React element
                 return controlItem;
-              } else if (controlItem.name && controlItem.config) {
+              }
+              if (controlItem.name && controlItem.config) {
                 return this.renderControl(controlItem);
               }
               return null;

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -133,9 +133,11 @@ export class DisplayQueryButton extends React.PureComponent {
   renderQueryModalBody() {
     if (this.state.isLoading) {
       return <Loading />;
-    } else if (this.state.error) {
+    }
+    if (this.state.error) {
       return <pre>{this.state.error}</pre>;
-    } else if (this.state.query) {
+    }
+    if (this.state.query) {
       return (
         <div>
           <CopyToClipboard
@@ -158,9 +160,11 @@ export class DisplayQueryButton extends React.PureComponent {
   renderResultsModalBody() {
     if (this.state.isLoading) {
       return <Loading />;
-    } else if (this.state.error) {
+    }
+    if (this.state.error) {
       return <pre>{this.state.error}</pre>;
-    } else if (this.state.data) {
+    }
+    if (this.state.data) {
       if (this.state.data.length === 0) {
         return 'No data';
       }
@@ -212,9 +216,11 @@ export class DisplayQueryButton extends React.PureComponent {
   renderSamplesModalBody() {
     if (this.state.isLoading) {
       return <Loading />;
-    } else if (this.state.error) {
+    }
+    if (this.state.error) {
       return <pre>{this.state.error}</pre>;
-    } else if (this.state.data) {
+    }
+    if (this.state.data) {
       return this.renderDataTable(this.state.data);
     }
     return null;

--- a/superset-frontend/src/explore/components/FilterDefinitionOption.jsx
+++ b/superset-frontend/src/explore/components/FilterDefinitionOption.jsx
@@ -40,9 +40,11 @@ export default function FilterDefinitionOption({ option }) {
         <span className="option-label">{option.saved_metric_name}</span>
       </div>
     );
-  } else if (option.column_name) {
+  }
+  if (option.column_name) {
     return <ColumnOption column={option} showType />;
-  } else if (option.label) {
+  }
+  if (option.label) {
     return <AdhocMetricStaticOption adhocMetric={option} showType />;
   }
 }

--- a/superset-frontend/src/explore/components/MetricDefinitionOption.jsx
+++ b/superset-frontend/src/explore/components/MetricDefinitionOption.jsx
@@ -38,9 +38,11 @@ const propTypes = {
 function MetricDefinitionOption({ option, addWarningToast }) {
   if (option.metric_name) {
     return <MetricOption metric={option} showType />;
-  } else if (option.column_name) {
+  }
+  if (option.column_name) {
     return <ColumnOption column={option} showType />;
-  } else if (option.aggregate_name) {
+  }
+  if (option.aggregate_name) {
     return <AggregateOption aggregate={option} showType />;
   }
   addWarningToast(

--- a/superset-frontend/src/explore/components/controls/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricsControl.jsx
@@ -107,26 +107,32 @@ function getDefaultAggregateForColumn(column) {
   const { type } = column;
   if (typeof type !== 'string') {
     return AGGREGATES.COUNT;
-  } else if (type === '' || type === 'expression') {
+  }
+  if (type === '' || type === 'expression') {
     return AGGREGATES.SUM;
-  } else if (
+  }
+  if (
     type.match(/.*char.*/i) ||
     type.match(/string.*/i) ||
     type.match(/.*text.*/i)
   ) {
     return AGGREGATES.COUNT_DISTINCT;
-  } else if (
+  }
+  if (
     type.match(/.*int.*/i) ||
     type === 'LONG' ||
     type === 'DOUBLE' ||
     type === 'FLOAT'
   ) {
     return AGGREGATES.SUM;
-  } else if (type.match(/.*bool.*/i)) {
+  }
+  if (type.match(/.*bool.*/i)) {
     return AGGREGATES.MAX;
-  } else if (type.match(/.*time.*/i)) {
+  }
+  if (type.match(/.*time.*/i)) {
     return AGGREGATES.COUNT;
-  } else if (type.match(/unknown/i)) {
+  }
+  if (type.match(/unknown/i)) {
     return AGGREGATES.COUNT;
   }
   return null;

--- a/superset-frontend/src/explore/components/controls/SpatialControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SpatialControl.jsx
@@ -119,9 +119,11 @@ export default class SpatialControl extends React.Component {
     }
     if (this.state.type === spatialTypes.latlong) {
       return `${this.state.lonCol} | ${this.state.latCol}`;
-    } else if (this.state.type === spatialTypes.delimited) {
+    }
+    if (this.state.type === spatialTypes.delimited) {
       return `${this.state.lonlatCol}`;
-    } else if (this.state.type === spatialTypes.geohash) {
+    }
+    if (this.state.type === spatialTypes.geohash) {
       return `${this.state.geohashCol}`;
     }
     return null;

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -100,7 +100,8 @@ function handleMissingChoice(control) {
     if (control.multi && value.length > 0) {
       alteredControl.value = value.filter(el => choiceValues.indexOf(el) > -1);
       return alteredControl;
-    } else if (!control.multi && choiceValues.indexOf(value) < 0) {
+    }
+    if (!control.multi && choiceValues.indexOf(value) < 0) {
       alteredControl.value = null;
       return alteredControl;
     }

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -93,13 +93,17 @@ export function supersetURL(rootUrl, getParams = {}) {
 export function optionLabel(opt) {
   if (opt === null) {
     return NULL_STRING;
-  } else if (opt === '') {
+  }
+  if (opt === '') {
     return '<empty string>';
-  } else if (opt === true) {
+  }
+  if (opt === true) {
     return '<true>';
-  } else if (opt === false) {
+  }
+  if (opt === false) {
     return '<false>';
-  } else if (typeof opt !== 'string' && opt.toString) {
+  }
+  if (typeof opt !== 'string' && opt.toString) {
     return opt.toString();
   }
   return opt;

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -539,13 +539,15 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
 
                 if (!selected.length) {
                   return t('0 Selected');
-                } else if (virtualCount && !physicalCount) {
+                }
+                if (virtualCount && !physicalCount) {
                   return t(
                     '%s Selected (Virtual)',
                     selected.length,
                     virtualCount,
                   );
-                } else if (physicalCount && !virtualCount) {
+                }
+                if (physicalCount && !virtualCount) {
                   return t(
                     '%s Selected (Physical)',
                     selected.length,

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -43,9 +43,11 @@ function colorFromBounds(value, bounds, colorBounds = ACCESSIBLE_COLOR_BOUNDS) {
         .domain([min, (max + min) / 2, max])
         .range([minColor, 'grey', maxColor]);
       return colorScale(value);
-    } else if (min !== null) {
+    }
+    if (min !== null) {
       return value >= min ? maxColor : minColor;
-    } else if (max !== null) {
+    }
+    if (max !== null) {
       return value < max ? maxColor : minColor;
     }
   }


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `no-else-return`, which was disabled in PR #10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
