### PR TITLE
fix: enabled pylint rules in `db_engines` module

### DIFF
--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -17,16 +17,16 @@
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pyhive.hive import Cursor  # pylint: disable=unused-import
-    from TCLIService.ttypes import TFetchOrientation  # pylint: disable=unused-import
+    from pyhive.hive import Cursor
+    from TCLIService.ttypes import TFetchOrientation
 
 # pylint: disable=protected-access
 # TODO: contribute back to pyhive.
 def fetch_logs(
     self: "Cursor",
-    max_rows: int = 1024,  # pylint: disable=unused-argument
+    _max_rows: int = 1024,
     orientation: Optional["TFetchOrientation"] = None,
-) -> str:  # pylint: disable=unused-argument
+) -> str:
     """Mocked. Retrieve the logs produced by the execution of the query.
     Can be called multiple times to fetch the logs produced after
     the previous call.
@@ -37,7 +37,7 @@ def fetch_logs(
     """
     from pyhive import hive
     from TCLIService import ttypes
-    from thrift import Thrift  # pylint: disable=import-error
+    from thrift import Thrift
 
     orientation = orientation or ttypes.TFetchOrientation.FETCH_NEXT
     try:


### PR DESCRIPTION
### SUMMARY
Enabled pylint rules in `hive.py/db_engines` module:
- `unused_import` and `import_error` - not promting anymore
- changed unused param to private and removed `unused_argument`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
