### PR TITLE
fix(listview): hide actions column if no actions are allowed

### DIFF
--- a/superset-frontend/src/SqlLab/components/QuerySearch.jsx
+++ b/superset-frontend/src/SqlLab/components/QuerySearch.jsx
@@ -47,6 +47,10 @@ const TableWrapper = styled.div`
 `;
 
 const TableStyles = styled.div`
+  table {
+    background-color: ${({ theme }) => theme.colors.grayscale.light4};
+  }
+
   .table > thead > tr > th {
     border-bottom: ${({ theme }) => theme.gridUnit / 2}px solid
       ${({ theme }) => theme.colors.grayscale.light2};

--- a/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
+++ b/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
@@ -34,6 +34,7 @@ interface TableCollectionProps {
 }
 
 export const Table = styled.table`
+  background-color: ${({ theme }) => theme.colors.grayscale.light5};
   border-collapse: separate;
   border-radius: ${({ theme }) => theme.borderRadius}px;
 

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -268,9 +268,6 @@ function ChartList(props: ChartListProps) {
         Cell: ({ row: { original } }: any) => {
           const handleDelete = () => handleChartDelete(original);
           const openEditModal = () => openChartEditModal(original);
-          if (!canEdit && !canDelete) {
-            return null;
-          }
 
           return (
             <span className="actions">
@@ -325,6 +322,7 @@ function ChartList(props: ChartListProps) {
         Header: t('Actions'),
         id: 'actions',
         disableSortBy: true,
+        hidden: !canEdit && !canDelete,
       },
     ],
     [canEdit, canDelete],

--- a/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
+++ b/superset-frontend/src/views/CRUD/csstemplates/CssTemplatesList.tsx
@@ -151,15 +151,12 @@ function CssTemplatesList({
               : null,
           ].filter(item => !!item);
 
-          if (!canEdit && !canDelete) {
-            return null;
-          }
-
           return <ActionsBar actions={actions as ActionProps[]} />;
         },
         Header: t('Actions'),
         id: 'actions',
         disableSortBy: true,
+        hidden: !canEdit && !canDelete,
         size: 'xl',
       },
     ],

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -267,9 +267,7 @@ function DashboardList(props: DashboardListProps) {
           const handleDelete = () => handleDashboardDelete(original);
           const handleEdit = () => openDashboardEditModal(original);
           const handleExport = () => handleBulkDashboardExport([original]);
-          if (!canEdit && !canDelete && !canExport) {
-            return null;
-          }
+
           return (
             <span className="actions">
               {canDelete && (
@@ -341,6 +339,7 @@ function DashboardList(props: DashboardListProps) {
         },
         Header: t('Actions'),
         id: 'actions',
+        hidden: !canEdit && !canDelete && !canExport,
         disableSortBy: true,
       },
     ],

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -239,9 +239,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
         Cell: ({ row: { original } }: any) => {
           const handleEdit = () => handleDatabaseEdit(original);
           const handleDelete = () => openDatabaseDeleteModal(original);
-          if (!canEdit && !canDelete) {
-            return null;
-          }
+
           return (
             <span className="actions">
               {canEdit && (
@@ -282,6 +280,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
         },
         Header: t('Actions'),
         id: 'actions',
+        hidden: !canEdit && !canDelete,
         disableSortBy: true,
       },
     ],

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -266,9 +266,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         Cell: ({ row: { original } }: any) => {
           const handleEdit = () => openDatasetEditModal(original);
           const handleDelete = () => openDatasetDeleteModal(original);
-          if (!canEdit && !canDelete) {
-            return null;
-          }
+
           return (
             <span className="actions">
               {canDelete && (
@@ -309,6 +307,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         },
         Header: t('Actions'),
         id: 'actions',
+        hidden: !canEdit && !canDelete,
         disableSortBy: true,
       },
     ],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- see title
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before:
<img width="1678" alt="Screen Shot 2020-10-19 at 8 45 33 PM" src="https://user-images.githubusercontent.com/10255196/96537860-1db2be80-124c-11eb-8cf0-7dfc9e71476a.png">
after:
<img width="1679" alt="Screen Shot 2020-10-19 at 8 44 40 PM" src="https://user-images.githubusercontent.com/10255196/96537872-25726300-124c-11eb-8206-64a61e8698bf.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- create a user with no edit, delete, and export permissions for dashboards
- sign in as user
- navigate to dashboards list 
- 👀 no actions column

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
