### PR TITLE
fix: filters push out apply button on dashboard

### DIFF
--- a/superset-frontend/src/components/Select/OnPasteSelect.jsx
+++ b/superset-frontend/src/components/Select/OnPasteSelect.jsx
@@ -76,7 +76,13 @@ export default class OnPasteSelect extends React.Component {
 
   render() {
     const { selectWrap: SelectComponent, ...restProps } = this.props;
-    return <SelectComponent {...restProps} onPaste={this.onPaste} menuPortalTarget={document.body} />;
+    return (
+      <SelectComponent
+        {...restProps}
+        onPaste={this.onPaste}
+        menuPortalTarget={document.body}
+      />
+    );
   }
 }
 

--- a/superset-frontend/src/components/Select/OnPasteSelect.jsx
+++ b/superset-frontend/src/components/Select/OnPasteSelect.jsx
@@ -76,7 +76,7 @@ export default class OnPasteSelect extends React.Component {
 
   render() {
     const { selectWrap: SelectComponent, ...restProps } = this.props;
-    return <SelectComponent {...restProps} onPaste={this.onPaste} />;
+    return <SelectComponent {...restProps} onPaste={this.onPaste} menuPortalTarget={document.body} />;
   }
 }
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -276,7 +276,7 @@ class Chart extends React.Component {
       : {};
 
     return (
-      <div>
+      <div className="chart-slice">
         <SliceHeader
           innerRef={this.setHeaderRef}
           slice={slice}

--- a/superset-frontend/src/dashboard/stylesheets/components/chart.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/chart.less
@@ -23,6 +23,7 @@
   background-color: @lightest;
   position: relative;
   padding: 16px;
+  overflow-y: auto;
 
   // transitionable traits for when a filter is being actively focused
   transition: opacity 0.2s, border-color 0.2s, box-shadow 0.2s;

--- a/superset-frontend/src/dashboard/stylesheets/components/chart.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/chart.less
@@ -112,6 +112,10 @@
   }
 }
 
+.chart-slice {
+  height: calc(100% - 32px);
+}
+
 .dot {
   @dot-diameter: 4px;
 


### PR DESCRIPTION
### SUMMARY
Changed behaviour of too big filter block:
* Added class and calculated height (100%-padding) for blocks -> otherwise scroll was appearing in every chart
* Added auto overflow for blocks on dashboards so scroll will appear when there will be too many filters
* Added `menuPortalTarget` because dropdown menu was limited to the box of chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1038" alt="97113844-1fe0a700-16aa-11eb-9be6-879800b42ca2" src="https://user-images.githubusercontent.com/2536609/98274018-384a9e80-1f93-11eb-848f-30f2f9327642.png">

After:
![Large GIF (490x694)](https://user-images.githubusercontent.com/2536609/98274825-33d2b580-1f94-11eb-9297-3fe34b6e6bdc.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11419
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
