### PR TITLE
fix(chart-data-api): ignore missing filters

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -237,7 +237,6 @@ class QueryContext:
                     col
                     for col in query_obj.columns
                     + query_obj.groupby
-                    + [flt["col"] for flt in query_obj.filter]
                     + utils.get_column_names_from_metrics(query_obj.metrics)
                     if col not in self.datasource.column_names
                 ]

--- a/tests/query_context_tests.py
+++ b/tests/query_context_tests.py
@@ -211,23 +211,6 @@ class TestQueryContext(SupersetTestCase):
         query_payload = query_context.get_payload()
         assert query_payload[0].get("error") is not None
 
-    def test_sql_injection_via_filters(self):
-        """
-        Ensure that calling invalid columns names in filters are caught
-        """
-        self.login(username="admin")
-        table_name = "birth_names"
-        table = self.get_table_by_name(table_name)
-        payload = get_query_context(table.name, table.id, table.type)
-        payload["queries"][0]["groupby"] = ["name"]
-        payload["queries"][0]["metrics"] = []
-        payload["queries"][0]["filters"] = [
-            {"col": "*", "op": FilterOperator.EQUALS.value, "val": ";"}
-        ]
-        query_context = ChartDataQueryContextSchema().load(payload)
-        query_payload = query_context.get_payload()
-        assert query_payload[0].get("error") is not None
-
     def test_sql_injection_via_metrics(self):
         """
         Ensure that calling invalid columns names in filters are caught


### PR DESCRIPTION
### SUMMARY
#10451 introduced a regression where filters referencing columns that aren't present in a datasource returned a 400. Since the SQLA model ignores missing filters, this assertion is unnecessary, and will cause trouble if a dashboard emits filters that reference columns that are not present in a chart's datasource.

### TEST PLAN
CI + new test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #11078 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
