### PR TITLE
fix: simply is_adhoc_metric

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1040,24 +1040,9 @@ def backend() -> str:
 
 
 def is_adhoc_metric(metric: Metric) -> bool:
-    if not isinstance(metric, dict):
-        return False
-    metric = cast(Dict[str, Any], metric)
-    return bool(
-        (
-            (
-                metric.get("expressionType") == AdhocMetricExpressionType.SIMPLE
-                and metric.get("column")
-                and cast(Dict[str, Any], metric["column"]).get("column_name")
-                and metric.get("aggregate")
-            )
-            or (
-                metric.get("expressionType") == AdhocMetricExpressionType.SQL
-                and metric.get("sqlExpression")
-            )
-        )
-        and metric.get("label")
-    )
+    if isinstance(metric, dict):
+        return True
+    return False
 
 
 def get_metric_name(metric: Metric) -> str:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1040,9 +1040,7 @@ def backend() -> str:
 
 
 def is_adhoc_metric(metric: Metric) -> bool:
-    if isinstance(metric, dict):
-        return True
-    return False
+    return isinstance(metric, dict)
 
 
 def get_metric_name(metric: Metric) -> str:


### PR DESCRIPTION
### SUMMARY
Currently the `is_adhoc_metric` utility function checks can fail for a metric that has been defined with `{"expressionType": "SIMPLE", "aggregate": None}`, which is supported by certain analytical databases and works on Superset 0.36.0 but not 0.37.x. In the future we should introduce `TypedDict` to enforce these datastructures, perform a migration on the chart metadata to ensure all metadata is compliant (potentially even introduce a metadata data quality checker) and make the metric modal more strict about what types of aggregation options are possible.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #10956
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
