### PR TITLE
ESLint: Re-enable rule no-unused-state

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -131,7 +131,6 @@ module.exports = {
         'react/no-string-refs': 0,
         'react/no-unescaped-entities': 0,
         'react/no-unused-prop-types': 0,
-        'react/no-unused-state': 0, // disabled temporarily
         'react/prop-types': 0,
         'react/require-default-props': 0,
         'react/sort-comp': 0, // disabled temporarily
@@ -254,7 +253,6 @@ module.exports = {
     'react/no-string-refs': 0,
     'react/no-unescaped-entities': 0,
     'react/no-unused-prop-types': 0,
-    'react/no-unused-state': 0, // disabled temporarily
     'react/prop-types': 0,
     'react/require-default-props': 0,
     'react/sort-comp': 0, // disabled temporarily

--- a/superset-frontend/src/SqlLab/components/QuerySearch.jsx
+++ b/superset-frontend/src/SqlLab/components/QuerySearch.jsx
@@ -43,8 +43,6 @@ class QuerySearch extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      userLoading: false,
-      userOptions: [],
       databaseId: null,
       userId: null,
       searchText: null,

--- a/superset-frontend/src/SqlLab/components/QueryTable.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable.jsx
@@ -48,26 +48,11 @@ const defaultProps = {
 };
 
 class QueryTable extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    const uri = window.location.toString();
-    const cleanUri = uri.substring(0, uri.indexOf('#'));
-    this.state = {
-      cleanUri,
-      showVisualizeModal: false,
-      activeQuery: null,
-    };
-  }
   openQuery(id) {
     const url = `/superset/sqllab?queryId=${id}`;
     window.open(url);
   }
-  hideVisualizeModal() {
-    this.setState({ showVisualizeModal: false });
-  }
-  showVisualizeModal(query) {
-    this.setState({ activeQuery: query, showVisualizeModal: true });
-  }
+
   restoreSql(query) {
     this.props.actions.queryEditorSetSql({ id: query.sqlEditorId }, query.sql);
   }

--- a/superset-frontend/src/SqlLab/components/SaveQuery.jsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery.jsx
@@ -82,8 +82,8 @@ class SaveQuery extends React.PureComponent {
   close() {
     if (this.saveModal) this.saveModal.close();
   }
-  toggleSave(e) {
-    this.setState({ target: e.target, showSave: !this.state.showSave });
+  toggleSave() {
+    this.setState({ showSave: !this.state.showSave });
   }
   renderModalBody() {
     const isSaved = !!this.props.query.remoteId;

--- a/superset-frontend/src/addSlice/AddSliceContainer.tsx
+++ b/superset-frontend/src/addSlice/AddSliceContainer.tsx
@@ -75,7 +75,6 @@ export default class AddSliceContainer extends React.PureComponent<
     this.setState({
       datasourceValue: option.value,
       datasourceId: option.value.split('__')[0],
-      datasourceType: option.value.split('__')[1],
     });
   }
 

--- a/superset-frontend/src/dashboard/components/CssEditor.jsx
+++ b/superset-frontend/src/dashboard/components/CssEditor.jsx
@@ -44,7 +44,6 @@ class CssEditor extends React.PureComponent {
     super(props);
     this.state = {
       css: props.initialCss,
-      cssTemplateOptions: [],
     };
     this.changeCss = this.changeCss.bind(this);
     this.changeCssTemplate = this.changeCssTemplate.bind(this);

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -49,10 +49,8 @@ class SaveModal extends React.Component {
     this.state = {
       saveToDashboardId: null,
       newSliceName: props.sliceName,
-      dashboards: [],
       alert: null,
       action: props.can_overwrite ? 'overwrite' : 'saveas',
-      vizType: props.form_data.viz_type,
     };
     this.onDashboardSelectChange = this.onDashboardSelectChange.bind(this);
     this.onSliceNameChange = this.onSliceNameChange.bind(this);

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl.jsx
@@ -50,9 +50,6 @@ const defaultProps = {
 export default class ColorSchemeControl extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = {
-      scheme: this.props.value,
-    };
     this.onChange = this.onChange.bind(this);
     this.renderOption = this.renderOption.bind(this);
   }
@@ -60,7 +57,6 @@ export default class ColorSchemeControl extends React.PureComponent {
   onChange(option) {
     const optionValue = option ? option.value : null;
     this.props.onChange(optionValue);
-    this.setState({ scheme: optionValue });
   }
 
   renderOption(key) {

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -60,7 +60,6 @@ class DatasourceControl extends React.PureComponent {
     this.state = {
       showEditDatasourceModal: false,
       showChangeDatasourceModal: false,
-      menuExpanded: false,
     };
     this.onDatasourceSave = this.onDatasourceSave.bind(this);
     this.toggleChangeDatasourceModal = this.toggleChangeDatasourceModal.bind(


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `no-unused-state`, which was disabled in PR #10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
