### PR TITLE
chore: allow passing bash args into the pytest

### DIFF
--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -25,4 +25,4 @@ superset db upgrade
 superset init
 
 echo "Running tests"
-pytest --maxfail=1 --cov=superset
+pytest --maxfail=1 --cov=superset $@


### PR DESCRIPTION

### SUMMARY
As a developer , sometimes when  running tests you want only to run specific ones****
So by allowing bash args to be passed to pylint it gives the ability to pass marks as a parameters



### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
