### PR TITLE
fix: 'Save Chart' modal's dashboard dropdown isn't sticky

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -873,6 +873,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "form_data": slc.form_data,
             "slice": slc.data,
             "dashboard_url": dash.url if dash else None,
+            "dashboard_id": dash.id if dash else None,
         }
 
         if dash and request.args.get("goto_dash") == "true":


### PR DESCRIPTION
### SUMMARY
It appears that the logic that makes the dashboard selection sticky
in the 'Save Chart' modal (explore) was broken at some time.

While working on a dashboard, it's nice if this modal can remember the
dashboard selection.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="630" alt="Screen Shot 2020-10-19 at 9 47 24 PM" src="https://user-images.githubusercontent.com/487433/96541387-b5b4a600-1254-11eb-8713-26806012934b.png">

### TEST PLAN
Manually tested/validated that it works with a new dashboard, an existing one, as well as with no dashboard selected.
