### PR TITLE
fix: Remove "required" from SaveModal Add to dashboard field

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.jsx
@@ -217,7 +217,7 @@ class SaveModal extends React.Component {
             />
           </FormGroup>
           <FormGroup data-test="save-chart-modal-select-dashboard-form">
-            <FormLabel required>{t('Add to dashboard')}</FormLabel>
+            <FormLabel>{t('Add to dashboard')}</FormLabel>
             <CreatableSelect
               id="dashboard-creatable-select"
               className="save-modal-selector"


### PR DESCRIPTION
### SUMMARY
Remove an asterisk from SaveModal, which indicated that Add to dashboard field is required.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/99056735-06d96080-259b-11eb-8c92-7b5d49cc8332.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11468
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @ktmud 