### PR TITLE
fix: change chart title by clicking

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -655,7 +655,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         # slc perms
         slice_add_perm = security_manager.can_access("can_add", "SliceModelView")
-        slice_overwrite_perm = is_owner(slc, g.user) if slc else False
+        slice_overwrite_perm = (
+            security_manager.can_access("can_edit", "SliceModelView") if slc else False
+        )
         slice_download_perm = security_manager.can_access(
             "can_download", "SliceModelView"
         )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- this pr fixed admins were not able to edit chart title owned by other users on explore
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
https://www.loom.com/share/0daf089f48fd43ebabf9825af67b6855

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
