### PR TITLE
fix: do not drop calculated column on metadata sync

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -128,10 +128,8 @@ class BaseDatasource(
             ),
         )
 
-    # placeholder for a relationship to a derivative of BaseColumn
-    columns: List[Any] = []
-    # placeholder for a relationship to a derivative of BaseMetric
-    metrics: List[Any] = []
+    columns: List["BaseColumn"] = []
+    metrics: List["BaseMetric"] = []
 
     @property
     def type(self) -> str:

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -453,6 +453,8 @@ class DruidDatasource(Model, BaseDatasource):
     type = "druid"
     query_language = "json"
     cluster_class = DruidCluster
+    columns: List[DruidColumn] = []
+    metrics: List[DruidMetric] = []
     metric_class = DruidMetric
     column_class = DruidColumn
     owner_class = security_manager.user_model

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -454,9 +454,13 @@ class TableModelView(  # pylint: disable=too-many-ancestors
         validate_sqlatable(item)
 
     def post_add(  # pylint: disable=arguments-differ
-        self, item: "TableModelView", flash_message: bool = True
+        self,
+        item: "TableModelView",
+        flash_message: bool = True,
+        fetch_metadata: bool = True,
     ) -> None:
-        item.fetch_metadata()
+        if fetch_metadata:
+            item.fetch_metadata()
         create_table_permissions(item)
         if flash_message:
             flash(
@@ -470,7 +474,7 @@ class TableModelView(  # pylint: disable=too-many-ancestors
             )
 
     def post_update(self, item: "TableModelView") -> None:
-        self.post_add(item, flash_message=False)
+        self.post_add(item, flash_message=False, fetch_metadata=False)
 
     def _delete(self, pk: int) -> None:
         DeleteMixin._delete(self, pk)


### PR DESCRIPTION
### SUMMARY
PR #10645 introduced a regression that caused calculated columns to be dropped when syncing datasource metadata in the legacy CRUD list. When saving the dataset in the legacy CRUD view, metadata was also automatically synced, causing loss of calculated columns. Previously the metadata refresh was triggered every time the dataset was saved in the legacy CRUD view, but the effect of this was less noticeable as the previous metadata refresh only added new columns, updated existing types and left non-present physical columns in the dataset metadata.

This changes behavior in the following way:
- Metadata is no longer automatically synced when saved in the legacy CRUD view.
- Calculated columns are no longer dropped when synced in the legacy CRUD list.
- Calculated columns are replaced with its physical counterpart if a physical column with the same name has been added to the dataset.

### TEST PLAN
Local testing + CI + new tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
