### PR TITLE
docs: fix ubuntu 20.04 installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -157,7 +157,7 @@ the required dependencies are installed: ::
 
 **Ubuntu 20.04** the following command will ensure that the required dependencies are installed: ::
 
-    sudo apt-get install build-essential libssl-dev libffi-dev python3-dev python-pip libsasl2-dev libldap2-dev
+    sudo apt-get install build-essential libssl-dev libffi-dev python3-dev python3-pip libsasl2-dev libldap2-dev
 
 otherwise build for ``cryptography`` fails.
 

--- a/docs/src/pages/docs/installation/installing_scratch.mdx
+++ b/docs/src/pages/docs/installation/installing_scratch.mdx
@@ -22,11 +22,10 @@ The following command will ensure that the required dependencies are installed:
 sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip libsasl2-dev libldap2-dev
 ```
 
-In Ubuntu 18.04 If you have python3.6 installed alongside with python2.7 (which is default on Ubuntu
-18.04), run this command also:
+In Ubuntu 20.04 the following command will ensure that the required dependencies are installed:
 
 ```
-sudo apt-get install build-essential libssl-dev libffi-dev python3.6-dev python-pip libsasl2-dev libldap2-dev
+sudo apt-get install build-essential libssl-dev libffi-dev python3-dev python3-pip libsasl2-dev libldap2-dev
 ```
 
 **Fedora and RHEL-derivative Linux distributions**


### PR DESCRIPTION
### SUMMARY
The update to the installation instructions introduced in #10841 was not migrated to the new site. This updates the new site + fixes an incorrect reference to `python-pip` which is in fact `python3-pip` on ubuntu 20.04 (command tested on a local ubuntu 20.04 instance).

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
