### PR TITLE
test: test_cache_logging is not depending on other dashboard

### DIFF
--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -591,7 +591,7 @@ class TestCore(SupersetTestCase):
         girls_slice = self.get_slice("Girls", db.session)
         self.get_json_resp("/superset/warm_up_cache?slice_id={}".format(girls_slice.id))
         ck = db.session.query(CacheKey).order_by(CacheKey.id.desc()).first()
-        assert ck.datasource_uid == f"{girls_slice.datasource_id}__table"
+        assert ck.datasource_uid == f"{girls_slice.table.id}__table"
 
     def test_shortner(self):
         self.login(username="admin")

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -588,10 +588,10 @@ class TestCore(SupersetTestCase):
         ) == [{"slice_id": slc.id, "viz_error": None, "viz_status": "success"}]
 
     def test_cache_logging(self):
-        slc = self.get_slice("Girls", db.session)
-        self.get_json_resp("/superset/warm_up_cache?slice_id={}".format(slc.id))
+        girls_slice = self.get_slice("Girls", db.session)
+        self.get_json_resp("/superset/warm_up_cache?slice_id={}".format(girls_slice.id))
         ck = db.session.query(CacheKey).order_by(CacheKey.id.desc()).first()
-        assert ck.datasource_uid == "3__table"
+        assert ck.datasource_uid == f"{girls_slice.datasource_id}__table"
 
     def test_shortner(self):
         self.login(username="admin")


### PR DESCRIPTION
Assertion in test depends on order of created dashboards (if energy dashboard is created before, the dashboard uuid is `3__table`. It is fixed to base on table id which is used in test.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
