### PR TITLE
style(sqllab): make database errors more clear and render as monospace

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -60,7 +60,7 @@ interface ResultSetState {
 const MonospaceDiv = styled.div`
   font-family: ${({ theme }) => theme.typography.families.monospace};
   white-space: pre;
-`
+`;
 
 export default class ResultSet extends React.PureComponent<
   ResultSetProps,
@@ -234,13 +234,12 @@ export default class ResultSet extends React.PureComponent<
       return <Alert bsStyle="warning">Query was stopped</Alert>;
     }
     if (query.state === 'failed') {
-      const subtitle = <MonospaceDiv>{query.errorMessage}</MonospaceDiv>
       return (
         <div className="result-set-error-message">
           <ErrorMessageWithStackTrace
             title={t('Database Error')}
             error={query?.errors?.[0]}
-            subtitle={subtitle}
+            subtitle={<MonospaceDiv>{query.errorMessage}</MonospaceDiv>}
             copyText={query.errorMessage || undefined}
             link={query.link}
             source="sqllab"

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -20,7 +20,7 @@ import React, { CSSProperties } from 'react';
 import { Alert, ButtonGroup, ProgressBar } from 'react-bootstrap';
 import Button from 'src/components/Button';
 import shortid from 'shortid';
-import { t } from '@superset-ui/core';
+import { styled, t } from '@superset-ui/core';
 
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import Loading from '../../components/Loading';
@@ -56,6 +56,11 @@ interface ResultSetState {
   showExploreResultsButton: boolean;
   data: Record<string, any>[];
 }
+
+const MonospaceDiv = styled.div`
+  font-family: ${({ theme }) => theme.typography.families.monospace};
+  white-space: pre;
+`
 
 export default class ResultSet extends React.PureComponent<
   ResultSetProps,
@@ -229,14 +234,15 @@ export default class ResultSet extends React.PureComponent<
       return <Alert bsStyle="warning">Query was stopped</Alert>;
     }
     if (query.state === 'failed') {
+      const subtitle = <MonospaceDiv>{query.errorMessage}</MonospaceDiv>
       return (
         <div className="result-set-error-message">
           <ErrorMessageWithStackTrace
             title={t('Database Error')}
             error={query?.errors?.[0]}
-            subtitle={query.errorMessage || undefined}
+            subtitle={subtitle}
+            copyText={query.errorMessage || undefined}
             link={query.link}
-            subtitleAsMonospace
             source="sqllab"
           />
         </div>

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -232,9 +232,11 @@ export default class ResultSet extends React.PureComponent<
       return (
         <div className="result-set-error-message">
           <ErrorMessageWithStackTrace
+            title={t('Database Error')}
             error={query?.errors?.[0]}
-            message={query.errorMessage || undefined}
+            subtitle={query.errorMessage || undefined}
             link={query.link}
+            subtitleAsMonospace
             source="sqllab"
           />
         </div>

--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -166,7 +166,7 @@ class Chart extends React.PureComponent {
     return (
       <ErrorMessageWithStackTrace
         error={error}
-        message={chartAlert || queryResponse?.message}
+        subtitle={chartAlert || queryResponse?.message}
         link={queryResponse ? queryResponse.link : null}
         source={dashboardId ? 'dashboard' : 'explore'}
         stackTrace={chartStackTrace}

--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -163,10 +163,12 @@ class Chart extends React.PureComponent {
       extra.owners = owners;
       error.extra = extra;
     }
+    const message = chartAlert || queryResponse?.message;
     return (
       <ErrorMessageWithStackTrace
         error={error}
-        subtitle={chartAlert || queryResponse?.message}
+        subtitle={message}
+        copyText={message}
         link={queryResponse ? queryResponse.link : null}
         source={dashboardId ? 'dashboard' : 'explore'}
         stackTrace={chartStackTrace}

--- a/superset-frontend/src/components/ErrorBoundary.jsx
+++ b/superset-frontend/src/components/ErrorBoundary.jsx
@@ -56,6 +56,7 @@ export default class ErrorBoundary extends React.Component {
         return (
           <ErrorMessageWithStackTrace
             subtitle={message}
+            copyText={message}
             stackTrace={info ? info.componentStack : null}
           />
         );

--- a/superset-frontend/src/components/ErrorBoundary.jsx
+++ b/superset-frontend/src/components/ErrorBoundary.jsx
@@ -55,7 +55,7 @@ export default class ErrorBoundary extends React.Component {
       if (this.props.showMessage) {
         return (
           <ErrorMessageWithStackTrace
-            message={message}
+            subtitle={message}
             stackTrace={info ? info.componentStack : null}
           />
         );

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -40,11 +40,6 @@ const ErrorAlertDiv = styled.div<{ level: ErrorLevel }>`
     justify-content: space-between;
   }
 
-  .monospace {
-    font-family: ${({ theme }) => theme.typography.families.monospace};
-    white-space: pre;
-  }
-
   .error-body {
     padding-top: ${({ theme }) => theme.gridUnit}px;
     padding-left: ${({ theme }) => 8 * theme.gridUnit}px;
@@ -93,7 +88,6 @@ interface ErrorAlertProps {
   copyText?: string;
   level: ErrorLevel;
   source?: ErrorSource;
-  subtitleAsMonospace?: boolean;
   subtitle: ReactNode;
   title: ReactNode;
 }
@@ -103,7 +97,6 @@ export default function ErrorAlert({
   copyText,
   level,
   source = 'dashboard',
-  subtitleAsMonospace = false,
   subtitle,
   title,
 }: ErrorAlertProps) {
@@ -131,9 +124,7 @@ export default function ErrorAlert({
       </div>
       {isExpandable ? (
         <div className="error-body">
-          <p>
-            {subtitle}
-          </p>
+          <p>{subtitle}</p>
           {body && (
             <>
               {!isBodyExpanded && (

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -41,7 +41,7 @@ const ErrorAlertDiv = styled.div<{ level: ErrorLevel }>`
   }
 
   .monospace {
-    font-family: monospace;
+    font-family: ${({ theme }) => theme.typography.families.monospace};
     white-space: pre;
   }
 

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -131,7 +131,7 @@ export default function ErrorAlert({
       </div>
       {isExpandable ? (
         <div className="error-body">
-          <p className={subtitleAsMonospace ? 'monospace' : undefined}>
+          <p>
             {subtitle}
           </p>
           {body && (

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -40,6 +40,11 @@ const ErrorAlertDiv = styled.div<{ level: ErrorLevel }>`
     justify-content: space-between;
   }
 
+  .monospace {
+    font-family: monospace;
+    white-space: pre;
+  }
+
   .error-body {
     padding-top: ${({ theme }) => theme.gridUnit}px;
     padding-left: ${({ theme }) => 8 * theme.gridUnit}px;
@@ -88,6 +93,7 @@ interface ErrorAlertProps {
   copyText?: string;
   level: ErrorLevel;
   source?: ErrorSource;
+  subtitleAsMonospace?: boolean;
   subtitle: ReactNode;
   title: ReactNode;
 }
@@ -97,6 +103,7 @@ export default function ErrorAlert({
   copyText,
   level,
   source = 'dashboard',
+  subtitleAsMonospace = false,
   subtitle,
   title,
 }: ErrorAlertProps) {
@@ -124,7 +131,7 @@ export default function ErrorAlert({
       </div>
       {isExpandable ? (
         <div className="error-body">
-          <p>{subtitle}</p>
+          <p className={subtitleAsMonospace ? 'monospace' : null}>{subtitle}</p>
           {body && (
             <>
               {!isBodyExpanded && (

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -131,7 +131,9 @@ export default function ErrorAlert({
       </div>
       {isExpandable ? (
         <div className="error-body">
-          <p className={subtitleAsMonospace ? 'monospace' : null}>{subtitle}</p>
+          <p className={subtitleAsMonospace ? 'monospace' : undefined}>
+            {subtitle}
+          </p>
           {body && (
             <>
               {!isBodyExpanded && (

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -27,8 +27,8 @@ type Props = {
   title?: string;
   error?: SupersetError;
   link?: string;
-  subtitle?: string;
-  subtitleAsMonospace?: boolean;
+  subtitle?: React.ReactNode;
+  copyText?: string;
   stackTrace?: string;
   source?: ErrorSource;
 };
@@ -37,7 +37,7 @@ export default function ErrorMessageWithStackTrace({
   title = t('Unexpected Error'),
   error,
   subtitle,
-  subtitleAsMonospace = false,
+  copyText,
   link,
   stackTrace,
   source,
@@ -57,8 +57,7 @@ export default function ErrorMessageWithStackTrace({
       level="warning"
       title={title}
       subtitle={subtitle}
-      subtitleAsMonospace={subtitleAsMonospace}
-      copyText={subtitle}
+      copyText={copyText}
       source={source}
       body={
         link || stackTrace ? (

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -23,6 +23,8 @@ import getErrorMessageComponentRegistry from './getErrorMessageComponentRegistry
 import { SupersetError, ErrorSource } from './types';
 import ErrorAlert from './ErrorAlert';
 
+const DEFAULT_TITLE = t('Unexpected Error');
+
 type Props = {
   title?: string;
   error?: SupersetError;
@@ -34,7 +36,7 @@ type Props = {
 };
 
 export default function ErrorMessageWithStackTrace({
-  title = t('Unexpected Error'),
+  title = DEFAULT_TITLE,
   error,
   subtitle,
   copyText,

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -24,16 +24,20 @@ import { SupersetError, ErrorSource } from './types';
 import ErrorAlert from './ErrorAlert';
 
 type Props = {
+  title?: string;
   error?: SupersetError;
   link?: string;
-  message?: string;
+  subtitle?: string;
+  subtitleAsMonospace?: boolean;
   stackTrace?: string;
   source?: ErrorSource;
 };
 
 export default function ErrorMessageWithStackTrace({
+  title = t('Unexpected Error'),
   error,
-  message,
+  subtitle,
+  subtitleAsMonospace = false,
   link,
   stackTrace,
   source,
@@ -51,9 +55,10 @@ export default function ErrorMessageWithStackTrace({
   return (
     <ErrorAlert
       level="warning"
-      title={t('Unexpected Error')}
-      subtitle={message}
-      copyText={message}
+      title={title}
+      subtitle={subtitle}
+      subtitleAsMonospace={subtitleAsMonospace}
+      copyText={subtitle}
       source={source}
       body={
         link || stackTrace ? (


### PR DESCRIPTION
In SQL Lab, when a database error message is returned, generally because
of a user error in the SQL, it's identified as an "Unexpected Error" and
some of the text formatting of the error message (\n, spaces, tabs, ...)
are lost as they are rendered in html.

This PR identifies the error as a "Database Error", and renders like
more like a <pre>, using a monospace font.

## after
<img width="1304" alt="Screen Shot 2020-09-25 at 10 40 51 PM" src="https://user-images.githubusercontent.com/487433/94331417-ffc1a900-ff80-11ea-93ba-7d0f21fb373f.png">

## before
<img width="1303" alt="Screen Shot 2020-09-25 at 10 48 27 PM" src="https://user-images.githubusercontent.com/487433/94331453-4c0ce900-ff81-11ea-888b-9f4480449fff.png">
