### PR TITLE
fix: keeping Markdown content while resizing window on Dashboard

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/dashboard.helper.ts
@@ -45,3 +45,14 @@ export function drag(selector: string, content: string | number | RegExp) {
     },
   };
 }
+
+export function resize(selector: string) {
+  return {
+    to(cordX: number, cordY: number) {
+      cy.get(selector)
+        .trigger('mousedown', { which: 1 })
+        .trigger('mousemove', { which: 1, cordX, cordY, force: true })
+        .trigger('mouseup', { which: 1, force: true });
+    },
+  };
+}

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/markdown.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { TABBED_DASHBOARD, drag } from './dashboard.helper';
+import { TABBED_DASHBOARD, drag, resize } from './dashboard.helper';
 
 describe('Dashboard edit markdown', () => {
   beforeEach(() => {
@@ -56,9 +56,20 @@ describe('Dashboard edit markdown', () => {
         '✨Markdown✨Markdown✨MarkdownClick here to edit markdown',
       )
       .click();
+
     cy.get('[data-test="dashboard-component-chart-holder"]')
       .find('.ace_content')
       .contains('Click here to edit [markdown](https://bit.ly/1dQOfRK)');
+
+    cy.get('[data-test="dashboard-markdown-editor"]')
+      .click()
+      .type('Test resize');
+
+    resize(
+      '[data-test="dashboard-markdown-editor"] .resizable-container span div',
+    ).to(500, 600);
+
+    cy.get('[data-test="dashboard-markdown-editor"]').contains('Test resize');
 
     // entering edit mode does not add new scripts
     // (though scripts may still be removed by others)

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
@@ -203,24 +203,27 @@ class Markdown extends React.PureComponent {
       ...this.state,
       editorMode: mode,
     };
-
     if (mode === 'preview') {
-      const { updateComponents, component } = this.props;
-      if (component.meta.code !== this.state.markdownSource) {
-        updateComponents({
-          [component.id]: {
-            ...component,
-            meta: {
-              ...component.meta,
-              code: this.state.markdownSource,
-            },
-          },
-        });
-      }
+      this.updateMarkdownContent()
       nextState.hasError = false;
     }
 
     this.setState(nextState);
+  }
+
+  updateMarkdownContent(){
+    const { updateComponents, component } = this.props;
+    if (component.meta.code !== this.state.markdownSource) {
+      updateComponents({
+        [component.id]: {
+          ...component,
+          meta: {
+            ...component.meta,
+            code: this.state.markdownSource,
+          },
+        },
+      });
+    }
   }
 
   handleMarkdownChange(nextValue) {
@@ -232,6 +235,16 @@ class Markdown extends React.PureComponent {
   handleDeleteComponent() {
     const { deleteComponent, id, parentId } = this.props;
     deleteComponent(id, parentId);
+  }
+
+  handleResizeStart(e){
+    const { editorMode } = this.state;
+    const { editMode, onResizeStart } = this.props;
+    const isEditing = editorMode === 'edit';
+    onResizeStart(e);
+    if (editMode && isEditing) {
+      this.updateMarkdownContent();
+    }
   }
 
   renderEditMode() {
@@ -286,7 +299,6 @@ class Markdown extends React.PureComponent {
       depth,
       availableColumnCount,
       columnWidth,
-      onResizeStart,
       onResize,
       onResizeStop,
       handleComponentDrop,
@@ -343,11 +355,9 @@ class Markdown extends React.PureComponent {
                 minWidthMultiple={GRID_MIN_COLUMN_COUNT}
                 minHeightMultiple={GRID_MIN_ROW_UNITS}
                 maxWidthMultiple={availableColumnCount + widthMultiple}
-                onResizeStart={onResizeStart}
+                onResizeStart={this.handleResizeStart}
                 onResize={onResize}
                 onResizeStop={onResizeStop}
-                // disable resize when editing because if state is not synced
-                // with props it will reset the editor text to whatever props is
                 editMode={isFocused ? false : editMode}
               >
                 <div

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown.jsx
@@ -105,6 +105,7 @@ class Markdown extends React.PureComponent {
     this.handleChangeEditorMode = this.handleChangeEditorMode.bind(this);
     this.handleMarkdownChange = this.handleMarkdownChange.bind(this);
     this.handleDeleteComponent = this.handleDeleteComponent.bind(this);
+    this.handleResizeStart = this.handleResizeStart.bind(this);
     this.setEditor = this.setEditor.bind(this);
   }
 
@@ -204,14 +205,14 @@ class Markdown extends React.PureComponent {
       editorMode: mode,
     };
     if (mode === 'preview') {
-      this.updateMarkdownContent()
+      this.updateMarkdownContent();
       nextState.hasError = false;
     }
 
     this.setState(nextState);
   }
 
-  updateMarkdownContent(){
+  updateMarkdownContent() {
     const { updateComponents, component } = this.props;
     if (component.meta.code !== this.state.markdownSource) {
       updateComponents({
@@ -237,7 +238,7 @@ class Markdown extends React.PureComponent {
     deleteComponent(id, parentId);
   }
 
-  handleResizeStart(e){
+  handleResizeStart(e) {
     const { editorMode } = this.state;
     const { editMode, onResizeStart } = this.props;
     const isEditing = editorMode === 'edit';


### PR DESCRIPTION
### SUMMARY
 #11257 
After editing markdown and resizing window, edited text remains and window stays in Editor mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
![Large GIF (340x522)](https://user-images.githubusercontent.com/2536609/97032974-e9e4db00-1562-11eb-9e77-31f14dc5d3af.gif)

After
![Large GIF (512x504)](https://user-images.githubusercontent.com/2536609/97032957-e2253680-1562-11eb-9aa1-eb934f79c0f8.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
