### PR TITLE
chore: disable flaky cypress test

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/AdhocFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/AdhocFilters.test.ts
@@ -24,7 +24,7 @@ describe('AdhocFilters', () => {
     cy.route('POST', '/superset/explore_json/**').as('postJson');
   });
 
-  it('Set simple adhoc filter', () => {
+  xit('Set simple adhoc filter', () => {
     cy.visitChartByName('Num Births Trend');
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
 


### PR DESCRIPTION
### SUMMARY

Flaky cypress test is hurting everyone, let's disable it first and assign fixing it to someone.