### PR TITLE
feat: enable ETag header for dashboard GET requests

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -297,6 +297,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Experimental feature introducing a client (browser) cache
     "CLIENT_CACHE": False,
     "ENABLE_EXPLORE_JSON_CSRF_PROTECTION": False,
+    "ENABLE_DASHBOARD_ETAG_HEADER": False,
     "KV_STORE": False,
     "PRESTO_EXPAND_DATA": False,
     # Exposes API endpoint to compute thumbnails

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -17,7 +17,6 @@
 # pylint: disable=comparison-with-callable
 import logging
 import re
-from collections import defaultdict
 from contextlib import closing
 from datetime import datetime
 from typing import Any, cast, Dict, List, Optional, Union
@@ -26,7 +25,17 @@ from urllib import parse
 import backoff
 import pandas as pd
 import simplejson as json
-from flask import abort, flash, g, Markup, redirect, render_template, request, Response
+from flask import (
+    abort,
+    flash,
+    g,
+    make_response,
+    Markup,
+    redirect,
+    render_template,
+    request,
+    Response,
+)
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
@@ -114,11 +123,15 @@ from superset.views.utils import (
     _deserialize_results_payload,
     apply_display_max_row_limit,
     bootstrap_user_data,
+    check_dashboard_perms,
     check_datasource_perms,
     check_slice_perms,
     get_cta_schema_name,
+    get_dashboard,
     get_dashboard_extra_filters,
+    get_dashboard_latest_changed_on,
     get_datasource_info,
+    get_datasources_from_dashboard,
     get_form_data,
     get_viz,
     is_owner,
@@ -1585,42 +1598,18 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return json_success(json.dumps({"published": dash.published}))
 
     @has_access
+    @etag_cache(
+        0,
+        check_perms=check_dashboard_perms,
+        check_latest_changed_on=get_dashboard_latest_changed_on,
+    )
     @expose("/dashboard/<dashboard_id_or_slug>/")
     def dashboard(  # pylint: disable=too-many-locals
         self, dashboard_id_or_slug: str
     ) -> FlaskResponse:
         """Server side rendering for a dashboard"""
-        session = db.session()
-        qry = session.query(Dashboard)
-        if dashboard_id_or_slug.isdigit():
-            qry = qry.filter_by(id=int(dashboard_id_or_slug))
-        else:
-            qry = qry.filter_by(slug=dashboard_id_or_slug)
-
-        dash = qry.one_or_none()
-        if not dash:
-            abort(404)
-
-        datasources = defaultdict(list)
-        for slc in dash.slices:
-            datasource = slc.datasource
-            if datasource:
-                datasources[datasource].append(slc)
-
-        if config["ENABLE_ACCESS_REQUEST"]:
-            for datasource in datasources:
-                if datasource and not security_manager.can_access_datasource(
-                    datasource
-                ):
-                    flash(
-                        __(
-                            security_manager.get_datasource_access_error_msg(datasource)
-                        ),
-                        "danger",
-                    )
-                    return redirect(
-                        "superset/request_access/?" f"dashboard_id={dash.id}&"
-                    )
+        dash = get_dashboard(dashboard_id_or_slug)
+        datasources = get_datasources_from_dashboard(dash)
 
         # Filter out unneeded fields from the datasource payload
         datasources_payload = {
@@ -1661,7 +1650,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         if is_feature_enabled("REMOVE_SLICE_LEVEL_LABEL_COLORS"):
             # dashboard metadata has dashboard-level label_colors,
             # so remove slice-level label_colors from its form_data
-            for slc in dashboard_data.get("slices"):
+            for slc in dashboard_data.get("slices") or []:
                 form_data = slc.get("form_data")
                 form_data.pop("label_colors", None)
 
@@ -1695,15 +1684,17 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 json.dumps(bootstrap_data, default=utils.pessimistic_json_iso_dttm_ser)
             )
 
-        return self.render_template(
-            "superset/dashboard.html",
-            entry="dashboard",
-            standalone_mode=standalone_mode,
-            title=dash.dashboard_title,
-            custom_css=dashboard_data.get("css"),
-            bootstrap_data=json.dumps(
-                bootstrap_data, default=utils.pessimistic_json_iso_dttm_ser
-            ),
+        return make_response(
+            self.render_template(
+                "superset/dashboard.html",
+                entry="dashboard",
+                standalone_mode=standalone_mode,
+                title=dash.dashboard_title,
+                custom_css=dashboard_data.get("css"),
+                bootstrap_data=json.dumps(
+                    bootstrap_data, default=utils.pessimistic_json_iso_dttm_ser
+                ),
+            )
         )
 
     @api

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -16,19 +16,27 @@
 # under the License.
 import logging
 from collections import defaultdict
-from datetime import date
+from datetime import date, datetime
 from typing import Any, Callable, DefaultDict, Dict, List, Optional, Set, Tuple, Union
 from urllib import parse
 
 import msgpack
 import pyarrow as pa
 import simplejson as json
-from flask import g, request
+from flask import abort, flash, g, redirect, request
 from flask_appbuilder.security.sqla import models as ab_models
 from flask_appbuilder.security.sqla.models import User
+from flask_babel import gettext as __
 
 import superset.models.core as models
-from superset import app, dataframe, db, is_feature_enabled, result_set
+from superset import (
+    app,
+    dataframe,
+    db,
+    is_feature_enabled,
+    result_set,
+    security_manager,
+)
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetException, SupersetSecurityException
@@ -298,6 +306,46 @@ def get_time_range_endpoints(
 CONTAINER_TYPES = ["COLUMN", "GRID", "TABS", "TAB", "ROW"]
 
 
+def get_dashboard(dashboard_id_or_slug: str,) -> Dashboard:
+    session = db.session()
+    qry = session.query(Dashboard)
+    if dashboard_id_or_slug.isdigit():
+        qry = qry.filter_by(id=int(dashboard_id_or_slug))
+    else:
+        qry = qry.filter_by(slug=dashboard_id_or_slug)
+    dashboard = qry.one_or_none()
+
+    if not dashboard:
+        abort(404)
+
+    return dashboard
+
+
+def get_datasources_from_dashboard(
+    dashboard: Dashboard,
+) -> DefaultDict[Any, List[Any]]:
+    datasources = defaultdict(list)
+    for slc in dashboard.slices:
+        datasource = slc.datasource
+        if datasource:
+            datasources[datasource].append(slc)
+    return datasources
+
+
+def get_dashboard_latest_changed_on(_self: Any, dashboard_id_or_slug: str) -> datetime:
+    """
+    Get latest changed datetime for a dashboard. The change could be dashboard
+    metadata change, or any of its slice data change.
+
+    This function takes `self` since it must have the same signature as the
+    the decorated method.
+    """
+    dash = get_dashboard(dashboard_id_or_slug)
+    dash_changed_on = dash.changed_on
+    slices_changed_on = max([s.changed_on for s in dash.slices])
+    return max(dash_changed_on, slices_changed_on)
+
+
 def get_dashboard_extra_filters(
     slice_id: int, dashboard_id: int
 ) -> List[Dict[str, Any]]:
@@ -488,6 +536,26 @@ def check_slice_perms(_self: Any, slice_id: int) -> None:
         )
 
         viz_obj.raise_for_access()
+
+
+def check_dashboard_perms(_self: Any, dashboard_id_or_slug: str) -> None:
+    """
+    Check if user can access a cached response from explore_json.
+
+    This function takes `self` since it must have the same signature as the
+    the decorated method.
+    """
+
+    dash = get_dashboard(dashboard_id_or_slug)
+    datasources = get_datasources_from_dashboard(dash)
+    if app.config["ENABLE_ACCESS_REQUEST"]:
+        for datasource in datasources:
+            if datasource and not security_manager.can_access_datasource(datasource):
+                flash(
+                    __(security_manager.get_datasource_access_error_msg(datasource)),
+                    "danger",
+                )
+                redirect("superset/request_access/?" f"dashboard_id={dash.id}&")
 
 
 def _deserialize_results_payload(

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -67,6 +67,7 @@ from superset.utils.core import (
 from superset.utils import schema
 from superset.views.utils import (
     build_extra_filters,
+    get_dashboard_changedon_dt,
     get_form_data,
     get_time_range_endpoints,
 )
@@ -1134,3 +1135,14 @@ class TestUtils(SupersetTestCase):
         assert get_form_data_token({"token": "token_abcdefg1"}) == "token_abcdefg1"
         generated_token = get_form_data_token({})
         assert re.match(r"^token_[a-z0-9]{8}$", generated_token) is not None
+
+    def test_get_dashboard_changedon_dt(self) -> None:
+        slug = "world_health"
+        dashboard = db.session.query(Dashboard).filter_by(slug=slug).one()
+        dashboard_last_changedon = dashboard.changed_on
+        slices = dashboard.slices
+        slices_last_changedon = max([slc.changed_on for slc in slices])
+        # drop microsecond in datetime
+        assert get_dashboard_changedon_dt(self, slug) == max(
+            dashboard_last_changedon, slices_last_changedon
+        ).replace(microsecond=0)


### PR DESCRIPTION
### SUMMARY
[ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) header is widely used as efficient server-side caching mechanism. Superset had ETag support for explore_json, this PR is to expand the coverage to dashboard GET request.

When dashboard request come in, Superset need to gather all the datasource metadata and all the slices query parameters that are used for this dashboard, and return as a big blob of data. For a large dashboard in airbnb, we saw some dashboard can have 100+ datasources and 300+ slices. This server-side processing can take 4 seconds, and make the whole dashboard load became very slow.

eTag could be a good solution for large dashboards with less frequent changes:
![782-imported-1443570282-782-imported-1443554751-54-original](https://user-images.githubusercontent.com/27990562/93966348-5331be00-fd19-11ea-8a7b-5e6453b295d2.png)


### TEST PLAN
- Open a regular dashboard page, you can see it get 200 response from browser dev tool.
- Reload the same dashboard from browser, you will see 304 response, and response time is really fast (~50 ms)
- Try change dashboard layout, or modify one of the chart from another browser window.
- Reload the same dashboard from browser, you will see 200 response again, since the cache is stale.

For example: regular GET request takes about 4 seconds. If enabled eTag header, 2nd request will get 304 and faster responded since there is no server-side processing:
<img width="1323" alt="Screen Shot 2020-09-25 at 10 55 56 AM" src="https://user-images.githubusercontent.com/27990562/94322502-a25d3600-ff47-11ea-8bcc-87b8c1b3690f.png">

cc @betodealmeida @etr2460 
