### PR TITLE
fix(dashboard): use server-side lastModifiedTime for co-edit check

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/reducers/dashboardState_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/reducers/dashboardState_spec.js
@@ -131,19 +131,22 @@ describe('dashboardState reducer', () => {
     expect(result.updatedColorScheme).toBe(false);
   });
 
-  it('should set lastModifiedTime on save', () => {
-    const lastModifiedTime = Math.round(new Date().getTime() / 1000);
+  it('should reset lastModifiedTime on save', () => {
+    const initTime = new Date().getTime() / 1000;
     dashboardStateReducer(
       {
-        lastModifiedTime,
+        lastModifiedTime: initTime,
       },
       {},
     );
 
+    const lastModifiedTime = Math.round(new Date().getTime() / 1000);
     expect(
-      dashboardStateReducer({ hasUnsavedChanges: true }, { type: ON_SAVE })
-        .lastModifiedTime,
-    ).toBeGreaterThanOrEqual(lastModifiedTime);
+      dashboardStateReducer(
+        { hasUnsavedChanges: true },
+        { type: ON_SAVE, lastModifiedTime },
+      ).lastModifiedTime,
+    ).toBeGreaterThanOrEqual(initTime);
   });
 
   it('should clear the focused filter field', () => {

--- a/superset-frontend/spec/javascripts/dashboard/reducers/dashboardState_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/reducers/dashboardState_spec.js
@@ -132,7 +132,7 @@ describe('dashboardState reducer', () => {
   });
 
   it('should set lastModifiedTime on save', () => {
-    const lastModifiedTime = new Date().getTime() / 1000;
+    const lastModifiedTime = Math.round(new Date().getTime() / 1000);
     dashboardStateReducer(
       {
         lastModifiedTime,

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -152,8 +152,8 @@ export function onChange() {
 }
 
 export const ON_SAVE = 'ON_SAVE';
-export function onSave() {
-  return { type: ON_SAVE };
+export function onSave(lastModifiedTime) {
+  return { type: ON_SAVE, lastModifiedTime };
 }
 
 export const SET_REFRESH_FREQUENCY = 'SET_REFRESH_FREQUENCY';
@@ -161,9 +161,9 @@ export function setRefreshFrequency(refreshFrequency, isPersistent = false) {
   return { type: SET_REFRESH_FREQUENCY, refreshFrequency, isPersistent };
 }
 
-export function saveDashboardRequestSuccess() {
+export function saveDashboardRequestSuccess(lastModifiedTime) {
   return dispatch => {
-    dispatch(onSave());
+    dispatch(onSave(lastModifiedTime));
     // clear layout undo history
     dispatch(UndoActionCreators.clearHistory());
   };
@@ -199,7 +199,7 @@ export function saveDashboardRequest(data, id, saveType) {
       },
     })
       .then(response => {
-        dispatch(saveDashboardRequestSuccess());
+        dispatch(saveDashboardRequestSuccess(response.json.last_modified_time));
         dispatch(addSuccessToast(t('This dashboard was saved successfully.')));
         return response;
       })

--- a/superset-frontend/src/dashboard/reducers/dashboardInfo.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardInfo.js
@@ -25,7 +25,8 @@ export default function dashboardStateReducer(state = {}, action) {
       return {
         ...state,
         ...action.newInfo,
-        lastModifiedTime: new Date().getTime() / 1000,
+        // server-side compare last_modified_time in second level
+        lastModifiedTime: Math.round(new Date().getTime() / 1000),
       };
     default:
       return state;

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -107,7 +107,7 @@ export default function dashboardStateReducer(state = {}, action) {
         editMode: false,
         updatedColorScheme: false,
         // server-side compare last_modified_time in second level
-        lastModifiedTime: new Date().getTime() / 1000,
+        lastModifiedTime: Math.round(new Date().getTime() / 1000),
       };
     },
     [SET_UNSAVED_CHANGES]() {

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -106,8 +106,8 @@ export default function dashboardStateReducer(state = {}, action) {
         maxUndoHistoryExceeded: false,
         editMode: false,
         updatedColorScheme: false,
-        // server-side compare last_modified_time in second level
-        lastModifiedTime: Math.round(new Date().getTime() / 1000),
+        // server-side returns last_modified_time for latest change
+        lastModifiedTime: action.lastModifiedTime,
       };
     },
     [SET_UNSAVED_CHANGES]() {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1085,8 +1085,14 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         DashboardDAO.set_dash_metadata(dash, data)
         session.merge(dash)
         session.commit()
+
+        # get updated changed_on
+        dash = session.query(Dashboard).get(dashboard_id)
+        last_modified_time = dash.changed_on.replace(microsecond=0).timestamp()
         session.close()
-        return json_success(json.dumps({"status": "SUCCESS"}))
+        return json_success(
+            json.dumps({"status": "SUCCESS", "last_modified_time": last_modified_time,})
+        )
 
     @api
     @has_access_api


### PR DESCRIPTION
### SUMMARY
In #11220 and #11305, we introduced a feature that prevent mid-air collision when 2 users editing same dashboard. There are some users in airbnb reported that when only 1 user editing dashboard a couple of times they will see the warning message, even there is no co-editing happens, see issue #11477

When i debug this issue, i found when error happens, it shows client-side last_updated_time and dashboard's changed_on has a very subtle mis-match, for example:

```
remote:1604869261.688
changed_on:1604869262.0
```
it seems dashboards table's changed_on is rounded-up to second level, while client-side last_update_time is not. 
So i will add a round function in client-side and try to make this number match in the second level.


### TEST PLAN
CI and manual test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11220 and #11305 

cc @ktmud @eschutho @mistercrunch @zuzana-vej 