### PR TITLE
fix: typo in prefer typescript

### DIFF
--- a/.github/workflows/prefer-typescript.yml
+++ b/.github/workflows/prefer-typescript.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get changed files
         id: changed
-        uses: trilom/file-changes-action@master
+        uses: trilom/file-changes-action@v1.2.4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
@@ -21,7 +21,9 @@ jobs:
           js_files_added() {
             jq -r '
               map(
-                select((endswith(".js") or endswith(".jsx"))
+                select(
+                  endswith(".js") or endswith(".jsx")
+                )
               ) | join("\n")
             ' ${HOME}/files_added.json
           }


### PR DESCRIPTION
### SUMMARY

Prefer TypeScript has stopped working since #10170 because of a [typo](https://github.com/apache/incubator-superset/pull/10170/files#diff-0f1a9bbd1316e385c51f8aba1583bd99R24) in `jq` script.

Also fix the `trilom/file-changes-action` GH Action version so the process can be more predictable.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Test in my fork: https://github.com/ktmud/incubator-superset/pull/214/checks?check_run_id=1134954395

This PR contains a new jsx file and the CI was able to successfully identify it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
