### PR TITLE
refactor: remove useless filters in form_data

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -342,8 +342,8 @@ class BaseViz:
         merge_extra_filters(self.form_data)
         utils.split_adhoc_filters_into_base_filters(self.form_data)
         # Normalize various filters, and then remove the original filters
-        self.form_data.pop('adhoc_filters', None)
-        self.form_data.pop('extra_filters', None)
+        self.form_data.pop("adhoc_filters", None)
+        self.form_data.pop("extra_filters", None)
 
     def query_obj(self) -> QueryObjectDict:
         """Building a query object"""

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -341,6 +341,9 @@ class BaseViz:
         utils.convert_legacy_filters_into_adhoc(self.form_data)
         merge_extra_filters(self.form_data)
         utils.split_adhoc_filters_into_base_filters(self.form_data)
+        # Normalize various filters, and then remove the original filters
+        self.form_data.pop('adhoc_filters', None)
+        self.form_data.pop('extra_filters', None)
 
     def query_obj(self) -> QueryObjectDict:
         """Building a query object"""


### PR DESCRIPTION
### SUMMARY
After the filter transformation is done(extra_filters into adhoc_filters; split adhoc_filter into base filters)

adhoc_filters and extra_filters are useless. remote it,  easy to debug and understand the filter logic