### PR TITLE
fix: changed top overflow for charts

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -45,6 +45,7 @@ const propTypes = {
 const Styles = styled.div`
   height: 100%;
   max-height: 100%;
+  overflow: auto;
   .remove-alert {
     cursor: pointer;
   }

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -59,7 +59,6 @@ const propTypes = {
 const Styles = styled.div`
   height: ${({ height }) => height};
   min-height: ${({ height }) => height};
-  overflow: hidden;
   text-align: left;
   position: relative;
   width: 100%;

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -54,6 +54,7 @@ const getHotKeys = () =>
 
 const Styles = styled.div`
   display: flex;
+  flex-shrink: 0;
   flex-direction: row;
   align-items: center;
   padding-bottom: ${({ theme }) => 2 * theme.gridUnit}px;


### PR DESCRIPTION
### SUMMARY
The top of charts was overflowed when changed to another type of chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before

![Screenshot 2020-11-05 at 12 59 40](https://user-images.githubusercontent.com/2536609/98263122-b94f6900-1f86-11eb-985c-22857897fb1c.png)

After:

![Screenshot 2020-11-05 at 16 51 55](https://user-images.githubusercontent.com/2536609/98263533-3ed31900-1f87-11eb-9961-2ccd4e5138c6.png)


### TEST PLAN
It's not exact reproduction of issue but go to the charts and pick one of them. Click on one of the filters on left and then click tab a lot of times (until focus goes to the bottom of page). Tab shouldn't break like in screen in before section (on master it did).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11541
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
