### PR TITLE
feat(db-engine-specs): add support for Postgres root cert

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -182,7 +182,9 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
               ? `${t('ERROR: ')}${
                   typeof error.message === 'string'
                     ? error.message
-                    : (error.message as Record<string, string[]>).sqlalchemy_uri
+                    : Object.entries(error.message as Record<string, string[]>)
+                        .map(([key, value]) => `(${key}) ${value.join(', ')}`)
+                        .join('\n')
                 }`
               : t('ERROR: Connection failed. '),
           );

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -600,7 +600,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             item = DatabaseTestConnectionSchema().load(request.json)
         # This validates custom Schema with custom validations
         except ValidationError as error:
-            return self.response_400(message=error.messages)
+            return self.response_400(
+                message=f"incorrect request parameters: {', '.join(error.messages.keys())}"
+            )
         try:
             TestConnectionDatabaseCommand(g.user, item).run()
             return self.response(200, message="OK")

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -600,9 +600,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             item = DatabaseTestConnectionSchema().load(request.json)
         # This validates custom Schema with custom validations
         except ValidationError as error:
-            return self.response_400(
-                message=f"incorrect request parameters: {', '.join(error.messages.keys())}"
-            )
+            return self.response_400(message=error.messages)
         try:
             TestConnectionDatabaseCommand(g.user, item).run()
             return self.response(200, message="OK")

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -139,7 +139,7 @@ def sqlalchemy_uri_validator(value: str) -> str:
             [
                 _(
                     "Invalid connection string, a valid string usually follows: "
-                    "dirver://user:password@database-host/database-name"
+                    "driver://user:password@database-host/database-name"
                 )
             ]
         )

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -65,6 +65,7 @@ class DruidEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
 
         :param database: database instance from which to extract extras
         :raises CertificateException: If certificate is not valid/unparseable
+        :raises JSONDecodeError: If database extra json payload is unparseable
         """
         try:
             extra = json.loads(database.extra or "{}")

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional, TYPE_CHECKING
 
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.exceptions import SupersetException
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
@@ -65,13 +66,12 @@ class DruidEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
 
         :param database: database instance from which to extract extras
         :raises CertificateException: If certificate is not valid/unparseable
-        :raises JSONDecodeError: If database extra json payload is unparseable
+        :raises SupersetException: If database extra json payload is unparseable
         """
         try:
             extra = json.loads(database.extra or "{}")
-        except json.JSONDecodeError as ex:
-            logger.error(ex)
-            raise ex
+        except json.JSONDecodeError:
+            raise SupersetException("Unable to parse database extras")
 
         if database.server_cert:
             engine_params = extra.get("engine_params", {})

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -24,6 +24,7 @@ from pytz import _FixedOffset  # type: ignore
 from sqlalchemy.dialects.postgresql.base import PGInspector
 
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.exceptions import SupersetException
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
@@ -132,8 +133,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
         try:
             extra = json.loads(database.extra or "{}")
         except json.JSONDecodeError as ex:
-            logger.error(ex)
-            raise ex
+            raise SupersetException("Unable to parse database extras")
 
         if database.server_cert:
             engine_params = extra.get("engine_params", {})

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -128,11 +128,11 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
 
         :param database: database instance from which to extract extras
         :raises CertificateException: If certificate is not valid/unparseable
-        :raises JSONDecodeError: If database extra json payload is unparseable
+        :raises SupersetException: If database extra json payload is unparseable
         """
         try:
             extra = json.loads(database.extra or "{}")
-        except json.JSONDecodeError as ex:
+        except json.JSONDecodeError:
             raise SupersetException("Unable to parse database extras")
 
         if database.server_cert:

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import json
+import logging
 import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
@@ -26,6 +28,8 @@ from superset.utils import core as utils
 
 if TYPE_CHECKING:
     from superset.models.core import Database  # pragma: no cover
+
+logger = logging.getLogger()
 
 
 # Replace psycopg2.tz.FixedOffsetTimezone with pytz, which is serializable by PyArrow
@@ -115,3 +119,28 @@ class PostgresEngineSpec(PostgresBaseEngineSpec):
             dttm_formatted = dttm.isoformat(sep=" ", timespec="microseconds")
             return f"""TO_TIMESTAMP('{dttm_formatted}', 'YYYY-MM-DD HH24:MI:SS.US')"""
         return None
+
+    @staticmethod
+    def get_extra_params(database: "Database") -> Dict[str, Any]:
+        """
+        For Postgres, the path to a SSL certificate is placed in `connect_args`.
+
+        :param database: database instance from which to extract extras
+        :raises CertificateException: If certificate is not valid/unparseable
+        :raises JSONDecodeError: If database extra json payload is unparseable
+        """
+        try:
+            extra = json.loads(database.extra or "{}")
+        except json.JSONDecodeError as ex:
+            logger.error(ex)
+            raise ex
+
+        if database.server_cert:
+            engine_params = extra.get("engine_params", {})
+            connect_args = engine_params.get("connect_args", {})
+            connect_args["sslmode"] = connect_args.get("sslmode", "verify-full")
+            path = utils.create_ssl_cert_file(database.server_cert)
+            connect_args["sslrootcert"] = path
+            engine_params["connect_args"] = connect_args
+            extra["engine_params"] = engine_params
+        return extra

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -200,7 +200,7 @@ class TestDatabaseApi(SupersetTestCase):
         database_data = {
             "database_name": "test-create-database",
             "sqlalchemy_uri": example_db.sqlalchemy_uri_decrypted,
-            "server_cert": ssl_certificate,
+            "server_cert": None,
             "extra": json.dumps(extra),
         }
 
@@ -761,7 +761,7 @@ class TestDatabaseApi(SupersetTestCase):
             "extra": json.dumps(extra),
             "impersonate_user": False,
             "sqlalchemy_uri": example_db.safe_sqlalchemy_uri(),
-            "server_cert": ssl_certificate,
+            "server_cert": None,
         }
         url = "api/v1/database/test_connection"
         rv = self.post_assert_metric(url, data, "test_connection")

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+default_db_extra = """{
+  "metadata_params": {},
+  "engine_params": {},
+  "metadata_cache_timeout": {},
+  "schemas_allowed_for_csv_upload": []
+}"""


### PR DESCRIPTION
### SUMMARY
Add support for SSL root cert verification to Postgres. Also add proper error message for incorrect test request if e.g. `extra` is not parseable (see screenshot below).

### BEFORE
With the following unparseable database extra object, the following toast is raised (does not actually show on some versions of Chrome):
![image](https://user-images.githubusercontent.com/33317356/104325076-e2ddc100-54f0-11eb-95d6-cc692d0ffce8.png)
![image](https://user-images.githubusercontent.com/33317356/104206146-e06b6080-5437-11eb-8ff3-7a7b57dfe9e4.png)

### AFTER
The new error toast shows the marshmallow error:
![image](https://user-images.githubusercontent.com/33317356/104324624-57643000-54f0-11eb-907c-4b7145f4f611.png)

When also specifying an incorrect connection string, the following error is displayed (both errors are displayed):
![image](https://user-images.githubusercontent.com/33317356/104325897-ca21db00-54f1-11eb-806e-86bf74a75d5e.png)

### TEST PLAN
CI + new tests. Also added missing tests to Druid connector.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
