### PR TITLE
refactor: use contextmanager for event_logger decorators

### DIFF
--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -33,7 +33,6 @@ from superset.extensions import (
     talisman,
 )
 from superset.security import SupersetSecurityManager
-from superset.utils.log import DBEventLogger, get_event_logger_from_cfg_value
 
 #  All of the fields located here should be considered legacy. The correct way
 #  to declare "global" dependencies is to define it in extensions.py,


### PR DESCRIPTION
### SUMMARY

Add a `log_context` method  and `log_manually` decorator to `EventLogger` so we don't have to use the empty function hack to call the `log_this` decorator.

Most changes are indentation. Please "Hide whitespace changes" while reviewing the diff:

<img src="https://user-images.githubusercontent.com/335541/95646423-4208e100-0a7d-11eb-9ef0-0256cc557b7a.png"  width="400" />

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
