### PR TITLE
fix: Add Item Overflow on Dataset Editor

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -24,18 +24,16 @@ import { FORM_DATA_DEFAULTS, NUM_METRIC } from './visualizations/shared.helper';
 describe('Datasource control', () => {
   const newMetricName = `abc${Date.now()}`;
 
-  before(() => {
-    cy.server();
-    cy.login();
-    cy.route('GET', '/superset/explore_json/**').as('getJson');
-    cy.route('POST', '/superset/explore_json/**').as('postJson');
-  });
-
   it('should allow edit datasource', () => {
     let numScripts = 0;
 
+    cy.login();
+    cy.server();
+    cy.route('GET', '/superset/explore_json/**').as('getJson');
+    cy.route('POST', '/superset/explore_json/**').as('postJson');
     cy.visitChartByName('Num Births Trend');
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
+
     cy.get('#datasource_menu').click();
 
     cy.get('script').then(nodes => {

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -48,7 +48,7 @@ describe('Datasource control', () => {
     });
 
     // create new metric
-    cy.get('table button').contains('Add Item', { timeout: 10000 }).click();
+    cy.get('button').contains('Add Item', { timeout: 10000 }).click();
     cy.get('input[value="<new metric>"]').click();
     cy.get('input[value="<new metric>"]')
       .focus()

--- a/superset-frontend/src/CRUD/CollectionTable.tsx
+++ b/superset-frontend/src/CRUD/CollectionTable.tsx
@@ -160,12 +160,7 @@ export default class CRUDCollection extends React.PureComponent<
 
   renderHeaderRow() {
     const cols = this.effectiveTableColumns();
-    const {
-      allowAddItem,
-      allowDeletes,
-      expandFieldset,
-      extraButtons,
-    } = this.props;
+    const { allowDeletes, expandFieldset, extraButtons } = this.props;
     return (
       <thead>
         <tr>
@@ -174,15 +169,8 @@ export default class CRUDCollection extends React.PureComponent<
             <th key={col}>{this.getLabel(col)}</th>
           ))}
           {extraButtons}
-          {allowDeletes && !allowAddItem && (
+          {allowDeletes && (
             <th key="delete-item" aria-label="Delete" className="tiny-cell" />
-          )}
-          {allowAddItem && (
-            <th key="add-item">
-              <Button buttonStyle="primary" onClick={this.onAddItem}>
-                <i className="fa fa-plus" /> {t('Add Item')}
-              </Button>
-            </th>
           )}
         </tr>
       </thead>
@@ -293,6 +281,17 @@ export default class CRUDCollection extends React.PureComponent<
   render() {
     return (
       <div className="CRUD">
+        <span className="float-right m-t-10 m-r-10">
+          {this.props.allowAddItem && (
+            <Button
+              buttonSize="sm"
+              buttonStyle="primary"
+              onClick={this.onAddItem}
+            >
+              <i className="fa fa-plus" /> {t('Add Item')}
+            </Button>
+          )}
+        </span>
         <table className="table">
           {this.renderHeaderRow()}
           {this.renderTableBody()}

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -20,7 +20,7 @@
 @import './less/variables.less';
 @import './less/index.less';
 
-@datasource-sql-expression-width: 450px;
+@datasource-sql-expression-width: 315px;
 
 .alert.alert-danger > .debugger {
   color: @danger;
@@ -229,6 +229,7 @@ table.table-no-hover tr:hover {
   font-family: @font-family-monospace;
   display: inline-block;
   min-width: @datasource-sql-expression-width;
+  width: 100%;
 }
 
 .editable-title.datasource-sql-expression input {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- moved `+ Add Item` to the top of `CollectionTable`
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Screen Shot 2020-09-21 at 1 48 59 PM](https://user-images.githubusercontent.com/5705598/93820082-7bce9080-fc11-11ea-8bd4-0de8e928c4e8.png)

After: 
Screen width: 768px
![Screen Shot 2020-09-21 at 11 28 19 AM](https://user-images.githubusercontent.com/5705598/93818854-bfc09600-fc0f-11ea-94e4-47f35b7777cf.png)
Screen width: 1440px
![Screen Shot 2020-09-21 at 11 28 30 AM](https://user-images.githubusercontent.com/5705598/93818905-d5ce5680-fc0f-11ea-97aa-a5c22b123257.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #10838 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
