### PR TITLE
chore: Cleaning up ENABLE_REACT_CRUD_VIEWS config

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -313,6 +313,10 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "TAGGING_SYSTEM": False,
     "SQLLAB_BACKEND_PERSISTENCE": False,
     "LISTVIEWS_DEFAULT_CARD_VIEW": False,
+    # Enables the replacement React views for all the FAB views (list, edit, show) with
+    # designs introduced in https://github.com/apache/incubator-superset/issues/8976
+    # (SIP-34). This is a work in progress so not all features available in FAB have
+    # been implemented.
     "ENABLE_REACT_CRUD_VIEWS": True,
     # When True, this flag allows display of HTML tags in Markdown components
     "DISPLAY_MARKDOWN_HTML": True,
@@ -848,11 +852,6 @@ BUG_REPORT_URL = None
 DOCUMENTATION_URL = None
 DOCUMENTATION_TEXT = "Documentation"
 DOCUMENTATION_ICON = None  # Recommended size: 16x16
-
-# Enables the replacement react views for all the FAB views (list, edit, show) with
-# designs introduced in SIP-34: https://github.com/apache/incubator-superset/issues/8976
-# This is a work in progress so not all features available in FAB have been implemented
-ENABLE_REACT_CRUD_VIEWS = DEFAULT_FEATURE_FLAGS["ENABLE_REACT_CRUD_VIEWS"]
 
 # What is the Last N days relative in the time selector to:
 # 'today' means it is midnight (00:00:00) in the local timezone

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -30,7 +30,7 @@ from flask_babel import gettext as __, lazy_gettext as _
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms.validators import Regexp
 
-from superset import app, db
+from superset import app, db, is_feature_enabled
 from superset.connectors.base.views import DatasourceModelView
 from superset.connectors.sqla import models
 from superset.constants import RouteMethod
@@ -559,7 +559,7 @@ class TableModelView(  # pylint: disable=too-many-ancestors
     @expose("/list/")
     @has_access
     def list(self) -> FlaskResponse:
-        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
+        if not is_feature_enabled("ENABLE_REACT_CRUD_VIEWS"):
             return super().list()
 
         return super().render_app_template()

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -23,9 +23,8 @@ from flask_appbuilder.security.decorators import has_access
 from flask_babel import lazy_gettext as _
 from wtforms.validators import StopValidation
 
-from superset import app
+from superset import is_feature_enabled
 from superset.constants import RouteMethod
-from superset.extensions import feature_flag_manager
 from superset.models.annotations import Annotation, AnnotationLayer
 from superset.typing import FlaskResponse
 from superset.views.base import SupersetModelView
@@ -101,8 +100,8 @@ class AnnotationModelView(
     @has_access
     def annotation(self, pk: int) -> FlaskResponse:  # pylint: disable=unused-argument
         if not (
-            app.config["ENABLE_REACT_CRUD_VIEWS"]
-            and feature_flag_manager.is_feature_enabled("SIP_34_ANNOTATIONS_UI")
+            is_feature_enabled("ENABLE_REACT_CRUD_VIEWS")
+            and is_feature_enabled("SIP_34_ANNOTATIONS_UI")
         ):
             return super().list()
 
@@ -128,8 +127,8 @@ class AnnotationLayerModelView(SupersetModelView):  # pylint: disable=too-many-a
     @has_access
     def list(self) -> FlaskResponse:
         if not (
-            app.config["ENABLE_REACT_CRUD_VIEWS"]
-            and feature_flag_manager.is_feature_enabled("SIP_34_ANNOTATIONS_UI")
+            is_feature_enabled("ENABLE_REACT_CRUD_VIEWS")
+            and is_feature_enabled("SIP_34_ANNOTATIONS_UI")
         ):
             return super().list()
 

--- a/superset/views/chart/views.py
+++ b/superset/views/chart/views.py
@@ -20,7 +20,7 @@ from flask_appbuilder import expose, has_access
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import lazy_gettext as _
 
-from superset import app, db
+from superset import db, is_feature_enabled
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.constants import RouteMethod
 from superset.models.slice import Slice
@@ -74,7 +74,7 @@ class SliceModelView(
     @expose("/list/")
     @has_access
     def list(self) -> FlaskResponse:
-        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
+        if not is_feature_enabled("ENABLE_REACT_CRUD_VIEWS"):
             return super().list()
 
         return super().render_app_template()

--- a/superset/views/css_templates.py
+++ b/superset/views/css_templates.py
@@ -19,7 +19,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
 from flask_babel import lazy_gettext as _
 
-from superset import app
+from superset import is_feature_enabled
 from superset.constants import RouteMethod
 from superset.models import core as models
 from superset.typing import FlaskResponse
@@ -45,7 +45,7 @@ class CssTemplateModelView(  # pylint: disable=too-many-ancestors
     @expose("/list/")
     @has_access
     def list(self) -> FlaskResponse:
-        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
+        if not is_feature_enabled("ENABLE_REACT_CRUD_VIEWS"):
             return super().list()
 
         return super().render_app_template()

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -24,7 +24,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __, lazy_gettext as _
 
-from superset import app, db, event_logger
+from superset import db, event_logger, is_feature_enabled
 from superset.constants import RouteMethod
 from superset.models.dashboard import Dashboard as DashboardModel
 from superset.typing import FlaskResponse
@@ -55,7 +55,7 @@ class DashboardModelView(
     @has_access
     @expose("/list/")
     def list(self) -> FlaskResponse:
-        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
+        if not is_feature_enabled("ENABLE_REACT_CRUD_VIEWS"):
             return super().list()
 
         return super().render_app_template()

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -28,7 +28,7 @@ from wtforms.fields import StringField
 from wtforms.validators import ValidationError
 
 import superset.models.core as models
-from superset import app, db
+from superset import app, db, is_feature_enabled
 from superset.connectors.sqla.models import SqlaTable
 from superset.constants import RouteMethod
 from superset.exceptions import CertificateException
@@ -98,7 +98,7 @@ class DatabaseView(
     @expose("/list/")
     @has_access
     def list(self) -> FlaskResponse:
-        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
+        if not is_feature_enabled("ENABLE_REACT_CRUD_VIEWS"):
             return super().list()
 
         return super().render_app_template()

--- a/superset/views/sql_lab.py
+++ b/superset/views/sql_lab.py
@@ -21,7 +21,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_babel import lazy_gettext as _
 
-from superset import app, db
+from superset import db, is_feature_enabled
 from superset.constants import RouteMethod
 from superset.models.sql_lab import Query, SavedQuery, TableSchema, TabState
 from superset.typing import FlaskResponse
@@ -78,7 +78,7 @@ class SavedQueryView(
     @expose("/list/")
     @has_access
     def list(self) -> FlaskResponse:
-        if not app.config["ENABLE_REACT_CRUD_VIEWS"]:
+        if not is_feature_enabled("ENABLE_REACT_CRUD_VIEWS"):
             return super().list()
 
         return super().render_app_template()

--- a/tests/superset_test_config.py
+++ b/tests/superset_test_config.py
@@ -55,6 +55,7 @@ FEATURE_FLAGS = {
     "KV_STORE": True,
     "SHARE_QUERIES_VIA_KV_STORE": True,
     "ENABLE_TEMPLATE_PROCESSING": True,
+    "ENABLE_REACT_CRUD_VIEWS": os.environ.get("ENABLE_REACT_CRUD_VIEWS", False),
 }
 
 
@@ -73,11 +74,7 @@ PUBLIC_ROLE_LIKE = "Gamma"
 AUTH_ROLE_PUBLIC = "Public"
 EMAIL_NOTIFICATIONS = False
 ENABLE_ROW_LEVEL_SECURITY = True
-ENABLE_REACT_CRUD_VIEWS = os.environ.get("ENABLE_REACT_CRUD_VIEWS", False)
-
 CACHE_CONFIG = {"CACHE_TYPE": "simple"}
-
-
 REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
 REDIS_PORT = os.environ.get("REDIS_PORT", "6379")
 REDIS_CELERY_DB = os.environ.get("REDIS_CELERY_DB", 2)


### PR DESCRIPTION
### SUMMARY

Now that `ENABLE_REACT_CRUD_VIEWS` is behind a feature flag (https://github.com/apache/incubator-superset/pull/11371) there seems to be merit in deprecating the config parameter with the same name (DRY) and using the feature flag framework to check the status, otherwise you'll likely need to override this in two places.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
