### PR TITLE
build: optimize eslintrc for webpack configs

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -27,6 +27,12 @@ module.exports = {
   env: {
     browser: true,
   },
+  settings: {
+    'import/resolver': 'webpack',
+    react: {
+      version: 'detect',
+    },
+  },
   plugins: ['prettier', 'react'],
   overrides: [
     {
@@ -38,8 +44,13 @@ module.exports = {
     },
     {
       files: ['webpack*.js'],
-      rules: {
-        'import/no-extraneous-dependencies': 0,
+      env: {
+        node: true,
+      },
+      settings: {
+        'import/resolver': {
+          node: {},
+        },
       },
     },
     {
@@ -240,11 +251,5 @@ module.exports = {
     'react/require-default-props': 0,
     'react/static-property-placement': 0, // disabled temporarily
     'prettier/prettier': 'error',
-  },
-  settings: {
-    'import/resolver': 'webpack',
-    react: {
-      version: 'detect',
-    },
   },
 };


### PR DESCRIPTION
### SUMMARY

Minor optimization for `eslintrc` configs:

1. Instead of disabling `import/no-extraneous-dependencies`, use `env: node` and set appropriate import resolver for `webpack*.js` (ref: https://github.com/benmosher/eslint-plugin-import/issues/1396#issuecomment-511007063)
2. Move `settings` to top of the file so it's more discoverable.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
