### PR TITLE
fix: several disabled pylint rules in models/helpers.py

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -21,8 +21,6 @@ import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set, Union
 
-# isort and pylint disagree, isort should win
-# pylint: disable=ungrouped-imports
 import humanize
 import pandas as pd
 import pytz

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -322,11 +322,11 @@ class ImportMixin:
         return json_to_dict(self.template_params)  # type: ignore
 
 
-def _user_link(_user: User) -> Union[Markup, str]:
-    if not _user:
+def _user_link(user: User) -> Union[Markup, str]:
+    if not user:
         return ""
-    url = "/superset/profile/{}/".format(_user.username)
-    return Markup('<a href="{}">{}</a>'.format(url, escape(_user) or ""))
+    url = "/superset/profile/{}/".format(user.username)
+    return Markup('<a href="{}">{}</a>'.format(url, escape(user) or ""))
 
 
 class AuditMixinNullable(AuditMixin):
@@ -427,7 +427,11 @@ class ExtraJSONMixin:
             return json.loads(self.extra_json)
         except (TypeError, JSONDecodeError) as exc:
             logger.error(
-                "Unable to load an extra json: %r. Leaving empty.", exc, exc_info=True
+                "Unable to load an extra JSON: %r. "
+                "Leaving empty. Extra JSON content: %d",
+                exc,
+                self.extra_json,
+                exc_info=True,
             )
             return {}
 

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -310,11 +310,9 @@ class ImportMixin:
         self.created_by = None
         self.changed_by = None
         # flask global context might not exist (in cli or tests for example)
-        try:
-            if g.user:
-                self.owners = [g.user]
-        except Exception:  # pylint: disable=broad-except
-            self.owners = []
+        self.owners = []
+        if g and hasattr(g, "user"):
+            self.owners = [g.user]
 
     @property
     def params_dict(self) -> Dict[Any, Any]:

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -323,11 +323,11 @@ class ImportMixin:
         return json_to_dict(self.template_params)  # type: ignore
 
 
-def _user_link(user: User) -> Union[Markup, str]:  # pylint: disable=no-self-use
-    if not user:
+def _user_link(_user: User) -> Union[Markup, str]:
+    if not _user:
         return ""
-    url = "/superset/profile/{}/".format(user.username)
-    return Markup('<a href="{}">{}</a>'.format(url, escape(user) or ""))
+    url = "/superset/profile/{}/".format(_user.username)
+    return Markup('<a href="{}">{}</a>'.format(url, escape(_user) or ""))
 
 
 class AuditMixinNullable(AuditMixin):

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -427,11 +427,7 @@ class ExtraJSONMixin:
             return json.loads(self.extra_json)
         except (TypeError, JSONDecodeError) as exc:
             logger.error(
-                "Unable to load an extra JSON: %r. "
-                "Leaving empty. Extra JSON content: %d",
-                exc,
-                self.extra_json,
-                exc_info=True,
+                "Unable to load an extra json: %r. Leaving empty.", exc, exc_info=True
             )
             return {}
 


### PR DESCRIPTION
### SUMMARY
Fixed several disabled pylint rules in models/helpers.py:
- pylint import list seems not conflicting with isort anymore
- changed escaping of `[` to double backslash
- changed private method which is used as public
- defined more specific exception handling in JSON loading
- removed unnecessary error handling and replaced with condition

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
