### PR TITLE
style(explore): use tertiary button against gray background

### DIFF
--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -73,7 +73,7 @@ export default function QueryAndSaveBtns({
   chartIsStale,
   errorMessage,
 }) {
-  let qryButtonStyle = 'secondary';
+  let qryButtonStyle = 'tertiary';
   if (errorMessage) {
     qryButtonStyle = 'danger';
   } else if (chartIsStale) {
@@ -108,7 +108,7 @@ export default function QueryAndSaveBtns({
         <ButtonGroup className="query-and-save">
           {qryOrStopButton}
           <Button
-            buttonStyle="secondary"
+            buttonStyle="tertiary"
             buttonSize="small"
             data-target="#save_modal"
             data-toggle="modal"


### PR DESCRIPTION
"primary" style buttons seem to expect a white background and really
look muted against the gray background. Using "tertiary" style button makes
things much better.

Eventually we may reconsider the layout and gray background and go back
to secondary, but for now this makes these important pop much more

## after
<img width="567" alt="Screen Shot 2020-09-22 at 11 45 29 PM" src="https://user-images.githubusercontent.com/487433/93976342-b6c5e680-fd2d-11ea-80ea-5e6324d8af50.png">


## before

<img width="574" alt="Screen Shot 2020-09-22 at 11 41 03 PM" src="https://user-images.githubusercontent.com/487433/93976305-a57cda00-fd2d-11ea-8d04-b4404b0f1001.png">
