### PR TITLE
Replace reactable with DataTable from superset-ui in QueryTable

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/QueryTable_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/QueryTable_spec.jsx
@@ -18,27 +18,28 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Table } from 'reactable-arc';
+import DataTable from '@superset-ui/plugin-chart-table/lib/DataTable';
 import QueryTable from 'src/SqlLab/components/QueryTable';
 
-import { queries } from './fixtures';
+import { dataTableProps } from 'spec/javascripts/sqllab/fixtures';
 
 describe('QueryTable', () => {
   const mockedProps = {
-    queries,
+    ...dataTableProps,
+    displayLimit: 10000,
   };
   it('is valid', () => {
-    expect(React.isValidElement(<QueryTable />)).toBe(true);
+    expect(React.isValidElement(<QueryTable {...mockedProps} />)).toBe(true);
   });
   it('is valid with props', () => {
     expect(React.isValidElement(<QueryTable {...mockedProps} />)).toBe(true);
   });
   it('renders a proper table', () => {
     const wrapper = shallow(<QueryTable {...mockedProps} />);
-    expect(wrapper.find(Table)).toExist();
-    expect(wrapper.find(Table).shallow().find('table')).toExist();
-    expect(wrapper.find(Table).shallow().find('table').find('Tr')).toHaveLength(
-      2,
-    );
+    expect(wrapper.find(DataTable)).toExist();
+    expect(wrapper.find(DataTable).shallow().find('table')).toExist();
+    expect(
+      wrapper.find(DataTable).shallow().find('tbody').find('tr'),
+    ).toHaveLength(2);
   });
 });

--- a/superset-frontend/spec/javascripts/sqllab/QueryTable_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/QueryTable_spec.jsx
@@ -19,11 +19,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import DataTable from '@superset-ui/plugin-chart-table/lib/DataTable';
+import * as useMountedMemo from '@superset-ui/plugin-chart-table/lib/DataTable/utils/useMountedMemo';
 import QueryTable from 'src/SqlLab/components/QueryTable';
 
 import { dataTableProps } from 'spec/javascripts/sqllab/fixtures';
 
 describe('QueryTable', () => {
+  // hack for mocking hook that implements sticky behaviour of DataTable
+  jest
+    .spyOn(useMountedMemo, 'default')
+    .mockImplementation(() => ({ width: 100, height: 100 }));
   const mockedProps = {
     ...dataTableProps,
     displayLimit: 10000,

--- a/superset-frontend/spec/javascripts/sqllab/fixtures.ts
+++ b/superset-frontend/spec/javascripts/sqllab/fixtures.ts
@@ -493,3 +493,8 @@ export const query = {
   ctas: false,
   cached: false,
 };
+
+export const dataTableProps = {
+  columns: ['dbId', 'sql'],
+  queries,
+};

--- a/superset-frontend/src/SqlLab/components/QueryTable.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable.jsx
@@ -213,20 +213,20 @@ class QueryTable extends React.PureComponent {
       })
       .reverse();
     return (
-      <div className="QueryTable">
-        <DataTable
-          tableClassName="table table-condensed"
-          columns={this.props.columns.map(column => ({
-            accessor: column,
-            Header: () => <th>{column}</th>,
-            Cell: ({ value }) => <td>{value}</td>,
-          }))}
-          data={data}
-          pageSize={10}
-          maxPageItemCount={9}
-          searchInput={false}
-        />
-      </div>
+      <DataTable
+        tableClassName="table table-condensed"
+        columns={this.props.columns.map(column => ({
+          accessor: column,
+          Header: () => <th>{column}</th>,
+          Cell: ({ value }) => <td>{value}</td>,
+        }))}
+        data={data}
+        pageSize={10}
+        maxPageItemCount={9}
+        searchInput={false}
+        height="100%"
+        sticky
+      />
     );
   }
 }

--- a/superset-frontend/src/SqlLab/components/QueryTable.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable.jsx
@@ -19,17 +19,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { Table } from 'reactable-arc';
 import { ProgressBar, Well } from 'react-bootstrap';
 import Label from 'src/components/Label';
 import { t } from '@superset-ui/core';
+import DataTable from '@superset-ui/plugin-chart-table/lib/DataTable';
 
 import Button from 'src/components/Button';
+import { fDuration } from 'src/modules/dates';
 import Link from '../../components/Link';
 import ResultSet from './ResultSet';
 import ModalTrigger from '../../components/ModalTrigger';
 import HighlightedSql from './HighlightedSql';
-import { fDuration } from '../../modules/dates';
 import QueryStateLabel from './QueryStateLabel';
 
 const propTypes = {
@@ -214,11 +214,17 @@ class QueryTable extends React.PureComponent {
       .reverse();
     return (
       <div className="QueryTable">
-        <Table
-          columns={this.props.columns}
-          className="table table-condensed"
+        <DataTable
+          tableClassName="table table-condensed"
+          columns={this.props.columns.map(column => ({
+            accessor: column,
+            Header: () => <th>{column}</th>,
+            Cell: ({ value }) => <td>{value}</td>,
+          }))}
           data={data}
-          itemsPerPage={50}
+          pageSize={10}
+          maxPageItemCount={9}
+          searchInput={false}
         />
       </div>
     );


### PR DESCRIPTION
### SUMMARY
The goal is to replace all uses of `reactable-arc` library with DataTable from superset-ui (which uses `react-table` under the hood) and keep the UI/UX mostly unchanged. The reason for that is that `reactable-arc` has been unsupported for 2 years now, uses deprecated lifecycle methods and is incompatible with Typescript.
This PR replaces `reactable-arc` in QueryTable component

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![image](https://user-images.githubusercontent.com/15073128/93799605-a9cac980-fc3f-11ea-8de3-938f111ddc1c.png)

After:

![image](https://user-images.githubusercontent.com/15073128/93799544-93247280-fc3f-11ea-8795-3bbed63b1e87.png)

As you can see, there's an additional field where we can change the items per page param. Currently `DataTable` doesn't support not showing this field.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
