### PR TITLE
fix: Disabling timezone of dataframe before passing Prophet

### DIFF
--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -599,7 +599,7 @@ def _prophet_fit_and_predict(  # pylint: disable=too-many-arguments
         weekly_seasonality=weekly_seasonality,
         daily_seasonality=daily_seasonality,
     )
-    df['ds'] = df['ds'].dt.tz_convert(None)
+    df["ds"] = df["ds"].dt.tz_convert(None)
     model.fit(df)
     future = model.make_future_dataframe(periods=periods, freq=freq)
     forecast = model.predict(future)[["ds", "yhat", "yhat_lower", "yhat_upper"]]

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -599,7 +599,8 @@ def _prophet_fit_and_predict(  # pylint: disable=too-many-arguments
         weekly_seasonality=weekly_seasonality,
         daily_seasonality=daily_seasonality,
     )
-    df["ds"] = df["ds"].dt.tz_convert(None)
+    if df["ds"].dt.tz:
+        df["ds"] = df["ds"].dt.tz_convert(None)
     model.fit(df)
     future = model.make_future_dataframe(periods=periods, freq=freq)
     forecast = model.predict(future)[["ds", "yhat", "yhat_lower", "yhat_upper"]]

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -599,6 +599,7 @@ def _prophet_fit_and_predict(  # pylint: disable=too-many-arguments
         weekly_seasonality=weekly_seasonality,
         daily_seasonality=daily_seasonality,
     )
+    df['ds'] = df['ds'].dt.tz_convert(None)
     model.fit(df)
     future = model.make_future_dataframe(periods=periods, freq=freq)
     forecast = model.predict(future)[["ds", "yhat", "yhat_lower", "yhat_upper"]]


### PR DESCRIPTION
While running forecasting with Druid. Prophet throws the following exception. This PR removes the timezone info. 
ValueError: Column ds has timezone specified, which is not supported. Remove timezone
https://github.com/apache/incubator-superset/issues/11106

@villebro

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: 
![image](https://user-images.githubusercontent.com/391567/94595315-84d9e600-023f-11eb-9872-59815d95d23c.png)

After: 
![image](https://user-images.githubusercontent.com/391567/94595346-8d322100-023f-11eb-8957-ddcec8a8109d.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
