### PR TITLE
feat: keep modal open when saving database failed

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/database/helper.ts
+++ b/superset-frontend/cypress-base/cypress/integration/database/helper.ts
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+export const DATABASE_LIST = '/databaseview/list';

--- a/superset-frontend/cypress-base/cypress/integration/database/modal.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/database/modal.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { DATABASE_LIST } from './helper';
+
+describe('Add database', () => {
+  beforeEach(() => {
+    cy.server();
+    cy.login();
+  });
+
+  it('should keep create modal open when error', () => {
+    cy.visit(DATABASE_LIST);
+
+    // open modal
+    cy.get('[data-test="btn-create-database"]').click();
+
+    // type values
+    cy.get('[data-test="database-modal"] input[name="database_name"]')
+      .focus()
+      .type('cypress');
+    cy.get('[data-test="database-modal"] input[name="sqlalchemy_uri"]')
+      .focus()
+      .type('bad_db_uri');
+
+    // click save
+    cy.get('[data-test="modal-confirm-button"]:not(:disabled)').click();
+
+    // should show error alerts and keep modal open
+    cy.get('.toast').contains('error');
+    cy.wait(1000); // wait for potential (incorrect) closing annimation
+    cy.get('[data-test="database-modal"]').should('be.visible');
+
+    // should be able to close modal
+    cy.get('[data-test="modal-cancel-button"]').click();
+    cy.get('[data-test="database-modal"]').should('not.be.visible');
+  });
+
+  it('should keep update modal open when error', () => {
+    // open modal
+    cy.get('[data-test="database-edit"]:last').click();
+
+    cy.get('[data-test="database-modal"]:last input[name="sqlalchemy_uri"]')
+      .focus()
+      .dblclick()
+      .type('{selectall}{backspace}bad_uri');
+
+    // click save
+    cy.get('[data-test="modal-confirm-button"]:not(:disabled)').click();
+
+    // should show error alerts
+    cy.get('.toast').contains('error').should('be.visible');
+
+    // modal should still be open
+    cy.wait(1000); // wait for potential (incorrect) closing annimation
+    cy.get('[data-test="database-modal"]').should('be.visible');
+  });
+});

--- a/superset-frontend/src/common/components/Modal/Modal.tsx
+++ b/superset-frontend/src/common/components/Modal/Modal.tsx
@@ -32,6 +32,7 @@ interface ModalProps {
   primaryButtonName?: string;
   primaryButtonType?: 'primary' | 'danger';
   show: boolean;
+  name?: string;
   title: React.ReactNode;
   width?: string;
   maxWidth?: string;
@@ -114,6 +115,7 @@ const CustomModal = ({
   primaryButtonName = t('OK'),
   primaryButtonType = 'primary',
   show,
+  name,
   title,
   width,
   maxWidth,
@@ -159,7 +161,7 @@ const CustomModal = ({
         </span>
       }
       footer={!hideFooter ? modalFooter : null}
-      wrapProps={{ 'data-test': `${title}-modal`, ...wrapProps }}
+      wrapProps={{ 'data-test': `${name || title}-modal`, ...wrapProps }}
       {...rest}
     >
       {children}

--- a/superset-frontend/src/utils/getClientErrorObject.ts
+++ b/superset-frontend/src/utils/getClientErrorObject.ts
@@ -29,7 +29,9 @@ export type ClientErrorObject = {
   error: string;
   errors?: SupersetError[];
   link?: string;
-  message?: string;
+  // marshmallow field validation returns the error mssage in the format
+  // of { field: [msg1, msg2] }
+  message?: string | Record<string, string[]>;
   severity?: string;
   stacktrace?: string;
 } & Partial<SupersetClientResponse>;

--- a/superset-frontend/src/utils/getClientErrorObject.ts
+++ b/superset-frontend/src/utils/getClientErrorObject.ts
@@ -31,7 +31,7 @@ export type ClientErrorObject = {
   link?: string;
   // marshmallow field validation returns the error mssage in the format
   // of { field: [msg1, msg2] }
-  message?: string | Record<string, string[]>;
+  message?: string;
   severity?: string;
   stacktrace?: string;
 } & Partial<SupersetClientResponse>;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -132,6 +132,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
   if (canCreate) {
     menuData.buttons = [
       {
+        'data-test': 'btn-create-database',
         name: (
           <>
             <i className="fa fa-plus" /> {t('Database')}{' '}
@@ -295,6 +296,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
                 >
                   <span
                     role="button"
+                    data-test="database-edit"
                     tabIndex={0}
                     className="action-button"
                     onClick={handleEdit}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -175,7 +175,13 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       .catch(response =>
         getClientErrorObject(response).then(error => {
           addDangerToast(
-            t('ERROR: Connection failed. ') + error?.message || '',
+            error?.message
+              ? `${t('ERROR: ')}${
+                  typeof error.message === 'string'
+                    ? error.message
+                    : error.message.sqlalchemy_uri
+                }`
+              : t('ERROR: Connection failed. '),
           );
         }),
       );
@@ -358,6 +364,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                 type="text"
                 name="sqlalchemy_uri"
                 value={db ? db.sqlalchemy_uri : ''}
+                autoComplete="off"
                 placeholder={t(
                   'dialect+driver://username:password@host:port/database',
                 )}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -179,7 +179,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
               ? `${t('ERROR: ')}${
                   typeof error.message === 'string'
                     ? error.message
-                    : error.message.sqlalchemy_uri
+                    : (error.message as Record<string, string[]>).sqlalchemy_uri
                 }`
               : t('ERROR: Connection failed. '),
           );
@@ -315,6 +315,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
 
   return (
     <Modal
+      name="database"
       className="database-modal"
       disablePrimaryButton={disableSave}
       onHandledPrimaryAction={onSave}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -202,22 +202,24 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       }
 
       if (db && db.id) {
-        updateResource(db.id, update).then(() => {
-          if (onDatabaseAdd) {
-            onDatabaseAdd();
+        updateResource(db.id, update).then(result => {
+          if (result) {
+            if (onDatabaseAdd) {
+              onDatabaseAdd();
+            }
+            hide();
           }
-
-          hide();
         });
       }
     } else if (db) {
       // Create
-      createResource(db).then(() => {
-        if (onDatabaseAdd) {
-          onDatabaseAdd();
+      createResource(db).then(dbId => {
+        if (dbId) {
+          if (onDatabaseAdd) {
+            onDatabaseAdd();
+          }
+          hide();
         }
-
-        hide();
       });
     }
   };
@@ -356,7 +358,9 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                 type="text"
                 name="sqlalchemy_uri"
                 value={db ? db.sqlalchemy_uri : ''}
-                placeholder={t('SQLAlchemy URI')}
+                placeholder={t(
+                  'dialect+driver://username:password@host:port/database',
+                )}
                 onChange={onInputChange}
               />
               <Button buttonStyle="primary" onClick={testConnection} cta>

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -211,6 +211,7 @@ export function useSingleViewResource<D extends object = any>(
           updateState({
             resource: json.result,
           });
+          return json.result;
         },
         createErrorHandler(errMsg =>
           handleErrorMsg(
@@ -243,7 +244,6 @@ export function useSingleViewResource<D extends object = any>(
           updateState({
             resource: json.result,
           });
-
           return json.id;
         },
         createErrorHandler(errMsg =>
@@ -277,6 +277,7 @@ export function useSingleViewResource<D extends object = any>(
           updateState({
             resource: json.result,
           });
+          return json.result;
         },
         createErrorHandler(errMsg =>
           handleErrorMsg(

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -249,7 +249,7 @@ export function useSingleViewResource<D extends object = any>(
         createErrorHandler(errMsg =>
           handleErrorMsg(
             t(
-              'An error occurred while fetching %ss: %s',
+              'An error occurred while creating %ss: %s',
               resourceLabel,
               JSON.stringify(errMsg),
             ),

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -135,11 +135,8 @@ def sqlalchemy_uri_validator(value: str) -> str:
         raise ValidationError(
             [
                 _(
-                    "Invalid connection string, a valid string usually follows:"
-                    "'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
-                    "<p>"
-                    "Example:'postgresql://user:password@your-postgres-db/database'"
-                    "</p>"
+                    "Invalid connection string, a valid string usually follows: "
+                    "dirver://user:password@database-host/database-name"
                 )
             ]
         )

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -131,7 +131,7 @@ def sqlalchemy_uri_validator(value: str) -> str:
     """
     try:
         make_url(value.strip())
-    except (ArgumentError, AttributeError):
+    except (ArgumentError, AttributeError, ValueError):
         raise ValidationError(
             [
                 _(

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -46,6 +46,7 @@ from sqlalchemy import (
 from sqlalchemy.engine import Dialect, Engine, url
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import make_url, URL
+from sqlalchemy.exc import ArgumentError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.pool import NullPool
@@ -646,7 +647,11 @@ class Database(
 
     @property
     def sqlalchemy_uri_decrypted(self) -> str:
-        conn = sqla.engine.url.make_url(self.sqlalchemy_uri)
+        try:
+            conn = sqla.engine.url.make_url(self.sqlalchemy_uri)
+        except ArgumentError:
+            # if the URI is invalid, ignore and return a placeholder url
+            return "dialect://host"
         if custom_password_store:
             conn.password = custom_password_store(conn)
         else:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -649,9 +649,10 @@ class Database(
     def sqlalchemy_uri_decrypted(self) -> str:
         try:
             conn = sqla.engine.url.make_url(self.sqlalchemy_uri)
-        except ArgumentError:
+        except (ArgumentError, ValueError):
             # if the URI is invalid, ignore and return a placeholder url
-            return "dialect://host"
+            # (so users see 500 less often)
+            return "dialect://invalid_uri"
         if custom_password_store:
             conn.password = custom_password_store(conn)
         else:

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -297,17 +297,9 @@ class TestDatabaseApi(SupersetTestCase):
         rv = self.client.post(uri, json=database_data)
         response = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(rv.status_code, 400)
-        expected_response = {
-            "message": {
-                "sqlalchemy_uri": [
-                    "Invalid connection string, a valid string usually "
-                    "follows:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
-                    "<p>Example:'postgresql://user:password@your-postgres-db/database'"
-                    "</p>"
-                ]
-            }
-        }
-        self.assertEqual(response, expected_response)
+        self.assertIn(
+            "Invalid connection string", response["message"]["sqlalchemy_uri"][0],
+        )
 
     def test_create_database_fail_sqllite(self):
         """
@@ -456,17 +448,9 @@ class TestDatabaseApi(SupersetTestCase):
         rv = self.client.put(uri, json=database_data)
         response = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(rv.status_code, 400)
-        expected_response = {
-            "message": {
-                "sqlalchemy_uri": [
-                    "Invalid connection string, a valid string usually "
-                    "follows:'DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME'"
-                    "<p>Example:'postgresql://user:password@your-postgres-db/database'"
-                    "</p>"
-                ]
-            }
-        }
-        self.assertEqual(response, expected_response)
+        self.assertIn(
+            "Invalid connection string", response["message"]["sqlalchemy_uri"][0],
+        )
 
     def test_delete_database(self):
         """


### PR DESCRIPTION
### SUMMARY

When adding or editing a database, users may fail to save the database because of a typo in their connection string. Keep the modal open makes it easier for them to correct the typo because they don't have to open the modal again. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### After

![Snip20201108_2](https://user-images.githubusercontent.com/335541/98510843-ace23f00-2218-11eb-9a43-e904d7dbc71d.png)

### TEST PLAN

- Go to Data -> Databases, create or edit a datasource.
- Modal should keep open if saving was not successful.
- Modal should close if saving was successful.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @riahk @nytai 