### PR TITLE
chore: bump pypi cryptography from 2.4.2 to 3.2.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ click==7.1.2              # via apache-superset, flask, flask-appbuilder
 colorama==0.4.3           # via apache-superset, flask-appbuilder
 contextlib2==0.6.0.post1  # via apache-superset
 croniter==0.3.34          # via apache-superset
-cryptography==3.1.1       # via apache-superset
+cryptography==3.2.1       # via apache-superset
 decorator==4.4.2          # via retry
 defusedxml==0.6.0         # via python3-openid
 dnspython==2.0.0          # via email-validator

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "colorama",
         "contextlib2",
         "croniter>=0.3.28",
-        "cryptography>=2.4.2",
+        "cryptography>=3.2.1",
         "flask>=1.1.0, <2.0.0",
         "flask-appbuilder>=3.1.1, <4.0.0",
         "flask-caching",


### PR DESCRIPTION
### SUMMARY
title ^^^ 