### PR TITLE
fix(jest): using UTC mock date

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
@@ -28,7 +28,7 @@ import ControlHeader from 'src/explore/components/ControlHeader';
 
 // Mock moment.js to use a specific date
 jest.mock('moment', () => {
-  const testDate = new Date('09/07/2020');
+  const testDate = new Date('2020-09-07');
 
   return () => jest.requireActual('moment')(testDate);
 });

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ setenv =
     # docker run -p 8080:8080 --name presto prestosql/presto
     mysql-presto: SUPERSET__SQLALCHEMY_EXAMPLES_URI = presto://localhost:8080/memory/default
     # based on https://github.com/big-data-europe/docker-hadoop
-    # close the repo & run docker-compose up -d to test locally
+    # clone the repo & run docker-compose up -d to test locally
     mysql-hive: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
     mysql-hive: SUPERSET__SQLALCHEMY_EXAMPLES_URI = hive://localhost:10000/default
     # make sure that directory is accessible by docker


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
My local environment timezone is UTF+8, when I run jest, failed.
```
$  jest spec/javascripts/explore/components/DateFilterControl_spec.jsx
.....
  ● DateFilterControl › renders the correct time range in tooltip

    expect(received).toEqual(expected) // deep equality

    Expected: "2020-09-06 < col < 2020-09-07"
    Received: "2020-09-05 < col < 2020-09-06"
```

the root cause is , new Date('09/07/2020') => Date Mon Sep 07 2020 00:00:00 GMT+0800 (China Standard Time).

so we need construct a UTC datetime using new Date('2020-09-07')

reference: 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
