### PR TITLE
chore: Leverage SQLALchemy ping rather than explicit SELECT 1 for testconn

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -33,7 +33,7 @@ from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_appbuilder.security.sqla import models as ab_models
 from flask_babel import gettext as __, lazy_gettext as _
 from jinja2.exceptions import TemplateError
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, or_
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import (
     ArgumentError,
@@ -1129,8 +1129,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             username = g.user.username if g.user is not None else None
             engine = database.get_sqla_engine(user_name=username)
 
-            with closing(engine.connect()) as conn:
-                conn.scalar(select([1]))
+            with closing(engine.raw_connection()) as conn:
+                engine.dialect.do_ping(conn)
                 return json_success('"OK"')
         except CertificateException as ex:
             logger.info("Certificate exception")


### PR DESCRIPTION
### SUMMARY

The SQLAlchemy dialect has a [`do_ping`](https://github.com/sqlalchemy/sqlalchemy/blob/056c929e15c735059b2f17f9ae5391d3ad244907/lib/sqlalchemy/engine/default.py#L624) method for pinging the database engine (which defaults to running a `SELECT 1`). Certain dialects/drivers override this and thus I thought there was merit in replacing the explicit `SELECT 1` query when testing the connection with the SQLAlchemy abstraction.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

Unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
