### PR TITLE
ESLint: Re-enable rule jsx-curly-brace-presence

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -121,7 +121,6 @@ module.exports = {
         'react/default-props-match-prop-types': 0, // disabled temporarily
         'react/destructuring-assignment': 0, // re-enable up for discussion
         'react/forbid-prop-types': 0,
-        'react/jsx-curly-brace-presence': 0, // disabled temporarily
         'react/jsx-filename-extension': [1, { extensions: ['.jsx', '.tsx'] }],
         'react/jsx-fragments': 1,
         'react/jsx-no-bind': 0,
@@ -244,7 +243,6 @@ module.exports = {
     'react/default-props-match-prop-types': 0, // disabled temporarily
     'react/destructuring-assignment': 0, // re-enable up for discussion
     'react/forbid-prop-types': 0,
-    'react/jsx-curly-brace-presence': 0, // disabled temporarily
     'react/jsx-filename-extension': [1, { extensions: ['.jsx', '.tsx'] }],
     'react/jsx-fragments': 1,
     'react/jsx-no-bind': 0,

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -106,7 +106,7 @@ const bulkSelectColumnConfig = {
   Header: ({ getToggleAllRowsSelectedProps }: any) => (
     <IndeterminateCheckbox
       {...getToggleAllRowsSelectedProps()}
-      id={'header-toggle-all'}
+      id="header-toggle-all"
     />
   ),
   id: 'selection',

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -188,7 +188,7 @@ export function Menu({
         <Nav className="navbar-right">
           {!navbarRight.user_is_anonymous && <NewMenu />}
           {settings && settings.length && (
-            <NavDropdown id={`settings-dropdown`} title="Settings">
+            <NavDropdown id="settings-dropdown" title="Settings">
               {flatSettings.map((section, index) => {
                 if (section === '-') {
                   return (

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -160,7 +160,7 @@ function ColumnCollectionTable({
                       database/column name level via the extra parameter.`)}
                 </div>
               }
-              control={<TextControl placeholder={'%y/%m/%d'} />}
+              control={<TextControl placeholder="%y/%m/%d" />}
             />
           </Fieldset>
         </FormContainer>

--- a/superset-frontend/src/explore/components/ControlHeader.jsx
+++ b/superset-frontend/src/explore/components/ControlHeader.jsx
@@ -100,7 +100,7 @@ export default class ControlHeader extends React.Component {
                 <OverlayTrigger
                   placement="top"
                   overlay={
-                    <Tooltip id={'error-tooltip'}>{this.props.warning}</Tooltip>
+                    <Tooltip id="error-tooltip">{this.props.warning}</Tooltip>
                   }
                 >
                   <i className="fa fa-exclamation-circle text-warning" />
@@ -112,7 +112,7 @@ export default class ControlHeader extends React.Component {
                 <OverlayTrigger
                   placement="top"
                   overlay={
-                    <Tooltip id={'error-tooltip'}>{this.props.danger}</Tooltip>
+                    <Tooltip id="error-tooltip">{this.props.danger}</Tooltip>
                   }
                 >
                   <i className="fa fa-exclamation-circle text-danger" />
@@ -124,7 +124,7 @@ export default class ControlHeader extends React.Component {
                 <OverlayTrigger
                   placement="top"
                   overlay={
-                    <Tooltip id={'error-tooltip'}>
+                    <Tooltip id="error-tooltip">
                       {this.props.validationErrors.join(' ')}
                     </Tooltip>
                   }

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -125,7 +125,7 @@ export default function QueryAndSaveBtns({
             <OverlayTrigger
               placement="right"
               overlay={
-                <Tooltip id={'query-error-tooltip'}>{errorMessage}</Tooltip>
+                <Tooltip id="query-error-tooltip">{errorMessage}</Tooltip>
               }
             >
               <i className="fa fa-exclamation-circle text-danger fa-lg" />

--- a/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
@@ -454,7 +454,7 @@ export default class AnnotationLayer extends React.PureComponent {
                     ? 'Interval Start column'
                     : 'Event Time Column'
                 }
-                description={'This column must contain date/time information.'}
+                description="This column must contain date/time information."
                 validationErrors={!timeColumn ? ['Mandatory'] : []}
                 clearable={false}
                 options={timeColumnOptions}
@@ -467,7 +467,7 @@ export default class AnnotationLayer extends React.PureComponent {
                 hovered
                 name="annotation-layer-intervalEnd"
                 label="Interval End column"
-                description={'This column must contain date/time information.'}
+                description="This column must contain date/time information."
                 validationErrors={!intervalEndColumn ? ['Mandatory'] : []}
                 options={columns}
                 value={intervalEndColumn}
@@ -478,7 +478,7 @@ export default class AnnotationLayer extends React.PureComponent {
               hovered
               name="annotation-layer-title"
               label="Title Column"
-              description={'Pick a title for you annotation.'}
+              description="Pick a title for you annotation."
               options={[{ value: '', label: 'None' }].concat(columns)}
               value={titleColumn}
               onChange={v => this.setState({ titleColumn: v })}
@@ -643,7 +643,7 @@ export default class AnnotationLayer extends React.PureComponent {
             hovered
             name="annotation-layer-show-markers"
             label="Show Markers"
-            description={'Shows or hides markers for the time series'}
+            description="Shows or hides markers for the time series"
             value={showMarkers}
             onChange={v => this.setState({ showMarkers: v })}
           />
@@ -653,7 +653,7 @@ export default class AnnotationLayer extends React.PureComponent {
             hovered
             name="annotation-layer-hide-line"
             label="Hide Line"
-            description={'Hides the Line for the time series'}
+            description="Hides the Line for the time series"
             value={hideLine}
             onChange={v => this.setState({ hideLine: v })}
           />

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -171,7 +171,7 @@ class DatasourceControl extends React.PureComponent {
           <OverlayTrigger
             placement="right"
             overlay={
-              <Tooltip id={'toggle-datasource-tooltip'}>
+              <Tooltip id="toggle-datasource-tooltip">
                 {t('Expand/collapse datasource configuration')}
               </Tooltip>
             }

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -435,7 +435,7 @@ function ChartList(props: ChartListProps) {
         title={chart.slice_name}
         url={bulkSelectEnabled ? undefined : chart.url}
         imgURL={chart.thumbnail_url ?? ''}
-        imgFallbackURL={'/static/assets/images/chart-card-fallback.png'}
+        imgFallbackURL="/static/assets/images/chart-card-fallback.png"
         description={t('Last modified %s', chart.changed_on_delta_humanized)}
         coverLeft={(chart.owners || []).slice(0, 5).map(owner => (
           <AvatarIcon


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `jsx-curly-brace-presence`, which was disabled in PR #10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
