### PR TITLE
fix: Missing styles in FilterScopeSelector modal

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/dashboard.less
+++ b/superset-frontend/src/dashboard/stylesheets/dashboard.less
@@ -120,13 +120,15 @@ body {
   }
 }
 
-.modal {
-  .modal-body {
-    padding: 24px 24px 29px 24px;
+.ant-modal-root {
+  .ant-modal-body {
+    padding: 24px 24px 29px 24px !important;
   }
 
-  .modal-dialog.filter-scope-modal {
-    width: 80%;
+  .filter-scope-modal {
+    .ant-modal {
+      width: 80% !important;
+    }
   }
 
   .refresh-warning-container {

--- a/superset-frontend/src/dashboard/stylesheets/filter-scope-selector.less
+++ b/superset-frontend/src/dashboard/stylesheets/filter-scope-selector.less
@@ -125,6 +125,7 @@
       height: 35px;
       display: flex;
       align-items: center;
+      justify-content: center;
       padding: 0 24px;
       margin-left: -24px;
 


### PR DESCRIPTION
### SUMMARY
After refactoring modals to Antd, some CSS selectors were broken and styles weren't applied.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/99403847-382f9480-28eb-11eb-93fe-54eaf7dfbd35.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11721
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @rusackas 