### PR TITLE
fix: 📜 `/docs/api` won't render

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -1,13 +1,5 @@
 name: E2E
 
-on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-
 jobs:
   Cypress:
     runs-on: ubuntu-18.04

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -1,5 +1,7 @@
 name: E2E
 
+on: [push, pull_request]
+
 jobs:
   Cypress:
     runs-on: ubuntu-18.04

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -1,13 +1,5 @@
 name: Frontend
 
-on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -1,5 +1,7 @@
 name: Frontend
 
+on: [push, pull_request]
+
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/superset-python.yml
+++ b/.github/workflows/superset-python.yml
@@ -1,14 +1,6 @@
 # Python unit tests
 name: Python
 
-on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-
 jobs:
   lint:
     runs-on: ubuntu-18.04

--- a/.github/workflows/superset-python.yml
+++ b/.github/workflows/superset-python.yml
@@ -1,6 +1,8 @@
 # Python unit tests
 name: Python
 
+on: [push, pull_request]
+
 jobs:
   lint:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -1,13 +1,5 @@
 name: Hive
 
-on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-
 jobs:
   test-postgres-hive:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -1,5 +1,7 @@
 name: Hive
 
+on: [push, pull_request]
+
 jobs:
   test-postgres-hive:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test-presto.yml
+++ b/.github/workflows/test-presto.yml
@@ -1,5 +1,7 @@
 name: Presto
 
+on: [push, pull_request]
+
 jobs:
   test-postgres-presto:
       runs-on: ubuntu-18.04

--- a/.github/workflows/test-presto.yml
+++ b/.github/workflows/test-presto.yml
@@ -1,13 +1,5 @@
 name: Presto
 
-on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-
 jobs:
   test-postgres-presto:
       runs-on: ubuntu-18.04

--- a/docs/src/components/AnchorNavigator.tsx
+++ b/docs/src/components/AnchorNavigator.tsx
@@ -52,7 +52,7 @@ const HeaderNav = () => {
     <div css={anchorNavStyle}>
       <Anchor>
         {headings.map((e) => (
-          <Link href={`#${e.slug}`} title={e.value} />
+          <Link key={e.slug} href={`#${e.slug}`} title={e.value} />
         ))}
       </Anchor>
     </div>

--- a/docs/src/components/MainMenu.tsx
+++ b/docs/src/components/MainMenu.tsx
@@ -133,9 +133,9 @@ export default class MainMenu extends React.Component {
     const { visible } = this.state;
     return (
       <Layout.Header css={headerStyle}>
-        <Link to="https://superset.incubator.apache.org">
+        <a href="https://superset.incubator.apache.org">
           <img height="50" css={logoStyle} src={logoSvg} alt="logo" />
-        </Link>
+        </a>
         <MenuItems toggleDrawer={this.toggleDrawer} mode="horizontal" />
         <Drawer
           title="Menu"

--- a/docs/src/pages/docs/api.mdx
+++ b/docs/src/pages/docs/api.mdx
@@ -1,7 +1,7 @@
 ---
 name: API
 title: API
-route: /docs/api
+route: /docs/rest-api
 ---
 ## API
 
@@ -17,6 +17,7 @@ documented here. The docs bellow are generated using
 [Swagger React UI](https://www.npmjs.com/package/swagger-ui-react).
 
 <Alert
+  type="info"
   message={
     <div>
       <strong>NOTE! </strong>
@@ -25,7 +26,6 @@ documented here. The docs bellow are generated using
       at <strong>/swagger/v1</strong> (if enabled)
     </div>
   }
-  type="info"
 />
 
 <br /><br /><hr />


### PR DESCRIPTION
It's unclear to me exactly why, but docz is flimsy with the way things are named and runs into odd collision and error messages.

Somehow renaming the route seem to help. Jut rolling with it after many `gatsby clean`

Also fixing a few warnings here while I'm at it, and turning off the github-actions path-ignore that doesn't work for us in the current state.