### PR TITLE
fix(crud): set default extra value when adding database

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -125,6 +125,9 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const [isHidden, setIsHidden] = useState<boolean>(true);
 
   const isEditMode = database !== null;
+  const defaultExtra =
+    '{\n  "metadata_params": {},\n  "engine_params": {},' +
+    '\n  "metadata_cache_timeout": {},\n  "schemas_allowed_for_csv_upload": [] \n}';
 
   // Database fetch logic
   const {
@@ -588,11 +591,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
             <div className="input-container">
               <textarea
                 name="extra"
-                value={db ? db.extra || '' : ''}
-                placeholder={
-                  '{\n  "metadata_params": {},\n  "engine_params": {},' +
-                  '\n  "metadata_cache_timeout": {},\n  "schemas_allowed_for_csv_upload": [] \n}'
-                }
+                value={(db && db.extra) ?? defaultExtra}
                 onChange={onTextChange}
               />
             </div>


### PR DESCRIPTION
### SUMMARY
When adding a new database via the new React CRUD, the connection times out due to the `extra` field not being prepopulated with default values (they were only shown as a `placeholder`).

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
