### PR TITLE
fix(logging): Change log level to warn for failure to get table/view names from DB

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -508,7 +508,7 @@ class Database(
                 utils.DatasourceName(table=table, schema=schema) for table in tables
             ]
         except Exception as ex:  # pylint: disable=broad-except
-            logger.exception(ex)
+            logger.warning(ex)
 
     @cache_util.memoized_func(
         key=lambda *args, **kwargs: f"db:{{}}:schema:{kwargs.get('schema')}:view_list",  # type: ignore
@@ -538,7 +538,7 @@ class Database(
             )
             return [utils.DatasourceName(table=view, schema=schema) for view in views]
         except Exception as ex:  # pylint: disable=broad-except
-            logger.exception(ex)
+            logger.warning(ex)
 
     @cache_util.memoized_func(
         key=lambda *args, **kwargs: "db:{}:schema_list", attribute_in_key="id"


### PR DESCRIPTION
### SUMMARY
Changes the log level from `exception` to `warning` for failed attempts to load table/view schemas from analytics DBs. These failures are typically due to misconfiguration of the database credentials, or transient failures in connecting to or querying the DB, and therefore should not log as an exception.

An example error that will be converted from `exception` level logging to `warning`:
```
(psycopg2.OperationalError) could not translate host name "scratchdb-aws-c1.us-west2-aws.production.test.zone" to address: Name or service not known
```

### TEST PLAN
Verify log level of `warning` for failures to fetch table/view schemas from analytics DBs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
