### PR TITLE
fix: style multiselect input

### DIFF
--- a/superset-frontend/src/components/Select/SupersetStyledSelect.tsx
+++ b/superset-frontend/src/components/Select/SupersetStyledSelect.tsx
@@ -57,6 +57,8 @@ import {
   VALUE_LABELED_STYLES,
   PartialThemeConfig,
   PartialStylesConfig,
+  SelectComponentsType,
+  InputProps,
 } from './styles';
 import { findValue } from './utils';
 
@@ -223,11 +225,11 @@ function styled<
 
     // Handle onPaste event
     if (onPaste) {
-      const Input = components.Input || defaultComponents.Input;
-      components.Input = props => (
-        <div onPaste={onPaste}>
-          <Input {...props} />
-        </div>
+      const Input =
+        (components.Input as SelectComponentsType['Input']) ||
+        (defaultComponents.Input as SelectComponentsType['Input']);
+      components.Input = (props: InputProps) => (
+        <Input {...props} onPaste={onPaste} />
       );
     }
     // for CreaTable

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -128,7 +128,7 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   clearIndicator: provider => [
     provider,
     css`
-      padding-right: 0;
+      padding: 4px 0 4px 6px;
     `,
   ],
   control: (
@@ -156,6 +156,7 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
           border-color: ${borderColor};
           box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
         }
+        flex-wrap: nowrap;
       `,
     ];
   },
@@ -245,11 +246,11 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   input: (provider, { selectProps }) => [
     provider,
     css`
-      padding: ${selectProps?.isMulti && selectProps?.value?.length
-        ? '0 6px'
-        : '0'};
       margin-left: 0;
       vertical-align: middle;
+      ${selectProps?.isMulti && selectProps?.value?.length
+        ? 'padding: 0 6px; width: 100%'
+        : 'padding: 0; flex: 1 1 auto;'};
     `,
   ],
 };
@@ -329,6 +330,7 @@ export const VALUE_LABELED_STYLES: PartialStylesConfig = {
   ) => ({
     ...provider,
     paddingLeft: getValue().length > 0 ? 1 : baseUnit * 3,
+    overflow: 'visible',
   }),
   // render single value as is they are multi-value
   singleValue: (provider, props) => {

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -30,6 +30,8 @@ import { Props as SelectProps } from 'react-select/src/Select';
 import { colors as reactSelectColros } from 'react-select/src/theme';
 import { supersetColors } from 'src/components/styles';
 import { DeepNonNullable } from 'react-select/src/components';
+import { OptionType } from 'antd/lib/select';
+import { SupersetStyledSelectProps } from './SupersetStyledSelect';
 
 export const DEFAULT_CLASS_NAME = 'Select';
 export const DEFAULT_CLASS_NAME_PREFIX = 'Select';
@@ -255,15 +257,29 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   ],
 };
 
-type SelectComponentsType = Omit<SelectComponentsConfig<any>, 'Input'> & {
+const inputTagStyles = {
+  background: 'none',
+  border: 'none',
+  outline: 'none',
+  padding: 0,
+  width: '100%',
+};
+
+export type SelectComponentsType = Omit<
+  SelectComponentsConfig<any>,
+  'Input'
+> & {
   Input: ComponentType<InputProps>;
 };
 
 // react-select is missing selectProps from their props type
 // so overwriting it here to avoid errors
-type InputProps = ReactSelectInputProps & {
+export type InputProps = ReactSelectInputProps & {
   placeholder?: ReactNode;
   selectProps: SelectProps;
+  autocomplete?: string;
+  onPaste?: SupersetStyledSelectProps<OptionType>['onPaste'];
+  inputStyle?: object;
 };
 
 const {
@@ -313,6 +329,8 @@ export const DEFAULT_COMPONENTS: SelectComponentsType = {
         {...props}
         placeholder={isMultiWithValue ? placeholder : undefined}
         css={getStyles('input', props)}
+        autocomplete="chrome-off"
+        inputStyle={inputTagStyles}
       />
     );
   },
@@ -326,11 +344,12 @@ export const VALUE_LABELED_STYLES: PartialStylesConfig = {
       theme: {
         spacing: { baseUnit },
       },
+      isMulti,
     },
   ) => ({
     ...provider,
     paddingLeft: getValue().length > 0 ? 1 : baseUnit * 3,
-    overflow: 'visible',
+    overflow: isMulti && getValue().length > 0 ? 'visible' : 'hidden',
   }),
   // render single value as is they are multi-value
   singleValue: (provider, props) => {

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -590,3 +590,9 @@ hr {
   background-image: url('../images/icons/error_solid_small_red.svg') !important;
   background-position: -2px center !important;
 }
+
+.Select__value-container--is-multi .Select__input {
+  input {
+    width: 100% !important;
+  }
+}

--- a/superset-frontend/stylesheets/superset.less
+++ b/superset-frontend/stylesheets/superset.less
@@ -590,9 +590,3 @@ hr {
   background-image: url('../images/icons/error_solid_small_red.svg') !important;
   background-position: -2px center !important;
 }
-
-.Select__value-container--is-multi .Select__input {
-  input {
-    width: 100% !important;
-  }
-}


### PR DESCRIPTION
### SUMMARY
Per @ktmud's findings from https://github.com/apache/incubator-superset/pull/11289 there is some jumpy behavior if the 
placeholder is very wide. It looks like react-select is setting a dynamic width on the input based on the length of the placeholder. Then there's an overflow: hidden to cut down the size to fit the component. Together with the existing flex-box styling, it forced the element to go off the element to the left. The width element is somewhat fighting with the flex-box functionality, so I overwrote it and relied solely on flexbox to determine the width of the elements and let it adjust more gracefully. I'm not 100% familiar with the react-select library, so there may be more tooling hid somewhere that we can utilize. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![select_dropdown (1)](https://user-images.githubusercontent.com/5186919/99469536-ce69b780-28f7-11eb-87a9-9c835c93f0d3.gif)

### TEST PLAN
tested visuallly in storybook

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
