### PR TITLE
fix: adding `nofollow` to 3rd party links on docs site

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -458,7 +458,7 @@ const Theme = () => {
                     href={href}
                     target="_blank"
                     key={imageName}
-                    rel="noreferrer"
+                    rel="noreferrer nofollow"
                   >
                     <DbImage
                       {...{


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Apache prefers we add the 'nofollow' flag, so folks know we're unaffiliated.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
