### PR TITLE
ESLint: Re-enable rule no-non-null-assertion

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -59,7 +59,6 @@ module.exports = {
         '@typescript-eslint/ban-types': 0, // disabled temporarily
         '@typescript-eslint/no-empty-function': 0,
         '@typescript-eslint/no-explicit-any': 0,
-        '@typescript-eslint/no-non-null-assertion': 0, // disabled temporarily
         '@typescript-eslint/no-use-before-define': 1, // disabled temporarily
         '@typescript-eslint/no-unused-vars': 0, // disabled temporarily
         '@typescript-eslint/explicit-function-return-type': 0,

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -289,7 +289,7 @@ export default class FilterableTable extends PureComponent<
   }
 
   fitTableToWidthIfNeeded() {
-    const containerWidth = this.container.current!.clientWidth;
+    const containerWidth = this.container.current?.clientWidth ?? 0;
     if (this.totalTableWidth < containerWidth) {
       // fit table width if content doesn't fill the width of the container
       this.totalTableWidth = containerWidth;


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `no-non-null-assertion`, which was disabled in PR #10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
