### PR TITLE
feat(dashboard): leaner filter indicator panel with wrapped text

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useState } from 'react';
-import { t, tn, useTheme } from '@superset-ui/core';
+import { t, useTheme } from '@superset-ui/core';
 import {
   SearchOutlined,
   MinusCircleFilled,
@@ -32,7 +32,6 @@ import {
   Panel,
   Reset,
   Title,
-  Summary,
   FilterValue,
 } from './Styles';
 import { Indicator } from './selectors';
@@ -105,16 +104,8 @@ const DetailsPanelPopover = ({
     }
   }
 
-  const total =
-    appliedIndicators.length +
-    incompatibleIndicators.length +
-    unsetIndicators.length;
-
   const content = (
     <Panel>
-      <Summary>
-        {tn('%d Scoped Filter', '%d Scoped Filters', total, total)}
-      </Summary>
       <Reset>
         <Collapse
           ghost

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel.tsx
@@ -25,7 +25,16 @@ import {
   ExclamationCircleFilled,
 } from '@ant-design/icons';
 import { Collapse, Popover } from 'src/common/components/index';
-import { Indent, Item, ItemIcon, Panel, Reset, Title, Summary } from './Styles';
+import {
+  Indent,
+  Item,
+  ItemIcon,
+  Panel,
+  Reset,
+  Title,
+  Summary,
+  FilterValue,
+} from './Styles';
 import { Indicator } from './selectors';
 
 export interface IndicatorProps {
@@ -39,11 +48,14 @@ const Indicator = ({
 }: IndicatorProps) => {
   return (
     <Item onClick={() => onClick([...path, `LABEL-${column}`])}>
-      <ItemIcon>
-        <SearchOutlined />
-      </ItemIcon>
-      <Title bold>{name.toUpperCase()}</Title>
-      {value.length ? `: ${value.join(', ')}` : ''}
+      <Title bold>
+        <ItemIcon>
+          <SearchOutlined />
+        </ItemIcon>
+        {name.toUpperCase()}
+        {value.length ? ': ' : ''}
+      </Title>
+      <FilterValue>{value.length ? value.join(', ') : ''}</FilterValue>
     </Item>
   );
 };
@@ -115,7 +127,7 @@ const DetailsPanelPopover = ({
               header={
                 <Title bold>
                   <CheckCircleFilled color={theme.colors.success.base} />{' '}
-                  {t('Applied (%d)', appliedIndicators.length)}
+                  {t('Applied Filters (%d)', appliedIndicators.length)}
                 </Title>
               }
             >
@@ -136,7 +148,10 @@ const DetailsPanelPopover = ({
               header={
                 <Title bold>
                   <ExclamationCircleFilled color={theme.colors.alert.base} />{' '}
-                  {t('Incompatible (%d)', incompatibleIndicators.length)}
+                  {t(
+                    'Incompatible Filters (%d)',
+                    incompatibleIndicators.length,
+                  )}
                 </Title>
               }
             >
@@ -157,7 +172,7 @@ const DetailsPanelPopover = ({
               header={
                 <Title bold>
                   <MinusCircleFilled />{' '}
-                  {t('Unset (%d)', unsetIndicators.length)}
+                  {t('Unset Filters (%d)', unsetIndicators.length)}
                 </Title>
               }
               disabled={!unsetIndicators.length}

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -87,17 +87,14 @@ export interface TitleProps {
 }
 
 export const Title = styled.span<TitleProps>`
+  position: relative;
+  margin-right: ${({ theme }) => theme.gridUnit}px;
   font-weight: ${({ bold, theme }) => {
     return bold ? theme.typography.weights.bold : 'auto';
   }};
 `;
 
-export const Summary = styled.div`
-  font-weight: ${({ theme }) => theme.typography.weights.bold};
-`;
-
 export const ItemIcon = styled.i`
-  display: none;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -106,20 +103,26 @@ export const ItemIcon = styled.i`
 
 export const Item = styled.button`
   cursor: pointer;
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  text-align: left;
   padding: 0;
   border: none;
   background: none;
-  white-space: nowrap;
-  position: relative;
   outline: none;
+  width: 100%;
 
   &::-moz-focus-inner {
     border: 0;
   }
 
-  &:hover > i {
-    display: block;
+  & i svg {
+    color: transparent;
+    margin-right: ${({ theme }) => theme.gridUnit}px;
+  }
+
+  &:hover i svg {
+    color: inherit;
   }
 `;
 
@@ -134,6 +137,12 @@ export const Indent = styled.div`
 
 export const Panel = styled.div`
   min-width: 200px;
-  max-width: 400px;
+  max-width: 300px;
   overflow-x: hidden;
+`;
+
+export const FilterValue = styled.div`
+  max-width: 100%;
+  flex-grow: 1;
+  overflow: auto;
 `;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- decreased max width of panel from 400 to 300px
- text wrap on filter values (it stays next to the filter name if there's room, and flex-wraps underneath if necessary)
- removed the "X Scoped Filters" title, it was a bit redundant

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Both screenshots are after the change (can see before screenshot in #11591):

<img width="321" alt="Screen Shot 2020-11-05 at 3 50 59 PM" src="https://user-images.githubusercontent.com/1858430/98310073-f9135200-1f80-11eb-969b-62bf359146b2.png">
<img width="382" alt="Screen Shot 2020-11-05 at 3 51 44 PM" src="https://user-images.githubusercontent.com/1858430/98310083-fadd1580-1f80-11eb-9f97-fc40c4fc874a.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #11591
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
