### PR TITLE
chore: cleanup FAB update perms

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,8 @@ assists people when migrating to a new version.
 
 ## Next
 
+* [11155](https://github.com/apache/incubator-superset/pull/11155): The `FAB_UPDATE_PERMS` config parameter is no longer required as the Superset application correctly informs FAB under which context permissions should be updated.
+
 * [10887](https://github.com/apache/incubator-superset/pull/10887): Breaking change: The custom cache backend changed in order to support the Flask-Caching factory method approach and thus must be registered as a custom type. See [here](https://flask-caching.readthedocs.io/en/latest/#custom-cache-backends) for specifics.
 
 * [10674](https://github.com/apache/incubator-superset/pull/10674): Breaking change: PUBLIC_ROLE_LIKE_GAMMA was removed is favour of the new PUBLIC_ROLE_LIKE so it can be set it whatever role you want.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -276,23 +276,6 @@ server (`superset run` or `flask run`) is not intended for production use.
 If not using gunicorn, you may want to disable the use of flask-compress
 by setting `COMPRESS_REGISTER = False` in your `superset_config.py`
 
-Flask-AppBuilder Permissions
-----------------------------
-
-By default, every time the Flask-AppBuilder (FAB) app is initialized the
-permissions and views are added automatically to the backend and associated with
-the ‘Admin’ role. The issue, however, is when you are running multiple concurrent
-workers this creates a lot of contention and race conditions when defining
-permissions and views.
-
-To alleviate this issue, the automatic updating of permissions can be disabled
-by setting `FAB_UPDATE_PERMS = False` (defaults to True).
-
-In a production environment initialization could take on the following form:
-
-  superset init
-  gunicorn -w 10 ... superset:app
-
 Configuration behind a load balancer
 ------------------------------------
 

--- a/docs/src/pages/docs/installation/configuring.mdx
+++ b/docs/src/pages/docs/installation/configuring.mdx
@@ -65,22 +65,6 @@ you can add the endpoints to `WTF_CSRF_EXEMPT_LIST`:
 WTF_CSRF_EXEMPT_LIST = [‘’]
 ```
 
-### Flask AppBuilder Permissions
-
-By default, every time the Flask-AppBuilder (FAB) app is initialized the permissions and views are
-added automatically to the backend and associated with the ‘Admin’ role. The issue, however, is when
-you are running multiple concurrent workers this creates a lot of contention and race conditions
-when defining permissions and views.
-
-To alleviate this issue, the automatic updating of permissions can be disabled by setting
-`FAB_UPDATE_PERMS = False` (defaults to True).
-
-In a production environment initialization could take on the following form:
-
-```
-superset init gunicorn -w 10 … superset:app
-```
-
 ### Running on a WSGI HTTP Server
 
 While you can run Superset on NGINX or Apache, we recommend using Gunicorn in async mode. This

--- a/superset/app.py
+++ b/superset/app.py
@@ -552,7 +552,6 @@ class SupersetAppInitializer:
         appbuilder.indexview = SupersetIndexView
         appbuilder.base_template = "superset/base.html"
         appbuilder.security_manager_class = custom_sm
-        appbuilder.update_perms = False
         appbuilder.init_app(self.flask_app, db.session)
 
     def configure_url_map_converters(self) -> None:

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -22,7 +22,6 @@ class CacheManager:
     def __init__(self) -> None:
         super().__init__()
 
-<<<<<<< HEAD
         self._cache = Cache()
         self._tables_cache = Cache()
         self._thumbnail_cache = Cache()
@@ -31,26 +30,6 @@ class CacheManager:
         self._cache.init_app(app, app.config["CACHE_CONFIG"])
         self._tables_cache.init_app(app, app.config["TABLE_NAMES_CACHE_CONFIG"])
         self._thumbnail_cache.init_app(app, app.config["THUMBNAIL_CACHE_CONFIG"])
-=======
-        self._cache = self._setup_cache(app.config["CACHE_CONFIG"])
-        self._tables_cache = self._setup_cache(app.config["TABLE_NAMES_CACHE_CONFIG"])
-        self._thumbnail_cache = self._setup_cache(app.config["THUMBNAIL_CACHE_CONFIG"])
-
-    def init_app(self, app: Flask) -> None:
-        self._cache.init_app(app)
-        self._tables_cache.init_app(app)
-        self._thumbnail_cache.init_app(app)
-
-    @staticmethod
-    def _setup_cache(cache_config: CacheConfig) -> Cache:
-        """Setup the flask-cache on a flask app"""
-        if isinstance(cache_config, dict):
-            return Cache(config=cache_config)
-
-        # Accepts a custom cache initialization function, returning an object compatible
-        # with Flask-Caching API.
-        return cache_config()
->>>>>>> f4db8315a... chore: Using cache factory method
 
     @property
     def tables_cache(self) -> Cache:

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -22,6 +22,7 @@ class CacheManager:
     def __init__(self) -> None:
         super().__init__()
 
+<<<<<<< HEAD
         self._cache = Cache()
         self._tables_cache = Cache()
         self._thumbnail_cache = Cache()
@@ -30,6 +31,26 @@ class CacheManager:
         self._cache.init_app(app, app.config["CACHE_CONFIG"])
         self._tables_cache.init_app(app, app.config["TABLE_NAMES_CACHE_CONFIG"])
         self._thumbnail_cache.init_app(app, app.config["THUMBNAIL_CACHE_CONFIG"])
+=======
+        self._cache = self._setup_cache(app.config["CACHE_CONFIG"])
+        self._tables_cache = self._setup_cache(app.config["TABLE_NAMES_CACHE_CONFIG"])
+        self._thumbnail_cache = self._setup_cache(app.config["THUMBNAIL_CACHE_CONFIG"])
+
+    def init_app(self, app: Flask) -> None:
+        self._cache.init_app(app)
+        self._tables_cache.init_app(app)
+        self._thumbnail_cache.init_app(app)
+
+    @staticmethod
+    def _setup_cache(cache_config: CacheConfig) -> Cache:
+        """Setup the flask-cache on a flask app"""
+        if isinstance(cache_config, dict):
+            return Cache(config=cache_config)
+
+        # Accepts a custom cache initialization function, returning an object compatible
+        # with Flask-Caching API.
+        return cache_config()
+>>>>>>> f4db8315a... chore: Using cache factory method
 
     @property
     def tables_cache(self) -> Cache:


### PR DESCRIPTION
### SUMMARY

Superset has now configured FAB correctly in terms of when permissions should be updated, i.e., by default they shouldn't (per [here](https://github.com/apache/incubator-superset/blob/3a08fd04f3f9ebaaa48fa554028c26062de42f02/superset/extensions.py#L135)) and only updated when running `superset init` (per [here](https://github.com/apache/incubator-superset/blob/ac2937a6c58b63c2723917a1cd111a8363a728a0/superset/cli.py#L74)) and thus it seems the documentation regarding `FAB_UPDATE_PERMS` is obsolete (it was originally added for a use case prior to FAB 2.0).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
