### PR TITLE
feat: Added setup for running Cypress tests in docker locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -677,6 +677,9 @@ As an alternative you can use docker-compose environment for testing:
 Make sure you have added below line to your /etc/hosts file:
 ```127.0.0.1 db```
 
+If you already have launched Docker environment please use the following command to assure a fresh database instance:
+```docker-compose down -v```
+
 Launch environment:
 
 CYPRESS_CONFIG=true docker-compose up

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -672,6 +672,27 @@ CYPRESS_BASE_URL=<your url> npm run cypress open
 
 See [`superset-frontend/cypress_build.sh`](https://github.com/apache/incubator-superset/blob/master/superset-frontend/cypress_build.sh).
 
+As an alternative you can use docker-compose environment for testing:
+
+Make sure you have added below line to your /etc/hosts file:
+```127.0.0.1 db```
+
+Launch environment:
+
+CYPRESS_CONFIG=true docker-compose up
+
+It will serve backend and frontend on port 8088.
+
+Run Cypres tests:
+
+```bash
+cd cypress-base
+npm install
+```
+
+# run tests via headless Chrome browser (requires Chrome 64+)
+npm run cypress-run-chrome
+
 ### Storybook
 
 Superset includes a [Storybook](https://storybook.js.org/) to preview the layout/styling of various Superset components, and variations thereof. To open and view the Storybook:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:5432:5432"
+    volumes:
+      - db_home:/var/lib/postgresql/data
 
   superset:
     env_file: docker/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ x-superset-volumes: &superset-volumes
   - ./superset:/app/superset
   - ./superset-frontend:/app/superset-frontend
   - superset_home:/app/superset_home
+  - ./tests:/app/tests
 
 version: "3.7"
 services:
@@ -43,8 +44,6 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:5432:5432"
-    volumes:
-      - db_home:/var/lib/postgresql/data
 
   superset:
     env_file: docker/.env
@@ -57,6 +56,8 @@ services:
     user: "root"
     depends_on: *superset-depends-on
     volumes: *superset-volumes
+    environment:
+      CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
 
   superset-init:
     image: *superset-image
@@ -66,6 +67,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    environment:
+      CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
 
   superset-node:
     image: node:12

--- a/docker/.env
+++ b/docker/.env
@@ -42,3 +42,6 @@ REDIS_PORT=6379
 FLASK_ENV=development
 SUPERSET_ENV=development
 SUPERSET_LOAD_EXAMPLES=yes
+CYPRESS_CONFIG=false
+SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset
+SUPERSET_CONFIG=tests.superset_test_config

--- a/docker/.env
+++ b/docker/.env
@@ -43,5 +43,3 @@ FLASK_ENV=development
 SUPERSET_ENV=development
 SUPERSET_LOAD_EXAMPLES=yes
 CYPRESS_CONFIG=false
-SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset
-SUPERSET_CONFIG=tests.superset_test_config

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -19,7 +19,12 @@
 set -eo pipefail
 
 REQUIREMENTS_LOCAL="/app/docker/requirements-local.txt"
-
+# If Cypress run – overwrite the password for admin and export env variables
+if [ "$CYPRESS_CONFIG" == "true" ]; then
+    export SUPERSET_CONFIG=tests.superset_test_config
+    export SUPERSET_TESTENV=true
+    export ENABLE_REACT_CRUD_VIEWS=true
+fi
 #
 # Make sure we have dev requirements installed
 #

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -24,6 +24,7 @@ if [ "$CYPRESS_CONFIG" == "true" ]; then
     export SUPERSET_CONFIG=tests.superset_test_config
     export SUPERSET_TESTENV=true
     export ENABLE_REACT_CRUD_VIEWS=true
+    export SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset
 fi
 #
 # Make sure we have dev requirements installed

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-set -e
+set -ex
 
 #
 # Always install local overrides first
@@ -37,22 +37,28 @@ Init Step ${1}/${STEP_CNT} [${2}] -- ${3}
 
 EOF
 }
-
+ADMIN_PASSWORD="admin"
+# If Cypress run – overwrite the password for admin and export env variables
+if [ "$CYPRESS_CONFIG" == "true" ]; then
+    ADMIN_PASSWORD="general"
+    export SUPERSET_CONFIG=tests.superset_test_config
+    export SUPERSET_TESTENV=true
+    export ENABLE_REACT_CRUD_VIEWS=true
+fi
 # Initialize the database
 echo_step "1" "Starting" "Applying DB migrations"
 superset db upgrade
 echo_step "1" "Complete" "Applying DB migrations"
 
 # Create an admin user
-echo_step "2" "Starting" "Setting up admin user ( admin / admin )"
+echo_step "2" "Starting" "Setting up admin user ( admin / $ADMIN_PASSWORD )"
 superset fab create-admin \
               --username admin \
               --firstname Superset \
               --lastname Admin \
               --email admin@superset.com \
-              --password admin
+              --password $ADMIN_PASSWORD
 echo_step "2" "Complete" "Setting up admin user"
-
 # Create default roles and permissions
 echo_step "3" "Starting" "Setting up roles and perms"
 superset init
@@ -61,6 +67,12 @@ echo_step "3" "Complete" "Setting up roles and perms"
 if [ "$SUPERSET_LOAD_EXAMPLES" = "yes" ]; then
     # Load some data to play with
     echo_step "4" "Starting" "Loading examples"
-    superset load_examples
+    # If Cypress run which consumes superset_test_config – load required data for tests
+    if [ "$CYPRESS_CONFIG" == "true" ]; then
+        superset load_test_users
+        superset load_examples --load-test-data
+    else
+        superset load_examples
+    fi
     echo_step "4" "Complete" "Loading examples"
 fi

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-set -ex
+set -e
 
 #
 # Always install local overrides first
@@ -44,6 +44,7 @@ if [ "$CYPRESS_CONFIG" == "true" ]; then
     export SUPERSET_CONFIG=tests.superset_test_config
     export SUPERSET_TESTENV=true
     export ENABLE_REACT_CRUD_VIEWS=true
+    export SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset
 fi
 # Initialize the database
 echo_step "1" "Starting" "Applying DB migrations"


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR provides an option to run locally cypress tests with docker container. I updated contributor guide with required steps for this and added steps for making local CRUD views enabled and proper configuration set.

It needs to be tested before approve!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Scenario:
Make sure you have in your /etc/hosts file line:
```127.0.0.1 db```
and then run:
```CYPRESS_CONFIG=true docker-compose up```

When build is finished (superset_node finished webpack work) you can proceed with cypress tests ( ``` in superset-fronend/cypress-base run ./node_modules/cypress/bin/cypress run```)
Tests should pass.

Could you test it again @agatapst?

Could you take a look @craig-rueda? I had to modify docker-compose file because without this change, every time we call docker-compose we do not have clean state of database. With removed line of volume - we avoid sharing data between docker-compose runs. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [] Introduces new feature or API
- [ ] Removes existing feature or API
