### PR TITLE
chore(sqla): assert query does not exceed 1 statement

### DIFF
--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -187,3 +187,45 @@ class TestDatabaseModel(SupersetTestCase):
         if get_example_database().backend != "presto":
             with pytest.raises(QueryObjectValidationError):
                 table.get_sqla_query(**query_obj)
+
+    def test_multiple_sql_statements_raises_exception(self):
+        base_query_obj = {
+            "granularity": None,
+            "from_dttm": None,
+            "to_dttm": None,
+            "groupby": ["grp"],
+            "metrics": [],
+            "is_timeseries": False,
+            "filter": [],
+        }
+
+        table = SqlaTable(
+            table_name="test_has_extra_cache_keys_table",
+            sql="SELECT 'foo' as grp, 1 as num; SELECT 'bar' as grp, 2 as num",
+            database=get_example_database(),
+        )
+
+        query_obj = dict(**base_query_obj, extras={})
+        with pytest.raises(QueryObjectValidationError):
+            table.get_sqla_query(**query_obj)
+
+    def test_dml_statement_raises_exception(self):
+        base_query_obj = {
+            "granularity": None,
+            "from_dttm": None,
+            "to_dttm": None,
+            "groupby": ["grp"],
+            "metrics": [],
+            "is_timeseries": False,
+            "filter": [],
+        }
+
+        table = SqlaTable(
+            table_name="test_has_extra_cache_keys_table",
+            sql="DELETE FROM foo",
+            database=get_example_database(),
+        )
+
+        query_obj = dict(**base_query_obj, extras={})
+        with pytest.raises(QueryObjectValidationError):
+            table.get_sqla_query(**query_obj)


### PR DESCRIPTION
### SUMMARY
Raise understandable error if query consists of multiple statements.

### AFTER
For DML queries:
![image](https://user-images.githubusercontent.com/33317356/95741934-db134400-0c97-11eb-9ac0-c73dcdc92af5.png)
For multiple statements:
![image](https://user-images.githubusercontent.com/33317356/95740467-3a238980-0c95-11eb-931d-447072f7c35d.png)

### BEFORE
For DML queries:
![image](https://user-images.githubusercontent.com/33317356/95741998-fbdb9980-0c97-11eb-949c-28dd95e8c821.png)
For multiple statements:
![image](https://user-images.githubusercontent.com/33317356/95740413-1d875180-0c95-11eb-953d-83e7d00a1103.png)

### TEST PLAN
CI + new test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
