### PR TITLE
fix: Adding authlib as a requirement package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
     zip_safe=False,
     entry_points={"console_scripts": ["superset=superset.cli:superset"]},
     install_requires=[
+        "authlib",
         "backoff>=1.8.0",
         "bleach>=3.0.2, <4.0.0",
         "cachelib>=0.1.1,<0.2",


### PR DESCRIPTION
### SUMMARY
Adding `authlib` as a required package. In the documentation, superset supports Oauth, but since authlib is now separated from flask, this is required if one wants to use authlib.

### TEST PLAN
Tested by building via docker and importing authlib package via:
`superset/config.py line 37`
```
from flask_appbuilder.security.manager import AUTH_DB, AUTH_OAUTH
```
Allows one to set up oauth correctly.
