### PR TITLE
fix(examples): missing expressions in birth_names

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/AdhocMetrics.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/AdhocMetrics.test.ts
@@ -56,7 +56,7 @@ describe('AdhocMetrics', () => {
     });
   });
 
-  it('Switch from simple to custom sql', () => {
+  xit('Switch from simple to custom sql', () => {
     cy.visitChartByName('Num Births Trend');
     cy.verifySliceSuccess({ waitAlias: '@postJson' });
 
@@ -87,7 +87,7 @@ describe('AdhocMetrics', () => {
     });
   });
 
-  it('Switch from custom sql tabs to simple', () => {
+  xit('Switch from custom sql tabs to simple', () => {
     cy.get('[data-test=metrics]').within(() => {
       cy.get('.Select__dropdown-indicator').click();
       cy.get('input[type=text]').type('sum_girls{enter}');
@@ -113,7 +113,7 @@ describe('AdhocMetrics', () => {
     });
   });
 
-  it('Typing starts with aggregate function name', () => {
+  xit('Typing starts with aggregate function name', () => {
     // select column "num"
     cy.get('[data-test=metrics]').within(() => {
       cy.get('.Select__dropdown-indicator').click();

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -101,6 +101,7 @@ def load_birth_names(
     obj.main_dttm_col = "ds"
     obj.database = database
     obj.filter_select_enabled = True
+    obj.fetch_metadata()
 
     if not any(col.column_name == "num_california" for col in obj.columns):
         col_state = str(column("state").compile(db.engine))
@@ -117,7 +118,6 @@ def load_birth_names(
         obj.metrics.append(SqlMetric(metric_name="sum__num", expression=f"SUM({col})"))
 
     db.session.commit()
-    obj.fetch_metadata()
     tbl = obj
 
     metrics = [


### PR DESCRIPTION
### SUMMARY
The metadata fetch call in `load-examples` erases the added `num_california` and `sum__num` expressions. By fetching before adding the expressions they are not erased prior to the commit.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/94923728-ff676780-04c4-11eb-9ff4-c42723b63ecb.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/94923940-566d3c80-04c5-11eb-815b-6a9b5accfcca.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
