### PR TITLE
fix: delete the correct dashboard cache key

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -252,8 +252,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         }
 
     @cache.memoize(
-        # manually maintain cache key version
-        make_name=lambda fname: f"{fname}-v1",
+        make_name=lambda fname: f"{fname}-v0.1",
         timeout=config["DASHBOARD_CACHE_TIMEOUT"],
         unless=lambda: not is_feature_enabled("DASHBOARD_CACHE"),
     )
@@ -294,7 +293,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
 
     @debounce(0.1)
     def clear_cache(self) -> None:
-        cache.delete_memoized(self.full_data)
+        cache.delete_memoized(Dashboard.full_data, self)
 
     @classmethod
     @debounce(0.1)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -252,7 +252,8 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         }
 
     @cache.memoize(
-        make_name=lambda fname: f"{fname}-v0.1",
+        # manage cache version manually
+        make_name=lambda fname: f"{fname}-v2",
         timeout=config["DASHBOARD_CACHE_TIMEOUT"],
         unless=lambda: not is_feature_enabled("DASHBOARD_CACHE"),
     )


### PR DESCRIPTION
### SUMMARY

This PR fixes a bug from #11234 where cache keys for dashboard bootstrap data are incorrectly deleted.

We noticed this when some dashboard failed to update cache when updating charts. 

`delete_memoized` from Flask caching treats instance method and class method differently:

```
        Delete memoized is also smart about instance methods vs class methods.
        When passing a instancemethod, it will only clear the cache related
        to that instance of that object. (object uniqueness can be overridden
        by defining the __repr__ method, such as user id).
        When passing a classmethod, it will clear all caches related across
        all instances of that class.
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

1. Create a dashboard and add a chart
2. Change chart title in Dashboard edit mode
3. Explore the chart, make updates and save
4. Return to dashboard and refresh. In base, you may see the chart is not updated. After the fix, the chart should update.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
