### PR TITLE
feat: annotation layers delete logic + linking w/ annotation view

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/annotationlayers/AnnotationLayersList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/annotationlayers/AnnotationLayersList_spec.jsx
@@ -28,8 +28,8 @@ import SubMenu from 'src/components/Menu/SubMenu';
 import ListView from 'src/components/ListView';
 import Filters from 'src/components/ListView/Filters';
 import DeleteModal from 'src/components/DeleteModal';
-// import Button from 'src/components/Button';
-// import IndeterminateCheckbox from 'src/components/IndeterminateCheckbox';
+import Button from 'src/components/Button';
+import IndeterminateCheckbox from 'src/components/IndeterminateCheckbox';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { act } from 'react-dom/test-utils';
 
@@ -128,9 +128,7 @@ describe('AnnotationLayersList', () => {
 
     expect(
       wrapper.find(DeleteModal).first().props().description,
-    ).toMatchInlineSnapshot(
-      `"This action will permanently delete the layer."`,
-    );
+    ).toMatchInlineSnapshot(`"This action will permanently delete the layer."`);
 
     act(() => {
       wrapper
@@ -147,5 +145,16 @@ describe('AnnotationLayersList', () => {
     await waitForComponentToPaint(wrapper);
 
     expect(fetchMock.calls(/annotation_layer\/0/, 'DELETE')).toHaveLength(1);
+  });
+
+  it('shows/hides bulk actions when bulk actions is clicked', async () => {
+    const button = wrapper.find(Button).at(0);
+    act(() => {
+      button.props().onClick();
+    });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(IndeterminateCheckbox)).toHaveLength(
+      mocklayers.length + 1, // 1 for each row and 1 for select all
+    );
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/annotationlayers/AnnotationLayersList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/annotationlayers/AnnotationLayersList_spec.jsx
@@ -27,7 +27,7 @@ import AnnotationLayerModal from 'src/views/CRUD/annotationlayers/AnnotationLaye
 import SubMenu from 'src/components/Menu/SubMenu';
 import ListView from 'src/components/ListView';
 import Filters from 'src/components/ListView/Filters';
-// import DeleteModal from 'src/components/DeleteModal';
+import DeleteModal from 'src/components/DeleteModal';
 // import Button from 'src/components/Button';
 // import IndeterminateCheckbox from 'src/components/IndeterminateCheckbox';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
@@ -39,7 +39,7 @@ const store = mockStore({});
 
 const layersInfoEndpoint = 'glob:*/api/v1/annotation_layer/_info*';
 const layersEndpoint = 'glob:*/api/v1/annotation_layer/?*';
-// const layerEndpoint = 'glob:*/api/v1/annotation_layer/*';
+const layerEndpoint = 'glob:*/api/v1/annotation_layer/*';
 const layersRelatedEndpoint = 'glob:*/api/v1/annotation_layer/related/*';
 
 const mocklayers = [...new Array(3)].map((_, i) => ({
@@ -63,8 +63,8 @@ fetchMock.get(layersEndpoint, {
   layers_count: 3,
 });
 
-/* fetchMock.delete(layerEndpoint, {});
-fetchMock.delete(layersEndpoint, {}); */
+fetchMock.delete(layerEndpoint, {});
+fetchMock.delete(layersEndpoint, {});
 
 fetchMock.get(layersRelatedEndpoint, {
   created_by: {
@@ -118,5 +118,34 @@ describe('AnnotationLayersList', () => {
     expect(fetchMock.lastCall()[0]).toMatchInlineSnapshot(
       `"http://localhost/api/v1/annotation_layer/?q=(filters:!((col:name,opr:ct,value:foo)),order_column:name,order_direction:desc,page:0,page_size:25)"`,
     );
+  });
+
+  it('deletes', async () => {
+    act(() => {
+      wrapper.find('[data-test="delete-action"]').first().props().onClick();
+    });
+    await waitForComponentToPaint(wrapper);
+
+    expect(
+      wrapper.find(DeleteModal).first().props().description,
+    ).toMatchInlineSnapshot(
+      `"This action will permanently delete the layer."`,
+    );
+
+    act(() => {
+      wrapper
+        .find('#delete')
+        .first()
+        .props()
+        .onChange({ target: { value: 'DELETE' } });
+    });
+    await waitForComponentToPaint(wrapper);
+    act(() => {
+      wrapper.find('button').last().props().onClick();
+    });
+
+    await waitForComponentToPaint(wrapper);
+
+    expect(fetchMock.calls(/annotation_layer\/0/, 'DELETE')).toHaveLength(1);
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/annotationlayers/AnnotationLayersList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/annotationlayers/AnnotationLayersList_spec.jsx
@@ -64,7 +64,7 @@ fetchMock.get(layersEndpoint, {
 });
 
 /* fetchMock.delete(layerEndpoint, {});
-fetchMock.delete(layersEndpoint, {});*/
+fetchMock.delete(layersEndpoint, {}); */
 
 fetchMock.get(layersRelatedEndpoint, {
   created_by: {

--- a/superset-frontend/spec/javascripts/views/CRUD/annotationlayers/AnnotationLayersList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/annotationlayers/AnnotationLayersList_spec.jsx
@@ -64,7 +64,7 @@ fetchMock.get(layersEndpoint, {
 });
 
 /* fetchMock.delete(layerEndpoint, {});
-fetchMock.delete(layersEndpoint, {}); */
+fetchMock.delete(layersEndpoint, {});*/
 
 fetchMock.get(layersRelatedEndpoint, {
   created_by: {

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -384,7 +384,9 @@ function ListView<T extends object = any>({
           {!loading && rows.length === 0 && (
             <EmptyWrapper>
               <Empty
-                image={<EmptyImage />}
+                image={
+                  <EmptyImage />
+                }
                 description={emptyState.message || 'No Data'}
               >
                 {emptyState.slot || null}

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -384,9 +384,7 @@ function ListView<T extends object = any>({
           {!loading && rows.length === 0 && (
             <EmptyWrapper>
               <Empty
-                image={
-                  <EmptyImage />
-                }
+                image={<EmptyImage />}
                 description={emptyState.message || 'No Data'}
               >
                 {emptyState.slot || null}

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -56,13 +56,12 @@ const ListViewStyles = styled.div`
         text-align: right;
       }
     }
-    .body {
-      background: ${({ theme }) => theme.colors.grayscale.light5};
+
+    .body.empty table {
+      margin-bottom: 0;
     }
 
     .ant-empty {
-      padding-bottom: 160px;
-
       .ant-empty-image {
         height: auto;
       }
@@ -157,7 +156,11 @@ const ViewModeContainer = styled.div`
 `;
 
 const EmptyWrapper = styled.div`
-  margin: ${({ theme }) => theme.gridUnit * 40}px 0;
+  padding: ${({ theme }) => theme.gridUnit * 40}px 0;
+
+  &.table {
+    background: ${({ theme }) => theme.colors.grayscale.light5};
+  }
 `;
 
 const ViewModeToggle = ({
@@ -321,7 +324,7 @@ function ListView<T extends object = any>({
             )}
           </div>
         </div>
-        <div className="body">
+        <div className={`body ${rows.length === 0 ? 'empty' : ''}`}>
           {bulkSelectEnabled && (
             <BulkSelectWrapper
               data-test="bulk-select-controls"
@@ -382,7 +385,7 @@ function ListView<T extends object = any>({
             />
           )}
           {!loading && rows.length === 0 && (
-            <EmptyWrapper>
+            <EmptyWrapper className={viewingMode}>
               <Empty
                 image={<EmptyImage />}
                 description={emptyState.message || 'No Data'}

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -97,8 +97,8 @@ export interface ButtonProps {
 
 export interface SubMenuProps {
   buttons?: Array<ButtonProps>;
-  name?: string;
-  tabs?: MenuChild[];
+  name: string | ReactNode;
+  children?: MenuChild[];
   activeChild?: MenuChild['name'];
   /* If usesRouter is true, a react-router <Link> component will be used instead of href.
    *  ONLY set usesRouter to true if SubMenu is wrapped in a react-router <Router>;

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -97,7 +97,8 @@ export interface ButtonProps {
 
 export interface SubMenuProps {
   buttons?: Array<ButtonProps>;
-  name: string | ReactNode;
+  name?: string | ReactNode;
+  tabs?: MenuChild[];
   children?: MenuChild[];
   activeChild?: MenuChild['name'];
   /* If usesRouter is true, a react-router <Link> component will be used instead of href.

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
@@ -18,8 +18,9 @@
  */
 
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
-import { useParams } from 'react-router-dom';
-import { t, SupersetClient } from '@superset-ui/core';
+import { useParams, Link, useHistory } from 'react-router-dom';
+import { t, styled, SupersetClient } from '@superset-ui/core';
+
 import moment from 'moment';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
 import ListView from 'src/components/ListView';
@@ -164,10 +165,43 @@ function AnnotationList({ addDangerToast }: AnnotationListProps) {
     },
   });
 
+  const StyledHeader = styled.div`
+    display: flex;
+    flex-direction: row;
+
+    a,
+    Link {
+      margin-left: 16px;
+      font-size: 12px;
+      font-weight: normal;
+      text-decoration: underline;
+    }
+  `;
+
+  let hasHistory = true;
+
+  try {
+    useHistory();
+  } catch (err) {
+    // If error is thrown, we know not to use <Link> in render
+    hasHistory = false;
+  }
+
   return (
     <>
       <SubMenu
-        name={t(`Annotation Layer ${annotationLayerName}`)}
+        name={
+          <StyledHeader>
+            <span>{t(`Annotation Layer ${annotationLayerName}`)}</span>
+            <span>
+              {hasHistory ? (
+                <Link to="/annotationlayermodelview/list/">Back to all</Link>
+              ) : (
+                <a href="/annotationlayermodelview/list/">Back to all</a>
+              )}
+            </span>
+          </StyledHeader>
+        }
         buttons={subMenuButtons}
       />
       {/* <AnnotationModal

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx
@@ -131,9 +131,9 @@ const AnnotationLayerModal: FunctionComponent<AnnotationLayerModalProps> = ({
       }
     } else if (currentLayer) {
       // Create
-      createResource(currentLayer).then(() => {
+      createResource(currentLayer).then(response => {
         if (onLayerAdd) {
-          onLayerAdd();
+          onLayerAdd(response);
         }
 
         hide();

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
@@ -20,6 +20,7 @@
 import React, { useMemo, useState } from 'react';
 import rison from 'rison';
 import { t, SupersetClient } from '@superset-ui/core';
+import { Link, useHistory } from 'react-router-dom';
 import moment from 'moment';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
@@ -124,6 +125,28 @@ function AnnotationLayersList({
       {
         accessor: 'name',
         Header: t('Name'),
+        Cell: ({
+          row: {
+            original: { id, name },
+          },
+        }: any) => {
+          let hasHistory = true;
+
+          try {
+            useHistory();
+          } catch (err) {
+            // If error is thrown, we know not to use <Link> in render
+            hasHistory = false;
+          }
+
+          if (hasHistory) {
+            return (
+              <Link to={`/annotationmodelview/${id}/annotation`}>{name}</Link>
+            );
+          }
+
+          return <a href={`/annotationmodelview/${id}/annotation`}>{name}</a>;
+        },
       },
       {
         accessor: 'descr',

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
@@ -145,6 +145,16 @@ function AnnotationLayersList({
         size: 'xl',
       },
       {
+        Cell: ({
+          row: {
+            original: { changed_on_delta_humanized: changedOn },
+          },
+        }: any) => changedOn,
+        Header: t('Last Modified'),
+        accessor: 'changed_on_delta_humanized',
+        size: 'xl',
+      },
+      {
         Cell: ({ row: { original } }: any) => {
           const handleEdit = () => handleAnnotationLayerEdit(original);
           const handleDelete = () => {}; // openAnnotationLayerDeleteModal(original);

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
@@ -145,16 +145,6 @@ function AnnotationLayersList({
         size: 'xl',
       },
       {
-        Cell: ({
-          row: {
-            original: { changed_on_delta_humanized: changedOn },
-          },
-        }: any) => changedOn,
-        Header: t('Last Modified'),
-        accessor: 'changed_on_delta_humanized',
-        size: 'xl',
-      },
-      {
         Cell: ({ row: { original } }: any) => {
           const handleEdit = () => handleAnnotationLayerEdit(original);
           const handleDelete = () => {}; // openAnnotationLayerDeleteModal(original);

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
@@ -324,13 +324,17 @@ function AnnotationLayersList({
     slot: EmptyStateButton,
   };
 
+  const onLayerAdd = (id?: number) => {
+    window.location.href = `/annotationmodelview/${id}/annotation`;
+  };
+
   return (
     <>
       <SubMenu name={t('Annotation Layers')} buttons={subMenuButtons} />
       <AnnotationLayerModal
         addDangerToast={addDangerToast}
         layer={currentAnnotationLayer}
-        onLayerAdd={() => refreshData()}
+        onLayerAdd={onLayerAdd}
         onHide={() => setAnnotationLayerModalOpen(false)}
         show={annotationLayerModalOpen}
       />

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -238,6 +238,8 @@ export function useSingleViewResource<D extends object = any>(
           updateState({
             resource: json.result,
           });
+
+          return json.id;
         },
         createErrorHandler(errMsg =>
           handleErrorMsg(

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -28,7 +28,6 @@ from superset.constants import RouteMethod
 from superset.models.annotations import Annotation, AnnotationLayer
 from superset.typing import FlaskResponse
 from superset.views.base import SupersetModelView
-from superset.typing import FlaskResponse
 
 
 class StartEndDttmValidator:  # pylint: disable=too-few-public-methods

--- a/superset/views/annotations.py
+++ b/superset/views/annotations.py
@@ -28,6 +28,7 @@ from superset.constants import RouteMethod
 from superset.models.annotations import Annotation, AnnotationLayer
 from superset.typing import FlaskResponse
 from superset.views.base import SupersetModelView
+from superset.typing import FlaskResponse
 
 
 class StartEndDttmValidator:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
### SUMMARY
- [x] Add delete and bulk select/delete logic
- [x] On clicking an annotation layer name, link to the annotation view for that layer
- [x] Add `back to all' button on individual annotations view
- [x] On layer create, link to that annotation layer

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1213" alt="Screen Shot 2020-11-02 at 11 39 54 AM" src="https://user-images.githubusercontent.com/8216382/97911481-2c937980-1d00-11eb-84a7-ddaf42eaa752.png">
<img width="1208" alt="Screen Shot 2020-11-02 at 11 39 36 AM" src="https://user-images.githubusercontent.com/8216382/97911479-29988900-1d00-11eb-8e05-653de5afaaf8.png">
<img width="1210" alt="Screen Shot 2020-11-02 at 11 42 06 AM" src="https://user-images.githubusercontent.com/8216382/97911639-70867e80-1d00-11eb-8a56-bb189cf26c38.png">


### TEST PLAN
- [x] Update `AnnotationLayersList_spec`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
