### PR TITLE
fix: Revert #11335 to prevent chart overwritten by other users

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -652,9 +652,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         # slc perms
         slice_add_perm = security_manager.can_access("can_add", "SliceModelView")
-        slice_overwrite_perm = (
-            security_manager.can_access("can_edit", "SliceModelView") if slc else False
-        )
+        slice_overwrite_perm = is_owner(slc, g.user) if slc else False
         slice_download_perm = security_manager.can_access(
             "can_download", "SliceModelView"
         )


### PR DESCRIPTION
Please see issue reported by #11490.

Reverts apache/incubator-superset#11335

@etr2460 @nytai @ktmud 