### PR TITLE
fix: Overflowing tab's styling in TabbedSqlEditors

### DIFF
--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -61,7 +61,6 @@ let queryCount = 1;
 const TabTitleWrapper = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
 `;
 
 const TabTitle = styled.span`


### PR DESCRIPTION
### SUMMARY
When the tab bar in SqlLab were overflown, the tabs shown in dropdown were justified to center instead of left.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/96273460-aa9d1400-0fcf-11eb-87f8-b07893f2711d.png)

After:
![image](https://user-images.githubusercontent.com/15073128/96273246-6873d280-0fcf-11eb-953b-a8e1f8d5050c.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
