### PR TITLE
chore(prophet): ignore logged warning for missing plotly package

### DIFF
--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -595,6 +595,8 @@ def _prophet_fit_and_predict(  # pylint: disable=too-many-arguments
 
         prophet_logger.setLevel(logging.CRITICAL)
         from fbprophet import Prophet  # pylint: disable=import-error
+
+        prophet_logger.setLevel(logging.NOTSET)
     except ModuleNotFoundError:
         raise QueryObjectValidationError(_("`fbprophet` package not installed"))
     model = Prophet(

--- a/superset/utils/pandas_postprocessing.py
+++ b/superset/utils/pandas_postprocessing.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
 from functools import partial
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 
@@ -590,6 +591,9 @@ def _prophet_fit_and_predict(  # pylint: disable=too-many-arguments
     Fit a prophet model and return a DataFrame with predicted results.
     """
     try:
+        prophet_logger = logging.getLogger("fbprophet.plot")
+
+        prophet_logger.setLevel(logging.CRITICAL)
         from fbprophet import Prophet  # pylint: disable=import-error
     except ModuleNotFoundError:
         raise QueryObjectValidationError(_("`fbprophet` package not installed"))


### PR DESCRIPTION
### SUMMARY
When running Prophet for the first time, the following error is logged:

```ERROR:fbprophet.plot:Importing plotly failed. Interactive plots will not work.```

This PR disables this warning as recommended here: https://github.com/facebook/prophet/pull/1332#issuecomment-587184404

### TEST PLAN
Tested locally that the error is no longer logged.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
