### PR TITLE
chore: remove SIP_34_DATABASE_UI feature flag 

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -309,7 +309,6 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "SIP_38_VIZ_REARCHITECTURE": False,
     "TAGGING_SYSTEM": False,
     "SQLLAB_BACKEND_PERSISTENCE": False,
-    "SIP_34_DATABASE_UI": False,
 }
 
 # This is merely a default.

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -32,7 +32,6 @@ from superset import app, db
 from superset.connectors.sqla.models import SqlaTable
 from superset.constants import RouteMethod
 from superset.exceptions import CertificateException
-from superset.extensions import feature_flag_manager
 from superset.sql_parse import Table
 from superset.typing import FlaskResponse
 from superset.utils import core as utils
@@ -99,10 +98,7 @@ class DatabaseView(
     @expose("/list/")
     @has_access
     def list(self) -> FlaskResponse:
-        if not (
-            app.config["ENABLE_REACT_CRUD_VIEWS"]
-            and feature_flag_manager.is_feature_enabled("SIP_34_DATABASE_UI")
-        ):
+        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
             return super().list()
 
         return super().render_app_template()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`SIP_34_DATABASE_UI` was a feature flag used when the database CRUD ui was under construction. Removing this flag should enable the new database UI when `ENABLE_REACT_CRUD_VIEWS = True`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
CI passes
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
