### PR TITLE
fix: Ensure consistent naming for testconn

### DIFF
--- a/superset/templates/superset/models/database/macros.html
+++ b/superset/templates/superset/models/database/macros.html
@@ -41,12 +41,12 @@
           uri: $.trim($("#sqlalchemy_uri").val()),
           name: $('#database_name').val(),
           impersonate_user: $('#impersonate_user').is(':checked'),
-          extras: extra ? JSON.parse(extra) : {},
+          extra: extra ? JSON.parse(extra) : {},
           encrypted_extra: encryptedExtra ? JSON.parse(encryptedExtra) : {},
           server_cert: $("#server_cert").val(),
         })
       } catch(parse_error){
-        alert("Malformed JSON in the extras field: " + parse_error);
+        alert("Malformed JSON in the extra fields: " + parse_error);
         return false
       }
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1135,12 +1135,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 if existing_database and uri == existing_database.safe_sqlalchemy_uri():
                     uri = existing_database.sqlalchemy_uri_decrypted
 
-            # this is the database instance that will be tested
+            # This is the database instance that will be tested. Note the extra fields
+            # are represented as JSON encoded strings in the model.
             database = models.Database(
-                # extras is sent as json, but required to be a string in the Database
-                # model
                 server_cert=request.json.get("server_cert"),
-                extra=json.dumps(request.json.get("extras", {})),
+                extra=json.dumps(request.json.get("extra", {})),
                 impersonate_user=request.json.get("impersonate_user"),
                 encrypted_extra=json.dumps(request.json.get("encrypted_extra", {})),
             )


### PR DESCRIPTION
### SUMMARY

For testing the database connection the POST request uses `extras` (plural) payload field for representing the `extra` (singular) field in the `dbs` table. This PR simply ensures consistent naming, i.e., `extra`, throughout.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI and tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
