### PR TITLE
fix: Adding timeout to flaky cypress test, to wait for animation to complete

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/edit_mode.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/edit_mode.test.js
@@ -40,6 +40,9 @@ describe('Dashboard edit mode', () => {
 
     cy.get('.tabs-components .nav-tabs li a').contains('Charts').click();
 
+    // wait for tab-switching animation to complete
+    cy.wait(1000);
+
     // find box plot is available from list
     cy.get('.tabs-components')
       .find('.chart-card-container')

--- a/superset-frontend/src/dashboard/stylesheets/builder-sidepane.less
+++ b/superset-frontend/src/dashboard/stylesheets/builder-sidepane.less
@@ -101,7 +101,7 @@
       background: fade(@lightest, @opacity-medium-light);
       white-space: nowrap;
       overflow: hidden;
-
+      pointer-events: all;
       &:hover {
         background: @gray-bg;
       }

--- a/superset-frontend/src/dashboard/stylesheets/builder-sidepane.less
+++ b/superset-frontend/src/dashboard/stylesheets/builder-sidepane.less
@@ -101,7 +101,7 @@
       background: fade(@lightest, @opacity-medium-light);
       white-space: nowrap;
       overflow: hidden;
-      pointer-events: all;
+
       &:hover {
         background: @gray-bg;
       }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `remove, and add chart flow` test seems to flake out fairly often, and I've seen it do so with errors saying that pointer-events were disabled by a parent's CSS, and that the element was still animating. I'm assuming that all of this is due to the animation and such that takes place when switching tabs. Here's hoping 1s of waiting will properly cover that issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Keep an eye on CI!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
