### PR TITLE
fix: card thumbnails now always show border.

### DIFF
--- a/superset-frontend/src/components/ListViewCard/ImageLoader.tsx
+++ b/superset-frontend/src/components/ListViewCard/ImageLoader.tsx
@@ -30,8 +30,9 @@ const ImageContainer = styled.div<ImageContainerProps>`
   background-size: cover;
   background-position: center ${({ position }) => position};
   display: inline-block;
-  height: 100%;
-  width: 100%;
+  height: calc(100% - 1px);
+  width: calc(100% - 2px);
+  margin: 1px 1px 0 1px;
 `;
 interface ImageLoaderProps
   extends React.DetailedHTMLProps<

--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -80,6 +80,7 @@ const StyledCard = styled(Card)`
 
 const Cover = styled.div`
   height: 264px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   overflow: hidden;
 
   .cover-footer {


### PR DESCRIPTION
Co-Authored-By: Evan Rusackas <evan@preset.io>

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Cards (on any view, home page or dashboards list, for example) had the thumbnail image covering the cards' borders. This meant that images with white or gray backgrounds would look very odd. This PR makes some tweaks to allow the border to show at all times, and also adds the 1px horizontal rule between the thumbnail area and the footer, as per the original design.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before (two views)
<img width="999" alt="Screen Shot 2020-11-09 at 10 47 51 PM" src="https://user-images.githubusercontent.com/812905/98637901-f5176500-22dd-11eb-889b-fbc7803a406e.png">
<img width="988" alt="Screen Shot 2020-11-09 at 10 47 17 PM" src="https://user-images.githubusercontent.com/812905/98637907-f8aaec00-22dd-11eb-93b0-f40665ec94da.png">


After (same two views)
<img width="1004" alt="Screen Shot 2020-11-09 at 10 46 12 PM" src="https://user-images.githubusercontent.com/812905/98637925-fea0cd00-22dd-11eb-9aed-303ff68b01b1.png">
<img width="996" alt="Screen Shot 2020-11-09 at 10 45 24 PM" src="https://user-images.githubusercontent.com/812905/98637936-01032700-22de-11eb-8358-3eec6cb59f22.png">


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
👀 visual validation

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #11624
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
