### PR TITLE
feat: annotation delete modal, bulk delete and empty state

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/annotation/AnnotationList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/annotation/AnnotationList_spec.jsx
@@ -23,9 +23,14 @@ import fetchMock from 'fetch-mock';
 import { styledMount as mount } from 'spec/helpers/theming';
 
 import AnnotationList from 'src/views/CRUD/annotation/AnnotationList';
-import SubMenu from 'src/components/Menu/SubMenu';
+import Button from 'src/components/Button';
+import DeleteModal from 'src/components/DeleteModal';
+import IndeterminateCheckbox from 'src/components/IndeterminateCheckbox';
 import ListView from 'src/components/ListView';
+import SubMenu from 'src/components/Menu/SubMenu';
+
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
+import { act } from 'react-dom/test-utils';
 
 // store needed for withToasts(AnnotationList)
 const mockStore = configureStore([thunk]);
@@ -34,7 +39,9 @@ const store = mockStore({});
 const annotationsEndpoint = 'glob:*/api/v1/annotation_layer/*/annotation*';
 const annotationLayerEndpoint = 'glob:*/api/v1/annotation_layer/*';
 
-const mockannotation = [...new Array(3)].map((_, i) => ({
+fetchMock.delete(annotationsEndpoint, {});
+
+const mockannotations = [...new Array(3)].map((_, i) => ({
   changed_on_delta_humanized: `${i} day(s) ago`,
   created_by: {
     first_name: `user`,
@@ -53,7 +60,7 @@ const mockannotation = [...new Array(3)].map((_, i) => ({
 
 fetchMock.get(annotationsEndpoint, {
   ids: [2, 0, 1],
-  result: mockannotation,
+  result: mockannotations,
   count: 3,
 });
 
@@ -108,6 +115,46 @@ describe('AnnotationList', () => {
     expect(callsQ).toHaveLength(2);
     expect(callsQ[0][0]).toMatchInlineSnapshot(
       `"http://localhost/api/v1/annotation_layer/1/annotation/?q=(order_column:short_descr,order_direction:desc,page:0,page_size:25)"`,
+    );
+  });
+
+  it('renders a DeleteModal', () => {
+    expect(wrapper.find(DeleteModal)).toExist();
+  });
+
+  it('deletes', async () => {
+    act(() => {
+      wrapper.find('[data-test="delete-action"]').first().props().onClick();
+    });
+    await waitForComponentToPaint(wrapper);
+
+    expect(
+      wrapper.find(DeleteModal).first().props().description,
+    ).toMatchInlineSnapshot(
+      `"Are you sure you want to delete annotation 0 label?"`,
+    );
+
+    act(() => {
+      wrapper
+        .find('#delete')
+        .first()
+        .props()
+        .onChange({ target: { value: 'DELETE' } });
+    });
+    await waitForComponentToPaint(wrapper);
+    act(() => {
+      wrapper.find('button').last().props().onClick();
+    });
+  });
+
+  it('shows/hides bulk actions when bulk actions is clicked', async () => {
+    const button = wrapper.find('[data-test="annotation-bulk-select"]').first();
+    act(() => {
+      button.props().onClick();
+    });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(IndeterminateCheckbox)).toHaveLength(
+      mockannotations.length + 1, // 1 for each row and 1 for select all
     );
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/annotation/AnnotationList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/annotation/AnnotationList_spec.jsx
@@ -23,7 +23,6 @@ import fetchMock from 'fetch-mock';
 import { styledMount as mount } from 'spec/helpers/theming';
 
 import AnnotationList from 'src/views/CRUD/annotation/AnnotationList';
-import Button from 'src/components/Button';
 import DeleteModal from 'src/components/DeleteModal';
 import IndeterminateCheckbox from 'src/components/IndeterminateCheckbox';
 import ListView from 'src/components/ListView';

--- a/superset-frontend/src/common/components/common.stories.tsx
+++ b/superset-frontend/src/common/components/common.stories.tsx
@@ -27,6 +27,10 @@ import AntdTooltip from './Tooltip';
 import { Menu } from '.';
 import { Dropdown } from './Dropdown';
 import InfoTooltip from './InfoTooltip';
+import {
+  DatePicker as AntdDatePicker,
+  RangePicker as AntdRangePicker,
+} from './DatePicker';
 
 export default {
   title: 'Common Components',
@@ -224,3 +228,12 @@ StyledInfoTooltip.argTypes = {
     },
   },
 };
+
+export const DatePicker = () => <AntdDatePicker showTime />;
+export const DateRangePicker = () => (
+  <AntdRangePicker
+    format="YYYY-MM-DD hh:mm a"
+    showTime={{ format: 'hh:mm a' }}
+    use12Hours
+  />
+);

--- a/superset-frontend/src/components/Menu/SubMenu.tsx
+++ b/superset-frontend/src/components/Menu/SubMenu.tsx
@@ -86,6 +86,7 @@ type MenuChild = {
 export interface ButtonProps {
   name: ReactNode;
   onClick: OnClickHandler;
+  'data-test'?: string;
   buttonStyle:
     | 'primary'
     | 'secondary'
@@ -159,6 +160,7 @@ const SubMenu: React.FunctionComponent<SubMenuProps> = props => {
               key={`${i}`}
               buttonStyle={btn.buttonStyle}
               onClick={btn.onClick}
+              data-test={btn['data-test']}
             >
               {btn.name}
             </Button>

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
@@ -119,7 +119,7 @@ function AnnotationList({
     annotationsToDelete: AnnotationObject[],
   ) => {
     SupersetClient.delete({
-      endpoint: `/api/v1/css_template/?q=${rison.encode(
+      endpoint: `/api/v1/annotation_layer/${annotationLayerId}/annotation/?q=${rison.encode(
         annotationsToDelete.map(({ id }) => id),
       )}`,
     }).then(
@@ -129,7 +129,7 @@ function AnnotationList({
       },
       createErrorHandler(errMsg =>
         addDangerToast(
-          t('There was an issue deleting the selected templates: %s', errMsg),
+          t('There was an issue deleting the selected annotations: %s', errMsg),
         ),
       ),
     );
@@ -217,6 +217,7 @@ function AnnotationList({
     name: t('Bulk Select'),
     onClick: toggleBulkSelect,
     buttonStyle: 'secondary',
+    'data-test': 'annotation-bulk-select',
   });
 
   const StyledHeader = styled.div`
@@ -302,7 +303,7 @@ function AnnotationList({
       <ConfirmStatusChange
         title={t('Please confirm')}
         description={t(
-          'Are you sure you want to delete the selected templates?',
+          'Are you sure you want to delete the selected annotations?',
         )}
         onConfirm={handleBulkAnnotationsDelete}
       >

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
@@ -23,6 +23,7 @@ import { t, styled, SupersetClient } from '@superset-ui/core';
 
 import moment from 'moment';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
+import Button from 'src/components/Button';
 import ListView from 'src/components/ListView';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import getClientErrorObject from 'src/utils/getClientErrorObject';
@@ -64,7 +65,7 @@ function AnnotationList({ addDangerToast }: AnnotationListProps) {
     setCurrentAnnotation,
   ] = useState<AnnotationObject | null>(null);
 
-  const handleAnnotationEdit = (annotation: AnnotationObject) => {
+  const handleAnnotationEdit = (annotation: AnnotationObject | null) => {
     setCurrentAnnotation(annotation);
     setAnnotationModalOpen(true);
   };
@@ -159,8 +160,7 @@ function AnnotationList({ addDangerToast }: AnnotationListProps) {
     ),
     buttonStyle: 'primary',
     onClick: () => {
-      setCurrentAnnotation(null);
-      setAnnotationModalOpen(true);
+      handleAnnotationEdit(null);
     },
   });
 
@@ -185,6 +185,24 @@ function AnnotationList({ addDangerToast }: AnnotationListProps) {
     // If error is thrown, we know not to use <Link> in render
     hasHistory = false;
   }
+
+  const EmptyStateButton = (
+    <Button
+      buttonStyle="primary"
+      onClick={() => {
+        handleAnnotationEdit(null);
+      }}
+    >
+      <>
+        <i className="fa fa-plus" /> {t('Annotation Layer')}
+      </>
+    </Button>
+  );
+
+  const emptyState = {
+    message: 'No annotation yet',
+    slot: EmptyStateButton,
+  };
 
   return (
     <>
@@ -220,6 +238,7 @@ function AnnotationList({ addDangerToast }: AnnotationListProps) {
         initialSort={initialSort}
         loading={loading}
         pageSize={PAGE_SIZE}
+        emptyState={emptyState}
       />
     </>
   );

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
@@ -251,13 +251,13 @@ function AnnotationList({
       }}
     >
       <>
-        <i className="fa fa-plus" /> {t('Annotation Layer')}
+        <i className="fa fa-plus" /> {t('Annotation')}
       </>
     </Button>
   );
 
   const emptyState = {
-    message: 'No annotation yet',
+    message: t('No annotation yet'),
     slot: EmptyStateButton,
   };
 

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationList.tsx
@@ -20,8 +20,9 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import { useParams, Link, useHistory } from 'react-router-dom';
 import { t, styled, SupersetClient } from '@superset-ui/core';
-
 import moment from 'moment';
+import rison from 'rison';
+
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
 import Button from 'src/components/Button';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
@@ -135,7 +136,7 @@ function AnnotationList({
     );
   };
 
-  // get the owners of this slice
+  // get the Annotation Layer
   useEffect(() => {
     fetchAnnotationLayer();
   }, [fetchAnnotationLayer]);

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx
@@ -287,9 +287,9 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
           <span className="required">*</span>
         </div>
         <RangePicker
+          format="YYYY-MM-DD hh:mm a"
           onChange={onDateChange}
           showTime={{ format: 'hh:mm a' }}
-          format="YYYY-MM-DD hh:mm a"
           use12Hours
           // @ts-ignore
           value={

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
@@ -320,7 +320,7 @@ function AnnotationLayersList({
   );
 
   const emptyState = {
-    message: 'No annotation layers yet',
+    message: t('No annotation layers yet'),
     slot: EmptyStateButton,
   };
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- added `DatePicker` and `RangePicker` to storybook
- empty state for annotation CRUD list view
- bulk delete action annotations list 
- annotation delete modal
- add data-test on submenu buttons

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**DELETE MODAL:**
<img width="917" alt="Screen Shot 2020-11-03 at 4 51 49 PM" src="https://user-images.githubusercontent.com/5705598/98056569-10bdcf80-1df5-11eb-9234-b4fd3d7aee45.png">

**BULK DELETE:**
<img width="1786" alt="Screen Shot 2020-11-03 at 4 51 31 PM" src="https://user-images.githubusercontent.com/5705598/98056562-0dc2df00-1df5-11eb-88c6-4df31bbbaa60.png">
<img width="1790" alt="Screen Shot 2020-11-03 at 4 51 40 PM" src="https://user-images.githubusercontent.com/5705598/98056568-10253900-1df5-11eb-9dde-72faac150c0c.png">

**EMPTY STATE**
<img width="1792" alt="Screen Shot 2020-11-03 at 4 52 25 PM" src="https://user-images.githubusercontent.com/5705598/98056570-11566600-1df5-11eb-918f-fa510dc743e4.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- unit test for annotation delete modal and bulk delete
 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
