### PR TITLE
feat: disable save button when saving datasource is in progress

### DIFF
--- a/superset-frontend/src/datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/datasource/DatasourceModal.tsx
@@ -82,6 +82,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
 }) => {
   const [currentDatasource, setCurrentDatasource] = useState(datasource);
   const [errors, setErrors] = useState<any[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
   const dialog = useRef<any>(null);
 
   const onConfirmSave = () => {
@@ -90,6 +91,9 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       currentDatasource.schema ||
       currentDatasource.databaseSelector?.schema ||
       currentDatasource.tableSelector?.schema;
+
+    setIsSaving(true);
+
     SupersetClient.post({
       endpoint: '/datasource/save/',
       postPayload: {
@@ -111,7 +115,8 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
         onDatasourceSave(json);
         onHide();
       })
-      .catch(response =>
+      .catch(response => {
+        setIsSaving(false);
         getClientErrorObject(response).then(({ error }) => {
           dialog.current.show({
             title: 'Error',
@@ -120,8 +125,8 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
             actions: [Dialog.DefaultAction('Ok', () => {}, 'btn-danger')],
             body: error || t('An error has occurred'),
           });
-        }),
-      );
+        });
+      });
   };
 
   const onDatasourceChange = (data: Record<string, any>, err: Array<any>) => {
@@ -196,7 +201,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
             className="m-r-5"
             data-test="datasource-modal-save"
             onClick={onClickSave}
-            disabled={errors.length > 0}
+            disabled={isSaving || errors.length > 0}
           >
             {t('Save')}
           </Button>


### PR DESCRIPTION
### SUMMARY

Disabled the "Save" button when saving a datasource is still in progress. This way users at least have some feedback in case of slow network/backend response.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img src="https://user-images.githubusercontent.com/335541/97617873-8c75e180-19db-11eb-91e7-277e62c71ca3.png" width="600">

### TEST PLAN

Manual

1. Go edit a datasource
2. Throttle your network
3. Click on save

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
