### PR TITLE
refactor: Replace usages of reactable in TableLoader

### DIFF
--- a/superset-frontend/src/components/TableLoader.jsx
+++ b/superset-frontend/src/components/TableLoader.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import memoize from 'lodash/memoize';
 import { t, SupersetClient } from '@superset-ui/core';
-import { TableView } from 'src/components/ListView';
+import TableView from 'src/components/TableView';
 import withToasts from '../messageToasts/enhancers/withToasts';
 import Loading from './Loading';
 import '../../stylesheets/reactable-pagination.less';

--- a/superset-frontend/src/components/TableLoader.jsx
+++ b/superset-frontend/src/components/TableLoader.jsx
@@ -24,6 +24,7 @@ import TableView from 'src/components/TableView';
 import withToasts from '../messageToasts/enhancers/withToasts';
 import Loading from './Loading';
 import '../../stylesheets/reactable-pagination.less';
+import { EmptyWrapperType } from './TableView/TableView';
 
 const propTypes = {
   dataEndpoint: PropTypes.string.isRequired,
@@ -77,10 +78,12 @@ class TableLoader extends React.PureComponent {
       if (!columns && data.length > 0) {
         tableColumns = Object.keys(data[0]).filter(col => col[0] !== '_');
       }
-      return tableColumns.map(column => ({
-        accessor: column,
-        Header: column,
-      }));
+      return tableColumns
+        ? tableColumns.map(column => ({
+            accessor: column,
+            Header: column,
+          }))
+        : [];
     });
 
     delete tableProps.dataEndpoint;
@@ -93,6 +96,7 @@ class TableLoader extends React.PureComponent {
         data={this.state.data}
         pageSize={50}
         loading={this.state.isLoading}
+        emptyWrapperType={EmptyWrapperType.Small}
         {...tableProps}
       />
     );

--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -25,6 +25,11 @@ import { SortColumns } from './types';
 
 const DEFAULT_PAGE_SIZE = 10;
 
+export enum EmptyWrapperType {
+  Default,
+  Small,
+}
+
 export interface TableViewProps {
   columns: any[];
   data: any[];
@@ -33,6 +38,8 @@ export interface TableViewProps {
   initialSortBy?: SortColumns;
   loading?: boolean;
   withPagination?: boolean;
+  emptyWrapperType?: EmptyWrapperType;
+  noDataText?: string;
   className?: string;
 }
 
@@ -65,6 +72,8 @@ const TableView = ({
   initialSortBy = [],
   loading = false,
   withPagination = true,
+  emptyWrapperType = EmptyWrapperType.Default,
+  noDataText,
   ...props
 }: TableViewProps) => {
   const initialState = {
@@ -95,6 +104,21 @@ const TableView = ({
   );
 
   const content = withPagination ? page : rows;
+
+  let EmptyWrapperComponent;
+  switch (emptyWrapperType) {
+    case EmptyWrapperType.Small:
+      EmptyWrapperComponent = ({ children }: any) => <>{children}</>;
+      break;
+    case EmptyWrapperType.Default:
+    default:
+      EmptyWrapperComponent = ({ children }: any) => (
+        <EmptyWrapper>{children}</EmptyWrapper>
+      );
+  }
+
+  const isEmpty = !loading && content.length === 0;
+
   return (
     <TableViewStyles {...props}>
       <TableCollection
@@ -106,10 +130,17 @@ const TableView = ({
         columns={columns}
         loading={loading}
       />
-      {!loading && content.length === 0 && (
-        <EmptyWrapper>
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
-        </EmptyWrapper>
+      {isEmpty && (
+        <EmptyWrapperComponent>
+          {noDataText ? (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={noDataText}
+            />
+          ) : (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+          )}
+        </EmptyWrapperComponent>
       )}
       {pageCount > 1 && withPagination && (
         <div className="pagination-container">

--- a/superset-frontend/src/profile/components/CreatedContent.tsx
+++ b/superset-frontend/src/profile/components/CreatedContent.tsx
@@ -39,7 +39,7 @@ class CreatedContent extends React.PureComponent<CreatedContentProps> {
     return (
       <TableLoader
         dataEndpoint={`/superset/created_slices/${this.props.user.userId}/`}
-        className="table table-condensed"
+        className="table-condensed"
         columns={['slice', 'favorited']}
         mutator={mutator}
         noDataText={t('No charts')}
@@ -57,7 +57,7 @@ class CreatedContent extends React.PureComponent<CreatedContentProps> {
       }));
     return (
       <TableLoader
-        className="table table-condensed"
+        className="table-condensed"
         mutator={mutator}
         dataEndpoint={`/superset/created_dashboards/${this.props.user.userId}/`}
         noDataText={t('No dashboards')}

--- a/superset-frontend/src/profile/components/Favorites.tsx
+++ b/superset-frontend/src/profile/components/Favorites.tsx
@@ -40,7 +40,7 @@ export default class Favorites extends React.PureComponent<FavoritesProps> {
     return (
       <TableLoader
         dataEndpoint={`/superset/fave_slices/${this.props.user.userId}/`}
-        className="table table-condensed"
+        className="table-condensed"
         columns={['slice', 'creator', 'favorited']}
         mutator={mutator}
         noDataText={t('No favorite charts yet, go click on stars!')}
@@ -58,7 +58,7 @@ export default class Favorites extends React.PureComponent<FavoritesProps> {
       }));
     return (
       <TableLoader
-        className="table table-condensed"
+        className="table-condensed"
         mutator={mutator}
         dataEndpoint={`/superset/fave_dashboards/${this.props.user.userId}/`}
         noDataText={t('No favorite dashboards yet, go click on stars!')}

--- a/superset-frontend/src/profile/components/RecentActivity.tsx
+++ b/superset-frontend/src/profile/components/RecentActivity.tsx
@@ -42,7 +42,7 @@ export default function RecentActivity({ user }: RecentActivityProps) {
   return (
     <div>
       <TableLoader
-        className="table table-condensed"
+        className="table-condensed"
         mutator={mutator}
         sortable
         dataEndpoint={`/superset/recent_activity/${user.userId}/?limit=${rowLimit}`}


### PR DESCRIPTION
### SUMMARY
This PR refactors `TableLoader` to use `TableView`, based on `react-table` library. The goal was to get rid of `reactable`.
This PR replaces https://github.com/apache/incubator-superset/pull/10999.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
