### PR TITLE
feat(dashboard): change dashboard edit action

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard_list/card_view.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard_list/card_view.test.ts
@@ -106,16 +106,10 @@ describe('Dashboard card view', () => {
     cy.get('[data-test="modal-cancel-button"]').click();
   });
 
-  it('should edit correctly', () => {
-    // show edit modal
+  it('should show edit link', () => {
     cy.get('[data-test="more-horiz"]').last().trigger('mouseover');
-    cy.get('[data-test="dashboard-card-option-edit-button"]')
-      .should('be.visible')
-      .click();
-    cy.get('[data-test="dashboard-edit-properties-form"]').should('be.visible');
-    cy.get('[data-test="dashboard-title-input"]').should('not.have.value');
-    cy.get('[data-test="properties-modal-cancel-button"]')
-      .contains('Cancel')
-      .click();
+    cy.get('[data-test="dashboard-card-option-edit-button"]').should(
+      'be.visible',
+    );
   });
 });

--- a/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
@@ -81,8 +81,6 @@ fetchMock.get(dashboardsEndpoint, {
 global.URL.createObjectURL = jest.fn();
 fetchMock.get('/thumbnail', { body: new Blob(), sendAsJson: false });
 
-const oldWindowLocationAssign = window.location.assign;
-
 describe('DashboardList', () => {
   const isFeatureEnabledMock = jest
     .spyOn(featureFlags, 'isFeatureEnabled')
@@ -99,15 +97,6 @@ describe('DashboardList', () => {
 
   beforeAll(async () => {
     await waitForComponentToPaint(wrapper);
-    window.location.assign = jest.fn();
-  });
-
-  afterEach(() => {
-    window.location.assign.mockReset();
-  });
-
-  afterAll(() => {
-    window.location.assign = oldWindowLocationAssign;
   });
 
   it('renders', () => {
@@ -142,13 +131,11 @@ describe('DashboardList', () => {
   });
 
   it('edits', () => {
-    wrapper.find('[data-test="edit-alt"]').first().simulate('click');
-    expect(window.location.assign).toHaveBeenCalledWith('url?edit=true');
-  });
-
-  it('card view edits', () => {
-    wrapper.find('[data-test="edit-alt"]').last().simulate('click');
-    expect(window.location.assign).toHaveBeenCalledWith('url?edit=true');
+    const { href } = wrapper
+      .find('[data-test="edit-dashboard-action"]')
+      .first()
+      .props();
+    expect(href).toEqual('url?edit=true');
   });
 
   it('delete', () => {

--- a/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/dashboard/DashboardList_spec.jsx
@@ -29,7 +29,6 @@ import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import DashboardList from 'src/views/CRUD/dashboard/DashboardList';
 import ListView from 'src/components/ListView';
 import ListViewCard from 'src/components/ListViewCard';
-import PropertiesModal from 'src/dashboard/components/PropertiesModal';
 
 // store needed for withToasts(DashboardTable)
 const mockStore = configureStore([thunk]);
@@ -82,6 +81,8 @@ fetchMock.get(dashboardsEndpoint, {
 global.URL.createObjectURL = jest.fn();
 fetchMock.get('/thumbnail', { body: new Blob(), sendAsJson: false });
 
+const oldWindowLocationAssign = window.location.assign;
+
 describe('DashboardList', () => {
   const isFeatureEnabledMock = jest
     .spyOn(featureFlags, 'isFeatureEnabled')
@@ -98,6 +99,15 @@ describe('DashboardList', () => {
 
   beforeAll(async () => {
     await waitForComponentToPaint(wrapper);
+    window.location.assign = jest.fn();
+  });
+
+  afterEach(() => {
+    window.location.assign.mockReset();
+  });
+
+  afterAll(() => {
+    window.location.assign = oldWindowLocationAssign;
   });
 
   it('renders', () => {
@@ -132,14 +142,13 @@ describe('DashboardList', () => {
   });
 
   it('edits', () => {
-    expect(wrapper.find(PropertiesModal)).not.toExist();
     wrapper.find('[data-test="edit-alt"]').first().simulate('click');
-    expect(wrapper.find(PropertiesModal)).toExist();
+    expect(window.location.assign).toHaveBeenCalledWith('url?edit=true');
   });
 
   it('card view edits', () => {
     wrapper.find('[data-test="edit-alt"]').last().simulate('click');
-    expect(wrapper.find(PropertiesModal)).toExist();
+    expect(window.location.assign).toHaveBeenCalledWith('url?edit=true');
   });
 
   it('delete', () => {

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
@@ -41,7 +41,7 @@ interface DashboardCardProps {
   loading: boolean;
   addDangerToast: (msg: string) => void;
   addSuccessToast: (msg: string) => void;
-  openDashboardEditModal?: (d: Dashboard) => void;
+  handleDashboardEdit?: (d: Dashboard) => void;
   saveFavoriteStatus: (id: number, isStarred: boolean) => void;
   favoriteStatus: boolean;
   dashboardFilter?: string;
@@ -57,7 +57,7 @@ function DashboardCard({
   userId,
   addDangerToast,
   addSuccessToast,
-  openDashboardEditModal,
+  handleDashboardEdit,
   favoriteStatus,
   saveFavoriteStatus,
 }: DashboardCardProps) {
@@ -67,13 +67,11 @@ function DashboardCard({
 
   const menu = (
     <Menu>
-      {canEdit && openDashboardEditModal && (
+      {canEdit && handleDashboardEdit && (
         <Menu.Item
           role="button"
           tabIndex={0}
-          onClick={() =>
-            openDashboardEditModal && openDashboardEditModal(dashboard)
-          }
+          onClick={() => handleDashboardEdit && handleDashboardEdit(dashboard)}
           data-test="dashboard-card-option-edit-button"
         >
           <ListViewCard.MenuIcon name="edit-alt" /> Edit

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
@@ -41,7 +41,6 @@ interface DashboardCardProps {
   loading: boolean;
   addDangerToast: (msg: string) => void;
   addSuccessToast: (msg: string) => void;
-  handleDashboardEdit?: (d: Dashboard) => void;
   saveFavoriteStatus: (id: number, isStarred: boolean) => void;
   favoriteStatus: boolean;
   dashboardFilter?: string;
@@ -57,7 +56,6 @@ function DashboardCard({
   userId,
   addDangerToast,
   addSuccessToast,
-  handleDashboardEdit,
   favoriteStatus,
   saveFavoriteStatus,
 }: DashboardCardProps) {
@@ -67,18 +65,19 @@ function DashboardCard({
 
   const menu = (
     <Menu>
-      {canEdit && handleDashboardEdit && (
-        <Menu.Item
-          role="button"
-          tabIndex={0}
-          onClick={() => handleDashboardEdit && handleDashboardEdit(dashboard)}
-          data-test="dashboard-card-option-edit-button"
-        >
-          <ListViewCard.MenuIcon name="edit-alt" /> Edit
+      {canEdit && (
+        <Menu.Item key="edit">
+          <a
+            href={`${dashboard.url}?edit=true`}
+            data-test="dashboard-card-option-edit-button"
+          >
+            <ListViewCard.MenuIcon name="edit-alt" /> Edit
+          </a>
         </Menu.Item>
       )}
       {canExport && (
         <Menu.Item
+          key="export"
           role="button"
           tabIndex={0}
           onClick={() => handleBulkDashboardExport([dashboard])}
@@ -87,7 +86,7 @@ function DashboardCard({
         </Menu.Item>
       )}
       {canDelete && (
-        <Menu.Item>
+        <Menu.Item key="delete">
           <ConfirmStatusChange
             title={t('Please Confirm')}
             description={
@@ -147,7 +146,6 @@ function DashboardCard({
           <ListViewCard.Actions
             onClick={e => {
               e.stopPropagation();
-              e.preventDefault();
             }}
           >
             <FaveStar

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -264,6 +264,7 @@ function DashboardList(props: DashboardListProps) {
                   placement="bottom"
                 >
                   <a
+                    data-test="edit-dashboard-action"
                     className="action-button"
                     href={`${original.url}?edit=true`}
                   >

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardList.tsx
@@ -94,10 +94,6 @@ function DashboardList(props: DashboardListProps) {
 
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
-  function handleDashboardEdit({ url }: Dashboard) {
-    window.location.assign(`${url}?edit=true`);
-  }
-
   function handleBulkDashboardDelete(dashboardsToDelete: Dashboard[]) {
     return SupersetClient.delete({
       endpoint: `/api/v1/dashboard/?q=${rison.encode(
@@ -209,7 +205,6 @@ function DashboardList(props: DashboardListProps) {
               props.addSuccessToast,
               props.addDangerToast,
             );
-          const handleEdit = () => handleDashboardEdit(original);
           const handleExport = () => handleBulkDashboardExport([original]);
 
           return (
@@ -268,14 +263,12 @@ function DashboardList(props: DashboardListProps) {
                   tooltip={t('Edit')}
                   placement="bottom"
                 >
-                  <span
-                    role="button"
-                    tabIndex={0}
+                  <a
                     className="action-button"
-                    onClick={handleEdit}
+                    href={`${original.url}?edit=true`}
                   >
                     <Icon name="edit-alt" />
-                  </span>
+                  </a>
                 </TooltipWrapper>
               )}
             </span>
@@ -383,7 +376,6 @@ function DashboardList(props: DashboardListProps) {
         loading={loading}
         addDangerToast={props.addDangerToast}
         addSuccessToast={props.addSuccessToast}
-        handleDashboardEdit={handleDashboardEdit}
         saveFavoriteStatus={saveFavoriteStatus}
         favoriteStatus={favoriteStatus[dashboard.id]}
       />

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -17,16 +17,15 @@
  * under the License.
  */
 import React, { useState, useMemo } from 'react';
-import { SupersetClient, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import { Dashboard, DashboardTableProps } from 'src/views/CRUD/types';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
-import PropertiesModal from 'src/dashboard/components/PropertiesModal';
 import DashboardCard from 'src/views/CRUD/dashboard/DashboardCard';
 import SubMenu from 'src/components/Menu/SubMenu';
 import Icon from 'src/components/Icon';
 import EmptyState from './EmptyState';
-import { createErrorHandler, CardContainer, IconContainer } from '../utils';
+import { CardContainer, IconContainer } from '../utils';
 
 const PAGE_SIZE = 3;
 
@@ -44,7 +43,6 @@ function DashboardTable({
 }: DashboardTableProps) {
   const {
     state: { loading, resourceCollection: dashboards },
-    setResourceCollection: setDashboards,
     hasPerm,
     refreshData,
     fetchData,
@@ -61,29 +59,10 @@ function DashboardTable({
     dashboardIds,
     addDangerToast,
   );
-  const [editModal, setEditModal] = useState<Dashboard>();
   const [dashboardFilter, setDashboardFilter] = useState('Mine');
 
-  const handleDashboardEdit = (edits: Dashboard) => {
-    return SupersetClient.get({
-      endpoint: `/api/v1/dashboard/${edits.id}`,
-    }).then(
-      ({ json = {} }) => {
-        setDashboards(
-          dashboards.map(dashboard => {
-            if (dashboard.id === json.id) {
-              return json.result;
-            }
-            return dashboard;
-          }),
-        );
-      },
-      createErrorHandler(errMsg =>
-        addDangerToast(
-          t('An error occurred while fetching dashboards: %s', errMsg),
-        ),
-      ),
-    );
+  const handleDashboardEdit = ({ url }: Dashboard) => {
+    window.location.assign(`${url}?edit=true`);
   };
 
   const getFilters = (filterName: string) => {
@@ -167,14 +146,6 @@ function DashboardTable({
           },
         ]}
       />
-      {editModal && (
-        <PropertiesModal
-          dashboardId={editModal?.id}
-          show
-          onHide={() => setEditModal(undefined)}
-          onSubmit={handleDashboardEdit}
-        />
-      )}
       {dashboards.length > 0 && (
         <CardContainer>
           {dashboards.map(e => (
@@ -189,9 +160,7 @@ function DashboardTable({
               addSuccessToast={addSuccessToast}
               userId={user?.userId}
               loading={loading}
-              openDashboardEditModal={(dashboard: Dashboard) =>
-                setEditModal(dashboard)
-              }
+              handleDashboardEdit={handleDashboardEdit}
               saveFavoriteStatus={saveFavoriteStatus}
               favoriteStatus={favoriteStatus[e.id]}
             />

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -61,10 +61,6 @@ function DashboardTable({
   );
   const [dashboardFilter, setDashboardFilter] = useState('Mine');
 
-  const handleDashboardEdit = ({ url }: Dashboard) => {
-    window.location.assign(`${url}?edit=true`);
-  };
-
   const getFilters = (filterName: string) => {
     const filters = [];
     if (filterName === 'Mine') {
@@ -160,7 +156,6 @@ function DashboardTable({
               addSuccessToast={addSuccessToast}
               userId={user?.userId}
               loading={loading}
-              handleDashboardEdit={handleDashboardEdit}
               saveFavoriteStatus={saveFavoriteStatus}
               favoriteStatus={favoriteStatus[e.id]}
             />


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replaces the dashboard edit action to open the dashboard in edit mode instead of the properties modal. See linked issue for details
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- CI
- manually tested dashboard card/list edit opens dashboard in edit mode
- manually tested homes screen card opens dashboard in edit mode 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #11520
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
