### PR TITLE
fix: reenable pylint rule `unused-import` in charts and connectors modules

### DIFF
--- a/superset/charts/dao.py
+++ b/superset/charts/dao.py
@@ -25,7 +25,6 @@ from superset.extensions import db
 from superset.models.slice import Slice
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from superset.connectors.base.models import BaseDatasource
 
 logger = logging.getLogger(__name__)

--- a/superset/connectors/connector_registry.py
+++ b/superset/connectors/connector_registry.py
@@ -20,7 +20,6 @@ from sqlalchemy import or_
 from sqlalchemy.orm import Session, subqueryload
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from collections import OrderedDict
 
     from superset.connectors.base.models import BaseDatasource


### PR DESCRIPTION
### SUMMARY
Pylint rule `unused-import` isn't prompting error anymore - removing disabled rule from `charts` and `connectors` modules.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
