### PR TITLE
fix: Hidden overflow issues in Dashboard Builder tabs

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -104,6 +104,14 @@ const StyledTabsContainer = styled.div`
     top: ${({ theme }) => theme.gridUnit * 2}px;
   }
 
+  .ant-tabs {
+    overflow: visible;
+
+    .ant-tabs-content-holder {
+      overflow: visible;
+    }
+  }
+
   div .ant-tabs-tab-btn {
     text-transform: none;
   }


### PR DESCRIPTION
### SUMMARY
On Dashboard Builder, when you added a component to a tab, its left-side control buttons were invisible due to `overflow: hidden` on Antd Tabs. The same applies for Markdown's edit menu.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issues
After:
![image](https://user-images.githubusercontent.com/15073128/99045871-45b6e880-2592-11eb-9041-54f01331edea.png)
![image](https://user-images.githubusercontent.com/15073128/99045927-57988b80-2592-11eb-96df-4359ccce0538.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11681, https://github.com/apache/incubator-superset/issues/11642
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @graceguo-supercat, @junlincc, @kkucharc, @rusackas 