### PR TITLE
chore: skip celery_test unit test and skip fixture when necessary

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -552,6 +552,7 @@ def load_test_users() -> None:
     """
     print(Fore.GREEN + "Loading a set of users for unit tests")
     load_test_users_run()
+    print(Fore.RESET)
 
 
 def load_test_users_run() -> None:

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -33,6 +33,7 @@ from tests.base_tests import login
 from tests.conftest import CTAS_SCHEMA_NAME
 from tests.test_app import app
 from superset import db, sql_lab
+from superset import config
 from superset.result_set import SupersetResultSet
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.extensions import celery_app
@@ -220,6 +221,7 @@ def test_run_async_query_cta_config(setup_sqllab, ctas_method):
     )
 
 
+@pytest.mark.skipif(config.CELERY_CONFIG is None, reason="Celery not configured")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 def test_run_async_cta_query(setup_sqllab, ctas_method):
     table_name = f"{TEST_ASYNC_CTA}_{ctas_method.lower()}"
@@ -240,6 +242,7 @@ def test_run_async_cta_query(setup_sqllab, ctas_method):
     assert query.select_as_cta_used
 
 
+@pytest.mark.skipif(config.CELERY_CONFIG is None, reason="Celery not configured")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 def test_run_async_cta_query_with_lower_limit(setup_sqllab, ctas_method):
     tmp_table = f"{TEST_ASYNC_LOWER_LIMIT}_{ctas_method.lower()}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # isort:skip_file
+import os
 from typing import Any
 
 import pytest
@@ -28,9 +29,11 @@ from superset.utils.core import get_example_database
 
 CTAS_SCHEMA_NAME = "sqllab_test_db"
 ADMIN_SCHEMA_NAME = "admin_database"
+# setting SKIP_SUPERSET_SAMPLE_LOAD environment variable to skip setup fixture
+AUTOUSE = False if "SKIP_SUPERSET_SAMPLE_LOAD" in os.environ else True
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=AUTOUSE, scope="session")
 def setup_sample_data() -> Any:
     with app.app_context():
         setup_presto_if_needed()


### PR DESCRIPTION
### SUMMARY
1. Skip celery_async_cta_query when Celery not config
2. using environment variable "SKIP_SUPERSET_SAMPLE_LOAD" skip fixture
