### PR TITLE
fix: menu shows a 0 when there are no settings

### DIFF
--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -187,7 +187,7 @@ export function Menu({
         </Nav>
         <Nav className="navbar-right">
           {!navbarRight.user_is_anonymous && <NewMenu />}
-          {settings && settings.length && (
+          {settings && settings.length > 0 && (
             <NavDropdown id="settings-dropdown" title="Settings">
               {flatSettings.map((section, index) => {
                 if (section === '-') {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Noticed a weird `0` in the menu component while testing out a user with the `Gamma` role. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="293" alt="Screen Shot 2020-09-22 at 6 48 34 PM" src="https://user-images.githubusercontent.com/10255196/93955363-6f773000-fd04-11ea-9330-d9ea980db833.png">
After:
<img width="468" alt="Screen Shot 2020-09-22 at 6 48 15 PM" src="https://user-images.githubusercontent.com/10255196/93955387-7bfb8880-fd04-11ea-9ad8-b5530c2102fc.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
👀 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
