### PR TITLE
fix: "Select all" option in SelectControl on Explore view

### DIFF
--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -109,11 +109,9 @@ export default class SelectControl extends React.PureComponent {
         opt.forEach(o => {
           // select all options
           if (o.meta === true) {
-            this.props.onChange(
-              this.getOptions(this.props)
-                .filter(x => !x.meta)
-                .map(x => x[this.props.valueKey]),
-            );
+            optionValue = this.getOptions(this.props)
+              .filter(x => !x.meta)
+              .map(x => x[this.props.valueKey]);
             return;
           }
           optionValue.push(o[this.props.valueKey] || o);


### PR DESCRIPTION
### SUMMARY
On Explore view, "Select all" option on select controls did not work.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/15073128/99056342-76028500-259a-11eb-8146-1b6cd7286461.gif)

### TEST PLAN
Go to Explore, select a Table chart, click Group by -> select all.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11368
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @graceguo-supercat @junlincc @rusackas 