### PR TITLE
fix(api): unable to delete virtual dataset, wrong permission name

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -551,7 +551,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
 
     @property
     def database_name(self) -> str:
-        return self.database.database_name
+        return self.database.name
 
     @classmethod
     def get_datasource_by_name(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -551,7 +551,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
 
     @property
     def database_name(self) -> str:
-        return self.database.name
+        return self.database.database_name
 
     @classmethod
     def get_datasource_by_name(

--- a/superset/datasets/commands/delete.py
+++ b/superset/datasets/commands/delete.py
@@ -46,27 +46,29 @@ class DeleteDatasetCommand(BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
+            dataset = DatasetDAO.delete(self._model, commit=False)
+
             view_menu = (
                 security_manager.find_view_menu(self._model.get_perm())
                 if self._model
                 else None
             )
-            if not view_menu:
-                logger.error(
-                    "Could not find the data access permission for the dataset"
-                )
-                raise DatasetDeleteFailedError()
-            permission_views = (
-                db.session.query(security_manager.permissionview_model)
-                .filter_by(view_menu=view_menu)
-                .all()
-            )
-            dataset = DatasetDAO.delete(self._model, commit=False)
-
-            for permission_view in permission_views:
-                db.session.delete(permission_view)
             if view_menu:
-                db.session.delete(view_menu)
+                permission_views = (
+                    db.session.query(security_manager.permissionview_model)
+                        .filter_by(view_menu=view_menu)
+                        .all()
+                )
+
+                for permission_view in permission_views:
+                    db.session.delete(permission_view)
+                if view_menu:
+                    db.session.delete(view_menu)
+            else:
+                if not view_menu:
+                    logger.error(
+                        "Could not find the data access permission for the dataset"
+                    )
             db.session.commit()
         except (SQLAlchemyError, DAODeleteFailedError) as ex:
             logger.exception(ex)

--- a/superset/datasets/commands/delete.py
+++ b/superset/datasets/commands/delete.py
@@ -53,11 +53,12 @@ class DeleteDatasetCommand(BaseCommand):
                 if self._model
                 else None
             )
+
             if view_menu:
                 permission_views = (
                     db.session.query(security_manager.permissionview_model)
-                        .filter_by(view_menu=view_menu)
-                        .all()
+                    .filter_by(view_menu=view_menu)
+                    .all()
                 )
 
                 for permission_view in permission_views:

--- a/superset/migrations/versions/3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
+++ b/superset/migrations/versions/3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""fix data access permissions for virtual datasets
+
+Revision ID: 3fbbc6e8d654
+Revises: e5ef6828ac4e
+Create Date: 2020-09-24 12:04:33.827436
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "3fbbc6e8d654"
+down_revision = "e5ef6828ac4e"
+
+import re
+
+from alembic import op
+from sqlalchemy import orm
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def upgrade():
+    """
+    Previous sqla_viz behaviour when creating a virtual dataset was faulty
+    by creating an associated data access permission with [None] on the database name.
+
+    This migration revision, fixes all faulty permissions that may exist on the db
+    Only fixes permissions that still have an associated dataset (fetch by id)
+    and replaces them with the current (correct) permission name
+    """
+    from flask_appbuilder.security.sqla.models import ViewMenu
+    from superset.connectors.sqla.models import SqlaTable
+
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    faulty_perms = (
+        session.query(ViewMenu).filter(ViewMenu.name.ilike("[None].%(id:%)")).all()
+    )
+    for faulty_perm in faulty_perms:
+        match_ds_id = re.match("\[None\]\.\[.*\]\(id:(.*)\)", faulty_perm.name)
+        if match_ds_id:
+            try:
+                dataset_id = int(match_ds_id.group(1))
+            except ValueError:
+                continue
+            dataset = session.query(SqlaTable).get(dataset_id)
+            if dataset:
+                faulty_perm.name = dataset.get_perm()
+    try:
+        session.commit()
+    except SQLAlchemyError:
+        session.rollback()
+
+
+def downgrade():
+    pass

--- a/superset/migrations/versions/3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
+++ b/superset/migrations/versions/3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
@@ -188,12 +188,12 @@ def upgrade():
                 # A view_menu permission with the right name already exists,
                 # so delete the faulty one later
                 if existing_view_menu:
-                    orphaned_faulty_view_menus.append(existing_view_menu)
+                    orphaned_faulty_view_menus.append(faulty_view_menu)
                 # No view_menu permission with this name exists
                 # so safely change this one
                 else:
                     faulty_view_menu.name = new_view_menu
-    # Commit all possible changes
+    # Commit all view_menu updates
     try:
         session.commit()
     except SQLAlchemyError:

--- a/superset/migrations/versions/3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
+++ b/superset/migrations/versions/3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
@@ -167,12 +167,9 @@ def upgrade():
     orphaned_faulty_view_menus = []
     for faulty_view_menu in faulty_view_menus:
         # Get the dataset id from the view_menu name
-        match_ds_id = re.match("\[None\]\.\[.*\]\(id:(.*)\)", faulty_view_menu.name)
+        match_ds_id = re.match("\[None\]\.\[.*\]\(id:(\d+)\)", faulty_view_menu.name)
         if match_ds_id:
-            try:
-                dataset_id = int(match_ds_id.group(1))
-            except ValueError:
-                continue
+            dataset_id = int(match_ds_id.group(1))
             dataset = session.query(SqlaTable).get(dataset_id)
             if dataset:
                 try:

--- a/superset/migrations/versions/3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
+++ b/superset/migrations/versions/3fbbc6e8d654_fix_data_access_permissions_for_virtual_.py
@@ -29,8 +29,118 @@ down_revision = "e5ef6828ac4e"
 import re
 
 from alembic import op
-from sqlalchemy import orm
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    orm,
+    Sequence,
+    String,
+    Table,
+    UniqueConstraint,
+)
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import backref, relationship
+
+Base = declarative_base()
+
+# Partial freeze of the current metadata db schema
+
+
+class Permission(Base):
+    __tablename__ = "ab_permission"
+    id = Column(Integer, Sequence("ab_permission_id_seq"), primary_key=True)
+    name = Column(String(100), unique=True, nullable=False)
+
+
+class ViewMenu(Base):
+    __tablename__ = "ab_view_menu"
+    id = Column(Integer, Sequence("ab_view_menu_id_seq"), primary_key=True)
+    name = Column(String(250), unique=True, nullable=False)
+
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__)) and (self.name == other.name)
+
+    def __neq__(self, other):
+        return self.name != other.name
+
+
+assoc_permissionview_role = Table(
+    "ab_permission_view_role",
+    Base.metadata,
+    Column("id", Integer, Sequence("ab_permission_view_role_id_seq"), primary_key=True),
+    Column("permission_view_id", Integer, ForeignKey("ab_permission_view.id")),
+    Column("role_id", Integer, ForeignKey("ab_role.id")),
+    UniqueConstraint("permission_view_id", "role_id"),
+)
+
+
+class Role(Base):
+    __tablename__ = "ab_role"
+
+    id = Column(Integer, Sequence("ab_role_id_seq"), primary_key=True)
+    name = Column(String(64), unique=True, nullable=False)
+    permissions = relationship(
+        "PermissionView", secondary=assoc_permissionview_role, backref="role"
+    )
+
+
+class PermissionView(Base):
+    __tablename__ = "ab_permission_view"
+    __table_args__ = (UniqueConstraint("permission_id", "view_menu_id"),)
+    id = Column(Integer, Sequence("ab_permission_view_id_seq"), primary_key=True)
+    permission_id = Column(Integer, ForeignKey("ab_permission.id"))
+    permission = relationship("Permission")
+    view_menu_id = Column(Integer, ForeignKey("ab_view_menu.id"))
+    view_menu = relationship("ViewMenu")
+
+
+sqlatable_user = Table(
+    "sqlatable_user",
+    Base.metadata,
+    Column("id", Integer, primary_key=True),
+    Column("user_id", Integer, ForeignKey("ab_user.id")),
+    Column("table_id", Integer, ForeignKey("tables.id")),
+)
+
+
+class Database(Base):  # pylint: disable=too-many-public-methods
+
+    """An ORM object that stores Database related information"""
+
+    __tablename__ = "dbs"
+    __table_args__ = (UniqueConstraint("database_name"),)
+
+    id = Column(Integer, primary_key=True)
+    verbose_name = Column(String(250), unique=True)
+    # short unique name, used in permissions
+    database_name = Column(String(250), unique=True, nullable=False)
+
+    def __repr__(self) -> str:
+        return self.name
+
+    @property
+    def name(self) -> str:
+        return self.verbose_name if self.verbose_name else self.database_name
+
+
+class SqlaTable(Base):
+    __tablename__ = "tables"
+    __table_args__ = (UniqueConstraint("database_id", "table_name"),)
+
+    # Base columns from Basedatasource
+    id = Column(Integer, primary_key=True)
+    table_name = Column(String(250), nullable=False)
+    database_id = Column(Integer, ForeignKey("dbs.id"), nullable=False)
+    database = relationship(
+        "Database",
+        backref=backref("tables", cascade="all, delete-orphan"),
+        foreign_keys=[database_id],
+    )
+
+    def get_perm(self) -> str:
+        return f"[{self.database}].[{self.table_name}](id:{self.id})"
 
 
 def upgrade():
@@ -42,13 +152,6 @@ def upgrade():
     Only fixes permissions that still have an associated dataset (fetch by id)
     and replaces them with the current (correct) permission name
     """
-    from flask_appbuilder.security.sqla.models import (
-        ViewMenu,
-        PermissionView,
-        Role,
-        Permission,
-    )
-    from superset.connectors.sqla.models import SqlaTable
 
     bind = op.get_bind()
     session = orm.Session(bind=bind)


### PR DESCRIPTION
### SUMMARY
When creating a virtual dataset using SQLLab -> Explorer the call to `superset/sqllab_viz` creates a new `SqlaTable` with `database_id` set, not `database`. This causes a problem on the SQLAlchemy listener that creates/updates permissions on insert/update. Because the `database` relation is not set yet at this time the `get_perm()` method on the SqlaTable return a permission with `[None].[<VIRTUAL DS NAME>](id:22)` instead of `[examples].[<VIRTUAL_DS_NAME>](id:22)`

When deleting the new dataset delete command will check if the permission for the dataset exists (to delete it also) and this sanity check failed, refusing to delete the dataset. We will delete the dataset and just log an error on this PR.

Also added a migration revision that does its best on fixing any existing faulty data access permissions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
