### PR TITLE
feat: globally disable underscore for links in menu items

### DIFF
--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -17,16 +17,37 @@
  * under the License.
  */
 import { styled } from '@superset-ui/core';
-import { Skeleton } from 'antd';
+// eslint-disable-next-line no-restricted-imports
+import { Skeleton, Menu as AntdMenu } from 'antd';
 
 /*
-  Antd is exported from here so we can override components with Emotion as needed.
+  Antd is re-exported from here so we can override components with Emotion as needed.
 
   For documentation, see https://ant.design/components/overview/
  */
-/* eslint no-restricted-imports: 0 */
+// eslint-disable-next-line no-restricted-imports
+export {
+  Avatar,
+  Card,
+  Collapse,
+  Empty,
+  Dropdown,
+  Modal,
+  Popover,
+  Skeleton,
+  Tabs,
+  Tooltip,
+} from 'antd';
 
-export * from 'antd';
+export const MenuItem = styled(AntdMenu.Item)`
+  > a {
+    text-decoration: none;
+  }
+`;
+
+export const Menu = Object.assign(AntdMenu, {
+  Item: MenuItem,
+});
 
 export const ThinSkeleton = styled(Skeleton)`
   h3 {


### PR DESCRIPTION
### SUMMARY

Globally disable underscore for links in menu items. Adding style overrides with styled components.

Developers should now use `import { MenuItem } from "src/common/components"`, instead of `Menu.Item`.

Also makes antd exports explicit so that it's easier to override components under the same name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

https://github.com/apache/incubator-superset/pull/11395#issuecomment-715812311

#### After

<img src="https://user-images.githubusercontent.com/335541/97613759-508c4d80-19d6-11eb-9641-3056651138c6.png" width="300">

### TEST PLAN

Manual

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11395 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
