### PR TITLE
fix: dashboard tab only shows move cursor when editing

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/components/tabs.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/tabs.less
@@ -46,7 +46,7 @@
         }
       }
 
-      & .dragdroppable-tab {
+      & .dragdroppable-tab[draggable='true'] {
         cursor: move;
       }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before (display mode, wrong cursor):
![before](https://user-images.githubusercontent.com/812905/97528822-d58e4d00-196b-11eb-8450-f3348c20f77f.gif)

After (display)
![after-display](https://user-images.githubusercontent.com/812905/97528841-dfb04b80-196b-11eb-80b3-a0a810f82eb8.gif)

After (edit mode)
![after-edit](https://user-images.githubusercontent.com/812905/97528846-e2ab3c00-196b-11eb-8e17-a05e0145bae6.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #11471 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
