### PR TITLE
fix: Bring back import menu

### DIFF
--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -277,11 +277,6 @@ export default function MenuWrapper({ data }: MenuProps) {
     Manage: true,
   };
 
-  // Menu items that should be ignored
-  const ignore = {
-    'Import Dashboards': true,
-  };
-
   // Cycle through menu.menu to build out cleanedMenu and settings
   const cleanedMenu: MenuObjectProps[] = [];
   const settings: MenuObjectProps[] = [];
@@ -301,10 +296,7 @@ export default function MenuWrapper({ data }: MenuProps) {
       item.childs.forEach((child: MenuObjectChildProps | string) => {
         if (typeof child === 'string') {
           children.push(child);
-        } else if (
-          (child as MenuObjectChildProps).label &&
-          !ignore.hasOwnProperty(child.label)
-        ) {
+        } else if ((child as MenuObjectChildProps).label) {
           children.push(child);
         }
       });


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Superset `master` currently has the ability to export dashboards, but they can't be imported because the menu is explicitly ignored. After talking with @mistercrunch and @nytai it seems like this was disabled because the functionality is not mature.

Since this is a regression and we had users complaining about the missing functionality (cc: @eugeniamz), I'm bringing this back while we work on refactoring the export/import functionality so that it's more stable.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

![2020-09-22-174818_299x306_scrot](https://user-images.githubusercontent.com/1534870/93951680-d47a5800-fcfb-11ea-8be5-858318837b54.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
