### PR TITLE
feat: replace edit modal with Explore navigation in chart cards/list

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/chart_list/card_view.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/card_view.test.ts
@@ -110,14 +110,6 @@ describe('chart card view', () => {
   it('should show explore link', () => {
     // show edit modal
     cy.get('[data-test="more-horiz"]').last().trigger('mouseover');
-    cy.get('[data-test="chart-list-edit-option"]').should('be.visible');
-    cy.get('[data-test="chart-list-edit-option"]').click();
-    cy.get('[data-test="properties-edit-modal"]').should('be.visible');
-    cy.get('[data-test="properties-modal-name-input"]').should(
-      'not.have.value',
-    );
-    cy.get('[data-test="properties-modal-cancel-button"]')
-      .contains('Cancel')
-      .click();
+    cy.get('[data-test="chart-list-explore-option"]').should('be.visible');
   });
 });

--- a/superset-frontend/cypress-base/cypress/integration/chart_list/card_view.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/card_view.test.ts
@@ -120,4 +120,18 @@ describe('chart card view', () => {
       .contains('Cancel')
       .click();
   });
+
+  it('should show explore link', () => {
+    // show edit modal
+    cy.get('[data-test="more-horiz"]').last().trigger('mouseover');
+    cy.get('[data-test="chart-list-edit-option"]').should('be.visible');
+    cy.get('[data-test="chart-list-edit-option"]').click();
+    cy.get('[data-test="properties-edit-modal"]').should('be.visible');
+    cy.get('[data-test="properties-modal-name-input"]').should(
+      'not.have.value',
+    );
+    cy.get('[data-test="properties-modal-cancel-button"]')
+      .contains('Cancel')
+      .click();
+  });
 });

--- a/superset-frontend/cypress-base/cypress/integration/chart_list/card_view.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/card_view.test.ts
@@ -107,20 +107,6 @@ describe('chart card view', () => {
     cy.get('[data-test="modal-cancel-button"]').click();
   });
 
-  it('should edit correctly', () => {
-    // show edit modal
-    cy.get('[data-test="more-horiz"]').last().trigger('mouseover');
-    cy.get('[data-test="chart-list-edit-option"]').should('be.visible');
-    cy.get('[data-test="chart-list-edit-option"]').click();
-    cy.get('[data-test="properties-edit-modal"]').should('be.visible');
-    cy.get('[data-test="properties-modal-name-input"]').should(
-      'not.have.value',
-    );
-    cy.get('[data-test="properties-modal-cancel-button"]')
-      .contains('Cancel')
-      .click();
-  });
-
   it('should show explore link', () => {
     // show edit modal
     cy.get('[data-test="more-horiz"]').last().trigger('mouseover');

--- a/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
@@ -28,7 +28,6 @@ import { styledMount as mount } from 'spec/helpers/theming';
 import ChartList from 'src/views/CRUD/chart/ChartList';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import ListView from 'src/components/ListView';
-import PropertiesModal from 'src/explore/components/PropertiesModal';
 import ListViewCard from 'src/components/ListViewCard';
 // store needed for withToasts(ChartTable)
 const mockStore = configureStore([thunk]);
@@ -134,12 +133,6 @@ describe('ChartList', () => {
   it('renders a table view', () => {
     wrapper.find('[data-test="list-view"]').first().simulate('click');
     expect(wrapper.find('table')).toExist();
-  });
-
-  it('edits', () => {
-    expect(wrapper.find(PropertiesModal)).not.toExist();
-    wrapper.find('[data-test="edit-alt"]').first().simulate('click');
-    expect(wrapper.find(PropertiesModal)).toExist();
   });
 
   it('delete', () => {

--- a/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
@@ -146,4 +146,8 @@ describe('ChartList', () => {
     wrapper.find('[data-test="trash"]').first().simulate('click');
     expect(wrapper.find(ConfirmStatusChange)).toExist();
   });
+
+  it('renders explore link as an `a` tag', () => {
+    expect(wrapper.find('a.action-button [data-test="nav-explore"]').first()).toExist();
+  });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
@@ -148,6 +148,8 @@ describe('ChartList', () => {
   });
 
   it('renders explore link as an `a` tag', () => {
-    expect(wrapper.find('a.action-button [data-test="nav-explore"]').first()).toExist();
+    expect(
+      wrapper.find('a.action-button [data-test="nav-explore"]').first(),
+    ).toExist();
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/chart/ChartList_spec.jsx
@@ -142,7 +142,7 @@ describe('ChartList', () => {
 
   it('renders explore link as an `a` tag', () => {
     expect(
-      wrapper.find('a.action-button [data-test="nav-explore"]').first(),
+      wrapper.find('a.action-button [data-test="edit-alt"]').first(),
     ).toExist();
   });
 });

--- a/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
@@ -120,6 +120,16 @@ export default function ChartCard({
           <ListViewCard.MenuIcon name="edit-alt" /> {t('Edit')}
         </Menu.Item>
       )}
+      {canEdit && (
+        <Menu.Item
+          data-test="chart-list-explore-option"
+          role="button"
+          tabIndex={0}
+          onClick={() => window.location.href = chart.url}
+        >
+          <ListViewCard.MenuIcon name="nav-explore" /> {t('Explore')}
+        </Menu.Item>
+      )}
     </Menu>
   );
   return (

--- a/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
@@ -33,7 +33,6 @@ import { handleChartDelete, handleBulkChartExport, CardStyles } from '../utils';
 interface ChartCardProps {
   chart: Chart;
   hasPerm: (perm: string) => boolean;
-  openChartEditModal: (chart: Chart) => void;
   bulkSelectEnabled: boolean;
   addDangerToast: (msg: string) => void;
   addSuccessToast: (msg: string) => void;
@@ -48,7 +47,6 @@ interface ChartCardProps {
 export default function ChartCard({
   chart,
   hasPerm,
-  openChartEditModal,
   bulkSelectEnabled,
   addDangerToast,
   addSuccessToast,
@@ -108,16 +106,6 @@ export default function ChartCard({
           onClick={() => handleBulkChartExport([chart])}
         >
           <ListViewCard.MenuIcon name="share" /> {t('Export')}
-        </Menu.Item>
-      )}
-      {canEdit && (
-        <Menu.Item
-          data-test="chart-list-edit-option"
-          role="button"
-          tabIndex={0}
-          onClick={() => openChartEditModal(chart)}
-        >
-          <ListViewCard.MenuIcon name="edit-alt" /> {t('Edit')}
         </Menu.Item>
       )}
       {canEdit && (

--- a/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
@@ -117,7 +117,7 @@ export default function ChartCard({
             window.location.href = chart.url;
           }}
         >
-          <ListViewCard.MenuIcon name="nav-explore" /> {t('Explore')}
+          <ListViewCard.MenuIcon name="edit-alt" /> {t('Edit')}
         </Menu.Item>
       )}
     </Menu>

--- a/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
@@ -125,7 +125,9 @@ export default function ChartCard({
           data-test="chart-list-explore-option"
           role="button"
           tabIndex={0}
-          onClick={() => {window.location.href = chart.url}}
+          onClick={() => {
+            window.location.href = chart.url;
+          }}
         >
           <ListViewCard.MenuIcon name="nav-explore" /> {t('Explore')}
         </Menu.Item>

--- a/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartCard.tsx
@@ -125,7 +125,7 @@ export default function ChartCard({
           data-test="chart-list-explore-option"
           role="button"
           tabIndex={0}
-          onClick={() => window.location.href = chart.url}
+          onClick={() => {window.location.href = chart.url}}
         >
           <ListViewCard.MenuIcon name="nav-explore" /> {t('Explore')}
         </Menu.Item>

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -242,7 +242,8 @@ function ChartList(props: ChartListProps) {
         size: 'xl',
       },
       {
-        Cell: ({ row: { original } }: any) => {
+
+        Cell: ({ row: { original: { url, ...original } } }: any) => {
           const handleDelete = () =>
             handleChartDelete(
               original,
@@ -306,7 +307,7 @@ function ChartList(props: ChartListProps) {
               {canEdit && (
                 <TooltipWrapper
                   label="edit-action"
-                  tooltip={t('Edit')}
+                  tooltip={t('Edit Chart Properties')}
                   placement="bottom"
                 >
                   <span
@@ -317,6 +318,20 @@ function ChartList(props: ChartListProps) {
                   >
                     <Icon name="edit-alt" />
                   </span>
+                </TooltipWrapper>
+              )}
+              {canEdit && (
+                <TooltipWrapper
+                  label="explore-action"
+                  tooltip={t('Explore Chart')}
+                  placement="bottom"
+                >
+                  <a href={url}
+                    role="button"
+                    tabIndex={0}
+                    className="action-button">
+                    <Icon name="nav-explore" />
+                  </a>
                 </TooltipWrapper>
               )}
             </span>

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -27,11 +27,7 @@ import {
   handleBulkChartExport,
   handleChartDelete,
 } from 'src/views/CRUD/utils';
-import {
-  useListViewResource,
-  useFavoriteStatus,
-  useChartEditModal,
-} from 'src/views/CRUD/hooks';
+import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import Icon from 'src/components/Icon';
@@ -42,7 +38,6 @@ import ListView, {
   SelectOption,
 } from 'src/components/ListView';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
-import PropertiesModal from 'src/explore/components/PropertiesModal';
 import Chart from 'src/types/Chart';
 import TooltipWrapper from 'src/components/TooltipWrapper';
 import ChartCard from './ChartCard';
@@ -103,7 +98,6 @@ function ChartList(props: ChartListProps) {
       resourceCollection: charts,
       bulkSelectEnabled,
     },
-    setResourceCollection: setCharts,
     hasPerm,
     fetchData,
     toggleBulkSelect,
@@ -117,13 +111,6 @@ function ChartList(props: ChartListProps) {
     chartIds,
     props.addDangerToast,
   );
-  const {
-    sliceCurrentlyEditing,
-    handleChartUpdated,
-    openChartEditModal,
-    closeChartEditModal,
-  } = useChartEditModal(setCharts, charts);
-
   const canCreate = hasPerm('can_add');
   const canEdit = hasPerm('can_edit');
   const canDelete = hasPerm('can_delete');
@@ -254,7 +241,6 @@ function ChartList(props: ChartListProps) {
               props.addDangerToast,
               refreshData,
             );
-          const openEditModal = () => openChartEditModal(original);
           const handleExport = () => handleBulkChartExport([original]);
           if (!canEdit && !canDelete && !canExport) {
             return null;
@@ -304,22 +290,6 @@ function ChartList(props: ChartListProps) {
                     onClick={handleExport}
                   >
                     <Icon name="share" />
-                  </span>
-                </TooltipWrapper>
-              )}
-              {canEdit && (
-                <TooltipWrapper
-                  label="edit-action"
-                  tooltip={t('Edit Chart Properties')}
-                  placement="bottom"
-                >
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className="action-button"
-                    onClick={openEditModal}
-                  >
-                    <Icon name="edit-alt" />
                   </span>
                 </TooltipWrapper>
               )}
@@ -470,7 +440,6 @@ function ChartList(props: ChartListProps) {
       <ChartCard
         chart={chart}
         hasPerm={hasPerm}
-        openChartEditModal={openChartEditModal}
         bulkSelectEnabled={bulkSelectEnabled}
         addDangerToast={props.addDangerToast}
         addSuccessToast={props.addSuccessToast}
@@ -505,14 +474,6 @@ function ChartList(props: ChartListProps) {
   return (
     <>
       <SubMenu name={t('Charts')} buttons={subMenuButtons} />
-      {sliceCurrentlyEditing && (
-        <PropertiesModal
-          onHide={closeChartEditModal}
-          onSave={handleChartUpdated}
-          show
-          slice={sliceCurrentlyEditing}
-        />
-      )}
       <ConfirmStatusChange
         title={t('Please confirm')}
         description={t('Are you sure you want to delete the selected charts?')}

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -296,7 +296,7 @@ function ChartList(props: ChartListProps) {
               {canEdit && (
                 <TooltipWrapper
                   label="explore-action"
-                  tooltip={t('Explore Chart')}
+                  tooltip={t('Edit')}
                   placement="bottom"
                 >
                   <a
@@ -305,7 +305,7 @@ function ChartList(props: ChartListProps) {
                     tabIndex={0}
                     className="action-button"
                   >
-                    <Icon name="nav-explore" />
+                    <Icon name="edit-alt" />
                   </a>
                 </TooltipWrapper>
               )}

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -242,8 +242,11 @@ function ChartList(props: ChartListProps) {
         size: 'xl',
       },
       {
-
-        Cell: ({ row: { original: { url, ...original } } }: any) => {
+        Cell: ({
+          row: {
+            original: { url, ...original },
+          },
+        }: any) => {
           const handleDelete = () =>
             handleChartDelete(
               original,
@@ -326,10 +329,12 @@ function ChartList(props: ChartListProps) {
                   tooltip={t('Explore Chart')}
                   placement="bottom"
                 >
-                  <a href={url}
+                  <a
+                    href={url}
                     role="button"
                     tabIndex={0}
-                    className="action-button">
+                    className="action-button"
+                  >
                     <Icon name="nav-explore" />
                   </a>
                 </TooltipWrapper>

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -23,7 +23,6 @@ import { makeApi, SupersetClient, t } from '@superset-ui/core';
 import { createErrorHandler } from 'src/views/CRUD/utils';
 import { FetchDataConfig } from 'src/components/ListView';
 import { FilterValue } from 'src/components/ListView/types';
-import Chart, { Slice } from 'src/types/Chart';
 import copyTextToClipboard from 'src/utils/copy';
 import { FavoriteStatus } from './types';
 

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -393,44 +393,6 @@ export function useFavoriteStatus(
   return [saveFaveStar, favoriteStatus] as const;
 }
 
-export const useChartEditModal = (
-  setCharts: (charts: Array<Chart>) => void,
-  charts: Array<Chart>,
-) => {
-  const [
-    sliceCurrentlyEditing,
-    setSliceCurrentlyEditing,
-  ] = useState<Slice | null>(null);
-
-  function openChartEditModal(chart: Chart) {
-    setSliceCurrentlyEditing({
-      slice_id: chart.id,
-      slice_name: chart.slice_name,
-      description: chart.description,
-      cache_timeout: chart.cache_timeout,
-    });
-  }
-
-  function closeChartEditModal() {
-    setSliceCurrentlyEditing(null);
-  }
-
-  function handleChartUpdated(edits: Chart) {
-    // update the chart in our state with the edited info
-    const newCharts = charts.map((chart: Chart) =>
-      chart.id === edits.id ? { ...chart, ...edits } : chart,
-    );
-    setCharts(newCharts);
-  }
-
-  return {
-    sliceCurrentlyEditing,
-    handleChartUpdated,
-    openChartEditModal,
-    closeChartEditModal,
-  };
-};
-
 export const copyQueryLink = (
   id: number,
   addDangerToast: (arg0: string) => void,

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -18,13 +18,8 @@
  */
 import React, { useState, useMemo } from 'react';
 import { t } from '@superset-ui/core';
-import {
-  useListViewResource,
-  useChartEditModal,
-  useFavoriteStatus,
-} from 'src/views/CRUD/hooks';
+import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
-import PropertiesModal from 'src/explore/components/PropertiesModal';
 import { User } from 'src/types/bootstrapTypes';
 import Icon from 'src/components/Icon';
 import ChartCard from 'src/views/CRUD/chart/ChartCard';
@@ -52,7 +47,6 @@ function ChartTable({
 }: ChartTableProps) {
   const {
     state: { resourceCollection: charts, bulkSelectEnabled },
-    setResourceCollection: setCharts,
     hasPerm,
     refreshData,
     fetchData,
@@ -69,12 +63,6 @@ function ChartTable({
     chartIds,
     addDangerToast,
   );
-  const {
-    sliceCurrentlyEditing,
-    openChartEditModal,
-    handleChartUpdated,
-    closeChartEditModal,
-  } = useChartEditModal(setCharts, charts);
 
   const [chartFilter, setChartFilter] = useState('Mine');
 
@@ -113,15 +101,6 @@ function ChartTable({
 
   return (
     <>
-      {sliceCurrentlyEditing && (
-        <PropertiesModal
-          onHide={closeChartEditModal}
-          onSave={handleChartUpdated}
-          show
-          slice={sliceCurrentlyEditing}
-        />
-      )}
-
       <SubMenu
         activeChild={chartFilter}
         // eslint-disable-next-line react/no-children-prop
@@ -165,7 +144,6 @@ function ChartTable({
           {charts.map(e => (
             <ChartCard
               key={`${e.id}`}
-              openChartEditModal={openChartEditModal}
               chartFilter={chartFilter}
               chart={e}
               userId={user?.userId}

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -26,8 +26,7 @@ span,
 div,
 li,
 i,
-a,
-{
+a {
   &:focus {
     outline: none;
   }

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -24,7 +24,10 @@
 
 span,
 div,
-i {
+li,
+i,
+a,
+{
   &:focus {
     outline: none;
   }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I found myself using the "edit" link for charts, and being bummed that it was the metadata modal, not the Explore view... so I added the icon/link for explore view in card and list views! This wasn't part of the original design, so I want to make sure that folks are cool with it!

**EDIT** By popular demand (ok, two people mentioned it) I removed the Edit link that pops the chart modal. See update screenshot and comments below

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After (cards/lists)

![card](https://user-images.githubusercontent.com/812905/98970094-67499e80-24c4-11eb-9dc2-cca17c118d4e.gif)
![list](https://user-images.githubusercontent.com/812905/98970109-6c0e5280-24c4-11eb-9e36-438046c93c75.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
