### PR TITLE
fix(chart-data): ignore orderby on sample result type

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -148,6 +148,7 @@ class QueryContext:
         if self.result_type == utils.ChartDataResultType.SAMPLES:
             row_limit = query_obj.row_limit or math.inf
             query_obj = copy.copy(query_obj)
+            query_obj.orderby = []
             query_obj.groupby = []
             query_obj.metrics = []
             query_obj.post_processing = []

--- a/tests/fixtures/query_context.py
+++ b/tests/fixtures/query_context.py
@@ -25,7 +25,7 @@ QUERY_OBJECTS = {
         "is_timeseries": False,
         "metrics": [{"label": "sum__num"}],
         "order_desc": True,
-        "orderby": [],
+        "orderby": [["sum__num", False]],
         "row_limit": 100,
         "time_range": "100 years ago : now",
         "timeseries_limit": 0,


### PR DESCRIPTION
### SUMMARY
If a query object has defined an `orderby` based on a metric, requesting sample data for the dataset causes an error.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/98815771-551e2080-2430-11eb-9c26-dec13c2eaf8c.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/98815953-97dff880-2430-11eb-9efd-d0ffd4eeec66.png)

### TEST PLAN
Local testing + updated test fixture
