### PR TITLE
ESLint: Re-enable rule sort-comp

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -134,7 +134,6 @@ module.exports = {
         'react/no-unused-state': 0, // disabled temporarily
         'react/prop-types': 0,
         'react/require-default-props': 0,
-        'react/sort-comp': 0, // disabled temporarily
         'react/state-in-constructor': 0, // disabled temporarily
         'react/static-property-placement': 0, // re-enable up for discussion
         'prettier/prettier': 'error',
@@ -257,7 +256,6 @@ module.exports = {
     'react/no-unused-state': 0, // disabled temporarily
     'react/prop-types': 0,
     'react/require-default-props': 0,
-    'react/sort-comp': 0, // disabled temporarily
     'react/state-in-constructor': 0, // disabled temporarily
     'react/static-property-placement': 0, // disabled temporarily
     'prettier/prettier': 'error',

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -246,12 +246,12 @@ class SqlEditor extends React.PureComponent {
       this.props.actions.estimateQueryCost(query);
     }
   }
-  handleWindowResize() {
-    this.setState({ height: this.getSqlEditorHeight() });
-  }
   handleToggleAutocompleteEnabled = () => {
     this.setState({ autocompleteEnabled: !this.state.autocompleteEnabled });
   };
+  handleWindowResize() {
+    this.setState({ height: this.getSqlEditorHeight() });
+  }
   elementStyle(dimension, elementSize, gutterSize) {
     return {
       [dimension]: `calc(${elementSize}% - ${

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -123,6 +123,13 @@ export default class FilterableTable extends PureComponent<
     expandedColumns: [],
   };
 
+  list: List<Datum>;
+  complexColumns: Record<string, boolean>;
+  widthsForColumnsByKey: Record<string, number>;
+  totalTableWidth: number;
+  totalTableHeight: number;
+  container: React.RefObject<HTMLDivElement>;
+
   constructor(props: FilterableTableProps) {
     super(props);
     this.list = List(this.formatTableData(props.data));
@@ -227,13 +234,6 @@ export default class FilterableTable extends PureComponent<
     }
     return this.complexColumns[columnKey] ? truncated : content;
   }
-
-  list: List<Datum>;
-  complexColumns: Record<string, boolean>;
-  widthsForColumnsByKey: Record<string, number>;
-  totalTableWidth: number;
-  totalTableHeight: number;
-  container: React.RefObject<HTMLDivElement>;
 
   formatTableData(data: Record<string, unknown>[]): Datum[] {
     const formattedData = data.map(row => {

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -40,23 +40,6 @@ class DashboardTable extends React.PureComponent<
   DashboardTableProps,
   DashboardTableState
 > {
-  state = {
-    dashboards: [],
-    dashboard_count: 0,
-    loading: false,
-  };
-
-  componentDidUpdate(prevProps: DashboardTableProps) {
-    if (prevProps.search !== this.props.search) {
-      this.fetchDataDebounced({
-        pageSize: PAGE_SIZE,
-        pageIndex: 0,
-        sortBy: this.initialSort,
-        filters: [],
-      });
-    }
-  }
-
   columns = [
     {
       accessor: 'dashboard_title',
@@ -109,6 +92,23 @@ class DashboardTable extends React.PureComponent<
 
   initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
+  state = {
+    dashboards: [],
+    dashboard_count: 0,
+    loading: false,
+  };
+
+  componentDidUpdate(prevProps: DashboardTableProps) {
+    if (prevProps.search !== this.props.search) {
+      this.fetchDataDebounced({
+        pageSize: PAGE_SIZE,
+        pageIndex: 0,
+        sortBy: this.initialSort,
+        filters: [],
+      });
+    }
+  }
+
   fetchData = ({ pageIndex, pageSize, sortBy, filters }: FetchDataConfig) => {
     this.setState({ loading: true });
     const filterExps = Object.keys(filters)
@@ -159,6 +159,8 @@ class DashboardTable extends React.PureComponent<
       .finally(() => this.setState({ loading: false }));
   };
 
+  // sort-comp disabled because of conflict with no-use-before-define rule
+  // eslint-disable-next-line react/sort-comp
   fetchDataDebounced = debounce(this.fetchData, 200);
 
   render() {


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `sort-comp`, which was disabled in PR https://github.com/apache/incubator-superset/pull/10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
