### PR TITLE
feat: support 'chevron' library for templating as jinja alternative

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ setup(
         "teradata": ["sqlalchemy-teradata==0.9.0.dev0"],
         "thumbnails": ["Pillow>=7.0.0, <8.0.0"],
         "vertica": ["sqlalchemy-vertica-python>=0.5.9, < 0.6"],
+        "chevron": ["chevron==0.13.1"],
     },
     python_requires="~=3.6",
     author="Apache Software Foundation",

--- a/superset/config.py
+++ b/superset/config.py
@@ -302,6 +302,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "CLIENT_CACHE": False,
     "ENABLE_EXPLORE_JSON_CSRF_PROTECTION": False,
     "ENABLE_TEMPLATE_PROCESSING": False,
+    "CHEVRON_TEMPLATE_PROCESSING": False,
     "KV_STORE": False,
     "PRESTO_EXPAND_DATA": False,
     # Exposes API endpoint to compute thumbnails

--- a/superset/config.py
+++ b/superset/config.py
@@ -301,8 +301,16 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Experimental feature introducing a client (browser) cache
     "CLIENT_CACHE": False,
     "ENABLE_EXPLORE_JSON_CSRF_PROTECTION": False,
+    # -----------------------------------
+    # Template processing section
+    # -----------------------------------
+    # Whether any template processing is enabled at all
     "ENABLE_TEMPLATE_PROCESSING": False,
+    # Use jinja2, most powerful but has potential security pitfalls
+    "JINJA_TEMPLATE_PROCESSING": True,
+    # Use Chevron, a python implementation of mustache.js
     "CHEVRON_TEMPLATE_PROCESSING": False,
+    # -----------------------------------
     "KV_STORE": False,
     "PRESTO_EXPAND_DATA": False,
     # Exposes API endpoint to compute thumbnails

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -257,6 +257,15 @@ class NoOpTemplateProcessor(
         return sql
 
 
+class ChevronTemplateProcessor(
+    BaseTemplateProcessor
+):  # pylint: disable=too-few-public-methods
+    def process_template(self, sql: str, **kwargs: Any) -> str:
+        import chevron  # late import for optional dependency
+
+        return chevron.render(sql, kwargs)
+
+
 class PrestoTemplateProcessor(BaseTemplateProcessor):
     """Presto Jinja context
 
@@ -338,6 +347,8 @@ def get_template_processor(
         template_processor = template_processors.get(
             database.backend, BaseTemplateProcessor
         )
+    elif feature_flag_manager.is_feature_enabled("CHEVRON_TEMPLATE_PROCESSING"):
+        template_processor = ChevronTemplateProcessor
     else:
         template_processor = NoOpTemplateProcessor
     return template_processor(database=database, table=table, query=query, **kwargs)

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -343,12 +343,14 @@ def get_template_processor(
     query: Optional["Query"] = None,
     **kwargs: Any,
 ) -> BaseTemplateProcessor:
+    template_processor = None
     if feature_flag_manager.is_feature_enabled("ENABLE_TEMPLATE_PROCESSING"):
-        template_processor = template_processors.get(
-            database.backend, BaseTemplateProcessor
-        )
-    elif feature_flag_manager.is_feature_enabled("CHEVRON_TEMPLATE_PROCESSING"):
-        template_processor = ChevronTemplateProcessor
-    else:
+        if feature_flag_manager.is_feature_enabled("JINJA_TEMPLATE_PROCESSING"):
+            template_processor = template_processors.get(
+                database.backend, BaseTemplateProcessor
+            )
+        elif feature_flag_manager.is_feature_enabled("CHEVRON_TEMPLATE_PROCESSING"):
+            template_processor = ChevronTemplateProcessor
+    if not template_processor:
         template_processor = NoOpTemplateProcessor
     return template_processor(database=database, table=table, query=query, **kwargs)


### PR DESCRIPTION
### SUMMARY
[chevron](https://github.com/noahmorrison/chevron) is a python implementation of mustache.js, and seems much safer by scope (project tagline is "Logic-less templates" !) than `jinja2` could ever be.

While the library is not super active lately, it appears to be feature complete and is easy to review from a security standpoint as it's a few short-ish modules. Overall the whole library is <1k lines.

This PR adds support for the chevron library behind a feature flag.


### SHORTCOMINGS
- one shortcoming is the html escaping that we have to work around using triple curlies ie:`{{{ ... }}}`. I submitted a PR to enable turning this off in our context here https://github.com/noahmorrison/chevron/pull/81
- accessing a position in an array seems impossible in the release using the undocumented `{{mylist.0}}` mustache feature, but works in chevron's `master`, highlighting the fact that the lib hasn't released to PyPI in a long time
- given the security risks here, we should do a full audit of chevron's [small] codebase, and pin the lib. Bumping the lib should force a deep analysis of the changelog/changeset to make sure there are no security regressions

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="427" alt="Screen Shot 2020-11-08 at 10 10 55 PM" src="https://user-images.githubusercontent.com/487433/98505994-65a38080-220f-11eb-8840-fa3da51a8407.png">
