### PR TITLE
fix: remove extra flash import

### DIFF
--- a/superset/templates/superset/import_dashboards.html
+++ b/superset/templates/superset/import_dashboards.html
@@ -41,7 +41,7 @@
                     id="my-file-selector"
                     type="file"
                     name="file"
-                    accept=".yml, .json"
+                    accept=".json"
                     style="display:none;"
                     onchange="$('#upload-file-info').html(this.files[0].name)"/>
                   {{ _("Choose File") }}

--- a/superset/templates/superset/import_dashboards.html
+++ b/superset/templates/superset/import_dashboards.html
@@ -21,8 +21,6 @@
 {% block title %}{{ _("Import dashboards") }}{% endblock %}
 
 {% block content %}
-  {% include "superset/flash_wrapper.html" %}
-
   <div class="container">
     <div class="panel">
       <div class="panel-heading"><h3>{{ _("Import Dashboard(s)") }}</h3></div>
@@ -43,6 +41,7 @@
                     id="my-file-selector"
                     type="file"
                     name="file"
+                    accept=".yml, .json"
                     style="display:none;"
                     onchange="$('#upload-file-info').html(this.files[0].name)"/>
                   {{ _("Choose File") }}


### PR DESCRIPTION
### SUMMARY
@mistercrunch found this bug: 
![image](https://user-images.githubusercontent.com/5186919/94732000-7f9d9980-031a-11eb-9347-e8a2bd620301.png)

This removes the extra error message, and also adds an `accept` on the file input to only allow the user to select the formats that are valid. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
no visual tests available, but all other regression tests should pass

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
