### PR TITLE
ESLint: Re-enable rule state-in-constructor

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -128,7 +128,6 @@ module.exports = {
         'react/no-unused-prop-types': 0,
         'react/prop-types': 0,
         'react/require-default-props': 0,
-        'react/state-in-constructor': 0, // disabled temporarily
         'react/static-property-placement': 0, // re-enable up for discussion
         'prettier/prettier': 'error',
       },
@@ -245,7 +244,6 @@ module.exports = {
     'react/no-unused-prop-types': 0,
     'react/prop-types': 0,
     'react/require-default-props': 0,
-    'react/state-in-constructor': 0, // disabled temporarily
     'react/static-property-placement': 0, // disabled temporarily
     'prettier/prettier': 'error',
   },

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -92,11 +92,14 @@ class DashboardTable extends React.PureComponent<
 
   initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
-  state = {
-    dashboards: [],
-    dashboard_count: 0,
-    loading: false,
-  };
+  constructor(props: DashboardTableProps) {
+    super(props);
+    this.state = {
+      dashboards: [],
+      dashboard_count: 0,
+      loading: false,
+    };
+  }
 
   componentDidUpdate(prevProps: DashboardTableProps) {
     if (prevProps.search !== this.props.search) {


### PR DESCRIPTION
### SUMMARY
Re-enable ESLint rule `state-in-constructor`, which was disabled in PR #10839. Code was refactored to fix the errors raised by the rule.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
