### PR TITLE
fix: Fix tabs switching in SouthPane

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane.jsx
@@ -160,8 +160,9 @@ export class SouthPane extends React.PureComponent {
     return (
       <div className="SouthPane" ref={this.southPaneRef}>
         <Tabs
-          defaultActiveKey={this.props.activeSouthPaneTab}
+          activeKey={this.props.activeSouthPaneTab}
           className="SouthPaneTabs"
+          onChange={this.switchTab}
           id={shortid.generate()}
           fullWidth={false}
         >


### PR DESCRIPTION
### SUMMARY
Fixes issue https://github.com/apache/incubator-superset/issues/11329 - tabs didn't automatically switch after selecting a schema, but stayed on "Results".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![after](https://user-images.githubusercontent.com/15073128/96577119-7a0cf100-12d3-11eb-81e5-8b03af1db28f.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11329
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
