### PR TITLE
fix: show recent visited dashboards and charts in recent_activity

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1203,7 +1203,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             .outerjoin(Slice, Slice.id == Log.slice_id)
             .filter(
                 and_(
-                    Log.action.in_(("queries", "shortner", "sql_json")),
+                    Log.action.in_(("explore", "dashboard")),
                     Log.user_id == user_id,
                 )
             )

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1193,10 +1193,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         self, user_id: int
     ) -> FlaskResponse:
         """Recent activity (actions) for a given user"""
-        if request.args.get("limit"):
-            limit = int(request.args["limit"])
-        else:
-            limit = 1000
+        limit = request.args.get("limit")
+        limit = int(limit) if limit and limit.isdigit() else 100
         actions = request.args.get("actions", "explore,dashboard").split(",")
         # whether to get distinct subjects
         distinct = request.args.get("distinct") != "false"

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -18,7 +18,7 @@
 import logging
 import re
 from contextlib import closing
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Callable, cast, Dict, List, Optional, Union
 from urllib import parse
 
@@ -36,6 +36,7 @@ from sqlalchemy import and_, or_
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ArgumentError, DBAPIError, NoSuchModuleError, SQLAlchemyError
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql import functions as func
 from werkzeug.urls import Href
 
 from superset import (
@@ -1196,37 +1197,91 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             limit = int(request.args["limit"])
         else:
             limit = 1000
+        actions = request.args.get("actions", "explore,dashboard").split(",")
+        # whether to get distinct subjects
+        distinct = request.args.get("distinct") != "false"
 
-        qry = (
-            db.session.query(Log, Dashboard, Slice)
-            .outerjoin(Dashboard, Dashboard.id == Log.dashboard_id)
-            .outerjoin(Slice, Slice.id == Log.slice_id)
-            .filter(
-                and_(
-                    Log.action.in_(("explore", "dashboard")),
-                    Log.user_id == user_id,
-                )
-            )
-            .order_by(Log.dttm.desc())
-            .limit(limit)
+        has_subject_title = or_(
+            and_(
+                Dashboard.dashboard_title is not None, Dashboard.dashboard_title != "",
+            ),
+            and_(Slice.slice_name is not None, Slice.slice_name != ""),
         )
+
+        if distinct:
+            one_year_ago = datetime.today() - timedelta(days=365)
+            subqry = (
+                db.session.query(
+                    Log.dashboard_id,
+                    Log.slice_id,
+                    Log.action,
+                    func.max(Log.dttm).label("dttm"),
+                )
+                .group_by(Log.dashboard_id, Log.slice_id, Log.action)
+                .filter(
+                    and_(
+                        Log.action.in_(actions),
+                        Log.user_id == user_id,
+                        # limit to one year of data to improve performance
+                        Log.dttm > one_year_ago,
+                        or_(Log.dashboard_id != None, Log.slice_id != None),
+                    )
+                )
+                .subquery()
+            )
+            qry = (
+                db.session.query(
+                    subqry,
+                    Dashboard.slug.label("dashboard_slug"),
+                    Dashboard.dashboard_title,
+                    Slice.slice_name,
+                )
+                .outerjoin(Dashboard, Dashboard.id == subqry.c.dashboard_id)
+                .outerjoin(Slice, Slice.id == subqry.c.slice_id,)
+                .filter(has_subject_title)
+                .order_by(subqry.c.dttm.desc())
+                .limit(limit)
+            )
+        else:
+            qry = (
+                db.session.query(
+                    Log.dttm,
+                    Log.action,
+                    Log.dashboard_id,
+                    Log.slice_id,
+                    Dashboard.slug.label("dashboard_slug"),
+                    Dashboard.dashboard_title,
+                    Slice.slice_name,
+                )
+                .outerjoin(Dashboard, Dashboard.id == Log.dashboard_id)
+                .outerjoin(Slice, Slice.id == Log.slice_id)
+                .filter(has_subject_title)
+                .order_by(Log.dttm.desc())
+                .limit(limit)
+            )
+
         payload = []
         for log in qry.all():
             item_url = None
             item_title = None
-            if log.Dashboard:
-                item_url = log.Dashboard.url
-                item_title = log.Dashboard.dashboard_title
-            elif log.Slice:
-                item_url = log.Slice.slice_url
-                item_title = log.Slice.slice_name
+            item_type = None
+            if log.dashboard_id:
+                item_type = "dashboard"
+                item_url = Dashboard(id=log.dashboard_id, slug=log.dashboard_slug).url
+                item_title = log.dashboard_title
+            elif log.slice_id:
+                slc = Slice(id=log.slice_id, slice_name=log.slice_name)
+                item_type = "slice"
+                item_url = slc.slice_url
+                item_title = slc.chart
 
             payload.append(
                 {
-                    "action": log.Log.action,
+                    "action": log.action,
+                    "item_type": item_type,
                     "item_url": item_url,
                     "item_title": item_title,
-                    "time": log.Log.dttm,
+                    "time": log.dttm,
                 }
             )
         return json_success(json.dumps(payload, default=utils.json_int_dttm_ser))

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1222,7 +1222,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                         Log.user_id == user_id,
                         # limit to one year of data to improve performance
                         Log.dttm > one_year_ago,
-                        or_(Log.dashboard_id != None, Log.slice_id != None),
+                        or_(Log.dashboard_id.isnot(None), Log.slice_id.isnot(None)),
                     )
                 )
                 .subquery()


### PR DESCRIPTION
### SUMMARY

The `/recent_actively` API now almost always returns empty arrays. We don't know how long has it been broken but it seems the intention was to show dashboards and charts users recently viewed.

This PR fixes this API endpoint by using the correct logging actions for the Explore and Dashboard page.

This endpoint is used on the `/superset/welcome` page and user profile page. Since PR #11206 will make the recently viewed info more prominent, it is important to get this fixed.

I also added a "distinct" mode (which is the default and can be turned off by setting `distinct=false`) that will return only distinct subjects with their latest viewed date.

Currently I'm just throwing stuff in the `views/core.py` file, it might worth creating a `superset.users` module and migrating this to a better-tested and better-documented new API endpoint in the future.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

![Snip20201029_114](https://user-images.githubusercontent.com/335541/97543600-b2709700-1985-11eb-955a-7c661b60296d.png)

#### After

![Snip20201029_113](https://user-images.githubusercontent.com/335541/97543608-b56b8780-1985-11eb-81cd-f69d04649227.png)


### TEST PLAN

Manual

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @pkdotson @rusackas @nytai @villebro 