### PR TITLE
test: add admin to the owners of birth_names slices

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -90,10 +90,8 @@ build-instrumented-assets() {
 setup-postgres() {
   say "::group::Initialize database"
   psql "postgresql://superset:superset@127.0.0.1:15432/superset" <<-EOF
-    DROP SCHEMA IF EXISTS superset CASCADE;
     DROP SCHEMA IF EXISTS sqllab_test_db CASCADE;
     DROP SCHEMA IF EXISTS admin_database CASCADE;
-    CREATE SCHEMA superset;
     CREATE SCHEMA sqllab_test_db;
     CREATE SCHEMA admin_database;
 EOF

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -90,9 +90,11 @@ build-instrumented-assets() {
 setup-postgres() {
   say "::group::Initialize database"
   psql "postgresql://superset:superset@127.0.0.1:15432/superset" <<-EOF
-    DROP SCHEMA IF EXISTS sqllab_test_db;
+    DROP SCHEMA IF EXISTS superset CASCADE;
+    DROP SCHEMA IF EXISTS sqllab_test_db CASCADE;
+    DROP SCHEMA IF EXISTS admin_database CASCADE;
+    CREATE SCHEMA superset;
     CREATE SCHEMA sqllab_test_db;
-    DROP SCHEMA IF EXISTS admin_database;
     CREATE SCHEMA admin_database;
 EOF
   say "::endgroup::"

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -135,6 +135,7 @@ def load_birth_names(
         "compare_lag": "10",
         "compare_suffix": "o10Y",
         "limit": "25",
+        "time_range": "No filter",
         "granularity_sqla": "ds",
         "groupby": [],
         "row_limit": config["ROW_LIMIT"],
@@ -354,7 +355,6 @@ def load_birth_names(
             viz_type="table",
             datasource_type="table",
             datasource_id=tbl.id,
-            created_by=admin,
             params=get_slice_json(
                 defaults,
                 groupby=["ds"],
@@ -467,9 +467,13 @@ def load_birth_names(
         ),
     ]
     for slc in slices:
+        slc.owners = [admin]
+        slc.created_by = admin
         merge_slice(slc)
 
     for slc in misc_slices:
+        slc.owners = [admin]
+        slc.created_by = admin
         merge_slice(slc)
         misc_dash_slices.add(slc.slice_name)
 
@@ -478,6 +482,8 @@ def load_birth_names(
 
     if not dash:
         dash = Dashboard()
+        dash.owners = [admin]
+        dash.created_by = admin
         db.session.add(dash)
     dash.published = True
     dash.json_metadata = textwrap.dedent(


### PR DESCRIPTION
### SUMMARY

Add `admin` to the creator and owners of birth_names slices so that it's possible to add these slices to the test dashboard.

Also set the default time range to "No filter" so these charts can have results by default.

This is useful when one wants to add more slices to a dashboard to manually test something.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

The `birth_names` slices doesn't show up in available charts when editing a dashboard.

#### After

<img src="https://user-images.githubusercontent.com/335541/95666847-b2157680-0b12-11eb-9733-94a5a6820aa1.png" width="500" />

### TEST PLAN

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
