### PR TITLE
refactor: Remove usages of reactable from TableLoader

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -230,6 +230,7 @@ export interface ListViewProps<T extends object = any> {
   sticky?: boolean;
   fullHeight?: boolean;
   manualSortBy?: boolean;
+  manualPagination?: boolean;
 }
 
 function ListView<T extends object = any>({
@@ -252,6 +253,7 @@ function ListView<T extends object = any>({
   sticky = true,
   fullHeight = false,
   manualSortBy = true,
+  manualPagination = true,
 }: ListViewProps<T>) {
   const {
     getTableProps,
@@ -276,6 +278,7 @@ function ListView<T extends object = any>({
     initialSort,
     initialFilters: filters,
     manualSortBy,
+    manualPagination,
   });
   const filterable = Boolean(filters.length);
   const withPagination = Boolean(count);

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -56,8 +56,24 @@ const ListViewStyles = styled.div<ListViewStylesProps>`
       ${({ fullHeight }) =>
         !fullHeight &&
         css`
-          overflow: scroll;
+          overflow: auto;
           max-height: 64vh;
+
+          &::-webkit-scrollbar {
+            -webkit-appearance: none;
+            &:vertical {
+              width: 7px;
+            }
+            &:horizontal {
+              height: 7px;
+            }
+          }
+
+          &::-webkit-scrollbar-thumb {
+            border-radius: 4px;
+            background-color: rgba(0, 0, 0, 0.5);
+            -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+          }
         `};
     }
   }

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -48,12 +48,12 @@ const ListViewStyles = styled.div<ListViewStylesProps>`
   .superset-list-view {
     text-align: left;
     background-color: white;
-    border-radius: 4px 0;
-    margin: 0 16px;
-    padding-bottom: 48px;
+    border-radius: ${({ theme }) => theme.gridUnit}px 0;
+    margin: 0 ${({ theme }) => theme.gridUnit * 4}px;
+    padding-bottom: ${({ theme }) => theme.gridUnit * 12}px;
 
     .body {
-      ${({ fullHeight }) =>
+      ${({ fullHeight, theme }) =>
         !fullHeight &&
         css`
           overflow: auto;
@@ -62,17 +62,17 @@ const ListViewStyles = styled.div<ListViewStylesProps>`
           &::-webkit-scrollbar {
             -webkit-appearance: none;
             &:vertical {
-              width: 7px;
+              width: ${theme.gridUnit * 2}px;
             }
             &:horizontal {
-              height: 7px;
+              height: ${theme.gridUnit * 2}px;
             }
           }
 
           &::-webkit-scrollbar-thumb {
-            border-radius: 4px;
-            background-color: rgba(0, 0, 0, 0.5);
-            -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+            border-radius: ${theme.gridUnit}px;
+            background-color: ${theme.colors.secondary.dark2}80;
+            -webkit-box-shadow: 0 0 1px ${theme.colors.secondary.light5}80;
           }
         `};
     }

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -111,6 +111,7 @@ interface UseListViewConfig {
     Cell: (conf: any) => React.ReactNode;
   };
   manualSortBy: boolean;
+  manualPagination: boolean;
 }
 
 export function useListViewState({
@@ -124,6 +125,7 @@ export function useListViewState({
   bulkSelectMode = false,
   bulkSelectColumnConfig,
   manualSortBy,
+  manualPagination,
 }: UseListViewConfig) {
   const [query, setQuery] = useQueryParams({
     filters: JsonParam,
@@ -159,7 +161,7 @@ export function useListViewState({
     getTableProps,
     getTableBodyProps,
     headerGroups,
-    rows,
+    page,
     prepareRow,
     canPreviousPage,
     canNextPage,
@@ -178,7 +180,7 @@ export function useListViewState({
       disableSortRemove: true,
       initialState,
       manualFilters: true,
-      manualPagination: true,
+      manualPagination,
       autoResetFilters: false,
       pageCount: Math.ceil(count / initialPageSize),
       manualSortBy,
@@ -255,7 +257,7 @@ export function useListViewState({
     headerGroups,
     pageCount,
     prepareRow,
-    rows,
+    rows: page,
     selectedFlatRows,
     setAllFilters,
     state: { pageIndex, pageSize, sortBy, filters, internalFilters },

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -232,7 +232,7 @@ export function useListViewState({
 
   const applyFilterValue = (index: number, value: any) => {
     setInternalFilters(currentInternalFilters => {
-      // skip redunundant updates
+      // skip redundant updates
       if (currentInternalFilters[index].value === value) {
         return currentInternalFilters;
       }

--- a/superset-frontend/src/components/TableLoader.jsx
+++ b/superset-frontend/src/components/TableLoader.jsx
@@ -68,7 +68,7 @@ class TableLoader extends React.PureComponent {
     });
   };
 
-  fetchData = ({ sortBy }) => {
+  fetchOrSortData = ({ sortBy }) => {
     const { dataEndpoint, mutator } = this.props;
 
     if (this.state.data.length > 0 && sortBy.length > 0) {
@@ -116,7 +116,7 @@ class TableLoader extends React.PureComponent {
         data={this.state.data}
         count={this.state.data.length}
         pageSize={50}
-        fetchData={this.fetchData}
+        fetchData={this.fetchOrSortData}
         loading={this.state.isLoading}
       />
     );

--- a/superset-frontend/src/components/TableLoader.jsx
+++ b/superset-frontend/src/components/TableLoader.jsx
@@ -18,11 +18,10 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table, Tr, Td } from 'reactable-arc';
 import { t, SupersetClient } from '@superset-ui/core';
 
+import ListView from 'src/components/ListView';
 import withToasts from '../messageToasts/enhancers/withToasts';
-import Loading from './Loading';
 import '../../stylesheets/reactable-pagination.less';
 
 const propTypes = {
@@ -44,8 +43,41 @@ class TableLoader extends React.PureComponent {
     };
   }
 
-  UNSAFE_componentWillMount() {
+  sortDataByColumn = (data, sortById, desc, elementSelector = e => e) => {
+    const id = data[0].hasOwnProperty(`_${sortById}`)
+      ? `_${sortById}`
+      : sortById;
+    return data.sort((row1, row2) => {
+      const rows = desc ? [row2, row1] : [row1, row2];
+      let firstVal = rows[0][id];
+      let secondVal = rows[1][id];
+      if (typeof firstVal === 'object' && typeof secondVal === 'object') {
+        firstVal = elementSelector(firstVal);
+        secondVal = elementSelector(secondVal);
+      }
+      if (typeof firstVal === 'string' && typeof secondVal === 'string') {
+        return secondVal.localeCompare(firstVal);
+      }
+      if (typeof firstVal === 'number' && typeof secondVal === 'number') {
+        return secondVal - firstVal;
+      }
+      if (typeof firstVal === 'undefined' || firstVal === null) {
+        return 1;
+      }
+      return -1;
+    });
+  };
+
+  fetchData = ({ sortBy }) => {
     const { dataEndpoint, mutator } = this.props;
+
+    if (this.state.data.length > 0 && sortBy.length > 0) {
+      const { id, desc } = sortBy[0];
+      this.setState(({ data }) => ({
+        data: this.sortDataByColumn(data, id, desc, e => e.props.children),
+      }));
+      return;
+    }
 
     SupersetClient.get({ endpoint: dataEndpoint })
       .then(({ json }) => {
@@ -56,13 +88,9 @@ class TableLoader extends React.PureComponent {
         this.setState({ isLoading: false });
         this.props.addDangerToast(t('An error occurred'));
       });
-  }
+  };
 
   render() {
-    if (this.state.isLoading) {
-      return <Loading />;
-    }
-
     const {
       addDangerToast,
       addInfoToast,
@@ -71,8 +99,8 @@ class TableLoader extends React.PureComponent {
       ...tableProps
     } = this.props;
 
-    let { columns } = this.props;
-    if (!columns && this.state.data.length > 0) {
+    let { columns = [] } = this.props;
+    if (columns.length === 0 && this.state.data.length > 0) {
       columns = Object.keys(this.state.data[0]).filter(col => col[0] !== '_');
     }
     delete tableProps.dataEndpoint;
@@ -80,31 +108,17 @@ class TableLoader extends React.PureComponent {
     delete tableProps.columns;
 
     return (
-      <Table
-        {...tableProps}
-        className="table"
-        itemsPerPage={50}
-        style={{ textTransform: 'capitalize' }}
-      >
-        {this.state.data.map((row, i) => (
-          <Tr key={i}>
-            {columns.map(col => {
-              if (row.hasOwnProperty(`_${col}`)) {
-                return (
-                  <Td key={col} column={col} value={row[`_${col}`]}>
-                    {row[col]}
-                  </Td>
-                );
-              }
-              return (
-                <Td key={col} column={col}>
-                  {row[col]}
-                </Td>
-              );
-            })}
-          </Tr>
-        ))}
-      </Table>
+      <ListView
+        columns={columns.map(column => ({
+          accessor: column,
+          Header: column,
+        }))}
+        data={this.state.data}
+        count={this.state.data.length}
+        pageSize={50}
+        fetchData={this.fetchData}
+        loading={this.state.isLoading}
+      />
     );
   }
 }

--- a/superset-frontend/src/components/TableLoader.jsx
+++ b/superset-frontend/src/components/TableLoader.jsx
@@ -118,6 +118,7 @@ class TableLoader extends React.PureComponent {
         pageSize={50}
         fetchData={this.fetchOrSortData}
         loading={this.state.isLoading}
+        manualPagination={false}
       />
     );
   }


### PR DESCRIPTION
### SUMMARY
The goal is to replace all uses of `reactable-arc` library with DataTable from superset-ui (which uses `react-table` under the hood) and keep the UI/UX mostly unchanged. The reason for that is that `reactable-arc` has been unsupported for 2 years now, uses deprecated lifecycle methods and is incompatible with Typescript.
This PR replaces `reactable-arc` in `TableLoader` component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (nothing renders here, even though the data is correctly fetched. Bug perhaps?):

![image](https://user-images.githubusercontent.com/15073128/93886557-e18c4c80-fce5-11ea-98c2-ef809950f3f4.png)

After:

![image](https://user-images.githubusercontent.com/15073128/93886198-6a56b880-fce5-11ea-862b-d1bda171820e.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
