### PR TITLE
style: make <Label/> not uppercase

### DIFF
--- a/superset-frontend/stylesheets/less/cosmo/bootswatch.less
+++ b/superset-frontend/stylesheets/less/cosmo/bootswatch.less
@@ -279,7 +279,6 @@ table,
   border-radius: 21px;
   padding: 0.35em 0.8em 0.35em;
   font-weight: @font-weight-normal;
-  text-transform: uppercase;
   font-size: @font-size-s;
 }
 .label-default:hover {


### PR DESCRIPTION
### SUMMARY
Rolling back the change I made that forced all `<Label/>` to be `uppercase`. In many cases, labels contain table names, viz type names, filter summary and other things where case matters. We should leave as is by default.

The original intent was to have good vertical alignment of letters inside the label, and having all letters have the same height make things look more even, but I think that doesn't matter much.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### after
<img width="504" alt="Screen Shot 2020-10-20 at 10 55 44 PM" src="https://user-images.githubusercontent.com/487433/96678902-7b680900-1327-11eb-90b0-ce8b5371fd1d.png">

#### before
<img width="501" alt="Screen Shot 2020-10-20 at 10 56 16 PM" src="https://user-images.githubusercontent.com/487433/96678909-7dca6300-1327-11eb-897e-158f59333089.png">


### TEST PLAN
CSS change, so a simple visual review of the application

