### PR TITLE
chore: Remove Obsolete WARNING_MSG from config

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -498,11 +498,6 @@ MAX_TABLE_NAMES = 3000
 SQLLAB_SAVE_WARNING_MESSAGE = None
 SQLLAB_SCHEDULE_WARNING_MESSAGE = None
 
-# If defined, shows this text in an alert-warning box in the navbar
-# one example use case may be "STAGING" to make it clear that this is
-# not the production version of the site.
-WARNING_MSG = None
-
 # Default celery config is to use SQLA as a broker, in a production setting
 # you'll want to use a proper broker as specified here:
 # http://docs.celeryproject.org/en/latest/getting-started/brokers/index.html


### PR DESCRIPTION
### SUMMARY

It seems that the `WARNING_MSG` config is no longer used as part of the header refactor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
