### PR TITLE
fix: sql lab autocomplete width

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -423,7 +423,9 @@ div.tablePopover {
   font-family: @font-family-monospace;
 
   &.ace_autocomplete {
-    width: 520px;
+    // Use !important because Ace Editor applies extra CSS at the last second
+    // when opening the autocomplete.
+    width: 520px !important;
   }
 }
 


### PR DESCRIPTION
### SUMMARY
Unfortunately, the previous fix doesn't work in production environments because Ace Editor applies a bunch of new CSS when the autocomplete is open, thus overriding the selector in SQL Lab. Because this doesn't repro in dev, and I don't think such a small change is worth a huge amount of investigation, I've added `!important` and a comment.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
See the correct class being applied: 
<img width="233" alt="Screen Shot 2020-09-25 at 9 03 18 AM" src="https://user-images.githubusercontent.com/7409244/94289958-622d9180-ff0e-11ea-8467-8fbd7fbf4d11.png">

### TEST PLAN
CI, we can't test this in dev for some reason, so I applied the same css change in our prod env and it worked

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @suddjian @graceguo-supercat 