### PR TITLE
fix(cypress): table viz failed to run in postgres12

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/shared.helper.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/shared.helper.js
@@ -87,25 +87,13 @@ export const MAX_DS = {
 };
 
 export const MAX_STATE = {
-  expressionType: 'SIMPLE',
-  column: {
-    id: 337,
-    column_name: 'state',
-    verbose_name: null,
-    description: null,
-    expression: null,
-    filterable: true,
-    groupby: true,
-    is_dttm: false,
-    type: 'VARCHAR(10)',
-    python_date_format: null,
-    optionName: '_col_state',
-  },
-  aggregate: 'MAX',
-  sqlExpression: null,
+  expressionType: 'SQL',
+  sqlExpression: 'MAX(UPPER(state))',
+  column: null,
+  aggregate: null,
   isNew: false,
   hasCustomLabel: false,
-  label: 'MAX(state)',
+  label: 'MAX(UPPER(state))',
   optionName: 'metric_kvval50pvbo_hewj3pzacb',
 };
 

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/table.test.ts
@@ -66,7 +66,7 @@ describe('Visualization > Table', () => {
     cy.get('.chart-container td:nth-child(1)').contains('2008 Q1');
     // other column with timestamp use raw timestamp
     cy.get('.chart-container td:nth-child(3)').contains('2008-01-01T00:00:00');
-    cy.get('.chart-container td:nth-child(4)').contains('other');
+    cy.get('.chart-container td:nth-child(4)').contains('TX');
   });
 
   it('Format with table_timestamp_format', () => {
@@ -87,7 +87,7 @@ describe('Visualization > Table', () => {
     // time column should not use time granularity when timestamp format is set
     cy.get('.chart-container td').contains('2008 Q1').should('not.exist');
     // other num numeric metric column should stay as string
-    cy.get('.chart-container td').contains('other');
+    cy.get('.chart-container td').contains('TX');
   });
 
   it('Test table with groupby', () => {


### PR DESCRIPTION
### SUMMARY
Failed to run cypress with postgres12, It seems that the problem is caused by the character order.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/2016594/95681552-01db6700-0c13-11eb-97ac-cfe04b2d92a8.png)

