### PR TITLE
fix: Revert "Replace reactable with DataTable from superset-ui in QueryTab…

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/QueryTable_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/QueryTable_spec.jsx
@@ -18,33 +18,27 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import DataTable from '@superset-ui/plugin-chart-table/lib/DataTable';
-import * as useMountedMemo from '@superset-ui/plugin-chart-table/lib/DataTable/utils/useMountedMemo';
+import { Table } from 'reactable-arc';
 import QueryTable from 'src/SqlLab/components/QueryTable';
 
-import { dataTableProps } from 'spec/javascripts/sqllab/fixtures';
+import { queries } from './fixtures';
 
 describe('QueryTable', () => {
-  // hack for mocking hook that implements sticky behaviour of DataTable
-  jest
-    .spyOn(useMountedMemo, 'default')
-    .mockImplementation(() => ({ width: 100, height: 100 }));
   const mockedProps = {
-    ...dataTableProps,
-    displayLimit: 10000,
+    queries,
   };
   it('is valid', () => {
-    expect(React.isValidElement(<QueryTable {...mockedProps} />)).toBe(true);
+    expect(React.isValidElement(<QueryTable />)).toBe(true);
   });
   it('is valid with props', () => {
     expect(React.isValidElement(<QueryTable {...mockedProps} />)).toBe(true);
   });
   it('renders a proper table', () => {
     const wrapper = shallow(<QueryTable {...mockedProps} />);
-    expect(wrapper.find(DataTable)).toExist();
-    expect(wrapper.find(DataTable).shallow().find('table')).toExist();
-    expect(
-      wrapper.find(DataTable).shallow().find('tbody').find('tr'),
-    ).toHaveLength(2);
+    expect(wrapper.find(Table)).toExist();
+    expect(wrapper.find(Table).shallow().find('table')).toExist();
+    expect(wrapper.find(Table).shallow().find('table').find('Tr')).toHaveLength(
+      2,
+    );
   });
 });

--- a/superset-frontend/spec/javascripts/sqllab/fixtures.ts
+++ b/superset-frontend/spec/javascripts/sqllab/fixtures.ts
@@ -493,8 +493,3 @@ export const query = {
   ctas: false,
   cached: false,
 };
-
-export const dataTableProps = {
-  columns: ['dbId', 'sql'],
-  queries,
-};

--- a/superset-frontend/src/SqlLab/components/QueryTable.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable.jsx
@@ -19,17 +19,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { Table } from 'reactable-arc';
 import { ProgressBar, Well } from 'react-bootstrap';
 import Label from 'src/components/Label';
 import { t } from '@superset-ui/core';
-import DataTable from '@superset-ui/plugin-chart-table/lib/DataTable';
 
 import Button from 'src/components/Button';
-import { fDuration } from 'src/modules/dates';
 import Link from '../../components/Link';
 import ResultSet from './ResultSet';
 import ModalTrigger from '../../components/ModalTrigger';
 import HighlightedSql from './HighlightedSql';
+import { fDuration } from '../../modules/dates';
 import QueryStateLabel from './QueryStateLabel';
 
 const propTypes = {
@@ -213,20 +213,14 @@ class QueryTable extends React.PureComponent {
       })
       .reverse();
     return (
-      <DataTable
-        tableClassName="table table-condensed"
-        columns={this.props.columns.map(column => ({
-          accessor: column,
-          Header: () => <th>{column}</th>,
-          Cell: ({ value }) => <td>{value}</td>,
-        }))}
-        data={data}
-        pageSize={10}
-        maxPageItemCount={9}
-        searchInput={false}
-        height="100%"
-        sticky
-      />
+      <div className="QueryTable">
+        <Table
+          columns={this.props.columns}
+          className="table table-condensed"
+          data={data}
+          itemsPerPage={50}
+        />
+      </div>
     );
   }
 }


### PR DESCRIPTION
…le (#10981)"

This reverts commit e93d92e8ac6d4f85d193943e27d585fb6e01568c.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

See linked issue

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
-CI, manual verification 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #11096
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
