### PR TITLE
fix: hide extra blank space in dashboard chart menu

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -179,12 +179,14 @@ class SliceHeaderControls extends React.PureComponent {
             style={{ height: 'auto', lineHeight: 'initial' }}
           >
             {t('Force refresh')}
-            <div
-              className="refresh-tooltip"
-              data-test="dashboard-slice-refresh-tooltip"
-            >
-              {refreshTooltip}
-            </div>
+            {refreshTooltip && (
+              <div
+                className="refresh-tooltip"
+                data-test="dashboard-slice-refresh-tooltip"
+              >
+                {refreshTooltip}
+              </div>
+            )}
           </Menu.Item>
 
           <Menu.Divider />


### PR DESCRIPTION
### SUMMARY

Hide extra blank space in the "Force Refresh" link in dashboard chart's dropdown menu, while chart query is still running.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img src="https://user-images.githubusercontent.com/335541/98049168-03e4b000-1de4-11eb-9f98-0e1f5a5580c2.png" width="200">

Not sure if it was by design originally, but it always kind of bothers me.

#### After

<img src="https://user-images.githubusercontent.com/335541/98049176-07783700-1de4-11eb-9d22-128b869fa081.png" width="200">

### TEST PLAN

Manual

1. Go to a dashboard with charts with very slow query
2. Click on "Force Refresh"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
