### PR TITLE
fix: long labels now truncate with ellipsis

### DIFF
--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -38,6 +38,10 @@ export interface LabelProps {
 const SupersetLabel = styled(BootstrapLabel)`
   /* un-bunch them! */
   margin-right: ${({ theme }) => theme.gridUnit}px;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &:first-of-type {
     margin-left: 0;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some labels had long text that was causing layout issues. Now they stop at 100% of their parent's width, and truncate the text with an ellipsis.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
![image](https://user-images.githubusercontent.com/812905/96936305-a44ce300-147a-11eb-8688-d7a2f515fd75.png)

After: 
![image](https://user-images.githubusercontent.com/812905/96936209-80899d00-147a-11eb-8246-714914a02039.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
