### PR TITLE
fix: make higher chart box resizable

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -93,7 +93,7 @@ const StyledDashboardContent = styled.div`
     transition: opacity ${({ theme }) => theme.transitionTiming}s,
       border-color ${({ theme }) => theme.transitionTiming}s,
       box-shadow ${({ theme }) => theme.transitionTiming}s;
-    border: ${({ theme }) => theme.gridUnit / 2}px solid transparent;
+    border: 0px solid transparent;
   }
 `;
 

--- a/superset-frontend/src/dashboard/stylesheets/components/markdown.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/markdown.less
@@ -45,14 +45,6 @@
   #brace-editor {
     border: none;
   }
-
-  .resizable-container {
-    span {
-      div {
-        z-index: @z-index-above-dashboard-charts;
-      }
-    }
-  }
 }
 
 /* maximize editing space */

--- a/superset-frontend/src/dashboard/stylesheets/dnd.less
+++ b/superset-frontend/src/dashboard/stylesheets/dnd.less
@@ -28,6 +28,16 @@
   width: 100%;
 }
 
+.dragdroppable-column {
+  .resizable-container {
+    span {
+      div {
+        z-index: @z-index-above-dashboard-charts;
+      }
+    }
+  }
+}
+
 /* drop indicators */
 .drop-indicator {
   display: block;

--- a/superset-frontend/src/dashboard/stylesheets/popover-menu.less
+++ b/superset-frontend/src/dashboard/stylesheets/popover-menu.less
@@ -30,11 +30,11 @@
 .with-popover-menu--focused:after {
   content: '';
   position: absolute;
-  top: 1px;
-  left: -1px;
+  top: 0px;
+  left: 0px;
   width: 100%;
   height: 100%;
-  box-shadow: inset 0 0 0 2px @indicator-color;
+  border: 2px solid @indicator-color;
   pointer-events: none;
 }
 


### PR DESCRIPTION
### SUMMARY
PR with 2 parts requested in #11472 :
1. When chart is higher than other elements it is still possible to resize it.
2. Adjusted size of hovered border and markdown's edit border to match grey border of an external box.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
1. Before:
![Large GIF (772x686)](https://user-images.githubusercontent.com/2536609/98980890-8aed0300-251d-11eb-94d1-f34309adc991.gif)

1. After:
![Large GIF (830x580)](https://user-images.githubusercontent.com/2536609/98981365-21212900-251e-11eb-999c-10933eafc9af.gif)

2. Before
![Screenshot 2020-11-12 at 19 19 02](https://user-images.githubusercontent.com/2536609/98980980-ac4def00-251d-11eb-8f35-92bebb6cf946.png)

2. After
![Screenshot 2020-11-12 at 19 19 26](https://user-images.githubusercontent.com/2536609/98981010-b40d9380-251d-11eb-9a69-dee2c7cf0f87.png)


### TEST PLAN
1. Go to dashboard
2. Add Tab
3. Add a Markdown and any of charts inside tab
4. Resize the Markdown smaller than the chart
5. Try resize the chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11472
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
