### PR TITLE
docs: fix typo in doc

### DIFF
--- a/docs/src/pages/docs/installation/installing_scratch.mdx
+++ b/docs/src/pages/docs/installation/installing_scratch.mdx
@@ -63,7 +63,7 @@ pip install --upgrade setuptools pip
 
 ### Python Virtual Environment
 
-We highly recommend installing Superset insode of a virtual environment. Python 3 ships with
+We highly recommend installing Superset inside of a virtual environment. Python 3 ships with
 `virtualenv` out of the box but you can install it using:
 
 ```


### PR DESCRIPTION
Fix typo, `insode` should be `inside`.
