### PR TITLE
fix: database connection validation when creation

### DIFF
--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -30,6 +30,7 @@ from superset.databases.commands.exceptions import (
     DatabaseInvalidError,
     DatabaseRequiredFieldValidationError,
 )
+from superset.databases.commands.test_connection import TestConnectionDatabaseCommand
 from superset.databases.dao import DatabaseDAO
 from superset.extensions import db, security_manager
 
@@ -46,13 +47,15 @@ class CreateDatabaseCommand(BaseCommand):
         try:
             database = DatabaseDAO.create(self._properties, commit=False)
             database.set_sqlalchemy_uri(database.sqlalchemy_uri)
-            # adding a new database we always want to force refresh schema list
-            # TODO Improve this simplistic implementation for catching DB conn fails
+
             try:
-                schemas = database.get_all_schema_names()
+                TestConnectionDatabaseCommand(self._actor, self._properties).run()
             except Exception:
                 db.session.rollback()
                 raise DatabaseConnectionFailedError()
+
+            # adding a new database we always want to force refresh schema list
+            schemas = database.get_all_schema_names(cache=False)
             for schema in schemas:
                 security_manager.add_permission_view_menu(
                     "schema_access", security_manager.get_schema_perm(database, schema)

--- a/tests/superset_test_config.py
+++ b/tests/superset_test_config.py
@@ -88,6 +88,11 @@ CACHE_CONFIG = {
     "CACHE_REDIS_URL": f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CACHE_DB}",
 }
 
+TABLE_NAMES_CACHE_CONFIG = {
+    **CACHE_CONFIG,
+    "CACHE_KEY_PREFIX": "superset_data_cache",
+}
+
 
 class CeleryConfig(object):
     BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"


### PR DESCRIPTION
### SUMMARY

Better database connection validation when creating a database. Discovered this bug while developing #11509 , the symptom of the failed test on the user side is you can add databases with wrong passwords as long as `TABLE_NAMES_CACHE_CONFIG` is enabled. The cause is that [Database.get_all_schema_names](https://github.com/apache/incubator-superset/blob/edb9619731658151ed864321ede06980d767501d/superset/models/core.py#L547) is a cached function with `self.id` as cache key, but a newly created uncommitted Database instance always has `self.id == None`.

Also renames a couple of test databases to make it easier to debug in case some of them slip through failed tests and got incorrectly created.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

To reproduce the bug with unit tests:

1. Add `TABLE_NAMES_CACHE_CONFIG` in test config. E.g.
   ```
   TABLE_NAMES_CACHE_CONFIG = {
     **CACHE_CONFIG,
     "CACHE_KEY_PREFIX": "superset_data_cache",
   }
   ```
2. Run test case
    ```
    pytest tests/databases/api_tests.py::TestDatabaseApi::test_create_database_conn_fail
    ```
    multiple times
3. You test will fail with `AssertionError: 201 != 422`


To reproduce the bug in user interface:

1. Enable `TABLE_NAMES_CACHE_CONFIG`
2. Try adding a database with wrong password multiple times.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @dpgaspar @john-bodley 