### PR TITLE
fix: dashboard cache invalid join query

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -312,10 +312,10 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
             [dashboard_slices.c.dashboard_id], distinct=True,
         ).select_from(
             join(
-                Slice,
                 dashboard_slices,
-                Slice.id == dashboard_slices.c.slice_id,
-                Slice.datasource_id == datasource_id,
+                Slice,
+                (Slice.id == dashboard_slices.c.slice_id)
+                & (Slice.datasource_id == datasource_id),
             )
         )
         for (dashboard_id,) in db.session.execute(filter_query):
@@ -598,7 +598,7 @@ if is_feature_enabled("DASHBOARD_CACHE"):
     sqla.event.listen(Slice, "after_update", clear_dashboard_cache)
     sqla.event.listen(Slice, "after_delete", clear_dashboard_cache)
     sqla.event.listen(
-        BaseDatasource, "after_update", clear_dashboard_cache, propagage=True
+        BaseDatasource, "after_update", clear_dashboard_cache, propagate=True
     )
     # also clear cache on column/metric updates since updates to these will not
     # trigger update events for BaseDatasource.

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -302,7 +302,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
         filter_query = select([dashboard_slices.c.dashboard_id], distinct=True).where(
             dashboard_slices.c.slice_id == slice_id
         )
-        for (dashboard_id,) in db.session.execute(filter_query):
+        for (dashboard_id,) in db.engine.execute(filter_query):
             cls(id=dashboard_id).clear_cache()
 
     @classmethod
@@ -318,7 +318,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
                 & (Slice.datasource_id == datasource_id),
             )
         )
-        for (dashboard_id,) in db.session.execute(filter_query):
+        for (dashboard_id,) in db.engine.execute(filter_query):
             cls(id=dashboard_id).clear_cache()
 
     @classmethod


### PR DESCRIPTION
### SUMMARY

This fixes a bug where when `DASHBOARD_CACHE` feature flag is enabled, saving datasource will become too slow and sometimes generate the following error: 

> (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely) (pymysql.err.OperationalError) (1205, 'Lock wait timeout exceeded; try restarting transaction') [SQL: UPDATE table_columns SET changed_on=%(changed_on)s, is_active=%(is_active)s, changed_by_fk=%(changed_by_fk)s WHERE table_columns.id = %(table_columns_id)s] [parameters: {'changed_on': datetime.datetime(2020, 10, 20, 17, 15, 11, 547150), 'is_active': None, 'changed_by_fk': 9117, 'table_columns_id': 1555231}] (Background on this error at: http://sqlalche.me/e/13/e3q8)

This is because of a wrong join condition where I thought multiple join conditions can be passed to SQLAlchemy's [join](https://docs.sqlalchemy.org/en/13/core/selectable.html#sqlalchemy.sql.expression.join) as consecutive positional arguments, when it's actually expecting only one positional argument for the join conditions.

Also fixes a typo that has made editing datasource unable to update the dashboard cache.

cc @graceguo-supercat @serenajiang 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

- Enable `DASHBOARD_CACHE`
- Try edit a datasource in the Explore view

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11234 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
