### PR TITLE
refactor: Simplifying tabOverride logic in control sections

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -185,23 +185,21 @@ class ControlPanelsContainer extends React.Component {
     const querySectionsToRender = [];
     const displaySectionsToRender = [];
     this.sectionsToRender().forEach(section => {
-      // if at least one control in the section is not `renderTrigger`
-      // or asks to be displayed at the Data tab
-      if (
-        section.tabOverride === 'data' ||
-        section.controlSetRows.some(rows =>
-          rows.some(
-            control =>
-              control &&
-              control.config &&
-              (!control.config.renderTrigger ||
-                control.config.tabOverride === 'data'),
-          ),
-        )
-      ) {
-        querySectionsToRender.push(section);
-      } else {
+      if ( section.tabOverride === 'customize' ){
         displaySectionsToRender.push(section);
+      }
+      else if ( section.tabOverride === 'data' ) {
+        querySectionsToRender.push(section);
+      }
+      else {
+        const allRenderTriggers = section.controlSetRows.every(rows =>
+          rows.every(
+            control =>
+              control?.config?.renderTrigger
+          ),
+        );
+        // if at least one control in the section is not `renderTrigger`, it goes to the query section
+        allRenderTriggers ? displaySectionsToRender.push(section) : querySectionsToRender.push(section);
       }
     });
 

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -194,8 +194,11 @@ class ControlPanelsContainer extends React.Component {
           rows.every(control => control?.config?.renderTrigger),
         );
         // if at least one control in the section is not `renderTrigger`, it goes to the query section
-        if (allRenderTriggers) displaySectionsToRender.push(section);
-        else querySectionsToRender.push(section);
+        if (allRenderTriggers) {
+          displaySectionsToRender.push(section);
+        } else {
+          querySectionsToRender.push(section);
+        }
       }
     });
 

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -185,21 +185,17 @@ class ControlPanelsContainer extends React.Component {
     const querySectionsToRender = [];
     const displaySectionsToRender = [];
     this.sectionsToRender().forEach(section => {
-      if ( section.tabOverride === 'customize' ){
+      if (section.tabOverride === 'customize') {
         displaySectionsToRender.push(section);
-      }
-      else if ( section.tabOverride === 'data' ) {
+      } else if (section.tabOverride === 'data') {
         querySectionsToRender.push(section);
-      }
-      else {
+      } else {
         const allRenderTriggers = section.controlSetRows.every(rows =>
-          rows.every(
-            control =>
-              control?.config?.renderTrigger
-          ),
+          rows.every(control => control?.config?.renderTrigger),
         );
         // if at least one control in the section is not `renderTrigger`, it goes to the query section
-        allRenderTriggers ? displaySectionsToRender.push(section) : querySectionsToRender.push(section);
+        if (allRenderTriggers) displaySectionsToRender.push(section);
+        else querySectionsToRender.push(section);
       }
     });
 

--- a/superset-frontend/src/explore/controlPanels/sections.jsx
+++ b/superset-frontend/src/explore/controlPanels/sections.jsx
@@ -100,7 +100,6 @@ export const annotations = {
           default: [],
           description: 'Annotation Layers',
           renderTrigger: true,
-          tabOverride: 'data',
         },
       },
     ],

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -49,7 +49,8 @@
      show a warning based on the value of another component. It's also possible to bind
      arbitrary data from the redux store to the component this way.
  * - tabOverride: set to 'data' if you want to force a renderTrigger to show up on the `Data`
-     tab, otherwise `renderTrigger: true` components will show up on the `Style` tab.
+     tab, or 'customize' if you want it to show up on that tam. Otherwise sections with ALL 
+     `renderTrigger: true` components will show up on the `Customize` tab.
  *
  * Note that the keys defined in controls in this file that are not listed above represent
  * props specific for the React component defined as `type`. Also note that this module work

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -37,7 +37,10 @@
  * - renderTrigger: a bool that defines whether the visualization should be re-rendered
      when changed. This should `true` for controls that only affect the rendering (client side)
      and don't affect the query or backend data processing as those require to re run a query
-     and fetch the data
+     and fetch the data. Note that if ALL controls in a seciton are set to "renderTrigger: true"
+     the section will appear in the "Customize" tab rather than the "Data" tab. You can add a
+     "tabOverride" parameter to the controls section with a value of "data" or "customize" if 
+     you'd like to override this behavior either way
  * - validators: an array of functions that will receive the value of the component and
      should return error messages when the value is not valid. The error message gets
      bubbled up to the control header, section header and query panel header.
@@ -48,9 +51,7 @@
      anything external to it, like another control's value. For instance it's possible to
      show a warning based on the value of another component. It's also possible to bind
      arbitrary data from the redux store to the component this way.
- * - tabOverride: set to 'data' if you want to force a renderTrigger to show up on the `Data`
-     tab, or 'customize' if you want it to show up on that tam. Otherwise sections with ALL 
-     `renderTrigger: true` components will show up on the `Customize` tab.
+
  *
  * Note that the keys defined in controls in this file that are not listed above represent
  * props specific for the React component defined as `type`. Also note that this module work

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -39,7 +39,7 @@
      and don't affect the query or backend data processing as those require to re run a query
      and fetch the data. Note that if ALL controls in a seciton are set to "renderTrigger: true"
      the section will appear in the "Customize" tab rather than the "Data" tab. You can add a
-     "tabOverride" parameter to the controls section with a value of "data" or "customize" if 
+     "tabOverride" parameter to the controls section with a value of "data" or "customize" if
      you'd like to override this behavior either way
  * - validators: an array of functions that will receive the value of the component and
      should return error messages when the value is not valid. The error message gets


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Various control sections have been showing up under unexpected tabs. This PR makes it simpler/easier to shove control sections under the correct tab, by allowing "tabOverride" to be either "data" or "customize" and simplifying (essentially inverting) the logic that takes place when neither is specified. This also removes support for putting the "tabOverride" in a singular control, and just keeps it to the control section, for simplicity.

I have half a mind to just make it "tab" instead of "tabOverride" and bake it into every control section, as a standard practice... but I'll pocket that one, as a control layout refactor will likely be coming soon (reconsidering the current rows/columns approach). But that's another story, and probably another PR...

Also, there will be a PR over on `superset-ui` that utilizes this new "customize" value in numerous places. We can merge that one before this one, I think, and I'll bump all the chart versions as part of this PR when it exits draft mode.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [x] Removes existing feature or API
