### PR TITLE
fix(chart-api): cached-indicator always shows value is cached

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -282,7 +282,7 @@ class QueryContext:
             "cache_timeout": self.cache_timeout,
             "df": df,
             "error": error_message,
-            "is_cached": cache_key is not None,
+            "is_cached": cache_value is not None,
             "query": query,
             "status": status,
             "stacktrace": stacktrace,


### PR DESCRIPTION
### SUMMARY
Currently the chart data endpoint always shows data as being cached. This differs from how the legacy endpoint works, which for the first or forced load doesn't show the `cached` pill. This changes the behaviour on the new endpoint to work similar to how the old one works.

### Expected behaviour (legacy endpoint)
In this video we can see how the `CACHED` pill is deactivated when the data is force refreshed:
![line-current](https://user-images.githubusercontent.com/33317356/96441025-7d3fa880-1211-11eb-97d7-db9661b260bc.gif)

### Current behaviour (v1 chart data endpoint)
Here we see the new data endpoint before the change. Note how the `CACHED` pill is always active:
![echarts-before](https://user-images.githubusercontent.com/33317356/96441115-a102ee80-1211-11eb-82e4-84289fce3dc9.gif)

### New behaviour (v1 chart data endpoint)
Here we see the new data endpoint after the change:
![echarts-after](https://user-images.githubusercontent.com/33317356/96441055-89c40100-1211-11eb-9607-ae16ad5ccaf9.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
