### PR TITLE
fix (dashboard): remove default filters parameters from dashboard url

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -17,9 +17,7 @@
 import json
 import logging
 from functools import partial
-from json.decoder import JSONDecodeError
 from typing import Any, Callable, Dict, List, Set, Union
-from urllib import parse
 
 import sqlalchemy as sqla
 from flask_appbuilder import Model
@@ -160,27 +158,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
 
     @property
     def url(self) -> str:
-        url = f"/superset/dashboard/{self.slug or self.id}/"
-        if self.json_metadata:
-            # add default_filters to the preselect_filters of dashboard
-            json_metadata = json.loads(self.json_metadata)
-            default_filters = json_metadata.get("default_filters")
-            # make sure default_filters is not empty and is valid
-            if default_filters and default_filters != "{}":
-                try:
-                    if json.loads(default_filters):
-                        filters = parse.quote(default_filters.encode("utf8"))
-                        return "/superset/dashboard/{}/?preselect_filters={}".format(
-                            self.slug or self.id, filters
-                        )
-                except (TypeError, JSONDecodeError) as exc:
-                    logger.error(
-                        "Unable to parse json for url: %r. Returning default url.",
-                        exc,
-                        exc_info=True,
-                    )
-                    return url
-        return url
+        return f"/superset/dashboard/{self.slug or self.id}/"
 
     @property
     def datasources(self) -> Set[BaseDatasource]:

--- a/tests/dashboard_tests.py
+++ b/tests/dashboard_tests.py
@@ -180,7 +180,8 @@ class TestDashboard(SupersetTestCase):
 
         updatedDash = db.session.query(Dashboard).filter_by(slug="world_health").first()
         new_url = updatedDash.url
-        self.assertIn("region", new_url)
+        self.assertIn("world_health", new_url)
+        self.assertNotIn("preselect_filters", new_url)
 
         resp = self.get_resp(new_url)
         self.assertIn("North America", resp)


### PR DESCRIPTION
### SUMMARY
We found an issue when user tried to change default filter value for a dashboard:
1. from dashboard list, user open a dashboard. current dashboard url contains default filters in the url: for example: 
http://localhost:8080/superset/dashboard/67/?preselect_filters=%7B"1086"%3A%20%7B"region"%3A%20""%7D%2C%20"1101"%3A%20%7B"__time_range"%3A%20"2014-01-01%20%3A%202014-01-02"%7D%7D
1. user can change dashboard filters, or make change in Dashboard Properties, and save dashboard. Then user will assume dashboard default filters are changed and saved.
1. Then they want see the new default filters. If they just reload dashboard, because dashboard is loaded with `preselect_filters` in the url, dashboard's metadata is overwritten by old request parameter. So users can not see the new change.

We added "preselect_filters" in the dashboard url long time ago, at that time we didn't load and parse all dashboard metadata. Right now we got same information from dashboard metadata, I think we don't need to append in the dashboard url, because the old state in the url will cause problem after dashboard is updated.

We will still keep the functionality that parse "preselect_filters" in dashboard, and url parameter can overwrite dashboard metadata. If users want to dynamic generate dashboard link with preselect_filters, this behavior won't be changed.




### TEST PLAN
CI and manual test
