### PR TITLE
fix: keep placeholder in multivalue select when a value exists

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
@@ -19,7 +19,7 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { Select, CreatableSelect } from 'src/components/Select';
 import OnPasteSelect from 'src/components/Select/OnPasteSelect';
 import SelectControl from 'src/explore/components/controls/SelectControl';
@@ -45,25 +45,6 @@ describe('SelectControl', () => {
 
   beforeEach(() => {
     wrapper = shallow(<SelectControl {...defaultProps} />);
-  });
-
-  it('renders with Select by default', () => {
-    expect(wrapper.find(OnPasteSelect)).not.toExist();
-    expect(wrapper.findWhere(x => x.type() === Select)).toHaveLength(1);
-  });
-
-  it('renders with OnPasteSelect when multi', () => {
-    wrapper.setProps({ multi: true });
-    expect(wrapper.find(OnPasteSelect)).toExist();
-    expect(wrapper.findWhere(x => x.type() === Select)).toHaveLength(0);
-  });
-
-  it('renders with Creatable when freeForm', () => {
-    wrapper.setProps({ freeForm: true });
-    expect(wrapper.find(OnPasteSelect)).not.toExist();
-    expect(wrapper.findWhere(x => x.type() === CreatableSelect)).toHaveLength(
-      1,
-    );
   });
 
   it('uses Select in onPasteSelect when freeForm=false', () => {
@@ -98,6 +79,52 @@ describe('SelectControl', () => {
     wrapper.setProps(selectAllProps);
     wrapper.instance().onChange([{ meta: true, value: 'Select All' }]);
     expect(selectAllProps.onChange.calledWith(expectedValues)).toBe(true);
+  });
+
+  describe('render', () => {
+    it('renders with Select by default', () => {
+      expect(wrapper.find(OnPasteSelect)).not.toExist();
+      expect(wrapper.findWhere(x => x.type() === Select)).toHaveLength(1);
+    });
+
+    it('renders with OnPasteSelect when multi', () => {
+      wrapper.setProps({ multi: true });
+      expect(wrapper.find(OnPasteSelect)).toExist();
+      expect(wrapper.findWhere(x => x.type() === Select)).toHaveLength(0);
+    });
+
+    it('renders with Creatable when freeForm', () => {
+      wrapper.setProps({ freeForm: true });
+      expect(wrapper.find(OnPasteSelect)).not.toExist();
+      expect(wrapper.findWhere(x => x.type() === CreatableSelect)).toHaveLength(
+        1,
+      );
+    });
+    describe('when select is multi', () => {
+      it('renders the placeholder when a selection has been made', () => {
+        wrapper = mount(
+          <SelectControl
+            {...defaultProps}
+            multi
+            value={50}
+            placeholder="add something"
+          />,
+        );
+        expect(wrapper.html()).toContain('add something');
+      });
+    });
+    describe('when select is single', () => {
+      it('does not render the placeholder when a selection has been made', () => {
+        wrapper = mount(
+          <SelectControl
+            {...defaultProps}
+            value={50}
+            placeholder="add something"
+          />,
+        );
+        expect(wrapper.html()).not.toContain('add something');
+      });
+    });
   });
 
   describe('getOptions', () => {

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -241,6 +241,14 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   }),
 };
 
+const multiInputSpanStyle = css`
+  color: '#879399',
+  position: 'absolute',
+  top: '2px',
+  left: '4px',
+  width: '100vw',
+`;
+
 const { ClearIndicator, DropdownIndicator, Option, Input } = defaultComponents;
 
 type SelectComponentsType = SelectComponentsConfig<any> & {
@@ -298,17 +306,7 @@ export const DEFAULT_COMPONENTS: SelectComponentsType = {
     <div style={{ position: 'relative' }}>
       <Input {...props} />
       {!!(props.selectProps.isMulti && props.selectProps.value.length) && (
-        <span
-          style={{
-            color: '#879399',
-            position: 'absolute',
-            top: '2px',
-            left: '4px',
-            width: '100vw',
-          }}
-        >
-          {props.selectProps.placeholder}
-        </span>
+        <span css={multiInputSpanStyle}>{props.selectProps.placeholder}</span>
       )}
     </div>
   ),

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, ComponentType } from 'react';
 import { css, SerializedStyles, ClassNames } from '@emotion/core';
 import { supersetTheme } from '@superset-ui/core';
 import {
@@ -241,9 +241,31 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   }),
 };
 
-const { ClearIndicator, DropdownIndicator, Option } = defaultComponents;
+const { ClearIndicator, DropdownIndicator, Option, Input } = defaultComponents;
 
-export const DEFAULT_COMPONENTS: SelectComponentsConfig<any> = {
+type SelectComponentsType = SelectComponentsConfig<any> & {
+  Input: ComponentType<InputProps>;
+};
+
+// react-select is missing selectProps from their props type
+// so overwriting it here to avoid errors
+type InputProps = {
+  selectProps: {
+    isMulti: boolean;
+    value: {
+      length: number;
+    };
+    placeholder: string;
+  };
+  cx: (a: string | null, b: any, c: string) => string | void;
+  innerRef: (element: React.Ref<any>) => void;
+  isHidden: boolean;
+  isDisabled?: boolean | undefined;
+  className?: string | undefined;
+  getStyles: any;
+};
+
+export const DEFAULT_COMPONENTS: SelectComponentsType = {
   Option: ({ children, innerProps, data, ...props }) => (
     <ClassNames>
       {({ css }) => (
@@ -271,6 +293,24 @@ export const DEFAULT_COMPONENTS: SelectComponentsConfig<any> = {
         }`}
       />
     </DropdownIndicator>
+  ),
+  Input: (props: InputProps) => (
+    <div style={{ position: 'relative' }}>
+      <Input {...props} />
+      {!!(props.selectProps.isMulti && props.selectProps.value.length) && (
+        <span
+          style={{
+            color: '#879399',
+            position: 'absolute',
+            top: '2px',
+            left: '4px',
+            width: '100vw',
+          }}
+        >
+          {props.selectProps.placeholder}
+        </span>
+      )}
+    </div>
   ),
 };
 

--- a/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
@@ -267,7 +267,7 @@ export default class AdhocFilterControl extends React.Component {
         <OnPasteSelect
           isMulti
           name={`select-${this.props.name}`}
-          placeholder={t('choose a column or metric')}
+          placeholder={t('choose one or more column or metric')}
           options={this.state.options}
           value={this.state.values}
           labelKey="label"

--- a/superset-frontend/src/explore/components/controls/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricsControl.jsx
@@ -337,7 +337,11 @@ export default class MetricsControl extends React.PureComponent {
         <OnPasteSelect
           isMulti={this.props.multi}
           name={`select-${this.props.name}`}
-          placeholder={t('choose a column or aggregate function')}
+          placeholder={
+            this.props.multi
+              ? t('choose one or more column or aggregate function')
+              : t('choose a column or aggregate function')
+          }
           options={this.state.options}
           value={this.state.value}
           labelKey="label"


### PR DESCRIPTION
### SUMMARY
Some users were not noticing that they could enter multiple values in some fields, and it was also difficult to know which were single vs multiple, just by looking at the select input. With some input from others, I have updated the placeholder to indicate that multiple selections can be made, and also kept the placeholder in the input field after a selection has been made. We also talked about keeping the focus on the new input after a selection was made, but decided to put that in a separate PR.  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Growth_Rate__vBFmtRXfi_](https://user-images.githubusercontent.com/5186919/95270694-efb39000-07f0-11eb-8f66-1fb822896b1d.png)

### TEST PLAN
unit tests added 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
