### PR TITLE
fix: Explore popovers issues

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/AdhocFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/AdhocFilters.test.ts
@@ -50,13 +50,17 @@ describe('AdhocFilters', () => {
   });
 
   it('Set simple adhoc filter', () => {
-    cy.get('#filter-edit-popover').within(() => {
-      cy.get('[data-test=adhoc-filter-simple-value]').within(() => {
-        cy.get('.Select__control').click();
-        cy.get('input[type=text]').focus().type('Any{enter}');
-      });
-      cy.get('button').contains('Save').click();
-    });
+    cy.get('[data-test=adhoc-filter-simple-value] .Select__control').click();
+    cy.get('[data-test=adhoc-filter-simple-value] input[type=text]')
+      .focus()
+      .type('Jack{enter}', { delay: 20 });
+
+    cy.get('[data-test="adhoc-filter-edit-popover-save-button"]').click();
+
+    cy.get(
+      '[data-test=adhoc_filters] .Select__control span.option-label',
+    ).contains('name = Jack');
+
     cy.get('button[data-test="run-query-button"]').click();
     cy.verifySliceSuccess({
       waitAlias: '@postJson',
@@ -65,26 +69,34 @@ describe('AdhocFilters', () => {
   });
 
   it('Set custom adhoc filter', () => {
-    cy.visitChartByName('Num Births Trend');
-    cy.verifySliceSuccess({ waitAlias: '@postJson' });
+    const filterType = 'name';
+    const filterContent = "'Amy' OR name = 'Donald'";
 
     cy.get('[data-test=adhoc_filters] .Select__control')
       .scrollIntoView()
       .click();
+
+    // remove previous input
     cy.get('[data-test=adhoc_filters] input[type=text]')
       .focus()
-      .type('name{enter}', { delay: 20 });
-    cy.get('[data-test="adhoc_filters"]').within(() => {
-      cy.contains('name = ').should('be.visible').click();
-    });
+      .type('{backspace}');
+
+    cy.get('[data-test=adhoc_filters] input[type=text]')
+      .focus()
+      .type(`${filterType}{enter}`);
+
     cy.wait('@filterValues');
 
+    // selecting a new filter should auto-open the popup,
+    // so the tabshould be visible by now
     cy.get('#filter-edit-popover #adhoc-filter-edit-tabs-tab-SQL').click();
     cy.get('#filter-edit-popover .ace_content').click();
-    cy.get('#filter-edit-popover .ace_text-input').type(
-      "'Amy' OR name = 'Bob'",
-    );
-    cy.get('#filter-edit-popover button').contains('Save').click();
+    cy.get('#filter-edit-popover .ace_text-input').type(filterContent);
+    cy.get('[data-test="adhoc-filter-edit-popover-save-button"]').click();
+
+    cy.get(
+      '[data-test=adhoc_filters] .Select__control span.option-label',
+    ).contains(`${filterType} = ${filterContent}`);
 
     cy.get('button[data-test="run-query-button"]').click();
     cy.verifySliceSuccess({

--- a/superset-frontend/cypress-base/cypress/integration/explore/AdhocFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/AdhocFilters.test.ts
@@ -94,6 +94,7 @@ describe('AdhocFilters', () => {
     cy.get('#filter-edit-popover .ace_text-input').type(filterContent);
     cy.get('[data-test="adhoc-filter-edit-popover-save-button"]').click();
 
+    // check if the filter was saved correctly
     cy.get(
       '[data-test=adhoc_filters] .Select__control span.option-label',
     ).contains(`${filterType} = ${filterContent}`);

--- a/superset-frontend/cypress-base/cypress/integration/explore/AdhocMetrics.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/AdhocMetrics.test.ts
@@ -42,7 +42,6 @@ describe('AdhocMetrics', () => {
       .trigger('mousedown')
       .click();
 
-    cy.get('[data-test="option-label"]').first().click();
     cy.get('[data-test="AdhocMetricEditTitle#trigger"]').click();
     cy.get('[data-test="AdhocMetricEditTitle#input"]').type(metricName);
     cy.get('[data-test="AdhocMetricEdit#save"]').contains('Save').click();

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -152,45 +152,6 @@ describe('Time range filter', () => {
   });
 });
 
-describe('AdhocFilter control', () => {
-  beforeEach(() => {
-    cy.login();
-    cy.server();
-    cy.route('GET', '/superset/explore_json/**').as('getJson');
-    cy.route('POST', '/superset/explore_json/**').as('postJson');
-  });
-
-  it('Sets an adhoc filter', () => {
-    const filterType = 'gender';
-    const filterValue = 'boy or girl';
-
-    cy.visitChartByName('Participants');
-    cy.verifySliceSuccess({ waitAlias: '@postJson' });
-
-    cy.get('[data-test=adhoc-filter-control]').within(() => {
-      cy.wait(1000);
-      cy.get('input[type=text]').focus().type(`${filterType}{enter}`);
-    });
-
-    cy.get('[data-test="filter-edit-popover"]').should('be.visible');
-    cy.get('[data-test="filter-edit-popover"]').within(() => {
-      cy.get('[data-test="adhoc-filter-edit-tabs"]').within(() => {
-        cy.get('#adhoc-filter-edit-tabs-tab-SQL').click();
-      });
-      cy.wait(1000);
-      cy.get('textarea.ace_text-input').focus().type(`${filterValue}`);
-      cy.get('[data-test="adhoc-filter-edit-popover-save-button"]').click();
-    });
-
-    cy.get('[data-test="filter-edit-popover"]').should('not.be.visible');
-    cy.get('[data-test="adhoc-filter-control"]').within(() => {
-      cy.get('.Select__control').within(() => {
-        cy.get('span.option-label').contains(`${filterType} = ${filterValue}`);
-      });
-    });
-  });
-});
-
 describe('Groupby control', () => {
   it('Set groupby', () => {
     cy.server();

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -152,6 +152,45 @@ describe('Time range filter', () => {
   });
 });
 
+describe('AdhocFilter control', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.server();
+    cy.route('GET', '/superset/explore_json/**').as('getJson');
+    cy.route('POST', '/superset/explore_json/**').as('postJson');
+  });
+
+  it.only('Sets an adhoc filter', () => {
+    const filterType = 'gender';
+    const filterValue = 'boy or girl';
+
+    cy.visitChartByName('Participants');
+    cy.verifySliceSuccess({ waitAlias: '@postJson' });
+
+    cy.get('[data-test=adhoc-filter-control]').within(() => {
+      cy.wait(1000);
+      cy.get('input[type=text]').focus().type(`${filterType}{enter}`);
+    });
+
+    cy.get('[data-test="filter-edit-popover"]').should('be.visible');
+    cy.get('[data-test="filter-edit-popover"]').within(() => {
+      cy.get('[data-test="adhoc-filter-edit-tabs"]').within(() => {
+        cy.get('#adhoc-filter-edit-tabs-tab-SQL').click();
+      });
+      cy.wait(1000);
+      cy.get('textarea.ace_text-input').focus().type(`${filterValue}`);
+      cy.get('[data-test="adhoc-filter-edit-popover-save-button"]').click();
+    });
+
+    cy.get('[data-test="filter-edit-popover"]').should('not.be.visible');
+    cy.get('[data-test="adhoc-filter-control"]').within(() => {
+      cy.get('.Select__control').within(() => {
+        cy.get('span.option-label').contains(`${filterType} = ${filterValue}`);
+      });
+    });
+  });
+});
+
 describe('Groupby control', () => {
   it('Set groupby', () => {
     cy.server();

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -160,7 +160,7 @@ describe('AdhocFilter control', () => {
     cy.route('POST', '/superset/explore_json/**').as('postJson');
   });
 
-  it.only('Sets an adhoc filter', () => {
+  it('Sets an adhoc filter', () => {
     const filterType = 'gender';
     const filterValue = 'boy or girl';
 

--- a/superset-frontend/spec/javascripts/explore/components/AdhocFilterOption_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocFilterOption_spec.jsx
@@ -19,7 +19,7 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import sinon from 'sinon';
-import { styledShallow as shallow } from 'spec/helpers/theming';
+import { shallow } from 'enzyme';
 import Popover from 'src/common/components/Popover';
 
 import Label from 'src/components/Label';
@@ -46,7 +46,7 @@ function setup(overrides) {
     datasource: {},
     ...overrides,
   };
-  const wrapper = shallow(<AdhocFilterOption {...props} />).dive();
+  const wrapper = shallow(<AdhocFilterOption {...props} />);
   return { wrapper };
 }
 

--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricOption_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricOption_spec.jsx
@@ -19,7 +19,7 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import sinon from 'sinon';
-import { styledShallow as shallow } from 'spec/helpers/theming';
+import { shallow } from 'enzyme';
 
 import Popover from 'src/common/components/Popover';
 import Label from 'src/components/Label';
@@ -46,7 +46,7 @@ function setup(overrides) {
     columns,
     ...overrides,
   };
-  const wrapper = shallow(<AdhocMetricOption {...props} />).dive();
+  const wrapper = shallow(<AdhocMetricOption {...props} />);
   return { wrapper, onMetricEdit };
 }
 
@@ -73,11 +73,13 @@ describe('AdhocMetricOption', () => {
 
   it('returns to default labels when the custom label is cleared', () => {
     const { wrapper } = setup();
+    expect(wrapper.state('title').label).toBe('SUM(value)');
+
     wrapper.instance().onLabelChange({ target: { value: 'new label' } });
+    expect(wrapper.state('title').label).toBe('new label');
+
     wrapper.instance().onLabelChange({ target: { value: '' } });
-    // close and open the popover
-    wrapper.instance().closeMetricEditOverlay();
-    wrapper.instance().onOverlayEntered();
+
     expect(wrapper.state('title').label).toBe('SUM(value)');
     expect(wrapper.state('title').hasCustomLabel).toBe(false);
   });

--- a/superset-frontend/src/common/components/Popover.tsx
+++ b/superset-frontend/src/common/components/Popover.tsx
@@ -17,8 +17,7 @@
  * under the License.
  */
 import { Popover as AntdPopover } from 'src/common/components';
-import { styled } from '@superset-ui/core';
 
-const SupersetPopover = styled(AntdPopover)``;
+const SupersetPopover = AntdPopover;
 
 export default SupersetPopover;

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -94,7 +94,12 @@ class AdhocFilterOption extends React.PureComponent {
       />
     );
     return (
-      <div role="button" tabIndex={0} onMouseDown={e => e.stopPropagation()}>
+      <div
+        role="button"
+        tabIndex={0}
+        onMouseDown={e => e.stopPropagation()}
+        onKeyDown={e => e.stopPropagation()}
+      >
         {adhocFilter.isExtra && (
           <InfoTooltipWithTrigger
             icon="exclamation-triangle"

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -45,7 +45,6 @@ class AdhocFilterOption extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onPopoverResize = this.onPopoverResize.bind(this);
-    this.getContent = this.getContent.bind(this);
     this.openPopover = this.openPopover.bind(this);
     this.closePopover = this.closePopover.bind(this);
     this.togglePopover = this.togglePopover.bind(this);
@@ -55,30 +54,19 @@ class AdhocFilterOption extends React.PureComponent {
     };
   }
 
-  onPopoverResize() {
-    this.forceUpdate();
+  componentDidMount() {
+    const { adhocFilter } = this.props;
+    // isNew is used to auto-open the popup. Once popup is opened, it's not
+    // considered new anymore.
+    // put behind setTimeout so in case consequetive re-renderings are triggered
+    // for some reason, the popup can still show up.
+    setTimeout(() => {
+      adhocFilter.isNew = false;
+    });
   }
 
-  getContent() {
-    const {
-      adhocFilter,
-      onFilterEdit,
-      options,
-      datasource,
-      partitionColumn,
-    } = this.props;
-
-    return (
-      <AdhocFilterEditPopover
-        adhocFilter={adhocFilter}
-        options={options}
-        datasource={datasource}
-        partitionColumn={partitionColumn}
-        onResize={this.onPopoverResize}
-        onChange={onFilterEdit}
-        onClose={this.closePopover}
-      />
-    );
+  onPopoverResize() {
+    this.forceUpdate();
   }
 
   openPopover() {
@@ -99,10 +87,17 @@ class AdhocFilterOption extends React.PureComponent {
 
   render() {
     const { adhocFilter } = this.props;
-    const { isNew } = adhocFilter;
-    if (isNew) {
-      adhocFilter.isNew = false;
-    }
+    const overlayContent = (
+      <AdhocFilterEditPopover
+        adhocFilter={adhocFilter}
+        options={this.props.options}
+        datasource={this.props.datasource}
+        partitionColumn={this.props.partitionColumn}
+        onResize={this.onPopoverResize}
+        onClose={this.closePopover}
+        onChange={this.props.onFilterEdit}
+      />
+    );
 
     return (
       <div
@@ -125,8 +120,8 @@ class AdhocFilterOption extends React.PureComponent {
         <Popover
           placement="right"
           trigger="click"
-          content={this.getContent}
-          defaultVisible={isNew}
+          content={overlayContent}
+          defaultVisible={adhocFilter.isNew}
           visible={this.state.popoverVisible}
           onVisibleChange={visible => {
             this.setState({ popoverVisible: visible });

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -45,26 +45,17 @@ class AdhocFilterOption extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onPopoverResize = this.onPopoverResize.bind(this);
-    this.onOverlayEntered = this.onOverlayEntered.bind(this);
-    this.onOverlayExited = this.onOverlayExited.bind(this);
-    this.handleVisibleChange = this.handleVisibleChange.bind(this);
     this.getContent = this.getContent.bind(this);
-    this.state = { overlayShown: undefined };
+    this.openPopover = this.openPopover.bind(this);
+    this.closePopover = this.closePopover.bind(this);
+    this.state = {
+      // automatically open the popover the the metric is new
+      popoverVisible: !!props.adhocFilter.isNew,
+    };
   }
 
   onPopoverResize() {
     this.forceUpdate();
-  }
-
-  onOverlayEntered() {
-    // isNew is used to indicate whether to automatically open the overlay
-    // once the overlay has been opened, the metric/filter will never be
-    // considered new again.
-    this.setState({ overlayShown: true });
-  }
-
-  onOverlayExited() {
-    this.setState({ overlayShown: false });
   }
 
   getContent() {
@@ -75,30 +66,34 @@ class AdhocFilterOption extends React.PureComponent {
       datasource,
       partitionColumn,
     } = this.props;
-    adhocFilter.isNew = false;
+
     return (
       <AdhocFilterEditPopover
-        onResize={this.onPopoverResize}
         adhocFilter={adhocFilter}
-        onChange={onFilterEdit}
-        onClose={this.onOverlayExited}
         options={options}
         datasource={datasource}
         partitionColumn={partitionColumn}
+        onResize={this.onPopoverResize}
+        onChange={onFilterEdit}
+        onClose={this.closePopover}
       />
     );
   }
 
-  handleVisibleChange(visible) {
-    if (visible) {
-      this.onOverlayEntered();
-    } else {
-      this.onOverlayExited();
-    }
+  closePopover() {
+    this.setState({ popoverVisible: false });
+  }
+
+  openPopover() {
+    this.setState({ popoverVisible: false });
   }
 
   render() {
     const { adhocFilter } = this.props;
+    const { isNew } = adhocFilter;
+    if (isNew) {
+      adhocFilter.isNew = false;
+    }
 
     return (
       <div
@@ -122,17 +117,15 @@ class AdhocFilterOption extends React.PureComponent {
           placement="right"
           trigger="click"
           content={this.getContent}
-          defaultVisible={adhocFilter.isNew}
-          visible={this.state.overlayShown}
-          onVisibleChange={this.handleVisibleChange}
+          defaultVisible={isNew}
+          visible={this.state.popoverVisible}
+          onVisibleChange={visible => {
+            this.setState({ popoverVisible: visible });
+          }}
         >
           <Label className="option-label adhoc-option adhoc-filter-option">
             {adhocFilter.getDefaultLabel()}
-            <i
-              className={`fa fa-caret-${
-                this.state.overlayShown ? 'left' : 'right'
-              } adhoc-label-arrow`}
-            />
+            <i className="fa fa-caret-right adhoc-label-arrow" />
           </Label>
         </Popover>
       </div>

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -48,6 +48,7 @@ class AdhocFilterOption extends React.PureComponent {
     this.getContent = this.getContent.bind(this);
     this.openPopover = this.openPopover.bind(this);
     this.closePopover = this.closePopover.bind(this);
+    this.togglePopover = this.togglePopover.bind(this);
     this.state = {
       // automatically open the popover the the metric is new
       popoverVisible: !!props.adhocFilter.isNew,
@@ -80,12 +81,20 @@ class AdhocFilterOption extends React.PureComponent {
     );
   }
 
+  openPopover() {
+    this.setState({ popoverVisible: false });
+  }
+
   closePopover() {
     this.setState({ popoverVisible: false });
   }
 
-  openPopover() {
-    this.setState({ popoverVisible: false });
+  togglePopover(visible) {
+    this.setState(({ popoverVisible }) => {
+      return {
+        popoverVisible: visible === undefined ? !popoverVisible : visible,
+      };
+    });
   }
 
   render() {

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -45,7 +45,6 @@ class AdhocFilterOption extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onPopoverResize = this.onPopoverResize.bind(this);
-    this.openPopover = this.openPopover.bind(this);
     this.closePopover = this.closePopover.bind(this);
     this.togglePopover = this.togglePopover.bind(this);
     this.state = {
@@ -67,10 +66,6 @@ class AdhocFilterOption extends React.PureComponent {
 
   onPopoverResize() {
     this.forceUpdate();
-  }
-
-  openPopover() {
-    this.setState({ popoverVisible: false });
   }
 
   closePopover() {
@@ -123,9 +118,7 @@ class AdhocFilterOption extends React.PureComponent {
           content={overlayContent}
           defaultVisible={adhocFilter.isNew}
           visible={this.state.popoverVisible}
-          onVisibleChange={visible => {
-            this.setState({ popoverVisible: visible });
-          }}
+          onVisibleChange={this.togglePopover}
         >
           <Label className="option-label adhoc-option adhoc-filter-option">
             {adhocFilter.getDefaultLabel()}

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -18,10 +18,10 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Popover from 'src/common/components/Popover';
 import { t } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 
+import Popover from 'src/common/components/Popover';
 import Label from 'src/components/Label';
 import AdhocFilterEditPopover from './AdhocFilterEditPopover';
 import AdhocFilter from '../AdhocFilter';

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -68,17 +68,23 @@ class AdhocFilterOption extends React.PureComponent {
   }
 
   getContent() {
-    const { adhocFilter } = this.props;
+    const {
+      adhocFilter,
+      onFilterEdit,
+      options,
+      datasource,
+      partitionColumn,
+    } = this.props;
     adhocFilter.isNew = false;
     return (
       <AdhocFilterEditPopover
         onResize={this.onPopoverResize}
         adhocFilter={adhocFilter}
-        onChange={this.props.onFilterEdit}
+        onChange={onFilterEdit}
         onClose={this.onOverlayExited}
-        options={this.props.options}
-        datasource={this.props.datasource}
-        partitionColumn={this.props.partitionColumn}
+        options={options}
+        datasource={datasource}
+        partitionColumn={partitionColumn}
       />
     );
   }

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Popover from 'src/common/components/Popover';
-import { t, withTheme } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 
 import Label from 'src/components/Label';
@@ -44,12 +44,12 @@ const propTypes = {
 class AdhocFilterOption extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.closeFilterEditOverlay = this.closeFilterEditOverlay.bind(this);
     this.onPopoverResize = this.onPopoverResize.bind(this);
     this.onOverlayEntered = this.onOverlayEntered.bind(this);
     this.onOverlayExited = this.onOverlayExited.bind(this);
     this.handleVisibleChange = this.handleVisibleChange.bind(this);
-    this.state = { overlayShown: false };
+    this.getContent = this.getContent.bind(this);
+    this.state = { overlayShown: undefined };
   }
 
   onPopoverResize() {
@@ -60,7 +60,6 @@ class AdhocFilterOption extends React.PureComponent {
     // isNew is used to indicate whether to automatically open the overlay
     // once the overlay has been opened, the metric/filter will never be
     // considered new again.
-    this.props.adhocFilter.isNew = false;
     this.setState({ overlayShown: true });
   }
 
@@ -68,8 +67,20 @@ class AdhocFilterOption extends React.PureComponent {
     this.setState({ overlayShown: false });
   }
 
-  closeFilterEditOverlay() {
-    this.setState({ overlayShown: false });
+  getContent() {
+    const { adhocFilter } = this.props;
+    adhocFilter.isNew = false;
+    return (
+      <AdhocFilterEditPopover
+        onResize={this.onPopoverResize}
+        adhocFilter={adhocFilter}
+        onChange={this.props.onFilterEdit}
+        onClose={this.onOverlayExited}
+        options={this.props.options}
+        datasource={this.props.datasource}
+        partitionColumn={this.props.partitionColumn}
+      />
+    );
   }
 
   handleVisibleChange(visible) {
@@ -82,17 +93,7 @@ class AdhocFilterOption extends React.PureComponent {
 
   render() {
     const { adhocFilter } = this.props;
-    const content = (
-      <AdhocFilterEditPopover
-        onResize={this.onPopoverResize}
-        adhocFilter={adhocFilter}
-        onChange={this.props.onFilterEdit}
-        onClose={this.closeFilterEditOverlay}
-        options={this.props.options}
-        datasource={this.props.datasource}
-        partitionColumn={this.props.partitionColumn}
-      />
-    );
+
     return (
       <div
         role="button"
@@ -114,8 +115,7 @@ class AdhocFilterOption extends React.PureComponent {
         <Popover
           placement="right"
           trigger="click"
-          disabled
-          content={content}
+          content={this.getContent}
           defaultVisible={adhocFilter.isNew}
           visible={this.state.overlayShown}
           onVisibleChange={this.handleVisibleChange}
@@ -134,6 +134,6 @@ class AdhocFilterOption extends React.PureComponent {
   }
 }
 
-export default withTheme(AdhocFilterOption);
+export default AdhocFilterOption;
 
 AdhocFilterOption.propTypes = propTypes;

--- a/superset-frontend/src/explore/components/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricOption.jsx
@@ -41,6 +41,7 @@ class AdhocMetricOption extends React.PureComponent {
     this.onLabelChange = this.onLabelChange.bind(this);
     this.openPopover = this.openPopover.bind(this);
     this.closePopover = this.closePopover.bind(this);
+    this.togglePopover = this.togglePopover.bind(this);
     this.state = {
       popoverVisible: undefined,
       title: {
@@ -64,12 +65,20 @@ class AdhocMetricOption extends React.PureComponent {
     this.forceUpdate();
   }
 
+  openPopover() {
+    this.setState({ popoverVisible: false });
+  }
+
   closePopover() {
     this.setState({ popoverVisible: false });
   }
 
-  openPopover() {
-    this.setState({ popoverVisible: false });
+  togglePopover(visible) {
+    this.setState(({ popoverVisible }) => {
+      return {
+        popoverVisible: visible === undefined ? !popoverVisible : visible,
+      };
+    });
   }
 
   render() {
@@ -119,9 +128,7 @@ class AdhocMetricOption extends React.PureComponent {
           content={overlayContent}
           defaultVisible={isNew}
           visible={this.state.popoverVisible}
-          onVisibleChange={visible => {
-            this.setState({ popoverVisible: visible });
-          }}
+          onVisibleChange={this.togglePopover}
           title={popoverTitle}
         >
           <Label className="option-label adhoc-option" data-test="option-label">

--- a/superset-frontend/src/explore/components/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricOption.jsx
@@ -39,7 +39,6 @@ class AdhocMetricOption extends React.PureComponent {
     super(props);
     this.onPopoverResize = this.onPopoverResize.bind(this);
     this.onLabelChange = this.onLabelChange.bind(this);
-    this.openPopover = this.openPopover.bind(this);
     this.closePopover = this.closePopover.bind(this);
     this.togglePopover = this.togglePopover.bind(this);
     this.state = {
@@ -74,10 +73,6 @@ class AdhocMetricOption extends React.PureComponent {
 
   onPopoverResize() {
     this.forceUpdate();
-  }
-
-  openPopover() {
-    this.setState({ popoverVisible: false });
   }
 
   closePopover() {

--- a/superset-frontend/src/explore/components/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricOption.jsx
@@ -51,12 +51,23 @@ class AdhocMetricOption extends React.PureComponent {
     };
   }
 
+  componentDidMount() {
+    const { adhocMetric } = this.props;
+    // isNew is used to auto-open the popup. Once popup is opened, it's not
+    // considered new anymore.
+    // put behind setTimeout so in case consequetive re-renderings are triggered
+    // for some reason, the popup can still show up.
+    setTimeout(() => {
+      adhocMetric.isNew = false;
+    });
+  }
+
   onLabelChange(e) {
     const label = e.target.value;
     this.setState({
       title: {
-        label,
-        hasCustomLabel: true,
+        label: label || this.props.adhocMetric.label,
+        hasCustomLabel: !!label,
       },
     });
   }
@@ -83,14 +94,6 @@ class AdhocMetricOption extends React.PureComponent {
 
   render() {
     const { adhocMetric } = this.props;
-    const { isNew } = adhocMetric;
-    if (isNew) {
-      // new metrics automaticall open the popover
-      // once the metric is rendered, then it's not new.
-      // testing this by selecting multiple new columns to create multiple
-      // new adhoc metrics
-      adhocMetric.isNew = false;
-    }
 
     const overlayContent = (
       <AdhocMetricEditPopover
@@ -99,8 +102,8 @@ class AdhocMetricOption extends React.PureComponent {
         columns={this.props.columns}
         datasourceType={this.props.datasourceType}
         onResize={this.onPopoverResize}
-        onChange={this.props.onMetricEdit}
         onClose={this.closePopover}
+        onChange={this.props.onMetricEdit}
       />
     );
 
@@ -126,7 +129,7 @@ class AdhocMetricOption extends React.PureComponent {
           trigger="click"
           disabled
           content={overlayContent}
-          defaultVisible={isNew}
+          defaultVisible={adhocMetric.isNew}
           visible={this.state.popoverVisible}
           onVisibleChange={this.togglePopover}
           title={popoverTitle}

--- a/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
@@ -262,7 +262,7 @@ export default class AdhocFilterControl extends React.Component {
 
   render() {
     return (
-      <div className="metrics-select">
+      <div className="metrics-select" data-test="adhoc-filter-control">
         <ControlHeader {...this.props} />
         <OnPasteSelect
           isMulti

--- a/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/AdhocFilterControl.jsx
@@ -180,9 +180,10 @@ export default class AdhocFilterControl extends React.Component {
             operator: OPERATORS['>'],
             comparator: 0,
             clause: CLAUSES.HAVING,
+            isNew: true,
           });
         }
-        // has a custom label
+        // has a custom label, meaning it's custom column
         if (option.label) {
           return new AdhocFilter({
             expressionType:
@@ -196,6 +197,7 @@ export default class AdhocFilterControl extends React.Component {
             operator: OPERATORS['>'],
             comparator: 0,
             clause: CLAUSES.HAVING,
+            isNew: true,
           });
         }
         // add a new filter item


### PR DESCRIPTION
### SUMMARY
Fixes issues https://github.com/apache/incubator-superset/issues/11388 and https://github.com/apache/incubator-superset/issues/11404.
Changes in `AdhocFilterOption` might be in conflict with https://github.com/apache/incubator-superset/pull/11412 by @mistercrunch - unfortunately it seems that mutating a `adhocFilter.isNew` prop is necessary until we do a deeper refactor. Simply making that prop a part of the state leads to various issues regarding auto-opening the popup when new filter is added - particularly when there are multiple unsaved filters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
As shown on the gif, the popup opens automatically and typing spaces and comas works properly.
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/15073128/97195498-b5b02b00-17ab-11eb-8d15-680dc201c63f.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11388, https://github.com/apache/incubator-superset/issues/11404
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
