### PR TITLE
perf(api): improve API info performance

### DIFF
--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -57,7 +57,7 @@ export function useListViewResource<D extends object = any>(
 
   useEffect(() => {
     SupersetClient.get({
-      endpoint: `/api/v1/${resource}/_info`,
+      endpoint: `/api/v1/${resource}/_info?q=(keys:!(permissions))`,
     }).then(
       ({ json: infoJson = {} }) => {
         updateState({


### PR DESCRIPTION
### SUMMARY
FAB's `_info` endpoint serves several information: permissions, filters, add fields, edit fields etc, by default fetches them all.
This change increases performance on this API call by just fetching permissions, note that this is hit on every React list view load

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
