### PR TITLE
test: datasource uid of cache in test_csv_response_format is asserted with table id

### DIFF
--- a/tests/query_context_tests.py
+++ b/tests/query_context_tests.py
@@ -181,7 +181,7 @@ class TestQueryContext(SupersetTestCase):
         self.assertEqual(len(data.split("\n")), 12)
 
         ck = db.session.query(CacheKey).order_by(CacheKey.id.desc()).first()
-        assert ck.datasource_uid == "3__table"
+        assert ck.datasource_uid == f"{table.id}__table"
 
     def test_sql_injection_via_groupby(self):
         """


### PR DESCRIPTION
To be not depending on order of created tables, now assertion of cache's datasource uid is compared to table id of which it supposed be created.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
