### PR TITLE
fix: enable consistent etag across workers and force no-cache for dashboards

### DIFF
--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -114,18 +114,19 @@ def etag_cache(
                 response = f(*args, **kwargs)
                 response.last_modified = content_changed_time
 
-                # only set Expires header if required
+                # when needed, instruct the browser to always revalidate cache
                 if must_revalidate:
-                    # Cache-Control: no-cache asks the browser to always store the cache,
+                    # `Cache-Control: no-cache` asks the browser to always store the cache,
                     # but also must validate it with the server.
                     response.cache_control.no_cache = True
                 else:
-                    # Cache-Control: Public asks the browser to always store the cache
+                    # `Cache-Control: Public` asks the browser to always store the cache
                     response.cache_control.public = True
-                    expiration = max_age if max_age != 0 else FAR_FUTURE
-                    response.expires = response.last_modified + timedelta(
-                        seconds=expiration
-                    )
+
+                expiration = max_age if max_age != 0 else FAR_FUTURE
+                response.expires = response.last_modified + timedelta(
+                    seconds=expiration
+                )
 
                 response.add_etag()
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -171,6 +171,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     logger = logging.getLogger(__name__)
 
+    def __repr__(self):
+        """Determinate string representation of the view instance for etag_cache."""
+        return "Superset.views.core.Superset@v{}{}".format(
+            self.appbuilder.app.config["VERSION_STRING"],
+            self.appbuilder.app.config["VERSION_SHA"],
+        )
+
     @has_access_api
     @expose("/datasources/")
     def datasources(self) -> FlaskResponse:
@@ -1605,6 +1612,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         skip=lambda _self, dashboard_id_or_slug: not is_feature_enabled(
             "ENABLE_DASHBOARD_ETAG_HEADER"
         ),
+        must_revalidate=True,
     )
     @expose("/dashboard/<dashboard_id_or_slug>/")
     def dashboard(  # pylint: disable=too-many-locals

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1606,7 +1606,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @etag_cache(
-        CACHE_DEFAULT_TIMEOUT,
+        0,
         check_perms=check_dashboard_perms,
         get_last_modified=get_dashboard_changedon_dt,
         skip=lambda _self, dashboard_id_or_slug: not is_feature_enabled(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1606,7 +1606,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @etag_cache(
-        0,
+        CACHE_DEFAULT_TIMEOUT,
         check_perms=check_dashboard_perms,
         get_last_modified=get_dashboard_changedon_dt,
         skip=lambda _self, dashboard_id_or_slug: not is_feature_enabled(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -171,7 +171,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     logger = logging.getLogger(__name__)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Determinate string representation of the view instance for etag_cache."""
         return "Superset.views.core.Superset@v{}{}".format(
             self.appbuilder.app.config["VERSION_STRING"],


### PR DESCRIPTION
### SUMMARY

This PR fixes a bug in #7032 and #10963 where different ETags are generated for requests to different running Superset instances even when the underlying data are the same. Currently new ETags will be generated every time Flask is restarted or when there are multiple WSGI workers running at the same time (either via gunicorn or some other tools).

Also added `cache-control: no-cache` for dashboards so that the browser always asks the server to validate data freshness, instead of serving disk cache sometimes.

#### Problem

When running Superset behind Gunicorn with multiple workers, each worker instance generates different ETags in `etag_cache`, making the ETags much less useful because when visiting the same page, users would often hit a different worker on each request, then constantly invalidate previous Etags from other workers.

This is because `flask_caching` memoization does not work well with [class instance methods](https://github.com/apache/incubator-superset/blob/5f145ac2aab74b3c9f00d97800aaa5899678a499/superset/views/core.py#L517-L520). In `_memoize_make_cache_key`, [positional arguments are used to generate cache keys](https://github.com/sh4nks/flask-caching/blob/e81c0b9c11ab66e3ab05538f36417a64f2b37a25/flask_caching/__init__.py#L650-L657
), but for a class instance method, the first argument will always be `self`, which by default is formatted to a unique string with memory locations. E.g.

```
<superset.views.core.Superset object at 0x7ffb67416a50>
```

#### Solution

Give `superset.views.core.Superset` a determinate `__repr__` string so that the cache keys generated by `flask_caching` can be more stable. I'm using app version string since it makes sense to invalidate the cache every time Superset is upgraded.

So instead of generating the following cache key update string [here]([here](https://github.com/sh4nks/flask-caching/blob/v1.9.0/flask_caching/__init__.py#L657)):

```
superset.views.core.Superset.dashboard('<superset.views.core.Superset object at 0x7ffb67416a50>', '15634')OrderedDict()
```

it will generates something like this:

```
superset.views.core.Superset.dashboard('Superset.views.core.Superset@v0.999.0dev', '15634')OrderedDict()
```

### BEFORE/AFTER SCREENSHOTS

#### Before

Second visit to a dashboard page uses disk cache if not a refresh:

<img src="https://user-images.githubusercontent.com/335541/94875266-2a8c8100-0409-11eb-80a6-8770b2334e1d.png" width="450" />

A refresh request (almost) always returns 200.

#### After

Second and subsequent visits to a dashboard page (regardless whether is a refresh or not) correctly make a roundtrip request to the server and the server correctly returns HTTP 304 (not modified).

<img src="https://user-images.githubusercontent.com/335541/94875844-c4086280-040a-11eb-8c50-aa647ccf82d1.png" width="450" />

### TEST PLAN

1. Start Superset with gunicorn and multiple workers
   ```
    gunicorn \
      --bind 0.0.0.0:8089 \
      --workers 5 \
      "superset.app:create_app()"
   ```
2. Visit the dashboard page and refresh the page multiple times. DO NOT disable browser cache.
3. Previously you will almost always see HTTP 200 responses, with this fix, you should see HTTP 304 since the second request and most subsequent page loads are going to be much faster.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Some caveats:

1. Not sure `__repr__` is used in other places, but I doubt they will require memory locations and version string is not enough.
2. For custom Superset builds with fixed `VERSION_STRING` and `VERSION_SHA`, i.e., not tied to Git SHAs or official Superset versions (e.g. when build the exported `incubator-superset` outside of Git, it will use the default 0.999.0dev from `package.json`),  users might be served with stale cache if:
   1. It has been less than CACHE_DEFAULT_TIMEOUT (default to 1 day) since user's last visit to a dashboard page
   2. A new Superset version is deployed and some code related to the dashboard view has changed
   3. The dashboard and related slices haven't been updated.