### PR TITLE
build: update webpack for npm linking plugins

### DIFF
--- a/superset-frontend/tsconfig.json
+++ b/superset-frontend/tsconfig.json
@@ -30,5 +30,6 @@
     "./node_modules/*superset-ui*/**/types/**/*",
     // and the type defs of their dependencies
     "./node_modules/*superset-ui*/**/node_modules/**/*.d.ts"
-  ]
+  ],
+  "exclude": ["./node_modules/*superset-ui*/**/node_modules/@superset-ui/**/*"]
 }

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -265,12 +265,19 @@ const config = {
     },
   },
   resolve: {
+    modules: [APP_DIR, 'node_modules'],
     alias: {
-      src: path.resolve(APP_DIR, './src'),
       'react-dom': '@hot-loader/react-dom',
-      stylesheets: path.resolve(APP_DIR, './stylesheets'),
-      images: path.resolve(APP_DIR, './images'),
-      spec: path.resolve(APP_DIR, './spec'),
+      // force using absolute import path of the @superset-ui/core and @superset-ui/chart-controls
+      // so that we can `npm link` viz plugins without linking these two base packages
+      '@superset-ui/core': path.resolve(
+        APP_DIR,
+        './node_modules/@superset-ui/core',
+      ),
+      '@superset-ui/chart-controls': path.resolve(
+        APP_DIR,
+        './node_modules/@superset-ui/chart-controls',
+      ),
     },
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
     symlinks: false,


### PR DESCRIPTION
### SUMMARY

Update webpack config so that developers can `npm link .../plugin-path` without also having to `npm link ../path/to/superset-ui/packages/superset-ui-core/`.  Currently you have to do the additional linking because `npm link` will install its own version of `@superset-ui/core` under the plugin's `node_modules`, which will take precedent for the plugin's JS modules during module resolution.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

1. clone the [superset-ui](https://github.com/apache-superset/superset-ui/) repo
2. npm link a plugin `npm link ~/projects/superset-ui/plugins/legacy-preset-chart-nvd3/` in `superset-frontend`
3. Your plugin should show up in viz type selection

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


cc @rusackas @villebro 
