### PR TITLE
feat(explore): change save button text when users cannot override

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -232,7 +232,9 @@ class SaveModal extends React.Component {
               disabled={!this.state.newSliceName}
               data-test="btn-modal-save"
             >
-              {t('Save')}
+              {!this.props.can_overwrite && this.props.slice
+                ? t('Save as new chart')
+                : t('Save')}
             </Button>
           </div>
         </Modal.Footer>


### PR DESCRIPTION
### SUMMARY

Change the save button text to "Save as new chart" when users cannot override an existing chart (normally because they are not the owner of the chart).

Wanted to add this change because I tried to edit a chart from someone else's dashboard today, after saving it I didn't see the change in the dashboard and got confused.

The text will only change if you are editing from an existing chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Open an existing chart that you are not an owner of, try save the chart:

#### Before

![Snip20201014_25](https://user-images.githubusercontent.com/335541/96060321-0be4ac00-0e45-11eb-8765-fdd54773eb7e.png)

#### After

![Snip20201014_24](https://user-images.githubusercontent.com/335541/96060336-12732380-0e45-11eb-8b84-323faf1085be.png)


### TEST PLAN

- Creating a new chart: the button text should be "Save"
- Editing a chart of your own: the text should be "Save"
- Editing other people's chart: the text should be "Save as new chart"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
