### PR TITLE
fix (explore): handle null value in date filter

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
@@ -81,6 +81,19 @@ describe('DateFilterControl', () => {
     expect(close).toBeCalled();
   });
 
+  it('should handle null value', () => {
+    const open = jest.fn();
+    const close = jest.fn();
+    const props = {
+      ...defaultProps,
+      value: null,
+      onOpenDateFilterControl: open,
+      onCloseDateFilterControl: close,
+    };
+
+    expect(mount(<DateFilterControl {...props} />)).toExist();
+  });
+
   it('renders two tabs in popover', () => {
     const popoverContent = wrapper.find(Popover).first().props().content;
     const popoverContentWrapper = mount(popoverContent);

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -236,11 +236,11 @@ class DateFilterControl extends React.Component {
     };
 
     const { value } = props;
-    if (value.indexOf(SEPARATOR) >= 0) {
+    if (value && value.indexOf(SEPARATOR) >= 0) {
       this.state = { ...this.state, ...getStateFromSeparator(value) };
     } else if (COMMON_TIME_FRAMES.indexOf(value) >= 0) {
       this.state = { ...this.state, ...getStateFromCommonTimeFrame(value) };
-    } else {
+    } else if (value) {
       this.state = { ...this.state, ...getStateFromCustomRange(value) };
     }
 


### PR DESCRIPTION
### SUMMARY
when Date Filter got `null` in props, explore view page crash and throw JS error like:
```
TypeError: Cannot read property 'indexOf' of null
```


### TEST PLAN
CI and manual test

