### PR TITLE
refactor: Replace usages of reactable in ChangeDatasourceModal

### DIFF
--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -33,7 +33,14 @@ interface ChangeDatasourceModalProps {
   show: boolean;
 }
 
-const TABLE_COLUMNS = ['name', 'type', 'schema', 'connection', 'creator'];
+const TABLE_COLUMNS = [
+  'name',
+  'type',
+  'schema',
+  'connection',
+  'creator',
+].map(col => ({ accessor: col, Header: col }));
+
 const TABLE_FILTERABLE = ['rawName', 'type', 'schema', 'connection', 'creator'];
 const CHANGE_WARNING_MSG = t(
   'Changing the dataset may break the chart if the chart relies ' +
@@ -119,11 +126,6 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
     setFilter((event.currentTarget?.value as string) ?? '');
   };
 
-  const columns = useMemo(
-    () => TABLE_COLUMNS.map(col => ({ accessor: col, Header: col })),
-    [],
-  );
-
   const data = useMemo(
     () =>
       filter && datasources
@@ -158,7 +160,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
         {loading && <Loading />}
         {datasources && (
           <TableView
-            columns={columns}
+            columns={TABLE_COLUMNS}
             data={data}
             pageSize={20}
             className="table-condensed"

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -19,7 +19,7 @@
 import React, { FunctionComponent, useState, useRef, useMemo } from 'react';
 import { Alert, FormControl, FormControlProps, Modal } from 'react-bootstrap';
 import { SupersetClient, t } from '@superset-ui/core';
-import { TableView } from '../components/ListView';
+import TableView from 'src/components/TableView';
 
 import getClientErrorObject from '../utils/getClientErrorObject';
 import Loading from '../components/Loading';

--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { FunctionComponent, useState, useRef } from 'react';
-// @ts-ignore
-import { Table } from 'reactable-arc';
+import React, { FunctionComponent, useState, useRef, useMemo } from 'react';
 import { Alert, FormControl, FormControlProps, Modal } from 'react-bootstrap';
 import { SupersetClient, t } from '@superset-ui/core';
+import { TableView } from '../components/ListView';
 
 import getClientErrorObject from '../utils/getClientErrorObject';
 import Loading from '../components/Loading';
@@ -120,6 +119,21 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
     setFilter((event.currentTarget?.value as string) ?? '');
   };
 
+  const columns = useMemo(
+    () => TABLE_COLUMNS.map(col => ({ accessor: col, Header: col })),
+    [],
+  );
+
+  const data = useMemo(
+    () =>
+      filter && datasources
+        ? datasources.filter((datasource: any) =>
+            TABLE_FILTERABLE.some(field => datasource[field]?.includes(filter)),
+          )
+        : datasources,
+    [datasources, filter],
+  );
+
   return (
     <Modal show={show} onHide={onHide} onEnter={onEnterModal} bsSize="large">
       <Modal.Header closeButton>
@@ -143,14 +157,11 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
         </div>
         {loading && <Loading />}
         {datasources && (
-          <Table
-            columns={TABLE_COLUMNS}
-            className="table table-condensed"
-            data={datasources}
-            itemsPerPage={20}
-            filterable={TABLE_FILTERABLE}
-            filterBy={filter}
-            hideFilterInput
+          <TableView
+            columns={columns}
+            data={data}
+            pageSize={20}
+            className="table-condensed"
           />
         )}
       </Modal.Body>


### PR DESCRIPTION
### SUMMARY
This PR refactors `ChangeDatasourceModal` to use `TableView`, based on `react-table` library. The goal was to get rid of `reactable`.
This PR replaces https://github.com/apache/incubator-superset/pull/10982.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
