### PR TITLE
fix: fix alembic migration

### DIFF
--- a/superset/migrations/versions/18532d70ab98_fix_table_unique_constraint_in_mysql.py
+++ b/superset/migrations/versions/18532d70ab98_fix_table_unique_constraint_in_mysql.py
@@ -17,14 +17,14 @@
 """Delete table_name unique constraint in mysql
 
 Revision ID: 18532d70ab98
-Revises: e5ef6828ac4e
+Revises: 3fbbc6e8d654
 Create Date: 2020-09-25 10:56:13.711182
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "18532d70ab98"
-down_revision = "e5ef6828ac4e"
+down_revision = "3fbbc6e8d654"
 
 from alembic import op
 


### PR DESCRIPTION
### SUMMARY
Fixes the order of the migrations

```
3fbbc6e8d654 -> 18532d70ab98 (head), Delete table_name unique constraint in mysql
e5ef6828ac4e -> 3fbbc6e8d654, fix data access permissions for virtual datasets
ae19b4ee3692 -> e5ef6828ac4e, add rls filter type and grouping key
175ea3592453, 2e5a0ee25ed4 -> ae19b4ee3692 (mergepoint), empty message
f80a3b88324b -> 175ea3592453, Add cache to datasource lookup table.
f80a3b88324b -> 2e5a0ee25ed4, refractor_alerting
978245563a02, f120347acb39 -> f80a3b88324b (branchpoint) (mergepoint), empty message
f2672aa8350a -> 978245563a02, Migrate iframe in dashboard to markdown component
f2672aa8350a -> f120347acb39, Add extra column to tables and metrics
2f1d15e8a6af -> f2672aa8350a (branchpoint), add_slack_to_alerts
a72cb0ebeb22 -> 2f1d15e8a6af, add_alerts
ea396d202291 -> a72cb0ebeb22, deprecate dbs.perm column
e557699a813e -> ea396d202291, Add ctas_method to the Query object
743a117f0d98 -> e557699a813e, add_tables_relation_to_row_level_security
620241d1153f -> 743a117f0d98, Add slack to the schedule
f9a30386bd74 -> 620241d1153f, update time_grain_sqla
b5998378c225 -> f9a30386bd74, cleanup_time_grainularity
72428d1ea401 -> b5998378c225, add certificate to dbs
0a6f12f60c73 -> 72428d1ea401, Add tmp_schema_name to the query object.
3325d4caccc8 -> 0a6f12f60c73, add_role_level_security
e96dbf2cfef0 -> 3325d4caccc8, empty message
817e1c9b09d0 -> e96dbf2cfef0, datasource_cluster_fk
89115a40e8ea -> 817e1c9b09d0, add_not_null_to_dbs_sqlalchemy_url
5afa9079866a -> 89115a40e8ea, Change table schema description to long text
db4b49eb0782 -> 5afa9079866a, serialize_schema_permissions.py
78ee127d0d1d -> db4b49eb0782, Add tables for SQL Lab state
c2acd2cf3df2 -> 78ee127d0d1d, reconvert legacy filters into adhoc
cca2f5d568c8 -> c2acd2cf3df2, alter type of dbs encrypted_extra
```