### PR TITLE
fix: bring back type ignore for config import

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -956,7 +956,7 @@ if CONFIG_PATH_ENV_VAR in os.environ:
 elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         import superset_config  # pylint: disable=import-error
-        from superset_config import *  # pylint: disable=import-error,wildcard-import,unused-wildcard-import
+        from superset_config import *  # type: ignore # pylint: disable=import-error,wildcard-import,unused-wildcard-import
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:


### PR DESCRIPTION
_Quickfix_
Without #type ignore there is CI problem in pre-commit:

```
superset/config.py:959: error: Incompatible import of "CELERY_CONFIG" (imported name has type "Type[superset_config.CeleryConfig]", local name has type "Type[superset.config.CeleryConfig]")
superset/config.py:959: error: Incompatible import of "CeleryConfig" (imported name has type "Type[superset_config.CeleryConfig]", local name has type "Type[superset.config.CeleryConfig]")
```


### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
