### PR TITLE
fix: enable several pylint rules partially in db_engines_specs module

### DIFF
--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -25,7 +25,7 @@ from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
-    from superset.models.core import Database  # pylint: disable=unused-import
+    from superset.models.core import Database
 
 logger = logging.getLogger(__name__)
 
@@ -62,9 +62,11 @@ class MssqlEngineSpec(BaseEngineSpec):
         if tt == utils.TemporalType.DATE:
             return f"CONVERT(DATE, '{dttm.date().isoformat()}', 23)"
         if tt == utils.TemporalType.DATETIME:
-            return f"""CONVERT(DATETIME, '{dttm.isoformat(timespec="milliseconds")}', 126)"""  # pylint: disable=line-too-long
+            datetime_formatted = dttm.isoformat(timespec="milliseconds")
+            return f"""CONVERT(DATETIME, '{datetime_formatted}', 126)"""
         if tt == utils.TemporalType.SMALLDATETIME:
-            return f"""CONVERT(SMALLDATETIME, '{dttm.isoformat(sep=" ", timespec="seconds")}', 20)"""  # pylint: disable=line-too-long
+            datetime_formatted = dttm.isoformat(sep=" ", timespec="seconds")
+            return f"""CONVERT(SMALLDATETIME, '{datetime_formatted}', 20)"""
         return None
 
     @classmethod

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -56,7 +56,8 @@ class MySQLEngineSpec(BaseEngineSpec):
         if tt == utils.TemporalType.DATE:
             return f"STR_TO_DATE('{dttm.date().isoformat()}', '%Y-%m-%d')"
         if tt == utils.TemporalType.DATETIME:
-            return f"""STR_TO_DATE('{dttm.isoformat(sep=" ", timespec="microseconds")}', '%Y-%m-%d %H:%i:%s.%f')"""  # pylint: disable=line-too-long
+            datetime_formatted = dttm.isoformat(sep=" ", timespec="microseconds")
+            return f"""STR_TO_DATE('{datetime_formatted}', '%Y-%m-%d %H:%i:%s.%f')"""
         return None
 
     @classmethod
@@ -70,7 +71,7 @@ class MySQLEngineSpec(BaseEngineSpec):
     def get_datatype(cls, type_code: Any) -> Optional[str]:
         if not cls.type_code_map:
             # only import and store if needed at least once
-            import MySQLdb  # pylint: disable=import-error
+            import MySQLdb
 
             ft = MySQLdb.constants.FIELD_TYPE
             cls.type_code_map = {
@@ -94,6 +95,6 @@ class MySQLEngineSpec(BaseEngineSpec):
         try:
             if isinstance(ex.args, tuple) and len(ex.args) > 1:
                 message = ex.args[1]
-        except Exception:  # pylint: disable=broad-except
+        except (AttributeError, KeyError):
             pass
         return message

--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -46,9 +46,11 @@ class OracleEngineSpec(BaseEngineSpec):
         if tt == utils.TemporalType.DATE:
             return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
         if tt == utils.TemporalType.DATETIME:
-            return f"""TO_DATE('{dttm.isoformat(timespec="seconds")}', 'YYYY-MM-DD"T"HH24:MI:SS')"""  # pylint: disable=line-too-long
+            datetime_formatted = dttm.isoformat(timespec="seconds")
+            return f"""TO_DATE('{datetime_formatted}', 'YYYY-MM-DD"T"HH24:MI:SS')"""
         if tt == utils.TemporalType.TIMESTAMP:
-            return f"""TO_TIMESTAMP('{dttm.isoformat(timespec="microseconds")}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""  # pylint: disable=line-too-long
+            return f"""TO_TIMESTAMP('{dttm
+                .isoformat(timespec="microseconds")}', 'YYYY-MM-DD"T"HH24:MI:SS.ff6')"""
         return None
 
     @classmethod

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -85,9 +85,7 @@ class PinotEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
             if not granularity:
                 raise NotImplementedError("No pinot grain spec for " + str(time_grain))
         else:
-            return TimestampExpression(
-                f"{{col}}", col  # pylint: disable=f-string-without-interpolation
-            )
+            return TimestampExpression("{{col}}", col)
         # In pinot the output is a string since there is no timestamp column like pg
         time_expr = f"DATETIMECONVERT({{col}}, '{tf}', '{tf}', '{granularity}')"
         return TimestampExpression(time_expr, col)

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -24,7 +24,6 @@ from superset.db_engine_specs.base import BaseEngineSpec
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from superset.models.core import Database  # pragma: no cover
 
 
@@ -86,5 +85,6 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
         if tt == utils.TemporalType.DATE:
             return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
         if tt == utils.TemporalType.TIMESTAMP:
-            return f"""TO_TIMESTAMP('{dttm.isoformat(sep=" ", timespec="microseconds")}', 'YYYY-MM-DD HH24:MI:SS.US')"""  # pylint: disable=line-too-long
+            dttm_formatted = dttm.isoformat(sep=" ", timespec="microseconds")
+            return f"""TO_TIMESTAMP('{dttm_formatted}', 'YYYY-MM-DD HH24:MI:SS.US')"""
         return None

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -53,7 +53,7 @@ from superset.utils import core as utils
 
 if TYPE_CHECKING:
     # prevent circular imports
-    from superset.models.core import Database  # pylint: disable=unused-import
+    from superset.models.core import Database
 
 QueryStatus = utils.QueryStatus
 config = app.config

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -25,7 +25,7 @@ from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
-    from superset.models.core import Database  # pylint: disable=unused-import
+    from superset.models.core import Database
 
 
 class SnowflakeEngineSpec(PostgresBaseEngineSpec):

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -24,7 +24,7 @@ from superset.utils import core as utils
 
 if TYPE_CHECKING:
     # prevent circular imports
-    from superset.models.core import Database  # pylint: disable=unused-import
+    from superset.models.core import Database
 
 
 class SqliteEngineSpec(BaseEngineSpec):


### PR DESCRIPTION
### SUMMARY
Enabling pylint rules in `db_engines_specs` module (similar to [PR-10998](https://github.com/apache/incubator-superset/pull/10998)):
- `unused-import` isn't triggered anymore
- changed too long lines
- changed `fstring` to `string`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
