### PR TITLE
build: add PR lint action

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,8 +1,0 @@
-{
-  "title": [
-    {
-      "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|style|test|other)((.+))?:\\s.+",
-      "message": "Your title needs to be prefixed with a topic."
-    }
-  ]
-}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,7 +1,7 @@
 name: PR Lint
 
 on:
-  pull_request:
+  pull_request_target:
     # By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. We
     # explicity override here so that PR titles are re-linted when the PR text content is edited.
     #

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,22 @@
+name: PR Lint
+
+on:
+  pull_request:
+    # By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. We
+    # explicity override here so that PR titles are re-linted when the PR text content is edited.
+    #
+    # Possible values: https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: morrisoncole/pr-lint-action@v1.3.0
+        with:
+          title-regex: ^(build|chore|ci|docs|feat|fix|perf|refactor|style|test|other)((.+))?:\\s.+
+          on-failed-regex-fail-action: true
+          on-failed-regex-create-review: true
+          on-failed-regex-comment:
+            "Please format your PR title to match: `%regex%`!"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.3.0
         with:
-          title-regex: ^(build|chore|ci|docs|feat|fix|perf|refactor|style|test|other)((.+))?:\\s.+
+          title-regex: "^(build|chore|ci|docs|feat|fix|perf|refactor|style|test|other)((.+))?:\\s.+"
           on-failed-regex-fail-action: true
           on-failed-regex-create-review: true
           on-failed-regex-comment:
             "Please format your PR title to match: `%regex%`!"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,7 +1,7 @@
 name: PR Lint
 
 on:
-  pull_request_target:
+  pull_request:
     # By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. We
     # explicity override here so that PR titles are re-linted when the PR text content is edited.
     #


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Brings back PR title linting. This time it run as a github actions workflow instead of a bot that depends on apache infra.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
