### PR TITLE
fix(viz): downgrade exception for missing viz/datasource

### DIFF
--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -27,6 +27,7 @@ from flask import abort, flash, g, redirect, request
 from flask_appbuilder.security.sqla import models as ab_models
 from flask_appbuilder.security.sqla.models import User
 from flask_babel import gettext as __
+from sqlalchemy.orm.exc import NoResultFound
 
 import superset.models.core as models
 from superset import (
@@ -494,12 +495,21 @@ def check_datasource_perms(
             )
         )
 
-    viz_obj = get_viz(
-        datasource_type=datasource_type,
-        datasource_id=datasource_id,
-        form_data=form_data,
-        force=False,
-    )
+    try:
+        viz_obj = get_viz(
+            datasource_type=datasource_type,
+            datasource_id=datasource_id,
+            form_data=form_data,
+            force=False,
+        )
+    except NoResultFound:
+        raise SupersetSecurityException(
+            SupersetError(
+                error_type=SupersetErrorType.UNKNOWN_DATASOURCE_TYPE_ERROR,
+                level=ErrorLevel.ERROR,
+                message="Could not find viz object",
+            )
+        )
 
     viz_obj.raise_for_access()
 
@@ -518,12 +528,21 @@ def check_slice_perms(_self: Any, slice_id: int) -> None:
     form_data, slc = get_form_data(slice_id, use_slice_data=True)
 
     if slc:
-        viz_obj = get_viz(
-            datasource_type=slc.datasource.type,
-            datasource_id=slc.datasource.id,
-            form_data=form_data,
-            force=False,
-        )
+        try:
+            viz_obj = get_viz(
+                datasource_type=slc.datasource.type,
+                datasource_id=slc.datasource.id,
+                form_data=form_data,
+                force=False,
+            )
+        except NoResultFound:
+            raise SupersetSecurityException(
+                SupersetError(
+                    error_type=SupersetErrorType.UNKNOWN_DATASOURCE_TYPE_ERROR,
+                    level=ErrorLevel.ERROR,
+                    message="Could not find viz object",
+                )
+            )
 
         viz_obj.raise_for_access()
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -491,7 +491,7 @@ def check_datasource_perms(
             SupersetError(
                 error_type=SupersetErrorType.UNKNOWN_DATASOURCE_TYPE_ERROR,
                 level=ErrorLevel.ERROR,
-                message="Could not determine datasource type",
+                message=__("Could not determine datasource type"),
             )
         )
 
@@ -507,7 +507,7 @@ def check_datasource_perms(
             SupersetError(
                 error_type=SupersetErrorType.UNKNOWN_DATASOURCE_TYPE_ERROR,
                 level=ErrorLevel.ERROR,
-                message="Could not find viz object",
+                message=__("Could not find viz object"),
             )
         )
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -142,11 +142,7 @@ class BaseViz:
         force: bool = False,
     ) -> None:
         if not datasource:
-            raise QueryObjectValidationError(
-                _(
-                    "Viz is missing a datasource. Please make sure the datasource still exists."
-                )
-            )
+            raise QueryObjectValidationError(_("Viz is missing a datasource"))
 
         self.datasource = datasource
         self.request = request

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -142,7 +142,11 @@ class BaseViz:
         force: bool = False,
     ) -> None:
         if not datasource:
-            raise Exception(_("Viz is missing a datasource"))
+            raise QueryObjectValidationError(
+                _(
+                    "Viz is missing a datasource. Please make sure the datasource still exists."
+                )
+            )
 
         self.datasource = datasource
         self.request = request


### PR DESCRIPTION
### SUMMARY
`viz.py` raises an `Exception` if a viz is referencing a datasource that doesn't exist. As this indicates corrupted viz metadata (usually a datasource has been deleted), this constitutes a `QueryObjectValidationError`, which is an expected exception type for invalid viz requests. In addition, if a viz has been deleted, checking permissions for a slice should reraise `NoResultFound` to a `SupersetSecurityException` to be handled correctly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
