### PR TITLE
fix(viz treemap): Cannot nest more than three levels

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -972,7 +972,12 @@ class TreemapViz(BaseViz):
         if nlevels == 1:
             result = [{"name": n, "value": v} for n, v in zip(df.index, df[metric])]
         else:
-            this_level_index = {i[0] for i in df.index}
+            this_level_index_set = set()
+            this_level_index = []
+            for i in df.index:
+                if i[0] not in this_level_index_set:
+                    this_level_index.append(i[0])
+                    this_level_index_set.add(i[0])
             result = [
                 {"name": l, "children": self._nest(metric, df.loc[l])}
                 for l in this_level_index

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -972,9 +972,10 @@ class TreemapViz(BaseViz):
         if nlevels == 1:
             result = [{"name": n, "value": v} for n, v in zip(df.index, df[metric])]
         else:
+            this_level_index = {i[0] for i in df.index}
             result = [
                 {"name": l, "children": self._nest(metric, df.loc[l])}
-                for l in df.index.levels[0]
+                for l in this_level_index
             ]
         return result
 

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -1430,7 +1430,6 @@ class TestTreemapViz(SupersetTestCase):
                 [111, 112, 121, 122, 211, 212, 221, 222],
             ],
         )
-        #  Before fixing, this line will raise a keyerror
         result = test_viz._nest(metric="a", df=df)
         expected = [
             {

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -1391,25 +1391,85 @@ class TestTreemapViz(SupersetTestCase):
         datasource = self.get_datasource_mock()
         form_data = {}
         test_viz = viz.TreemapViz(datasource, form_data)
-        df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8]},
-                          index=[[1, 1, 1, 1, 2, 2, 2, 2], [11, 11, 12, 12, 21, 21, 22, 22]])
-        # Correct
-        result = test_viz._nest(metric='a', df=df)
-        self.assertTrue(bool(result))
-        self.assertTrue(isinstance(result, list))
-        self.assertTrue(result[0]['children'][3]['value'] == 4)
-        self.assertTrue(len(result[0]['children']) == 4)
+        df = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8]},
+            index=[[1, 1, 1, 1, 2, 2, 2, 2], [11, 11, 12, 12, 21, 21, 22, 22]],
+        )
+        result = test_viz._nest(metric="a", df=df)
+        expected = [
+            {
+                "name": 1,
+                "children": [
+                    {"name": 11, "value": 1},
+                    {"name": 11, "value": 2},
+                    {"name": 12, "value": 3},
+                    {"name": 12, "value": 4},
+                ],
+            },
+            {
+                "name": 2,
+                "children": [
+                    {"name": 21, "value": 5},
+                    {"name": 21, "value": 6},
+                    {"name": 22, "value": 7},
+                    {"name": 22, "value": 8},
+                ],
+            },
+        ]
+        self.assertEqual(result, expected)
 
     def test_nest3(self):
         datasource = self.get_datasource_mock()
         form_data = {}
         test_viz = viz.TreemapViz(datasource, form_data)
-        df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8]},
-                          index=[[1, 1, 1, 1, 2, 2, 2, 2], [11, 11, 12, 12, 21, 21, 22, 22],
-                                 [111, 112, 121, 122, 211, 212, 221, 222]])
+        df = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8]},
+            index=[
+                [1, 1, 1, 1, 2, 2, 2, 2],
+                [11, 11, 12, 12, 21, 21, 22, 22],
+                [111, 112, 121, 122, 211, 212, 221, 222],
+            ],
+        )
         #  Before fixing, this line will raise a keyerror
-        result = test_viz._nest(metric='a', df=df)
-        self.assertTrue(len(result)==2)
-        self.assertTrue(result[0]['name']==1)
-        self.assertTrue(result[0]['children'][0]['name']==11)
-        self.assertTrue(result[0]['children'][0]['children'][0]['name'] == 111)
+        result = test_viz._nest(metric="a", df=df)
+        expected = [
+            {
+                "name": 1,
+                "children": [
+                    {
+                        "name": 11,
+                        "children": [
+                            {"name": 111, "value": 1},
+                            {"name": 112, "value": 2},
+                        ],
+                    },
+                    {
+                        "name": 12,
+                        "children": [
+                            {"name": 121, "value": 3},
+                            {"name": 122, "value": 4},
+                        ],
+                    },
+                ],
+            },
+            {
+                "name": 2,
+                "children": [
+                    {
+                        "name": 21,
+                        "children": [
+                            {"name": 211, "value": 5},
+                            {"name": 212, "value": 6},
+                        ],
+                    },
+                    {
+                        "name": 22,
+                        "children": [
+                            {"name": 221, "value": 7},
+                            {"name": 222, "value": 8},
+                        ],
+                    },
+                ],
+            },
+        ]
+        self.assertEqual(result, expected)

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -1384,3 +1384,32 @@ class TestPivotTableViz(SupersetTestCase):
     def test_format_datetime_from_int(self):
         assert viz.PivotTableViz._format_datetime(123) == 123
         assert viz.PivotTableViz._format_datetime(123.0) == 123.0
+
+
+class TestTreemapViz(SupersetTestCase):
+    def test_nest2(self):
+        datasource = self.get_datasource_mock()
+        form_data = {}
+        test_viz = viz.TreemapViz(datasource, form_data)
+        df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8]},
+                          index=[[1, 1, 1, 1, 2, 2, 2, 2], [11, 11, 12, 12, 21, 21, 22, 22]])
+        # Correct
+        result = test_viz._nest(metric='a', df=df)
+        self.assertTrue(bool(result))
+        self.assertTrue(isinstance(result, list))
+        self.assertTrue(result[0]['children'][3]['value'] == 4)
+        self.assertTrue(len(result[0]['children']) == 4)
+
+    def test_nest3(self):
+        datasource = self.get_datasource_mock()
+        form_data = {}
+        test_viz = viz.TreemapViz(datasource, form_data)
+        df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8]},
+                          index=[[1, 1, 1, 1, 2, 2, 2, 2], [11, 11, 12, 12, 21, 21, 22, 22],
+                                 [111, 112, 121, 122, 211, 212, 221, 222]])
+        #  Before fixing, this line will raise a keyerror
+        result = test_viz._nest(metric='a', df=df)
+        self.assertTrue(len(result)==2)
+        self.assertTrue(result[0]['name']==1)
+        self.assertTrue(result[0]['children'][0]['name']==11)
+        self.assertTrue(result[0]['children'][0]['children'][0]['name'] == 111)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Treemap cannot be nested more than three levels before I modify it.
If the nesting is more than three levels, keyerror will be raised.
The unit tests I added can replicate this problem.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Create a new chart

Select tree map

Select at least three dimensions in group by, and each dimension has at least two cardinalities

Run this query

This will trigger a keyerror before I modify it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
