### PR TITLE
fix: bump superset-ui/core (P0 filters branch)

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -15148,12 +15148,90 @@
         "@superset-ui/core": "0.15.2",
         "lodash": "^4.17.15",
         "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+      "version": "0.15.9",
+      "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.9.tgz",
+      "integrity": "sha512-YbaIFcA2llYRh/6cxrFJb4expTHxoJXAhUo9lJwYG3czhhp8c2RQk0dJpgD39UAlJvAKwNngIvZvwRcqCPTNpw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "@emotion/core": "^10.0.28",
@@ -15193,6 +15271,11 @@
             "resize-observer-polyfill": "1.5.1"
           }
         },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
         "d3-interpolate": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
@@ -15202,11 +15285,11 @@
           }
         },
         "d3-scale": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.2.tgz",
-          "integrity": "sha512-3Mvi5HfqPFq0nlyeFlkskGjeqrR/790pINMHc4RXKJ2E6FraTd3juaRIRZZHyMAbi3LjAMW0EH4FB1WgoGyeXg==",
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
           "requires": {
-            "d3-array": "1.2.0 - 2",
+            "d3-array": "^2.3.0",
             "d3-format": "1 - 2",
             "d3-interpolate": "1.2.0 - 2",
             "d3-time": "1 - 2",
@@ -15236,10 +15319,81 @@
         "prop-types": "^15.6.2"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
         "d3-array": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
           "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
         }
       }
     },
@@ -15253,6 +15407,84 @@
         "d3": "^3.5.17",
         "prop-types": "^15.6.2",
         "react": "^16.13.1"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-country-map": {
@@ -15267,10 +15499,81 @@
         "prop-types": "^15.6.2"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
         "d3-array": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
           "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
         }
       }
     },
@@ -15283,6 +15586,84 @@
         "@superset-ui/chart-controls": "0.15.5",
         "@superset-ui/core": "0.15.2",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-force-directed": {
@@ -15294,6 +15675,84 @@
         "@superset-ui/core": "0.15.2",
         "d3": "^3.5.17",
         "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-heatmap": {
@@ -15307,6 +15766,84 @@
         "d3-svg-legend": "^1.x",
         "d3-tip": "^0.9.1",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-histogram": {
@@ -15324,6 +15861,72 @@
         "prop-types": "^15.6.2"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          },
+          "dependencies": {
+            "d3-array": {
+              "version": "2.8.0",
+              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+              "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+            },
+            "d3-interpolate": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+              "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+              "requires": {
+                "d3-color": "1"
+              }
+            },
+            "d3-scale": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+              "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+              "requires": {
+                "d3-array": "^2.3.0",
+                "d3-format": "1 - 2",
+                "d3-interpolate": "1.2.0 - 2",
+                "d3-time": "1 - 2",
+                "d3-time-format": "2 - 3"
+              }
+            },
+            "d3-time-format": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+              "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+              "requires": {
+                "d3-time": "1"
+              }
+            }
+          }
+        },
         "@vx/group": {
           "version": "0.0.198",
           "resolved": "https://registry.npmjs.org/@vx/group/-/group-0.0.198.tgz",
@@ -15396,6 +15999,67 @@
         "prop-types": "^15.6.2"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          },
+          "dependencies": {
+            "d3-interpolate": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+              "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+              "requires": {
+                "d3-color": "1"
+              }
+            },
+            "d3-time-format": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+              "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+              "requires": {
+                "d3-time": "1"
+              }
+            }
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
         "d3-array": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
@@ -15430,6 +16094,82 @@
         "viewport-mercator-project": "^6.1.1"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
         "immutable": {
           "version": "3.8.2",
           "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -15449,6 +16189,82 @@
         "reactable-arc": "0.15.0"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
         "reactable-arc": {
           "version": "0.15.0",
           "resolved": "https://registry.npmjs.org/reactable-arc/-/reactable-arc-0.15.0.tgz",
@@ -15465,6 +16281,84 @@
         "@superset-ui/core": "0.15.2",
         "d3": "^3.5.17",
         "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-partition": {
@@ -15477,6 +16371,84 @@
         "d3": "^3.5.17",
         "d3-hierarchy": "^1.1.8",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-pivot-table": {
@@ -15489,6 +16461,84 @@
         "d3": "^3.5.17",
         "datatables.net-bs": "^1.10.15",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-rose": {
@@ -15501,6 +16551,84 @@
         "d3": "^3.5.17",
         "nvd3": "1.8.6",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-sankey": {
@@ -15513,6 +16641,84 @@
         "d3": "^3.5.17",
         "d3-sankey": "^0.4.2",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-sankey-loop": {
@@ -15525,6 +16731,84 @@
         "d3-sankey-diagram": "^0.7.3",
         "d3-selection": "^1.4.0",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-sunburst": {
@@ -15536,6 +16820,84 @@
         "@superset-ui/core": "0.15.2",
         "d3": "^3.5.17",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-treemap": {
@@ -15548,6 +16910,84 @@
         "d3-hierarchy": "^1.1.8",
         "d3-selection": "^1.4.0",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-world-map": {
@@ -15564,6 +17004,49 @@
         "prop-types": "^15.6.2"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
         "d3-array": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
@@ -15573,6 +17056,34 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
           "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
         }
       }
     },
@@ -15588,6 +17099,84 @@
         "@types/shortid": "^0.0.29",
         "d3-color": "^1.2.3",
         "shortid": "^2.2.14"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/legacy-preset-chart-deckgl": {
@@ -15633,6 +17222,84 @@
         "nvd3-fork": "2.0.3",
         "prop-types": "^15.6.2",
         "urijs": "^1.18.10"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/plugin-chart-echarts": {
@@ -15644,6 +17311,84 @@
         "@superset-ui/core": "0.15.2",
         "@types/echarts": "^4.6.3",
         "echarts": "^4.9.0"
+      },
+      "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
       }
     },
     "@superset-ui/plugin-chart-table": {
@@ -15666,10 +17411,81 @@
         "xss": "^1.0.6"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
         "d3-array": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
           "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+          "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "1 - 2",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
         }
       }
     },
@@ -15688,6 +17504,67 @@
         "encodable": "^0.7.6"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          },
+          "dependencies": {
+            "d3-interpolate": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+              "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+              "requires": {
+                "d3-color": "1"
+              }
+            },
+            "d3-time-format": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+              "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+              "requires": {
+                "d3-time": "1"
+              }
+            }
+          }
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
+        },
         "d3-array": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
@@ -15725,6 +17602,72 @@
         "reselect": "^4.0.0"
       },
       "dependencies": {
+        "@superset-ui/core": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/@superset-ui/core/-/core-0.15.2.tgz",
+          "integrity": "sha512-NZngspkaov9T7n5s5F9biADSS/noFLdRdQfGrd3p6KI8pkwksOEy/XxuVzbQ4/f0z8jGtzt5LYM0kYlV+8MqrQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^10.0.28",
+            "@emotion/styled": "^10.0.27",
+            "@types/d3-format": "^1.3.0",
+            "@types/d3-interpolate": "^1.3.1",
+            "@types/d3-scale": "^2.1.1",
+            "@types/d3-time": "^1.0.9",
+            "@types/d3-time-format": "^2.1.0",
+            "@types/lodash": "^4.14.149",
+            "@vx/responsive": "^0.0.197",
+            "csstype": "^2.6.4",
+            "d3-format": "^1.3.2",
+            "d3-interpolate": "^1.4.0",
+            "d3-scale": "^3.0.0",
+            "d3-time": "^1.0.10",
+            "d3-time-format": "^2.2.0",
+            "emotion-theming": "^10.0.27",
+            "fetch-retry": "^4.0.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.11",
+            "pretty-ms": "^7.0.0",
+            "react-error-boundary": "^1.2.5",
+            "reselect": "^4.0.0",
+            "whatwg-fetch": "^3.0.0"
+          },
+          "dependencies": {
+            "d3-array": {
+              "version": "2.8.0",
+              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+              "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+            },
+            "d3-interpolate": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+              "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+              "requires": {
+                "d3-color": "1"
+              }
+            },
+            "d3-scale": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+              "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+              "requires": {
+                "d3-array": "^2.3.0",
+                "d3-format": "1 - 2",
+                "d3-interpolate": "1.2.0 - 2",
+                "d3-time": "1 - 2",
+                "d3-time-format": "2 - 3"
+              }
+            },
+            "d3-time-format": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+              "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+              "requires": {
+                "d3-time": "1"
+              }
+            }
+          }
+        },
         "@vx/axis": {
           "version": "0.0.198",
           "resolved": "https://registry.npmjs.org/@vx/axis/-/axis-0.0.198.tgz",
@@ -15777,6 +17720,18 @@
           "version": "0.0.198",
           "resolved": "https://registry.npmjs.org/@vx/point/-/point-0.0.198.tgz",
           "integrity": "sha512-oFlw8uBLf4JDX7OJc+7eQXcnlLszdQgEs531u0t6HNpARQY/jTeeMLVUlp8sNF0XBOC+iVHU8Qe8TJdz/ONBAA=="
+        },
+        "@vx/responsive": {
+          "version": "0.0.197",
+          "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.197.tgz",
+          "integrity": "sha512-Qv15PJ/Hy79LjyfJ/9E8z+zacKAnD43O2Jg9wvB6PFSNs73xPEDy/mHTYxH+FZv94ruAE3scBO0330W29sQpyg==",
+          "requires": {
+            "@types/lodash": "^4.14.146",
+            "@types/react": "*",
+            "lodash": "^4.17.10",
+            "prop-types": "^15.6.1",
+            "resize-observer-polyfill": "1.5.1"
+          }
         },
         "@vx/scale": {
           "version": "0.0.197",
@@ -21003,28 +22958,28 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
@@ -21035,14 +22990,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
@@ -21053,35 +23008,35 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "optional": true,
@@ -21091,35 +23046,35 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
@@ -21136,7 +23091,7 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "optional": true,
@@ -21151,14 +23106,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
@@ -21168,7 +23123,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "optional": true,
@@ -21178,7 +23133,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
@@ -21189,21 +23144,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
@@ -21213,14 +23168,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
@@ -21237,14 +23192,14 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "dev": true,
               "optional": true,
@@ -21256,7 +23211,7 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "dev": true,
               "optional": true,
@@ -21275,7 +23230,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
@@ -21286,14 +23241,14 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "dev": true,
               "optional": true,
@@ -21304,7 +23259,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
@@ -21317,21 +23272,21 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
@@ -21341,21 +23296,21 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
@@ -21366,21 +23321,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
@@ -21393,7 +23348,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "optional": true,
@@ -21409,7 +23364,7 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "optional": true,
@@ -21419,49 +23374,49 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
@@ -21473,7 +23428,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
@@ -21483,7 +23438,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "optional": true,
@@ -21493,21 +23448,21 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
@@ -21517,7 +23472,7 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true,
               "optional": true
@@ -37732,9 +39687,9 @@
       "dev": true
     },
     "pretty-ms": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",
-      "integrity": "sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
       "requires": {
         "parse-ms": "^2.1.0"
       }

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -65,7 +65,7 @@
     "@data-ui/sparkline": "^0.0.84",
     "@emotion/core": "^10.0.28",
     "@superset-ui/chart-controls": "^0.15.5",
-    "@superset-ui/core": "^0.15.2",
+    "@superset-ui/core": "^0.15.9",
     "@superset-ui/legacy-plugin-chart-calendar": "^0.15.5",
     "@superset-ui/legacy-plugin-chart-chord": "^0.15.5",
     "@superset-ui/legacy-plugin-chart-country-map": "^0.15.5",


### PR DESCRIPTION
### SUMMARY
The new version of `superset-ui/core` hadn't been released at the time of the previous PR, hence this bump was missing. This is required to make new charts work with new filter indicator.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Local testing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
