### PR TITLE
fix: disabled caret change from left to right

### DIFF
--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -117,11 +117,7 @@ class AdhocFilterOption extends React.PureComponent {
         >
           <Label className="option-label adhoc-option adhoc-filter-option">
             {adhocFilter.getDefaultLabel()}
-            <i
-              className={`fa fa-caret-${
-                this.state.overlayShown ? 'left' : 'right'
-              } adhoc-label-arrow`}
-            />
+            <i className="fa fa-caret-right adhoc-label-arrow" />
           </Label>
         </Popover>
       </div>

--- a/superset-frontend/src/explore/components/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricOption.jsx
@@ -135,11 +135,7 @@ class AdhocMetricOption extends React.PureComponent {
         >
           <Label className="option-label adhoc-option" data-test="option-label">
             {adhocMetric.label}
-            <i
-              className={`fa fa-caret-${
-                this.state.overlayShown ? 'left' : 'right'
-              } adhoc-label-arrow`}
-            />
+            <i className="fa fa-caret-right adhoc-label-arrow" />
           </Label>
         </Popover>
       </div>


### PR DESCRIPTION
### SUMMARY
When clicking on monitor or filter value, caret was changing from left to right while popup was showing up. Right now a caret has only right direction.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Large GIF (436x264)](https://user-images.githubusercontent.com/2536609/97468264-5ede5900-1945-11eb-8cdb-674d71c26dc4.gif)

&
![Large GIF (436x264)](https://user-images.githubusercontent.com/2536609/97468280-643ba380-1945-11eb-8cc2-6671c80dccaf.gif)

After:
![Large GIF (436x264)](https://user-images.githubusercontent.com/2536609/97468297-6a318480-1945-11eb-8847-28ecf1a0b114.gif)
&
![Large GIF (436x264)](https://user-images.githubusercontent.com/2536609/97468387-833a3580-1945-11eb-821d-f1a3d830f675.gif)

### TEST PLAN
1. Go to Data > Datasets
2. Choose one of datasets
3. Add Filters and click on it to see popup
3. Add `Percentage Metrics` and `Sort By` options and click on them to see popup

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
Fixes #11434
- [ ] Has associated issue: 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
