### PR TITLE
refactor: Remove usages of reactable from TimeTable

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -213,6 +213,7 @@ export interface ListViewProps<T extends object = any> {
   defaultViewMode?: ViewModeType;
   sticky?: boolean;
   fullHeight?: boolean;
+  manualSortBy?: boolean;
 }
 
 function ListView<T extends object = any>({
@@ -234,6 +235,7 @@ function ListView<T extends object = any>({
   defaultViewMode = 'card',
   sticky = true,
   fullHeight = false,
+  manualSortBy = true,
 }: ListViewProps<T>) {
   const {
     getTableProps,
@@ -257,6 +259,7 @@ function ListView<T extends object = any>({
     initialPageSize,
     initialSort,
     initialFilters: filters,
+    manualSortBy,
   });
   const filterable = Boolean(filters.length);
   const withPagination = Boolean(count);

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { t, styled } from '@superset-ui/core';
+import { css } from '@emotion/core';
 import React, { useState } from 'react';
 import { Alert } from 'react-bootstrap';
 import { Empty } from 'src/common/components';
@@ -37,7 +38,11 @@ import {
 } from './types';
 import { ListViewError, useListViewState } from './utils';
 
-const ListViewStyles = styled.div`
+interface ListViewStylesProps {
+  fullHeight: boolean;
+}
+
+const ListViewStyles = styled.div<ListViewStylesProps>`
   text-align: center;
 
   .superset-list-view {
@@ -48,8 +53,12 @@ const ListViewStyles = styled.div`
     padding-bottom: 48px;
 
     .body {
-      overflow: scroll;
-      max-height: 64vh;
+      ${({ fullHeight }) =>
+        !fullHeight &&
+        css`
+          overflow: scroll;
+          max-height: 64vh;
+        `};
     }
   }
 
@@ -202,6 +211,8 @@ export interface ListViewProps<T extends object = any> {
   renderCard?: (row: T & { loading: boolean }) => React.ReactNode;
   cardSortSelectOptions?: Array<CardSortSelectOption>;
   defaultViewMode?: ViewModeType;
+  sticky?: boolean;
+  fullHeight?: boolean;
 }
 
 function ListView<T extends object = any>({
@@ -221,6 +232,8 @@ function ListView<T extends object = any>({
   renderCard,
   cardSortSelectOptions,
   defaultViewMode = 'card',
+  sticky = true,
+  fullHeight = false,
 }: ListViewProps<T>) {
   const {
     getTableProps,
@@ -246,6 +259,7 @@ function ListView<T extends object = any>({
     initialFilters: filters,
   });
   const filterable = Boolean(filters.length);
+  const withPagination = Boolean(count);
   if (filterable) {
     const columnAccessors = columns.reduce(
       (acc, col) => ({ ...acc, [col.accessor || col.id]: true }),
@@ -266,7 +280,7 @@ function ListView<T extends object = any>({
   );
 
   return (
-    <ListViewStyles>
+    <ListViewStyles fullHeight={fullHeight}>
       <div className={`superset-list-view ${className}`}>
         <div className="header">
           {cardViewEnabled && (
@@ -350,6 +364,7 @@ function ListView<T extends object = any>({
               rows={rows}
               columns={columns}
               loading={loading}
+              sticky={sticky}
             />
           )}
           {!loading && rows.length === 0 && (
@@ -360,23 +375,25 @@ function ListView<T extends object = any>({
         </div>
       </div>
 
-      <div className="pagination-container">
-        <Pagination
-          totalPages={pageCount || 0}
-          currentPage={pageCount ? pageIndex + 1 : 0}
-          onChange={(p: number) => gotoPage(p - 1)}
-          hideFirstAndLastPageLinks
-        />
-        <div className="row-count-container">
-          {!loading &&
-            t(
-              '%s-%s of %s',
-              pageSize * pageIndex + (rows.length && 1),
-              pageSize * pageIndex + rows.length,
-              count,
-            )}
+      {withPagination && (
+        <div className="pagination-container">
+          <Pagination
+            totalPages={pageCount || 0}
+            currentPage={pageCount ? pageIndex + 1 : 0}
+            onChange={(p: number) => gotoPage(p - 1)}
+            hideFirstAndLastPageLinks
+          />
+          <div className="row-count-container">
+            {!loading &&
+              t(
+                '%s-%s of %s',
+                pageSize * pageIndex + (rows.length && 1),
+                pageSize * pageIndex + rows.length,
+                count,
+              )}
+          </div>
         </div>
-      </div>
+      )}
     </ListViewStyles>
   );
 }

--- a/superset-frontend/src/components/ListView/TableCollection.tsx
+++ b/superset-frontend/src/components/ListView/TableCollection.tsx
@@ -30,14 +30,19 @@ interface TableCollectionProps {
   rows: TableInstance['rows'];
   columns: TableInstance['column'][];
   loading: boolean;
+  sticky: boolean;
 }
 
-const Table = styled.table`
+interface TableProps {
+  sticky: boolean;
+}
+
+const Table = styled.table<TableProps>`
   border-collapse: separate;
 
   th {
     background: ${({ theme }) => theme.colors.grayscale.light5};
-    position: sticky;
+    position: ${({ sticky }) => sticky && 'sticky'};
     top: 0;
 
     &:first-of-type {
@@ -199,9 +204,10 @@ export default function TableCollection({
   columns,
   rows,
   loading,
+  sticky,
 }: TableCollectionProps) {
   return (
-    <Table {...getTableProps()} className="table table-hover">
+    <Table {...getTableProps()} sticky={sticky} className="table table-hover">
       <thead>
         {headerGroups.map(headerGroup => (
           <tr {...headerGroup.getHeaderGroupProps()}>

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -110,6 +110,7 @@ interface UseListViewConfig {
     Header: (conf: any) => React.ReactNode;
     Cell: (conf: any) => React.ReactNode;
   };
+  manualSortBy: boolean;
 }
 
 export function useListViewState({
@@ -122,6 +123,7 @@ export function useListViewState({
   initialSort = [],
   bulkSelectMode = false,
   bulkSelectColumnConfig,
+  manualSortBy,
 }: UseListViewConfig) {
   const [query, setQuery] = useQueryParams({
     filters: JsonParam,
@@ -177,9 +179,9 @@ export function useListViewState({
       initialState,
       manualFilters: true,
       manualPagination: true,
-      manualSortBy: true,
       autoResetFilters: false,
       pageCount: Math.ceil(count / initialPageSize),
+      manualSortBy,
     },
     useFilters,
     useSortBy,

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -94,7 +94,7 @@ class TimeTable extends React.PureComponent {
     { accessor: 'metric', Header: 'Metric' },
     ...this.props.columnConfigs.map((columnConfig, i) => ({
       accessor: columnConfig.key,
-      width: columnConfig.colType === 'spark' ? '1%' : null,
+      cellProps: columnConfig.colType === 'spark' && { style: { width: '1%' } },
       Header: () => (
         <>
           {columnConfig.label}{' '}


### PR DESCRIPTION
### SUMMARY
The goal is to replace all uses of `reactable-arc` library with DataTable from superset-ui (which uses `react-table` under the hood) and keep the UI/UX mostly unchanged. The reason for that is that `reactable-arc` has been unsupported for 2 years now, uses deprecated lifecycle methods and is incompatible with Typescript.
This PR replaces `reactable-arc` in `TimeTable` component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![image](https://user-images.githubusercontent.com/15073128/94174974-4a1a2b80-fe96-11ea-8f62-e3f06e37360a.png)

After:

![image](https://user-images.githubusercontent.com/15073128/94416605-585e9500-017f-11eb-8473-a83a97266ab1.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
