### PR TITLE
feat: improve presto query perf

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -730,10 +730,10 @@ class PrestoEngineSpec(BaseEngineSpec):
             )
 
             if not latest_parts:
-                latest_parts = tuple([None] * len(col_names))  # type: ignore
+                latest_parts = tuple([None] * len(col_names))
             metadata["partitions"] = {
                 "cols": cols,
-                "latest": dict(zip(col_names, latest_parts)),  # type: ignore
+                "latest": dict(zip(col_names, latest_parts)),
                 "partitionQuery": pql,
             }
 
@@ -925,6 +925,7 @@ class PrestoEngineSpec(BaseEngineSpec):
         return None
 
     @classmethod
+    @cache.memoize(timeout=60)
     def latest_partition(
         cls,
         table_name: str,


### PR DESCRIPTION
### SUMMARY
The `latest_partition` function results shouldn't change from second to second, yet it could be called many times simultaneously if a dashboard has many charts dependent on the same table. Conservatively memoize the result of this function for 60 seconds to prevent an extra roundtrip to the Presto db. Perhaps this could be extended to 5 minutes in the future, but wanted to start out conservatively

### TEST PLAN
CI, add print statements to the function and see that the function isn't called when run for the 2nd or 3rd time in a minute

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @villebro @john-bodley @betodealmeida 