### PR TITLE
fix: Allow "EXPLAIN" queries when "Allow DML" setting is False

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -89,7 +89,6 @@ class ParsedQuery:
 
         logger.debug("Parsing with sqlparse statement: %s", self.sql)
         self._parsed = sqlparse.parse(self.stripped())
-        logger.debug(self._parsed[0])
         for statement in self._parsed:
             self._limit = _extract_limit_from_query(statement)
 

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -112,14 +112,12 @@ class ParsedQuery:
 
     def is_explain(self) -> bool:
         # Remove comments
-        statements_without_comments = [
-            statement.strip(" \t\n;")
-            for statement in self.stripped().upper().splitlines()
-            if not statement.startswith("--")
-        ]
+        statements_without_comments = sqlparse.format(
+            self.stripped(), strip_comments=True
+        )
 
         # Explain statements will only be the first statement
-        if statements_without_comments[0].startswith("EXPLAIN"):
+        if statements_without_comments.startswith("EXPLAIN"):
             return True
 
         return False

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -112,7 +112,11 @@ class ParsedQuery:
 
     def is_explain(self) -> bool:
         # Remove comments
-        statements_without_comments = [statement.strip(" \t\n;") for statement in self.stripped().upper().splitlines() if not statement.startswith("--")]
+        statements_without_comments = [
+            statement.strip(" \t\n;")
+            for statement in self.stripped().upper().splitlines()
+            if not statement.startswith("--")
+        ]
 
         # Explain statements will only be the first statement
         if statements_without_comments[0].startswith("EXPLAIN"):

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -89,6 +89,7 @@ class ParsedQuery:
 
         logger.debug("Parsing with sqlparse statement: %s", self.sql)
         self._parsed = sqlparse.parse(self.stripped())
+        logger.debug(self._parsed[0])
         for statement in self._parsed:
             self._limit = _extract_limit_from_query(statement)
 
@@ -111,7 +112,11 @@ class ParsedQuery:
         return self._parsed[0].get_type() == "SELECT"
 
     def is_explain(self) -> bool:
-        return self.stripped().upper().startswith("EXPLAIN")
+        # Parsing SQL statement for EXPLAIN and filtering out commente
+        for statement in self.stripped().upper().splitlines():
+            if statement.upper().startswith("EXPLAIN"):
+                return True
+        return False
 
     def is_readonly(self) -> bool:
         """Pessimistic readonly, 100% sure statement won't mutate anything"""

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -117,10 +117,7 @@ class ParsedQuery:
         )
 
         # Explain statements will only be the first statement
-        if statements_without_comments.startswith("EXPLAIN"):
-            return True
-
-        return False
+        return statements_without_comments.startswith("EXPLAIN")
 
     def is_readonly(self) -> bool:
         """Pessimistic readonly, 100% sure statement won't mutate anything"""

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -111,10 +111,13 @@ class ParsedQuery:
         return self._parsed[0].get_type() == "SELECT"
 
     def is_explain(self) -> bool:
-        # Parsing SQL statement for EXPLAIN and filtering out comments
-        for statement in self.stripped().upper().splitlines():
-            if statement.upper().startswith("EXPLAIN"):
-                return True
+        # Remove comments
+        statements_without_comments = [statement.strip(" \t\n;") for statement in self.stripped().upper().splitlines() if not statement.startswith("--")]
+
+        # Explain statements will only be the first statement
+        if statements_without_comments[0].startswith("EXPLAIN"):
+            return True
+
         return False
 
     def is_readonly(self) -> bool:

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -111,7 +111,7 @@ class ParsedQuery:
         return self._parsed[0].get_type() == "SELECT"
 
     def is_explain(self) -> bool:
-        # Parsing SQL statement for EXPLAIN and filtering out commente
+        # Parsing SQL statement for EXPLAIN and filtering out comments
         for statement in self.stripped().upper().splitlines():
             if statement.upper().startswith("EXPLAIN"):
                 return True

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -602,3 +602,12 @@ class TestSupersetSqlParse(unittest.TestCase):
         """
         parsed = ParsedQuery(query)
         self.assertEqual(parsed.is_explain(), True)
+
+        query = """
+            -- comment  
+            select * from table
+            where col1 = 'something'
+            -- comment 2
+        """
+        parsed = ParsedQuery(query)
+        self.assertEqual(parsed.is_explain(), False)

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -589,12 +589,16 @@ class TestSupersetSqlParse(unittest.TestCase):
         parsed = ParsedQuery(query)
         self.assertEqual(parsed.is_explain(), True)
 
-        # query = """
-        #     -- comment  
-        #     EXPLAIN select * from table
-        #     where col1 = 'something'
-        #     -- comment 2
-        # """
-        # parsed = ParsedQuery(query)
-        # self.assertEqual(parsed.is_explain(), True)
-        self.assertEqual(True, True)
+        query = """
+            -- comment  
+            EXPLAIN select * from table
+            where col1 = 'something'
+            -- comment 2
+
+            -- comment 3
+            EXPLAIN select * from table
+            where col1 = 'something'
+            -- comment 4
+        """
+        parsed = ParsedQuery(query)
+        self.assertEqual(parsed.is_explain(), True)

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -582,7 +582,7 @@ class TestSupersetSqlParse(unittest.TestCase):
 
     def test_is_explain(self):
         query = """
-            -- comment  
+            -- comment
             EXPLAIN select * from table
             -- comment 2
         """
@@ -590,7 +590,7 @@ class TestSupersetSqlParse(unittest.TestCase):
         self.assertEqual(parsed.is_explain(), True)
 
         query = """
-            -- comment  
+            -- comment
             EXPLAIN select * from table
             where col1 = 'something'
             -- comment 2
@@ -604,7 +604,7 @@ class TestSupersetSqlParse(unittest.TestCase):
         self.assertEqual(parsed.is_explain(), True)
 
         query = """
-            -- comment  
+            -- comment
             select * from table
             where col1 = 'something'
             -- comment 2

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -604,6 +604,22 @@ class TestSupersetSqlParse(unittest.TestCase):
         self.assertEqual(parsed.is_explain(), True)
 
         query = """
+            -- This is a comment
+                -- this is another comment but with a space in the front
+            EXPLAIN SELECT * FROM TABLE
+        """
+        parsed = ParsedQuery(query)
+        self.assertEqual(parsed.is_explain(), True)
+
+        query = """
+            /* This is a comment
+                 with stars instead */
+            EXPLAIN SELECT * FROM TABLE
+        """
+        parsed = ParsedQuery(query)
+        self.assertEqual(parsed.is_explain(), True)
+
+        query = """
             -- comment
             select * from table
             where col1 = 'something'

--- a/tests/sql_parse_tests.py
+++ b/tests/sql_parse_tests.py
@@ -579,3 +579,22 @@ class TestSupersetSqlParse(unittest.TestCase):
                 reindent=True,
             ),
         )
+
+    def test_is_explain(self):
+        query = """
+            -- comment  
+            EXPLAIN select * from table
+            -- comment 2
+        """
+        parsed = ParsedQuery(query)
+        self.assertEqual(parsed.is_explain(), True)
+
+        # query = """
+        #     -- comment  
+        #     EXPLAIN select * from table
+        #     where col1 = 'something'
+        #     -- comment 2
+        # """
+        # parsed = ParsedQuery(query)
+        # self.assertEqual(parsed.is_explain(), True)
+        self.assertEqual(True, True)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixing `is_explain` function in sql_parse to properly catch EXPLAIN statements. sqlparse out of the box doesn't handle comments well, so we have to parse the query ourselves.

Closes #8827

#### Before
<img width="1071" alt="Screen Shot 2020-10-20 at 6 08 19 PM" src="https://user-images.githubusercontent.com/27827808/96660790-60819e80-12ff-11eb-86f5-4f01efd32508.png">

#### After
<img width="1205" alt="Screen Shot 2020-10-20 at 6 08 47 PM" src="https://user-images.githubusercontent.com/27827808/96660796-624b6200-12ff-11eb-8fc7-d98146ac94b5.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. Goto Sqllab

2. Run the following query:
```
EXPLAIN SELECT * FROM logs
```

3. See results populate

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

