### PR TITLE
fix(saved query): handle null sql field

### DIFF
--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryPreviewModal.tsx
@@ -162,7 +162,7 @@ const SavedQueryPreviewModal: FunctionComponent<SavedQueryPreviewModalProps> = (
         <QueryTitle>query name</QueryTitle>
         <QueryLabel>{savedQuery.label}</QueryLabel>
         <SyntaxHighlighter language="sql" style={github}>
-          {savedQuery.sql}
+          {savedQuery.sql || ''}
         </SyntaxHighlighter>
       </StyledModal>
     </div>

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -56,6 +56,6 @@ export type SavedQueryObject = {
   id: number;
   label: string;
   schema: string;
-  sql: string;
+  sql: string | null;
   sql_tables?: { catalog?: string; schema: string; table: string }[];
 };


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There's an error in the typing of SavedQueryObject, `sql` field can be null which causes the preview modal to error out.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- manually tested that a blank query does not error out in the saved query preview modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
