### PR TITLE
perf(explore): render datasource details only when needed

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
@@ -60,14 +60,14 @@ describe('DatasourceControl', () => {
     });
   }
 
-  it('renders a Modal', () => {
+  it('should not render Modal', () => {
     const wrapper = setup();
-    expect(wrapper.find(DatasourceModal)).toExist();
+    expect(wrapper.find(DatasourceModal)).toHaveLength(0);
   });
 
-  it('renders a ChangeDatasourceModal', () => {
+  it('should not render ChangeDatasourceModal', () => {
     const wrapper = setup();
-    expect(wrapper.find(ChangeDatasourceModal)).toExist();
+    expect(wrapper.find(ChangeDatasourceModal)).toHaveLength(0);
   });
 
   it('show or hide Edit Datasource option', () => {

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -73,6 +73,17 @@ const Styles = styled.div`
   }
 `;
 
+/**
+ * <Col> used in column details.
+ */
+const ColumnsCol = styled(Col)`
+  overflow: auto; /* for very very long columns names */
+  white-space: nowrap; /* make sure tooltip trigger is on the same line as the metric */
+  .and-more {
+    padding-left: 38px;
+  }
+`;
+
 class DatasourceControl extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -117,7 +128,7 @@ class DatasourceControl extends React.PureComponent {
   renderDatasource() {
     const { datasource } = this.props;
     const { showDatasource } = this.state;
-    const maxNumColumns = 30;
+    const maxNumColumns = 50;
     return (
       <div className="m-t-10">
         <Well className="m-t-0">
@@ -129,22 +140,28 @@ class DatasourceControl extends React.PureComponent {
           </div>
           {showDatasource && (
             <Row className="datasource-container">
-              <Col md={6}>
+              <ColumnsCol md={6}>
                 <strong>Columns</strong>
                 {datasource.columns.slice(0, maxNumColumns).map(col => (
                   <div key={col.column_name}>
                     <ColumnOption showType column={col} />
                   </div>
                 ))}
-              </Col>
-              <Col md={6}>
+                {datasource.columns.length > maxNumColumns && (
+                  <div className="and-more">...</div>
+                )}
+              </ColumnsCol>
+              <ColumnsCol md={6}>
                 <strong>Metrics</strong>
                 {datasource.metrics.slice(0, maxNumColumns).map(m => (
                   <div key={m.metric_name}>
                     <MetricOption metric={m} showType />
                   </div>
                 ))}
-              </Col>
+                {datasource.columns.length > maxNumColumns && (
+                  <div className="and-more">...</div>
+                )}
+              </ColumnsCol>
             </Row>
           )}
         </Well>
@@ -218,7 +235,7 @@ class DatasourceControl extends React.PureComponent {
         <Collapse in={this.state.showDatasource}>
           {this.renderDatasource()}
         </Collapse>
-        {showChangeDatasourceModal && (
+        {showEditDatasourceModal && (
           <DatasourceModal
             datasource={datasource}
             show={showEditDatasourceModal}

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -116,6 +116,8 @@ class DatasourceControl extends React.PureComponent {
 
   renderDatasource() {
     const { datasource } = this.props;
+    const { showDatasource } = this.state;
+    const maxNumColumns = 30;
     return (
       <div className="m-t-10">
         <Well className="m-t-0">
@@ -125,24 +127,26 @@ class DatasourceControl extends React.PureComponent {
             </Label>
             {` ${datasource.database.name} `}
           </div>
-          <Row className="datasource-container">
-            <Col md={6}>
-              <strong>Columns</strong>
-              {datasource.columns.map(col => (
-                <div key={col.column_name}>
-                  <ColumnOption showType column={col} />
-                </div>
-              ))}
-            </Col>
-            <Col md={6}>
-              <strong>Metrics</strong>
-              {datasource.metrics.map(m => (
-                <div key={m.metric_name}>
-                  <MetricOption metric={m} showType />
-                </div>
-              ))}
-            </Col>
-          </Row>
+          {showDatasource && (
+            <Row className="datasource-container">
+              <Col md={6}>
+                <strong>Columns</strong>
+                {datasource.columns.slice(0, maxNumColumns).map(col => (
+                  <div key={col.column_name}>
+                    <ColumnOption showType column={col} />
+                  </div>
+                ))}
+              </Col>
+              <Col md={6}>
+                <strong>Metrics</strong>
+                {datasource.metrics.slice(0, maxNumColumns).map(m => (
+                  <div key={m.metric_name}>
+                    <MetricOption metric={m} showType />
+                  </div>
+                ))}
+              </Col>
+            </Row>
+          )}
         </Well>
       </div>
     );
@@ -214,18 +218,22 @@ class DatasourceControl extends React.PureComponent {
         <Collapse in={this.state.showDatasource}>
           {this.renderDatasource()}
         </Collapse>
-        <DatasourceModal
-          datasource={datasource}
-          show={showEditDatasourceModal}
-          onDatasourceSave={this.onDatasourceSave}
-          onHide={this.toggleEditDatasourceModal}
-        />
-        <ChangeDatasourceModal
-          onDatasourceSave={this.onDatasourceSave}
-          onHide={this.toggleChangeDatasourceModal}
-          show={showChangeDatasourceModal}
-          onChange={onChange}
-        />
+        {showChangeDatasourceModal && (
+          <DatasourceModal
+            datasource={datasource}
+            show={showEditDatasourceModal}
+            onDatasourceSave={this.onDatasourceSave}
+            onHide={this.toggleEditDatasourceModal}
+          />
+        )}
+        {showChangeDatasourceModal && (
+          <ChangeDatasourceModal
+            onDatasourceSave={this.onDatasourceSave}
+            onHide={this.toggleChangeDatasourceModal}
+            show={showChangeDatasourceModal}
+            onChange={onChange}
+          />
+        )}
       </Styles>
     );
   }


### PR DESCRIPTION
### SUMMARY

For large datasources with many columns and metrics, the unnecessary rendering of datasource details and the editor/change datasource modals makes the UI very unresponsive when interacting with the DatasourceControl.

This PR limits the number of columns and metrics to render (currently 30) in the expandable datasource details box and skip rendering of the modals if users don't actually need them:

<img src="https://user-images.githubusercontent.com/335541/93397918-6a5f4000-f82f-11ea-9610-9b0e3fafb83c.png" width="400" />

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

1. Go to Explore page
2. Choose a datasource with many columns (> 100)
3. Try change or edit datasource
4. The UI should be more responsive with this PR

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
