### PR TITLE
ESLint: Re-enable rule no-restricted-globals

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -98,7 +98,6 @@ module.exports = {
         'no-multi-spaces': 0,
         'no-plusplus': 0,
         'no-prototype-builtins': 0,
-        'no-restricted-globals': 0, // disabled temporarily
         'no-restricted-properties': 0,
         'no-restricted-syntax': 0,
         'no-restricted-imports': [
@@ -212,7 +211,6 @@ module.exports = {
     'jsx-a11y/mouse-events-have-key-events': 0, // re-enable up for discussion
     'lines-between-class-members': 0, // disabled temporarily
     'new-cap': 0,
-    'no-restricted-globals': 0, // disabled temporarily
     'no-else-return': 0, // disabled temporarily
     'no-bitwise': 0,
     'no-confusing-arrow': 0,

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper.tsx
@@ -153,7 +153,7 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
   ) {
     // If the prefix starts with a number, don't try to autocomplete with a
     // table name or schema or anything else
-    if (!isNaN(parseInt(prefix, 10))) {
+    if (!Number.isNaN(parseInt(prefix, 10))) {
       return;
     }
     const completer = {

--- a/superset-frontend/src/components/SearchInput.tsx
+++ b/superset-frontend/src/components/SearchInput.tsx
@@ -53,13 +53,13 @@ const commonStyles = `
   cursor: pointer;
 `;
 const SearchIcon = styled(Icon)`
-  ${commonStyles}
+  ${commonStyles};
   top: 1px;
   left: 2px;
 `;
 
 const ClearIcon = styled(Icon)`
-  ${commonStyles}
+  ${commonStyles};
   right: 0px;
   top: 1px;
 `;

--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -466,7 +466,7 @@ class Header extends React.PureComponent {
                 setColorSchemeAndUnsavedChanges(updates.colorScheme);
                 dashboardTitleChanged(updates.title);
                 if (updates.slug) {
-                  history.pushState(
+                  window.history.pushState(
                     { event: 'dashboard_properties_changed' },
                     '',
                     `/superset/dashboard/${updates.slug}/`,

--- a/superset-frontend/src/dashboard/util/getComponentWidthFromDrop.js
+++ b/superset-frontend/src/dashboard/util/getComponentWidthFromDrop.js
@@ -50,7 +50,7 @@ export default function getComponentWidthFromDrop({
   let destinationCapacity =
     destinationWidth.width - destinationWidth.occupiedWidth;
 
-  if (isNaN(destinationCapacity)) {
+  if (Number.isNaN(destinationCapacity)) {
     const grandparentWidth = getDetailedComponentWidth({
       id: findParentId({
         childId: destination.id,
@@ -63,7 +63,7 @@ export default function getComponentWidthFromDrop({
       grandparentWidth.width - grandparentWidth.occupiedWidth;
   }
 
-  if (isNaN(destinationCapacity) || isNaN(draggingWidth.width)) {
+  if (Number.isNaN(destinationCapacity) || Number.isNaN(draggingWidth.width)) {
     return draggingWidth.width;
   } else if (destinationCapacity >= draggingWidth.width) {
     return draggingWidth.width;

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -241,9 +241,9 @@ class ExploreViewContainer extends React.Component {
     const longUrl = getExploreLongUrl(this.props.form_data, null, false);
     try {
       if (isReplace) {
-        history.replaceState(payload, title, longUrl);
+        window.history.replaceState(payload, title, longUrl);
       } else {
-        history.pushState(payload, title, longUrl);
+        window.history.pushState(payload, title, longUrl);
       }
     } catch (e) {
       logging.warn(
@@ -268,7 +268,7 @@ class ExploreViewContainer extends React.Component {
   }
 
   handlePopstate() {
-    const formData = history.state;
+    const formData = window.history.state;
     if (formData && Object.keys(formData).length) {
       this.props.actions.setExploreControls(formData);
       this.props.actions.postChartFormData(

--- a/superset-frontend/src/explore/components/controls/BoundsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/BoundsControl.jsx
@@ -64,10 +64,10 @@ export default class BoundsControl extends React.Component {
   onChange() {
     const mm = this.state.minMax;
     const errors = [];
-    if (mm[0] && isNaN(mm[0])) {
+    if (mm[0] && Number.isNaN(mm[0])) {
       errors.push(t('`Min` value should be numeric or empty'));
     }
-    if (mm[1] && isNaN(mm[1])) {
+    if (mm[1] && Number.isNaN(mm[1])) {
       errors.push(t('`Max` value should be numeric or empty'));
     }
     if (errors.length === 0) {

--- a/superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterBoxItemControl.jsx
@@ -114,9 +114,9 @@ export default class FilterBoxItemControl extends React.Component {
         if (type === 'BOOLEAN') {
           typedValue = value === 'true';
         } else if (INTEGRAL_TYPES.has(type)) {
-          typedValue = isNaN(value) ? null : parseInt(value, 10);
+          typedValue = Number.isNaN(value) ? null : parseInt(value, 10);
         } else if (DECIMAL_TYPES.has(type)) {
-          typedValue = isNaN(value) ? null : parseFloat(value);
+          typedValue = Number.isNaN(value) ? null : parseFloat(value);
         }
       }
     }

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -117,9 +117,9 @@ export function getChartDataUri({ path, qs, allowDomainSharding = false }) {
   // but can be specified with curUrl (used for unit tests to spoof
   // the window.location).
   let uri = new URI({
-    protocol: location.protocol.slice(0, -1),
+    protocol: window.location.protocol.slice(0, -1),
     hostname: getHostName(allowDomainSharding),
-    port: location.port ? location.port : '',
+    port: window.location.port ? window.location.port : '',
     path,
   });
   if (qs) {

--- a/superset-frontend/src/modules/utils.js
+++ b/superset-frontend/src/modules/utils.js
@@ -65,7 +65,7 @@ export function getParam(name) {
   /* eslint no-useless-escape: 0 */
   const formattedName = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
   const regex = new RegExp(`[\\?&]${formattedName}=([^&#]*)`);
-  const results = regex.exec(location.search);
+  const results = regex.exec(window.location.search);
   return results === null
     ? ''
     : decodeURIComponent(results[1].replace(/\+/g, ' '));

--- a/superset-frontend/src/setup/setupApp.ts
+++ b/superset-frontend/src/setup/setupApp.ts
@@ -75,7 +75,7 @@ export default function setupApp() {
         url: ev.currentTarget.href,
         parseMethod: null,
       }).then(() => {
-        location.reload();
+        window.location.reload();
       });
     });
   });

--- a/superset-frontend/src/utils/hostNamesConfig.js
+++ b/superset-frontend/src/utils/hostNamesConfig.js
@@ -23,7 +23,7 @@ function getDomainsConfig() {
   }
 
   const bootstrapData = JSON.parse(appContainer.getAttribute('data-bootstrap'));
-  const availableDomains = new Set([location.hostname]);
+  const availableDomains = new Set([window.location.hostname]);
   if (
     bootstrapData &&
     bootstrapData.common &&


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `no restricted globals`, which was disabled in PR #10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
