### PR TITLE
style: override ace edit error icon

### DIFF
--- a/superset-frontend/images/icons/error_solid_small_red.svg
+++ b/superset-frontend/images/icons/error_solid_small_red.svg
@@ -1,0 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17.826 9.336L14.664 6.174C14.549 6.06436 14.3969 6.00221 14.238 6H9.762C9.60314 6.00221 9.45098 6.06436 9.336 6.174L6.174 9.336C6.06436 9.45098 6.00221 9.60314 6 9.762V14.238C6.00221 14.3969 6.06436 14.549 6.174 14.664L9.336 17.826C9.45098 17.9356 9.60314 17.9978 9.762 18H14.238C14.3969 17.9978 14.549 17.9356 14.664 17.826L17.826 14.664C17.9356 14.549 17.9978 14.3969 18 14.238V9.762C17.9978 9.60314 17.9356 9.45098 17.826 9.336Z" fill="#E04355"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11 8.83333C11 8.3731 11.4477 8 12 8C12.5523 8 13 8.3731 13 8.83333V12.1667C13 12.6269 12.5523 13 12 13C11.4477 13 11 12.6269 11 12.1667V8.83333ZM11 15C11 14.4477 11.4477 14 12 14C12.5523 14 13 14.4477 13 15C13 15.5523 12.5523 16 12 16C11.4477 16 11 15.5523 11 15Z" fill="white"/>
+</svg>

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -588,5 +588,5 @@ hr {
 }
 .ace_gutter-cell.ace_error {
   background-image: url('../images/icons/error_solid_small_red.svg') !important;
-  background-position: 0 center !important;
+  background-position: -2px center !important;
 }

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -586,3 +586,7 @@ input[type='radio']:checked:after {
 hr {
   border-top: 1px solid @gray-light;
 }
+.ace_gutter-cell.ace_error {
+  background-image: url('../images/icons/error_solid_small_red.svg') !important;
+  background-position: 0 center !important;
+}

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -369,7 +369,7 @@ const config = {
         issuer: {
           test: /\.(j|t)sx?$/,
         },
-        use: ['babel-loader', '@svgr/webpack', 'url-loader'],
+        use: ['@svgr/webpack'],
       },
       {
         test: /\.(jpg|gif)$/,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -369,7 +369,7 @@ const config = {
         issuer: {
           test: /\.(j|t)sx?$/,
         },
-        use: ['@svgr/webpack'],
+        use: ['babel-loader', '@svgr/webpack', 'url-loader'],
       },
       {
         test: /\.(jpg|gif)$/,
@@ -386,6 +386,9 @@ const config = {
       {
         test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         loader: 'file-loader',
+        options: {
+          esModule: false,
+        },
       },
     ],
   },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
replace the ace editor gutter error icon with the SIP-34 error icon.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before:
<img width="894" alt="Screen Shot 2020-10-01 at 9 15 10 PM" src="https://user-images.githubusercontent.com/10255196/94887568-88ca5b80-042b-11eb-9874-4d186a2d27df.png">

after:
<img width="388" alt="Screen Shot 2020-10-01 at 9 15 49 PM" src="https://user-images.githubusercontent.com/10255196/94887589-967fe100-042b-11eb-85e0-6cbdb2aa8b9a.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- 👀 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
