### PR TITLE
chore: remove a few obsolete logic

### DIFF
--- a/superset-frontend/src/dashboard/actions/sliceEntities.js
+++ b/superset-frontend/src/dashboard/actions/sliceEntities.js
@@ -85,23 +85,21 @@ export function fetchAllSlices(userId) {
                 datasource,
               };
             }
-            if (['markup', 'separator'].indexOf(slice.viz_type) === -1) {
-              slices[slice.id] = {
-                slice_id: slice.id,
-                slice_url: slice.url,
-                slice_name: slice.slice_name,
-                edit_url: slice.edit_url,
-                form_data,
-                datasource_name: slice.datasource_name_text,
-                datasource_url: slice.datasource_url,
-                changed_on: new Date(slice.changed_on_utc).getTime(),
-                description: slice.description,
-                description_markdown: slice.description_markeddown,
-                viz_type: slice.viz_type,
-                modified: slice.changed_on_delta_humanized,
-                changed_on_humanized: slice.changed_on_delta_humanized,
-              };
-            }
+            slices[slice.id] = {
+              slice_id: slice.id,
+              slice_url: slice.url,
+              slice_name: slice.slice_name,
+              edit_url: slice.edit_url,
+              form_data,
+              datasource_name: slice.datasource_name_text,
+              datasource_url: slice.datasource_url,
+              changed_on: new Date(slice.changed_on_utc).getTime(),
+              description: slice.description,
+              description_markdown: slice.description_markeddown,
+              viz_type: slice.viz_type,
+              modified: slice.changed_on_delta_humanized,
+              changed_on_humanized: slice.changed_on_delta_humanized,
+            };
           });
 
           return dispatch(setAllSlices(slices));

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -35,8 +35,6 @@ import { NEW_TAB_ID, DASHBOARD_ROOT_ID } from '../../util/constants';
 import { RENDER_TAB, RENDER_TAB_CONTENT } from './Tab';
 import { TAB_TYPE } from '../../util/componentTypes';
 
-const MAX_TAB_COUNT = 10;
-
 const propTypes = {
   id: PropTypes.string.isRequired,
   parentId: PropTypes.string.isRequired,
@@ -297,7 +295,6 @@ class Tabs extends React.PureComponent {
                 this.handleClickTab(tabIds.indexOf(key));
               }}
               onEdit={this.handleEdit}
-              hideAdd={tabIds.length >= MAX_TAB_COUNT}
               data-test="nav-list"
               type={editMode ? 'editable-card' : 'card'}
             >

--- a/superset-frontend/src/dashboard/util/constants.ts
+++ b/superset-frontend/src/dashboard/util/constants.ts
@@ -63,9 +63,6 @@ export const SAVE_TYPE_NEWDASHBOARD = 'newDashboard';
 // could be overwritten by server-side config
 export const DASHBOARD_POSITION_DATA_LIMIT = 65535;
 
-// filter indicators display length
-export const FILTER_INDICATORS_DISPLAY_LENGTH = 3;
-
 // in-component element types: can be added into
 // directPathToChild, used for in dashboard navigation and focus
 export const IN_COMPONENT_ELEMENT_TYPES = ['LABEL'];


### PR DESCRIPTION
### SUMMARY
Remove a few obsolete logic after recent new features and improvements:

- remove 'markup', 'separator' viz_type check
- remove hard limit for the number of tabs allowed in dashboard
- remove limit allowed for number of filter indicator.

### TEST PLAN
CI

