### PR TITLE
feat: prevent co-edit dashboard collision

### DIFF
--- a/superset-frontend/src/dashboard/components/Header.jsx
+++ b/superset-frontend/src/dashboard/components/Header.jsx
@@ -290,6 +290,7 @@ class Header extends React.PureComponent {
       label_colors: labelColors,
       dashboard_title: dashboardTitle,
       refresh_frequency: refreshFrequency,
+      last_modified_time: dashboardInfo.lastModifiedTime,
     };
 
     // make sure positions data less than DB storage limitation:

--- a/superset-frontend/src/dashboard/components/SaveModal.jsx
+++ b/superset-frontend/src/dashboard/components/SaveModal.jsx
@@ -129,6 +129,7 @@ class SaveModal extends React.PureComponent {
         saveType === SAVE_TYPE_NEWDASHBOARD ? newDashName : dashboardTitle,
       duplicate_slices: this.state.duplicateSlices,
       refresh_frequency: refreshFrequency,
+      last_modified_time: dashboardInfo.lastModifiedTime,
     };
 
     if (saveType === SAVE_TYPE_NEWDASHBOARD && !newDashName) {

--- a/superset-frontend/src/dashboard/reducers/getInitialState.js
+++ b/superset-frontend/src/dashboard/reducers/getInitialState.js
@@ -266,6 +266,7 @@ export default function getInitialState(bootstrapData) {
       id: dashboard.id,
       slug: dashboard.slug,
       metadata: dashboard.metadata,
+      lastModifiedTime: dashboard.last_modified_time,
       userId: user_id,
       dash_edit_perm: dashboard.dash_edit_perm,
       dash_save_perm: dashboard.dash_save_perm,

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -237,6 +237,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
             "slug": self.slug,
             "slices": [slc.data for slc in self.slices],
             "position_json": positions,
+            "last_modified_time": self.changed_on.replace(microsecond=0).timestamp(),
         }
 
     @property  # type: ignore

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1018,6 +1018,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         """Copy dashboard"""
         session = db.session()
         data = json.loads(request.form["data"])
+        # client-side send back last_modified_time which was set when
+        # the dashboard was open. it was use to avoid mid-air collision.
+        # remove it to avoid confusion.
+        data.pop("last_modified_time", None)
+
         dash = models.Dashboard()
         original_dash = session.query(Dashboard).get(dashboard_id)
 
@@ -1064,15 +1069,20 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         dash = session.query(Dashboard).get(dashboard_id)
         check_ownership(dash, raise_if_false=True)
         data = json.loads(request.form["data"])
+        # client-side send back last_modified_time which was set when
+        # the dashboard was open. it was use to avoid mid-air collision.
         remote_last_modified_time = data.get("last_modified_time")
         current_last_modified_time = dash.changed_on.replace(microsecond=0).timestamp()
-        # prevent mid-air collisions
         if remote_last_modified_time < current_last_modified_time:
             return json_error_response(
-                "This dashboard was changed recently. "
-                "Please reload dashboard to get latest version.",
+                __(
+                    "This dashboard was changed recently. "
+                    "Please reload dashboard to get latest version."
+                ),
                 412,
             )
+        # remove to avoid confusion.
+        data.pop("last_modified_time", None)
 
         DashboardDAO.set_dash_metadata(dash, data)
         session.merge(dash)

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset"""
+from datetime import datetime
 import json
 import unittest
 from random import random
@@ -89,6 +90,8 @@ class TestDashboard(SupersetTestCase):
             "expanded_slices": {},
             "positions": positions,
             "dashboard_title": dash.dashboard_title,
+            # set a further modified_time for unit test
+            "last_modified_time": datetime.now().timestamp() + 1000,
         }
         url = "/superset/save_dash/{}/".format(dash.id)
         resp = self.get_resp(url, data=dict(data=json.dumps(data)))
@@ -107,6 +110,8 @@ class TestDashboard(SupersetTestCase):
             "positions": positions,
             "dashboard_title": dash.dashboard_title,
             "default_filters": default_filters,
+            # set a further modified_time for unit test
+            "last_modified_time": datetime.now().timestamp() + 1000,
         }
 
         url = "/superset/save_dash/{}/".format(dash.id)
@@ -134,6 +139,8 @@ class TestDashboard(SupersetTestCase):
             "positions": positions,
             "dashboard_title": dash.dashboard_title,
             "default_filters": default_filters,
+            # set a further modified_time for unit test
+            "last_modified_time": datetime.now().timestamp() + 1000,
         }
 
         url = "/superset/save_dash/{}/".format(dash.id)
@@ -154,6 +161,8 @@ class TestDashboard(SupersetTestCase):
             "expanded_slices": {},
             "positions": positions,
             "dashboard_title": "new title",
+            # set a further modified_time for unit test
+            "last_modified_time": datetime.now().timestamp() + 1000,
         }
         url = "/superset/save_dash/{}/".format(dash.id)
         self.get_resp(url, data=dict(data=json.dumps(data)))
@@ -176,6 +185,8 @@ class TestDashboard(SupersetTestCase):
             "color_namespace": "Color Namespace Test",
             "color_scheme": "Color Scheme Test",
             "label_colors": new_label_colors,
+            # set a further modified_time for unit test
+            "last_modified_time": datetime.now().timestamp() + 1000,
         }
         url = "/superset/save_dash/{}/".format(dash.id)
         self.get_resp(url, data=dict(data=json.dumps(data)))
@@ -203,6 +214,8 @@ class TestDashboard(SupersetTestCase):
             "color_namespace": "Color Namespace Test",
             "color_scheme": "Color Scheme Test",
             "label_colors": new_label_colors,
+            # set a further modified_time for unit test
+            "last_modified_time": datetime.now().timestamp() + 1000,
         }
 
         # Save changes to Births dashboard and retrieve updated dash
@@ -271,6 +284,8 @@ class TestDashboard(SupersetTestCase):
             "expanded_slices": {},
             "positions": positions,
             "dashboard_title": dash.dashboard_title,
+            # set a further modified_time for unit test
+            "last_modified_time": datetime.now().timestamp() + 1000,
         }
 
         # save dash


### PR DESCRIPTION
### SUMMARY
For a long time, airbnb users reported when 2 people accidentally co-edit same dashboard at the same time, the 2nd edit will overwrite the 1st edit, because dashboard do not prevent mid-air collisions.

Ideally we want Superset to `merge the 2nd changes` on top of the first change, but this is not easy to implement. This PR is to fix this issue with a simplified solution: When user open dashboard, dashboard carries the last_modified for this dashboard, and Dashboard will send this last_modified time with `save` request. When 2nd edit submit, Superset server-side detect the remote dashboard is older than the latest version, server-side will reject this save request and throw error message. So the dashboard editor has to reload dashboard (abandon the change), edit and save it again. This way we can prevent 2nd user overwrite 1st user's change.

**Note**:
This PR only prevent co-edit collision from `/save_dash/` endpoint. I noticed **Dashboard Properties modal** save dashboard metadata changes by calling a different API `/api/v1/dashboard/` first, then user needs to click save button again (and call `/save_dash/` endpoint). This flow currently is very buggy and confusing. this PR **does not** want to cover this flow. If you want to support mid-air collisions in the `/api/v1/dashboard/` API, please create a separated PR.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**BEFORE:**
2nd edit overwrite first edit quietly.

**AFTER:**
2nd edit could not be saved, and dashboard show error message:
<img width="1252" alt="Screen Shot 2020-10-09 at 11 12 55 AM" src="https://user-images.githubusercontent.com/27990562/95617657-a0ec3d00-0a20-11eb-8452-04abdd2b3d9d.png">


### TEST PLAN
CI and manual tests.

@ktmud @zuzana-vej @etr2460 
