### PR TITLE
style(dashboard): minor improvements to chart context menu

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -158,20 +158,14 @@ class SliceHeaderControls extends React.PureComponent {
             </MenuItem>
           )}
 
-          {this.props.sliceCanEdit && (
-            <MenuItem href={slice.edit_url} target="_blank">
-              {t('Edit chart metadata')}
+          {this.props.supersetCanExplore && (
+            <MenuItem onClick={this.exploreChart}>
+              {t('Explore chart')}
             </MenuItem>
           )}
 
           {this.props.supersetCanCSV && (
             <MenuItem onClick={this.exportCSV}>{t('Export CSV')}</MenuItem>
-          )}
-
-          {this.props.supersetCanExplore && (
-            <MenuItem onClick={this.exploreChart}>
-              {t('Explore chart')}
-            </MenuItem>
           )}
 
           <MenuItem onClick={this.handleToggleFullSize}>{resizeLabel}</MenuItem>


### PR DESCRIPTION
Bumping "Explore/edit chart" as the first option. Getting rid of the
old "edit chart properties" deprecated CRUD link

# after

<img width="414" alt="Screen Shot 2020-10-05 at 9 52 35 PM" src="https://user-images.githubusercontent.com/487433/95160470-87fc3700-0755-11eb-928d-c2dc705ab7e7.png">


# before
<img width="391" alt="Screen Shot 2020-10-05 at 9 49 37 PM" src="https://user-images.githubusercontent.com/487433/95160483-8fbbdb80-0755-11eb-94c4-9748d006938c.png">
