### PR TITLE
fix: use dashboard id for stable cache key

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -156,7 +156,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
     ]
 
     def __repr__(self) -> str:
-        return f"Dashboard<{self.slug or self.id}>"
+        return f"Dashboard<{self.id or self.slug}>"
 
     @property
     def table_names(self) -> str:
@@ -253,7 +253,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
 
     @cache.memoize(
         # manage cache version manually
-        make_name=lambda fname: f"{fname}-v2",
+        make_name=lambda fname: f"{fname}-v2.1",
         timeout=config["DASHBOARD_CACHE_TIMEOUT"],
         unless=lambda: not is_feature_enabled("DASHBOARD_CACHE"),
     )


### PR DESCRIPTION
### SUMMARY

This fixes a bug where dashboard cache used while visiting dashboard via slug is not updated when editing an embedded chart.

I used `dashboard.slug` in the default dashboard `__repr__` string because I wanted to make it human readable, but since this is mostly used in cache and not all dashboards have slugs, human readability doesn't really matter. It's more important to have stable cache keys.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

1. Enable `DASHBOARD_CACHE` feature flag
2. Visit a dashboard with slug
3. Edit a chart in the dashboard
4. In base you will not see the chart updates when you return to dashboard and refresh. After the fix, the chart in dashboard should be updated.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11273 #11234 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
