### PR TITLE
chore: Fixed skipped cypress tests for sql queries

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/sqllab/query.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/query.test.ts
@@ -30,7 +30,7 @@ describe('SqlLab query panel', () => {
     cy.visit('/superset/sqllab');
   });
 
-  it.skip('supports entering and running a query', () => {
+  it('supports entering and running a query', () => {
     // row limit has to be < ~10 for us to be able to determine how many rows
     // are fetched below (because React _Virtualized_ does not render all rows)
     let clockTime = 0;
@@ -46,115 +46,118 @@ describe('SqlLab query panel', () => {
     cy.route({
       method: 'POST',
       url: '/superset/sql_json/',
-      delay: 1000,
+      delay: 2000,
       response: () => sampleResponse,
     }).as('mockSQLResponse');
 
-    cy.get('.TableSelector .Select:eq(0)').click();
-    cy.get('.TableSelector .Select:eq(0) input[type=text]')
-      .focus()
-      .type('{enter}');
+    cy.get('.ant-tabs-nav-list').children().first().click();
+    cy.get('[data-test="sql-editor-left-schema-pane-bar"]').within(() => {
+      cy.get('[data-test="database-selector-input"]').type('{enter}');
+    });
 
     cy.get('#brace-editor textarea')
       .focus()
       .clear()
       .type(`{selectall}{backspace}SELECT 1`);
 
-    cy.get('#js-sql-toolbar button:eq(0)').eq(0).click();
-
-    // wait for 300 milliseconds
-    cy.wait(300);
+    cy.get('[data-test="sql-editor-run-query-action-button"]').click();
 
     // started timer
-    cy.get('.sql-toolbar .label-success').then(node => {
-      clockTime = parseClockStr(node);
-      // should be longer than 0.2s
-      expect(clockTime).greaterThan(0.2);
-    });
+    cy.get('[data-test="sql-editor-actions-toolbar"]')
+      .find('.label-success')
+      .should('not.be.NaN')
+      .then(node => {
+        clockTime = parseClockStr(node);
+        // should be longer than 0.1s
+        expect(clockTime).greaterThan(0.1);
+      });
 
     cy.wait('@mockSQLResponse');
 
     // timer is increasing
-    cy.get('.sql-toolbar .label-success').then(node => {
-      const newClockTime = parseClockStr(node);
-      expect(newClockTime).greaterThan(0.9);
-      clockTime = newClockTime;
-    });
+    cy.get('[data-test="sql-editor-actions-toolbar"]')
+      .find('.label-success')
+      .then(node => {
+        const newClockTime = parseClockStr(node);
+        expect(newClockTime).greaterThan(0.9);
+        clockTime = newClockTime;
+      });
 
-    // rerun the query
-    cy.get('#js-sql-toolbar button:eq(0)').eq(0).click();
-
-    // should restart the timer
-    cy.get('.sql-toolbar .label-success').contains('00:00:00');
-    cy.wait('@mockSQLResponse');
-    cy.get('.sql-toolbar .label-success').then(node => {
-      expect(parseClockStr(node)).greaterThan(0.9);
-    });
+    cy.get('[data-test="sql-editor-actions-toolbar"]')
+      .find('.label-success')
+      .then(node => {
+        // rerun the query
+        cy.get('[data-test="sql-editor-run-query-action-button"]').click();
+        // should restart the timer
+        cy.get('[data-test="sql-editor-actions-toolbar"]')
+          .find('.label-success')
+          .should('not.have.text', node.text());
+        cy.wait('@mockSQLResponse');
+        cy.get('[data-test="sql-editor-actions-toolbar"]')
+          .find('.label-success')
+          .then(node => {
+            expect(parseClockStr(node)).greaterThan(0.9);
+          });
+      });
   });
 
   it.skip('successfully saves a query', () => {
-    cy.route('savedqueryviewapi/**').as('getSavedQuery');
-    cy.route('superset/tables/**').as('getTables');
-
     const query =
-      'SELECT ds, gender, name, num FROM main.birth_names ORDER BY name LIMIT 3';
+      'SELECT ds, gender, name, num FROM birth_names ORDER BY name LIMIT 3';
     const savedQueryTitle = `CYPRESS TEST QUERY ${shortid.generate()}`;
 
     // we will assert that the results of the query we save, and the saved query are the same
     let initialResultsTable: HTMLElement | null = null;
     let savedQueryResultsTable = null;
 
+    cy.get('[data-test="sql-editor-left-schema-pane-bar"]').within(() => {
+      cy.get('[data-test="database-selector-input"]').type('{enter}');
+    });
     cy.get('#brace-editor textarea')
+      .should('be.visible')
       .clear({ force: true })
       .type(`{selectall}{backspace}${query}`, { force: true })
       .focus() // focus => blur is required for updating the query that is to be saved
       .blur();
 
     // ctrl + r also runs query
+    cy.wait(1000);
     cy.get('#brace-editor textarea').type('{ctrl}r', { force: true });
-
-    cy.wait('@sqlLabQuery');
+    cy.get('[data-test="sql-editor-actions-toolbar"]')
+      .find('.label-success')
+      .should('be.visible');
 
     // Save results to check agains below
     selectResultsTab().then(resultsA => {
       initialResultsTable = resultsA[0];
     });
 
-    cy.get('#js-sql-toolbar button')
-      .eq(1) // save query
-      .click();
+    cy.get('[data-test="sql-editor-save-query-action-button"]').click();
 
     // Enter name + save into modal
-    cy.get('.modal-sm input')
-      .clear({ force: true })
-      .type(`{selectall}{backspace}${savedQueryTitle}`, {
-        force: true,
-      });
-
-    cy.get('.modal-sm .modal-body button')
-      .eq(0) // save
-      .click();
+    cy.get('.ant-modal-content').within(() => {
+      cy.get('input:first')
+        .should('have.attr', 'placeholder', 'Label for your query')
+        .clear({ force: true })
+        .type(`{selectall}{backspace}${savedQueryTitle}`, {
+          force: true,
+        });
+      cy.get('.btn-primary').should('have.text', 'Save').click();
+    });
 
     // visit saved queries
     cy.visit('/sqllab/my_queries/');
-
-    // first row contains most recent link, follow back to SqlLab
-    cy.get('table tr:first-child a[href*="savedQueryId"').click();
-
-    // will timeout without explicitly waiting here
-    cy.wait(['@getSavedQuery', '@getTables']);
-
-    // run the saved query
-    cy.get('#js-sql-toolbar button')
-      .eq(0) // run query
+    cy.get('[data-test="listview-table"]').within($table => {
+      const savedQueriesNumber = Cypress.$($table).find('tr').length;
+      cy.visit(`superset/sqllab?savedQueryId=${savedQueriesNumber}`);
+    });
+    cy.contains(query);
+    cy.get('[data-test="sql-editor-run-query-action-button"]')
+      .last()
+      .should('be.visible')
       .click();
-
-    cy.wait('@sqlLabQuery');
-
-    // assert the results of the saved query match the initial results
     selectResultsTab().then(resultsB => {
       savedQueryResultsTable = resultsB[0];
-
       assertSQLLabResultsAreEqual(initialResultsTable, savedQueryResultsTable);
     });
   });

--- a/superset-frontend/cypress-base/cypress/integration/sqllab/query.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/query.test.ts
@@ -46,7 +46,7 @@ describe('SqlLab query panel', () => {
     cy.route({
       method: 'POST',
       url: '/superset/sql_json/',
-      delay: 500,
+      delay: 2000,
       response: () => sampleResponse,
     }).as('mockSQLResponse');
 
@@ -70,7 +70,7 @@ describe('SqlLab query panel', () => {
       .contains('00:00')
       .then(node => {
         clockTime = parseClockStr(node);
-        // should be longer than 0.1s
+        // should be longer than 0.01s
         expect(clockTime).greaterThan(0.01);
       });
 
@@ -79,7 +79,7 @@ describe('SqlLab query panel', () => {
     // timer is increasing
     cy.get(timerLabel).then(node => {
       const newClockTime = parseClockStr(node);
-      expect(newClockTime).greaterThan(0.4);
+      expect(newClockTime).greaterThan(0.9);
       clockTime = newClockTime;
     });
 
@@ -87,11 +87,11 @@ describe('SqlLab query panel', () => {
     cy.get('[data-test="sql-editor-run-query-action-button"]').click();
 
     // should restart the timer
-    cy.get(timerLabel).contains('00:00:00');
+    cy.get(timerLabel).contains('00:00');
 
     cy.wait('@mockSQLResponse');
     cy.get(timerLabel).then(node => {
-      expect(parseClockStr(node)).greaterThan(0.4);
+      expect(parseClockStr(node)).greaterThan(0.9);
     });
   });
 

--- a/superset-frontend/cypress-base/cypress/integration/sqllab/sqllab.helper.js
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/sqllab.helper.js
@@ -17,7 +17,9 @@
  * under the License.
  */
 export const selectResultsTab = () =>
-  cy.get('.SouthPane .ReactVirtualized__Table', { timeout: 10000 });
+  cy
+    .get('[data-test="filterable-table-container"]', { timeout: 15000 })
+    .find('.ReactVirtualized__Table');
 
 // this function asserts that the result set for two SQL lab table results are equal
 export const assertSQLLabResultsAreEqual = (resultsA, resultsB) => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -477,10 +477,14 @@ class SqlEditor extends React.PureComponent {
       ? t('Schedule the query periodically')
       : t('You must run the query successfully first');
     return (
-      <div className="sql-toolbar" id="js-sql-toolbar">
+      <div
+        className="sql-toolbar"
+        id="js-sql-toolbar"
+        data-test="sql-editor-actions-toolbar"
+      >
         <div className="leftItems">
           <Form inline>
-            <span>
+            <span data-test="sql-editor-run-query-action-button">
               <RunQueryActionButton
                 allowAsync={
                   this.props.database
@@ -526,7 +530,7 @@ class SqlEditor extends React.PureComponent {
                 />
               </span>
             )}
-            <span>
+            <span data-test="sql-editor-save-query-action-button">
               <SaveQuery
                 query={qe}
                 defaultLabel={qe.title || qe.description}
@@ -594,7 +598,10 @@ class SqlEditor extends React.PureComponent {
           in={!this.props.hideLeftBar}
           timeout={300}
         >
-          <div className="schemaPane">
+          <div
+            className="schemaPane"
+            data-test="sql-editor-left-schema-pane-bar"
+          >
             <SqlEditorLeftBar
               database={this.props.database}
               queryEditor={this.props.queryEditor}

--- a/superset-frontend/src/components/DatabaseSelector.tsx
+++ b/superset-frontend/src/components/DatabaseSelector.tsx
@@ -228,7 +228,7 @@ export default function DatabaseSelector({
         value={currentDbId}
         valueKey="id"
         valueRenderer={(db: any) => (
-          <div>
+          <div data-test="database-selector-input">
             <span className="text-muted m-r-5">{t('Database:')}</span>
             {renderDatabaseOption(db)}
           </div>

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -554,6 +554,7 @@ export default class FilterableTable extends PureComponent<
       <div
         style={{ height }}
         className="filterable-table-container"
+        data-test="filterable-table-container"
         ref={this.container}
       >
         {this.state.fitted && (


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I fixed tests in query.test.ts file.   it('successfully saves a query', () => { required deep changes - only way I saw to open saved sql query was in new tab - cypress does not support this easily (ok supports but trick with href does not work in this case) so I visit url created in test and then verify final assertions.
I removed wait on requests - > with only one request it was unstable on my computer - one request was faster than cypress and it was waiting for already finished request.
I disabled second test to make this PR possible to merge - bigger problem in this second one. I work on this and I will submit another PR for this.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
