### PR TITLE
fix: pylint disabled rules in dashboard/api.py

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -302,7 +302,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     @statsd_metrics
-    def delete(self, pk: int) -> Response:  # pylint: disable=arguments-differ
+    def delete(self, pk: int) -> Response:
         """Deletes a Dashboard
         ---
         delete:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -232,7 +232,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     @statsd_metrics
-    def put(self, pk: int) -> Response:  # pylint: disable=arguments-differ
+    def put(self, pk: int) -> Response:
         """Changes a Dashboard
         ---
         put:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -232,9 +232,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     @statsd_metrics
-    def put(  # pylint: disable=too-many-return-statements, arguments-differ
-        self, pk: int
-    ) -> Response:
+    def put(self, pk: int) -> Response:  # pylint: disable=arguments-differ
         """Changes a Dashboard
         ---
         put:
@@ -286,18 +284,19 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             return self.response_400(message=error.messages)
         try:
             changed_model = UpdateDashboardCommand(g.user, pk, item).run()
-            return self.response(200, id=changed_model.id, result=item)
+            response = self.response(200, id=changed_model.id, result=item)
         except DashboardNotFoundError:
-            return self.response_404()
+            response = self.response_404()
         except DashboardForbiddenError:
-            return self.response_403()
+            response = self.response_403()
         except DashboardInvalidError as ex:
             return self.response_422(message=ex.normalized_messages())
         except DashboardUpdateFailedError as ex:
             logger.error(
                 "Error updating model %s: %s", self.__class__.__name__, str(ex)
             )
-            return self.response_422(message=str(ex))
+            response = self.response_422(message=str(ex))
+        return response
 
     @expose("/<pk>", methods=["DELETE"])
     @protect()

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -352,9 +352,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @rison(get_delete_ids_schema)
-    def bulk_delete(
-        self, **kwargs: Any
-    ) -> Response:  # pylint: disable=arguments-differ
+    def bulk_delete(self, **kwargs: Any) -> Response:
         """Delete bulk Dashboards
         ---
         delete:


### PR DESCRIPTION
### SUMMARY
Updated methods rules:
- refactored put with several return statements and removed disabled rule `too-many-return-statements`
- removed disable rule `arguments-differ` in `put()`
- removed disable rule `arguments-differ` in `delete()` method
- removed disable rule `arguments-differ` in bulk_delete()` method

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
