### PR TITLE
fix: Issues with filters and metrics popovers

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopoverSimpleTabContent_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopoverSimpleTabContent_spec.jsx
@@ -199,16 +199,4 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
       }),
     );
   });
-
-  it('expands when its multi comparator input field expands', () => {
-    const { wrapper, onHeightChange } = setup();
-
-    wrapper.instance().multiComparatorComponent = {
-      select: { select: { controlRef: { clientHeight: 57 } } },
-    };
-    wrapper.instance().handleMultiComparatorInputHeightChange();
-
-    expect(onHeightChange.calledOnce).toBe(true);
-    expect(onHeightChange.lastCall.args[0]).toBe(27);
-  });
 });

--- a/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopover_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopover_spec.jsx
@@ -126,9 +126,9 @@ describe('AdhocFilterEditPopover', () => {
     wrapper.instance().onDragDown = sinon.spy();
     wrapper.instance().forceUpdate();
 
-    expect(wrapper.find('i.fa-expand')).toExist();
+    expect(wrapper.find('.fa-expand')).toExist();
     expect(wrapper.instance().onDragDown.calledOnce).toBe(false);
-    wrapper.find('i.fa-expand').simulate('mouseDown', {});
+    wrapper.find('.fa-expand').simulate('mouseDown', {});
     expect(wrapper.instance().onDragDown.calledOnce).toBe(true);
   });
 });

--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
@@ -113,9 +113,9 @@ describe('AdhocMetricEditPopover', () => {
     wrapper.instance().onDragDown = sinon.spy();
     wrapper.instance().forceUpdate();
 
-    expect(wrapper.find('i.fa-expand')).toExist();
+    expect(wrapper.find('.fa-expand')).toExist();
     expect(wrapper.instance().onDragDown.calledOnce).toBe(false);
-    wrapper.find('i.fa-expand').simulate('mouseDown');
+    wrapper.find('.fa-expand').simulate('mouseDown');
     expect(wrapper.instance().onDragDown.calledOnce).toBe(true);
   });
 });

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from 'src/components/Button';
-import { t } from '@superset-ui/core';
+import { styled, t } from '@superset-ui/core';
 
 import Tabs from 'src/common/components/Tabs';
 import columnType from '../propTypes/columnType';
@@ -45,7 +45,11 @@ const propTypes = {
   theme: PropTypes.object,
 };
 
-const startingWidth = 300;
+const ResizeIcon = styled.i`
+  margin-left: ${({ theme }) => theme.gridUnit * 2}px;
+`;
+
+const startingWidth = 320;
 const startingHeight = 240;
 
 export default class AdhocFilterEditPopover extends React.Component {
@@ -63,6 +67,8 @@ export default class AdhocFilterEditPopover extends React.Component {
       width: startingWidth,
       height: startingHeight,
     };
+
+    this.popoverContentRef = React.createRef();
   }
 
   componentDidMount() {
@@ -136,6 +142,7 @@ export default class AdhocFilterEditPopover extends React.Component {
         id="filter-edit-popover"
         {...popoverProps}
         data-test="filter-edit-popover"
+        ref={this.popoverContentRef}
       >
         <Tabs
           id="adhoc-filter-edit-tabs"
@@ -156,6 +163,7 @@ export default class AdhocFilterEditPopover extends React.Component {
               datasource={datasource}
               onHeightChange={this.adjustHeight}
               partitionColumn={partitionColumn}
+              popoverRef={this.popoverContentRef}
             />
           </Tabs.TabPane>
           <Tabs.TabPane
@@ -195,7 +203,7 @@ export default class AdhocFilterEditPopover extends React.Component {
           >
             {t('Save')}
           </Button>
-          <i
+          <ResizeIcon
             role="button"
             aria-label="Resize"
             tabIndex={0}

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -51,6 +51,7 @@ const propTypes = {
   onHeightChange: PropTypes.func.isRequired,
   datasource: PropTypes.object,
   partitionColumn: PropTypes.string,
+  popoverRef: PropTypes.object,
 };
 
 const defaultProps = {
@@ -100,6 +101,12 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
       labelKey: 'label',
       autosize: false,
       clearable: false,
+    };
+
+    this.menuPortalProps = {
+      menuPortalTarget: props.popoverRef.current,
+      menuPosition: 'fixed',
+      menuPlacement: 'bottom',
     };
   }
 
@@ -328,10 +335,11 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     };
 
     return (
-      <span>
+      <>
         <FormGroup className="adhoc-filter-simple-column-dropdown">
           <Select
             {...this.selectProps}
+            {...this.menuPortalProps}
             {...subjectSelectProps}
             name="filter-column"
           />
@@ -339,6 +347,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
         <FormGroup>
           <Select
             {...this.selectProps}
+            {...this.menuPortalProps}
             {...operatorSelectProps}
             name="filter-operator"
           />
@@ -347,6 +356,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
           {MULTI_OPERATORS.has(operator) ||
           this.state.suggestions.length > 0 ? (
             <SelectControl
+              {...this.menuPortalProps}
               name="filter-value"
               autoFocus
               freeForm
@@ -373,7 +383,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
             />
           )}
         </FormGroup>
-      </span>
+      </>
     );
   }
 }

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -74,8 +74,6 @@ function translateOperator(operator) {
   return operator;
 }
 
-const SINGLE_LINE_SELECT_CONTROL_HEIGHT = 30;
-
 export default class AdhocFilterEditPopoverSimpleTabContent extends React.Component {
   constructor(props) {
     super(props);
@@ -87,11 +85,9 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     this.refreshComparatorSuggestions = this.refreshComparatorSuggestions.bind(
       this,
     );
-    this.multiComparatorRef = this.multiComparatorRef.bind(this);
 
     this.state = {
       suggestions: [],
-      multiComparatorHeight: SINGLE_LINE_SELECT_CONTROL_HEIGHT,
       abortActiveRequest: null,
     };
 
@@ -114,15 +110,10 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     this.refreshComparatorSuggestions();
   }
 
-  componentDidMount() {
-    this.handleMultiComparatorInputHeightChange();
-  }
-
   componentDidUpdate(prevProps) {
     if (prevProps.adhocFilter.subject !== this.props.adhocFilter.subject) {
       this.refreshComparatorSuggestions();
     }
-    this.handleMultiComparatorInputHeightChange();
   }
 
   onSubjectChange(option) {
@@ -199,27 +190,6 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     );
   }
 
-  handleMultiComparatorInputHeightChange() {
-    if (this.multiComparatorComponent) {
-      const multiComparatorDOMNode = this.multiComparatorComponent?.select
-        ?.select.controlRef;
-      if (multiComparatorDOMNode) {
-        if (
-          multiComparatorDOMNode.clientHeight !==
-          this.state.multiComparatorHeight
-        ) {
-          this.props.onHeightChange(
-            multiComparatorDOMNode.clientHeight -
-              this.state.multiComparatorHeight,
-          );
-          this.setState({
-            multiComparatorHeight: multiComparatorDOMNode.clientHeight,
-          });
-        }
-      }
-    }
-  }
-
   refreshComparatorSuggestions() {
     const { datasource } = this.props;
     const col = this.props.adhocFilter.subject;
@@ -274,12 +244,6 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
   focusComparator(ref) {
     if (ref) {
       ref.focus();
-    }
-  }
-
-  multiComparatorRef(ref) {
-    if (ref) {
-      this.multiComparatorComponent = ref;
     }
   }
 
@@ -367,7 +331,6 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
               onChange={this.onComparatorChange}
               showHeader={false}
               noResultsText={t('type a value here')}
-              selectRef={this.multiComparatorRef}
               disabled={DISABLE_INPUT_OPERATORS.includes(operator)}
             />
           ) : (

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -100,7 +100,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
     };
 
     this.menuPortalProps = {
-      menuPortalTarget: props.popoverRef.current,
+      menuPortalTarget: props.popoverRef?.current || document.body,
       menuPosition: 'fixed',
       menuPlacement: 'bottom',
     };

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
@@ -132,7 +132,7 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
           <SQLEditor
             ref={this.handleAceEditorRef}
             keywords={keywords}
-            height={`${height - 100}px`}
+            height={`${height - 130}px`}
             onChange={this.onSqlExpressionChange}
             width="100%"
             showGutter={false}

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -264,7 +264,7 @@ export default class AdhocMetricEditPopover extends React.Component {
                   showLoadingForImport
                   ref={this.handleAceEditorRef}
                   keywords={keywords}
-                  height={`${this.state.height - 43}px`}
+                  height={`${this.state.height - 80}px`}
                   onChange={this.onSqlExpressionChange}
                   width="100%"
                   showGutter={false}
@@ -286,6 +286,14 @@ export default class AdhocMetricEditPopover extends React.Component {
         </Tabs>
         <div>
           <Button
+            buttonSize="small"
+            onClick={this.props.onClose}
+            data-test="AdhocMetricEdit#cancel"
+            cta
+          >
+            Close
+          </Button>
+          <Button
             disabled={!stateIsValid}
             buttonStyle={
               hasUnsavedChanges && stateIsValid ? 'primary' : 'default'
@@ -297,14 +305,6 @@ export default class AdhocMetricEditPopover extends React.Component {
             cta
           >
             Save
-          </Button>
-          <Button
-            buttonSize="small"
-            onClick={this.props.onClose}
-            data-test="AdhocMetricEdit#cancel"
-            cta
-          >
-            Close
           </Button>
           <i
             role="button"

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -22,7 +22,7 @@ import { FormGroup } from 'react-bootstrap';
 import Tabs from 'src/common/components/Tabs';
 import Button from 'src/components/Button';
 import Select from 'src/components/Select';
-import { t } from '@superset-ui/core';
+import { styled, t } from '@superset-ui/core';
 import { ColumnOption } from '@superset-ui/chart-controls';
 
 import FormLabel from 'src/components/FormLabel';
@@ -50,7 +50,11 @@ const defaultProps = {
   columns: [],
 };
 
-const startingWidth = 300;
+const ResizeIcon = styled.i`
+  margin-left: ${({ theme }) => theme.gridUnit * 2}px;
+`;
+
+const startingWidth = 320;
 const startingHeight = 240;
 
 export default class AdhocMetricEditPopover extends React.Component {
@@ -65,17 +69,28 @@ export default class AdhocMetricEditPopover extends React.Component {
     this.onMouseUp = this.onMouseUp.bind(this);
     this.handleAceEditorRef = this.handleAceEditorRef.bind(this);
     this.refreshAceEditor = this.refreshAceEditor.bind(this);
+
+    this.popoverRef = React.createRef();
+
     this.state = {
       adhocMetric: this.props.adhocMetric,
       width: startingWidth,
       height: startingHeight,
     };
+
     this.selectProps = {
       labelKey: 'label',
       isMulti: false,
       autosize: false,
       clearable: true,
     };
+
+    this.menuPortalProps = {
+      menuPosition: 'fixed',
+      menuPlacement: 'bottom',
+      menuPortalTarget: this.popoverRef.current,
+    };
+
     document.addEventListener('mouseup', this.onMouseUp);
   }
 
@@ -215,6 +230,7 @@ export default class AdhocMetricEditPopover extends React.Component {
       <div
         id="metrics-edit-popover"
         data-test="metrics-edit-popover"
+        ref={this.popoverRef}
         {...popoverProps}
       >
         <Tabs
@@ -237,6 +253,7 @@ export default class AdhocMetricEditPopover extends React.Component {
               <Select
                 name="select-column"
                 {...this.selectProps}
+                {...this.menuPortalProps}
                 {...columnSelectProps}
               />
             </FormGroup>
@@ -247,6 +264,7 @@ export default class AdhocMetricEditPopover extends React.Component {
               <Select
                 name="select-aggregate"
                 {...this.selectProps}
+                {...this.menuPortalProps}
                 {...aggregateSelectProps}
                 autoFocus
               />
@@ -299,14 +317,13 @@ export default class AdhocMetricEditPopover extends React.Component {
               hasUnsavedChanges && stateIsValid ? 'primary' : 'default'
             }
             buttonSize="small"
-            className="m-r-5"
             data-test="AdhocMetricEdit#save"
             onClick={this.onSave}
             cta
           >
             Save
           </Button>
-          <i
+          <ResizeIcon
             role="button"
             aria-label="Resize"
             tabIndex={0}

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -53,6 +53,9 @@ const propTypes = {
   filterOption: PropTypes.func,
   promptTextCreator: PropTypes.func,
   commaChoosesOption: PropTypes.bool,
+  menuPortalTarget: PropTypes.element,
+  menuPosition: PropTypes.string,
+  menuPlacement: PropTypes.string,
 };
 
 const defaultProps = {
@@ -219,6 +222,9 @@ export default class SelectControl extends React.PureComponent {
       filterOption: this.props.filterOption,
       promptTextCreator: this.props.promptTextCreator,
       ignoreAccents: false,
+      menuPortalTarget: this.props.menuPortalTarget,
+      menuPosition: this.props.menuPosition,
+      menuPlacement: this.props.menuPlacement,
     };
 
     let SelectComponent;


### PR DESCRIPTION
### SUMMARY
Fixes issues described in https://github.com/apache/incubator-superset/issues/11546.
There was also another bug - select menu wasn't fully visible when it overflew the popover (which is almost always) - see the first gif.
The filters popover was jumpy and it was related to `handleMultiComparatorInputHeightChange` function in `AdhocFilterEditPopoverSimpleTabContent.jsx` file. I removed it, however if it was actually necessary for something I'd appreciate a feedback (@ktmud the last changes to that function was done by you - can you take a look?). 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![before-fix](https://user-images.githubusercontent.com/15073128/98257715-4b07a800-1f80-11eb-98e9-09a5d3525fec.gif)

After:
![after-fix](https://user-images.githubusercontent.com/15073128/98257741-50fd8900-1f80-11eb-9ae0-86e2fd48f87c.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11546
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
