### PR TITLE
refactor: Replace usages of reactable in TimeTable

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Mustache from 'mustache';
-import memoize from 'lodash/memoize';
 import { scaleLinear } from 'd3-scale';
 import TableView from 'src/components/TableView';
 import { formatNumber, formatTime, styled } from '@superset-ui/core';
@@ -98,33 +97,174 @@ const TimeTableStyles = styled.div`
   }
 `;
 
-class TimeTable extends React.PureComponent {
-  memoizedColumns = memoize(columnConfigs => [
-    { accessor: 'metric', Header: 'Metric' },
-    ...columnConfigs.map((columnConfig, i) => ({
-      accessor: columnConfig.key,
-      cellProps: columnConfig.colType === 'spark' && { style: { width: '1%' } },
-      Header: () => (
-        <>
-          {columnConfig.label}{' '}
-          {columnConfig.tooltip && (
-            <InfoTooltipWithTrigger
-              tooltip={columnConfig.tooltip}
-              label={`tt-col-${i}`}
-              placement="top"
-            />
-          )}
-        </>
-      ),
-      sortType: (rowA, rowB, columnId) => {
-        const rowAVal = rowA.values[columnId].props['data-value'];
-        const rowBVal = rowB.values[columnId].props['data-value'];
-        return rowAVal - rowBVal;
-      },
-    })),
-  ]);
+const TimeTable = ({
+  className,
+  height,
+  data,
+  columnConfigs,
+  rowType,
+  rows,
+  url,
+}) => {
+  const memoizedColumns = useMemo(
+    () => [
+      { accessor: 'metric', Header: 'Metric' },
+      ...columnConfigs.map((columnConfig, i) => ({
+        accessor: columnConfig.key,
+        cellProps: columnConfig.colType === 'spark' && {
+          style: { width: '1%' },
+        },
+        Header: () => (
+          <>
+            {columnConfig.label}{' '}
+            {columnConfig.tooltip && (
+              <InfoTooltipWithTrigger
+                tooltip={columnConfig.tooltip}
+                label={`tt-col-${i}`}
+                placement="top"
+              />
+            )}
+          </>
+        ),
+        sortType: (rowA, rowB, columnId) => {
+          const rowAVal = rowA.values[columnId].props['data-value'];
+          const rowBVal = rowB.values[columnId].props['data-value'];
+          return rowAVal - rowBVal;
+        },
+      })),
+    ],
+    [columnConfigs],
+  );
 
-  memoizedRows = memoize((data, rows, columnConfigs) => {
+  const memoizedRows = useMemo(() => {
+    const renderSparklineCell = (valueField, column, entries) => {
+      let sparkData;
+      if (column.timeRatio) {
+        // Period ratio sparkline
+        sparkData = [];
+        for (let i = column.timeRatio; i < entries.length; i += 1) {
+          const prevData = entries[i - column.timeRatio][valueField];
+          if (prevData && prevData !== 0) {
+            sparkData.push(entries[i][valueField] / prevData);
+          } else {
+            sparkData.push(null);
+          }
+        }
+      } else {
+        sparkData = entries.map(d => d[valueField]);
+      }
+
+      return (
+        <SparklineCell
+          width={parseInt(column.width, 10) || 300}
+          height={parseInt(column.height, 10) || 50}
+          data={sparkData}
+          data-value={sparkData[sparkData.length - 1]}
+          ariaLabel={`spark-${valueField}`}
+          numberFormat={column.d3format}
+          yAxisBounds={column.yAxisBounds}
+          showYAxis={column.showYAxis}
+          renderTooltip={({ index }) => (
+            <div>
+              <strong>{formatNumber(column.d3format, sparkData[index])}</strong>
+              <div>
+                {formatTime(
+                  column.dateFormat,
+                  moment.utc(entries[index].time).toDate(),
+                )}
+              </div>
+            </div>
+          )}
+        />
+      );
+    };
+
+    const renderValueCell = (valueField, column, reversedEntries) => {
+      const recent = reversedEntries[0][valueField];
+      let v;
+      let errorMsg;
+      if (column.colType === 'time') {
+        // Time lag ratio
+        const timeLag = column.timeLag || 0;
+        const totalLag = Object.keys(reversedEntries).length;
+        if (timeLag >= totalLag) {
+          errorMsg = `The time lag set at ${timeLag} is too large for the length of data at ${reversedEntries.length}. No data available.`;
+        } else {
+          v = reversedEntries[timeLag][valueField];
+        }
+        if (column.comparisonType === 'diff') {
+          v = recent - v;
+        } else if (column.comparisonType === 'perc') {
+          v = recent / v;
+        } else if (column.comparisonType === 'perc_change') {
+          v = recent / v - 1;
+        }
+        v = v || 0;
+      } else if (column.colType === 'contrib') {
+        // contribution to column total
+        v =
+          recent /
+          Object.keys(reversedEntries[0])
+            .map(k => (k !== 'time' ? reversedEntries[0][k] : null))
+            .reduce((a, b) => a + b);
+      } else if (column.colType === 'avg') {
+        // Average over the last {timeLag}
+        v =
+          reversedEntries
+            .map((k, i) => (i < column.timeLag ? k[valueField] : 0))
+            .reduce((a, b) => a + b) / column.timeLag;
+      }
+
+      const color = colorFromBounds(v, column.bounds);
+
+      return (
+        <span
+          key={column.key}
+          data-value={v}
+          style={
+            color && {
+              boxShadow: `inset 0px -2.5px 0px 0px ${color}`,
+              borderRight: '2px solid #fff',
+            }
+          }
+        >
+          {errorMsg ? (
+            { errorMsg }
+          ) : (
+            <span style={{ color }}>
+              <FormattedNumber num={v} format={column.d3format} />
+            </span>
+          )}
+        </span>
+      );
+    };
+
+    const renderLeftCell = row => {
+      const context = { metric: row };
+      const fullUrl = url ? Mustache.render(url, context) : null;
+
+      if (rowType === 'column') {
+        const column = row;
+        if (fullUrl) {
+          return (
+            <a href={fullUrl} rel="noopener noreferrer" target="_blank">
+              {column.label}
+            </a>
+          );
+        }
+        return column.label;
+      }
+
+      return (
+        <MetricOption
+          metric={row}
+          url={fullUrl}
+          showFormula={false}
+          openInNewWindow
+        />
+      );
+    };
+
     const entries = Object.keys(data)
       .sort()
       .map(time => ({ ...data[time], time }));
@@ -136,7 +276,7 @@ class TimeTable extends React.PureComponent {
         if (columnConfig.colType === 'spark') {
           return {
             ...acc,
-            [columnConfig.key]: this.renderSparklineCell(
+            [columnConfig.key]: renderSparklineCell(
               valueField,
               columnConfig,
               entries,
@@ -145,181 +285,39 @@ class TimeTable extends React.PureComponent {
         }
         return {
           ...acc,
-          [columnConfig.key]: this.renderValueCell(
+          [columnConfig.key]: renderValueCell(
             valueField,
             columnConfig,
             reversedEntries,
           ),
         };
       }, {});
-      return { ...row, ...cellValues, metric: this.renderLeftCell(row) };
+      return { ...row, ...cellValues, metric: renderLeftCell(row) };
     });
-  });
+  }, [columnConfigs, data, rowType, rows, url]);
 
-  initialSort = [{ id: 'metric', desc: false }];
+  const defaultSort =
+    rowType === 'column' && columnConfigs.length
+      ? [
+          {
+            id: columnConfigs[0].key,
+            desc: 'true',
+          },
+        ]
+      : [];
 
-  renderLeftCell(row) {
-    const { rowType, url } = this.props;
-    const context = { metric: row };
-    const fullUrl = url ? Mustache.render(url, context) : null;
-
-    if (rowType === 'column') {
-      const column = row;
-      if (fullUrl) {
-        return (
-          <a href={fullUrl} rel="noopener noreferrer" target="_blank">
-            {column.label}
-          </a>
-        );
-      }
-      return column.label;
-    }
-
-    return (
-      <MetricOption
-        metric={row}
-        url={fullUrl}
-        showFormula={false}
-        openInNewWindow
+  return (
+    <TimeTableStyles className={`time-table ${className}`} height={height}>
+      <TableView
+        className="table-no-hover"
+        columns={memoizedColumns}
+        data={memoizedRows}
+        initialSortBy={defaultSort}
+        withPagination={false}
       />
-    );
-  }
-
-  renderSparklineCell(valueField, column, entries) {
-    let sparkData;
-    if (column.timeRatio) {
-      // Period ratio sparkline
-      sparkData = [];
-      for (let i = column.timeRatio; i < entries.length; i += 1) {
-        const prevData = entries[i - column.timeRatio][valueField];
-        if (prevData && prevData !== 0) {
-          sparkData.push(entries[i][valueField] / prevData);
-        } else {
-          sparkData.push(null);
-        }
-      }
-    } else {
-      sparkData = entries.map(d => d[valueField]);
-    }
-
-    return (
-      <SparklineCell
-        width={parseInt(column.width, 10) || 300}
-        height={parseInt(column.height, 10) || 50}
-        data={sparkData}
-        data-value={sparkData[sparkData.length - 1]}
-        ariaLabel={`spark-${valueField}`}
-        numberFormat={column.d3format}
-        yAxisBounds={column.yAxisBounds}
-        showYAxis={column.showYAxis}
-        renderTooltip={({ index }) => (
-          <div>
-            <strong>{formatNumber(column.d3format, sparkData[index])}</strong>
-            <div>
-              {formatTime(
-                column.dateFormat,
-                moment.utc(entries[index].time).toDate(),
-              )}
-            </div>
-          </div>
-        )}
-      />
-    );
-  }
-
-  renderValueCell(valueField, column, reversedEntries) {
-    const recent = reversedEntries[0][valueField];
-    let v;
-    let errorMsg;
-    if (column.colType === 'time') {
-      // Time lag ratio
-      const timeLag = column.timeLag || 0;
-      const totalLag = Object.keys(reversedEntries).length;
-      if (timeLag >= totalLag) {
-        errorMsg = `The time lag set at ${timeLag} is too large for the length of data at ${reversedEntries.length}. No data available.`;
-      } else {
-        v = reversedEntries[timeLag][valueField];
-      }
-      if (column.comparisonType === 'diff') {
-        v = recent - v;
-      } else if (column.comparisonType === 'perc') {
-        v = recent / v;
-      } else if (column.comparisonType === 'perc_change') {
-        v = recent / v - 1;
-      }
-      v = v || 0;
-    } else if (column.colType === 'contrib') {
-      // contribution to column total
-      v =
-        recent /
-        Object.keys(reversedEntries[0])
-          .map(k => (k !== 'time' ? reversedEntries[0][k] : null))
-          .reduce((a, b) => a + b);
-    } else if (column.colType === 'avg') {
-      // Average over the last {timeLag}
-      v =
-        reversedEntries
-          .map((k, i) => (i < column.timeLag ? k[valueField] : 0))
-          .reduce((a, b) => a + b) / column.timeLag;
-    }
-
-    const color = colorFromBounds(v, column.bounds);
-
-    return (
-      <span
-        key={column.key}
-        data-value={v}
-        style={
-          color && {
-            boxShadow: `inset 0px -2.5px 0px 0px ${color}`,
-            borderRight: '2px solid #fff',
-          }
-        }
-      >
-        {errorMsg ? (
-          { errorMsg }
-        ) : (
-          <span style={{ color }}>
-            <FormattedNumber num={v} format={column.d3format} />
-          </span>
-        )}
-      </span>
-    );
-  }
-
-  render() {
-    const {
-      className,
-      height,
-      data,
-      columnConfigs,
-      rowType,
-      rows,
-    } = this.props;
-
-    const defaultSort =
-      rowType === 'column' && columnConfigs.length
-        ? [
-            {
-              id: columnConfigs[0].key,
-              desc: 'true',
-            },
-          ]
-        : [];
-
-    return (
-      <TimeTableStyles className={`time-table ${className}`} height={height}>
-        <TableView
-          className="table-no-hover"
-          columns={this.memoizedColumns(columnConfigs)}
-          data={this.memoizedRows(data, rows, columnConfigs)}
-          initialSortBy={defaultSort}
-          withPagination={false}
-        />
-      </TimeTableStyles>
-    );
-  }
-}
+    </TimeTableStyles>
+  );
+};
 
 TimeTable.propTypes = propTypes;
 TimeTable.defaultProps = defaultProps;

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -19,9 +19,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Mustache from 'mustache';
+import memoize from 'lodash/memoize';
 import { scaleLinear } from 'd3-scale';
-import { Table, Thead, Th, Tr, Td } from 'reactable-arc';
-import { formatNumber, formatTime } from '@superset-ui/core';
+import { TableView } from 'src/components/ListView';
+import { formatNumber, formatTime, styled } from '@superset-ui/core';
 import {
   InfoTooltipWithTrigger,
   MetricOption,
@@ -89,7 +90,74 @@ const defaultProps = {
   url: '',
 };
 
+const TimeTableStyles = styled.div`
+  height: ${props => props.height}px;
+
+  th {
+    z-index: 1; // to cover sparkline
+  }
+`;
+
 class TimeTable extends React.PureComponent {
+  memoizedColumns = memoize(columnConfigs => [
+    { accessor: 'metric', Header: 'Metric' },
+    ...columnConfigs.map((columnConfig, i) => ({
+      accessor: columnConfig.key,
+      cellProps: columnConfig.colType === 'spark' && { style: { width: '1%' } },
+      Header: () => (
+        <>
+          {columnConfig.label}{' '}
+          {columnConfig.tooltip && (
+            <InfoTooltipWithTrigger
+              tooltip={columnConfig.tooltip}
+              label={`tt-col-${i}`}
+              placement="top"
+            />
+          )}
+        </>
+      ),
+      sortType: (rowA, rowB, columnId) => {
+        const rowAVal = rowA.values[columnId].props['data-value'];
+        const rowBVal = rowB.values[columnId].props['data-value'];
+        return rowAVal - rowBVal;
+      },
+    })),
+  ]);
+
+  memoizedRows = memoize((data, rows, columnConfigs) => {
+    const entries = Object.keys(data)
+      .sort()
+      .map(time => ({ ...data[time], time }));
+    const reversedEntries = entries.concat().reverse();
+
+    return rows.map(row => {
+      const valueField = row.label || row.metric_name;
+      const cellValues = columnConfigs.reduce((acc, columnConfig) => {
+        if (columnConfig.colType === 'spark') {
+          return {
+            ...acc,
+            [columnConfig.key]: this.renderSparklineCell(
+              valueField,
+              columnConfig,
+              entries,
+            ),
+          };
+        }
+        return {
+          ...acc,
+          [columnConfig.key]: this.renderValueCell(
+            valueField,
+            columnConfig,
+            reversedEntries,
+          ),
+        };
+      }, {});
+      return { ...row, ...cellValues, metric: this.renderLeftCell(row) };
+    });
+  });
+
+  initialSort = [{ id: 'metric', desc: false }];
+
   renderLeftCell(row) {
     const { rowType, url } = this.props;
     const context = { metric: row };
@@ -107,10 +175,9 @@ class TimeTable extends React.PureComponent {
       return column.label;
     }
 
-    const metric = row;
     return (
       <MetricOption
-        metric={metric}
+        metric={row}
         url={fullUrl}
         showFormula={false}
         openInNewWindow
@@ -136,32 +203,27 @@ class TimeTable extends React.PureComponent {
     }
 
     return (
-      <Td
-        column={column.key}
-        key={column.key}
-        value={sparkData[sparkData.length - 1]}
-      >
-        <SparklineCell
-          width={parseInt(column.width, 10) || 300}
-          height={parseInt(column.height, 10) || 50}
-          data={sparkData}
-          ariaLabel={`spark-${valueField}`}
-          numberFormat={column.d3format}
-          yAxisBounds={column.yAxisBounds}
-          showYAxis={column.showYAxis}
-          renderTooltip={({ index }) => (
+      <SparklineCell
+        width={parseInt(column.width, 10) || 300}
+        height={parseInt(column.height, 10) || 50}
+        data={sparkData}
+        data-value={sparkData[sparkData.length - 1]}
+        ariaLabel={`spark-${valueField}`}
+        numberFormat={column.d3format}
+        yAxisBounds={column.yAxisBounds}
+        showYAxis={column.showYAxis}
+        renderTooltip={({ index }) => (
+          <div>
+            <strong>{formatNumber(column.d3format, sparkData[index])}</strong>
             <div>
-              <strong>{formatNumber(column.d3format, sparkData[index])}</strong>
-              <div>
-                {formatTime(
-                  column.dateFormat,
-                  moment.utc(entries[index].time).toDate(),
-                )}
-              </div>
+              {formatTime(
+                column.dateFormat,
+                moment.utc(entries[index].time).toDate(),
+              )}
             </div>
-          )}
-        />
-      </Td>
+          </div>
+        )}
+      />
     );
   }
 
@@ -204,10 +266,9 @@ class TimeTable extends React.PureComponent {
     const color = colorFromBounds(v, column.bounds);
 
     return (
-      <Td
-        column={column.key}
+      <span
         key={column.key}
-        value={v}
+        data-value={v}
         style={
           color && {
             boxShadow: `inset 0px -2.5px 0px 0px ${color}`,
@@ -216,32 +277,13 @@ class TimeTable extends React.PureComponent {
         }
       >
         {errorMsg ? (
-          <div>{errorMsg}</div>
+          { errorMsg }
         ) : (
-          <div style={{ color }}>
+          <span style={{ color }}>
             <FormattedNumber num={v} format={column.d3format} />
-          </div>
+          </span>
         )}
-      </Td>
-    );
-  }
-
-  renderRow(row, entries, reversedEntries) {
-    const { columnConfigs } = this.props;
-    const valueField = row.label || row.metric_name;
-    const leftCell = this.renderLeftCell(row);
-
-    return (
-      <Tr key={leftCell}>
-        <Td column="metric" data={leftCell}>
-          {leftCell}
-        </Td>
-        {columnConfigs.map(c =>
-          c.colType === 'spark'
-            ? this.renderSparklineCell(valueField, c, entries)
-            : this.renderValueCell(valueField, c, reversedEntries),
-        )}
-      </Tr>
+      </span>
     );
   }
 
@@ -255,49 +297,26 @@ class TimeTable extends React.PureComponent {
       rows,
     } = this.props;
 
-    const entries = Object.keys(data)
-      .sort()
-      .map(time => ({ ...data[time], time }));
-    const reversedEntries = entries.concat().reverse();
-
     const defaultSort =
       rowType === 'column' && columnConfigs.length
-        ? {
-            column: columnConfigs[0].key,
-            direction: 'desc',
-          }
-        : false;
+        ? [
+            {
+              id: columnConfigs[0].key,
+              desc: 'true',
+            },
+          ]
+        : [];
 
     return (
-      <div className={`time-table ${className}`} style={{ height }}>
-        <Table
-          className="table table-no-hover"
-          defaultSort={defaultSort}
-          sortBy={defaultSort}
-          sortable={columnConfigs.map(c => c.key)}
-        >
-          <Thead>
-            <Th column="metric">Metric</Th>
-            {columnConfigs.map((c, i) => (
-              <Th
-                key={c.key}
-                column={c.key}
-                width={c.colType === 'spark' ? '1%' : null}
-              >
-                {c.label}{' '}
-                {c.tooltip && (
-                  <InfoTooltipWithTrigger
-                    tooltip={c.tooltip}
-                    label={`tt-col-${i}`}
-                    placement="top"
-                  />
-                )}
-              </Th>
-            ))}
-          </Thead>
-          {rows.map(row => this.renderRow(row, entries, reversedEntries))}
-        </Table>
-      </div>
+      <TimeTableStyles className={`time-table ${className}`} height={height}>
+        <TableView
+          className="table-no-hover"
+          columns={this.memoizedColumns(columnConfigs)}
+          data={this.memoizedRows(data, rows, columnConfigs)}
+          initialSortBy={defaultSort}
+          withPagination={false}
+        />
+      </TimeTableStyles>
     );
   }
 }

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import Mustache from 'mustache';
 import memoize from 'lodash/memoize';
 import { scaleLinear } from 'd3-scale';
-import { TableView } from 'src/components/ListView';
+import TableView from 'src/components/TableView';
 import { formatNumber, formatTime, styled } from '@superset-ui/core';
 import {
   InfoTooltipWithTrigger,


### PR DESCRIPTION
### SUMMARY
This PR refactors TimeTable to use TableView, based on `react-table` library. The goal was to get rid of `reactable`.
This PR replaces https://github.com/apache/incubator-superset/pull/11046, which was reverted due to the issue https://github.com/apache/incubator-superset/issues/11142.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
