### PR TITLE
fix: enable pylint rules in db_engine_specs module

### DIFF
--- a/superset/db_engine_specs/athena.py
+++ b/superset/db_engine_specs/athena.py
@@ -48,7 +48,7 @@ class AthenaEngineSpec(BaseEngineSpec):
             return f"from_iso8601_date('{dttm.date().isoformat()}')"
         if tt == utils.TemporalType.TIMESTAMP:
             datetime_formatted = dttm.isoformat(timespec="microseconds")
-            return f"""from_iso8601_timestamp('{datetime_formatted}') """
+            return f"""from_iso8601_timestamp('{datetime_formatted}')"""
         return None
 
     @classmethod

--- a/superset/db_engine_specs/athena.py
+++ b/superset/db_engine_specs/athena.py
@@ -47,7 +47,8 @@ class AthenaEngineSpec(BaseEngineSpec):
         if tt == utils.TemporalType.DATE:
             return f"from_iso8601_date('{dttm.date().isoformat()}')"
         if tt == utils.TemporalType.TIMESTAMP:
-            return f"""from_iso8601_timestamp('{dttm.isoformat(timespec="microseconds")}')"""  # pylint: disable=line-too-long
+            datetime_formatted = dttm.isoformat(timespec="microseconds")
+            return f"""from_iso8601_timestamp('{datetime_formatted}') """
         return None
 
     @classmethod

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -59,10 +59,8 @@ from superset.utils import core as utils
 
 if TYPE_CHECKING:
     # prevent circular imports
-    from superset.connectors.sqla.models import (  # pylint: disable=unused-import
-        TableColumn,
-    )
-    from superset.models.core import Database  # pylint: disable=unused-import
+    from superset.connectors.sqla.models import TableColumn
+    from superset.models.core import Database
 
 logger = logging.getLogger()
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -27,7 +27,6 @@ from superset.db_engine_specs.base import BaseEngineSpec
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from superset.models.core import Database  # pragma: no cover
 
 

--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -59,7 +59,8 @@ class DrillEngineSpec(BaseEngineSpec):
         if tt == utils.TemporalType.DATE:
             return f"TO_DATE('{dttm.date().isoformat()}', 'yyyy-MM-dd')"
         if tt == utils.TemporalType.TIMESTAMP:
-            return f"""TO_TIMESTAMP('{dttm.isoformat(sep=" ", timespec="seconds")}', 'yyyy-MM-dd HH:mm:ss')"""  # pylint: disable=line-too-long
+            datetime_formatted = dttm.isoformat(sep=" ", timespec="seconds")
+            return f"""TO_TIMESTAMP('{datetime_formatted}', 'yyyy-MM-dd HH:mm:ss')"""
         return None
 
     @classmethod

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -23,10 +23,8 @@ from superset.db_engine_specs.base import BaseEngineSpec
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
-    from superset.connectors.sqla.models import (  # pylint: disable=unused-import
-        TableColumn,
-    )
-    from superset.models.core import Database  # pylint: disable=unused-import
+    from superset.connectors.sqla.models import TableColumn
+    from superset.models.core import Database
 
 logger = logging.getLogger()
 

--- a/superset/db_engine_specs/hana.py
+++ b/superset/db_engine_specs/hana.py
@@ -48,5 +48,6 @@ class HanaEngineSpec(PostgresBaseEngineSpec):
         if tt == utils.TemporalType.DATE:
             return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
         if tt == utils.TemporalType.TIMESTAMP:
-            return f"""TO_TIMESTAMP('{dttm.isoformat(timespec="microseconds")}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""  # pylint: disable=line-too-long
+            return f"""TO_TIMESTAMP('{dttm
+                .isoformat(timespec="microseconds")}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""
         return None

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -41,7 +41,7 @@ from superset.utils import core as utils
 
 if TYPE_CHECKING:
     # prevent circular imports
-    from superset.models.core import Database  # pylint: disable=unused-import
+    from superset.models.core import Database
 
 QueryStatus = utils.QueryStatus
 config = app.config
@@ -111,7 +111,7 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     @classmethod
     def patch(cls) -> None:
-        from pyhive import hive  # pylint: disable=no-name-in-module
+        from pyhive import hive
         from TCLIService import (
             constants as patched_constants,
             TCLIService as patched_TCLIService,
@@ -263,7 +263,8 @@ class HiveEngineSpec(PrestoEngineSpec):
         if tt == utils.TemporalType.DATE:
             return f"CAST('{dttm.date().isoformat()}' AS DATE)"
         if tt == utils.TemporalType.TIMESTAMP:
-            return f"""CAST('{dttm.isoformat(sep=" ", timespec="microseconds")}' AS TIMESTAMP)"""  # pylint: disable=line-too-long
+            return f"""CAST('{dttm
+                .isoformat(sep=" ", timespec="microseconds")}' AS TIMESTAMP)"""
         return None
 
     @classmethod
@@ -325,7 +326,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         cls, cursor: Any, query: Query, session: Session
     ) -> None:
         """Updates progress information"""
-        from pyhive import hive  # pylint: disable=no-name-in-module
+        from pyhive import hive
 
         unfinished_states = (
             hive.ttypes.TOperationState.INITIALIZED_STATE,

--- a/superset/db_engine_specs/kylin.py
+++ b/superset/db_engine_specs/kylin.py
@@ -47,5 +47,6 @@ class KylinEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
         if tt == utils.TemporalType.DATE:
             return f"CAST('{dttm.date().isoformat()}' AS DATE)"
         if tt == utils.TemporalType.TIMESTAMP:
-            return f"""CAST('{dttm.isoformat(sep=" ", timespec="seconds")}' AS TIMESTAMP)"""  # pylint: disable=line-too-long
+            datetime_fomatted = dttm.isoformat(sep=" ", timespec="seconds")
+            return f"""CAST('{datetime_fomatted}' AS TIMESTAMP)"""
         return None


### PR DESCRIPTION
### SUMMARY
Enabled several pylint rules in `athena.py`, `base.py`, `bigquery,py`, `drill.py`, `druid.py`, `hana.py`, `hive.py`, `kylin.py`:
* `disable=line-too-long` - after small enhancements it's possible to reenable
* `no-name-in-module`  - is not prompting error anymore
* `unused-import` - is not prompting error anymore

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
