### PR TITLE
chore: add slice_id to v1 chart data request

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/box_plot.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/box_plot.test.js
@@ -40,7 +40,7 @@ describe('Visualization > Box Plot', () => {
   beforeEach(() => {
     cy.server();
     cy.login();
-    cy.route('POST', '/api/v1/chart/data').as('getJson');
+    cy.route('POST', '/api/v1/chart/data*').as('getJson');
   });
 
   it('should work', () => {

--- a/superset-frontend/cypress-base/cypress/integration/explore/visualizations/pie.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/visualizations/pie.test.js
@@ -44,7 +44,7 @@ describe('Visualization > Pie', () => {
   beforeEach(() => {
     cy.server();
     cy.login();
-    cy.route('POST', '/api/v1/chart/data').as('getJson');
+    cy.route('POST', '/api/v1/chart/data*').as('getJson');
   });
 
   it('should work with ad-hoc metric', () => {

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -152,9 +152,12 @@ const v1ChartDataRequest = async (
   });
 
   // The dashboard id is added to query params for tracking purposes
-  const qs = requestParams.dashboard_id
-    ? { dashboard_id: requestParams.dashboard_id }
-    : {};
+  const { slice_id: sliceId } = formData;
+  const { dashboard_id: dashboardId } = requestParams;
+  const qs = {};
+  if (sliceId !== undefined) qs.form_data = `{"slice_id":${sliceId}}`;
+  if (dashboardId !== undefined) qs.dashboard_id = dashboardId;
+
   const allowDomainSharding =
     // eslint-disable-next-line camelcase
     domainShardingEnabled && requestParams?.dashboard_id;


### PR DESCRIPTION
### SUMMARY
Add `form_data={"slice_id":xyz}` to v1 chart data request query string so that it corresponds to the legacy endpoint request.

Ping @adam-stasiak 

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
