### PR TITLE
chore: Add __pycache__ to  gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 *.pyc
 *.sqllite
 *.swp
+__pycache__
+
 .bento*
 .cache-loader
 .coverage


### PR DESCRIPTION
### SUMMARY

We use `rsync` to sync local code changes to remote machines for debug. This small PR makes sure empty `__pycache__` folders aren't synced when using `rsync   --filter=":- .gitignore"`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Not needed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
