### PR TITLE
fix: Make spacings in Settings menu more consistent

### DIFF
--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -134,6 +134,19 @@ const StyledHeader = styled.header`
     display: flex;
     align-items: center;
   }
+
+  .ant-menu {
+    .ant-menu-item-group-title {
+      padding-bottom: ${({ theme }) => theme.gridUnit}px;
+    }
+    .ant-menu-item {
+      margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
+    }
+    .about-section {
+      margin: ${({ theme }) => theme.gridUnit}px 0
+        ${({ theme }) => theme.gridUnit * 2}px;
+    }
+  }
 `;
 
 export function Menu({
@@ -196,16 +209,18 @@ export function Menu({
                     key="about-section"
                     title={t('About')}
                   >
-                    {navbarRight.version_string && (
-                      <li className="version-info">
-                        <span>Version: {navbarRight.version_string}</span>
-                      </li>
-                    )}
-                    {navbarRight.version_sha && (
-                      <li className="version-info">
-                        <span>SHA: {navbarRight.version_sha}</span>
-                      </li>
-                    )}
+                    <div className="about-section">
+                      {navbarRight.version_string && (
+                        <li className="version-info">
+                          <span>Version: {navbarRight.version_string}</span>
+                        </li>
+                      )}
+                      {navbarRight.version_sha && (
+                        <li className="version-info">
+                          <span>SHA: {navbarRight.version_sha}</span>
+                        </li>
+                      )}
+                    </div>
                   </DropdownMenu.ItemGroup>,
                 ]}
               </DropdownMenu>


### PR DESCRIPTION
### SUMMARY
Decreases margin for item group title, increases margin for the last element of item group, increases margin for "About" section.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/99241426-2623f800-27fe-11eb-9fe9-91d0a0c19ed7.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11651
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @ktmud 