### PR TITLE
build: set actions/setup-python to v2

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.7'
     - name: OS dependencies

--- a/.github/workflows/superset-python.yml
+++ b/.github/workflows/superset-python.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v2.1.1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -111,7 +111,7 @@ jobs:
       steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v2.1.1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -168,7 +168,7 @@ jobs:
     - name: Start hadoop and hive
       run: docker-compose -f scripts/databases/hive/docker-compose.yml up -d
     - name: Setup Python
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -216,7 +216,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -262,7 +262,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -301,7 +301,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v2.1.1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Start hadoop and hive
       run: docker-compose -f scripts/databases/hive/docker-compose.yml up -d
     - name: Setup Python
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test-presto.yml
+++ b/.github/workflows/test-presto.yml
@@ -43,7 +43,7 @@ jobs:
       steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v2.1.1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION

### SUMMARY

This upgrades `actions/setup-python` in CI and pins it to the latest v2, which suppresses the following warning about `set-env` and `add-path`:

    Error: The `set-env` command is deprecated and will be disabled on November 16th. 
    Please upgrade to using Environment Files. For more information see:
    https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
