### PR TITLE
fix: dashboard edit button (again)

### DIFF
--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -437,13 +437,12 @@ class Header extends React.PureComponent {
             />
           )}
 
-          {!editMode && (
+          {!editMode && userCanEdit && (
             <span
               role="button"
               tabIndex={0}
               className="action-button"
               onClick={this.toggleEditMode}
-              disabled={!userCanEdit}
             >
               <Icon name="pencil" />
             </span>


### PR DESCRIPTION
### SUMMARY
This is 2nd try for the same problem in #11024. Originally the `edit` control is a `Button` so that we can set disabled attribute. But now it is `<span>` so the disabled attribute won't work. Sorry i didn't test it :(
This PR is to fix the issue by hide the icon when user do not have edit permit.


### TEST PLAN
CI and manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #11024 #10394 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @nytai @etr2460 @mistercrunch 