### PR TITLE
fix: support jinja templates

### DIFF
--- a/superset/tasks/alerts/observer.py
+++ b/superset/tasks/alerts/observer.py
@@ -22,8 +22,8 @@ from typing import Optional
 import pandas as pd
 from sqlalchemy.orm import Session
 
+from superset import jinja_context
 from superset.models.alerts import Alert, SQLObservation
-from superset.sql_parse import ParsedQuery
 
 logger = logging.getLogger("tasks.email_reports")
 
@@ -42,9 +42,9 @@ def observe(alert_id: int, session: Session) -> Optional[str]:
 
     value = None
 
-    parsed_query = ParsedQuery(sql_observer.sql)
-    sql = parsed_query.stripped()
-    df = sql_observer.database.get_df(sql)
+    tp = jinja_context.get_template_processor(database=sql_observer.database)
+    rendered_sql = tp.process_template(sql_observer.sql)
+    df = sql_observer.database.get_df(rendered_sql)
 
     error_msg = validate_observer_result(df, alert.id, alert.label)
 

--- a/tests/alerts_tests.py
+++ b/tests/alerts_tests.py
@@ -154,6 +154,27 @@ def test_alert_observer(setup_database):
     assert alert7.sql_observer[0].observations[-1].value is None
     assert alert7.sql_observer[0].observations[-1].error_msg is not None
 
+    # Test multiline SQLObserver
+    alert8 = create_alert(
+        dbsession,
+        """
+        -- comment
+        SELECT
+            1 -- comment
+        FROM test_table
+            WHERE first = 1
+        """,
+    )
+    observe(alert8.id, dbsession)
+    assert alert8.sql_observer[0].observations[-1].value == 1.0
+    assert alert8.sql_observer[0].observations[-1].error_msg is None
+
+    # Test jinja
+    alert9 = create_alert(dbsession, "SELECT {{ 2 }}")
+    observe(alert9.id, dbsession)
+    assert alert9.sql_observer[0].observations[-1].value == 2.0
+    assert alert9.sql_observer[0].observations[-1].error_msg is None
+
 
 @patch("superset.tasks.schedules.deliver_alert")
 def test_evaluate_alert(mock_deliver_alert, setup_database):


### PR DESCRIPTION
### SUMMARY

1. Adds jinja support to the alert queries
2. Removes comment stripping for better transparency for the users & easier audit

Side change:
* extra test to cover multi line queries & comments, is not related to the fix

### TEST PLAN
* unit tests
* local and staging testing
