### PR TITLE
ESLint: Enable anchor-has-content rule

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -79,7 +79,6 @@ module.exports = {
         'import/no-named-as-default-member': 0,
         'import/prefer-default-export': 0,
         indent: 0,
-        'jsx-a11y/anchor-has-content': 0,
         'jsx-a11y/anchor-is-valid': 0, // disabled temporarily
         'jsx-a11y/click-events-have-key-events': 0, // re-enable up for discussion
         'jsx-a11y/mouse-events-have-key-events': 0, // re-enable up for discussion
@@ -194,7 +193,6 @@ module.exports = {
     'import/no-named-as-default': 0,
     'import/prefer-default-export': 0,
     indent: 0,
-    'jsx-a11y/anchor-has-content': 0,
     'jsx-a11y/anchor-is-valid': 0, // disabled temporarily
     'jsx-a11y/click-events-have-key-events': 0, // re-enable up for discussion
     'jsx-a11y/mouse-events-have-key-events': 0, // re-enable up for discussion

--- a/superset-frontend/spec/javascripts/explore/components/ControlRow_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/ControlRow_spec.jsx
@@ -22,11 +22,13 @@ import ControlSetRow from 'src/explore/components/ControlRow';
 
 describe('ControlSetRow', () => {
   it('renders a single row with one element', () => {
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
     const wrapper = shallow(<ControlSetRow controls={[<a />]} />);
     expect(wrapper.find('.row')).toExist();
     expect(wrapper.find('.row').find('a')).toExist();
   });
   it('renders a single row with two elements', () => {
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
     const wrapper = shallow(<ControlSetRow controls={[<a />, <a />]} />);
     expect(wrapper.find('.row')).toExist();
     expect(wrapper.find('.row').find('a')).toHaveLength(2);

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -170,7 +170,11 @@ class TableElement extends React.PureComponent {
         />
         {table.selectStar && (
           <CopyToClipboard
-            copyNode={<a className="fa fa-clipboard pull-left m-l-2" />}
+            copyNode={
+              <a aria-label="Copy">
+                <i aria-hidden className="fa fa-clipboard pull-left m-l-2" />
+              </a>
+            }
             text={table.selectStar}
             shouldShowText={false}
             tooltipText={t('Copy SELECT statement to the clipboard')}


### PR DESCRIPTION
### SUMMARY
Enable jsx-a11y/anchor-has-content rule, refactor the code accordingly.

### TEST PLAN
Run `npm run lint` to verify there are no new linter errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
