### PR TITLE
fix: Overflowing tabs in SqlLab not styled properly

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -322,6 +322,7 @@ div.Workspace {
   .queryPane {
     flex: 1 1 auto;
     padding-left: 10px;
+    overflow: auto;
   }
 
   .schemaPane-enter-done,


### PR DESCRIPTION
### SUMMARY
In SouthPane component, when the tabs overflow there should be a dropdown component that shows invisible tabs. Currently, the overflowing tabs stretch the whole container. I fixed it by adding `overflow: auto` to QueryPane.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/96753681-7d39d700-13d0-11eb-9fc9-0919889653e5.png)

After:
![image](https://user-images.githubusercontent.com/15073128/96753850-bffbaf00-13d0-11eb-927c-1238da417192.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
