### PR TITLE
fix: saved query list sort by database

### DIFF
--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -241,10 +241,14 @@ function SavedQueryList({
         Header: t('Name'),
       },
       {
-        id: 'database',
         accessor: 'database.database_name',
         Header: t('Database'),
         size: 'xl',
+      },
+      {
+        accessor: 'database',
+        hidden: true,
+        disableSortBy: true,
       },
       {
         accessor: 'schema',


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sort by database is currently broken for the saved query list view, due to the api call being made with `database` instead of `database.database_name`. This PR fixes the columns config so the correct api call is issued. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
manually tested: saved query can sort and filter by database. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
