### PR TITLE
ESLint: Enable rule no-named-as-default

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -86,7 +86,6 @@ module.exports = {
             '.json': 'always',
           },
         ],
-        'import/no-named-as-default': 0,
         'import/no-named-as-default-member': 0,
         'import/prefer-default-export': 0,
         indent: 0,
@@ -201,7 +200,6 @@ module.exports = {
       },
     ],
     'import/no-cycle': 0, // re-enable up for discussion, might require some major refactors
-    'import/no-named-as-default': 0,
     'import/prefer-default-export': 0,
     indent: 0,
     'jsx-a11y/anchor-is-valid': 0, // disabled temporarily

--- a/superset-frontend/spec/javascripts/explore/components/ExploreViewContainer_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/ExploreViewContainer_spec.jsx
@@ -25,7 +25,7 @@ import { shallow } from 'enzyme';
 import getInitialState from 'src/explore/reducers/getInitialState';
 import ExploreViewContainer from 'src/explore/components/ExploreViewContainer';
 import QueryAndSaveBtns from 'src/explore/components/QueryAndSaveBtns';
-import ControlPanelsContainer from 'src/explore/components/ControlPanelsContainer';
+import ConnectedControlPanelsContainer from 'src/explore/components/ControlPanelsContainer';
 import ChartContainer from 'src/explore/components/ExploreChartPanel';
 import * as featureFlags from 'src/featureFlags';
 
@@ -72,7 +72,7 @@ describe('ExploreViewContainer', () => {
   });
 
   it('renders ControlPanelsContainer', () => {
-    expect(wrapper.find(ControlPanelsContainer)).toExist();
+    expect(wrapper.find(ConnectedControlPanelsContainer)).toExist();
   });
 
   it('renders ChartContainer', () => {

--- a/superset-frontend/spec/javascripts/sqllab/SqlEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/SqlEditor_spec.jsx
@@ -25,7 +25,7 @@ import {
 } from 'src/SqlLab/constants';
 import AceEditorWrapper from 'src/SqlLab/components/AceEditorWrapper';
 import LimitControl from 'src/SqlLab/components/LimitControl';
-import SouthPane from 'src/SqlLab/components/SouthPane';
+import ConnectedSouthPane from 'src/SqlLab/components/SouthPane';
 import SqlEditor from 'src/SqlLab/components/SqlEditor';
 import SqlEditorLeftBar from 'src/SqlLab/components/SqlEditorLeftBar';
 
@@ -64,15 +64,15 @@ describe('SqlEditor', () => {
     const wrapper = shallow(<SqlEditor {...mockedProps} />);
     expect(wrapper.find(AceEditorWrapper)).toExist();
   });
-  it('render an SouthPane', () => {
+  it('render a SouthPane', () => {
     const wrapper = shallow(<SqlEditor {...mockedProps} />);
-    expect(wrapper.find(SouthPane)).toExist();
+    expect(wrapper.find(ConnectedSouthPane)).toExist();
   });
   it('does not overflow the editor window', () => {
     const wrapper = shallow(<SqlEditor {...mockedProps} />);
     const totalSize =
       parseFloat(wrapper.find(AceEditorWrapper).props().height) +
-      wrapper.find(SouthPane).props().height +
+      wrapper.find(ConnectedSouthPane).props().height +
       SQL_TOOLBAR_HEIGHT +
       SQL_EDITOR_GUTTER_MARGIN * 2 +
       SQL_EDITOR_GUTTER_HEIGHT;
@@ -83,7 +83,7 @@ describe('SqlEditor', () => {
     wrapper.setState({ height: 450 });
     const totalSize =
       parseFloat(wrapper.find(AceEditorWrapper).props().height) +
-      wrapper.find(SouthPane).props().height +
+      wrapper.find(ConnectedSouthPane).props().height +
       SQL_TOOLBAR_HEIGHT +
       SQL_EDITOR_GUTTER_MARGIN * 2 +
       SQL_EDITOR_GUTTER_HEIGHT;

--- a/superset-frontend/src/SqlLab/components/App.jsx
+++ b/superset-frontend/src/SqlLab/components/App.jsx
@@ -169,5 +169,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export { App };
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton.jsx
@@ -128,7 +128,6 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export { ExploreCtasResultsButton };
 export default connect(
   mapStateToProps,
   mapDispatchToProps,

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton.jsx
@@ -253,7 +253,6 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export { ExploreResultsButton };
 export default connect(
   mapStateToProps,
   mapDispatchToProps,

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -40,7 +40,7 @@ import Hotkeys from 'src/components/Hotkeys';
 
 import LimitControl from './LimitControl';
 import TemplateParamsEditor from './TemplateParamsEditor';
-import SouthPane from './SouthPane';
+import ConnectedSouthPane from './SouthPane';
 import SaveQuery from './SaveQuery';
 import ScheduleQueryButton from './ScheduleQueryButton';
 import EstimateQueryCostButton from './EstimateQueryCostButton';
@@ -389,7 +389,7 @@ class SqlEditor extends React.PureComponent {
           />
           {this.renderEditorBottomBar(hotkeys)}
         </div>
-        <SouthPane
+        <ConnectedSouthPane
           editorQueries={this.props.editorQueries}
           latestQueryId={this.props.latestQuery && this.props.latestQuery.id}
           dataPreviewQueries={this.props.dataPreviewQueries}

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -442,6 +442,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export { TabbedSqlEditors };
-
 export default connect(mapStateToProps, mapDispatchToProps)(TabbedSqlEditors);

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -246,7 +246,7 @@ const defaultProps = {
   onChange: () => {},
 };
 
-export class DatasourceEditor extends React.PureComponent {
+class DatasourceEditor extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/superset-frontend/src/explore/components/ExploreActionButtons.jsx
+++ b/superset-frontend/src/explore/components/ExploreActionButtons.jsx
@@ -23,7 +23,7 @@ import { t } from '@superset-ui/core';
 
 import URLShortLinkButton from '../../components/URLShortLinkButton';
 import EmbedCodeButton from './EmbedCodeButton';
-import DisplayQueryButton from './DisplayQueryButton';
+import ConnectedDisplayQueryButton from './DisplayQueryButton';
 import { exportChart, getExploreLongUrl } from '../exploreUtils';
 
 const propTypes = {
@@ -100,7 +100,7 @@ export default function ExploreActionButtons({
           <i className="fa fa-file-text-o" /> .csv
         </a>
       )}
-      <DisplayQueryButton
+      <ConnectedDisplayQueryButton
         chartHeight={chartHeight}
         queryResponse={queryResponse}
         latestQueryFormData={latestQueryFormData}

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -22,7 +22,7 @@ import { ParentSize } from '@vx/responsive';
 import { styled } from '@superset-ui/core';
 import { chartPropShape } from '../../dashboard/util/propShapes';
 import ChartContainer from '../../chart/ChartContainer';
-import ExploreChartHeader from './ExploreChartHeader';
+import ConnectedExploreChartHeader from './ExploreChartHeader';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -110,7 +110,7 @@ class ExploreChartPanel extends React.PureComponent {
     }
 
     const header = (
-      <ExploreChartHeader
+      <ConnectedExploreChartHeader
         actions={this.props.actions}
         addHistory={this.props.addHistory}
         can_overwrite={this.props.can_overwrite}

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -24,7 +24,7 @@ import { connect } from 'react-redux';
 import { styled, logging, t } from '@superset-ui/core';
 
 import ExploreChartPanel from './ExploreChartPanel';
-import ControlPanelsContainer from './ControlPanelsContainer';
+import ConnectedControlPanelsContainer from './ControlPanelsContainer';
 import SaveModal from './SaveModal';
 import QueryAndSaveBtns from './QueryAndSaveBtns';
 import { getExploreLongUrl } from '../exploreUtils';
@@ -354,7 +354,7 @@ class ExploreViewContainer extends React.Component {
             errorMessage={this.renderErrorMessage()}
             datasourceType={this.props.datasource_type}
           />
-          <ControlPanelsContainer
+          <ConnectedControlPanelsContainer
             actions={this.props.actions}
             form_data={this.props.form_data}
             controls={this.props.controls}
@@ -417,8 +417,6 @@ function mapDispatchToProps(dispatch) {
     actions: bindActionCreators(actions, dispatch),
   };
 }
-
-export { ExploreViewContainer };
 
 export default connect(
   mapStateToProps,

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -250,5 +250,4 @@ function mapStateToProps({ explore, saveModal }) {
   };
 }
 
-export { SaveModal };
 export default connect(mapStateToProps, () => ({}))(SaveModal);

--- a/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
@@ -34,8 +34,9 @@ import SelectControl from './SelectControl';
 import TextControl from './TextControl';
 import CheckboxControl from './CheckboxControl';
 
-import ANNOTATION_TYPES, {
+import {
   ANNOTATION_SOURCE_TYPES,
+  ANNOTATION_TYPES,
   ANNOTATION_TYPES_METADATA,
   DEFAULT_ANNOTATION_TYPE,
   requiresQuery,

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -501,4 +501,3 @@ export const controls = {
     }),
   },
 };
-export default controls;

--- a/superset-frontend/src/explore/store.js
+++ b/superset-frontend/src/explore/store.js
@@ -19,7 +19,7 @@
 /* eslint camelcase: 0 */
 import { getChartControlPanelRegistry } from '@superset-ui/core';
 import { getAllControlsState, getFormDataFromControls } from './controlUtils';
-import controls from './controls';
+import { controls } from './controls';
 
 function handleDeprecatedControls(formData) {
   // Reacffectation / handling of deprecated controls

--- a/superset-frontend/src/modules/AnnotationTypes.js
+++ b/superset-frontend/src/modules/AnnotationTypes.js
@@ -77,5 +77,3 @@ export function applyNativeColumns(annotation) {
   }
   return annotation;
 }
-
-export default ANNOTATION_TYPES;

--- a/superset-frontend/src/utils/getControlsForVizType.js
+++ b/superset-frontend/src/utils/getControlsForVizType.js
@@ -19,7 +19,7 @@
 
 import memoize from 'lodash/memoize';
 import { getChartControlPanelRegistry } from '@superset-ui/core';
-import controls from '../explore/controls';
+import { controls } from '../explore/controls';
 
 const getControlsForVizType = memoize(vizType => {
   const controlsMap = {};

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -29,7 +29,7 @@ import FormLabel from 'src/components/FormLabel';
 import DateFilterControl from 'src/explore/components/controls/DateFilterControl';
 import ControlRow from 'src/explore/components/ControlRow';
 import Control from 'src/explore/components/Control';
-import controls from 'src/explore/controls';
+import { controls } from 'src/explore/controls';
 import { getExploreUrl } from 'src/explore/exploreUtils';
 import OnPasteSelect from 'src/components/Select/OnPasteSelect';
 import { getDashboardFilterKey } from 'src/dashboard/util/getDashboardFilterKey';


### PR DESCRIPTION
### SUMMARY
Enable ESLint rule `no-named-as-default`.
I removed some unused named exports.
In cases when both default and named exports where used, I renamed default imports with prefix "Connected" (to point out that it imports a component wrapped in redux's `connect`).
Finally, there were some variables that had both named and default exports. In such cases I removed the default export

### TEST PLAN
Run `npm run lint` and verify that there are no new linter errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
