### PR TITLE
fix: Unwinds icon fallout that came along with filters PR

### DIFF
--- a/superset-frontend/src/components/Icon/index.tsx
+++ b/superset-frontend/src/components/Icon/index.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import React, { SVGProps } from 'react';
-import { styled } from '@superset-ui/core';
 
 import { ReactComponent as AlertSolidIcon } from 'images/icons/alert_solid.svg';
 import { ReactComponent as AlertIcon } from 'images/icons/alert.svg';

--- a/superset-frontend/src/components/Icon/index.tsx
+++ b/superset-frontend/src/components/Icon/index.tsx
@@ -380,17 +380,17 @@ interface IconProps extends SVGProps<SVGSVGElement> {
   name: IconName;
 }
 
-const IconWrapper = styled.span`
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  svg {
-    width: 100%;
-    height: 100%;
-    color: currentColor;
-    vertical-align: middle;
-  }
-`;
+// const IconWrapper = styled.span`
+//   display: inline-block;
+//   width: 1em;
+//   height: 1em;
+//   svg {
+//     width: 100%;
+//     height: 100%;
+//     color: currentColor;
+//     vertical-align: middle;
+//   }
+// `;
 
 const Icon = ({
   name,
@@ -401,9 +401,7 @@ const Icon = ({
   const Component = iconsRegistry[name];
 
   return (
-    <IconWrapper>
-      <Component color={color} viewBox={viewBox} data-test={name} {...rest} />
-    </IconWrapper>
+    <Component color={color} viewBox={viewBox} data-test={name} {...rest} />
   );
 };
 

--- a/superset-frontend/src/components/Icon/index.tsx
+++ b/superset-frontend/src/components/Icon/index.tsx
@@ -380,18 +380,6 @@ interface IconProps extends SVGProps<SVGSVGElement> {
   name: IconName;
 }
 
-// const IconWrapper = styled.span`
-//   display: inline-block;
-//   width: 1em;
-//   height: 1em;
-//   svg {
-//     width: 100%;
-//     height: 100%;
-//     color: currentColor;
-//     vertical-align: middle;
-//   }
-// `;
-
 const Icon = ({
   name,
   color = '#666666',

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -20,8 +20,8 @@ import { styled } from '@superset-ui/core';
 
 export const Pill = styled.div`
   display: inline-block;
-  background: ${({ theme }) => theme.colors.grayscale.base};
   color: ${({ theme }) => theme.colors.grayscale.light5};
+  background: ${({ theme }) => theme.colors.grayscale.base};
   border-radius: 1em;
   vertical-align: text-top;
   padding: ${({ theme }) => `${theme.gridUnit}px ${theme.gridUnit * 2}px`};
@@ -36,6 +36,11 @@ export const Pill = styled.div`
   svg {
     position: relative;
     top: -1px;
+    color: ${({ theme }) => theme.colors.grayscale.light5};
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+    vertical-align: middle;
   }
 
   &:hover {
@@ -48,6 +53,9 @@ export const Pill = styled.div`
     background: ${({ theme }) => theme.colors.alert.base};
     &:hover {
       background: ${({ theme }) => theme.colors.alert.dark1};
+    }
+    svg {
+      color: ${({ theme }) => theme.colors.grayscale.dark2};
     }
   }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#10936 made some tweaks to how icons are sized, and this had some unintentional fallout. This rolls that back, and should allow us to carry the feature forward, while minimizing visual changes on other pages.

Another PR can move forward later, trying to size Icons relative to typographical sizing. It's not crucial to that particular feature.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/97515281-fa73c780-194d-11eb-9166-4bd5c487e2ff.png)

After:
![image](https://user-images.githubusercontent.com/812905/97515294-ffd11200-194d-11eb-9be9-2eaa0c325773.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Visual verification.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
