### PR TITLE
fix: surface connection error messages on the client

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -165,8 +165,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         addSuccessToast(t('Connection looks good!'));
       })
       .catch(response =>
-        getClientErrorObject(response).then((error) => {
-          addDangerToast(t('ERROR: Connection failed. ') + error?.message || '');
+        getClientErrorObject(response).then(error => {
+          addDangerToast(
+            t('ERROR: Connection failed. ') + error?.message || '',
+          );
         }),
       );
   };

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -166,7 +166,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       })
       .catch(response =>
         getClientErrorObject(response).then((error) => {
-          addDangerToast(t('ERROR: Connection failed. ') + error?.message || '',
+          addDangerToast(t('ERROR: Connection failed. ') + error?.message || '');
         }),
       );
   };
@@ -552,7 +552,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                 checked={db ? !!db.impersonate_user : false}
                 onChange={onInputChange}
               />
-              <div>{t('Impersonate Logged In User (Presto & Hive')}</div>
+              <div>{t('Impersonate Logged In User (Presto & Hive)')}</div>
               <InfoTooltipWithTrigger
                 label="impersonate"
                 tooltip={t(

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -21,6 +21,7 @@ import { styled, t, SupersetClient } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { useSingleViewResource } from 'src/views/CRUD/hooks';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
+import getClientErrorObject from 'src/utils/getClientErrorObject';
 import Icon from 'src/components/Icon';
 import Modal from 'src/common/components/Modal';
 import Tabs from 'src/common/components/Tabs';
@@ -163,11 +164,11 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       .then(() => {
         addSuccessToast(t('Connection looks good!'));
       })
-      .catch(() => {
-        addDangerToast(
-          t('ERROR: Connection failed, please check your connection settings'),
-        );
-      });
+      .catch(response =>
+        getClientErrorObject(response).then((error) => {
+          addDangerToast(t('ERROR: Connection failed. ') + error?.message || '',
+        }),
+      );
   };
 
   // Functions


### PR DESCRIPTION
### SUMMARY
I was trying to connect to BigQuery and was getting very generic error messages and nothing in the logs. The change here surfaces the good error handling done in the backend here:

https://github.com/apache/incubator-superset/blob/master/superset/databases/api.py#L576-L598