### PR TITLE
ESLint: enable no-confusing-arrow rule

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -90,7 +90,6 @@ module.exports = {
         'lines-between-class-members': 0, // disabled temporarily
         'new-cap': 0,
         'no-bitwise': 0,
-        'no-confusing-arrow': 0,
         'no-continue': 0,
         'no-else-return': 0, // disabled temporarily
         'no-mixed-operators': 0,
@@ -215,7 +214,6 @@ module.exports = {
     'no-restricted-globals': 0, // disabled temporarily
     'no-else-return': 0, // disabled temporarily
     'no-bitwise': 0,
-    'no-confusing-arrow': 0,
     'no-continue': 0,
     'no-mixed-operators': 0,
     'no-multi-assign': 0,


### PR DESCRIPTION
### SUMMARY
Enable ESLint rule `no-confusing-arrow`.

### TEST PLAN
Run `npm run lint`, verify that there are no new Javascript/Typescript errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
