### PR TITLE
fix(cypress): wait for filterValues request

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/AdhocFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/AdhocFilters.test.ts
@@ -22,6 +22,7 @@ describe('AdhocFilters', () => {
     cy.server();
     cy.route('GET', '/superset/explore_json/**').as('getJson');
     cy.route('POST', '/superset/explore_json/**').as('postJson');
+    cy.route('GET', '/superset/filter/table/*/name').as('filterValues');
   });
 
   it('Set simple adhoc filter', () => {
@@ -55,6 +56,8 @@ describe('AdhocFilters', () => {
       cy.get('.Select__control').click();
       cy.get('input[type=text]').focus().type('name{enter}');
     });
+
+    cy.wait('@filterValues');
 
     cy.get('#filter-edit-popover').within(() => {
       cy.get('#adhoc-filter-edit-tabs-tab-SQL').click();


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Seeing a lot of cypress failures for `explore/AdhocFilters` test. 🤞 this makes it less flaky. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A 
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
ran the cypress check 3 times without failures... seems to be an improvement 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
