### PR TITLE
fix(dashboard): navigate to a filter box without screwing up tab state

### DIFF
--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -124,13 +124,16 @@ export default function dashboardStateReducer(state = {}, action) {
       };
     },
     [SET_DIRECT_PATH]() {
-      return {
+      const newState = {
         ...state,
-        // change of direct path (tabs) will reset current mounted tab
-        mountedTab: null,
         directPathToChild: action.path,
         directPathLastUpdated: Date.now(),
       };
+      // change of direct path (tabs) will reset current mounted tab
+      // cannot just set mountedTab to null,
+      // as that is used when transitioning between tabs.
+      delete newState.mountedTab;
+      return newState;
     },
     [SET_MOUNTED_TAB]() {
       // set current mounted tab after tab is really mounted to DOM


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is more of a patch fix.

The true underlying problem is a bad state design for the "switching between tabs" state but I don't have the bandwidth to address that right now.

The reason this fix works/is necessary is that `gridComponents/Chart`'s `shouldComponentUpdate` function uses `mountedTab === null` state to check whether the chart should render. This is a bad way to represent that state, hence this bug. But it is what it is.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #11542
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
