### PR TITLE
fix: babel script broken by format string

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -578,7 +578,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             driver_name = make_url(item.get("sqlalchemy_uri")).drivername
             return self.response(
                 400,
-                message=_(f"Could not load database driver: {driver_name}"),
+                message=_("Could not load database driver: {}").format(driver_name),
                 driver_name=driver_name,
             )
         except DatabaseSecurityUnsafeError as ex:


### PR DESCRIPTION
### SUMMARY
babel script broken by format string, runing after translation script
```
 flask fab babel-extract --target superset/translations --output superset/translations/messages.pot --config superset/translations/babel.cfg -k _ -k __ -k t -k tn -k tct
```
raise bable exception

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/2016594/93290141-a506af80-f812-11ea-97bd-0c8c24308a9e.png">


### TEST PLAN
Do we need a tox task to add the translation testing? @mistercrunch 