### PR TITLE
fix: [dashboard] should not show edit button when user has no edit permit

### DIFF
--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -443,6 +443,7 @@ class Header extends React.PureComponent {
               tabIndex={0}
               className="action-button"
               onClick={this.toggleEditMode}
+              disabled={!userCanEdit}
             >
               <Icon name="pencil" />
             </span>


### PR DESCRIPTION
### SUMMARY
Dashboard Edit icon should only clickable when user has edit_permit.
Otherwise, user start edit dashboard, but when they save the changes, they will get error message.
<img width="343" alt="Screen Shot 2020-09-23 at 10 12 37 AM" src="https://user-images.githubusercontent.com/27990562/94046264-519ddf80-fd85-11ea-9779-f480c56c73b0.png">

### TEST PLAN
CI and manual tests.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #10394 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @mistercrunch @john-bodley 