### PR TITLE
chore: updated utils with pylint rules

### DIFF
--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -27,8 +27,7 @@ def view_cache_key(*args: Any, **kwargs: Any) -> str:  # pylint: disable=unused-
 
 
 def memoized_func(
-    key: Callable[..., str] = view_cache_key,  # pylint: disable=bad-whitespace
-    attribute_in_key: Optional[str] = None,
+    key: Callable[..., str] = view_cache_key, attribute_in_key: Optional[str] = None,
 ) -> Callable[..., Any]:
     """Use this decorator to cache functions that have predefined first arg.
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -310,7 +310,6 @@ class DashboardEncoder(json.JSONEncoder):
         super().__init__(*args, **kwargs)
         self.sort_keys = True
 
-    # pylint: disable=E0202
     def default(self, o: Any) -> Dict[Any, Any]:
         try:
             vals = {k: v for k, v in o.__dict__.items() if k != "_sa_instance_state"}

--- a/superset/utils/logging_configurator.py
+++ b/superset/utils/logging_configurator.py
@@ -46,10 +46,8 @@ class DefaultLoggingConfigurator(LoggingConfigurator):
             superset_logger.setLevel(logging.DEBUG)
         else:
             # In production mode, add log handler to sys.stderr.
-            superset_logger.addHandler(
-                logging.StreamHandler()
-            )  # pylint: disable=no-member
-            superset_logger.setLevel(logging.INFO)  # pylint: disable=no-member
+            superset_logger.addHandler(logging.StreamHandler())
+            superset_logger.setLevel(logging.INFO)
 
         logging.getLogger("pyhive.presto").setLevel(logging.INFO)
 

--- a/superset/utils/machine_auth.py
+++ b/superset/utils/machine_auth.py
@@ -29,7 +29,6 @@ from superset.utils.urls import headless_url
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from flask_appbuilder.security.sqla.models import User
 
 

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -26,12 +26,11 @@ from superset.utils.webdriver import WebDriverProxy, WindowSize
 logger = logging.getLogger(__name__)
 
 try:
-    from PIL import Image  # pylint: disable=import-error
+    from PIL import Image
 except ModuleNotFoundError:
     logger.info("No PIL installation found")
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from flask_appbuilder.security.sqla.models import User
     from flask_caching import Cache
 

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -40,7 +40,6 @@ SELENIUM_HEADSTART = 3
 
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from flask_appbuilder.security.sqla.models import User
 
 


### PR DESCRIPTION
### SUMMARY
Several disabled pylint rules `utils` files can be removed:
- `bad-whitespace` - autoformatting,
- `unused-import` and `import-error` not prompting error,
- `E0202`
- `no-member` in some cases are resolved.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
