### PR TITLE
fix: prior npm font source had a glitch

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -27582,6 +27582,16 @@
       "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
       "dev": true
     },
+    "fontsource-fira-code": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fontsource-fira-code/-/fontsource-fira-code-3.0.5.tgz",
+      "integrity": "sha512-pxhYUSBdgXYFnGIdO3QQTuemncqdRE3NEoVu94tm+jCx5/sUUGDugOdNdZqSY7Gd8w7Xk98hHbT5zFGgrxDL+A=="
+    },
+    "fontsource-inter": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fontsource-inter/-/fontsource-inter-3.0.5.tgz",
+      "integrity": "sha512-7AGbrHVjL2IcIz/Lv64IR5g0W+JuGQT/bFFF5nDD1zNOT5Ke8IMIMc+tE4rb5fCVNG2AGt0gtXH3kGLUURKY8w=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -46347,16 +46357,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "typeface-fira-code": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-fira-code/-/typeface-fira-code-1.1.13.tgz",
-      "integrity": "sha512-8TRlYeIGAqwNajMHB3eSFs58VVfKsAsA0JRVu7z895s/FBl3nrh4PCvbH8tqxadU0UXEbCxNBvZtXn/Jpt7C3Q=="
-    },
-    "typeface-inter": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-inter/-/typeface-inter-1.1.13.tgz",
-      "integrity": "sha512-XHTUTR+qqsVAtr1mjJBu3f5q4e3q6PhuhLXJhQbRGKwqLrQmhC7dCoZ5n5Vd+dEmZvc3TdHhOEYfjI01xzM7HA=="
     },
     "typescript": {
       "version": "4.0.3",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -108,6 +108,8 @@
     "d3-scale": "^2.1.2",
     "dnd-core": "^2.6.0",
     "dom-to-image": "^2.6.0",
+    "fontsource-fira-code": "^3.0.5",
+    "fontsource-inter": "^3.0.5",
     "geolib": "^2.0.24",
     "global-box": "^1.2.0",
     "immutable": "^4.0.0-rc.12",
@@ -165,8 +167,6 @@
     "regenerator-runtime": "^0.13.5",
     "rison": "^0.1.1",
     "shortid": "^2.2.6",
-    "typeface-fira-code": "^1.1.13",
-    "typeface-inter": "^1.1.13",
     "urijs": "^1.18.10",
     "use-query-params": "^0.4.5"
   },

--- a/superset-frontend/stylesheets/less/fonts.less
+++ b/superset-frontend/stylesheets/less/fonts.less
@@ -22,7 +22,7 @@
 /*************************************************************************/
 
 /******************************* Inter UI ********************************/
-@import '~typeface-inter/index.css';
+@import '~fontsource-inter/index.css';
 
 /******************************* Fira Code ********************************/
-@import '~typeface-fira-code/index.css';
+@import '~fontsource-fira-code/index.css';


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Welp, the fonts in #11718 _almost_ worked out quite nicely, but there's an issue with the boolean vector intersection of the uppercase A for some reason. Upon reading further, that font library is on a path to deprecation (ugh) and they recommend the one used in this PR instead. So, here we go!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://user-images.githubusercontent.com/812905/99347468-103d2400-284c-11eb-9cd0-2ef8b98b86cf.png)

After:
![image](https://user-images.githubusercontent.com/812905/99347160-357d6280-284b-11eb-805a-f32ac0bdae0f.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #11723 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
