### PR TITLE
fix: Datetime popover issues

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -197,6 +197,13 @@ const PopoverContentStyles = styled.div`
   .datetime {
     margin: ${({ theme }) => theme.gridUnit}px 0;
   }
+
+  .ant-tabs {
+    overflow: visible;
+    & > .ant-tabs-content-holder {
+      overflow: visible;
+    }
+  }
 `;
 
 class DateFilterControl extends React.Component {
@@ -454,7 +461,7 @@ class DateFilterControl extends React.Component {
           defaultActiveKey={this.state.tab === TABS.DEFAULTS ? '1' : '2'}
           id="type"
           className="time-filter-tabs"
-          onSelect={this.changeTab}
+          onChange={this.changeTab}
         >
           <Tabs.TabPane key="1" tab="Defaults" forceRender>
             <div className="timeframes-container">


### PR DESCRIPTION
### SUMMARY
Fixes issues described in https://github.com/apache/incubator-superset/issues/11609 and https://github.com/apache/incubator-superset/issues/11601.
I fixed the overflowing calendar issue by overriding tabs overflow styles in the popover. I don't think it's a perfect solution, because if the content of the tab changes to something that would actually require overflow, we'll need to do some workarounds.
I tried to render the calendar in a Portal (using `renderView` prop), outside of nodes with `overflow: hidden`, but react-datetime doesn't work well with portals - the calendar view relies on its parent's css class, so we can't mount it in a different place.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issues
After:
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/15073128/98571931-57a83b00-22b5-11eb-9ef6-c97f01c3b8b7.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11609, https://github.com/apache/incubator-superset/issues/11601
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc, @graceguo-supercat, @mistercrunch 