### PR TITLE
docs: Client side redirects (one POC)

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -71,5 +71,6 @@ module.exports = {
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,
+    `gatsby-plugin-client-side-redirect`,
   ],
 };

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 exports.createPages = ({ actions }) => {
   const { createRedirect } = actions; //actions is collection of many actions - https://www.gatsbyjs.org/docs/actions
   createRedirect({

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -1,0 +1,8 @@
+exports.createPages = ({ actions }) => {
+  const { createRedirect } = actions; //actions is collection of many actions - https://www.gatsbyjs.org/docs/actions
+  createRedirect({
+    fromPath: '/installation.html',
+    toPath: '/docs/installation/installing-superset-using-docker-compose',
+    isPermanent: true,
+  });
+};

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9994,6 +9994,26 @@
         "babel-plugin-import": "^1.13.0"
       }
     },
+    "gatsby-plugin-client-side-redirect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-client-side-redirect/-/gatsby-plugin-client-side-redirect-1.1.0.tgz",
+      "integrity": "sha512-ox3QpfQynNmH4SgBedMxi9WdEFVI/fQep0cpAu5mPSIQElIJmy+TF5fDZc56Ra+cvr/dz45sw+tUzE41aMlLfw==",
+      "requires": {
+        "fs-extra": "^7.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-compile-es6-packages": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-compile-es6-packages/-/gatsby-plugin-compile-es6-packages-2.1.0.tgz",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "gatsby-dynamical-navigation": "^0.4.1",
     "gatsby-image": "^2.4.14",
     "gatsby-plugin-antd": "^2.2.0",
+    "gatsby-plugin-client-side-redirect": "^1.1.0",
     "gatsby-plugin-emotion": "^4.3.10",
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-manifest": "^2.4.21",


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a gatsby plugin to render HTML files with client-side redirects, to support legacy URLs. This PR adds only one such link, but if it works on prod (rendered) we'll add more.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
