### PR TITLE
style: fixing tall filter indicators

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/dashboard.less
+++ b/superset-frontend/src/dashboard/stylesheets/dashboard.less
@@ -62,6 +62,7 @@ body {
   margin-bottom: 4px;
   display: flex;
   max-width: 100%;
+  align-items: flex-start;
 
   & > .header-title {
     overflow: hidden;


### PR DESCRIPTION
Co-Authored-By: Evan Rusackas <evan@preset.io>

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #11626 

When we un-truncated chart headers again, this issue crept in. As you can see by the screenshots, it now looks as intended.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="334" alt="Screen Shot 2020-11-09 at 3 44 22 PM" src="https://user-images.githubusercontent.com/812905/98609889-3a6a7100-22a3-11eb-8bd7-d4009fdc2e11.png">

After:
<img width="335" alt="Screen Shot 2020-11-09 at 3 46 03 PM" src="https://user-images.githubusercontent.com/812905/98609883-363e5380-22a3-11eb-9d7c-bf14d36415c7.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
