### PR TITLE
feat: update time_compare description and choices

### DIFF
--- a/superset-frontend/src/explore/controlPanels/sections.jsx
+++ b/superset-frontend/src/explore/controlPanels/sections.jsx
@@ -213,12 +213,13 @@ export const NVD3TimeSeries = [
               '30 days',
               '52 weeks',
               '1 year',
+              '2 years',
             ]),
             description: t(
               'Overlay one or more timeseries from a ' +
                 'relative time period. Expects relative time deltas ' +
                 'in natural language (example:  24 hours, 7 days, ' +
-                '56 weeks, 365 days)',
+                '52 weeks, 365 days). Free text is supported.',
             ),
           },
         },

--- a/superset-frontend/src/explore/controlPanels/sections.jsx
+++ b/superset-frontend/src/explore/controlPanels/sections.jsx
@@ -213,6 +213,7 @@ export const NVD3TimeSeries = [
               '30 days',
               '52 weeks',
               '1 year',
+              '104 weeks',
               '2 years',
             ]),
             description: t(


### PR DESCRIPTION
### SUMMARY
It was unclear that free text was supported in this field. Also adding `104 weeks` and `2 years` as a default option to further demonstrate the options available and because in the near future people will want to do 104 week/2 year comparisons more often as 2020 March => now has been... odd.

### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @rusackas @graceguo-supercat @ktmud 