### PR TITLE
ESLint: Re-enable rule prefer-destructuring (only for objects)

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -117,7 +117,7 @@ module.exports = {
         'no-use-before-define': 0, // disabled temporarily
         'padded-blocks': 0,
         'prefer-arrow-callback': 0,
-        'prefer-destructuring': 0, // disabled temporarily
+        'prefer-destructuring': ['error', { object: true, array: false }],
         'react/default-props-match-prop-types': 0, // disabled temporarily
         'react/destructuring-assignment': 0, // re-enable up for discussion
         'react/forbid-prop-types': 0,
@@ -240,7 +240,7 @@ module.exports = {
     'padded-blocks': 0,
     'prefer-arrow-callback': 0,
     'prefer-object-spread': 1,
-    'prefer-destructuring': 0, // disabled temporarily
+    'prefer-destructuring': ['error', { object: true, array: false }],
     'react/default-props-match-prop-types': 0, // disabled temporarily
     'react/destructuring-assignment': 0, // re-enable up for discussion
     'react/forbid-prop-types': 0,

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.js
@@ -30,7 +30,7 @@ describe('Dashboard load', () => {
 
     cy.get('#app').then(data => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
-      const slices = bootstrapData.dashboard_data.slices;
+      const { slices } = bootstrapData.dashboard_data;
       // then define routes and create alias for each requests
       slices.forEach(slice => {
         const alias = `getJson_${slice.slice_id}`;

--- a/superset-frontend/spec/helpers/shim.ts
+++ b/superset-frontend/spec/helpers/shim.ts
@@ -31,7 +31,7 @@ configure({ adapter: new Adapter() });
 
 const exposedProperties = ['window', 'navigator', 'document'];
 
-const defaultView = document.defaultView;
+const { defaultView } = document;
 if (defaultView != null) {
   Object.keys(defaultView).forEach(property => {
     if (typeof global[property] === 'undefined') {

--- a/superset-frontend/spec/javascripts/CRUD/CollectionTable_spec.jsx
+++ b/superset-frontend/spec/javascripts/CRUD/CollectionTable_spec.jsx
@@ -41,7 +41,7 @@ describe('CollectionTable', () => {
   });
 
   it('renders a table', () => {
-    const length = mockDatasource['7__table'].columns.length;
+    const { length } = mockDatasource['7__table'].columns;
     expect(wrapper.find('table')).toExist();
     expect(wrapper.find('tbody tr.row')).toHaveLength(length);
   });

--- a/superset-frontend/spec/javascripts/dashboard/actions/dashboardState_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/actions/dashboardState_spec.js
@@ -103,7 +103,7 @@ describe('dashboardState actions', () => {
       const thunk = saveDashboardRequest(newDashboardData, 1, 'save_dash');
       thunk(dispatch, getState);
       expect(postStub.callCount).toBe(1);
-      const postPayload = postStub.getCall(0).args[0].postPayload;
+      const { postPayload } = postStub.getCall(0).args[0];
       expect(postPayload.data.positions[DASHBOARD_GRID_ID].parents).toBe(
         mockParentsList,
       );

--- a/superset-frontend/spec/javascripts/dashboard/reducers/dashboardFilters_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/reducers/dashboardFilters_spec.js
@@ -39,7 +39,7 @@ import {
 import { filterComponent } from '../fixtures/mockDashboardLayout';
 
 describe('dashboardFilters reducer', () => {
-  const form_data = sliceEntitiesForDashboard.slices[filterId].form_data;
+  const { form_data } = sliceEntitiesForDashboard.slices[filterId];
   const component = filterComponent;
   const directPathToFilter = (component.parents || []).slice();
   directPathToFilter.push(component.id);

--- a/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -158,7 +158,7 @@ describe('SaveModal', () => {
     it('should save slice', () => {
       const wrapper = getWrapper();
       wrapper.instance().saveOrOverwrite(true);
-      const args = defaultProps.actions.saveSlice.getCall(0).args;
+      const { args } = defaultProps.actions.saveSlice.getCall(0);
       expect(args[0]).toEqual(defaultProps.form_data);
     });
 
@@ -168,7 +168,7 @@ describe('SaveModal', () => {
 
       wrapper.setState({ saveToDashboardId });
       wrapper.instance().saveOrOverwrite(true);
-      const args = defaultProps.actions.saveSlice.getCall(0).args;
+      const { args } = defaultProps.actions.saveSlice.getCall(0);
       expect(args[1].save_to_dashboard_id).toBe(saveToDashboardId);
     });
 
@@ -178,7 +178,7 @@ describe('SaveModal', () => {
 
       wrapper.setState({ newDashboardName });
       wrapper.instance().saveOrOverwrite(true);
-      const args = defaultProps.actions.saveSlice.getCall(0).args;
+      const { args } = defaultProps.actions.saveSlice.getCall(0);
       expect(args[1].new_dashboard_name).toBe(newDashboardName);
     });
 

--- a/superset-frontend/spec/javascripts/explore/utils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/utils_spec.jsx
@@ -33,7 +33,7 @@ import * as hostNamesConfig from 'src/utils/hostNamesConfig';
 import { getChartMetadataRegistry } from '@superset-ui/core';
 
 describe('exploreUtils', () => {
-  const location = window.location;
+  const { location } = window;
   const formData = {
     datasource: '1__table',
   };

--- a/superset-frontend/spec/javascripts/middleware/logger_spec.js
+++ b/superset-frontend/spec/javascripts/middleware/logger_spec.js
@@ -81,7 +81,7 @@ describe('logger middleware', () => {
     clock.tick(2000);
 
     expect(SupersetClient.post.callCount).toBe(1);
-    const events = SupersetClient.post.getCall(0).args[0].postPayload.events;
+    const { events } = SupersetClient.post.getCall(0).args[0].postPayload;
     const mockEventdata = action.payload.eventData;
     const mockEventname = action.payload.eventName;
     expect(events[0]).toMatchObject({

--- a/superset-frontend/spec/javascripts/sqllab/QuerySearch_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/QuerySearch_spec.jsx
@@ -69,7 +69,7 @@ describe('QuerySearch', () => {
   });
 
   it('refreshes queries when enter (only) is pressed on the input', () => {
-    const callCount = search.callCount;
+    const { callCount } = search;
     wrapper.find('input').simulate('keyDown', { keyCode: 'a'.charCodeAt(0) });
     expect(search.callCount).toBe(callCount);
     wrapper.find('input').simulate('keyDown', { keyCode: '\r'.charCodeAt(0) });
@@ -81,7 +81,7 @@ describe('QuerySearch', () => {
   });
 
   it('refreshes queries when clicked', () => {
-    const callCount = search.callCount;
+    const { callCount } = search;
     wrapper.find(Button).simulate('click');
     expect(search.callCount).toBe(callCount + 1);
   });

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper.tsx
@@ -237,7 +237,7 @@ class AceEditorWrapper extends React.PureComponent<Props, State> {
     });
   }
   getAceAnnotations() {
-    const validationResult = this.props.queryEditor.validationResult;
+    const { validationResult } = this.props.queryEditor;
     const resultIsReady = validationResult && validationResult.completed;
     if (resultIsReady && validationResult.errors.length > 0) {
       const errors = validationResult.errors.map((err: any) => ({

--- a/superset-frontend/src/SqlLab/components/ColumnElement.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement.tsx
@@ -47,10 +47,10 @@ interface ColumnElementProps {
 }
 
 export default function ColumnElement({ column }: ColumnElementProps) {
-  let name: React.ReactNode = column.name;
+  let columnName: React.ReactNode = column.name;
   let icons;
   if (column.keys && column.keys.length > 0) {
-    name = <strong>{column.name}</strong>;
+    columnName = <strong>{column.name}</strong>;
     icons = column.keys.map((key, i) => (
       <span key={i} className="ColumnElement">
         <OverlayTrigger
@@ -73,7 +73,7 @@ export default function ColumnElement({ column }: ColumnElementProps) {
   return (
     <div className="clearfix table-column">
       <div className="pull-left m-l-10 col-name">
-        {name}
+        {columnName}
         {icons}
       </div>
       <div className="pull-right text-muted">

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -53,7 +53,7 @@ class ExploreResultsButton extends React.PureComponent {
     );
   }
   onClick() {
-    const timeout = this.props.timeout;
+    const { timeout } = this.props;
     const msg = this.renderInvalidColumnMessage();
     if (Math.round(this.getQueryDuration()) > timeout) {
       this.dialog.show({
@@ -86,7 +86,7 @@ class ExploreResultsButton extends React.PureComponent {
     }
   }
   getColumns() {
-    const props = this.props;
+    const { props } = this;
     if (
       props.query &&
       props.query.results &&

--- a/superset-frontend/src/SqlLab/components/LimitControl.tsx
+++ b/superset-frontend/src/SqlLab/components/LimitControl.tsx
@@ -85,7 +85,7 @@ export default class LimitControl extends React.PureComponent<
   }
 
   renderPopover() {
-    const textValue = this.state.textValue;
+    const { textValue } = this.state;
     const isValid = this.isValidLimit(textValue);
     const errorMsg =
       t('Row limit must be positive integer') +

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -148,9 +148,9 @@ export default class ResultSet extends React.PureComponent<
   }
   renderControls() {
     if (this.props.search || this.props.visualize || this.props.csv) {
-      let data = this.props.query.results.data;
+      let { data } = this.props.query.results;
       if (this.props.cache && this.props.query.cached) {
-        data = this.state.data;
+        ({ data } = this.state);
       }
       return (
         <div className="ResultSetControls">
@@ -199,7 +199,7 @@ export default class ResultSet extends React.PureComponent<
     return <div className="noControls" />;
   }
   render() {
-    const query = this.props.query;
+    const { query } = this.props;
     const height = Math.max(
       0,
       this.props.search ? this.props.height - SEARCH_HEIGHT : this.props.height,
@@ -263,12 +263,12 @@ export default class ResultSet extends React.PureComponent<
         </div>
       );
     } else if (query.state === 'success' && query.results) {
-      const results = query.results;
+      const { results } = query;
       let data;
       if (this.props.cache && query.cached) {
-        data = this.state.data;
+        ({ data } = this.state);
       } else if (results && results.data) {
-        data = results.data;
+        ({ data } = results);
       }
       if (data && data.length > 0) {
         const expandedColumns = results.expanded_columns

--- a/superset-frontend/src/SqlLab/components/SouthPane.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane.jsx
@@ -94,7 +94,7 @@ export class SouthPane extends React.PureComponent {
     }
     const innerTabContentHeight = this.state.height - TAB_HEIGHT;
     let latestQuery;
-    const props = this.props;
+    const { props } = this;
     if (props.editorQueries.length > 0) {
       // get the latest query
       latestQuery = props.editorQueries.find(

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -129,7 +129,7 @@ class TabbedSqlEditors extends React.PureComponent {
         if (dbId) {
           dbId = parseInt(dbId, 10);
         } else {
-          const databases = this.props.databases;
+          const { databases } = this.props;
           const dbName = query.dbname;
           if (dbName) {
             Object.keys(databases).forEach(db => {

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -92,13 +92,13 @@ class TableElement extends React.PureComponent {
   }
 
   renderWell() {
-    const table = this.props.table;
+    const { table } = this.props;
     let header;
     if (table.partitions) {
       let partitionQuery;
       let partitionClipBoard;
       if (table.partitions.partitionQuery) {
-        partitionQuery = table.partitions.partitionQuery;
+        ({ partitionQuery } = table.partitions.partitionQuery);
         const tt = t('Copy partition query to clipboard');
         partitionClipBoard = (
           <CopyToClipboard
@@ -129,7 +129,7 @@ class TableElement extends React.PureComponent {
   }
   renderControls() {
     let keyLink;
-    const table = this.props.table;
+    const { table } = this.props;
     if (table.indexes && table.indexes.length > 0) {
       keyLink = (
         <ModalTrigger
@@ -191,7 +191,7 @@ class TableElement extends React.PureComponent {
     );
   }
   renderHeader() {
-    const table = this.props.table;
+    const { table } = this.props;
     return (
       <div className="clearfix">
         <div className="pull-left">
@@ -228,7 +228,7 @@ class TableElement extends React.PureComponent {
     );
   }
   renderBody() {
-    const table = this.props.table;
+    const { table } = this.props;
     let cols;
     if (table.columns) {
       cols = table.columns.slice();

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -144,7 +144,7 @@ export default function getInitialState({
     localStorage.getItem('redux') &&
     JSON.parse(localStorage.getItem('redux')).sqlLab
   ) {
-    const sqlLab = JSON.parse(localStorage.getItem('redux')).sqlLab;
+    const { sqlLab } = JSON.parse(localStorage.getItem('redux'));
 
     if (sqlLab.queryEditors.length === 0) {
       // migration was successful

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -375,7 +375,7 @@ export default function sqlLabReducer(state = {}, action) {
     },
     [actions.MIGRATE_QUERY_EDITOR]() {
       // remove migrated query editor from localStorage
-      const sqlLab = JSON.parse(localStorage.getItem('redux')).sqlLab;
+      const { sqlLab } = JSON.parse(localStorage.getItem('redux'));
       sqlLab.queryEditors = sqlLab.queryEditors.filter(
         qe => qe.id !== action.oldQueryEditor.id,
       );
@@ -390,7 +390,7 @@ export default function sqlLabReducer(state = {}, action) {
     },
     [actions.MIGRATE_TABLE]() {
       // remove migrated table from localStorage
-      const sqlLab = JSON.parse(localStorage.getItem('redux')).sqlLab;
+      const { sqlLab } = JSON.parse(localStorage.getItem('redux'));
       sqlLab.tables = sqlLab.tables.filter(
         table => table.id !== action.oldTable.id,
       );
@@ -405,7 +405,7 @@ export default function sqlLabReducer(state = {}, action) {
     },
     [actions.MIGRATE_TAB_HISTORY]() {
       // remove migrated tab from localStorage tabHistory
-      const sqlLab = JSON.parse(localStorage.getItem('redux')).sqlLab;
+      const { sqlLab } = JSON.parse(localStorage.getItem('redux'));
       sqlLab.tabHistory = sqlLab.tabHistory.filter(
         tabId => tabId !== action.oldId,
       );
@@ -492,7 +492,7 @@ export default function sqlLabReducer(state = {}, action) {
       let newQueries = { ...state.queries };
       // Fetch the updates to the queries present in the store.
       let change = false;
-      let queriesLastUpdate = state.queriesLastUpdate;
+      let { queriesLastUpdate } = state;
       for (const id in action.alteredQueries) {
         const changedQuery = action.alteredQueries[id];
         if (

--- a/superset-frontend/src/components/AlteredSliceTag.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag.jsx
@@ -139,7 +139,7 @@ export default class AlteredSliceTag extends React.Component {
   }
 
   renderRows() {
-    const diffs = this.state.diffs;
+    const { diffs } = this.state;
     const rows = [];
     for (const key in diffs) {
       rows.push(

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -239,9 +239,7 @@ export default function Button(props: ButtonProps) {
     bsSize: props.buttonSize,
     placement: props.placement || 'top',
   };
-  const tooltip = props.tooltip;
-  const placement = props.placement;
-  const dropdownItems = props.dropdownItems;
+  const { tooltip, placement, dropdownItems } = props;
   delete buttonProps.tooltip;
   delete buttonProps.placement;
 

--- a/superset-frontend/src/components/Select/WindowedSelect/WindowedMenuList.tsx
+++ b/superset-frontend/src/components/Select/WindowedSelect/WindowedMenuList.tsx
@@ -105,7 +105,7 @@ export default function WindowedMenuList<OptionType extends OptionTypeBase>({
   } = selectProps;
 
   // try get default option height from theme configs
-  let optionHeight = selectProps.optionHeight;
+  let { optionHeight } = selectProps;
   if (!optionHeight) {
     optionHeight = theme ? detectHeight(theme) : DEFAULT_OPTION_HEIGHT;
   }

--- a/superset-frontend/src/dashboard/actions/sliceEntities.js
+++ b/superset-frontend/src/dashboard/actions/sliceEntities.js
@@ -51,7 +51,7 @@ export function fetchAllSlices(userId) {
           const slices = {};
           json.result.forEach(slice => {
             let form_data = JSON.parse(slice.params);
-            let datasource = form_data.datasource;
+            let { datasource } = form_data;
             if (!datasource) {
               datasource = getDatasourceParameter(
                 slice.datasource_id,

--- a/superset-frontend/src/dashboard/components/CodeModal.jsx
+++ b/superset-frontend/src/dashboard/components/CodeModal.jsx
@@ -41,7 +41,7 @@ export default class CodeModal extends React.PureComponent {
   }
 
   beforeOpen() {
-    let code = this.props.code;
+    let { code } = this.props;
     if (!code && this.props.codeCallback) {
       code = this.props.codeCallback();
     }

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -145,7 +145,7 @@ class Dashboard extends React.PureComponent {
   componentDidUpdate() {
     const { hasUnsavedChanges, editMode } = this.props.dashboardState;
 
-    const appliedFilters = this.appliedFilters;
+    const { appliedFilters } = this;
     const { activeFilters } = this.props;
     // do not apply filter when dashboard in edit mode
     if (!editMode && !areObjectsEqual(appliedFilters, activeFilters)) {
@@ -186,7 +186,7 @@ class Dashboard extends React.PureComponent {
   }
 
   applyFilters() {
-    const appliedFilters = this.appliedFilters;
+    const { appliedFilters } = this;
     const { activeFilters } = this.props;
 
     // refresh charts if a filter was removed, added, or changed

--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -132,7 +132,7 @@ class Header extends React.PureComponent {
   }
 
   componentDidMount() {
-    const refreshFrequency = this.props.refreshFrequency;
+    const { refreshFrequency } = this.props;
     this.startPeriodicRender(refreshFrequency * 1000);
   }
 

--- a/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx
+++ b/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.jsx
@@ -303,7 +303,7 @@ export default class FilterScopeSelector extends React.PureComponent {
 
     const allFilterFieldScopes = this.allfilterFields.reduce(
       (map, filterKey) => {
-        const nodes = filterScopeMap[filterKey].nodes;
+        const { nodes } = filterScopeMap[filterKey];
         const checkedChartIds = filterScopeMap[filterKey].checked;
 
         return {

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -130,7 +130,7 @@ class Tabs extends React.PureComponent {
 
   handleClickTab(tabIndex, ev) {
     if (ev) {
-      const target = ev.target;
+      const { target } = ev;
       // special handler for clicking on anchor link icon (or whitespace nearby):
       // will show short link popover but do not change tab
       if (target && target.classList.contains('short-link-trigger')) {

--- a/superset-frontend/src/dashboard/containers/FilterIndicators.jsx
+++ b/superset-frontend/src/dashboard/containers/FilterIndicators.jsx
@@ -26,8 +26,8 @@ function mapStateToProps(
   { datasources, dashboardState, dashboardFilters, dashboardLayout, charts },
   ownProps,
 ) {
-  const chartId = ownProps.chartId;
-  const chartStatus = (charts[chartId] || {}).chartStatus;
+  const { chartId } = ownProps;
+  const { chartStatus } = charts[chartId] || {};
 
   return {
     datasources,

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -51,7 +51,7 @@ export default function dashboardStateReducer(state = {}, action) {
       };
     },
     [REMOVE_SLICE]() {
-      const sliceId = action.sliceId;
+      const { sliceId } = action;
       const updatedSliceIds = new Set(state.sliceIds);
       updatedSliceIds.delete(sliceId);
 
@@ -88,7 +88,7 @@ export default function dashboardStateReducer(state = {}, action) {
     },
     [TOGGLE_EXPAND_SLICE]() {
       const updatedExpandedSlices = { ...state.expandedSlices };
-      const sliceId = action.sliceId;
+      const { sliceId } = action;
       if (updatedExpandedSlices[sliceId]) {
         delete updatedExpandedSlices[sliceId];
       } else {

--- a/superset-frontend/src/dashboard/reducers/getInitialState.js
+++ b/superset-frontend/src/dashboard/reducers/getInitialState.js
@@ -171,8 +171,8 @@ export default function getInitialState(bootstrapData) {
     // build DashboardFilters for interactive filter features
     if (slice.form_data.viz_type === 'filter_box') {
       const configs = getFilterConfigsFromFormdata(slice.form_data);
-      let columns = configs.columns;
-      const labels = configs.labels;
+      let { columns } = configs;
+      const { labels } = configs;
       if (preselectFilters[key]) {
         Object.keys(columns).forEach(col => {
           if (preselectFilters[key][col]) {

--- a/superset-frontend/src/dashboard/util/getFilterScopeNodesTree.js
+++ b/superset-frontend/src/dashboard/util/getFilterScopeNodesTree.js
@@ -38,7 +38,7 @@ function traverse({
     return null;
   }
 
-  const type = currentNode.type;
+  const { type } = currentNode;
   if (
     CHART_TYPE === type &&
     currentNode &&

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -406,7 +406,7 @@ export class DatasourceEditor extends React.PureComponent {
   validate(callback) {
     let errors = [];
     let dups;
-    const datasource = this.state.datasource;
+    const { datasource } = this.state;
 
     // Looking for duplicate column_name
     dups = this.findDuplicates(datasource.columns, obj => obj.column_name);
@@ -438,7 +438,7 @@ export class DatasourceEditor extends React.PureComponent {
   }
 
   renderSettingsFieldset() {
-    const datasource = this.state.datasource;
+    const { datasource } = this.state;
     return (
       <Fieldset
         title={t('Basic')}
@@ -531,7 +531,7 @@ export class DatasourceEditor extends React.PureComponent {
   }
 
   renderAdvancedFieldset() {
-    const datasource = this.state.datasource;
+    const { datasource } = this.state;
     return (
       <Fieldset
         title={t('Advanced')}

--- a/superset-frontend/src/explore/AdhocFilter.js
+++ b/superset-frontend/src/explore/AdhocFilter.js
@@ -49,7 +49,7 @@ const OPERATORS_TO_SQL = {
 function translateToSql(adhocMetric, { useSimple } = {}) {
   if (adhocMetric.expressionType === EXPRESSION_TYPES.SIMPLE || useSimple) {
     const isMulti = MULTI_OPERATORS.has(adhocMetric.operator);
-    const subject = adhocMetric.subject;
+    const { subject } = adhocMetric;
     const operator =
       adhocMetric.operator && CUSTOM_OPERATORS.has(adhocMetric.operator)
         ? OPERATORS_TO_SQL[adhocMetric.operator](adhocMetric)

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -211,7 +211,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
   }
 
   refreshComparatorSuggestions() {
-    const datasource = this.props.datasource;
+    const { datasource } = this.props;
     const col = this.props.adhocFilter.subject;
     const having = this.props.adhocFilter.clause === CLAUSES.HAVING;
 

--- a/superset-frontend/src/explore/components/EmbedCodeButton.jsx
+++ b/superset-frontend/src/explore/components/EmbedCodeButton.jsx
@@ -57,8 +57,7 @@ export default class EmbedCodeButton extends React.Component {
   }
 
   handleInputChange(e) {
-    const value = e.currentTarget.value;
-    const name = e.currentTarget.name;
+    const { value, name } = e.currentTarget;
     const data = {};
     data[name] = value;
     this.setState(data);

--- a/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
@@ -104,7 +104,7 @@ export default class AdhocFilterControl extends React.Component {
         })
           .then(({ json }) => {
             if (json && json.partitions) {
-              const partitions = json.partitions;
+              const { partitions } = json;
               // for now only show latest_partition option
               // when table datasource has only 1 partition key.
               if (

--- a/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
@@ -427,7 +427,7 @@ export default class AnnotationLayer extends React.PureComponent {
       intervalEndColumn,
       descriptionColumns,
     } = this.state;
-    const slice = (valueOptions.find(x => x.value === value) || {}).slice;
+    const { slice } = valueOptions.find(x => x.value === value) || {};
     if (sourceType !== ANNOTATION_SOURCE_TYPES.NATIVE && slice) {
       const columns = (slice.data.groupby || [])
         .concat(slice.data.all_columns || [])

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -97,7 +97,7 @@ class DatasourceControl extends React.PureComponent {
   }
 
   renderDatasource() {
-    const datasource = this.props.datasource;
+    const { datasource } = this.props;
     return (
       <div className="m-t-10">
         <Well className="m-t-0">

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -207,7 +207,7 @@ class DateFilterControl extends React.Component {
       untilViewMode: 'days',
     };
 
-    const value = props.value;
+    const { value } = props;
     if (value.indexOf(SEPARATOR) >= 0) {
       this.state = { ...this.state, ...getStateFromSeparator(value) };
     } else if (COMMON_TIME_FRAMES.indexOf(value) >= 0) {
@@ -282,7 +282,7 @@ class DateFilterControl extends React.Component {
   }
 
   handleClick(e) {
-    const target = e.target;
+    const { target } = e;
     // switch to `TYPES.CUSTOM_START_END` when the calendar is clicked
     if (this.startEndSectionRef && this.startEndSectionRef.contains(target)) {
       this.setTypeCustomStartEnd();

--- a/superset-frontend/src/explore/components/controls/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricsControl.jsx
@@ -104,7 +104,7 @@ function coerceAdhocMetrics(value) {
 }
 
 function getDefaultAggregateForColumn(column) {
-  const type = column.type;
+  const { type } = column;
   if (typeof type !== 'string') {
     return AGGREGATES.COUNT;
   } else if (type === '' || type === 'expression') {

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -173,7 +173,7 @@ export default class SelectControl extends React.PureComponent {
   }
 
   handleKeyDownForCreate(event) {
-    const key = event.key;
+    const { key } = event;
     if (key === 'Tab' || (this.props.commaChoosesOption && key === ',')) {
       // simulate an Enter event
       if (this.select) {

--- a/superset-frontend/src/explore/components/controls/SpatialControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SpatialControl.jsx
@@ -74,7 +74,7 @@ export default class SpatialControl extends React.Component {
     this.onChange();
   }
   onChange() {
-    const type = this.state.type;
+    const { type } = this.state;
     const value = { type };
     const errors = [];
     const errMsg = t('Invalid lat/long configuration.');

--- a/superset-frontend/src/explore/components/controls/TextControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl.tsx
@@ -37,7 +37,7 @@ export default class TextControl extends React.Component<TextControlProps> {
     this.onChange = this.onChange.bind(this);
   }
   onChange(event: any) {
-    let value = event.target.value;
+    let { value } = event.target;
 
     // Validation & casting
     const errors = [];

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -34,7 +34,7 @@ export function getFormDataFromControls(controlsState) {
 }
 
 export function validateControl(control, processedState) {
-  const validators = control.validators;
+  const { validators } = control;
   const validationErrors = [];
   if (validators && validators.length > 0) {
     validators.forEach(f => {
@@ -88,7 +88,7 @@ export const getControlConfig = memoizeOne(function getControlConfig(
 
 function handleMissingChoice(control) {
   // If the value is not valid anymore based on choices, clear it
-  const value = control.value;
+  const { value } = control;
   if (
     control.type === 'SelectControl' &&
     !control.freeForm &&

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -160,7 +160,7 @@ const metrics = {
     return metric ? [metric] : null;
   },
   mapStateToProps: state => {
-    const datasource = state.datasource;
+    const { datasource } = state;
     return {
       columns: datasource ? datasource.columns : [],
       savedMetrics: datasource ? datasource.metrics : [],

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -29,7 +29,7 @@ import { safeStringify } from 'src/utils/safeStringify';
 const MAX_URL_LENGTH = 8000;
 
 export function getChartKey(explore) {
-  const slice = explore.slice;
+  const { slice } = explore;
   return slice ? slice.slice_id : 0;
 }
 

--- a/superset-frontend/src/explore/reducers/getInitialState.js
+++ b/superset-frontend/src/explore/reducers/getInitialState.js
@@ -28,7 +28,7 @@ import {
 
 export default function getInitialState(bootstrapData) {
   const { form_data: rawFormData } = bootstrapData;
-  const slice = bootstrapData.slice;
+  const { slice } = bootstrapData;
   const sliceName = slice ? slice.slice_name : null;
   const bootstrappedState = {
     ...bootstrapData,

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -117,7 +117,7 @@ const loggerMiddleware = store => next => action => {
   }
 
   if (eventData.target_id && dashboardLayout.present) {
-    const meta = dashboardLayout.present[eventData.target_id].meta;
+    const { meta } = dashboardLayout.present[eventData.target_id];
     // chart name or tab/header text
     eventData.target_name = meta.chartId ? meta.sliceName : meta.text;
   }

--- a/superset-frontend/src/reduxUtils.ts
+++ b/superset-frontend/src/reduxUtils.ts
@@ -160,7 +160,7 @@ export function areArraysShallowEqual(arr1: unknown[], arr2: unknown[]) {
   if (arr1.length !== arr2.length) {
     return false;
   }
-  const length = arr1.length;
+  const { length } = arr1;
   for (let i = 0; i < length; i++) {
     if (arr1[i] !== arr2[i]) {
       return false;

--- a/superset-frontend/src/showSavedQuery/index.jsx
+++ b/superset-frontend/src/showSavedQuery/index.jsx
@@ -27,7 +27,7 @@ const bootstrapData = JSON.parse(
   scheduleInfoContainer.getAttribute('data-bootstrap'),
 );
 const config = bootstrapData.common.feature_flags.SCHEDULED_QUERIES;
-const query = bootstrapData.common.query;
+const { query } = bootstrapData.common;
 const scheduleInfo = query.extra_json.schedule_info;
 const linkback = config.linkback ? interpolate(config.linkback, query) : null;
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -212,7 +212,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   };
 
   const onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const target = event.target;
+    const { target } = event;
     const data = {
       database_name: db ? db.database_name : '',
       sqlalchemy_uri: db ? db.sqlalchemy_uri : '',


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `prefer-destructuring`, which was disabled in PR #10839. I kept the rule disabled for arrays, because I think the destructuring syntax was less readable - e.g. `newValue = newValue[0]` versus `[newValue, ,] = newValue` (occurs in file `MetricsControl.jsx`). Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
