### PR TITLE
fix: error around latest partition in BigQuery

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -110,21 +110,20 @@ class TableElement extends React.PureComponent {
           />
         );
       }
-      const latestPartition = Object.entries(
-        table?.partitions?.latest || [],
-      ).map(([key, value]) => `${key}=${value}`);
-      if (latestPartition) {
-        return (
-          <Well bsSize="small">
-            <div>
-              <small>
-                {t('latest partition:')} {latestPartition.join('/')}
-              </small>{' '}
-              {partitionClipBoard}
-            </div>
-          </Well>
-        );
-      }
+      let latest = Object.entries(table.partitions?.latest || []).map(
+        ([key, value]) => `${key}=${value}`,
+      );
+      latest = latest.join('/');
+      header = (
+        <Well bsSize="small">
+          <div>
+            <small>
+              {t('latest partition:')} {latest}
+            </small>{' '}
+            {partitionClipBoard}
+          </div>
+        </Well>
+      );
     }
     return header;
   }

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -110,20 +110,21 @@ class TableElement extends React.PureComponent {
           />
         );
       }
-      let latest = Object.entries(table.partitions.latest).map(
+      const latestPartition = Object.entries(table?.partitions?.latest || []).map(
         ([key, value]) => `${key}=${value}`,
       );
-      latest = latest.join('/');
-      header = (
-        <Well bsSize="small">
-          <div>
-            <small>
-              {t('latest partition:')} {latest}
-            </small>{' '}
-            {partitionClipBoard}
-          </div>
-        </Well>
-      );
+      if (latestPartition) {
+        return (
+          <Well bsSize="small">
+            <div>
+              <small>
+                {t('latest partition:')} {latestPartition.join('/')}
+              </small>{' '}
+              {partitionClipBoard}
+            </div>
+          </Well>
+        );
+      }
     }
     return header;
   }

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -110,9 +110,9 @@ class TableElement extends React.PureComponent {
           />
         );
       }
-      const latestPartition = Object.entries(table?.partitions?.latest || []).map(
-        ([key, value]) => `${key}=${value}`,
-      );
+      const latestPartition = Object.entries(
+        table?.partitions?.latest || [],
+      ).map(([key, value]) => `${key}=${value}`);
       if (latestPartition) {
         return (
           <Well bsSize="small">

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -377,6 +377,18 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return None
 
     @classmethod
+    def normalize_indexes(cls, indexes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Normalizes indexes for more consistency across db engines
+
+        noop by default
+
+        :param indexes: Raw indexes as returned by SQLAlchemy
+        :return: cleaner, more aligned index definition
+        """
+        return indexes
+
+    @classmethod
     def extra_table_metadata(
         cls, database: "Database", table_name: str, schema_name: str
     ) -> Dict[str, Any]:

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -130,6 +130,25 @@ class BigQueryEngineSpec(BaseEngineSpec):
         return "_" + hashlib.md5(label.encode("utf-8")).hexdigest()
 
     @classmethod
+    def normalize_indexes(cls, indexes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Normalizes indexes for more consistency across db engines
+
+        :param indexes: Raw indexes as returned by SQLAlchemy
+        :return: cleaner, more aligned index definition
+        """
+        normalized_idxs = []
+        # Fixing a bug/behavior observed in pybigquery==0.4.15 where
+        # the index's `column_names` == [None]
+        # Here we're returning only non-None indexes
+        for ix in indexes:
+            column_names = ix.get("column_names") or []
+            column_names = [col for col in column_names if col is not None]
+            if column_names:
+                normalized_idxs.append(ix)
+        return normalized_idxs
+
+    @classmethod
     def extra_table_metadata(
         cls, database: "Database", table_name: str, schema_name: str
     ) -> Dict[str, Any]:

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -143,8 +143,8 @@ class BigQueryEngineSpec(BaseEngineSpec):
         # Here we're returning only non-None indexes
         for ix in indexes:
             column_names = ix.get("column_names") or []
-            column_names = [col for col in column_names if col is not None]
-            if column_names:
+            ix["column_names"] = [col for col in column_names if col is not None]
+            if ix["column_names"]:
                 normalized_idxs.append(ix)
         return normalized_idxs
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -619,7 +619,8 @@ class Database(
     def get_indexes(
         self, table_name: str, schema: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        return self.inspector.get_indexes(table_name, schema)
+        indexes = self.inspector.get_indexes(table_name, schema)
+        return self.db_engine_spec.normalize_indexes(indexes)
 
     def get_pk_constraint(
         self, table_name: str, schema: Optional[str] = None

--- a/tests/db_engine_specs/bigquery_tests.py
+++ b/tests/db_engine_specs/bigquery_tests.py
@@ -134,6 +134,15 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
         normalized_idx = BigQueryEngineSpec.normalize_indexes(indexes)
         self.assertEqual(normalized_idx, indexes)
 
+        indexes = [
+            {"name": "partition", "column_names": ["dttm", None], "unique": False}
+        ]
+        normalized_idx = BigQueryEngineSpec.normalize_indexes(indexes)
+        self.assertEqual(
+            normalized_idx,
+            [{"name": "partition", "column_names": ["dttm"], "unique": False}],
+        )
+
     def test_df_to_sql(self):
         """
         DB Eng Specs (bigquery): Test DataFrame to SQL contract

--- a/tests/db_engine_specs/bigquery_tests.py
+++ b/tests/db_engine_specs/bigquery_tests.py
@@ -122,16 +122,16 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
         )
         self.assertEqual(result, expected_result)
 
-    def test_normalize_index(self):
+    def test_normalize_indexes(self):
         """
         DB Eng Specs (bigquery): Test extra table metadata
         """
         indexes = [{"name": "partition", "column_names": [None], "unique": False}]
-        normalized_idx = BigQueryEngineSpec.normalize_index(indexes)
+        normalized_idx = BigQueryEngineSpec.normalize_indexes(indexes)
         self.assertEqual(normalized_idx, [])
 
         indexes = [{"name": "partition", "column_names": ["dttm"], "unique": False}]
-        normalized_idx = BigQueryEngineSpec.normalize_index(indexes)
+        normalized_idx = BigQueryEngineSpec.normalize_indexes(indexes)
         self.assertEqual(normalized_idx, indexes)
 
     def test_df_to_sql(self):

--- a/tests/db_engine_specs/bigquery_tests.py
+++ b/tests/db_engine_specs/bigquery_tests.py
@@ -122,6 +122,18 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
         )
         self.assertEqual(result, expected_result)
 
+    def test_normalize_index(self):
+        """
+        DB Eng Specs (bigquery): Test extra table metadata
+        """
+        indexes = [{"name": "partition", "column_names": [None], "unique": False}]
+        normalized_idx = BigQueryEngineSpec.normalize_index(indexes)
+        self.assertEqual(normalized_idx, [])
+
+        indexes = [{"name": "partition", "column_names": ["dttm"], "unique": False}]
+        normalized_idx = BigQueryEngineSpec.normalize_index(indexes)
+        self.assertEqual(normalized_idx, indexes)
+
     def test_df_to_sql(self):
         """
         DB Eng Specs (bigquery): Test DataFrame to SQL contract


### PR DESCRIPTION
Hit this bug while using BigQ. The SQLAlchemy inspector's `get_indexes` returns a list of columns that is wrong and get the SQL Lab frontend to hard crash. 

Here's the exact payload I was getting off of `get_indexes` for a particular table:
`[{'name': 'partition', 'column_names': [None], 'unique': False}]`

Here I'm adding a BigQuery specific mutation for the indexes that makes sure this doesn't happen. We're assuming that `pybigquery` will fix the root cause in a future version.

<img width="627" alt="Screen Shot 2020-10-18 at 10 27 37 PM" src="https://user-images.githubusercontent.com/487433/96405021-2befd480-1191-11eb-9b23-1f94094b6a22.png">

