### PR TITLE
fix: use nullpool even for user lookup in the celery

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -46,6 +46,7 @@ from retry.api import retry_call
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver import chrome, firefox
 from selenium.webdriver.remote.webdriver import WebDriver
+from sqlalchemy import func
 from sqlalchemy.exc import NoSuchColumnError, ResourceClosedError
 from sqlalchemy.orm import Session
 
@@ -200,12 +201,21 @@ def _get_url_path(view: str, user_friendly: bool = False, **kwargs: Any) -> str:
         return urllib.parse.urljoin(str(base_url), url_for(view, **kwargs))
 
 
-def create_webdriver() -> WebDriver:
-    return WebDriverProxy(driver_type=config["WEBDRIVER_TYPE"]).auth(get_reports_user())
+def create_webdriver(session: Session) -> WebDriver:
+    return WebDriverProxy(driver_type=config["WEBDRIVER_TYPE"]).auth(
+        get_reports_user(session)
+    )
 
 
-def get_reports_user() -> "User":
-    return security_manager.find_user(config["EMAIL_REPORTS_USER"])
+def get_reports_user(session: Session) -> "User":
+    return (
+        session.query(security_manager.user_model)
+        .filter(
+            func.lower(security_manager.user_model.username)
+            == func.lower(config["EMAIL_REPORTS_USER"])
+        )
+        .one_or_none()
+    )
 
 
 def destroy_webdriver(
@@ -249,7 +259,7 @@ def deliver_dashboard(  # pylint: disable=too-many-locals
         )
 
         # Create a driver, fetch the page, wait for the page to render
-        driver = create_webdriver()
+        driver = create_webdriver(session)
         window = config["WEBDRIVER_WINDOW"]["dashboard"]
         driver.set_window_size(*window)
         driver.get(dashboard_url)
@@ -303,7 +313,9 @@ def deliver_dashboard(  # pylint: disable=too-many-locals
             )
 
 
-def _get_slice_data(slc: Slice, delivery_type: EmailDeliveryType) -> ReportContent:
+def _get_slice_data(
+    slc: Slice, delivery_type: EmailDeliveryType, session: Session
+) -> ReportContent:
     slice_url = _get_url_path(
         "Superset.explore_json", csv="true", form_data=json.dumps({"slice_id": slc.id})
     )
@@ -315,7 +327,7 @@ def _get_slice_data(slc: Slice, delivery_type: EmailDeliveryType) -> ReportConte
 
     # Login on behalf of the "reports" user in order to get cookies to deal with auth
     auth_cookies = machine_auth_provider_factory.instance.get_auth_cookies(
-        get_reports_user()
+        get_reports_user(session)
     )
     # Build something like "session=cool_sess.val;other-cookie=awesome_other_cookie"
     cookie_str = ";".join([f"{key}={val}" for key, val in auth_cookies.items()])
@@ -384,10 +396,10 @@ def _get_slice_screenshot(slice_id: int, session: Session) -> ScreenshotData:
 
 
 def _get_slice_visualization(
-    slc: Slice, delivery_type: EmailDeliveryType
+    slc: Slice, delivery_type: EmailDeliveryType, session: Session
 ) -> ReportContent:
     # Create a driver, fetch the page, wait for the page to render
-    driver = create_webdriver()
+    driver = create_webdriver(session)
     window = config["WEBDRIVER_WINDOW"]["slice"]
     driver.set_window_size(*window)
 
@@ -438,9 +450,9 @@ def deliver_slice(  # pylint: disable=too-many-arguments
     slc = session.query(Slice).filter_by(id=slice_id).one()
 
     if email_format == SliceEmailReportFormat.data:
-        report_content = _get_slice_data(slc, delivery_type)
+        report_content = _get_slice_data(slc, delivery_type, session)
     elif email_format == SliceEmailReportFormat.visualization:
-        report_content = _get_slice_visualization(slc, delivery_type)
+        report_content = _get_slice_visualization(slc, delivery_type, session)
     else:
         raise RuntimeError("Unknown email report format")
 

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -214,7 +214,7 @@ def get_reports_user(session: Session) -> "User":
             func.lower(security_manager.user_model.username)
             == func.lower(config["EMAIL_REPORTS_USER"])
         )
-        .one_or_none()
+        .one()
     )
 
 

--- a/tests/schedules_test.py
+++ b/tests/schedules_test.py
@@ -171,7 +171,7 @@ class TestSchedules(SupersetTestCase):
         mock_driver_class.return_value = mock_driver
         mock_driver.find_elements_by_id.side_effect = [True, False]
 
-        create_webdriver()
+        create_webdriver(db.session)
         mock_driver.add_cookie.assert_called_once()
 
     @patch("superset.tasks.schedules.firefox.webdriver.WebDriver")


### PR DESCRIPTION
### SUMMARY
Follow up to the https://github.com/apache/incubator-superset/pull/10819

Security manager still relies on the default superset db pool instead of nullpool for celery.


### TEST PLAN
[x] existing unit tests
[x] local & staging env

Error msg:
```
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/thirdparty/superset_python3/superset-cpython-38/lib/superset/tasks/schedules.py", line 204, in create_webdriver
    return WebDriverProxy(driver_type=config["WEBDRIVER_TYPE"]).auth(get_reports_user())
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/thirdparty/superset_python3/superset-cpython-38/lib/superset/tasks/schedules.py", line 208, in get_reports_user
    return security_manager.find_user(config["EMAIL_REPORTS_USER"])
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/thirdparty/superset_python3/pip/flask-appbuilder/flask-appbuilder-cpython-38/lib/flask_appbuilder/security/sqla/manager.py", line 156, in find_user
    self.get_session.query(self.user_model)
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/orm/query.py", line 3432, in one_or_none
    ret = list(self)
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/orm/loading.py", line 100, in instances
    cursor.close()
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/util/langhelpers.py", line 68, in __exit__
    compat.raise_(
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/orm/loading.py", line 80, in instances
    rows = [proc(row) for row in fetch]
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/orm/loading.py", line 80, in <listcomp>
    rows = [proc(row) for row in fetch]
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/orm/loading.py", line 524, in _instance
    tuple([row[column] for column in pk_cols]),
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/orm/loading.py", line 524, in <listcomp>
    tuple([row[column] for column in pk_cols]),
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/engine/result.py", line 681, in _key_fallback
    util.raise_(
  File "/srv/yaps/mounts/superset/superset_build/eb36af9819e03e516ffc7d5b9aeabbf6cb067fe5-1280802881dce54672c405f194757e5f/celery.runfiles/__main__/pip/SQLAlchemy/SQLAlchemy-cpython-38/lib/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
sqlalchemy.exc.NoSuchColumnError: "Could not locate column in row for column 'ab_user.id'"
```