### PR TITLE
fix(query search): use new api to fetch users

### DIFF
--- a/superset-frontend/src/SqlLab/components/QuerySearch.jsx
+++ b/superset-frontend/src/SqlLab/components/QuerySearch.jsx
@@ -153,14 +153,10 @@ class QuerySearch extends React.PureComponent {
   }
 
   userMutator(data) {
-    const options = [];
-    for (let i = 0; i < data.pks.length; i += 1) {
-      options.push({
-        value: data.pks[i],
-        label: this.userLabel(data.result[i]),
-      });
-    }
-    return options;
+   return data.result.map(({ value, text}) => ({
+     label: text,
+     value,
+   })) 
   }
 
   dbMutator(data) {
@@ -209,7 +205,7 @@ class QuerySearch extends React.PureComponent {
         <div id="search-header" className="row space-1">
           <div className="col-sm-2">
             <AsyncSelect
-              dataEndpoint="/users/api/read"
+              dataEndpoint="api/v1/query/related/user"  
               mutator={this.userMutator}
               value={this.state.userId}
               onChange={this.changeUser}

--- a/superset-frontend/src/SqlLab/components/QuerySearch.jsx
+++ b/superset-frontend/src/SqlLab/components/QuerySearch.jsx
@@ -153,10 +153,10 @@ class QuerySearch extends React.PureComponent {
   }
 
   userMutator(data) {
-   return data.result.map(({ value, text}) => ({
-     label: text,
-     value,
-   })) 
+    return data.result.map(({ value, text }) => ({
+      label: text,
+      value,
+    }));
   }
 
   dbMutator(data) {
@@ -205,7 +205,7 @@ class QuerySearch extends React.PureComponent {
         <div id="search-header" className="row space-1">
           <div className="col-sm-2">
             <AsyncSelect
-              dataEndpoint="api/v1/query/related/user"  
+              dataEndpoint="api/v1/query/related/user"
               mutator={this.userMutator}
               value={this.state.userId}
               onChange={this.changeUser}

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -22,10 +22,7 @@ from superset.constants import RouteMethod
 from superset.models.sql_lab import Query
 from superset.queries.filters import QueryFilter
 from superset.queries.schemas import openapi_spec_methods_override
-from superset.views.base_api import (
-    BaseSupersetModelRestApi,
-    RelatedFieldFilter,
-)
+from superset.views.base_api import BaseSupersetModelRestApi, RelatedFieldFilter
 from superset.views.filters import FilterRelatedOwners
 
 logger = logging.getLogger(__name__)

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -22,7 +22,11 @@ from superset.constants import RouteMethod
 from superset.models.sql_lab import Query
 from superset.queries.filters import QueryFilter
 from superset.queries.schemas import openapi_spec_methods_override
-from superset.views.base_api import BaseSupersetModelRestApi
+from superset.views.base_api import (
+    BaseSupersetModelRestApi,
+    RelatedFieldFilter,
+)
+from superset.views.filters import FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +36,7 @@ class QueryRestApi(BaseSupersetModelRestApi):
 
     resource_name = "query"
     allow_browser_login = True
-    include_route_methods = {RouteMethod.GET, RouteMethod.GET_LIST}
+    include_route_methods = {RouteMethod.GET, RouteMethod.GET_LIST, RouteMethod.RELATED}
 
     class_permission_name = "QueryView"
     list_columns = [
@@ -73,3 +77,8 @@ class QueryRestApi(BaseSupersetModelRestApi):
 
     openapi_spec_tag = "Queries"
     openapi_spec_methods = openapi_spec_methods_override
+
+    related_field_filters = {
+        "created_by": RelatedFieldFilter("first_name", FilterRelatedOwners),
+    }
+    allowed_rel_fields = {"user"}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
switching over to use the new api endpoint which is much more secure than the `users/api/read` endpoint.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- CI.
- 👀 user dropdown in query search view is populated

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
