### PR TITLE
fix(extra-filters): add logic for identifying applied extra filters

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/QueryAndSaveBtns_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/QueryAndSaveBtns_spec.jsx
@@ -50,7 +50,7 @@ describe('QueryAndSaveButtons', () => {
 
     it('renders buttons with correct text', () => {
       expect(wrapper.find(Button).contains('Run')).toBe(true);
-      expect(wrapper.find(Button).contains(' Save')).toBe(true);
+      expect(wrapper.find(Button).contains('Save')).toBe(true);
     });
 
     it('calls onQuery when query button is clicked', () => {

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -188,7 +188,7 @@ export function Menu({
         <Nav className="navbar-right">
           {!navbarRight.user_is_anonymous && <NewMenu />}
           {settings && settings.length > 0 && (
-            <NavDropdown id="settings-dropdown" title="Settings">
+            <NavDropdown id="settings-dropdown" title={t('Settings')}>
               {flatSettings.map((section, index) => {
                 if (section === '-') {
                   return (

--- a/superset-frontend/src/dashboard/components/PublishedStatus.jsx
+++ b/superset-frontend/src/dashboard/components/PublishedStatus.jsx
@@ -69,7 +69,7 @@ export default class PublishedStatus extends React.Component {
                 this.togglePublished();
               }}
             >
-              Draft
+              {t('Draft')}
             </Label>
           </TooltipWrapper>
         );
@@ -80,7 +80,7 @@ export default class PublishedStatus extends React.Component {
           placement="bottom"
           tooltip={draftDivTooltip}
         >
-          <Label>Draft</Label>
+          <Label>{t('Draft')}</Label>
         </TooltipWrapper>
       );
     }
@@ -98,7 +98,7 @@ export default class PublishedStatus extends React.Component {
               this.togglePublished();
             }}
           >
-            Published
+            {t('Published')}
           </Label>
         </TooltipWrapper>
       );

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -88,7 +88,7 @@ export default function QueryAndSaveBtns({
       buttonSize="small"
       disabled={!canAdd}
     >
-      <i className="fa fa-stop-circle-o" /> Stop
+      <i className="fa fa-stop-circle-o" /> {t('Stop')}
     </Button>
   ) : (
     <Button
@@ -116,7 +116,7 @@ export default function QueryAndSaveBtns({
             onClick={onSave}
             data-test="query-save-button"
           >
-            <i className="fa fa-plus-circle" /> Save
+            <i className="fa fa-plus-circle" /> {t('Save')}
           </Button>
         </ButtonGroup>
         {errorMessage && (

--- a/superset-frontend/src/explore/controlPanels/sections.jsx
+++ b/superset-frontend/src/explore/controlPanels/sections.jsx
@@ -213,12 +213,14 @@ export const NVD3TimeSeries = [
               '30 days',
               '52 weeks',
               '1 year',
+              '104 weeks',
+              '2 years',
             ]),
             description: t(
               'Overlay one or more timeseries from a ' +
                 'relative time period. Expects relative time deltas ' +
                 'in natural language (example:  24 hours, 7 days, ' +
-                '56 weeks, 365 days)',
+                '52 weeks, 365 days). Free text is supported.',
             ),
           },
         },

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -22,7 +22,7 @@ from marshmallow.validate import Length, Range
 
 from superset.common.query_context import QueryContext
 from superset.utils import schema as utils
-from superset.utils.core import ExtraFiltersTimeColumnType, FilterOperator
+from superset.utils.core import FilterOperator
 
 #
 # RISON/JSON schemas for query parameters

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -22,7 +22,7 @@ from marshmallow.validate import Length, Range
 
 from superset.common.query_context import QueryContext
 from superset.utils import schema as utils
-from superset.utils.core import FilterOperator
+from superset.utils.core import ExtraFiltersTimeColumnType, FilterOperator
 
 #
 # RISON/JSON schemas for query parameters
@@ -705,6 +705,11 @@ class ChartDataExtrasSchema(Schema):
 
 
 class ChartDataQueryObjectSchema(Schema):
+    applied_time_extras = fields.Dict(
+        description="A mapping of temporal extras that have been applied to the query",
+        required=False,
+        example={"__time_range": "1 year ago : now"},
+    )
     filters = fields.List(fields.Nested(ChartDataFilterSchema), required=False)
     granularity = fields.String(
         description="Name of temporal column used for time filtering. For legacy Druid "
@@ -816,6 +821,13 @@ class ChartDataQueryObjectSchema(Schema):
         "as `having_druid`.",
         deprecated=True,
     )
+    druid_time_origin = fields.String(
+        description="Starting point for time grain counting on legacy Druid "
+        "datasources. Used to change e.g. Monday/Sunday first-day-of-week. "
+        "This field is deprecated and should be passed to `extras` "
+        "as `druid_time_origin`.",
+        allow_none=True,
+    )
 
 
 class ChartDataDatasourceSchema(Schema):
@@ -894,6 +906,12 @@ class ChartDataResponseResult(Schema):
         description="Amount of rows in result set", allow_none=False,
     )
     data = fields.List(fields.Dict(), description="A list with results")
+    applied_filters = fields.List(
+        fields.Dict(), description="A list with applied filters"
+    )
+    rejected_filters = fields.List(
+        fields.Dict(), description="A list with rejected filters"
+    )
 
 
 class ChartDataResponseSchema(Schema):

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -18,7 +18,7 @@ import copy
 import logging
 import math
 from datetime import datetime, timedelta
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, cast, ClassVar, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -160,6 +160,22 @@ class QueryContext:
         if status != utils.QueryStatus.FAILED:
             payload["data"] = self.get_data(df)
         del payload["df"]
+
+        filters = query_obj.filter
+        filter_columns = cast(List[str], [flt.get("col") for flt in filters])
+        columns = set(self.datasource.column_names)
+        applied_time_columns, rejected_time_columns = utils.get_time_filter_status(
+            self.datasource, query_obj.applied_time_extras
+        )
+        payload["applied_filters"] = [
+            {"column": col} for col in filter_columns if col in columns
+        ] + applied_time_columns
+        payload["rejected_filters"] = [
+            {"reason": "not_in_datasource", "column": col}
+            for col in filter_columns
+            if col not in columns
+        ] + rejected_time_columns
+
         if self.result_type == utils.ChartDataResultType.RESULTS:
             return {"data": payload["data"]}
         return payload

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -50,6 +50,7 @@ DEPRECATED_EXTRAS_FIELDS = (
     DeprecatedField(old_name="where", new_name="where"),
     DeprecatedField(old_name="having", new_name="having"),
     DeprecatedField(old_name="having_filters", new_name="having_druid"),
+    DeprecatedField(old_name="druid_time_origin", new_name="druid_time_origin"),
 )
 
 
@@ -59,6 +60,7 @@ class QueryObject:
     and druid. The query objects are constructed on the client.
     """
 
+    applied_time_extras: Dict[str, str]
     granularity: Optional[str]
     from_dttm: Optional[datetime]
     to_dttm: Optional[datetime]
@@ -79,6 +81,7 @@ class QueryObject:
 
     def __init__(
         self,
+        applied_time_extras: Optional[Dict[str, str]] = None,
         granularity: Optional[str] = None,
         metrics: Optional[List[Union[Dict[str, Any], str]]] = None,
         groupby: Optional[List[str]] = None,
@@ -100,6 +103,7 @@ class QueryObject:
         metrics = metrics or []
         extras = extras or {}
         is_sip_38 = is_feature_enabled("SIP_38_VIZ_REARCHITECTURE")
+        self.applied_time_extras = applied_time_extras or {}
         self.granularity = granularity
         self.from_dttm, self.to_dttm = utils.get_since_until(
             relative_start=extras.get(

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -156,7 +156,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
     ]
 
     def __repr__(self) -> str:
-        return f"Dashboard<{self.slug or self.id}>"
+        return f"Dashboard<{self.id or self.slug}>"
 
     @property
     def table_names(self) -> str:
@@ -253,7 +253,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
 
     @cache.memoize(
         # manage cache version manually
-        make_name=lambda fname: f"{fname}-v2",
+        make_name=lambda fname: f"{fname}-v2.1",
         timeout=config["DASHBOARD_CACHE_TIMEOUT"],
         unless=lambda: not is_feature_enabled("DASHBOARD_CACHE"),
     )

--- a/superset/templates/appbuilder/general/widgets/search.html
+++ b/superset/templates/appbuilder/general/widgets/search.html
@@ -37,7 +37,7 @@
             </table>
             <div class="filter-action" style="display:none">
             <button type="submit" class="btn btn-sm btn-primary" id="search-action">
-                Search&nbsp;&nbsp;<i class="fa fa-search"></i>
+                {{_("Search")}}&nbsp;&nbsp;<i class="fa fa-search"></i>
             </button>
             </div>
         </div>
@@ -54,7 +54,7 @@
                 $('.filter-action').toggle(true);
             } else {
                 $('.filter-action').toggle(true);
-                $('.filter-action > button').html('Refresh&nbsp;&nbsp;<i class="fa fa-refresh"></i>');
+                $('.filter-action > button').html('{{_("Refresh")}}&nbsp;&nbsp;<i class="fa fa-refresh"></i>');
             }
         }
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -910,6 +910,8 @@ def merge_extra_filters(  # pylint: disable=too-many-branches
     # that are external to the slice definition. We use those for dynamic
     # interactive filters like the ones emitted by the "Filter Box" visualization.
     # Note extra_filters only support simple filters.
+    applied_time_extras: Dict[str, str] = {}
+    form_data["applied_time_extras"] = applied_time_extras
     if "extra_filters" in form_data:
         # __form and __to are special extra_filters that target time
         # boundaries. The rest of extra_filters are simple
@@ -948,9 +950,13 @@ def merge_extra_filters(  # pylint: disable=too-many-branches
         ]:
             filtr["isExtra"] = True
             # Pull out time filters/options and merge into form data
-            if date_options.get(filtr["col"]):
-                if filtr.get("val"):
-                    form_data[date_options[filtr["col"]]] = filtr["val"]
+            filter_column = filtr["col"]
+            time_extra = date_options.get(filter_column)
+            if time_extra:
+                time_extra_value = filtr.get("val")
+                if time_extra_value:
+                    form_data[time_extra] = time_extra_value
+                    applied_time_extras[filter_column] = time_extra_value
             elif filtr["val"]:
                 # Merge column filters
                 filter_key = get_filter_key(filtr)
@@ -1567,5 +1573,82 @@ class RowLevelSecurityFilterType(str, Enum):
     BASE = "Base"
 
 
+class ExtraFiltersTimeColumnType(str, Enum):
+    GRANULARITY = "__granularity"
+    TIME_COL = "__time_col"
+    TIME_GRAIN = "__time_grain"
+    TIME_ORIGIN = "__time_origin"
+    TIME_RANGE = "__time_range"
+
+
 def is_test() -> bool:
     return strtobool(os.environ.get("SUPERSET_TESTENV", "false"))
+
+
+def get_time_filter_status(
+    datasource: "BaseDatasource", applied_time_extras: Dict[str, str],
+) -> Tuple[List[Dict[str, str]], List[Dict[str, str]]]:
+    temporal_columns = {
+        col.column_name for col in datasource.columns if col.is_temporal
+    }
+    applied: List[Dict[str, str]] = []
+    rejected: List[Dict[str, str]] = []
+    time_column = applied_time_extras.get(ExtraFiltersTimeColumnType.TIME_COL)
+    if time_column:
+        if time_column in temporal_columns:
+            applied.append({"column": ExtraFiltersTimeColumnType.TIME_COL})
+        else:
+            rejected.append(
+                {
+                    "reason": "not_in_datasource",
+                    "column": ExtraFiltersTimeColumnType.TIME_COL,
+                }
+            )
+
+    if ExtraFiltersTimeColumnType.TIME_GRAIN in applied_time_extras:
+        # are there any temporal columns to assign the time grain to?
+        if temporal_columns:
+            applied.append({"column": ExtraFiltersTimeColumnType.TIME_COL})
+        else:
+            rejected.append(
+                {
+                    "reason": "no_temporal_column",
+                    "column": ExtraFiltersTimeColumnType.TIME_GRAIN,
+                }
+            )
+
+    if ExtraFiltersTimeColumnType.TIME_RANGE in applied_time_extras:
+        # are there any temporal columns to assign the time grain to?
+        if temporal_columns:
+            applied.append({"column": ExtraFiltersTimeColumnType.TIME_RANGE})
+        else:
+            rejected.append(
+                {
+                    "reason": "no_temporal_column",
+                    "column": ExtraFiltersTimeColumnType.TIME_RANGE,
+                }
+            )
+
+    if ExtraFiltersTimeColumnType.TIME_ORIGIN in applied_time_extras:
+        if datasource.type == "druid":
+            applied.append({"column": ExtraFiltersTimeColumnType.TIME_ORIGIN})
+        else:
+            rejected.append(
+                {
+                    "reason": "not_druid_datasource",
+                    "column": ExtraFiltersTimeColumnType.TIME_ORIGIN,
+                }
+            )
+
+    if ExtraFiltersTimeColumnType.GRANULARITY in applied_time_extras:
+        if datasource.type == "druid":
+            applied.append({"column": ExtraFiltersTimeColumnType.GRANULARITY})
+        else:
+            rejected.append(
+                {
+                    "reason": "not_druid_datasource",
+                    "column": ExtraFiltersTimeColumnType.GRANULARITY,
+                }
+            )
+
+    return applied, rejected

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1585,7 +1585,7 @@ def is_test() -> bool:
     return strtobool(os.environ.get("SUPERSET_TESTENV", "false"))
 
 
-def get_time_filter_status(
+def get_time_filter_status(  # pylint: disable=too-many-branches
     datasource: "BaseDatasource", applied_time_extras: Dict[str, str],
 ) -> Tuple[List[Dict[str, str]], List[Dict[str, str]]]:
     temporal_columns = {
@@ -1608,7 +1608,7 @@ def get_time_filter_status(
     if ExtraFiltersTimeColumnType.TIME_GRAIN in applied_time_extras:
         # are there any temporal columns to assign the time grain to?
         if temporal_columns:
-            applied.append({"column": ExtraFiltersTimeColumnType.TIME_COL})
+            applied.append({"column": ExtraFiltersTimeColumnType.TIME_GRAIN})
         else:
             rejected.append(
                 {

--- a/superset/views/dashboard/mixin.py
+++ b/superset/views/dashboard/mixin.py
@@ -74,6 +74,7 @@ class DashboardMixin:  # pylint: disable=too-few-public-methods
         "slug": _("Slug"),
         "charts": _("Charts"),
         "owners": _("Owners"),
+        "published": _("Published"),
         "creator": _("Creator"),
         "modified": _("Modified"),
         "position_json": _("Position JSON"),

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -485,14 +485,18 @@ class BaseViz:
         filters = self.form_data.get("filters", [])
         filter_columns = [flt.get("col") for flt in filters]
         columns = set(self.datasource.column_names)
+        applied_time_extras = self.form_data.get("applied_time_extras", {})
+        applied_time_columns, rejected_time_columns = utils.get_time_filter_status(
+            self.datasource, applied_time_extras
+        )
         payload["applied_filters"] = [
             {"column": col} for col in filter_columns if col in columns
-        ]
+        ] + applied_time_columns
         payload["rejected_filters"] = [
             {"reason": "not_in_datasource", "column": col}
             for col in filter_columns
             if col not in columns
-        ]
+        ] + rejected_time_columns
 
         return payload
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -174,12 +174,18 @@ class TestUtils(SupersetTestCase):
     def test_merge_extra_filters(self):
         # does nothing if no extra filters
         form_data = {"A": 1, "B": 2, "c": "test"}
-        expected = {"A": 1, "B": 2, "c": "test"}
+        expected = {**form_data, "applied_time_extras": {}}
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
         # empty extra_filters
         form_data = {"A": 1, "B": 2, "c": "test", "extra_filters": []}
-        expected = {"A": 1, "B": 2, "c": "test", "adhoc_filters": []}
+        expected = {
+            "A": 1,
+            "B": 2,
+            "c": "test",
+            "adhoc_filters": [],
+            "applied_time_extras": {},
+        }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
         # copy over extra filters into empty filters
@@ -205,7 +211,8 @@ class TestUtils(SupersetTestCase):
                     "operator": "==",
                     "subject": "B",
                 },
-            ]
+            ],
+            "applied_time_extras": {},
         }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
@@ -248,7 +255,8 @@ class TestUtils(SupersetTestCase):
                     "operator": "==",
                     "subject": "B",
                 },
-            ]
+            ],
+            "applied_time_extras": {},
         }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
@@ -278,6 +286,13 @@ class TestUtils(SupersetTestCase):
             "time_grain_sqla": "years",
             "granularity": "90 seconds",
             "druid_time_origin": "now",
+            "applied_time_extras": {
+                "__time_range": "1 year ago :",
+                "__time_col": "birth_year",
+                "__time_grain": "years",
+                "__time_origin": "now",
+                "__granularity": "90 seconds",
+            },
         }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
@@ -290,7 +305,7 @@ class TestUtils(SupersetTestCase):
                 {"col": "B", "op": "==", "val": []},
             ]
         }
-        expected = {"adhoc_filters": []}
+        expected = {"adhoc_filters": [], "applied_time_extras": {}}
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
 
@@ -317,7 +332,8 @@ class TestUtils(SupersetTestCase):
                     "operator": "in",
                     "subject": None,
                 }
-            ]
+            ],
+            "applied_time_extras": {},
         }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
@@ -377,7 +393,8 @@ class TestUtils(SupersetTestCase):
                     "operator": "in",
                     "subject": "c",
                 },
-            ]
+            ],
+            "applied_time_extras": {},
         }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
@@ -429,7 +446,8 @@ class TestUtils(SupersetTestCase):
                     "operator": "in",
                     "subject": "a",
                 },
-            ]
+            ],
+            "applied_time_extras": {},
         }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
@@ -478,7 +496,8 @@ class TestUtils(SupersetTestCase):
                     "operator": "in",
                     "subject": "a",
                 },
-            ]
+            ],
+            "applied_time_extras": {},
         }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
@@ -537,7 +556,8 @@ class TestUtils(SupersetTestCase):
                     "operator": "==",
                     "subject": "B",
                 },
-            ]
+            ],
+            "applied_time_extras": {},
         }
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)


### PR DESCRIPTION
### SUMMARY
Adds support for `applied_filters` and `rejected_filters` to chart data endpoint + adds support for temporal extras to both `viz.py` and chart data endpoint.

Short summary of changes:
- In the legacy data `json_explore` endpoint, temporal extras (`__time_range` etc) are applied to `form_data` in `merge_extras` (see: https://github.com/apache/incubator-superset/blob/735123d1f5513d366955db1865faf6b064c9bd4a/superset/utils/core.py#L922-L953 ), information of which temporal filters have been overridden is lost. To get around this, we add the applied temporal extras in a dict called `applied_time_extras` that we can later reference to determine which of them were applied and which were not.
- since `superset-ui/core` merges temporal extras to the query object prior to sending the request, essentially performing the above operation (see: https://github.com/apache-superset/superset-ui/blob/master/packages/superset-ui-core/src/query/extractExtras.ts) , we need to pass along `applied_time_extras` in the request.

**Please note**: needs to upgrade to new version of `superset-ui/core` introduced here to function properly with v1 API plugins: https://github.com/apache-superset/superset-ui/pull/809 .

### SCREENSHOTS

In the below screenshot we can see that all temporal SQL filters are showing up as applied, while the druid ones aren't, as they aren't applicable to SQL datasources:
![image](https://user-images.githubusercontent.com/33317356/96431847-c2ada700-120c-11eb-8a0c-39c8a89267d7.png)

In the below screenshot we can see that all filters are flagged as incompatible, as the datasource doesn't have the gender column, nor any temporal SQL or Druid columns:
![image](https://user-images.githubusercontent.com/33317356/96415516-61c7a400-11f7-11eb-8caf-b3d2a11580da.png)

In this screenshot, we have both legacy (top row) and v1 (bottom row) viz plugins on the same dashboard. Notice that the filters apply similar to the legacy plugins:
![image](https://user-images.githubusercontent.com/33317356/96431717-95f98f80-120c-11eb-9e48-4504a2874028.png)

### TEST PLAN
CI with updated old tests + new E2E test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
