### PR TITLE
fix: is_temporal should be overridden by is_dttm value

### DIFF
--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -180,7 +180,7 @@ function ColumnCollectionTable({
               control={
                 <TextControl
                   controlId="python_date_format"
-                  placeholder="%y/%m/%d"
+                  placeholder="%Y/%m/%d"
                 />
               }
             />

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -181,6 +181,9 @@ class TableColumn(Model, BaseColumn):
 
     @property
     def is_numeric(self) -> bool:
+        """
+        Check if the column has a numeric datatype.
+        """
         db_engine_spec = self.table.database.db_engine_spec
         return db_engine_spec.is_db_column_type_match(
             self.type, utils.DbColumnType.NUMERIC
@@ -188,6 +191,9 @@ class TableColumn(Model, BaseColumn):
 
     @property
     def is_string(self) -> bool:
+        """
+        Check if the column has a string datatype.
+        """
         db_engine_spec = self.table.database.db_engine_spec
         return db_engine_spec.is_db_column_type_match(
             self.type, utils.DbColumnType.STRING
@@ -195,6 +201,14 @@ class TableColumn(Model, BaseColumn):
 
     @property
     def is_temporal(self) -> bool:
+        """
+        Check if the column has a temporal datatype. If column has been set as
+        temporal/non-temporal (`is_dttm` is True or False respectively), return that
+        value. This usually happens during initial metadata fetching or when a column
+        is manually set as temporal (for this `python_date_format` needs to be set).
+        """
+        if self.is_dttm is not None:
+            return self.is_dttm
         db_engine_spec = self.table.database.db_engine_spec
         return db_engine_spec.is_db_column_type_match(
             self.type, utils.DbColumnType.TEMPORAL

--- a/tests/sqla_models_tests.py
+++ b/tests/sqla_models_tests.py
@@ -44,6 +44,18 @@ class TestDatabaseModel(SupersetTestCase):
         col = TableColumn(column_name="__not_time", type="INTEGER", table=tbl)
         self.assertEqual(col.is_temporal, False)
 
+    def test_temporal_varchar(self):
+        """Ensure a column with is_dttm set to true evaluates to is_temporal == True"""
+
+        database = get_example_database()
+        tbl = SqlaTable(table_name="test_tbl", database=database)
+        col = TableColumn(column_name="ds", type="VARCHAR", table=tbl)
+        # by default, VARCHAR should not be assumed to be temporal
+        assert col.is_temporal is False
+        # changing to `is_dttm = True`, calling `is_temporal` should return True
+        col.is_dttm = True
+        assert col.is_temporal is True
+
     def test_db_column_types(self):
         test_cases: Dict[str, DbColumnType] = {
             # string


### PR DESCRIPTION
### SUMMARY
`TableColumn` has three properties to check the datatype of a column: `is_numeric`, `is_string` and `is_temporal`. `is_temporal` is usually referenced when a new dataset is added to populate default values for `is_dttm`, which indicates whether or not a column is to added to the time column dropdown. While we should usually directly reference `is_dttm`, the other slightly ambiguously named property can sometimes be used, causing incorrect behaviour.

This PR changes the behaviour of `is_temporal` to first check the value of `is_dttm`, and if that `is not None` (=after initial metadata extraction), return that value, otherwise check the datatype based on the column type. The placeholder text is also fixed, as it featured non-compliant syntax (Year is `%Y`, not `%y`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Added test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
