### PR TITLE
fix: js unit test when save dash

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/reducers/dashboardState_spec.js
+++ b/superset-frontend/spec/javascripts/dashboard/reducers/dashboardState_spec.js
@@ -140,7 +140,7 @@ describe('dashboardState reducer', () => {
       {},
     );
 
-    const lastModifiedTime = Math.round(new Date().getTime() / 1000);
+    const lastModifiedTime = new Date().getTime() / 1000;
     expect(
       dashboardStateReducer(
         { hasUnsavedChanges: true },


### PR DESCRIPTION
### SUMMARY
Fix a js unit test error introduced by #11614 
Error message is:
```
 FAIL  spec/javascripts/dashboard/reducers/dashboardState_spec.js
  ● dashboardState reducer › should reset lastModifiedTime on save

    expect(received).toBeGreaterThanOrEqual(expected)

    Expected: >= 1604968251.207
    Received:    1604968251

      147 |         { type: ON_SAVE, lastModifiedTime },
      148 |       ).lastModifiedTime,
    > 149 |     ).toBeGreaterThanOrEqual(initTime);
          |       ^
      150 |   });
      151 | 
      152 |   it('should clear the focused filter field', () => {

      at Object.<anonymous> (spec/javascripts/dashboard/reducers/dashboardState_spec.js:149:7)

```


### TEST PLAN
CI 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #11614 

