### PR TITLE
fix: prevent race condition when canceling query

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -324,6 +324,10 @@ export default function sqlLabReducer(state = {}, action) {
       });
     },
     [actions.QUERY_SUCCESS]() {
+      // prevent race condition were query succeeds shortly after being canceled
+      if (action.query.state === 'stopped') {
+        return state;
+      }
       const alts = {
         endDttm: now(),
         progress: 100,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

With the right timing, it's possible to cancel a query, see the message and toast saying "Query was stopped", but still have results being loaded in SQL Lab shortly after. I added a check to prevent this from happening.

Note that `actions.QUERY_FAILED` has a [similar check](https://github.com/apache/incubator-superset/pull/11449/files#diff-b8119ae678e250a0ce86a81c6ce6a84125a3c3fdf9bbc103586cf16043573011R344-R347).

I also noticed that this has been fixed in the past (https://github.com/apache/incubator-superset/pull/2164), but removed later (https://github.com/apache/incubator-superset/pull/4833). @graceguo-supercat and @john-bodley do you have context why it was removed? It doesn't seem obvious to me from the PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

The problem is hard to repro because of the sensitive timing, but I was able to make it happen twice by changing the examples database to async and canceling running queries at the right time.

After the fix was applied I wasn't able to repro the problem.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
