### PR TITLE
docs: Fix typo in installing from scratch

### DIFF
--- a/docs/src/pages/docs/installation/installing_scratch.mdx
+++ b/docs/src/pages/docs/installation/installing_scratch.mdx
@@ -63,7 +63,7 @@ pip install --upgrade setuptools pip
 
 ### Python Virtual Environment
 
-We highly recommend installing Superset insode of a virtual environment. Python 3 ships with
+We highly recommend installing Superset inside of a virtual environment. Python 3 ships with
 `virtualenv` out of the box but you can install it using:
 
 ```


### PR DESCRIPTION
Change "insode" to "inside".

Note:
Original PR was here https://github.com/apache/incubator-superset/pull/10985, but the CI seemed to continually be stuck even after multiple retries. So I'm trying again with a new PR and a new commit.
