### PR TITLE
fix: removed disabled lint rule `too-many-locals` in connectors/base/models.py

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -410,7 +410,7 @@ class BaseDatasource(
         fkmany: List[Column],
         fkmany_class: Type[Union["BaseColumn", "BaseMetric"]],
         key_attr: str,
-    ) -> List[Column]:  # pylint: disable=too-many-locals
+    ) -> List[Column]:
         """Update ORM one-to-many list from object list
 
         Used for syncing metrics and columns using the same code"""


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Lint rule `too-many-locals` isn't raising issues anymore.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
