### PR TITLE
feat: use rison for list view filters stateful urls

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -39151,12 +39151,13 @@
       "dev": true
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "version": "6.13.7",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
+      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -41186,6 +41187,22 @@
         "is-retina": "^1.0.3",
         "md5": "^2.1.0",
         "query-string": "^4.2.2"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        }
       }
     },
     "react-helmet-async": {
@@ -43484,24 +43501,9 @@
       }
     },
     "serialize-query-params": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-0.1.4.tgz",
-      "integrity": "sha512-d3GHKPAOBULhCMg+jM687vRIMnTXMo8M0lHUOVeFxSGYvfmNlksiOpLyb0orhXPhhFCvZvt+SwC2iPRVIhKS/g==",
-      "requires": {
-        "query-string": "^5.0.0"
-      },
-      "dependencies": {
-        "query-string": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
-          }
-        }
-      }
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-1.2.4.tgz",
+      "integrity": "sha512-m4hGkOY5y+ksPDSEkw12cNxt3HRUJv5G6oF9/4yq+GCw4LznudxC73qnz++VTHqXa0j1x1/iaBIpoiMBxr6w2w=="
     },
     "serve-favicon": {
       "version": "2.5.0",
@@ -44303,6 +44305,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -44572,9 +44579,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-convert": {
       "version": "0.2.1",
@@ -46743,11 +46750,11 @@
       }
     },
     "use-query-params": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-0.4.5.tgz",
-      "integrity": "sha512-HeSgLvEj26pkNRGeAIq+uTo6Z22iaAqDMosq+Be5lab4v57gwVIUKsS3iZ1BBgsUbLEKKpoqcVvqd9MUg+lkIw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-1.1.9.tgz",
+      "integrity": "sha512-WAJ1GrKbFWv1TBn1RQpHqAwC7yyJsLaJjBhIfefrbY/h6mFSngzBQKirJndYwCS1ry77EwhpR/tQi5iovXWvuw==",
       "requires": {
-        "serialize-query-params": "^0.1.4"
+        "serialize-query-params": "^1.2.3"
       }
     },
     "use-sidecar": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -125,6 +125,7 @@
     "omnibar": "^2.1.1",
     "polished": "^3.6.5",
     "prop-types": "^15.7.2",
+    "query-string": "^6.13.7",
     "re-resizable": "^6.6.1",
     "react": "^16.13.1",
     "react-ace": "^5.10.0",
@@ -166,7 +167,7 @@
     "rison": "^0.1.1",
     "shortid": "^2.2.6",
     "urijs": "^1.18.10",
-    "use-query-params": "^0.4.5"
+    "use-query-params": "^1.1.9"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.5",

--- a/superset-frontend/spec/helpers/MountWrapper.tsx
+++ b/superset-frontend/spec/helpers/MountWrapper.tsx
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { ThemeProvider } from '@superset-ui/core';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { QueryParamProvider } from 'use-query-params';
+
+// Wrapper component for mounting TODO: move to util file
+export function Wrapper(props: any) {
+  const { children, theme } = props;
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Router>
+        <QueryParamProvider
+          ReactRouterRoute={Route}
+          stringifyOptions={{ encode: false }}
+        >
+          {children}
+        </QueryParamProvider>
+      </Router>
+    </ThemeProvider>
+  );
+}

--- a/superset-frontend/spec/helpers/ProviderWrapper.tsx
+++ b/superset-frontend/spec/helpers/ProviderWrapper.tsx
@@ -23,7 +23,7 @@ import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 
 // Wrapper component for mounting TODO: move to util file
-export function Wrapper(props: any) {
+export function ProviderWrapper(props: any) {
   const { children, theme } = props;
 
   return (

--- a/superset-frontend/spec/helpers/ProviderWrapper.tsx
+++ b/superset-frontend/spec/helpers/ProviderWrapper.tsx
@@ -22,7 +22,6 @@ import { ThemeProvider } from '@superset-ui/core';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 
-// Wrapper component for mounting TODO: move to util file
 export function ProviderWrapper(props: any) {
   const { children, theme } = props;
 

--- a/superset-frontend/spec/helpers/theming.ts
+++ b/superset-frontend/spec/helpers/theming.ts
@@ -33,7 +33,7 @@ export function styledMount(
 ) {
   return enzymeMount(component, {
     ...options,
-    wrappingComponent: Wrapper,
+    wrappingComponent: ProviderWrapper,
     wrappingComponentProps: {
       theme: supersetTheme,
       ...options?.wrappingComponentProps,
@@ -47,7 +47,7 @@ export function styledShallow(
 ) {
   return enzymeShallow(component, {
     ...options,
-    wrappingComponent: Wrapper,
+    wrappingComponent: ProviderWrapper,
     wrappingComponentProps: {
       theme: supersetTheme,
       ...options?.wrappingComponentProps,

--- a/superset-frontend/spec/helpers/theming.ts
+++ b/superset-frontend/spec/helpers/theming.ts
@@ -19,7 +19,7 @@
 import { shallow as enzymeShallow, mount as enzymeMount } from 'enzyme';
 import { supersetTheme } from '@superset-ui/core';
 import { ReactElement } from 'react';
-import { Wrapper } from './MountWrapper';
+import { ProviderWrapper } from './ProviderWrapper';
 
 type optionsType = {
   wrappingComponentProps?: any;

--- a/superset-frontend/spec/helpers/theming.ts
+++ b/superset-frontend/spec/helpers/theming.ts
@@ -17,8 +17,9 @@
  * under the License.
  */
 import { shallow as enzymeShallow, mount as enzymeMount } from 'enzyme';
-import { supersetTheme, ThemeProvider } from '@superset-ui/core';
+import { supersetTheme } from '@superset-ui/core';
 import { ReactElement } from 'react';
+import { Wrapper } from './MountWrapper';
 
 type optionsType = {
   wrappingComponentProps?: any;
@@ -32,7 +33,7 @@ export function styledMount(
 ) {
   return enzymeMount(component, {
     ...options,
-    wrappingComponent: ThemeProvider,
+    wrappingComponent: Wrapper,
     wrappingComponentProps: {
       theme: supersetTheme,
       ...options?.wrappingComponentProps,
@@ -46,7 +47,7 @@ export function styledShallow(
 ) {
   return enzymeShallow(component, {
     ...options,
-    wrappingComponent: ThemeProvider,
+    wrappingComponent: Wrapper,
     wrappingComponentProps: {
       theme: supersetTheme,
       ...options?.wrappingComponentProps,

--- a/superset-frontend/spec/javascripts/components/AlteredSliceTag_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/AlteredSliceTag_spec.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { styledMount as mount } from 'spec/helpers/theming';
 import { getChartControlPanelRegistry } from '@superset-ui/core';
 
 import AlteredSliceTag from 'src/components/AlteredSliceTag';
@@ -34,7 +34,7 @@ import {
 } from './fixtures/AlteredSliceTag';
 
 const getTableWrapperFromModalBody = modalBody =>
-  modalBody.find(ListView).shallow().find(TableCollection).shallow();
+  modalBody.find(ListView).find(TableCollection);
 
 describe('AlteredSliceTag', () => {
   let wrapper;
@@ -47,7 +47,7 @@ describe('AlteredSliceTag', () => {
       fakePluginControls,
     );
     props = { ...defaultProps };
-    wrapper = shallow(<AlteredSliceTag {...props} />);
+    wrapper = mount(<AlteredSliceTag {...props} />);
     ({ controlsMap } = wrapper.instance().state);
   });
 
@@ -63,7 +63,7 @@ describe('AlteredSliceTag', () => {
       origFormData: props.origFormData,
       currentFormData: props.origFormData,
     };
-    wrapper = shallow(<AlteredSliceTag {...props} />);
+    wrapper = mount(<AlteredSliceTag {...props} />);
     expect(wrapper.instance().state.rows).toEqual([]);
     expect(wrapper.instance().state.hasDiffs).toBe(false);
     expect(wrapper.instance().render()).toBeNull();
@@ -78,7 +78,7 @@ describe('AlteredSliceTag', () => {
       currentFormData: { ...props.currentFormData },
       origFormData: { ...props.origFormData },
     };
-    wrapper = shallow(<AlteredSliceTag {...props} />);
+    wrapper = mount(<AlteredSliceTag {...props} />);
     const wrapperInstance = wrapper.instance();
     wrapperInstance.UNSAFE_componentWillReceiveProps(newProps);
     expect(getRowsFromDiffsStub).toHaveBeenCalled();
@@ -98,7 +98,7 @@ describe('AlteredSliceTag', () => {
 
   describe('renderTriggerNode', () => {
     it('renders a TooltipWrapper', () => {
-      const triggerNode = shallow(
+      const triggerNode = mount(
         <div>{wrapper.instance().renderTriggerNode()}</div>,
       );
       expect(triggerNode.find(TooltipWrapper)).toHaveLength(1);
@@ -107,14 +107,14 @@ describe('AlteredSliceTag', () => {
 
   describe('renderModalBody', () => {
     it('renders a Table', () => {
-      const modalBody = shallow(
+      const modalBody = mount(
         <div>{wrapper.instance().renderModalBody()}</div>,
       );
       expect(modalBody.find(ListView)).toHaveLength(1);
     });
 
     it('renders a thead', () => {
-      const modalBody = shallow(
+      const modalBody = mount(
         <div>{wrapper.instance().renderModalBody()}</div>,
       );
       expect(
@@ -123,7 +123,7 @@ describe('AlteredSliceTag', () => {
     });
 
     it('renders th', () => {
-      const modalBody = shallow(
+      const modalBody = mount(
         <div>{wrapper.instance().renderModalBody()}</div>,
       );
       const th = getTableWrapperFromModalBody(modalBody).find('th');
@@ -134,7 +134,7 @@ describe('AlteredSliceTag', () => {
     });
 
     it('renders the correct number of Tr', () => {
-      const modalBody = shallow(
+      const modalBody = mount(
         <div>{wrapper.instance().renderModalBody()}</div>,
       );
       const tr = getTableWrapperFromModalBody(modalBody).find('tr');
@@ -142,7 +142,7 @@ describe('AlteredSliceTag', () => {
     });
 
     it('renders the correct number of td', () => {
-      const modalBody = shallow(
+      const modalBody = mount(
         <div>{wrapper.instance().renderModalBody()}</div>,
       );
       const td = getTableWrapperFromModalBody(modalBody).find('td');
@@ -155,12 +155,12 @@ describe('AlteredSliceTag', () => {
 
   describe('renderRows', () => {
     it('returns an array of rows with one tr and three td', () => {
-      const modalBody = shallow(
+      const modalBody = mount(
         <div>{wrapper.instance().renderModalBody()}</div>,
       );
       const rows = getTableWrapperFromModalBody(modalBody).find('tr');
       expect(rows).toHaveLength(8);
-      const fakeRow = shallow(<div>{rows.get(1)}</div>);
+      const fakeRow = mount(<div>{rows.get(1)}</div>);
       expect(fakeRow.find('tr')).toHaveLength(1);
       expect(fakeRow.find('td')).toHaveLength(3);
     });

--- a/superset-frontend/spec/javascripts/components/ListView/ListView_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/ListView/ListView_spec.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { styledMount as mount } from 'spec/helpers/theming';
 import { act } from 'react-dom/test-utils';
 import { QueryParamProvider } from 'use-query-params';
 import { supersetTheme, ThemeProvider } from '@superset-ui/core';
@@ -338,7 +338,7 @@ describe('ListView', () => {
       filters: [...mockedProps.filters, { id: 'some_column' }],
     };
     expect(() => {
-      shallow(<ListView {...props} />, {
+      mount(<ListView {...props} />, {
         wrappingComponent: ThemeProvider,
         wrappingComponentProps: { theme: supersetTheme },
       });

--- a/superset-frontend/src/components/ListView/Filters.tsx
+++ b/superset-frontend/src/components/ListView/Filters.tsx
@@ -87,8 +87,18 @@ function SelectFilter({
   };
 
   const options = [clearFilterSelect, ...selects];
+  let initialOption = clearFilterSelect;
 
-  const [selectedOption, setSelectedOption] = useState(clearFilterSelect);
+  // Set initial value if not async
+  if (!fetchSelects) {
+    const matchingOption = options.find(x => x.value === initialValue);
+
+    if (matchingOption) {
+      initialOption = matchingOption;
+    }
+  }
+
+  const [selectedOption, setSelectedOption] = useState(initialOption);
   const onChange = (selected: SelectOption | null) => {
     if (selected === null) return;
     onSelect(

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t, styled } from '@superset-ui/core';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Alert } from 'react-bootstrap';
 import { Empty } from 'src/common/components';
 import { ReactComponent as EmptyImage } from 'images/empty.svg';
@@ -294,14 +294,6 @@ function ListView<T extends object = any>({
   }
 
   const cardViewEnabled = Boolean(renderCard);
-  const [viewingMode, setViewingMode] = useState<ViewModeType>(
-    cardViewEnabled ? viewMode || defaultViewMode : 'table',
-  );
-
-  const updateViewingMode = (mode: ViewModeType) => {
-    setViewingMode(mode);
-    setViewMode(mode);
-  };
 
   useEffect(() => {
     // discard selections if bulk select is disabled
@@ -314,7 +306,7 @@ function ListView<T extends object = any>({
         <div className="header">
           <div className="header-left">
             {cardViewEnabled && (
-              <ViewModeToggle mode={viewingMode} setMode={updateViewingMode} />
+              <ViewModeToggle mode={viewMode} setMode={setViewMode} />
             )}
             {filterable && (
               <FilterControls
@@ -325,7 +317,7 @@ function ListView<T extends object = any>({
             )}
           </div>
           <div className="header-right">
-            {viewingMode === 'card' && cardSortSelectOptions && (
+            {viewMode === 'card' && cardSortSelectOptions && (
               <CardSortSelect
                 initialSort={initialSort}
                 onChange={fetchData}
@@ -375,7 +367,7 @@ function ListView<T extends object = any>({
               )}
             </BulkSelectWrapper>
           )}
-          {viewingMode === 'card' && (
+          {viewMode === 'card' && (
             <CardCollection
               bulkSelectEnabled={bulkSelectEnabled}
               prepareRow={prepareRow}
@@ -384,7 +376,7 @@ function ListView<T extends object = any>({
               loading={loading}
             />
           )}
-          {viewingMode === 'table' && (
+          {viewMode === 'table' && (
             <TableCollection
               getTableProps={getTableProps}
               getTableBodyProps={getTableBodyProps}
@@ -397,7 +389,7 @@ function ListView<T extends object = any>({
             />
           )}
           {!loading && rows.length === 0 && (
-            <EmptyWrapper className={viewingMode}>
+            <EmptyWrapper className={viewMode}>
               <Empty
                 image={<EmptyImage />}
                 description={emptyState.message || 'No Data'}

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -34,6 +34,7 @@ import {
   Filters,
   SortColumn,
   CardSortSelectOption,
+  ViewModeType,
 } from './types';
 import { ListViewError, useListViewState } from './utils';
 
@@ -202,7 +203,6 @@ const ViewModeToggle = ({
   );
 };
 
-type ViewModeType = 'card' | 'table';
 export interface ListViewProps<T extends object = any> {
   columns: any[];
   data: T[];
@@ -263,7 +263,8 @@ function ListView<T extends object = any>({
     applyFilterValue,
     selectedFlatRows,
     toggleAllRowsSelected,
-    state: { pageIndex, pageSize, internalFilters },
+    setViewMode,
+    state: { pageIndex, pageSize, internalFilters, viewMode },
   } = useListViewState({
     bulkSelectColumnConfig,
     bulkSelectMode: bulkSelectEnabled && Boolean(bulkActions.length),
@@ -274,6 +275,7 @@ function ListView<T extends object = any>({
     initialPageSize,
     initialSort,
     initialFilters: filters,
+    renderCard: Boolean(renderCard),
   });
   const filterable = Boolean(filters.length);
   if (filterable) {
@@ -292,8 +294,13 @@ function ListView<T extends object = any>({
 
   const cardViewEnabled = Boolean(renderCard);
   const [viewingMode, setViewingMode] = useState<ViewModeType>(
-    cardViewEnabled ? defaultViewMode : 'table',
+    cardViewEnabled ? viewMode || defaultViewMode : 'table',
   );
+
+  const updateViewingMode = (mode: ViewModeType) => {
+    setViewingMode(mode);
+    setViewMode(mode);
+  };
 
   useEffect(() => {
     // discard selections if bulk select is disabled
@@ -306,7 +313,7 @@ function ListView<T extends object = any>({
         <div className="header">
           <div className="header-left">
             {cardViewEnabled && (
-              <ViewModeToggle mode={viewingMode} setMode={setViewingMode} />
+              <ViewModeToggle mode={viewingMode} setMode={updateViewingMode} />
             )}
             {filterable && (
               <FilterControls

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -276,6 +276,7 @@ function ListView<T extends object = any>({
     initialSort,
     initialFilters: filters,
     renderCard: Boolean(renderCard),
+    defaultViewMode,
   });
   const filterable = Boolean(filters.length);
   if (filterable) {

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -71,6 +71,8 @@ export interface Filter {
 
 export type Filters = Filter[];
 
+export type ViewModeType = 'card' | 'table';
+
 export interface FilterValue {
   id: string;
   operator?: string;

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -26,12 +26,7 @@ import {
   useTable,
 } from 'react-table';
 
-import {
-  // JsonParam,
-  NumberParam,
-  StringParam,
-  useQueryParams,
-} from 'use-query-params';
+import { NumberParam, StringParam, useQueryParams } from 'use-query-params';
 
 import rison from 'rison';
 import { isEqual } from 'lodash';
@@ -70,7 +65,6 @@ function updateInList(list: any[], index: number, update: any): any[] {
   ];
 }
 
-// TODO: update to handle new query.filters format ({id: value,...})
 function mergeCreateFilterValues(list: Filter[], updateObj: any) {
   return list.map(({ id, operator }) => {
     const update = updateObj[id] || [];
@@ -86,7 +80,7 @@ export function convertFilters(fts: InternalFilter[]): FilterValue[] {
     .map(({ value, operator, id }) => ({ value, operator, id }));
 }
 
-// convertFilters but to handle new decoded rison format TODO: update types
+// convertFilters but to handle new decoded rison format
 export function convertFiltersRison(filterObj: any): FilterValue[] {
   const filters: FilterValue[] = [];
 
@@ -234,7 +228,6 @@ export function useListViewState({
     // From internalFilters, produce a simplified obj
     const filterObj = {};
 
-    // TODO: maybe update the format of internalFilters???
     internalFilters.forEach(filter => {
       if (
         filter.value !== undefined &&
@@ -245,7 +238,6 @@ export function useListViewState({
     });
 
     const queryParams: any = {
-      // filters: internalFilters,
       filters: Object.keys(filterObj).length ? filterObj : undefined,
       pageIndex,
     };

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -235,7 +235,10 @@ export function useListViewState({
 
     // TODO: maybe update the format of internalFilters???
     internalFilters.forEach(filter => {
-      if (filter.value) {
+      if (
+        filter.value !== undefined &&
+        (typeof filter.value !== 'string' || filter.value.length > 0)
+      ) {
         filterObj[filter.id] = [filter.value, filter.operator];
       }
     });

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -133,6 +133,7 @@ interface UseListViewConfig {
     Cell: (conf: any) => React.ReactNode;
   };
   renderCard?: boolean;
+  defaultViewMode?: ViewModeType;
 }
 
 export function useListViewState({
@@ -146,6 +147,7 @@ export function useListViewState({
   bulkSelectMode = false,
   bulkSelectColumnConfig,
   renderCard = false,
+  defaultViewMode = 'card',
 }: UseListViewConfig) {
   const [query, setQuery] = useQueryParams({
     filters: RisonParam,
@@ -171,7 +173,8 @@ export function useListViewState({
   };
 
   const [viewMode, setViewMode] = useState<ViewModeType>(
-    (query.viewMode as ViewModeType) || 'table',
+    (query.viewMode as ViewModeType) ||
+      (renderCard ? defaultViewMode : 'table'),
   );
 
   const columnsWithSelect = useMemo(() => {

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -27,7 +27,7 @@ import {
 } from 'react-table';
 
 import {
-  JsonParam,
+  // JsonParam,
   NumberParam,
   StringParam,
   useQueryParams,
@@ -143,8 +143,8 @@ export function useListViewState({
   bulkSelectColumnConfig,
 }: UseListViewConfig) {
   const [query, setQuery] = useQueryParams({
-    filters: JsonParam,
-    filtersEncoded: StringParam,
+    // filters: JsonParam,
+    filters: StringParam,
     pageIndex: NumberParam,
     sortColumn: StringParam,
     sortOrder: StringParam,
@@ -161,9 +161,9 @@ export function useListViewState({
   // TODO: eventually replace filters with filtersEncoded, and update convertFilters to handle decoded rison
   const initialState = {
     // filters: convertFilters(query.filters || []),
-    filtersEncoded: query.filtersEncoded
-      ? convertFiltersRison(rison.decode(query.filtersEncoded))
-      : undefined,
+    filters: query.filters
+      ? convertFiltersRison(rison.decode(query.filters))
+      : [],
     pageIndex: query.pageIndex || 0,
     pageSize: initialPageSize,
     sortBy: initialSortBy,
@@ -213,8 +213,8 @@ export function useListViewState({
   );
 
   const [internalFilters, setInternalFilters] = useState<InternalFilter[]>(
-    query.filtersEncoded
-      ? convertFiltersRison(rison.decode(query.filtersEncoded))
+    query.filters && initialFilters.length
+      ? mergeCreateFilterValues(initialFilters, rison.decode(query.filters))
       : [],
   );
 
@@ -223,7 +223,7 @@ export function useListViewState({
       setInternalFilters(
         mergeCreateFilterValues(
           initialFilters,
-          query.filtersEncoded ? rison.decode(query.filtersEncoded) : {},
+          query.filters ? rison.decode(query.filters) : {},
         ),
       );
     }
@@ -242,7 +242,7 @@ export function useListViewState({
 
     const queryParams: any = {
       // filters: internalFilters,
-      filtersEncoded: Object.keys(filterObj).length
+      filters: Object.keys(filterObj).length
         ? rison.encode(filterObj)
         : undefined,
       pageIndex,

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -37,6 +37,7 @@ import {
   FilterValue,
   InternalFilter,
   SortColumn,
+  ViewModeType,
 } from './types';
 
 // Define custom RisonParam for proper encoding/decoding
@@ -131,6 +132,7 @@ interface UseListViewConfig {
     Header: (conf: any) => React.ReactNode;
     Cell: (conf: any) => React.ReactNode;
   };
+  renderCard?: boolean;
 }
 
 export function useListViewState({
@@ -143,12 +145,14 @@ export function useListViewState({
   initialSort = [],
   bulkSelectMode = false,
   bulkSelectColumnConfig,
+  renderCard = false,
 }: UseListViewConfig) {
   const [query, setQuery] = useQueryParams({
     filters: RisonParam,
     pageIndex: NumberParam,
     sortColumn: StringParam,
     sortOrder: StringParam,
+    viewMode: StringParam,
   });
 
   const initialSortBy = useMemo(
@@ -165,6 +169,10 @@ export function useListViewState({
     pageSize: initialPageSize,
     sortBy: initialSortBy,
   };
+
+  const [viewMode, setViewMode] = useState<ViewModeType>(
+    (query.viewMode as ViewModeType) || 'table',
+  );
 
   const columnsWithSelect = useMemo(() => {
     // add exact filter type so filters with falsey values are not filtered out
@@ -248,6 +256,10 @@ export function useListViewState({
       queryParams.sortOrder = sortBy[0].desc ? 'desc' : 'asc';
     }
 
+    if (renderCard) {
+      queryParams.viewMode = viewMode;
+    }
+
     const method =
       typeof query.pageIndex !== 'undefined' &&
       queryParams.pageIndex !== query.pageIndex
@@ -256,7 +268,7 @@ export function useListViewState({
 
     setQuery(queryParams, method);
     fetchData({ pageIndex, pageSize, sortBy, filters });
-  }, [fetchData, pageIndex, pageSize, sortBy, filters]);
+  }, [fetchData, pageIndex, pageSize, sortBy, filters, viewMode]);
 
   useEffect(() => {
     if (!isEqual(initialState.pageIndex, pageIndex)) {
@@ -294,9 +306,10 @@ export function useListViewState({
     rows,
     selectedFlatRows,
     setAllFilters,
-    state: { pageIndex, pageSize, sortBy, filters, internalFilters },
+    state: { pageIndex, pageSize, sortBy, filters, internalFilters, viewMode },
     toggleAllRowsSelected,
     applyFilterValue,
+    setViewMode,
   };
 }
 

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -41,8 +41,10 @@ import {
 
 // Define custom RisonParam for proper encoding/decoding
 const RisonParam = {
-  encode: (data: any | null | undefined) => rison.encode(data),
-  decode: (dataStr: string) => rison.decode(dataStr),
+  encode: (data: any | null | undefined) =>
+    data === undefined ? undefined : rison.encode(data),
+  decode: (dataStr: string | undefined) =>
+    dataStr === undefined ? undefined : rison.decode(dataStr),
 };
 
 export class ListViewError extends Error {

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -68,7 +68,10 @@ const App = () => (
     <ThemeProvider theme={supersetTheme}>
       <FlashProvider common={common}>
         <Router>
-          <QueryParamProvider ReactRouterRoute={Route}>
+          <QueryParamProvider
+            ReactRouterRoute={Route}
+            stringifyOptions={{ encode: false }}
+          >
             <Menu data={menu} />
             <Switch>
               <Route path="/superset/welcome/">


### PR DESCRIPTION
### SUMMARY
- [x] For `ListView` logic filter logic, update URL `filters` param to use a rison format
- [x] Clean up `filters` to only include filters set to non-default values and rm irrelevant data
- [x] Update `Filters` UI component to properly populate selected dropdown filter (for non-async filter options)
- [x] Add `viewMode` URL param

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1207" alt="Screen Shot 2020-11-13 at 12 41 00 PM" src="https://user-images.githubusercontent.com/8216382/99119356-f1216680-25ad-11eb-91bd-58c847e6e986.png">
<img width="1372" alt="Screen Shot 2020-11-13 at 12 41 39 PM" src="https://user-images.githubusercontent.com/8216382/99119361-f2eb2a00-25ad-11eb-8587-8d2dcba55866.png">

### TEST PLAN
- [x] Fix tests broken by update of `use-query-params` lib
- [x] Update the `styledMount`/`styledShallow` helper functions to include `Router` and `QueryParamProvider`

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache-superset/superset-roadmap/issues/59
- [x] Changes UI (by fixing filter dropdown/search bar populating logic)
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
