### PR TITLE
chore: refactor submenu's right nav to accept list of buttons

### DIFF
--- a/superset-frontend/spec/javascripts/components/SubMenu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/SubMenu_spec.jsx
@@ -101,7 +101,7 @@ describe('SubMenu', () => {
     ];
     const overrideProps = { buttons };
     const newWrapper = getWrapper(overrideProps);
-    expect(newWrapper.find('.navbar-right').children()).toHaveLength(2)
+    expect(newWrapper.find('.navbar-right').children()).toHaveLength(2);
     newWrapper.find('[buttonStyle="primary"]').simulate('click');
     expect(mockFunc).toHaveBeenCalled();
   });

--- a/superset-frontend/spec/javascripts/components/SubMenu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/SubMenu_spec.jsx
@@ -92,11 +92,11 @@ describe('SubMenu', () => {
       {
         name: 'test_button',
         onClick: mockFunc,
-        style: 'primary',
+        buttonStyle: 'primary',
       },
       {
         name: 'danger_button',
-        style: 'danger',
+        buttonStyle: 'danger',
       },
     ];
     const overrideProps = { buttons };

--- a/superset-frontend/spec/javascripts/components/SubMenu_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/SubMenu_spec.jsx
@@ -85,4 +85,24 @@ describe('SubMenu', () => {
     expect(routerWrapper.find(Link)).toHaveLength(2);
     expect(routerWrapper.find(MenuItem)).toHaveLength(1);
   });
+
+  it('renders buttons in the right nav of the submenu', () => {
+    const mockFunc = jest.fn();
+    const buttons = [
+      {
+        name: 'test_button',
+        onClick: mockFunc,
+        style: 'primary',
+      },
+      {
+        name: 'danger_button',
+        style: 'danger',
+      },
+    ];
+    const overrideProps = { buttons };
+    const newWrapper = getWrapper(overrideProps);
+    expect(newWrapper.find('.navbar-right').children()).toHaveLength(2)
+    newWrapper.find('[buttonStyle="primary"]').simulate('click');
+    expect(mockFunc).toHaveBeenCalled();
+  });
 });

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -68,20 +68,17 @@ type MenuChild = {
   usesRouter?: boolean;
 };
 
-export enum ButtonStyleTypes {
-  Primary = 'primary',
-  Secondary = 'secondary',
-  Dashed = 'dashed',
-  Danger = 'danger',
-  Link = 'link',
-  Warning = 'warning',
-  Success = 'success',
-}
-
-interface ButtonProps {
+export interface ButtonProps {
   name: any;
   onClick: OnClickHandler;
-  style: ButtonStyleTypes;
+  buttonStyle:
+    | 'primary'
+    | 'secondary'
+    | 'dashed'
+    | 'link'
+    | 'warning'
+    | 'success'
+    | 'tertiary';
 }
 
 export interface SubMenuProps {
@@ -140,7 +137,11 @@ const SubMenu: React.FunctionComponent<SubMenuProps> = props => {
         </Nav>
         <Nav className="navbar-right">
           {props.buttons?.map((btn, i) => (
-            <Button key={`${i}`} buttonStyle={btn.style} onClick={btn.onClick}>
+            <Button
+              key={`${i}`}
+              buttonStyle={btn.buttonStyle}
+              onClick={btn.onClick}
+            >
               {btn.name}
             </Button>
           ))}

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -71,8 +71,16 @@ type MenuChild = {
 interface ButtonProps {
   name: any;
   onClick: OnClickHandler;
-  style: string;
+  style:
+    | 'primary'
+    | 'secondary'
+    | 'dashed'
+    | 'danger'
+    | 'link'
+    | 'warning'
+    | 'success';
 }
+
 export interface SubMenuProps {
   buttons?: Array<ButtonProps>;
   name: string;

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -68,17 +68,20 @@ type MenuChild = {
   usesRouter?: boolean;
 };
 
+export enum ButtonStyleTypes {
+  Primary = 'primary',
+  Secondary = 'secondary',
+  Dashed = 'dashed',
+  Danger = 'danger',
+  Link = 'link',
+  Warning = 'warning',
+  Success = 'success',
+}
+
 interface ButtonProps {
   name: any;
   onClick: OnClickHandler;
-  style:
-    | 'primary'
-    | 'secondary'
-    | 'dashed'
-    | 'danger'
-    | 'link'
-    | 'warning'
-    | 'success';
+  style: ButtonStyleTypes;
 }
 
 export interface SubMenuProps {

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -35,22 +35,19 @@ const StyledHeader = styled.header`
       a,
       div {
         font-size: ${({ theme }) => theme.typography.sizes.s}px;
-        padding: ${({ theme }) => theme.gridUnit * 2}px 0;
+        padding: ${({ theme }) => theme.gridUnit * 2}px;
         margin: ${({ theme }) => theme.gridUnit * 2}px;
         color: ${({ theme }) => theme.colors.secondary.dark1};
-
         a {
           margin: 0;
           padding: ${({ theme }) => theme.gridUnit * 4}px;
         }
       }
-
       &.no-router a {
         padding: ${({ theme }) => theme.gridUnit * 2}px
           ${({ theme }) => theme.gridUnit * 4}px;
       }
     }
-
     li.active > a,
     li.active > div,
     li > a:hover,
@@ -65,19 +62,17 @@ const StyledHeader = styled.header`
 type MenuChild = {
   label: string;
   name: string;
-  url: string;
+  url?: string;
   usesRouter?: boolean;
 };
 
+interface Buttons {
+  name: any;
+  onClick: () => void;
+  style: string;
+}
 export interface SubMenuProps {
-  primaryButton?: {
-    name: React.ReactNode;
-    onClick: OnClickHandler;
-  };
-  secondaryButton?: {
-    name: React.ReactNode;
-    onClick: OnClickHandler;
-  };
+  buttons: Array<Buttons>;
   name: string;
   children?: MenuChild[];
   activeChild?: MenuChild['name'];
@@ -85,11 +80,14 @@ export interface SubMenuProps {
    *  ONLY set usesRouter to true if SubMenu is wrapped in a react-router <Router>;
    *  otherwise, a 'You should not use <Link> outside a <Router>' error will be thrown */
   usesRouter?: boolean;
+  links?: {
+    linkTitle: string;
+    link: string;
+  };
 }
 
 const SubMenu: React.FunctionComponent<SubMenuProps> = props => {
   let hasHistory = true;
-
   // If no parent <Router> component exists, useHistory throws an error
   try {
     useHistory();
@@ -97,7 +95,6 @@ const SubMenu: React.FunctionComponent<SubMenuProps> = props => {
     // If error is thrown, we know not to use <Link> in render
     hasHistory = false;
   }
-
   return (
     <StyledHeader>
       <Navbar inverse fluid role="navigation">
@@ -133,24 +130,11 @@ const SubMenu: React.FunctionComponent<SubMenuProps> = props => {
             })}
         </Nav>
         <Nav className="navbar-right">
-          {props.secondaryButton && (
-            <Button
-              buttonStyle="secondary"
-              onClick={props.secondaryButton.onClick}
-              cta
-            >
-              {props.secondaryButton.name}
+          {props.buttons?.map((btn, i) => (
+            <Button key={`${i}`} buttonStyle={btn.style} onClick={btn.onClick}>
+              {btn.name}
             </Button>
-          )}
-          {props.primaryButton && (
-            <Button
-              buttonStyle="primary"
-              onClick={props.primaryButton.onClick}
-              cta
-            >
-              {props.primaryButton.name}
-            </Button>
-          )}
+          ))}
         </Nav>
       </Navbar>
     </StyledHeader>

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -35,14 +35,16 @@ const StyledHeader = styled.header`
       a,
       div {
         font-size: ${({ theme }) => theme.typography.sizes.s}px;
-        padding: ${({ theme }) => theme.gridUnit * 2}px;
+        padding: ${({ theme }) => theme.gridUnit * 2}px 0;
         margin: ${({ theme }) => theme.gridUnit * 2}px;
         color: ${({ theme }) => theme.colors.secondary.dark1};
+
         a {
           margin: 0;
           padding: ${({ theme }) => theme.gridUnit * 4}px;
         }
       }
+
       &.no-router a {
         padding: ${({ theme }) => theme.gridUnit * 2}px
           ${({ theme }) => theme.gridUnit * 4}px;
@@ -62,7 +64,7 @@ const StyledHeader = styled.header`
 type MenuChild = {
   label: string;
   name: string;
-  url?: string;
+  url: string;
   usesRouter?: boolean;
 };
 
@@ -80,10 +82,6 @@ export interface SubMenuProps {
    *  ONLY set usesRouter to true if SubMenu is wrapped in a react-router <Router>;
    *  otherwise, a 'You should not use <Link> outside a <Router>' error will be thrown */
   usesRouter?: boolean;
-  links?: {
-    linkTitle: string;
-    link: string;
-  };
 }
 
 const SubMenu: React.FunctionComponent<SubMenuProps> = props => {

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -68,13 +68,13 @@ type MenuChild = {
   usesRouter?: boolean;
 };
 
-interface Buttons {
+interface ButtonProps {
   name: any;
-  onClick: () => void;
+  onClick: OnClickHandler;
   style: string;
 }
 export interface SubMenuProps {
-  buttons: Array<Buttons>;
+  buttons?: Array<ButtonProps>;
   name: string;
   children?: MenuChild[];
   activeChild?: MenuChild['name'];

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -24,7 +24,7 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
-import SubMenu, { ButtonStyleTypes } from 'src/components/Menu/SubMenu';
+import SubMenu from 'src/components/Menu/SubMenu';
 import AvatarIcon from 'src/components/AvatarIcon';
 import Icon from 'src/components/Icon';
 import FaveStar from 'src/components/FaveStar';
@@ -502,7 +502,7 @@ function ChartList(props: ChartListProps) {
             ? [
                 {
                   name: t('Bulk Select'),
-                  style: ButtonStyleTypes.Secondary,
+                  buttonStyle: 'secondary',
                   onClick: toggleBulkSelect,
                 },
               ]

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -497,13 +497,16 @@ function ChartList(props: ChartListProps) {
     <>
       <SubMenu
         name={t('Charts')}
-        secondaryButton={
+        buttons={
           canDelete
-            ? {
-                name: t('Bulk Select'),
-                onClick: toggleBulkSelect,
-              }
-            : undefined
+            ? [
+                {
+                  name: t('Bulk Select'),
+                  buttonStyle: 'Primary',
+                  onClick: toggleBulkSelect,
+                },
+              ]
+            : []
         }
       />
       {sliceCurrentlyEditing && (

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -24,7 +24,7 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
-import SubMenu from 'src/components/Menu/SubMenu';
+import SubMenu, { ButtonStyleTypes } from 'src/components/Menu/SubMenu';
 import AvatarIcon from 'src/components/AvatarIcon';
 import Icon from 'src/components/Icon';
 import FaveStar from 'src/components/FaveStar';
@@ -502,7 +502,7 @@ function ChartList(props: ChartListProps) {
             ? [
                 {
                   name: t('Bulk Select'),
-                  style: 'secondary',
+                  style: ButtonStyleTypes.Secondary,
                   onClick: toggleBulkSelect,
                 },
               ]

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -502,7 +502,7 @@ function ChartList(props: ChartListProps) {
             ? [
                 {
                   name: t('Bulk Select'),
-                  style: 'Primary',
+                  style: 'secondary',
                   onClick: toggleBulkSelect,
                 },
               ]

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -502,7 +502,7 @@ function ChartList(props: ChartListProps) {
             ? [
                 {
                   name: t('Bulk Select'),
-                  buttonStyle: 'Primary',
+                  style: 'Primary',
                   onClick: toggleBulkSelect,
                 },
               ]

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -499,12 +499,15 @@ function DashboardList(props: DashboardListProps) {
     <>
       <SubMenu
         name={t('Dashboards')}
-        secondaryButton={
+        buttons={
           canDelete || canExport
-            ? {
-                name: t('Bulk Select'),
-                onClick: toggleBulkSelect,
-              }
+            ? [
+                {
+                  name: t('Bulk Select'),
+                  style: 'secondary',
+                  onClick: toggleBulkSelect,
+                },
+              ]
             : undefined
         }
       />

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -23,7 +23,7 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
-import SubMenu from 'src/components/Menu/SubMenu';
+import SubMenu, { ButtonStyleTypes } from 'src/components/Menu/SubMenu';
 import AvatarIcon from 'src/components/AvatarIcon';
 import ListView, { ListViewProps, Filters } from 'src/components/ListView';
 import ExpandableList from 'src/components/ExpandableList';
@@ -504,7 +504,7 @@ function DashboardList(props: DashboardListProps) {
             ? [
                 {
                   name: t('Bulk Select'),
-                  style: 'secondary',
+                  style: ButtonStyleTypes.Secondary,
                   onClick: toggleBulkSelect,
                 },
               ]

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -23,7 +23,7 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
-import SubMenu, { ButtonStyleTypes } from 'src/components/Menu/SubMenu';
+import SubMenu from 'src/components/Menu/SubMenu';
 import AvatarIcon from 'src/components/AvatarIcon';
 import ListView, { ListViewProps, Filters } from 'src/components/ListView';
 import ExpandableList from 'src/components/ExpandableList';
@@ -504,7 +504,7 @@ function DashboardList(props: DashboardListProps) {
             ? [
                 {
                   name: t('Bulk Select'),
-                  style: ButtonStyleTypes.Secondary,
+                  buttonStyle: 'secondary',
                   onClick: toggleBulkSelect,
                 },
               ]

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -21,7 +21,10 @@ import React, { useState, useMemo } from 'react';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import { createErrorHandler } from 'src/views/CRUD/utils';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
-import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
+import SubMenu, {
+  SubMenuProps,
+  ButtonStyleTypes,
+} from 'src/components/Menu/SubMenu';
 import DeleteModal from 'src/components/DeleteModal';
 import TooltipWrapper from 'src/components/TooltipWrapper';
 import Icon from 'src/components/Icon';
@@ -134,7 +137,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
             <i className="fa fa-plus" /> {t('Database')}{' '}
           </>
         ),
-        style: 'primary',
+        style: ButtonStyleTypes.Primary,
         onClick: () => {
           // Ensure modal will be opened in add mode
           setCurrentDatabase(null);

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -126,19 +126,22 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
   };
 
   if (canCreate) {
-    menuData.primaryButton = {
-      name: (
-        <>
-          {' '}
-          <i className="fa fa-plus" /> {t('Database')}{' '}
-        </>
-      ),
-      onClick: () => {
-        // Ensure modal will be opened in add mode
-        setCurrentDatabase(null);
-        setDatabaseModalOpen(true);
+    menuData.buttons = [
+      {
+        name: (
+          <>
+            {' '}
+            <i className="fa fa-plus" /> {t('Database')}{' '}
+          </>
+        ),
+        style: 'primary',
+        onClick: () => {
+          // Ensure modal will be opened in add mode
+          setCurrentDatabase(null);
+          setDatabaseModalOpen(true);
+        },
       },
-    };
+    ];
   }
 
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -21,10 +21,7 @@ import React, { useState, useMemo } from 'react';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import { createErrorHandler } from 'src/views/CRUD/utils';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
-import SubMenu, {
-  SubMenuProps,
-  ButtonStyleTypes,
-} from 'src/components/Menu/SubMenu';
+import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import DeleteModal from 'src/components/DeleteModal';
 import TooltipWrapper from 'src/components/TooltipWrapper';
 import Icon from 'src/components/Icon';
@@ -137,7 +134,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
             <i className="fa fa-plus" /> {t('Database')}{' '}
           </>
         ),
-        style: ButtonStyleTypes.Primary,
+        buttonStyle: 'primary',
         onClick: () => {
           // Ensure modal will be opened in add mode
           setCurrentDatabase(null);

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -397,8 +397,10 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
     ...commonMenuData,
   };
 
+  const buttonArr = [];
+
   if (canCreate) {
-    menuData.primaryButton = {
+    buttonArr.push({
       name: (
         <>
           {' '}
@@ -406,15 +408,19 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         </>
       ),
       onClick: () => setDatasetAddModalOpen(true),
-    };
+      style: 'primary',
+    });
   }
 
   if (canDelete) {
-    menuData.secondaryButton = {
+    buttonArr.push({
       name: t('Bulk Select'),
       onClick: toggleBulkSelect,
-    };
+      style: 'secondary',
+    });
   }
+
+  menuData.buttons = [...buttonArr];
 
   const closeDatasetDeleteModal = () => {
     setDatasetCurrentlyDeleting(null);

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -29,7 +29,10 @@ import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import DatasourceModal from 'src/datasource/DatasourceModal';
 import DeleteModal from 'src/components/DeleteModal';
 import ListView, { ListViewProps, Filters } from 'src/components/ListView';
-import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
+import SubMenu, {
+  SubMenuProps,
+  ButtonStyleTypes,
+} from 'src/components/Menu/SubMenu';
 import { commonMenuData } from 'src/views/CRUD/data/common';
 import AvatarIcon from 'src/components/AvatarIcon';
 import Owner from 'src/types/Owner';
@@ -403,7 +406,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
     buttonArr.push({
       name: t('Bulk Select'),
       onClick: toggleBulkSelect,
-      style: 'secondary',
+      style: ButtonStyleTypes.Secondary,
     });
   }
 
@@ -416,7 +419,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         </>
       ),
       onClick: () => setDatasetAddModalOpen(true),
-      style: 'primary',
+      style: ButtonStyleTypes.Primary,
     });
   }
 

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -399,6 +399,14 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
 
   const buttonArr = [];
 
+  if (canDelete) {
+    buttonArr.push({
+      name: t('Bulk Select'),
+      onClick: toggleBulkSelect,
+      style: 'secondary',
+    });
+  }
+
   if (canCreate) {
     buttonArr.push({
       name: (
@@ -409,14 +417,6 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
       ),
       onClick: () => setDatasetAddModalOpen(true),
       style: 'primary',
-    });
-  }
-
-  if (canDelete) {
-    buttonArr.push({
-      name: t('Bulk Select'),
-      onClick: toggleBulkSelect,
-      style: 'secondary',
     });
   }
 

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -31,7 +31,7 @@ import DeleteModal from 'src/components/DeleteModal';
 import ListView, { ListViewProps, Filters } from 'src/components/ListView';
 import SubMenu, {
   SubMenuProps,
-  ButtonStyleTypes,
+  ButtonProps,
 } from 'src/components/Menu/SubMenu';
 import { commonMenuData } from 'src/views/CRUD/data/common';
 import AvatarIcon from 'src/components/AvatarIcon';
@@ -400,13 +400,13 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
     ...commonMenuData,
   };
 
-  const buttonArr = [];
+  const buttonArr: Array<ButtonProps> = [];
 
   if (canDelete) {
     buttonArr.push({
       name: t('Bulk Select'),
       onClick: toggleBulkSelect,
-      style: ButtonStyleTypes.Secondary,
+      buttonStyle: 'secondary',
     });
   }
 
@@ -419,7 +419,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         </>
       ),
       onClick: () => setDatasetAddModalOpen(true),
-      style: ButtonStyleTypes.Primary,
+      buttonStyle: 'primary',
     });
   }
 

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -420,7 +420,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
     });
   }
 
-  menuData.buttons = [...buttonArr];
+  menuData.buttons = buttonArr;
 
   const closeDatasetDeleteModal = () => {
     setDatasetCurrentlyDeleting(null);

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -30,7 +30,10 @@ import { Popover } from 'src/common/components';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
-import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
+import SubMenu, {
+  SubMenuProps,
+  ButtonProps,
+} from 'src/components/Menu/SubMenu';
 import ListView, { ListViewProps, Filters } from 'src/components/ListView';
 import DeleteModal from 'src/components/DeleteModal';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
@@ -101,17 +104,23 @@ function SavedQueryList({
     ...commonMenuData,
   };
 
-  menuData.primaryButton = {
-    name: t('+ Query'),
-    onClick: openNewQuery,
-  };
+  const subMenuButtons: Array<ButtonProps> = [];
 
   if (canDelete) {
-    menuData.secondaryButton = {
+    subMenuButtons.push({
       name: t('Bulk Select'),
       onClick: toggleBulkSelect,
-    };
+      buttonStyle: 'secondary',
+    });
   }
+
+  subMenuButtons.push({
+    name: t('+ Query'),
+    onClick: openNewQuery,
+    buttonStyle: 'primary',
+  });
+
+  menuData.buttons = subMenuButtons;
 
   // Action methods
   const openInSqlLab = (id: number) => {


### PR DESCRIPTION
### SUMMARY
This pr refactors the submenu right nav buttons to accept a list of button props which allows you to use any of the button components in our library.

Will updates tests as neccessary.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
