### PR TITLE
fix: update pylint disabled checks in common/query_context.py

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -124,9 +124,7 @@ class QueryContext:
         }
 
     @staticmethod
-    def df_metrics_to_num(  # pylint: disable=no-self-use
-        df: pd.DataFrame, query_object: QueryObject
-    ) -> None:
+    def df_metrics_to_num(df: pd.DataFrame, query_object: QueryObject) -> None:
         """Converting metrics to numeric when pandas.read_sql cannot"""
         for col, dtype in df.dtypes.items():
             if dtype.type == np.object_ and col in query_object.metrics:

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -202,7 +202,7 @@ class QueryContext:
         )
         return cache_key
 
-    def get_df_payload(  # pylint: disable=too-many-locals,too-many-statements
+    def get_df_payload(  # pylint: disable=too-many-statements
         self, query_obj: QueryObject, **kwargs: Any
     ) -> Dict[str, Any]:
         """Handles caching around the df payload retrieval"""

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -130,9 +130,7 @@ class QueryContext:
             if dtype.type == np.object_ and col in query_object.metrics:
                 df[col] = pd.to_numeric(df[col], errors="coerce")
 
-    def get_data(
-        self, df: pd.DataFrame,
-    ) -> Union[str, List[Dict[str, Any]]]:  # pylint: disable=no-self-use
+    def get_data(self, df: pd.DataFrame,) -> Union[str, List[Dict[str, Any]]]:
         if self.result_format == utils.ChartDataResultFormat.CSV:
             include_index = not isinstance(df.index, pd.RangeIndex)
             result = df.to_csv(index=include_index, **config["CSV_EXPORT"])


### PR DESCRIPTION
### SUMMARY
Updated pylint checks in `common/query_context.py`:
- removed disabled pylint rule no-self-use from `df_metrics_to_num()` since it has `@staticmethod`,
- the disabled check `too-many-locals` in `get_df_payload()` method is removed since it's not appearing while pylint check,
- removed `disable=no-self-use` in `get_data()`, because method has `self` as param,
- applied auto-formatting with black

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
