### PR TITLE
fix: resize Markdown placed in tab

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/components/markdown.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/markdown.less
@@ -45,6 +45,14 @@
   #brace-editor {
     border: none;
   }
+
+  .resizable-container {
+    span {
+      div {
+        z-index: @z-index-above-dashboard-charts;
+      }
+    }
+  }
 }
 
 /* maximize editing space */


### PR DESCRIPTION
### SUMMARY
Right down corner of markdown is overlapped by draggable placeholder of tab's bottom. It disables resizing markdown block when it's in the lowest row of tabs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Large GIF (470x464)](https://user-images.githubusercontent.com/2536609/97444542-9096f600-192c-11eb-98ea-3a4ee83ae5df.gif)

After:
![Large GIF (470x464)](https://user-images.githubusercontent.com/2536609/97444572-9b518b00-192c-11eb-9b98-7f822e980914.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11304
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
