### PR TITLE
chore(sql-lab): catch PyArrow deserialization error

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -93,3 +93,7 @@ class QueryObjectValidationError(SupersetException):
 
 class DashboardImportException(SupersetException):
     pass
+
+
+class SerializationError(SupersetException):
+    pass

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -82,6 +82,7 @@ from superset.databases.filters import DatabaseFilter
 from superset.exceptions import (
     CertificateException,
     DatabaseNotFound,
+    SerializationError,
     SupersetException,
     SupersetSecurityException,
     SupersetTimeoutException,
@@ -1967,7 +1968,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return self.results_exec(key)
 
     @staticmethod
-    def results_exec(key: str) -> FlaskResponse:
+    def results_exec(  # pylint: disable=too-many-return-statements
+        key: str,
+    ) -> FlaskResponse:
         """Serves a key off of the results backend
 
         It is possible to pass the `rows` query argument to limit the number
@@ -2001,9 +2004,15 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             return json_errors_response([ex.error], status=403)
 
         payload = utils.zlib_decompress(blob, decode=not results_backend_use_msgpack)
-        obj = _deserialize_results_payload(
-            payload, query, cast(bool, results_backend_use_msgpack)
-        )
+        try:
+            obj = _deserialize_results_payload(
+                payload, query, cast(bool, results_backend_use_msgpack)
+            )
+        except SerializationError:
+            return json_error_response(
+                __("Data could not be deserialized. You may want to re-run the query."),
+                status=404,
+            )
 
         if "rows" in request.args:
             try:

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -40,7 +40,11 @@ from superset import (
 )
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetException, SupersetSecurityException
+from superset.exceptions import (
+    SerializationError,
+    SupersetException,
+    SupersetSecurityException,
+)
 from superset.legacy import update_time_range
 from superset.models.core import Database
 from superset.models.dashboard import Dashboard
@@ -578,7 +582,10 @@ def _deserialize_results_payload(
             ds_payload = msgpack.loads(payload, raw=False)
 
         with stats_timing("sqllab.query.results_backend_pa_deserialize", stats_logger):
-            pa_table = pa.deserialize(ds_payload["data"])
+            try:
+                pa_table = pa.deserialize(ds_payload["data"])
+            except pa.ArrowSerializationError:
+                raise SerializationError("Unable to deserialize table")
 
         df = result_set.SupersetResultSet.convert_table_to_df(pa_table)
         ds_payload["data"] = dataframe.df_to_records(df) or []


### PR DESCRIPTION
### SUMMARY
When running Superset with `RESULTS_BACKEND`, SQL Lab will throw an ugly error when retrieving a result from the cache that isn't deserializable. This will happen if the version of `PyArrow` that has been used to serialize the payload isn't binary compatible with the currently installed version. Recently, this happened when `PyArrow` was bumped from `0.17` to `1.0`.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/95453547-b7888a80-0973-11eb-9bcb-d4c865d4dec6.png)
### BEFORE
![image](https://user-images.githubusercontent.com/33317356/95453615-d6871c80-0973-11eb-95bc-11bc8a93d336.png)

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
