### PR TITLE
fix: minor style touch on dashboard page

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -105,9 +105,8 @@ const StyledTabsContainer = styled.div`
     top: ${({ theme }) => theme.gridUnit * 2}px;
   }
 
-  .editable-title input {
-    cursor: pointer;
-    text-transform: uppercase;
+  div .ant-tabs-tab-btn {
+    text-transform: none;
   }
 `;
 

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.less
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.less
@@ -56,11 +56,15 @@
 .filter-container {
   display: flex;
   flex-direction: column;
+  margin-bottom: 10px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 
   label {
     display: flex;
     font-weight: @font-weight-bold;
-    margin: 0 0 8px 8px;
   }
 
   .filter-badge-container {


### PR DESCRIPTION
### SUMMARY

A couple of small styling fixes for the dashboard page.

1. Change tabs back to regular case: in general, user inputs should not be uppercase because if users really want to use uppercase, they can easily do that themself. Leaving uppercase labels to native UI elements also makes them more special and utility-like.
2. Adjust the margins in filter labels. Currently the text is kind of all over the place. 
3. Change the cursor for dashboard tabs in editing state from pointer (indicating a button) to text (indicating this is an input field).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img src="https://user-images.githubusercontent.com/335541/98190754-92ccf780-1ecc-11eb-8f17-a48bc68c99eb.png" width="400">

#### After

<img src="https://user-images.githubusercontent.com/335541/98190817-bdb74b80-1ecc-11eb-96e3-4fe04d4823a5.png" width="400">

##### On Explore page:

![Snip20201104_28](https://user-images.githubusercontent.com/335541/98190924-efc8ad80-1ecc-11eb-8790-17fd213a22e4.png)


### TEST PLAN

Manually check the style works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @rusackas @kgabryje 