### PR TITLE
fix(sqla): allow 'unknown' type queries in explore view

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -758,7 +758,8 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                 raise QueryObjectValidationError(
                     _("Virtual dataset query cannot consist of multiple statements")
                 )
-            if not ParsedQuery(from_sql).is_readonly():
+            parsed_query = ParsedQuery(from_sql)
+            if not (parsed_query.is_unknown() or parsed_query.is_readonly()):
                 raise QueryObjectValidationError(
                     _("Virtual dataset query must be read-only")
                 )

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -113,6 +113,9 @@ class ParsedQuery:
     def is_explain(self) -> bool:
         return self.stripped().upper().startswith("EXPLAIN")
 
+    def is_unknown(self) -> bool:
+        return self._parsed[0].get_type() == "UNKNOWN"
+
     def is_readonly(self) -> bool:
         """Pessimistic readonly, 100% sure statement won't mutate anything"""
         return self.is_select() or self.is_explain()


### PR DESCRIPTION
### SUMMARY
After we deployed #11236, several charts broke because the sql parser could not identify the type of the query and pessimistically classified them as write queries. These problems occur because the sql parser is sensitive to certain syntax issues that may not actually be problems in some dialects of sql (in this case, presto sql).

These errors are confusing to users because their queries work in sql lab but fail in explore view. Debugging and fixing the so-called "incorrect" syntax is very tedious.

In this PR, I am allowing queries with an "UNKNOWN" type (optimistic instead of pessimistic). This couuuuld potentially allow some write queries through, but it's still a step up from how things were before #11236.

### TEST PLAN
Some examples of correct queries that failed in explore view due to unknown type:
```sql
WITH x AS(SELECT 1 AS col) SELECT * FROM x
```

```sql
WITH events AS (SELECT 1 AS col) SELECT * FROM events
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #11310
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
