### PR TITLE
chore: Text change Allow Data Upload

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -601,10 +601,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                 checked={db ? !!db.allow_csv_upload : false}
                 onChange={onInputChange}
               />
-              <div>{t('Allow CSV/Excel Upload')}</div>
+              <div>{t('Allow Data Upload')}</div>
               <InfoTooltip
                 tooltip={t(
-                  'If selected, please set the schemas allowed for csv or Excel upload in Extra.',
+                  'If selected, please set the schemas allowed for data upload in Extra.',
                 )}
               />
             </div>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -601,10 +601,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                 checked={db ? !!db.allow_csv_upload : false}
                 onChange={onInputChange}
               />
-              <div>{t('Allow CSV Upload')}</div>
+              <div>{t('Allow CSV/Excel Upload')}</div>
               <InfoTooltip
                 tooltip={t(
-                  'If selected, please set the schemas allowed for csv upload in Extra.',
+                  'If selected, please set the schemas allowed for csv or Excel upload in Extra.',
                 )}
               />
             </div>


### PR DESCRIPTION

### SUMMARY
today there are 2 ways of uploading data CSV or Excel
config on the database allow_csv_upload applies to both options
so the client facing text should also indicate that

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![image](https://user-images.githubusercontent.com/47772523/99559136-1d355100-29cd-11eb-8b05-fae3188c76eb.png)
after will include /Excel in the text

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
