### PR TITLE
fix: Title change made in Edit Chart Properties is not showing on the title

### DIFF
--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -295,6 +295,7 @@ export const DisplayQueryButton = props => {
             show={isPropertiesModalOpen}
             onHide={closePropertiesModal}
             onSave={props.sliceUpdated}
+            persistOnModalClose={false}
           />,
         ]}
         <Menu.Item>

--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -158,6 +158,7 @@ export class ExploreChartHeader extends React.PureComponent {
                 onHide={this.closePropertiesModal}
                 onSave={this.props.sliceUpdated}
                 slice={this.props.slice}
+                persistOnModalClose={false}
               />
               <TooltipWrapper
                 label="edit-desc"

--- a/superset-frontend/src/explore/components/PropertiesModal.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal.tsx
@@ -41,7 +41,7 @@ type PropertiesModalProps = {
   show: boolean;
 
   // true if save the data to db on submit; false if save only in local store
-  persistOnModalClose: boolean;
+  persistOnModalClose?: boolean;
 };
 
 type OwnerOption = {
@@ -133,13 +133,13 @@ export default function PropertiesModal({
       slice_name: name || null,
       description: description || null,
       cache_timeout: cacheTimeout || null,
-      slice_updated: true,
     };
     if (owners) {
       payload.owners = owners.map(o => o.value);
     }
     try {
       if (!persistOnModalClose) {
+        payload.slice_updated = true;
         onSave(payload);
         onHide();
         return;

--- a/superset-frontend/src/explore/components/PropertiesModal.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal.tsx
@@ -128,7 +128,6 @@ export default function PropertiesModal({
   const onSubmit = async (event: React.FormEvent) => {
     event.stopPropagation();
     event.preventDefault();
-    setSubmitting(true);
     const payload: { [key: string]: any } = {
       slice_name: name || null,
       description: description || null,
@@ -137,14 +136,16 @@ export default function PropertiesModal({
     if (owners) {
       payload.owners = owners.map(o => o.value);
     }
-    try {
-      if (!persistOnModalClose) {
-        payload.slice_updated = true;
-        onSave(payload);
-        onHide();
-        return;
-      }
 
+    if (!persistOnModalClose) {
+      payload.slice_updated = true;
+      onSave(payload);
+      onHide();
+      return;
+    }
+
+    try {
+      setSubmitting(true);
       const res = await SupersetClient.put({
         endpoint: `/api/v1/chart/${slice.slice_id}`,
         headers: { 'Content-Type': 'application/json' },

--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -96,7 +96,7 @@ class SaveModal extends React.Component {
     actions.removeSaveModalAlert();
     const sliceParams = {};
 
-    if (slice && slice.slice_id) {
+    if (slice?.slice_id) {
       sliceParams.slice_id = slice.slice_id;
     }
     if (sliceParams.action === 'saveas') {
@@ -110,7 +110,7 @@ class SaveModal extends React.Component {
     sliceParams.save_to_dashboard_id = this.state.saveToDashboardId;
     sliceParams.new_dashboard_name = this.state.newDashboardName;
 
-    if (slice.slice_updated) {
+    if (slice?.slice_updated) {
       const payload = {
         description: slice.description || null,
         cache_timeout: slice.cache_timeout || null,

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -165,7 +165,7 @@ export default function exploreReducer(state = {}, action) {
           ...state.slice,
           ...action.slice,
         },
-        sliceName: action.slice.slice_name,
+        sliceName: action.slice.slice_name ?? state.sliceName,
       };
     },
   };

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -165,6 +165,7 @@ export default function exploreReducer(state = {}, action) {
           ...state.slice,
           ...action.slice,
         },
+        sliceName: action.slice.slice_name,
       };
     },
   };


### PR DESCRIPTION
### SUMMARY
When user edited a chart title through Edit properties modal, the title of the chart didn't update, even though it was correctly saved.
When user edits chart properties on Explore view, the changes are saved locally, but there is no request to API until the user clicks "Save" button. Modals on other views (ChartList and ChartTable) work as before.
On the gif you can see that no request is being made when editing chart title on Explore view until "save" button is clicked.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/15073128/98676856-731a5100-235c-11eb-9aac-f62dcb5d5860.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11623
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc 