### PR TITLE
chore: updated lint rules in models module

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -55,7 +55,6 @@ from superset.utils.dashboard_filter_scopes_converter import (
 from superset.utils.urls import get_url_path
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from superset.connectors.base.models import BaseDatasource
 
 metadata = Model.metadata  # pylint: disable=no-member
@@ -255,8 +254,11 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         return {}
 
     @classmethod
-    def import_obj(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-        cls, dashboard_to_import: "Dashboard", import_time: Optional[int] = None,
+    def import_obj(
+        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        cls,
+        dashboard_to_import: "Dashboard",
+        import_time: Optional[int] = None,
     ) -> int:
         """Imports the dashboard from the object to the database.
 

--- a/superset/models/datasource_access_request.py
+++ b/superset/models/datasource_access_request.py
@@ -26,9 +26,7 @@ from superset.models.helpers import AuditMixinNullable
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
-    from superset.connectors.base.models import (  # pylint: disable=unused-import
-        BaseDatasource,
-    )
+    from superset.connectors.base.models import BaseDatasource
 
 config = app.config
 
@@ -74,7 +72,6 @@ class DatasourceAccessRequest(Model, AuditMixinNullable):
         for role in pv.role:
             if role.name in self.ROLES_DENYLIST:
                 continue
-            # pylint: disable=no-member
             href = (
                 f"/superset/approve?datasource_type={self.datasource_type}&"
                 f"datasource_id={self.datasource_id}&"
@@ -87,8 +84,7 @@ class DatasourceAccessRequest(Model, AuditMixinNullable):
     @property
     def user_roles(self) -> str:
         action_list = ""
-        for role in self.created_by.roles:  # pylint: disable=no-member
-            # pylint: disable=no-member
+        for role in self.created_by.roles:
             href = (
                 f"/superset/approve?datasource_type={self.datasource_type}&"
                 f"datasource_id={self.datasource_id}&"

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -42,7 +42,6 @@ else:
     from superset.viz import BaseViz, viz_types  # type: ignore
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from superset.connectors.base.models import BaseDatasource
 
 metadata = Model.metadata  # pylint: disable=no-member
@@ -333,8 +332,7 @@ class Slice(
         return f"/superset/explore/?form_data=%7B%22slice_id%22%3A%20{self.id}%7D"
 
 
-def set_related_perm(mapper: Mapper, connection: Connection, target: Slice) -> None:
-    # pylint: disable=unused-argument
+def set_related_perm(_mapper: Mapper, _connection: Connection, target: Slice) -> None:
     src_class = target.cls_model
     id_ = target.datasource_id
     if id_:
@@ -344,8 +342,8 @@ def set_related_perm(mapper: Mapper, connection: Connection, target: Slice) -> N
             target.schema_perm = ds.schema_perm
 
 
-def event_after_chart_changed(  # pylint: disable=unused-argument
-    mapper: Mapper, connection: Connection, target: Slice
+def event_after_chart_changed(
+    _mapper: Mapper, _connection: Connection, target: Slice
 ) -> None:
     url = get_url_path("Superset.slice", slice_id=target.id, standalone="true")
     cache_chart_thumbnail.delay(url, target.digest, force=True)


### PR DESCRIPTION
### SUMMARY
Files `slice.py`, `dashboard.py`, `datasource_access_request.py` can have updated linting rules:
- `unused-import` can be removed
-  changed unused arguments to private (with `_` prefix) to remove `unused-argument` rule
- several `no-member` rules can be removed

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
