### PR TITLE
fix: Alembic migration 18532d70ab98

### DIFF
--- a/superset/migrations/versions/18532d70ab98_fix_table_unique_constraint_in_mysql.py
+++ b/superset/migrations/versions/18532d70ab98_fix_table_unique_constraint_in_mysql.py
@@ -28,14 +28,22 @@ down_revision = "3fbbc6e8d654"
 
 from alembic import op
 from sqlalchemy.dialects.mysql.base import MySQLDialect
+from sqlalchemy.engine.reflection import Inspector
+
+from superset.utils.core import generic_find_uq_constraint_name
 
 
 def upgrade():
     bind = op.get_bind()
+
+    # Uniqueness constraint if present only exists in MySQL.
     if isinstance(bind.dialect, MySQLDialect):
-        # index only exists in mysql db
-        with op.get_context().autocommit_block():
-            op.drop_constraint("table_name", "tables", type_="unique")
+        constraint_name = generic_find_uq_constraint_name(
+            "tables", {"table_name"}, Inspector.from_engine(bind)
+        )
+
+        if constraint_name:
+            op.drop_constraint(constraint_name, "tables", type_="unique")
 
 
 def downgrade():


### PR DESCRIPTION
### SUMMARY

This PR reverts some of the logic from [this](https://github.com/apache/incubator-superset/commit/50d80405a90c9c79f2a00b2c22cc6c1fdc333012) commit as it seems that this constraint may not exist for all MySQL deployments resulting in the migration to fail.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Ran 

```
superset db upgrade
superset db downgrade
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [x] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
