### PR TITLE
fix: Fix Time Column dropdown for date filter

### DIFF
--- a/superset-frontend/spec/javascripts/explore/fixtures.jsx
+++ b/superset-frontend/spec/javascripts/explore/fixtures.jsx
@@ -18,7 +18,8 @@
  */
 
 import React from 'react';
-import { ColumnOption, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
+import { ColumnOption } from '@superset-ui/chart-controls';
 
 export const controlPanelSectionsChartOptions = [
   {

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -63,9 +63,8 @@ import {
   getSequentialSchemeRegistry,
   legacyValidateInteger,
   validateNonEmpty,
-  ColumnOption,
 } from '@superset-ui/core';
-
+import { ColumnOption } from '@superset-ui/chart-controls';
 import { formatSelectOptions, mainMetric } from 'src/modules/utils';
 import { TIME_FILTER_LABELS } from './constants';
 


### PR DESCRIPTION
### SUMMARY
Steps to reproduce this issue:
1. create a date filter.
2. check **SHOW SQL TIME COLUMN** checkbox.
3. click on dropdown list in the filter: throw js error as shown below.

### BEFORE
<img width="1228" alt="Screen Shot 2020-09-28 at 3 45 07 PM" src="https://user-images.githubusercontent.com/27990562/94980177-19f90b00-04dc-11eb-9445-5cceb7d2de0f.png">

### AFTER
<img width="1244" alt="Screen Shot 2020-10-02 at 6 20 44 PM" src="https://user-images.githubusercontent.com/27990562/94980184-28472700-04dc-11eb-9539-597b0094b4cd.png">

cc @etr2460 @ktmud @mistercrunch 
