### PR TITLE
fix: added meaningful exception for loading births error

### DIFF
--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -30,6 +30,7 @@ from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.core import get_example_database
 
+from ..exceptions import NoDataException
 from .helpers import (
     config,
     get_example_data,
@@ -42,7 +43,7 @@ from .helpers import (
 
 admin = security_manager.find_user("admin")
 if admin is None:
-    raise Exception(
+    raise NoDataException(
         "Admin user does not exist. "
         "Please, check if test users are properly loaded "
         "(`superset load_test_users`)."

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -41,6 +41,12 @@ from .helpers import (
 )
 
 admin = security_manager.find_user("admin")
+if admin is None:
+    raise Exception(
+        "Admin user does not exist. "
+        "Please, check if test users are properly loaded "
+        "(`superset load_test_users`)."
+    )
 
 
 def gen_filter(

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -25,12 +25,12 @@ from sqlalchemy.sql import column
 from superset import db, security_manager
 from superset.connectors.base.models import BaseDatasource
 from superset.connectors.sqla.models import SqlMetric, TableColumn
+from superset.exceptions import NoDataException
 from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.core import get_example_database
 
-from ..exceptions import NoDataException
 from .helpers import (
     config,
     get_example_data,


### PR DESCRIPTION
### SUMMARY
Currently while loading example if there is no `admin` user loaded previously it will fail with:

`sqlalchemy.orm.exc.FlushError: Can't flush None value found in collection Slice.owners` ([details](https://github.com/apache/incubator-superset/issues/11360))

Added more meaningful error which will stop the script.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #11360
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
