### PR TITLE
chore: limiting load-examples to demo-worthy dashboards by default

### DIFF
--- a/superset-frontend/cypress_build.sh
+++ b/superset-frontend/cypress_build.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")"
 #run all the python steps in a background process
 time superset db upgrade
 time superset load_test_users
-time superset load_examples --load-test-data
+time superset load_examples
 time superset init
 echo "[completed python build steps]"
 PORT='8081'

--- a/superset-frontend/cypress_build.sh
+++ b/superset-frontend/cypress_build.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")"
 #run all the python steps in a background process
 time superset db upgrade
 time superset load_test_users
-time superset load_examples
+time superset load_examples --load-test-data
 time superset init
 echo "[completed python build steps]"
 PORT='8081'

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -106,19 +106,22 @@ def load_examples_run(
 
     examples.load_css_templates()
 
-    print("Loading energy related dataset")
-    examples.load_energy(only_metadata, force)
-
     print("Loading [World Bank's Health Nutrition and Population Stats]")
     examples.load_world_bank_health_n_pop(only_metadata, force)
 
     print("Loading [Birth names]")
     examples.load_birth_names(only_metadata, force)
 
-    print("Loading [Unicode test data]")
-    examples.load_unicode_test_data(only_metadata, force)
+    print("Loading DECK.gl demo")
+    examples.load_deck_dash()
 
     if not load_test_data:
+        print("Loading energy related dataset")
+        examples.load_energy(only_metadata, force)
+
+        print("Loading [Unicode test data]")
+        examples.load_unicode_test_data(only_metadata, force)
+
         print("Loading [Random time series data]")
         examples.load_random_time_series_data(only_metadata, force)
 
@@ -149,11 +152,8 @@ def load_examples_run(
         print("Loading [Misc Charts] dashboard")
         examples.load_misc_dashboard()
 
-        print("Loading DECK.gl demo")
-        examples.load_deck_dash()
-
-    print("Loading [Tabbed dashboard]")
-    examples.load_tabbed_dashboard(only_metadata)
+        print("Loading [Tabbed dashboard]")
+        examples.load_tabbed_dashboard(only_metadata)
 
 
 @with_appcontext

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -127,7 +127,7 @@ def load_examples_run(
     print("Loading DECK.gl demo")
     examples.load_deck_dash()
 
-    if not load_test_data:
+    if load_test_data:
         print("Loading energy related dataset")
         examples.load_energy(only_metadata, force)
 

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -96,6 +96,12 @@ def version(verbose: bool) -> None:
 def load_examples_run(
     load_test_data: bool, only_metadata: bool = False, force: bool = False
 ) -> None:
+    """Loads examples - includes sample data and objects (dashboards/charts)
+
+    NOTE: found the hard way that ordering here matters to cypress tests
+    as of fall 2020, it be great to refactor Cypress to not refer to
+    datasets by hard-coded, non-deterministic autonumber ids.
+    """
     if only_metadata:
         print("Loading examples metadata")
     else:
@@ -106,14 +112,33 @@ def load_examples_run(
 
     examples.load_css_templates()
 
+    print("Loading energy related dataset")
+    examples.load_energy(only_metadata, force)
+
     print("Loading [World Bank's Health Nutrition and Population Stats]")
     examples.load_world_bank_health_n_pop(only_metadata, force)
 
     print("Loading [Birth names]")
     examples.load_birth_names(only_metadata, force)
 
-    print("Loading [Random long/lat data]")
-    examples.load_long_lat_data(only_metadata, force)
+    if load_test_data:
+        print("Loading [Unicode test data]")
+        examples.load_unicode_test_data(only_metadata, force)
+
+        print("Loading [Random time series data]")
+        examples.load_random_time_series_data(only_metadata, force)
+
+        print("Loading [Random long/lat data]")
+        examples.load_long_lat_data(only_metadata, force)
+
+        print("Loading [Country Map data]")
+        examples.load_country_map_data(only_metadata, force)
+
+        print("Loading [Multiformat time series]")
+        examples.load_multiformat_time_series(only_metadata, force)
+
+    print("Loading [Paris GeoJson]")
+    examples.load_paris_iris_geojson(only_metadata, force)
 
     print("Loading [San Francisco population polygons]")
     examples.load_sf_population_polygons(only_metadata, force)
@@ -124,34 +149,17 @@ def load_examples_run(
     print("Loading [BART lines]")
     examples.load_bart_lines(only_metadata, force)
 
+    print("Loading [Multi Line]")
+    examples.load_multi_line(only_metadata)
+
+    if load_test_data:
+        print("Loading [Misc Charts] dashboard")
+        examples.load_misc_dashboard()
+
     print("Loading DECK.gl demo")
     examples.load_deck_dash()
 
     if load_test_data:
-        print("Loading energy related dataset")
-        examples.load_energy(only_metadata, force)
-
-        print("Loading [Unicode test data]")
-        examples.load_unicode_test_data(only_metadata, force)
-
-        print("Loading [Random time series data]")
-        examples.load_random_time_series_data(only_metadata, force)
-
-        print("Loading [Country Map data]")
-        examples.load_country_map_data(only_metadata, force)
-
-        print("Loading [Multiformat time series]")
-        examples.load_multiformat_time_series(only_metadata, force)
-
-        print("Loading [Paris GeoJson]")
-        examples.load_paris_iris_geojson(only_metadata, force)
-
-        print("Loading [Multi Line]")
-        examples.load_multi_line(only_metadata)
-
-        print("Loading [Misc Charts] dashboard")
-        examples.load_misc_dashboard()
-
         print("Loading [Tabbed dashboard]")
         examples.load_tabbed_dashboard(only_metadata)
 

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -112,6 +112,9 @@ def load_examples_run(
     print("Loading [Birth names]")
     examples.load_birth_names(only_metadata, force)
 
+    print("Loading [Random long/lat data]")
+    examples.load_long_lat_data(only_metadata, force)
+
     print("Loading DECK.gl demo")
     examples.load_deck_dash()
 
@@ -124,9 +127,6 @@ def load_examples_run(
 
         print("Loading [Random time series data]")
         examples.load_random_time_series_data(only_metadata, force)
-
-        print("Loading [Random long/lat data]")
-        examples.load_long_lat_data(only_metadata, force)
 
         print("Loading [Country Map data]")
         examples.load_country_map_data(only_metadata, force)

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -115,6 +115,15 @@ def load_examples_run(
     print("Loading [Random long/lat data]")
     examples.load_long_lat_data(only_metadata, force)
 
+    print("Loading [San Francisco population polygons]")
+    examples.load_sf_population_polygons(only_metadata, force)
+
+    print("Loading [Flights data]")
+    examples.load_flights(only_metadata, force)
+
+    print("Loading [BART lines]")
+    examples.load_bart_lines(only_metadata, force)
+
     print("Loading DECK.gl demo")
     examples.load_deck_dash()
 
@@ -136,15 +145,6 @@ def load_examples_run(
 
         print("Loading [Paris GeoJson]")
         examples.load_paris_iris_geojson(only_metadata, force)
-
-        print("Loading [San Francisco population polygons]")
-        examples.load_sf_population_polygons(only_metadata, force)
-
-        print("Loading [Flights data]")
-        examples.load_flights(only_metadata, force)
-
-        print("Loading [BART lines]")
-        examples.load_bart_lines(only_metadata, force)
 
         print("Loading [Multi Line]")
         examples.load_multi_line(only_metadata)


### PR DESCRIPTION
The CLI subcommand `superset load-examples` loads a bunch of
dubious-looking dashboards that are used for unit and integration tests.

Let's make that command limited to decent-looking dashboards by default
and the current extra datasets and dashboards used for tests can
be loaded with the existing --load-test-data flag
