### PR TITLE
fix: changes a pylint check in dashboard module

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -81,7 +81,7 @@ class DashboardDAO(BaseDAO):
             raise ex
 
     @staticmethod
-    def set_dash_metadata(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    def set_dash_metadata(
         dashboard: Dashboard,
         data: Dict[Any, Any],
         old_to_new_slice_ids: Optional[Dict[int, int]] = None,

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -44,7 +44,7 @@ def get_indexes_metadata(
 def get_col_type(col: Dict[Any, Any]) -> str:
     try:
         dtype = f"{col['type']}"
-    except Exception:  # pylint: disable=broad-except
+    except KeyError:
         # sqla.types.JSON __str__ has a bug, so using __class__.
         dtype = col["type"].__class__.__name__
     return dtype

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -44,7 +44,7 @@ def get_indexes_metadata(
 def get_col_type(col: Dict[Any, Any]) -> str:
     try:
         dtype = f"{col['type']}"
-    except KeyError:
+    except Exception:  # pylint: disable=broad-except
         # sqla.types.JSON __str__ has a bug, so using __class__.
         dtype = col["type"].__class__.__name__
     return dtype


### PR DESCRIPTION
### SUMMARY
In `dao.py` file following rules doesn't have to be disabled: `disable=too-many-locals`, `too-many-branches`, `too-many-statements`.
Changed broad exception in `utils.py` to `KeyError`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
