### PR TITLE
fix(saved-query): handle case where sql_tables in undefined

### DIFF
--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx
@@ -245,7 +245,7 @@ function SavedQueryList({
       {
         Cell: ({
           row: {
-            original: { sql_tables: tables },
+            original: { sql_tables: tables = [] },
           },
         }: any) => {
           const names = tables.map((table: any) => table.table);
@@ -385,9 +385,11 @@ function SavedQueryList({
           'saved_query',
           'database',
           createErrorHandler(errMsg =>
-            t(
-              'An error occurred while fetching dataset datasource values: %s',
-              errMsg,
+            addDangerToast(
+              t(
+                'An error occurred while fetching dataset datasource values: %s',
+                errMsg,
+              ),
             ),
           ),
         ),
@@ -403,7 +405,9 @@ function SavedQueryList({
           'saved_query',
           'schema',
           createErrorHandler(errMsg =>
-            t('An error occurred while fetching schema values: %s', errMsg),
+            addDangerToast(
+              t('An error occurred while fetching schema values: %s', errMsg),
+            ),
           ),
         ),
         paginate: true,
@@ -415,7 +419,7 @@ function SavedQueryList({
         operator: 'all_text',
       },
     ],
-    [],
+    [addDangerToast],
   );
 
   return (

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -56,5 +56,5 @@ export type SavedQueryObject = {
   label: string;
   schema: string;
   sql: string;
-  sql_tables: Array<{ catalog?: string; schema: string; table: string }>;
+  sql_tables?: { catalog?: string; schema: string; table: string }[];
 };


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Handles case where `sql_tables` is undefined in the api response. see linked issue for details. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
manually tested following steps listed in the linked issue

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #11647
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
