### PR TITLE
style: removing outlines on a few key elements

### DIFF
--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -22,6 +22,14 @@
 
 @datasource-sql-expression-width: 315px;
 
+span,
+div,
+i {
+  &:focus {
+    outline: none;
+  }
+}
+
 .alert.alert-danger > .debugger {
   color: @danger;
 }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
React-bootstrap adds styles with a VERY broad `:focus` style, adding goofy outlines all over the place. 

I'm removing that outline for a few key elements, namely `div` `span` and `i` so we don't see them in strange places. This should not affect focus on form elements and such, so it has a relatively low impact on accessibility. That said, I admit there may be areas where there's tab-based navigation we DO want to support. In such cases, we should make sure that it's supported (and styled) _properly_ in those relevant components, when we get to do a broader accessibility sweep to meet WCAG standards.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
![outline-before](https://user-images.githubusercontent.com/812905/96792268-e6105780-13ae-11eb-84d3-1bb19165a690.gif)

![check-before](https://user-images.githubusercontent.com/812905/96792900-2de3ae80-13b0-11eb-9f9f-86f21575f347.gif)


After:
![outline-after](https://user-images.githubusercontent.com/812905/96792283-ec9ecf00-13ae-11eb-8e10-321b4467f456.gif)

![after](https://user-images.githubusercontent.com/812905/96792909-320fcc00-13b0-11eb-88fa-e13f7b24e46f.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
