### PR TITLE
build: error handling for webpack proxy

### DIFF
--- a/superset-frontend/webpack.proxy-config.js
+++ b/superset-frontend/webpack.proxy-config.js
@@ -129,6 +129,10 @@ function processHTML(proxyResponse, response) {
     .on('data', data => {
       body = Buffer.concat([body, data]);
     })
+    .on('error', error => {
+      console.error(error);
+      response.end(`Error fetching proxied request: ${error.message}`);
+    })
     .on('end', () => {
       response.end(toDevHTML(body.toString()));
     });


### PR DESCRIPTION
### SUMMARY

Add error handling for Webpack proxy so it doesn't crash had the proxied request was unexpected cut short (e.g. the production server was down mid-flight).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

- Start Flask server behind a very slow proxy
- Start the dev-server proxy, before the HTTP request the Flask server can finish, shut down the proxy

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
