### PR TITLE
fix: remove disabled rule `pointless-string-statement` in dao files

### DIFF
--- a/superset/dao/base.py
+++ b/superset/dao/base.py
@@ -39,11 +39,11 @@ class BaseDAO:
     """
     Child classes need to state the Model class so they don't need to implement basic
     create, update and delete methods
-    """  # pylint: disable=pointless-string-statement
+    """
     base_filter: Optional[BaseFilter] = None
     """
     Child classes can register base filtering to be aplied to all filter methods
-    """  # pylint: disable=pointless-string-statement
+    """
 
     @classmethod
     def find_by_id(cls, model_id: int) -> Model:


### PR DESCRIPTION
### SUMMARY
`pointless-string-statement` disabled a pylint rule seems to be not necessary anymore.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
