### PR TITLE
fix: better error messages for dashboard properties modal

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal.jsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal.jsx
@@ -165,13 +165,25 @@ class PropertiesModal extends React.PureComponent {
   }
 
   async handleErrorResponse(response) {
-    const { error, statusText } = await getClientErrorObject(response);
+    const { error, statusText, message } = await getClientErrorObject(response);
+    let errorText = error || statusText || t('An error has occurred');
+
+    if (typeof message === 'object' && message.json_metadata) {
+      errorText = message.json_metadata;
+    } else if (typeof message === 'string') {
+      errorText = message;
+
+      if (message === 'Forbidden') {
+        errorText = t('You do not have permission to edit this dashboard');
+      }
+    }
+
     this.dialog.show({
       title: 'Error',
       bsSize: 'medium',
       bsStyle: 'danger',
       actions: [Dialog.DefaultAction('Ok', () => {}, 'btn-danger')],
-      body: error || statusText || t('An error has occurred'),
+      body: errorText,
     });
   }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The dashboard properties modal raises a generic error message for most cases. Since the api already sends back status codes and validation errors this PR simply exposes them to the user. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1025" alt="Screen Shot 2020-10-21 at 8 20 08 PM" src="https://user-images.githubusercontent.com/10255196/96820672-51701e80-13db-11eb-8a9c-ef85081e651b.png">
<img width="955" alt="Screen Shot 2020-10-21 at 8 20 22 PM" src="https://user-images.githubusercontent.com/10255196/96820676-52a14b80-13db-11eb-8e96-c247253f8baa.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- manually tested: entering invalid JSON in `json_metadata`, editing a dashboard that user does not own. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
