### PR TITLE
test: removed unicode_test example from unit tests

### DIFF
--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -28,6 +28,7 @@ from sqlalchemy import and_
 from sqlalchemy.sql import func
 
 from superset.utils.core import get_example_database
+from tests.fixtures.unicode_dashboard import load_unicode_dashboard_with_slice
 from tests.test_app import app
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.extensions import db, security_manager
@@ -567,6 +568,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 404)
 
+    @pytest.mark.usefixtures("load_unicode_dashboard_with_slice")
     def test_get_charts(self):
         """
         Chart API: Test get charts
@@ -733,6 +735,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
         assert rv.status_code == 200
         assert len(expected_models) == data["count"]
 
+    @pytest.mark.usefixtures("load_unicode_dashboard_with_slice")
     def test_get_charts_page(self):
         """
         Chart API: Test get charts filter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,6 @@ def setup_sample_data() -> Any:
         examples.load_energy(sample=True)
         examples.load_world_bank_health_n_pop(sample=True)
         examples.load_birth_names(sample=True)
-        examples.load_unicode_test_data(sample=True)
 
     yield
 
@@ -54,7 +53,6 @@ def setup_sample_data() -> Any:
         engine.execute("DROP TABLE energy_usage")
         engine.execute("DROP TABLE wb_health_population")
         engine.execute("DROP TABLE birth_names")
-        engine.execute("DROP TABLE unicode_test")
 
         # drop sqlachemy tables
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,6 @@ def setup_sample_data() -> Any:
         engine.execute("DROP TABLE energy_usage")
         engine.execute("DROP TABLE wb_health_population")
         engine.execute("DROP TABLE birth_names")
-        engine.execute("DROP TABLE IF EXISTS unicode_test")
 
         # drop sqlachemy tables
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ def setup_sample_data() -> Any:
         engine.execute("DROP TABLE energy_usage")
         engine.execute("DROP TABLE wb_health_population")
         engine.execute("DROP TABLE birth_names")
+        engine.execute("DROP TABLE IF EXISTS unicode_test")
 
         # drop sqlachemy tables
 

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -36,13 +36,15 @@ def create_table_for_dashboard(
         database.get_sqla_engine(),
         if_exists="replace",
         chunksize=500,
-        dtype=schema,
+        dtype=dtype,
         index=False,
         method="multi",
     )
 
     table_source = ConnectorRegistry.sources["table"]
-    table = db.session.query(table_source).filter_by(table_name=table_name).first()
+    table = (
+        db.session.query(table_source).filter_by(table_name=table_name).one_or_none()
+    )
     if not table:
         table = table_source(table_name=table_name)
     table.database = database
@@ -65,7 +67,7 @@ def create_slice(
 
 
 def create_dashboard(slug: str, title: str, position: str, slice: Slice) -> Dashboard:
-    dash = db.session.query(Dashboard).filter_by(slug=slug).first()
+    dash = db.session.query(Dashboard).filter_by(slug=slug).one_or_none()
 
     if not dash:
         dash = Dashboard()

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -14,22 +14,23 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# isort:skip_file
 """Utils to provide dashboards for tests"""
 
 import json
+from typing import Any, Dict
 
 from pandas import DataFrame
-from typing import Dict, Any
 
-from superset import db, ConnectorRegistry
+from superset import ConnectorRegistry, db
+from superset.connectors.sqla.models import SqlaTable
+from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 
 
 def create_table_for_dashboard(
-    df: DataFrame, tbl_name: str, database, schema: Dict[str, Any]
-):
+    df: DataFrame, tbl_name: str, database: "Database", schema: Dict[str, Any]
+) -> "SqlaTable":
     df.to_sql(
         tbl_name,
         database.get_sqla_engine(),
@@ -51,7 +52,9 @@ def create_table_for_dashboard(
     return obj
 
 
-def create_slice(title, viz_type, tbl, slices_dict: Dict[str, str]):
+def create_slice(
+    title: str, viz_type: str, tbl: SqlaTable, slices_dict: Dict[str, str]
+) -> Slice:
     return Slice(
         slice_name=title,
         viz_type=viz_type,
@@ -61,7 +64,7 @@ def create_slice(title, viz_type, tbl, slices_dict: Dict[str, str]):
     )
 
 
-def create_dashboard(slug: str, title: str, position: str, slc: Slice):
+def create_dashboard(slug: str, title: str, position: str, slc: Slice) -> Dashboard:
     dash = db.session.query(Dashboard).filter_by(slug=slug).first()
 
     if not dash:
@@ -76,3 +79,4 @@ def create_dashboard(slug: str, title: str, position: str, slc: Slice):
         dash.slices = [slc]
         db.session.merge(dash)
     db.session.commit()
+    return dash

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -29,7 +29,7 @@ from superset.models.slice import Slice
 
 
 def create_table_for_dashboard(
-    df: DataFrame, table_name: str, database: Database, schema: Dict[str, Any]
+    df: DataFrame, table_name: str, database: Database, dtype: Dict[str, Any]
 ) -> SqlaTable:
     df.to_sql(
         table_name,

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -17,25 +17,14 @@
 # isort:skip_file
 """Utils to provide dashboards for tests"""
 
-import datetime
 import json
 
-import random
 from pandas import DataFrame
 from typing import Dict, Any
 
 from superset import db, ConnectorRegistry
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
-
-
-def add_datetime_value_to_data(data):
-    data_dict = {}
-    for d in data:
-        data_dict["phrase"] = d
-        data_dict["dttm"] = datetime.datetime.now().date()
-        data_dict["value"] = [random.randint(1, 100) for _ in range(len(data))]
-    return data_dict
 
 
 def create_table_for_dashboard(
@@ -55,7 +44,6 @@ def create_table_for_dashboard(
     obj = db.session.query(tbl_source).filter_by(table_name=tbl_name).first()
     if not obj:
         obj = tbl_source(table_name=tbl_name)
-    obj.main_dttm_col = "dttm"
     obj.database = database
     db.session.merge(obj)
     db.session.commit()

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file
+"""Utils to provide dashboards for tests"""
+
+import datetime
+import json
+
+import random
+from pandas import DataFrame
+from typing import Dict, Any
+
+from superset import db, ConnectorRegistry
+from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
+
+
+def add_datetime_value_to_data(data):
+    data_dict = {}
+    for d in data:
+        data_dict["phrase"] = d
+        data_dict["dttm"] = datetime.datetime.now().date()
+        data_dict["value"] = [random.randint(1, 100) for _ in range(len(data))]
+    return data_dict
+
+
+def create_table_for_dashboard(
+    df: DataFrame, tbl_name: str, database, schema: Dict[str, Any]
+):
+    df.to_sql(
+        tbl_name,
+        database.get_sqla_engine(),
+        if_exists="replace",
+        chunksize=500,
+        dtype=schema,
+        index=False,
+        method="multi",
+    )
+
+    tbl_source = ConnectorRegistry.sources["table"]
+    obj = db.session.query(tbl_source).filter_by(table_name=tbl_name).first()
+    if not obj:
+        obj = tbl_source(table_name=tbl_name)
+    obj.main_dttm_col = "dttm"
+    obj.database = database
+    db.session.merge(obj)
+    db.session.commit()
+
+    return obj
+
+
+def create_slice(tbl, slices_dict: Dict[str, str]):
+    return Slice(
+        slice_name="Unicode Cloud",
+        viz_type="word_cloud",
+        datasource_type="table",
+        datasource_id=tbl.id,
+        params=json.dumps(slices_dict, indent=4, sort_keys=True),
+    )
+
+
+def create_dashboard(slug: str, title: str, position: str, slc: Slice):
+    dash = db.session.query(Dashboard).filter_by(slug=slug).first()
+
+    if not dash:
+        dash = Dashboard()
+    dash.dashboard_title = title
+    if position is not None:
+        js = position
+        pos = json.loads(js)
+        dash.position_json = json.dumps(pos, indent=4)
+    dash.slug = slug
+    if slc is not None:
+        dash.slices = [slc]
+        db.session.merge(dash)
+    db.session.commit()

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -29,8 +29,8 @@ from superset.models.slice import Slice
 
 
 def create_table_for_dashboard(
-    df: DataFrame, tbl_name: str, database: "Database", schema: Dict[str, Any]
-) -> "SqlaTable":
+    df: DataFrame, tbl_name: str, database: Database, schema: Dict[str, Any]
+) -> SqlaTable:
     df.to_sql(
         tbl_name,
         database.get_sqla_engine(),

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -77,6 +77,7 @@ def create_dashboard(slug: str, title: str, position: str, slice: Slice) -> Dash
     dash.slug = slug
     if slice is not None:
         dash.slices = [slice]
-        db.session.merge(dash)
+    db.session.merge(dash)
     db.session.commit()
+
     return dash

--- a/tests/dashboard_utils.py
+++ b/tests/dashboard_utils.py
@@ -51,10 +51,10 @@ def create_table_for_dashboard(
     return obj
 
 
-def create_slice(tbl, slices_dict: Dict[str, str]):
+def create_slice(title, viz_type, tbl, slices_dict: Dict[str, str]):
     return Slice(
-        slice_name="Unicode Cloud",
-        viz_type="word_cloud",
+        slice_name=title,
+        viz_type=viz_type,
         datasource_type="table",
         datasource_id=tbl.id,
         params=json.dumps(slices_dict, indent=4, sort_keys=True),

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -16,12 +16,13 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset"""
-
+import datetime
 import json
 
 import pandas as pd
 import prison
 import pytest
+import random
 
 from sqlalchemy import String, Date, Float
 from sqlalchemy.sql import func
@@ -32,7 +33,6 @@ from superset.models.core import Database
 from superset.utils.core import get_example_database, get_main_database
 from tests.base_tests import SupersetTestCase
 from tests.dashboard_utils import (
-    add_datetime_value_to_data,
     create_table_for_dashboard,
     create_dashboard,
 )
@@ -771,26 +771,19 @@ class TestDatabaseApi(SupersetTestCase):
     @pytest.fixture()
     def load_unicode_dashboard(self):
         data = [
-            "Под",
-            "řšž",
-            "視野無限廣",
-            "微風",
-            "中国智造",
-            "æøå",
-            "ëœéè",
-            "いろはにほ",
-            "다람쥐",
-            "Чешће",
-            "ŕľšťýď",
-            "žšč",
-            "éúüñóá",
-            "كۆچەج",
+            {"phrase": "Под"},
+            {"phrase": "řšž"},
+            {"phrase": "視野無限廣"},
+            {"phrase": "微風"},
+            {"phrase": "中国智造"},
+            {"phrase": "æøå"},
+            {"phrase": "ëœéè"},
+            {"phrase": "いろはにほ"},
         ]
         tbl_name = "unicode_test"
 
         # generate date/numeric data
-        unicode_data_dict = add_datetime_value_to_data(data)
-        df = pd.DataFrame.from_dict(unicode_data_dict)
+        df = pd.DataFrame.from_dict(data)
 
         with self.create_app().app_context():
             database = get_example_database()
@@ -803,7 +796,7 @@ class TestDatabaseApi(SupersetTestCase):
             obj.fetch_metadata()
 
             db.session.commit()
-            position = _get_position()
+            position = "{}"
             create_dashboard("unicode-test", "Unicode Test", position, None)
 
     @pytest.mark.usefixtures("load_unicode_dashboard")
@@ -838,45 +831,3 @@ class TestDatabaseApi(SupersetTestCase):
         uri = f"api/v1/database/{database.id}/related_objects/"
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 404)
-
-
-def _get_position():
-    return """{
-                    "CHART-Hkx6154FEm": {
-                        "children": [],
-                        "id": "CHART-Hkx6154FEm",
-                        "meta": {
-                            "chartId": 2225,
-                            "height": 30,
-                            "sliceName": "slice 1",
-                            "width": 4
-                        },
-                        "type": "CHART"
-                    },
-                    "GRID_ID": {
-                        "children": [
-                            "ROW-SyT19EFEQ"
-                        ],
-                        "id": "GRID_ID",
-                        "type": "GRID"
-                    },
-                    "ROOT_ID": {
-                        "children": [
-                            "GRID_ID"
-                        ],
-                        "id": "ROOT_ID",
-                        "type": "ROOT"
-                    },
-                    "ROW-SyT19EFEQ": {
-                        "children": [
-                            "CHART-Hkx6154FEm"
-                        ],
-                        "id": "ROW-SyT19EFEQ",
-                        "meta": {
-                            "background": "BACKGROUND_TRANSPARENT"
-                        },
-                        "type": "ROW"
-                    },
-                    "DASHBOARD_VERSION_KEY": "v2"
-                }
-                    """

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -37,6 +37,7 @@ from tests.dashboard_utils import (
     create_dashboard,
 )
 from tests.fixtures.certificates import ssl_certificate
+from tests.fixtures.unicode_dashboard import load_unicode_dashboard_with_position
 from tests.test_app import app
 
 
@@ -768,38 +769,7 @@ class TestDatabaseApi(SupersetTestCase):
         }
         self.assertEqual(response, expected_response)
 
-    @pytest.fixture()
-    def load_unicode_dashboard(self):
-        data = [
-            {"phrase": "Под"},
-            {"phrase": "řšž"},
-            {"phrase": "視野無限廣"},
-            {"phrase": "微風"},
-            {"phrase": "中国智造"},
-            {"phrase": "æøå"},
-            {"phrase": "ëœéè"},
-            {"phrase": "いろはにほ"},
-        ]
-        tbl_name = "unicode_test"
-
-        # generate date/numeric data
-        df = pd.DataFrame.from_dict(data)
-
-        with self.create_app().app_context():
-            database = get_example_database()
-            schema = {
-                "phrase": String(500),
-                "dttm": Date(),
-                "value": Float(),
-            }
-            obj = create_table_for_dashboard(df, tbl_name, database, schema)
-            obj.fetch_metadata()
-
-            db.session.commit()
-            position = "{}"
-            create_dashboard("unicode-test", "Unicode Test", position, None)
-
-    @pytest.mark.usefixtures("load_unicode_dashboard")
+    @pytest.mark.usefixtures("load_unicode_dashboard_with_position")
     def test_get_database_related_objects(self):
         """
         Database API: Test get chart and dashboard count related to a database

--- a/tests/fixtures/unicode_dashboard.py
+++ b/tests/fixtures/unicode_dashboard.py
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pandas as pd
+import pytest
+from pandas import DataFrame
+from sqlalchemy import String
+from sqlalchemy.engine import Engine
+
+from superset import db
+from superset.connectors.sqla.models import SqlaTable
+from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
+from superset.utils.core import get_example_database
+from tests.dashboard_utils import (
+    create_dashboard,
+    create_slice,
+    create_table_for_dashboard,
+)
+from tests.test_app import app
+
+
+@pytest.fixture()
+def load_unicode_dashboard_with_slice():
+    tbl_name = "unicode_test"
+    df = _get_dataframe()
+    with app.app_context():
+        yield _create_unicode_dashboard(df, tbl_name, "Unicode Cloud", None)
+
+        _cleanup()
+
+
+@pytest.fixture()
+def load_unicode_dashboard_with_position():
+    tbl_name = "unicode_test"
+    df = _get_dataframe()
+    position = "{}"
+    with app.app_context():
+        yield _create_unicode_dashboard(df, tbl_name, "Unicode Cloud", position)
+
+        _cleanup()
+
+
+def _get_dataframe():
+    data = _get_unicode_data()
+    return pd.DataFrame.from_dict(data)
+
+
+def _get_unicode_data():
+    return [
+        {"phrase": "Под"},
+        {"phrase": "řšž"},
+        {"phrase": "視野無限廣"},
+        {"phrase": "微風"},
+        {"phrase": "中国智造"},
+        {"phrase": "æøå"},
+        {"phrase": "ëœéè"},
+        {"phrase": "いろはにほ"},
+    ]
+
+
+def _create_unicode_dashboard(
+    df: DataFrame, tbl_name: str, slc_title: str, position: str
+) -> Dashboard:
+    database = get_example_database()
+    schema = {
+        "phrase": String(500),
+    }
+    obj = create_table_for_dashboard(df, tbl_name, database, schema)
+    obj.fetch_metadata()
+
+    tbl = obj
+
+    if slc_title:
+        slc = _create_and_commit_unicode_slice(tbl, slc_title)
+
+    return create_dashboard("unicode-test", "Unicode Test", position, slc)
+
+
+def _create_and_commit_unicode_slice(tbl: SqlaTable, title: str):
+    slc = create_slice(title, "word_cloud", tbl, {})
+    o = db.session.query(Slice).filter_by(slice_name=slc.slice_name).first()
+    if o:
+        db.session.delete(o)
+    db.session.add(slc)
+    db.session.commit()
+    return slc
+
+
+def _cleanup() -> None:
+    engine = get_example_database().get_sqla_engine()
+    engine.execute("DROP TABLE IF EXISTS unicode_test")
+    db.session.commit()

--- a/tests/fixtures/unicode_dashboard.py
+++ b/tests/fixtures/unicode_dashboard.py
@@ -78,10 +78,10 @@ def _create_unicode_dashboard(
     df: DataFrame, table_name: str, slice_title: str, position: str
 ) -> Dashboard:
     database = get_example_database()
-    schema = {
+    dtype = {
         "phrase": String(500),
     }
-    table = create_table_for_dashboard(df, table_name, database, schema)
+    table = create_table_for_dashboard(df, table_name, database, dtype)
     table.fetch_metadata()
 
     if slice_title:
@@ -92,7 +92,7 @@ def _create_unicode_dashboard(
 
 def _create_and_commit_unicode_slice(table: SqlaTable, title: str):
     slice = create_slice(title, "word_cloud", table, {})
-    o = db.session.query(Slice).filter_by(slice_name=slice.slice_name).first()
+    o = db.session.query(Slice).filter_by(slice_name=slice.slice_name).one_or_none()
     if o:
         db.session.delete(o)
     db.session.add(slice)
@@ -105,6 +105,6 @@ def _cleanup(dash: Dashboard, slice_name: str) -> None:
     engine.execute("DROP TABLE IF EXISTS unicode_test")
     db.session.delete(dash)
     if slice_name:
-        slice = db.session.query(Slice).filter_by(slice_name=slice_name).first()
+        slice = db.session.query(Slice).filter_by(slice_name=slice_name).one_or_none()
         db.session.delete(slice)
     db.session.commit()

--- a/tests/fixtures/unicode_dashboard.py
+++ b/tests/fixtures/unicode_dashboard.py
@@ -35,21 +35,21 @@ from tests.test_app import app
 
 @pytest.fixture()
 def load_unicode_dashboard_with_slice():
-    tbl_name = "unicode_test"
+    table_name = "unicode_test"
     df = _get_dataframe()
     with app.app_context():
-        yield _create_unicode_dashboard(df, tbl_name, "Unicode Cloud", None)
+        yield _create_unicode_dashboard(df, table_name, "Unicode Cloud", None)
 
         _cleanup()
 
 
 @pytest.fixture()
 def load_unicode_dashboard_with_position():
-    tbl_name = "unicode_test"
+    table_name = "unicode_test"
     df = _get_dataframe()
     position = "{}"
     with app.app_context():
-        yield _create_unicode_dashboard(df, tbl_name, "Unicode Cloud", position)
+        yield _create_unicode_dashboard(df, table_name, "Unicode Cloud", position)
 
         _cleanup()
 
@@ -73,31 +73,29 @@ def _get_unicode_data():
 
 
 def _create_unicode_dashboard(
-    df: DataFrame, tbl_name: str, slc_title: str, position: str
+    df: DataFrame, table_name: str, slice_title: str, position: str
 ) -> Dashboard:
     database = get_example_database()
     schema = {
         "phrase": String(500),
     }
-    obj = create_table_for_dashboard(df, tbl_name, database, schema)
-    obj.fetch_metadata()
+    table = create_table_for_dashboard(df, table_name, database, schema)
+    table.fetch_metadata()
 
-    tbl = obj
+    if slice_title:
+        slice = _create_and_commit_unicode_slice(table, slice_title)
 
-    if slc_title:
-        slc = _create_and_commit_unicode_slice(tbl, slc_title)
-
-    return create_dashboard("unicode-test", "Unicode Test", position, slc)
+    return create_dashboard("unicode-test", "Unicode Test", position, slice)
 
 
-def _create_and_commit_unicode_slice(tbl: SqlaTable, title: str):
-    slc = create_slice(title, "word_cloud", tbl, {})
-    o = db.session.query(Slice).filter_by(slice_name=slc.slice_name).first()
+def _create_and_commit_unicode_slice(table: SqlaTable, title: str):
+    slice = create_slice(title, "word_cloud", table, {})
+    o = db.session.query(Slice).filter_by(slice_name=slice.slice_name).first()
     if o:
         db.session.delete(o)
-    db.session.add(slc)
+    db.session.add(slice)
     db.session.commit()
-    return slc
+    return slice
 
 
 def _cleanup() -> None:

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -1158,7 +1158,7 @@ class TestRowLevelSecurity(SupersetTestCase):
             obj.fetch_metadata()
 
             tbl = obj
-            slc = create_slice(tbl, None)
+            slc = create_slice("Unicode Cloud", "word_cloud", tbl, None)
             o = db.session.query(Slice).filter_by(slice_name=slc.slice_name).first()
             if o:
                 db.session.delete(o)

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # isort:skip_file
+import datetime
 import inspect
 import re
 import unittest
@@ -23,6 +24,7 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import prison
 import pytest
+import random
 
 from flask import current_app, g
 from sqlalchemy import Float, Date, String
@@ -42,7 +44,6 @@ from .dashboard_utils import (
     create_table_for_dashboard,
     create_slice,
     create_dashboard,
-    add_datetime_value_to_data,
 )
 
 
@@ -1134,33 +1135,24 @@ class TestRowLevelSecurity(SupersetTestCase):
     @pytest.fixture()
     def load_unicode_dashboard(self):
         data = [
-            "Под",
-            "řšž",
-            "視野無限廣",
-            "微風",
-            "中国智造",
-            "æøå",
-            "ëœéè",
-            "いろはにほ",
-            "다람쥐",
-            "Чешће",
-            "ŕľšťýď",
-            "žšč",
-            "éúüñóá",
-            "كۆچەج",
+            {"phrase": "Под"},
+            {"phrase": "řšž"},
+            {"phrase": "視野無限廣"},
+            {"phrase": "微風"},
+            {"phrase": "中国智造"},
+            {"phrase": "æøå"},
+            {"phrase": "ëœéè"},
+            {"phrase": "いろはにほ"},
         ]
         tbl_name = "unicode_test"
 
         # generate date/numeric data
-        unicode_data_dict = add_datetime_value_to_data(data)
-        df = pd.DataFrame.from_dict(unicode_data_dict)
+        df = pd.DataFrame.from_dict(data)
 
         with self.create_app().app_context():
             database = get_example_database()
             schema = {
                 "phrase": String(500),
-                "dttm": Date(),
-                "value": Float(),
             }
             obj = create_table_for_dashboard(df, tbl_name, database, schema)
             obj.fetch_metadata()
@@ -1218,45 +1210,3 @@ class TestRowLevelSecurity(SupersetTestCase):
         assert not self.NAMES_B_REGEX.search(sql)
         assert not self.NAMES_Q_REGEX.search(sql)
         assert not self.BASE_FILTER_REGEX.search(sql)
-
-
-def _get_position():
-    return """{
-                    "CHART-Hkx6154FEm": {
-                        "children": [],
-                        "id": "CHART-Hkx6154FEm",
-                        "meta": {
-                            "chartId": 2225,
-                            "height": 30,
-                            "sliceName": "slice 1",
-                            "width": 4
-                        },
-                        "type": "CHART"
-                    },
-                    "GRID_ID": {
-                        "children": [
-                            "ROW-SyT19EFEQ"
-                        ],
-                        "id": "GRID_ID",
-                        "type": "GRID"
-                    },
-                    "ROOT_ID": {
-                        "children": [
-                            "GRID_ID"
-                        ],
-                        "id": "ROOT_ID",
-                        "type": "ROOT"
-                    },
-                    "ROW-SyT19EFEQ": {
-                        "children": [
-                            "CHART-Hkx6154FEm"
-                        ],
-                        "id": "ROW-SyT19EFEQ",
-                        "meta": {
-                            "background": "BACKGROUND_TRANSPARENT"
-                        },
-                        "type": "ROW"
-                    },
-                    "DASHBOARD_VERSION_KEY": "v2"
-                }
-                    """

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -227,7 +227,7 @@ class TestCacheWarmUp(SupersetTestCase):
             obj.fetch_metadata()
 
             tbl = obj
-            slc = create_slice(tbl, None)
+            slc = create_slice("Unicode Cloud", "word_cloud", tbl, None)
             o = db.session.query(Slice).filter_by(slice_name=slc.slice_name).first()
             if o:
                 db.session.delete(o)

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -16,11 +16,19 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset cache warmup"""
+
 import json
 from unittest.mock import MagicMock
+from sqlalchemy import String, Date, Float
 
-import tests.test_app
+import pytest
+import pandas as pd
+
+from superset.models.slice import Slice
+from superset.utils.core import get_example_database
+
 from superset import db
+
 from superset.models.core import Log
 from superset.models.tags import get_tag, ObjectTypes, TaggedObject, TagTypes
 from superset.tasks.cache import (
@@ -30,6 +38,12 @@ from superset.tasks.cache import (
 )
 
 from .base_tests import SupersetTestCase
+from .dashboard_utils import (
+    create_dashboard,
+    create_slice,
+    create_table_for_dashboard,
+    add_datetime_value_to_data,
+)
 
 URL_PREFIX = "http://0.0.0.0:8081"
 
@@ -193,6 +207,51 @@ class TestCacheWarmUp(SupersetTestCase):
                 db.session.delete(o)
             db.session.commit()
 
+    @pytest.fixture()
+    def load_unicode_dashboard(self):
+        data = [
+            "Под",
+            "řšž",
+            "視野無限廣",
+            "微風",
+            "中国智造",
+            "æøå",
+            "ëœéè",
+            "いろはにほ",
+            "다람쥐",
+            "Чешће",
+            "ŕľšťýď",
+            "žšč",
+            "éúüñóá",
+            "كۆچەج",
+        ]
+        tbl_name = "unicode_test"
+
+        # generate date/numeric data
+        unicode_data_dict = add_datetime_value_to_data(data)
+        df = pd.DataFrame.from_dict(unicode_data_dict)
+
+        with self.create_app().app_context():
+            database = get_example_database()
+            schema = {
+                "phrase": String(500),
+                "dttm": Date(),
+                "value": Float(),
+            }
+            obj = create_table_for_dashboard(df, tbl_name, database, schema)
+            obj.fetch_metadata()
+
+            tbl = obj
+            slc = create_slice(tbl, None)
+            o = db.session.query(Slice).filter_by(slice_name=slc.slice_name).first()
+            if o:
+                db.session.delete(o)
+            db.session.add(slc)
+
+            db.session.commit()
+            create_dashboard("unicode-test", "Unicode Test", None, slc)
+
+    @pytest.mark.usefixtures("load_unicode_dashboard")
     def test_dashboard_tags(self):
         tag1 = get_tag("tag1", db.session, TagTypes.custom)
         # delete first to make test idempotent
@@ -242,3 +301,45 @@ class TestCacheWarmUp(SupersetTestCase):
         result = sorted(strategy.get_urls())
         expected = sorted(tag1_urls + tag2_urls)
         self.assertEqual(result, expected)
+
+
+def _get_position():
+    return """{
+                    "CHART-Hkx6154FEm": {
+                        "children": [],
+                        "id": "CHART-Hkx6154FEm",
+                        "meta": {
+                            "chartId": 2225,
+                            "height": 30,
+                            "sliceName": "slice 1",
+                            "width": 4
+                        },
+                        "type": "CHART"
+                    },
+                    "GRID_ID": {
+                        "children": [
+                            "ROW-SyT19EFEQ"
+                        ],
+                        "id": "GRID_ID",
+                        "type": "GRID"
+                    },
+                    "ROOT_ID": {
+                        "children": [
+                            "GRID_ID"
+                        ],
+                        "id": "ROOT_ID",
+                        "type": "ROOT"
+                    },
+                    "ROW-SyT19EFEQ": {
+                        "children": [
+                            "CHART-Hkx6154FEm"
+                        ],
+                        "id": "ROW-SyT19EFEQ",
+                        "meta": {
+                            "background": "BACKGROUND_TRANSPARENT"
+                        },
+                        "type": "ROW"
+                    },
+                    "DASHBOARD_VERSION_KEY": "v2"
+                }
+                    """

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -16,9 +16,11 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset cache warmup"""
-
+import datetime
 import json
 from unittest.mock import MagicMock
+
+import random
 from sqlalchemy import String, Date, Float
 
 import pytest
@@ -38,12 +40,7 @@ from superset.tasks.cache import (
 )
 
 from .base_tests import SupersetTestCase
-from .dashboard_utils import (
-    create_dashboard,
-    create_slice,
-    create_table_for_dashboard,
-    add_datetime_value_to_data,
-)
+from .dashboard_utils import create_dashboard, create_slice, create_table_for_dashboard
 
 URL_PREFIX = "http://0.0.0.0:8081"
 
@@ -210,34 +207,22 @@ class TestCacheWarmUp(SupersetTestCase):
     @pytest.fixture()
     def load_unicode_dashboard(self):
         data = [
-            "Под",
-            "řšž",
-            "視野無限廣",
-            "微風",
-            "中国智造",
-            "æøå",
-            "ëœéè",
-            "いろはにほ",
-            "다람쥐",
-            "Чешће",
-            "ŕľšťýď",
-            "žšč",
-            "éúüñóá",
-            "كۆچەج",
+            {"phrase": "Под"},
+            {"phrase": "řšž"},
+            {"phrase": "視野無限廣"},
+            {"phrase": "微風"},
+            {"phrase": "中国智造"},
+            {"phrase": "æøå"},
+            {"phrase": "ëœéè"},
+            {"phrase": "いろはにほ"},
         ]
         tbl_name = "unicode_test"
 
-        # generate date/numeric data
-        unicode_data_dict = add_datetime_value_to_data(data)
-        df = pd.DataFrame.from_dict(unicode_data_dict)
+        df = pd.DataFrame.from_dict(data)
 
         with self.create_app().app_context():
             database = get_example_database()
-            schema = {
-                "phrase": String(500),
-                "dttm": Date(),
-                "value": Float(),
-            }
+            schema = {"phrase": String(500)}
             obj = create_table_for_dashboard(df, tbl_name, database, schema)
             obj.fetch_metadata()
 
@@ -301,45 +286,3 @@ class TestCacheWarmUp(SupersetTestCase):
         result = sorted(strategy.get_urls())
         expected = sorted(tag1_urls + tag2_urls)
         self.assertEqual(result, expected)
-
-
-def _get_position():
-    return """{
-                    "CHART-Hkx6154FEm": {
-                        "children": [],
-                        "id": "CHART-Hkx6154FEm",
-                        "meta": {
-                            "chartId": 2225,
-                            "height": 30,
-                            "sliceName": "slice 1",
-                            "width": 4
-                        },
-                        "type": "CHART"
-                    },
-                    "GRID_ID": {
-                        "children": [
-                            "ROW-SyT19EFEQ"
-                        ],
-                        "id": "GRID_ID",
-                        "type": "GRID"
-                    },
-                    "ROOT_ID": {
-                        "children": [
-                            "GRID_ID"
-                        ],
-                        "id": "ROOT_ID",
-                        "type": "ROOT"
-                    },
-                    "ROW-SyT19EFEQ": {
-                        "children": [
-                            "CHART-Hkx6154FEm"
-                        ],
-                        "id": "ROW-SyT19EFEQ",
-                        "meta": {
-                            "background": "BACKGROUND_TRANSPARENT"
-                        },
-                        "type": "ROW"
-                    },
-                    "DASHBOARD_VERSION_KEY": "v2"
-                }
-                    """

--- a/tests/strategy_tests.py
+++ b/tests/strategy_tests.py
@@ -20,7 +20,6 @@ import datetime
 import json
 from unittest.mock import MagicMock
 
-import random
 from sqlalchemy import String, Date, Float
 
 import pytest
@@ -41,6 +40,7 @@ from superset.tasks.cache import (
 
 from .base_tests import SupersetTestCase
 from .dashboard_utils import create_dashboard, create_slice, create_table_for_dashboard
+from .fixtures.unicode_dashboard import load_unicode_dashboard_with_slice
 
 URL_PREFIX = "http://0.0.0.0:8081"
 
@@ -204,39 +204,7 @@ class TestCacheWarmUp(SupersetTestCase):
                 db.session.delete(o)
             db.session.commit()
 
-    @pytest.fixture()
-    def load_unicode_dashboard(self):
-        data = [
-            {"phrase": "Под"},
-            {"phrase": "řšž"},
-            {"phrase": "視野無限廣"},
-            {"phrase": "微風"},
-            {"phrase": "中国智造"},
-            {"phrase": "æøå"},
-            {"phrase": "ëœéè"},
-            {"phrase": "いろはにほ"},
-        ]
-        tbl_name = "unicode_test"
-
-        df = pd.DataFrame.from_dict(data)
-
-        with self.create_app().app_context():
-            database = get_example_database()
-            schema = {"phrase": String(500)}
-            obj = create_table_for_dashboard(df, tbl_name, database, schema)
-            obj.fetch_metadata()
-
-            tbl = obj
-            slc = create_slice("Unicode Cloud", "word_cloud", tbl, None)
-            o = db.session.query(Slice).filter_by(slice_name=slc.slice_name).first()
-            if o:
-                db.session.delete(o)
-            db.session.add(slc)
-
-            db.session.commit()
-            create_dashboard("unicode-test", "Unicode Test", None, slc)
-
-    @pytest.mark.usefixtures("load_unicode_dashboard")
+    @pytest.mark.usefixtures("load_unicode_dashboard_with_slice")
     def test_dashboard_tags(self):
         tag1 = get_tag("tag1", db.session, TagTypes.custom)
         # delete first to make test idempotent


### PR DESCRIPTION
### SUMMARY
To improve development of unit/integration tests development, here is suggestion of removing `unicode_test` project examples loaded in tests setup and replacing it with fixtures that creates dashboard with sample of unicode data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
