### PR TITLE
fix: Fix styling in SqlLab when tabs overflow

### DIFF
--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -58,6 +58,12 @@ const defaultProps = {
 
 let queryCount = 1;
 
+const TabTitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const TabTitle = styled.span`
   margin-right: ${({ theme }) => theme.gridUnit * 2}px;
 `;
@@ -354,12 +360,12 @@ class TabbedSqlEditors extends React.PureComponent {
       );
 
       const tabHeader = (
-        <>
+        <TabTitleWrapper>
           <div data-test="dropdown-toggle-button">
             <Dropdown overlay={menu} trigger={['click']} />
           </div>
           <TabTitle>{qe.title}</TabTitle> <TabStatusIcon tabState={state} />{' '}
-        </>
+        </TabTitleWrapper>
       );
       return (
         <EditableTabs.TabPane

--- a/superset-frontend/src/common/components/Dropdown.tsx
+++ b/superset-frontend/src/common/components/Dropdown.tsx
@@ -32,6 +32,7 @@ const MenuDots = styled.div`
   ${dotStyle};
   font-weight: ${({ theme }) => theme.typography.weights.normal};
   display: inline-flex;
+  position: relative;
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.primary.base};
@@ -50,11 +51,11 @@ const MenuDots = styled.div`
   }
 
   &::before {
-    transform: translateY(-${({ theme }) => theme.gridUnit}px);
+    top: 4px;
   }
 
   &::after {
-    transform: translateY(${({ theme }) => theme.gridUnit}px);
+    bottom: 4px;
   }
 `;
 

--- a/superset-frontend/src/common/components/Dropdown.tsx
+++ b/superset-frontend/src/common/components/Dropdown.tsx
@@ -51,11 +51,11 @@ const MenuDots = styled.div`
   }
 
   &::before {
-    top: 4px;
+    top: ${({ theme }) => theme.gridUnit}px;
   }
 
   &::after {
-    bottom: 4px;
+    bottom: ${({ theme }) => theme.gridUnit}px;
   }
 `;
 

--- a/superset-frontend/src/common/components/Tabs.tsx
+++ b/superset-frontend/src/common/components/Tabs.tsx
@@ -52,10 +52,7 @@ const StyledTabs = styled(AntdTabs, {
     `};
 
   .ant-tabs-tab-btn {
-    display: flex;
     flex: 1 1 auto;
-    align-items: center;
-    justify-content: center;
     font-size: ${({ theme }) => theme.typography.sizes.s}px;
     text-align: center;
     text-transform: uppercase;


### PR DESCRIPTION
### SUMMARY
Related to issue https://github.com/apache/incubator-superset/issues/11188. The problem described in https://github.com/apache/incubator-superset/issues/11188 as the dropdown menu is scrollable, however the dropdown items were not styled properly. This PR fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: screenshot in https://github.com/apache/incubator-superset/issues/11188

After:
![image](https://user-images.githubusercontent.com/15073128/96104208-d7223480-0ed8-11eb-8de9-5dceb40a12e4.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
