### PR TITLE
feat: CSS Templates List Actions

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/csstemplates/CssTemplatesList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/csstemplates/CssTemplatesList_spec.jsx
@@ -124,7 +124,7 @@ describe('CssTemplatesList', () => {
 
   it('deletes', async () => {
     act(() => {
-      wrapper.find('span[data-test="delete-action"]').first().props().onClick();
+      wrapper.find('[data-test="delete-action"]').first().props().onClick();
     });
     await waitForComponentToPaint(wrapper);
 

--- a/superset-frontend/spec/javascripts/views/CRUD/csstemplates/CssTemplatesList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/csstemplates/CssTemplatesList_spec.jsx
@@ -25,9 +25,12 @@ import { styledMount as mount } from 'spec/helpers/theming';
 import CssTemplatesList from 'src/views/CRUD/csstemplates/CssTemplatesList';
 import SubMenu from 'src/components/Menu/SubMenu';
 import ListView from 'src/components/ListView';
-// import Filters from 'src/components/ListView/Filters';
+import Filters from 'src/components/ListView/Filters';
+import DeleteModal from 'src/components/DeleteModal';
+import Button from 'src/components/Button';
+import IndeterminateCheckbox from 'src/components/IndeterminateCheckbox';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
-// import { act } from 'react-dom/test-utils';
+import { act } from 'react-dom/test-utils';
 
 // store needed for withToasts(DatabaseList)
 const mockStore = configureStore([thunk]);
@@ -35,6 +38,8 @@ const store = mockStore({});
 
 const templatesInfoEndpoint = 'glob:*/api/v1/css_template/_info*';
 const templatesEndpoint = 'glob:*/api/v1/css_template/?*';
+const templateEndpoint = 'glob:*/api/v1/css_template/*';
+const templatesRelatedEndpoint = 'glob:*/api/v1/css_template/related/*';
 
 const mocktemplates = [...new Array(3)].map((_, i) => ({
   changed_on_delta_humanized: `${i} day(s) ago`,
@@ -56,6 +61,16 @@ fetchMock.get(templatesEndpoint, {
   templates_count: 3,
 });
 
+fetchMock.delete(templateEndpoint, {});
+fetchMock.delete(templatesEndpoint, {});
+
+fetchMock.get(templatesRelatedEndpoint, {
+  created_by: {
+    count: 0,
+    result: [],
+  },
+});
+
 describe('CssTemplatesList', () => {
   const wrapper = mount(<CssTemplatesList />, { context: { store } });
 
@@ -73,5 +88,77 @@ describe('CssTemplatesList', () => {
 
   it('renders a ListView', () => {
     expect(wrapper.find(ListView)).toExist();
+  });
+
+  it('fetches templates', () => {
+    const callsQ = fetchMock.calls(/css_template\/\?q/);
+    expect(callsQ).toHaveLength(1);
+    expect(callsQ[0][0]).toMatchInlineSnapshot(
+      `"http://localhost/api/v1/css_template/?q=(order_column:template_name,order_direction:desc,page:0,page_size:25)"`,
+    );
+  });
+
+  it('renders Filters', () => {
+    expect(wrapper.find(Filters)).toExist();
+  });
+
+  it('searches', async () => {
+    const filtersWrapper = wrapper.find(Filters);
+    act(() => {
+      filtersWrapper
+        .find('[name="template_name"]')
+        .first()
+        .props()
+        .onSubmit('fooo');
+    });
+    await waitForComponentToPaint(wrapper);
+
+    expect(fetchMock.lastCall()[0]).toMatchInlineSnapshot(
+      `"http://localhost/api/v1/css_template/?q=(filters:!((col:template_name,opr:ct,value:fooo)),order_column:template_name,order_direction:desc,page:0,page_size:25)"`,
+    );
+  });
+
+  it('renders a DeleteModal', () => {
+    expect(wrapper.find(DeleteModal)).toExist();
+  });
+
+  it('deletes', async () => {
+    act(() => {
+      wrapper.find('span[data-test="delete-action"]').first().props().onClick();
+    });
+    await waitForComponentToPaint(wrapper);
+
+    expect(
+      wrapper.find(DeleteModal).first().props().description,
+    ).toMatchInlineSnapshot(
+      `"This action will permanently delete the template."`,
+    );
+
+    act(() => {
+      wrapper
+        .find('#delete')
+        .first()
+        .props()
+        .onChange({ target: { value: 'DELETE' } });
+    });
+    await waitForComponentToPaint(wrapper);
+    act(() => {
+      wrapper.find('button').last().props().onClick();
+    });
+
+    await waitForComponentToPaint(wrapper);
+
+    expect(fetchMock.calls(/css_template\/0/, 'DELETE')).toHaveLength(1);
+  });
+
+  it('shows/hides bulk actions when bulk actions is clicked', async () => {
+    const button = wrapper.find(Button).at(0);
+    act(() => {
+      button.props().onClick();
+    });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(IndeterminateCheckbox)).toHaveLength(
+      mocktemplates.length + 1, // 1 for each row and 1 for select all
+    );
   });
 });

--- a/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
+++ b/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
@@ -103,6 +103,7 @@ function CssTemplatesList({
         Header: t('Created On'),
         accessor: 'created_on',
         size: 'xl',
+        disableSortBy: true,
       },
       {
         accessor: 'created_by',
@@ -125,6 +126,7 @@ function CssTemplatesList({
         Header: t('Last Modified'),
         accessor: 'changed_on_delta_humanized',
         size: 'xl',
+        disableSortBy: true,
       },
       {
         Cell: ({ row: { original } }: any) => {
@@ -188,7 +190,7 @@ function CssTemplatesList({
   const filters: Filters = useMemo(
     () => [
       {
-        Header: t('Created by'),
+        Header: t('Created By'),
         id: 'created_by',
         input: 'select',
         operator: 'rel_o_m',

--- a/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
+++ b/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
@@ -18,17 +18,14 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { t } from '@superset-ui/core';
-import { SupersetClient, t } from '@superset-ui/core';
+import { t, SupersetClient } from '@superset-ui/core';
+
 import rison from 'rison';
 import moment from 'moment';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
-import SubMenu, {
-  SubMenuProps,
-  ButtonProps,
-} from 'src/components/Menu/SubMenu';
+import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import DeleteModal from 'src/components/DeleteModal';
 import TooltipWrapper from 'src/components/TooltipWrapper';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';

--- a/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
+++ b/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
@@ -77,28 +77,6 @@ function CssTemplatesList({
   const canEdit = hasPerm('can_edit');
   const canDelete = hasPerm('can_delete');
 
-  const menuData: SubMenuProps = {
-    name: t('CSS Templates'),
-  };
-
-  const subMenuButtons: Array<ButtonProps> = [];
-
-  if (canDelete) {
-    subMenuButtons.push({
-      name: t('Bulk Select'),
-      onClick: toggleBulkSelect,
-      buttonStyle: 'secondary',
-    });
-  }
-
-  /* subMenuButtons.push({
-    name: t('+ CSS Template'),
-    onClick: openNewTemplate,
-    buttonStyle: 'primary',
-  }); */
-
-  menuData.buttons = subMenuButtons;
-
   const [
     templateCurrentlyDeleting,
     setTemplateCurrentlyDeleting,
@@ -260,6 +238,10 @@ function CssTemplatesList({
     [canDelete, canCreate],
   );
 
+  const menuData: SubMenuProps = {
+    name: t('CSS Templates'),
+  };
+
   const subMenuButtons: SubMenuProps['buttons'] = [];
 
   if (canCreate) {
@@ -277,6 +259,16 @@ function CssTemplatesList({
       },
     });
   }
+
+  if (canDelete) {
+    subMenuButtons.push({
+      name: t('Bulk Select'),
+      onClick: toggleBulkSelect,
+      buttonStyle: 'secondary',
+    });
+  }
+
+  menuData.buttons = subMenuButtons;
 
   const filters: Filters = useMemo(
     () => [

--- a/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
+++ b/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
@@ -144,7 +144,7 @@ function CssTemplatesList({
           return (
             <TooltipWrapper
               label="allow-run-async-header"
-              tooltip={`${t('Last modified by')} ${name}`}
+              tooltip={t('Last modified by %s', name)}
               placement="right"
             >
               <span>{changedOn}</span>

--- a/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
+++ b/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
@@ -21,12 +21,12 @@ import React, { useMemo, useState } from 'react';
 import { t } from '@superset-ui/core';
 import moment from 'moment';
 import { useListViewResource } from 'src/views/CRUD/hooks';
+import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import { IconName } from 'src/components/Icon';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
-// import ListView, { Filters } from 'src/components/ListView';
-import ListView from 'src/components/ListView';
+import ListView, { Filters } from 'src/components/ListView';
 import CssTemplateModal from './CssTemplateModal';
 import { TemplateObject } from './types';
 
@@ -185,6 +185,36 @@ function CssTemplatesList({
     });
   }
 
+  const filters: Filters = useMemo(
+    () => [
+      {
+        Header: t('Created by'),
+        id: 'created_by',
+        input: 'select',
+        operator: 'rel_o_m',
+        unfilteredLabel: 'All',
+        fetchSelects: createFetchRelated(
+          'css_template',
+          'created_by',
+          createErrorHandler(errMsg =>
+            t(
+              'An error occurred while fetching dataset datasource values: %s',
+              errMsg,
+            ),
+          ),
+        ),
+        paginate: true,
+      },
+      {
+        Header: t('Search'),
+        id: 'template_name',
+        input: 'search',
+        operator: 'ct',
+      },
+    ],
+    [],
+  );
+
   return (
     <>
       <SubMenu name={t('CSS Templates')} buttons={subMenuButtons} />
@@ -201,7 +231,7 @@ function CssTemplatesList({
         count={templatesCount}
         data={templates}
         fetchData={fetchData}
-        // filters={filters}
+        filters={filters}
         initialSort={initialSort}
         loading={loading}
         pageSize={PAGE_SIZE}

--- a/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
+++ b/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
@@ -24,6 +24,8 @@ import { useListViewResource } from 'src/views/CRUD/hooks';
 import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
+import SubMenu from 'src/components/Menu/SubMenu';
+import TooltipWrapper from 'src/components/TooltipWrapper';
 import { IconName } from 'src/components/Icon';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
 import ListView, { Filters } from 'src/components/ListView';
@@ -82,6 +84,36 @@ function CssTemplatesList({
       {
         Cell: ({
           row: {
+            original: {
+              changed_on_delta_humanized: changedOn,
+              changed_by: changedBy,
+            },
+          },
+        }: any) => {
+          let name = 'null';
+
+          if (changedBy) {
+            name = `${changedBy.first_name} ${changedBy.last_name}`;
+          }
+
+          return (
+            <TooltipWrapper
+              label="allow-run-async-header"
+              tooltip={`${t('Last modified by')} ${name}`}
+              placement="right"
+            >
+              <span>{changedOn}</span>
+            </TooltipWrapper>
+          );
+        },
+        Header: t('Last Modified'),
+        accessor: 'changed_on_delta_humanized',
+        size: 'xl',
+        disableSortBy: true,
+      },
+      {
+        Cell: ({
+          row: {
             original: { created_on: createdOn },
           },
         }: any) => {
@@ -116,17 +148,6 @@ function CssTemplatesList({
         }: any) =>
           createdBy ? `${createdBy.first_name} ${createdBy.last_name}` : '',
         size: 'xl',
-      },
-      {
-        Cell: ({
-          row: {
-            original: { changed_on_delta_humanized: changedOn },
-          },
-        }: any) => changedOn,
-        Header: t('Last Modified'),
-        accessor: 'changed_on_delta_humanized',
-        size: 'xl',
-        disableSortBy: true,
       },
       {
         Cell: ({ row: { original } }: any) => {

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -211,7 +211,7 @@ function SavedQueryList({
     );
   };
 
-  const handleBulkTemplateDelete = (queriesToDelete: SavedQueryObject[]) => {
+  const handleBulkQueryDelete = (queriesToDelete: SavedQueryObject[]) => {
     SupersetClient.delete({
       endpoint: `/api/v1/saved_query/?q=${rison.encode(
         queriesToDelete.map(({ id }) => id),
@@ -454,7 +454,7 @@ function SavedQueryList({
       <ConfirmStatusChange
         title={t('Please confirm')}
         description={t('Are you sure you want to delete the selected queries?')}
-        onConfirm={handleBulkTemplateDelete}
+        onConfirm={handleBulkQueryDelete}
       >
         {confirmDelete => {
           const bulkActions: ListViewProps['bulkActions'] = canDelete

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -331,7 +331,7 @@ function SavedQueryList({
           const handleCopy = () => {
             copyQueryLink(original.id);
           };
-          const handleDelete = () => setQueryCurrentlyDeleting(original); // openQueryDeleteModal(original);
+          const handleDelete = () => setQueryCurrentlyDeleting(original);
 
           const actions = [
             {

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -211,7 +211,7 @@ function SavedQueryList({
     );
   };
 
-  const handleBulkQueryDelete = (queriesToDelete: SavedQueryObject[]) => {
+  const handleBulkTemplateDelete = (queriesToDelete: SavedQueryObject[]) => {
     SupersetClient.delete({
       endpoint: `/api/v1/saved_query/?q=${rison.encode(
         queriesToDelete.map(({ id }) => id),
@@ -454,7 +454,7 @@ function SavedQueryList({
       <ConfirmStatusChange
         title={t('Please confirm')}
         description={t('Are you sure you want to delete the selected queries?')}
-        onConfirm={handleBulkQueryDelete}
+        onConfirm={handleBulkTemplateDelete}
       >
         {confirmDelete => {
           const bulkActions: ListViewProps['bulkActions'] = canDelete

--- a/superset/css_templates/api.py
+++ b/superset/css_templates/api.py
@@ -43,6 +43,7 @@ class CssTemplateRestApi(BaseSupersetModelRestApi):
     datamodel = SQLAInterface(CssTemplate)
 
     include_route_methods = RouteMethod.REST_MODEL_VIEW_CRUD_SET | {
+        RouteMethod.RELATED,
         "bulk_delete",  # not using RouteMethod since locally defined
     }
     class_permission_name = "CssTemplateModelView"
@@ -59,6 +60,7 @@ class CssTemplateRestApi(BaseSupersetModelRestApi):
     ]
     list_columns = [
         "changed_on_delta_humanized",
+        "changed_by",
         "created_on",
         "created_by.first_name",
         "created_by.id",
@@ -72,6 +74,7 @@ class CssTemplateRestApi(BaseSupersetModelRestApi):
     order_columns = ["template_name"]
 
     search_filters = {"template_name": [CssTemplateAllTextFilter]}
+    allowed_rel_fields = {"created_by"}
 
     apispec_parameter_schemas = {
         "get_delete_ids_schema": get_delete_ids_schema,

--- a/superset/views/css_templates.py
+++ b/superset/views/css_templates.py
@@ -21,7 +21,6 @@ from flask_babel import lazy_gettext as _
 
 from superset import app
 from superset.constants import RouteMethod
-from superset.extensions import feature_flag_manager
 from superset.models import core as models
 from superset.typing import FlaskResponse
 from superset.views.base import DeleteMixin, SupersetModelView
@@ -46,10 +45,7 @@ class CssTemplateModelView(  # pylint: disable=too-many-ancestors
     @expose("/list/")
     @has_access
     def list(self) -> FlaskResponse:
-        if not (
-            app.config["ENABLE_REACT_CRUD_VIEWS"]
-            and feature_flag_manager.is_feature_enabled("SIP_34_CSS_TEMPLATES_UI")
-        ):
+        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
             return super().list()
 
         return super().render_app_template()

--- a/tests/css_templates/api_tests.py
+++ b/tests/css_templates/api_tests.py
@@ -76,6 +76,7 @@ class TestCssTemplateApi(SupersetTestCase):
         assert data["count"] == len(css_templates)
         expected_columns = [
             "changed_on_delta_humanized",
+            "changed_by",
             "created_on",
             "created_by",
             "template_name",


### PR DESCRIPTION
### SUMMARY
- [x] Add filters support
- [x] Add single and bulk delete action functionality
- [x] Add modified by tooltip
- [x] Removes `SIP_34_CSS_TEMPLATES_UI` flag

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1208" alt="Screen Shot 2020-10-14 at 11 04 59 AM" src="https://user-images.githubusercontent.com/8216382/96028928-cd33ff00-0e0e-11eb-9f78-91eb43f1a186.png">
<img width="1203" alt="Screen Shot 2020-10-14 at 11 05 23 AM" src="https://user-images.githubusercontent.com/8216382/96028947-d1f8b300-0e0e-11eb-92d2-76f9a85260c2.png">
<img width="1202" alt="Screen Shot 2020-10-14 at 11 05 30 AM" src="https://user-images.githubusercontent.com/8216382/96028956-d45b0d00-0e0e-11eb-903d-54e6019a17c5.png">

### TEST PLAN
- [x] Update `CssTemplatesList_spec.jsx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
