### PR TITLE
fix: ModalTriggers styling in SqlLab

### DIFF
--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -53,6 +53,14 @@ export const MenuItem = styled(AntdMenu.Item)`
     height: ${({ theme }) => theme.gridUnit * 7}px;
     line-height: ${({ theme }) => theme.gridUnit * 7}px;
   }
+
+  &.ant-menu-item,
+  &.ant-dropdown-menu-item {
+    span[role='button'] {
+      display: inline-block;
+      width: 100%;
+    }
+  }
 `;
 
 export const Menu = Object.assign(AntdMenu, {

--- a/superset-frontend/src/components/ModalTrigger.jsx
+++ b/superset-frontend/src/components/ModalTrigger.jsx
@@ -102,9 +102,9 @@ export default class ModalTrigger extends React.Component {
     /* eslint-disable jsx-a11y/interactive-supports-focus */
     return (
       <>
-        <div onClick={this.open} role="button">
+        <span onClick={this.open} role="button">
           {this.props.triggerNode}
-        </div>
+        </span>
         {this.renderModal()}
       </>
     );


### PR DESCRIPTION
### SUMMARY
Change trigger node from ModalTrigger from div back to span. Added `display: inline-block` in Menu, so that the whole menu item is clickable.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/99313312-9d3da880-285f-11eb-8d76-53010160f926.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11715
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @mistercrunch @junlincc 