### PR TITLE
fix(legacy-druid): undefined filter key

### DIFF
--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -1400,7 +1400,7 @@ class DruidDatasource(Model, BaseDatasource):
                 if df is None:
                     df = pd.DataFrame()
                 qry["filter"] = self._add_filter_from_pre_query_data(
-                    df, pre_qry["dimensions"], qry["filter"]
+                    df, pre_qry["dimensions"], filters
                 )
                 qry["limit_spec"] = None
             if row_limit:


### PR DESCRIPTION
### SUMMARY
The legacy Druid connector leaves the `qry["filter"]` key unpopulated if there are no filters present. This fixes that (see related issue).

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #10928
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Ping: @elukey 