### PR TITLE
fix: moved frame to focused element from one position below 

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/popover-menu.less
+++ b/superset-frontend/src/dashboard/stylesheets/popover-menu.less
@@ -30,8 +30,8 @@
 .with-popover-menu--focused:after {
   content: '';
   position: absolute;
-  top: 1;
-  left: -1;
+  top: 1px;
+  left: -1px;
   width: 100%;
   height: 100%;
   box-shadow: inset 0 0 0 2px @indicator-color;


### PR DESCRIPTION
### SUMMARY
When focusing block (row, column, Markdown, etc) to edit, solid frame is appearing below the focused window.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="890" alt="Screenshot 2020-10-26 at 14 08 40" src="https://user-images.githubusercontent.com/2536609/97176469-47606e00-1795-11eb-9e17-f4c659fc0c88.png">

<img width="326" alt="Screenshot 2020-10-26 at 14 08 32" src="https://user-images.githubusercontent.com/2536609/97176483-4deee580-1795-11eb-9c72-65f317655cc3.png">

After:

<img width="984" alt="Screenshot 2020-10-26 at 14 05 45" src="https://user-images.githubusercontent.com/2536609/97176502-5515f380-1795-11eb-848c-6ed051a37655.png">

<img width="450" alt="Screenshot 2020-10-26 at 14 05 33" src="https://user-images.githubusercontent.com/2536609/97176554-63fca600-1795-11eb-8c2d-6c57a43c1faa.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
