### PR TITLE
style(sqllab): wrap text in monospace db-provided error messages

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -57,9 +57,14 @@ interface ResultSetState {
   data: Record<string, any>[];
 }
 
+// Making text render line breaks/tabs as is as monospace,
+// but wrapping text too so text doesn't overflow
 const MonospaceDiv = styled.div`
   font-family: ${({ theme }) => theme.typography.families.monospace};
   white-space: pre;
+  word-break: break-word;
+  overflow-x: auto;
+  white-space: pre-wrap;
 `;
 
 export default class ResultSet extends React.PureComponent<


### PR DESCRIPTION
### SUMMARY
closes https://github.com/apache/incubator-superset/issues/11352

> It seems that Superset errors do not wrap (the example is from SQL Lab and thus I'm uncertain how broad of an issue this is) meaning one needs to scroll horizontally in order to parse the message. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### after
<img width="588" alt="Screen Shot 2020-10-20 at 9 57 04 PM" src="https://user-images.githubusercontent.com/487433/96675322-8323af80-131f-11eb-86b7-346781080c88.png">

#### before
<img width="521" alt="Screen Shot 2020-10-20 at 9 59 01 PM" src="https://user-images.githubusercontent.com/487433/96675319-81f28280-131f-11eb-90c1-7f31e9612ad2.png">

### TEST PLAN
visual / manual checks with different error messages and screen sizes
