### PR TITLE
fix: address all disabled pylint checks in charts/api.py

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -426,7 +426,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     @statsd_metrics
-    def data(self) -> Response:  # pylint: disable=too-many-return-statements
+    def data(self) -> Response:
         """
         Takes a query context constructed in the client and returns payload
         data response for the given query.
@@ -480,10 +480,15 @@ class ChartRestApi(BaseSupersetModelRestApi):
             if query.get("error"):
                 return self.response_400(message=f"Error: {query['error']}")
         result_format = query_context.result_format
+
+        response = self.response_400(
+            message=f"Unsupported result_format: {result_format}"
+        )
+
         if result_format == ChartDataResultFormat.CSV:
             # return the first result
             result = payload[0]["data"]
-            return CsvResponse(
+            response = CsvResponse(
                 result,
                 status=200,
                 headers=generate_download_headers("csv"),
@@ -496,9 +501,9 @@ class ChartRestApi(BaseSupersetModelRestApi):
             )
             resp = make_response(response_data, 200)
             resp.headers["Content-Type"] = "application/json; charset=utf-8"
-            return resp
+            response = resp
 
-        return self.response_400(message=f"Unsupported result_format: {result_format}")
+        return response
 
     @expose("/<pk>/cache_screenshot/", methods=["GET"])
     @protect()

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -369,9 +369,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @rison(get_delete_ids_schema)
-    def bulk_delete(
-        self, **kwargs: Any
-    ) -> Response:  # pylint: disable=arguments-differ
+    def bulk_delete(self, **kwargs: Any) -> Response:
         """Delete bulk Charts
         ---
         delete:

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -246,7 +246,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     @statsd_metrics
-    def put(self, pk: int) -> Response:  # pylint: disable=arguments-differ
+    def put(self, pk: int) -> Response:
         """Changes a Chart
         ---
         put:

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -319,7 +319,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     @statsd_metrics
-    def delete(self, pk: int) -> Response:  # pylint: disable=arguments-differ
+    def delete(self, pk: int) -> Response:
         """Deletes a Chart
         ---
         delete:


### PR DESCRIPTION
### SUMMARY
Removed disabled pylint checks in `charts/api.py`:
-  `arguments-differ` in `put()`, `delete()` and `bulk_delete()` methods isn't an issue anymore,
- `put()` and `data()` refactored to remove disabled check ` too-many-return-statements` .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
