### PR TITLE
style: fix secondary label border

### DIFF
--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -38,12 +38,14 @@ export interface LabelProps {
 const SupersetLabel = styled(BootstrapLabel)`
   /* un-bunch them! */
   margin-right: ${({ theme }) => theme.gridUnit}px;
+
   &:first-of-type {
     margin-left: 0;
   }
   &:last-of-type {
     margin-right: 0;
   }
+  display: inline-block;
   border-width: 1px;
   border-style: solid;
   cursor: ${({ onClick }) => (onClick ? 'pointer' : 'default')};

--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -122,12 +122,12 @@ const SupersetLabel = styled(BootstrapLabel)`
     background-color: ${({ theme }) => theme.colors.secondary.base};
     color: ${({ theme }) => theme.colors.grayscale.light4};
     border-color: ${({ theme, onClick }) =>
-      onClick ? theme.colors.secondary.dark1 : 'inherit'};
+      onClick ? theme.colors.secondary.dark1 : 'transparent'};
     &:hover {
       background-color: ${({ theme, onClick }) =>
         onClick ? theme.colors.secondary.dark1 : theme.colors.secondary.base};
       border-color: ${({ theme, onClick }) =>
-        onClick ? theme.colors.secondary.dark2 : 'inherit'};
+        onClick ? theme.colors.secondary.dark2 : 'transparent'};
     }
   }
 `;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes an extraneous white border on the `secpndary` Label. My fault for missing this the last time around.

I also noticed the label was being cut off in certain layout instances, due to its `display:inline;` nature. Now it's `display:inline-block` and should prop open a containing div to its actual height.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/94514186-6ccd7c80-01d5-11eb-9b3d-393a3c9a2725.png)
![before](https://user-images.githubusercontent.com/812905/94514068-1d874c00-01d5-11eb-8cd0-764add27372d.gif)


After:
![image](https://user-images.githubusercontent.com/812905/94513920-c4b7b380-01d4-11eb-8a76-ddbe6c9daa00.png)
![after](https://user-images.githubusercontent.com/812905/94514074-211ad300-01d5-11eb-845b-418256c16433.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
