### PR TITLE
docs: add checkout tagged release instructions to docs

### DIFF
--- a/docs/src/pages/docs/installation/index.mdx
+++ b/docs/src/pages/docs/installation/index.mdx
@@ -51,6 +51,12 @@ $ git clone https://github.com/apache/incubator-superset.git
 Once that command completes successfully, you should see a new `incubator-superset` folder in your
 current directory.
 
+We recommend that you check out and run the code from the last tagged release:
+
+```bash
+$ git checkout $(git describe --tags)
+```
+
 ### 3. Launch Superset Through Docker Compose
 
 Navigate to the folder you created in step 1:
@@ -68,7 +74,7 @@ $ docker-compose up
 You should see a wall of logging output from the containers being launched on your machine. Once
 this output slows, you should have a running instance of Superset on your local machine!
 
-### 4. Login to Superset
+### 4. Log in to Superset
 
 Your local Superset instance also includes a Postgres server to store your data and is already
 pre-loaded with some example datasets that ship with Superset. You can access Superset now via your

--- a/docs/src/pages/docs/installation/installing_scratch.mdx
+++ b/docs/src/pages/docs/installation/installing_scratch.mdx
@@ -63,7 +63,7 @@ pip install --upgrade setuptools pip
 
 ### Python Virtual Environment
 
-We highly recommend installing Superset insode of a virtual environment. Python 3 ships with
+We highly recommend installing Superset inside of a virtual environment. Python 3 ships with
 `virtualenv` out of the box but you can install it using:
 
 ```


### PR DESCRIPTION
### SUMMARY
For new users "trying" Superset, it seems we would want to point them to a "stable" release instead of running on master. We could point them to checkout the latest tag for the best experience. Do we want to be clear that development should branch from master? Thoughts on the best wording?

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
