### PR TITLE
chore(engine): adapt postgres backend connection URI

### DIFF
--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -49,3 +49,8 @@ for (_, name, _) in pkgutil.iter_modules([Path(__file__).parent]):  # type: igno
             and attribute.engine != ""
         ):
             engines[attribute.engine] = attribute
+
+            # populate engine alias name to engine dictionary
+            if isinstance(attribute.engine_aliases, tuple) and attribute.engine_aliases:
+                for engine_alias in attribute.engine_aliases:
+                    engines[engine_alias] = attribute

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -51,6 +51,5 @@ for (_, name, _) in pkgutil.iter_modules([Path(__file__).parent]):  # type: igno
             engines[attribute.engine] = attribute
 
             # populate engine alias name to engine dictionary
-            if isinstance(attribute.engine_aliases, tuple) and attribute.engine_aliases:
-                for engine_alias in attribute.engine_aliases:
-                    engines[engine_alias] = attribute
+            for engine_alias in attribute.engine_aliases or []:
+                engines[engine_alias] = attribute

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -137,6 +137,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     """Abstract class for database engine specific configurations"""
 
     engine = "base"  # str as defined in sqlalchemy.engine.engine
+    engine_aliases: Optional[Tuple[str]] = None
     engine_name: Optional[
         str
     ] = None  # used for user messages, overridden in child classes

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -67,6 +67,7 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
 
 class PostgresEngineSpec(PostgresBaseEngineSpec):
     engine = "postgresql"
+    engine_aliases = ("postgres",)
     max_column_name_length = 63
     try_remove_schema_from_table_name = False
 

--- a/tests/db_engine_specs/base_tests.py
+++ b/tests/db_engine_specs/base_tests.py
@@ -17,7 +17,6 @@
 # isort:skip_file
 from datetime import datetime
 
-from tests.test_app import app
 from tests.base_tests import SupersetTestCase
 from superset.db_engine_specs.mysql import MySQLEngineSpec
 from superset.models.core import Database

--- a/tests/db_engine_specs/base_tests.py
+++ b/tests/db_engine_specs/base_tests.py
@@ -17,6 +17,7 @@
 # isort:skip_file
 from datetime import datetime
 
+from tests.test_app import app
 from tests.base_tests import SupersetTestCase
 from superset.db_engine_specs.mysql import MySQLEngineSpec
 from superset.models.core import Database

--- a/tests/db_engine_specs/postgres_tests.py
+++ b/tests/db_engine_specs/postgres_tests.py
@@ -19,6 +19,7 @@ from unittest import mock
 from sqlalchemy import column, literal_column
 from sqlalchemy.dialects import postgresql
 
+from superset.db_engine_specs import engines
 from superset.db_engine_specs.postgres import PostgresEngineSpec
 from tests.db_engine_specs.base_tests import TestDbEngineSpec
 
@@ -117,3 +118,9 @@ class TestPostgresDbEngineSpec(TestDbEngineSpec):
         cursor.description = []
         results = PostgresEngineSpec.fetch_data(cursor, 1000)
         self.assertEqual(results, [])
+
+    def test_engine_alias_name(self):
+        """
+        DB Eng Specs (postgres): Test "postgres" in engine spec
+        """
+        self.assertIn("postgres", engines)


### PR DESCRIPTION
### SUMMARY
postgres connection the URI scheme designator can be either postgresql:// or postgres://.

refer: https://www.postgresql.org/docs/10/libpq-connect.html#LIBPQ-CONNSTRING


