### PR TITLE
ESLint: Re-enable rule default-props-match-prop-types

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -118,7 +118,6 @@ module.exports = {
         'padded-blocks': 0,
         'prefer-arrow-callback': 0,
         'prefer-destructuring': 0, // disabled temporarily
-        'react/default-props-match-prop-types': 0, // disabled temporarily
         'react/destructuring-assignment': 0, // re-enable up for discussion
         'react/forbid-prop-types': 0,
         'react/jsx-curly-brace-presence': 0, // disabled temporarily
@@ -241,7 +240,6 @@ module.exports = {
     'prefer-arrow-callback': 0,
     'prefer-object-spread': 1,
     'prefer-destructuring': 0, // disabled temporarily
-    'react/default-props-match-prop-types': 0, // disabled temporarily
     'react/destructuring-assignment': 0, // re-enable up for discussion
     'react/forbid-prop-types': 0,
     'react/jsx-curly-brace-presence': 0, // disabled temporarily

--- a/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -62,9 +62,6 @@ describe('DashboardBuilder', () => {
     dashboardLayout,
     deleteTopLevelTabs() {},
     editMode: false,
-    showBuilderPane() {},
-    setColorSchemeAndUnsavedChanges() {},
-    colorScheme: undefined,
     handleComponentDrop() {},
     setDirectPathToChild: sinon.spy(),
   };

--- a/superset-frontend/src/CRUD/Field.jsx
+++ b/superset-frontend/src/CRUD/Field.jsx
@@ -39,10 +39,9 @@ const propTypes = {
   compact: PropTypes.bool,
 };
 const defaultProps = {
-  controlProps: {},
   onChange: () => {},
   compact: false,
-  desc: null,
+  description: null,
 };
 
 export default class Field extends React.PureComponent {

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx
@@ -37,10 +37,6 @@ const propTypes = {
   templateParams: PropTypes.string,
 };
 
-const defaultProps = {
-  vizRequest: {},
-};
-
 class ExploreCtasResultsButton extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -110,7 +106,6 @@ class ExploreCtasResultsButton extends React.PureComponent {
   }
 }
 ExploreCtasResultsButton.propTypes = propTypes;
-ExploreCtasResultsButton.defaultProps = defaultProps;
 
 function mapStateToProps({ sqlLab, common }) {
   return {

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -25,7 +25,7 @@ import TableSelector from '../../components/TableSelector';
 
 const propTypes = {
   queryEditor: PropTypes.object.isRequired,
-  height: PropTypes.number.isRequired,
+  height: PropTypes.number,
   tables: PropTypes.array,
   actions: PropTypes.object,
   database: PropTypes.object,

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -39,8 +39,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  label: null,
-  description: null,
   onChange: () => {},
   code: '{}',
 };

--- a/superset-frontend/src/components/Hotkeys.jsx
+++ b/superset-frontend/src/components/Hotkeys.jsx
@@ -33,10 +33,6 @@ const propTypes = {
   placement: PropTypes.string,
 };
 
-const defaultProps = {
-  hotkeys: [],
-};
-
 export default class Hotkeys extends React.PureComponent {
   componentDidMount() {
     this.props.hotkeys.forEach(keyConfig => {
@@ -84,4 +80,3 @@ export default class Hotkeys extends React.PureComponent {
 }
 
 Hotkeys.propTypes = propTypes;
-Hotkeys.defaultProps = defaultProps;

--- a/superset-frontend/src/components/Select/OnPasteSelect.jsx
+++ b/superset-frontend/src/components/Select/OnPasteSelect.jsx
@@ -81,12 +81,12 @@ export default class OnPasteSelect extends React.Component {
 }
 
 OnPasteSelect.propTypes = {
-  separator: PropTypes.array.isRequired,
+  separator: PropTypes.array,
   selectWrap: PropTypes.elementType,
   selectRef: PropTypes.func,
   onChange: PropTypes.func.isRequired,
-  valueKey: PropTypes.string.isRequired,
-  labelKey: PropTypes.string.isRequired,
+  valueKey: PropTypes.string,
+  labelKey: PropTypes.string,
   options: PropTypes.array,
   isMulti: PropTypes.bool,
   value: PropTypes.any,

--- a/superset-frontend/src/dashboard/components/ColorSchemeControlWrapper.jsx
+++ b/superset-frontend/src/dashboard/components/ColorSchemeControlWrapper.jsx
@@ -24,11 +24,12 @@ import { getCategoricalSchemeRegistry, t } from '@superset-ui/core';
 import ColorSchemeControl from 'src/explore/components/controls/ColorSchemeControl';
 
 const propTypes = {
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
   colorScheme: PropTypes.string,
 };
 
 const defaultProps = {
+  onChange: () => {},
   colorScheme: undefined,
 };
 

--- a/superset-frontend/src/dashboard/components/ColorSchemeControlWrapper.jsx
+++ b/superset-frontend/src/dashboard/components/ColorSchemeControlWrapper.jsx
@@ -30,7 +30,6 @@ const propTypes = {
 
 const defaultProps = {
   colorScheme: undefined,
-  onChange: () => {},
 };
 
 class ColorSchemeControlWrapper extends React.PureComponent {

--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -54,7 +54,7 @@ const propTypes = {
   dashboardLayout: PropTypes.object.isRequired,
   deleteTopLevelTabs: PropTypes.func.isRequired,
   editMode: PropTypes.bool.isRequired,
-  showBuilderPane: PropTypes.func.isRequired,
+  showBuilderPane: PropTypes.func,
   colorScheme: PropTypes.string,
   setColorSchemeAndUnsavedChanges: PropTypes.func.isRequired,
   handleComponentDrop: PropTypes.func.isRequired,
@@ -64,6 +64,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  showBuilderPane: () => {},
   directPathToChild: [],
   colorScheme: undefined,
 };

--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -64,7 +64,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  showBuilderPane: false,
   directPathToChild: [],
   colorScheme: undefined,
 };

--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -54,9 +54,6 @@ const propTypes = {
   dashboardLayout: PropTypes.object.isRequired,
   deleteTopLevelTabs: PropTypes.func.isRequired,
   editMode: PropTypes.bool.isRequired,
-  showBuilderPane: PropTypes.func,
-  colorScheme: PropTypes.string,
-  setColorSchemeAndUnsavedChanges: PropTypes.func.isRequired,
   handleComponentDrop: PropTypes.func.isRequired,
   directPathToChild: PropTypes.arrayOf(PropTypes.string),
   setDirectPathToChild: PropTypes.func.isRequired,
@@ -64,9 +61,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  showBuilderPane: () => {},
   directPathToChild: [],
-  colorScheme: undefined,
 };
 
 class DashboardBuilder extends React.Component {
@@ -155,14 +150,7 @@ class DashboardBuilder extends React.Component {
   }
 
   render() {
-    const {
-      handleComponentDrop,
-      dashboardLayout,
-      editMode,
-      showBuilderPane,
-      setColorSchemeAndUnsavedChanges,
-      colorScheme,
-    } = this.props;
+    const { handleComponentDrop, dashboardLayout, editMode } = this.props;
     const { tabIndex } = this.state;
     const dashboardRoot = dashboardLayout[DASHBOARD_ROOT_ID];
     const rootChildId = dashboardRoot.children[0];
@@ -272,9 +260,6 @@ class DashboardBuilder extends React.Component {
           {editMode && (
             <BuilderComponentPane
               topOffset={HEADER_HEIGHT + (topLevelTabs ? TABS_HEIGHT : 0)}
-              showBuilderPane={showBuilderPane}
-              setColorSchemeAndUnsavedChanges={setColorSchemeAndUnsavedChanges}
-              colorScheme={colorScheme}
             />
           )}
         </div>

--- a/superset-frontend/src/dashboard/components/PropertiesModal.jsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal.jsx
@@ -34,7 +34,7 @@ import '../stylesheets/buttons.less';
 
 const propTypes = {
   dashboardId: PropTypes.number.isRequired,
-  show: PropTypes.bool.isRequired,
+  show: PropTypes.bool,
   onHide: PropTypes.func,
   colorScheme: PropTypes.object,
   setColorSchemeAndUnsavedChanges: PropTypes.func,

--- a/superset-frontend/src/dashboard/components/SliceAdder.jsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.jsx
@@ -45,7 +45,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  selectedSliceIds: [],
   editMode: false,
   errorMessage: '',
   height: window.innerHeight,

--- a/superset-frontend/src/dashboard/components/SliceAdder.jsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.jsx
@@ -39,12 +39,13 @@ const propTypes = {
   lastUpdated: PropTypes.number.isRequired,
   errorMessage: PropTypes.string,
   userId: PropTypes.string.isRequired,
-  selectedSliceIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  selectedSliceIds: PropTypes.arrayOf(PropTypes.number),
   editMode: PropTypes.bool,
   height: PropTypes.number,
 };
 
 const defaultProps = {
+  selectedSliceIds: [],
   editMode: false,
   errorMessage: '',
   height: window.innerHeight,

--- a/superset-frontend/src/dashboard/components/SliceHeader.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader.jsx
@@ -53,7 +53,6 @@ const propTypes = {
 const defaultProps = {
   innerRef: null,
   forceRefresh: () => ({}),
-  removeSlice: () => ({}),
   updateSliceName: () => ({}),
   toggleExpandSlice: () => ({}),
   exploreChart: () => ({}),

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -56,10 +56,6 @@ const propTypes = {
   updateComponents: PropTypes.func.isRequired,
 };
 
-const defaultProps = {
-  rowHeight: null,
-};
-
 class Row extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -192,6 +188,5 @@ class Row extends React.PureComponent {
 }
 
 Row.propTypes = propTypes;
-Row.defaultProps = defaultProps;
 
 export default Row;

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -69,7 +69,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  children: null,
   renderTabContent: true,
   renderHoverMenu: true,
   availableColumnCount: 0,

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.jsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.jsx
@@ -35,7 +35,6 @@ const defaultProps = {
   children: null,
   disableClick: false,
   onChangeFocus: null,
-  onPressDelete() {},
   menuItems: [],
   isFocused: false,
   shouldFocus: (event, container) =>

--- a/superset-frontend/src/dashboard/containers/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardBuilder.jsx
@@ -21,7 +21,6 @@ import { connect } from 'react-redux';
 import DashboardBuilder from '../components/DashboardBuilder';
 
 import {
-  setColorSchemeAndUnsavedChanges,
   showBuilderPane,
   setDirectPathToChild,
   setMountedTab,
@@ -35,9 +34,7 @@ function mapStateToProps({ dashboardLayout: undoableLayout, dashboardState }) {
   return {
     dashboardLayout: undoableLayout.present,
     editMode: dashboardState.editMode,
-    showBuilderPane: dashboardState.showBuilderPane,
     directPathToChild: dashboardState.directPathToChild,
-    colorScheme: dashboardState.colorScheme,
   };
 }
 
@@ -47,7 +44,6 @@ function mapDispatchToProps(dispatch) {
       deleteTopLevelTabs,
       handleComponentDrop,
       showBuilderPane,
-      setColorSchemeAndUnsavedChanges,
       setDirectPathToChild,
       setMountedTab,
     },

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -53,7 +53,6 @@ const propTypes = {
 const defaultProps = {
   directPathToChild: [],
   directPathLastUpdated: 0,
-  isComponentVisible: true,
 };
 
 function mapStateToProps(

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -37,7 +37,6 @@ const propTypes = {
 const defaultProps = {
   onStop: () => {},
   onSave: () => {},
-  disabled: false,
 };
 
 // Prolly need to move this to a global context

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
@@ -35,8 +35,8 @@ const propTypes = {
   choices: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.array),
     PropTypes.func,
-  ]).isRequired,
-  schemes: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
+  ]),
+  schemes: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   isLinear: PropTypes.bool,
 };
 

--- a/superset-frontend/src/explore/components/controls/ViewportControl.jsx
+++ b/superset-frontend/src/explore/components/controls/ViewportControl.jsx
@@ -37,7 +37,7 @@ export const DEFAULT_VIEWPORT = {
 const PARAMS = ['longitude', 'latitude', 'zoom', 'bearing', 'pitch'];
 
 const propTypes = {
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
   value: PropTypes.shape({
     longitude: PropTypes.number,
     latitude: PropTypes.number,


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `default-props-match-prop-types`, which was disabled in PR #10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
