### PR TITLE
fix: Restructure chart header to wrap nicely

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader.jsx
@@ -60,17 +60,21 @@ const StyledHeader = styled.div`
   flex-direction: row;
   align-items: center;
   flex-wrap: wrap;
+  justify-content: space-between;
 
   span[role='button'] {
     display: flex;
     height: 100%;
   }
 
+  .title-panel {
+    display: flex;
+    align-items: center;
+  }
+
   .right-button-panel {
     display: flex;
-    flex: 1 1 auto;
     align-items: center;
-    justify-content: flex-end;
 
     > .btn-group {
       flex: 0 0 auto;
@@ -132,50 +136,52 @@ export class ExploreChartHeader extends React.PureComponent {
       this.props.chart.chartStatus,
     );
     return (
-      <StyledHeader id="slice-header" className="clearfix panel-title-large">
-        <EditableTitle
-          title={this.getSliceName()}
-          canEdit={!this.props.slice || this.props.can_overwrite}
-          onSaveTitle={this.props.actions.updateChartTitle}
-        />
-
-        {this.props.slice && (
-          <StyledButtons>
-            <FaveStar
-              itemId={this.props.slice.slice_id}
-              fetchFaveStar={this.props.actions.fetchFaveStar}
-              saveFaveStar={this.props.actions.saveFaveStar}
-              isStarred={this.props.isStarred}
-              showTooltip
-            />
-            <PropertiesModal
-              show={this.state.isPropertiesModalOpen}
-              onHide={this.closePropertiesModal}
-              onSave={this.props.sliceUpdated}
-              slice={this.props.slice}
-            />
-            <TooltipWrapper
-              label="edit-desc"
-              tooltip={t('Edit chart properties')}
-            >
-              <span
-                role="button"
-                tabIndex={0}
-                className="edit-desc-icon"
-                onClick={this.openProperiesModal}
-              >
-                <i className="fa fa-edit" />
-              </span>
-            </TooltipWrapper>
-          </StyledButtons>
-        )}
-        {this.props.chart.sliceFormData && (
-          <AlteredSliceTag
-            className="altered"
-            origFormData={this.props.chart.sliceFormData}
-            currentFormData={formData}
+      <StyledHeader id="slice-header" className="panel-title-large">
+        <div className="title-panel">
+          <EditableTitle
+            title={this.getSliceName()}
+            canEdit={!this.props.slice || this.props.can_overwrite}
+            onSaveTitle={this.props.actions.updateChartTitle}
           />
-        )}
+
+          {this.props.slice && (
+            <StyledButtons>
+              <FaveStar
+                itemId={this.props.slice.slice_id}
+                fetchFaveStar={this.props.actions.fetchFaveStar}
+                saveFaveStar={this.props.actions.saveFaveStar}
+                isStarred={this.props.isStarred}
+                showTooltip
+              />
+              <PropertiesModal
+                show={this.state.isPropertiesModalOpen}
+                onHide={this.closePropertiesModal}
+                onSave={this.props.sliceUpdated}
+                slice={this.props.slice}
+              />
+              <TooltipWrapper
+                label="edit-desc"
+                tooltip={t('Edit chart properties')}
+              >
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="edit-desc-icon"
+                  onClick={this.openProperiesModal}
+                >
+                  <i className="fa fa-edit" />
+                </span>
+              </TooltipWrapper>
+              {this.props.chart.sliceFormData && (
+                <AlteredSliceTag
+                  className="altered"
+                  origFormData={this.props.chart.sliceFormData}
+                  currentFormData={formData}
+                />
+              )}
+            </StyledButtons>
+          )}
+        </div>
         <div className="right-button-panel">
           {chartFinished && queryResponse && (
             <RowCountLabel


### PR DESCRIPTION
### SUMMARY
Chart header row behaved weirdly when there wasn't enough space on the screen. I restyled and restructured some html to make it wrap nicely.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/15073128/98712419-8fcb7e80-2386-11eb-96fd-26f801a56450.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11276
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @junlincc @rusackas 