### PR TITLE
docs: docs site footer link tweak

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,7 +19,7 @@
 ---
 github:
   description: "Apache Superset is a Data Visualization and Data Exploration Platform"
-  homepage: https://superset.apache.org/
+  homepage: https://superset.incubator.apache.org/
   labels:
     - superset
     - apache

--- a/docs/.htaccess
+++ b/docs/.htaccess
@@ -18,3 +18,6 @@
 RewriteEngine On
 RewriteCond %{SERVER_PORT} 80
 RewriteRule ^(.*)$ https://superset.apache.org/$1 [R,L]
+
+RewriteCond %{HTTP_HOST} ^superset.incubator.apache.org$ [NC]
+RewriteRule ^(.*)$ https://superset.apache.org/$1 [R=301,L]

--- a/docs/.htaccess
+++ b/docs/.htaccess
@@ -18,6 +18,3 @@
 RewriteEngine On
 RewriteCond %{SERVER_PORT} 80
 RewriteRule ^(.*)$ https://superset.apache.org/$1 [R,L]
-
-RewriteCond %{HTTP_HOST} ^superset.incubator.apache.org$ [NC]
-RewriteRule ^(.*)$ https://superset.apache.org/$1 [R=301,L]

--- a/docs/src/components/footer.tsx
+++ b/docs/src/components/footer.tsx
@@ -180,7 +180,7 @@ const LayoutFooter = () => (
         target="_blank"
         rel="noreferrer"
       >
-        Licenses
+        License
       </a>
     </div>
   </Footer>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Trying to turn this red bar green. Apparently the link is "/licenses" but the link text expected is "License"
![image](https://user-images.githubusercontent.com/812905/94892512-ae5e6180-0439-11eb-8beb-543eb0108c08.png)

Also adding 'incubator' to the URL in `asf.yaml` in hopes that we can turn this orange bar green (a bit of a shot in the dark 🤞):
![image](https://user-images.githubusercontent.com/812905/94892706-32b0e480-043a-11eb-89e0-01aef6928ec4.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
