### PR TITLE
chore: add dependabot.yml config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+
+  - package-ecosystem: "pip"
+    directory: "/requirements/"
+    schedule:
+      interval: "daily"
+    labels:
+      - pip
+      - dependabot


### PR DESCRIPTION
### SUMMARY
^^^ title

Flying a bit blind, but following instructions here https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow

We can adapt as needed.

It's unclear to me whether and how dependabot will understand our `pip-compile-multi` setup, but it claims being able to understand `pip-compile`, but I couldn't find much details. The goal here is to experiment and see if dependabots figures things out.

The intent is to stay on a `daily` config until we get up to speed, and pivot onto a weekly cadence to reduce the noise. 