### PR TITLE
fix: do not import superset_config on tests

### DIFF
--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -19,6 +19,7 @@
 set -e
 
 export SUPERSET_CONFIG=${SUPERSET_CONFIG:-tests.superset_test_config}
+export SUPERSET_TESTENV=true
 echo "Superset config module: $SUPERSET_CONFIG"
 
 superset db upgrade

--- a/superset/config.py
+++ b/superset/config.py
@@ -42,6 +42,7 @@ from superset.jinja_context import (  # pylint: disable=unused-import
 )
 from superset.stats_logger import DummyStatsLogger
 from superset.typing import CacheConfig
+from superset.utils.core import is_test
 from superset.utils.log import DBEventLogger
 from superset.utils.logging_configurator import DefaultLoggingConfigurator
 
@@ -629,11 +630,11 @@ UPLOADED_CSV_HIVE_NAMESPACE: Optional[str] = None
 # db configuration and a result of this function.
 
 # mypy doesn't catch that if case ensures list content being always str
-ALLOWED_USER_CSV_SCHEMA_FUNC: Callable[
-    ["Database", "models.User"], List[str]
-] = lambda database, user: [
-    UPLOADED_CSV_HIVE_NAMESPACE
-] if UPLOADED_CSV_HIVE_NAMESPACE else []
+ALLOWED_USER_CSV_SCHEMA_FUNC: Callable[["Database", "models.User"], List[str]] = (
+    lambda database, user: [UPLOADED_CSV_HIVE_NAMESPACE]
+    if UPLOADED_CSV_HIVE_NAMESPACE
+    else []
+)
 
 # Values that should be treated as nulls for the csv uploads.
 CSV_DEFAULT_NA_NAMES = list(STR_NA_VALUES)
@@ -952,7 +953,7 @@ if CONFIG_PATH_ENV_VAR in os.environ:
             "Failed to import config for %s=%s", CONFIG_PATH_ENV_VAR, cfg_path
         )
         raise
-elif importlib.util.find_spec("superset_config"):
+elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         import superset_config  # pylint: disable=import-error
         from superset_config import *  # type: ignore  # pylint: disable=import-error,wildcard-import,unused-wildcard-import

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -31,6 +31,7 @@ import traceback
 import uuid
 import zlib
 from datetime import date, datetime, time, timedelta
+from distutils.util import strtobool
 from email.mime.application import MIMEApplication
 from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
@@ -1556,4 +1557,4 @@ class RowLevelSecurityFilterType(str, Enum):
 
 
 def is_test() -> bool:
-    return "SUPERSET_TESTENV" in os.environ
+    return strtobool(os.environ.get("SUPERSET_TESTENV", "false"))

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1553,3 +1553,7 @@ class AdhocMetricExpressionType(str, Enum):
 class RowLevelSecurityFilterType(str, Enum):
     REGULAR = "Regular"
     BASE = "Base"
+
+
+def is_test() -> bool:
+    return "SUPERSET_TESTENV" in os.environ

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ deps =
     -rrequirements/testing.txt
 setenv =
     PYTHONPATH = {toxinidir}
+    SUPERSET_TESTENV = true
     SUPERSET_CONFIG = tests.superset_test_config
     SUPERSET_HOME = {envtmpdir}
     mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When running unit tests we import any `superset_config.py` files that are in the path, resulting in inconsistent local tests.

I modified the code so that we set an environment flag when running unit tests, and skip importing `superset_config.py` when the flag is set.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

NA

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

I had this custom configuration file:

```python
# superset_config.py
PREVENT_UNSAFE_DB_CONNECTIONS = False
```

Running SQLite unit tests will then fail:

```bash
$ tox -e py38-sqlite -- tests/databases/api_tests.py::TestDatabaseApi::test_create_database_fail_sqllite
...
>       self.assertEqual(response_data, expected_response)
E       AssertionError: {'message': 'Could not connect to database.'} != {'message': {'sqlalchemy_uri': ['SQLite database cann[48 chars].']}}
E       Diff is 194 characters long. Set self.maxDiff to None to see it.

tests/databases/api_tests.py:331: AssertionError
```

With this PR, `superset_config.py` is ignored and the tests pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
