### PR TITLE
build: disable pr reviews for pr-lint action

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           title-regex: "^(build|chore|ci|docs|feat|fix|perf|refactor|style|test|other)((.+))?:\\s.+"
           on-failed-regex-fail-action: true
-          on-failed-regex-create-review: true
+          on-failed-regex-request-changes: false
+          on-failed-regex-create-review: false
           on-failed-regex-comment:
             "Please format your PR title to match: `%regex%`!"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
the github action we're using to lint PR titles has a feature that adds PR reviews (as comments). Due to github permissions, this only works for PRs created from this repo (and not forks). We should disabled this feature as it provides an inconsistent experience and introduces some flakiness in the run (see https://github.com/apache/incubator-superset/pull/11371/checks?check_run_id=1310147435).  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
