### PR TITLE
fix: save query modal/button styling + convert to ant-d modal

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/SaveQuery_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/SaveQuery_spec.jsx
@@ -21,7 +21,7 @@ import { FormControl } from 'react-bootstrap';
 import { shallow } from 'enzyme';
 import * as sinon from 'sinon';
 import SaveQuery from 'src/SqlLab/components/SaveQuery';
-import ModalTrigger from 'src/components/ModalTrigger';
+import Modal from 'src/common/components/Modal';
 import Button from 'src/components/Button';
 
 describe('SavedQuery', () => {
@@ -40,9 +40,9 @@ describe('SavedQuery', () => {
   it('is valid with props', () => {
     expect(React.isValidElement(<SaveQuery {...mockedProps} />)).toBe(true);
   });
-  it('has a ModalTrigger', () => {
+  it('has a Modal', () => {
     const wrapper = shallow(<SaveQuery {...mockedProps} />);
-    expect(wrapper.find(ModalTrigger)).toExist();
+    expect(wrapper.find(Modal)).toExist();
   });
   it('has a cancel button', () => {
     const wrapper = shallow(<SaveQuery {...mockedProps} />);

--- a/superset-frontend/spec/javascripts/sqllab/SaveQuery_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/SaveQuery_spec.jsx
@@ -46,18 +46,21 @@ describe('SavedQuery', () => {
   });
   it('has a cancel button', () => {
     const wrapper = shallow(<SaveQuery {...mockedProps} />);
-    const modal = shallow(wrapper.instance().renderModalBody());
+    const modal = wrapper.find(Modal);
+
     expect(modal.find('.cancelQuery')).toHaveLength(1);
   });
   it('has 2 FormControls', () => {
     const wrapper = shallow(<SaveQuery {...mockedProps} />);
-    const modal = shallow(wrapper.instance().renderModalBody());
+    const modal = wrapper.find(Modal);
+
     expect(modal.find(FormControl)).toHaveLength(2);
   });
   it('has a save button if this is a new query', () => {
     const saveSpy = sinon.spy();
     const wrapper = shallow(<SaveQuery {...mockedProps} onSave={saveSpy} />);
-    const modal = shallow(wrapper.instance().renderModalBody());
+    const modal = wrapper.find(Modal);
+
     expect(modal.find(Button)).toHaveLength(2);
     modal.find(Button).at(0).simulate('click');
     expect(saveSpy.calledOnce).toBe(true);
@@ -72,7 +75,8 @@ describe('SavedQuery', () => {
       },
     };
     const wrapper = shallow(<SaveQuery {...props} onUpdate={updateSpy} />);
-    const modal = shallow(wrapper.instance().renderModalBody());
+    const modal = wrapper.find(Modal);
+
     expect(modal.find(Button)).toHaveLength(3);
     modal.find(Button).at(0).simulate('click');
     expect(updateSpy.calledOnce).toBe(true);

--- a/superset-frontend/src/SqlLab/components/SaveQuery.jsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery.jsx
@@ -23,7 +23,7 @@ import { t } from '@superset-ui/core';
 
 import Button from 'src/components/Button';
 import FormLabel from 'src/components/FormLabel';
-import ModalTrigger from 'src/components/ModalTrigger';
+import Modal from 'src/common/components/Modal';
 
 const propTypes = {
   query: PropTypes.object,
@@ -87,7 +87,8 @@ class SaveQuery extends React.PureComponent {
   }
 
   close() {
-    if (this.saveModal) this.saveModal.close();
+    this.setState(prevState => ({ showSave: false }));
+    // if (this.saveModal) this.saveModal.close();
   }
 
   toggleSave() {
@@ -147,6 +148,7 @@ class SaveQuery extends React.PureComponent {
                 buttonStyle="primary"
                 onClick={this.onUpdate}
                 className="m-r-3"
+                cta
               >
                 {t('Update')}
               </Button>
@@ -155,10 +157,11 @@ class SaveQuery extends React.PureComponent {
               buttonStyle={isSaved ? undefined : 'primary'}
               onClick={this.onSave}
               className="m-r-3"
+              cta
             >
               {isSaved ? t('Save New') : t('Save')}
             </Button>
-            <Button onClick={this.onCancel} className="cancelQuery">
+            <Button onClick={this.onCancel} className="cancelQuery" cta>
               {t('Cancel')}
             </Button>
           </Col>
@@ -168,26 +171,28 @@ class SaveQuery extends React.PureComponent {
   }
 
   render() {
+    const isSaved = !!this.props.query.remoteId;
+
     return (
       <span className="SaveQuery">
-        <ModalTrigger
-          ref={ref => {
-            this.saveModal = ref;
-          }}
-          modalTitle={t('Save Query')}
-          modalBody={this.renderModalBody()}
-          backdrop="static"
-          triggerNode={
-            <Button
-              buttonSize="small"
-              className="toggleSave"
-              onClick={this.toggleSave}
-            >
-              <i className="fa fa-save" /> {t('Save')}
-            </Button>
-          }
-          bsSize="small"
-        />
+        <Button
+          buttonSize="small"
+          className="toggleSave"
+          onClick={this.toggleSave}
+        >
+          <i className="fa fa-save" /> {t('Save')}
+        </Button>
+        <Modal
+          className="save-query-modal"
+          onHandledPrimaryAction={this.onSave}
+          onHide={this.onCancel}
+          primaryButtonName={isSaved ? t('Save') : t('Add')}
+          width="350px"
+          show={this.state.showSave}
+          title={<h4>{t('Save Query')}</h4>}
+        >
+          {this.renderModalBody()}
+        </Modal>
       </span>
     );
   }

--- a/superset-frontend/src/SqlLab/components/SaveQuery.jsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormControl, FormGroup, Row, Col } from 'react-bootstrap';
-import { t } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 
 import Button from 'src/components/Button';
 import FormLabel from 'src/components/FormLabel';
@@ -39,6 +39,23 @@ const defaultProps = {
   onSave: () => {},
   saveQueryWarning: null,
 };
+
+const StyledRow = styled(Row)`
+  div {
+    display: flex;
+    justify-content: flex-start;
+  }
+
+  button.cta {
+    margin: 0 7px;
+    min-width: 105px;
+    font-size: 12px;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+`;
 
 class SaveQuery extends React.PureComponent {
   constructor(props) {
@@ -87,8 +104,7 @@ class SaveQuery extends React.PureComponent {
   }
 
   close() {
-    this.setState(prevState => ({ showSave: false }));
-    // if (this.saveModal) this.saveModal.close();
+    this.setState(() => ({ showSave: false }));
   }
 
   toggleSave() {
@@ -141,7 +157,7 @@ class SaveQuery extends React.PureComponent {
             <br />
           </div>
         )}
-        <Row>
+        <StyledRow>
           <Col md={12}>
             {isSaved && (
               <Button
@@ -165,7 +181,7 @@ class SaveQuery extends React.PureComponent {
               {t('Cancel')}
             </Button>
           </Col>
-        </Row>
+        </StyledRow>
       </FormGroup>
     );
   }
@@ -187,9 +203,10 @@ class SaveQuery extends React.PureComponent {
           onHandledPrimaryAction={this.onSave}
           onHide={this.onCancel}
           primaryButtonName={isSaved ? t('Save') : t('Add')}
-          width="350px"
+          width="390px"
           show={this.state.showSave}
           title={<h4>{t('Save Query')}</h4>}
+          hideFooter
         >
           {this.renderModalBody()}
         </Modal>

--- a/superset-frontend/src/SqlLab/components/SaveQuery.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery.tsx
@@ -27,10 +27,36 @@ import Modal from 'src/common/components/Modal';
 interface SaveQueryProps {
   query: any;
   defaultLabel: string;
-  onSave: () => void;
-  onUpdate: () => void;
+  onSave: (arg0: QueryPayload) => void;
+  onUpdate: (arg0: QueryPayload) => void;
   saveQueryWarning: string | null;
 }
+
+type QueryPayload = {
+  autorun: boolean;
+  dbId: number;
+  description?: string;
+  id?: string;
+  latestQueryId: string;
+  queryLimit: number;
+  remoteId: number;
+  schema: string;
+  schemaOptions: Array<{
+    label: string;
+    title: string;
+    value: string;
+  }>;
+  selectedText: string | null;
+  sql: string;
+  tableOptions: Array<{
+    label: string;
+    schema: string;
+    title: string;
+    type: string;
+    value: string;
+  }>;
+  title: string;
+};
 
 const StyledRow = styled(Row)`
   div {
@@ -56,7 +82,9 @@ export default function SaveQuery({
   onUpdate,
   saveQueryWarning = null,
 }: SaveQueryProps) {
-  const [description, setDescription] = useState<string>(query.description || '');
+  const [description, setDescription] = useState<string>(
+    query.description || '',
+  );
   const [label, setLabel] = useState<string>(defaultLabel);
   const [showSave, setShowSave] = useState<boolean>(false);
   const isSaved = !!query.remoteId;
@@ -83,12 +111,12 @@ export default function SaveQuery({
     close();
   };
 
-  const onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLabel(e.target.value);
+  const onLabelChange = (e: React.FormEvent<FormControl>) => {
+    setLabel((e.target as HTMLInputElement).value);
   };
 
-  const onDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDescription(e.target.value);
+  const onDescriptionChange = (e: React.FormEvent<FormControl>) => {
+    setDescription((e.target as HTMLInputElement).value);
   };
 
   const toggleSave = () => {

--- a/superset-frontend/src/SqlLab/components/SaveQuery.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery.tsx
@@ -56,7 +56,7 @@ export default function SaveQuery({
   onUpdate,
   saveQueryWarning = null,
 }: SaveQueryProps) {
-  const [description, setDescription] = useState<string>('');
+  const [description, setDescription] = useState<string>(query.description || '');
   const [label, setLabel] = useState<string>(defaultLabel);
   const [showSave, setShowSave] = useState<boolean>(false);
   const isSaved = !!query.remoteId;

--- a/superset-frontend/src/SqlLab/components/SaveQuery.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery.tsx
@@ -101,9 +101,7 @@ export default function SaveQuery({
         <Row>
           <Col md={12}>
             <small>
-              <FormLabel className="control-label" htmlFor="embed-height">
-                {t('Label')}
-              </FormLabel>
+              <FormLabel htmlFor="embed-height">{t('Label')}</FormLabel>
             </small>
             <FormControl
               type="text"
@@ -117,9 +115,7 @@ export default function SaveQuery({
         <Row>
           <Col md={12}>
             <small>
-              <FormLabel className="control-label" htmlFor="embed-height">
-                {t('Description')}
-              </FormLabel>
+              <FormLabel htmlFor="embed-height">{t('Description')}</FormLabel>
             </small>
             <FormControl
               componentClass="textarea"

--- a/superset-frontend/src/SqlLab/components/SaveQuery.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 import { FormControl, FormGroup, Row, Col } from 'react-bootstrap';
 import { t, styled } from '@superset-ui/core';
 
@@ -25,20 +24,13 @@ import Button from 'src/components/Button';
 import FormLabel from 'src/components/FormLabel';
 import Modal from 'src/common/components/Modal';
 
-const propTypes = {
-  query: PropTypes.object,
-  defaultLabel: PropTypes.string,
-  animation: PropTypes.bool,
-  onSave: PropTypes.func,
-  onUpdate: PropTypes.func,
-  saveQueryWarning: PropTypes.string,
-};
-const defaultProps = {
-  defaultLabel: t('Undefined'),
-  animation: true,
-  onSave: () => {},
-  saveQueryWarning: null,
-};
+interface SaveQueryProps {
+  query: any;
+  defaultLabel: string;
+  onSave: () => void;
+  onUpdate: () => void;
+  saveQueryWarning: string | null;
+}
 
 const StyledRow = styled(Row)`
   div {
@@ -51,68 +43,59 @@ const StyledRow = styled(Row)`
     min-width: 105px;
     font-size: 12px;
 
-    &:first-child {
+    &:first-of-type {
       margin-left: 0;
     }
   }
 `;
 
-class SaveQuery extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      description: '',
-      label: props.defaultLabel,
-      showSave: false,
-    };
-    this.toggleSave = this.toggleSave.bind(this);
-    this.onSave = this.onSave.bind(this);
-    this.onUpdate = this.onUpdate.bind(this);
-    this.onCancel = this.onCancel.bind(this);
-    this.onLabelChange = this.onLabelChange.bind(this);
-    this.onDescriptionChange = this.onDescriptionChange.bind(this);
-  }
+export default function SaveQuery({
+  query,
+  defaultLabel = t('Undefined'),
+  onSave = () => {},
+  onUpdate,
+  saveQueryWarning = null,
+}: SaveQueryProps) {
+  const [description, setDescription] = useState<string>('');
+  const [label, setLabel] = useState<string>(defaultLabel);
+  const [showSave, setShowSave] = useState<boolean>(false);
+  const isSaved = !!query.remoteId;
 
-  onSave() {
-    this.props.onSave(this.queryPayload());
-    this.close();
-  }
-
-  onUpdate() {
-    this.props.onUpdate(this.queryPayload());
-    this.close();
-  }
-
-  onCancel() {
-    this.close();
-  }
-
-  onLabelChange(e) {
-    this.setState({ label: e.target.value });
-  }
-
-  onDescriptionChange(e) {
-    this.setState({ description: e.target.value });
-  }
-
-  queryPayload() {
+  const queryPayload = () => {
     return {
-      ...this.props.query,
-      title: this.state.label,
-      description: this.state.description,
+      ...query,
+      title: label,
+      description,
     };
-  }
+  };
 
-  close() {
-    this.setState(() => ({ showSave: false }));
-  }
+  const close = () => {
+    setShowSave(false);
+  };
 
-  toggleSave() {
-    this.setState(prevState => ({ showSave: !prevState.showSave }));
-  }
+  const onSaveWrapper = () => {
+    onSave(queryPayload());
+    close();
+  };
 
-  renderModalBody() {
-    const isSaved = !!this.props.query.remoteId;
+  const onUpdateWrapper = () => {
+    onUpdate(queryPayload());
+    close();
+  };
+
+  const onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLabel(e.target.value);
+  };
+
+  const onDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDescription(e.target.value);
+  };
+
+  const toggleSave = () => {
+    setShowSave(!showSave);
+  };
+
+  const renderModalBody = () => {
     return (
       <FormGroup bsSize="small">
         <Row>
@@ -125,8 +108,8 @@ class SaveQuery extends React.PureComponent {
             <FormControl
               type="text"
               placeholder={t('Label for your query')}
-              value={this.state.label}
-              onChange={this.onLabelChange}
+              value={label}
+              onChange={onLabelChange}
             />
           </Col>
         </Row>
@@ -141,17 +124,17 @@ class SaveQuery extends React.PureComponent {
             <FormControl
               componentClass="textarea"
               placeholder={t('Write a description for your query')}
-              value={this.state.description}
-              onChange={this.onDescriptionChange}
+              value={description}
+              onChange={onDescriptionChange}
             />
           </Col>
         </Row>
         <br />
-        {this.props.saveQueryWarning && (
+        {saveQueryWarning && (
           <div>
             <Row>
               <Col md={12}>
-                <small>{this.props.saveQueryWarning}</small>
+                <small>{saveQueryWarning}</small>
               </Col>
             </Row>
             <br />
@@ -162,7 +145,7 @@ class SaveQuery extends React.PureComponent {
             {isSaved && (
               <Button
                 buttonStyle="primary"
-                onClick={this.onUpdate}
+                onClick={onUpdateWrapper}
                 className="m-r-3"
                 cta
               >
@@ -171,50 +154,38 @@ class SaveQuery extends React.PureComponent {
             )}
             <Button
               buttonStyle={isSaved ? undefined : 'primary'}
-              onClick={this.onSave}
+              onClick={onSaveWrapper}
               className="m-r-3"
               cta
             >
               {isSaved ? t('Save New') : t('Save')}
             </Button>
-            <Button onClick={this.onCancel} className="cancelQuery" cta>
+            <Button onClick={close} className="cancelQuery" cta>
               {t('Cancel')}
             </Button>
           </Col>
         </StyledRow>
       </FormGroup>
     );
-  }
+  };
 
-  render() {
-    const isSaved = !!this.props.query.remoteId;
-
-    return (
-      <span className="SaveQuery">
-        <Button
-          buttonSize="small"
-          className="toggleSave"
-          onClick={this.toggleSave}
-        >
-          <i className="fa fa-save" /> {t('Save')}
-        </Button>
-        <Modal
-          className="save-query-modal"
-          onHandledPrimaryAction={this.onSave}
-          onHide={this.onCancel}
-          primaryButtonName={isSaved ? t('Save') : t('Add')}
-          width="390px"
-          show={this.state.showSave}
-          title={<h4>{t('Save Query')}</h4>}
-          hideFooter
-        >
-          {this.renderModalBody()}
-        </Modal>
-      </span>
-    );
-  }
+  return (
+    <span className="SaveQuery">
+      <Button buttonSize="small" className="toggleSave" onClick={toggleSave}>
+        <i className="fa fa-save" /> {t('Save')}
+      </Button>
+      <Modal
+        className="save-query-modal"
+        onHandledPrimaryAction={onSaveWrapper}
+        onHide={close}
+        primaryButtonName={isSaved ? t('Save') : t('Add')}
+        width="390px"
+        show={showSave}
+        title={<h4>{t('Save Query')}</h4>}
+        hideFooter
+      >
+        {renderModalBody()}
+      </Modal>
+    </span>
+  );
 }
-SaveQuery.propTypes = propTypes;
-SaveQuery.defaultProps = defaultProps;
-
-export default SaveQuery;

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -530,7 +530,7 @@ class SqlEditor extends React.PureComponent {
               <SaveQuery
                 query={qe}
                 defaultLabel={
-                  qe.description == null ? qe.title : qe.description
+                  qe.title || qe.description
                 }
                 onSave={this.props.actions.saveQuery}
                 onUpdate={this.props.actions.updateSavedQuery}

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -529,9 +529,7 @@ class SqlEditor extends React.PureComponent {
             <span>
               <SaveQuery
                 query={qe}
-                defaultLabel={
-                  qe.title || qe.description
-                }
+                defaultLabel={qe.title || qe.description}
                 onSave={this.props.actions.saveQuery}
                 onUpdate={this.props.actions.updateSavedQuery}
                 saveQueryWarning={this.props.saveQueryWarning}

--- a/superset-frontend/src/common/components/Modal.tsx
+++ b/superset-frontend/src/common/components/Modal.tsx
@@ -33,6 +33,7 @@ interface ModalProps {
   show: boolean;
   title: React.ReactNode;
   width?: string;
+  hideFooter?: boolean;
   centered?: boolean;
   footer?: React.ReactNode;
 }
@@ -99,6 +100,7 @@ export default function Modal({
   width,
   centered,
   footer,
+  hideFooter,
   ...rest
 }: ModalProps) {
   const modalFooter = isNil(footer)
@@ -131,7 +133,7 @@ export default function Modal({
           ×
         </span>
       }
-      footer={modalFooter}
+      footer={!hideFooter ? modalFooter : null}
       {...rest}
     >
       {children}


### PR DESCRIPTION
### SUMMARY
- [x] Fix modal size so buttons stay all on one line
- [x] Switch to using ant-d `Modal`, rm `ModalTrigger`
- [x] Convert to typescript
- [x] Add `hideFooter` option to `Modal` component

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="859" alt="Screen Shot 2020-10-05 at 12 27 03 PM" src="https://user-images.githubusercontent.com/8216382/95123091-498b5b80-0706-11eb-8647-9c61bc38f45c.png">

After:
<img width="893" alt="Screen Shot 2020-10-05 at 12 25 03 PM" src="https://user-images.githubusercontent.com/8216382/95123126-56a84a80-0706-11eb-84c3-d1669d8cbf02.png">


### TEST PLAN
- [x] Updated `SaveQuery_spec.jsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
