### PR TITLE
fix: questioning a few lines that force an ORDER clause

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -180,7 +180,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
         Header: (
           <TooltipWrapper
             label="allow-dml-header"
-            tooltip={t('Allow Data Danipulation Language')}
+            tooltip={t('Allow Data Manipulation Language')}
             placement="top"
           >
             <span>{t('DML')}</span>

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1082,9 +1082,6 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             qry = qry.where(and_(*where_clause_and))
         qry = qry.having(and_(*having_clause_and))
 
-        if not orderby and ((is_sip_38 and metrics) or (not is_sip_38 and not columns)):
-            orderby = [(main_metric_expr, not order_desc)]
-
         # To ensure correct handling of the ORDER BY labeling we need to reference the
         # metric instance if defined in the SELECT clause.
         metrics_exprs_by_label = {

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -724,6 +724,10 @@ class TableViz(BaseViz):
                 if sort_by_label not in d["metrics"]:
                     d["metrics"].append(sort_by)
                 d["orderby"] = [(sort_by, not fd.get("order_desc", True))]
+            elif d["metrics"]:
+                # Legacy behavior of sorting by first metric by default
+                first_metric = d["metrics"][0]
+                d["orderby"] = [(first_metric, not fd.get("order_desc", True))]
         return d
 
     def get_data(self, df: pd.DataFrame) -> VizData:


### PR DESCRIPTION
### SUMMARY

I'm questioning the need for these 2 lines here, and would like to understand what they are about. It seems like this should be handled by the caller if/when needed.

There's nothing really wrong about doing the unnecessary sort apart for the extra cost on the database backend. In the case of the line chart, it may make more sense to sort on time DESC [if anything] to make the forced row LIMIT to show something more consistent.

## before
<img width="1114" alt="Screen Shot 2020-10-03 at 9 39 34 AM" src="https://user-images.githubusercontent.com/487433/94996908-5ff5b380-055c-11eb-844c-7f7cd2f70715.png">

## after
<img width="1028" alt="Screen Shot 2020-10-03 at 9 33 47 AM" src="https://user-images.githubusercontent.com/487433/94996909-608e4a00-055c-11eb-9425-e18ef0a48fd7.png">
