### PR TITLE
refactor: Replace react-bootstrap tooltips with Antd tooltips

### DIFF
--- a/superset-frontend/spec/javascripts/components/FilterableTable/FilterableTable_spec.tsx
+++ b/superset-frontend/spec/javascripts/components/FilterableTable/FilterableTable_spec.tsx
@@ -17,7 +17,8 @@
  * under the License.
  */
 import React from 'react';
-import { mount, ReactWrapper } from 'enzyme';
+import { ReactWrapper } from 'enzyme';
+import { styledMount as mount } from 'spec/helpers/theming';
 import FilterableTable, {
   MAX_COLUMNS_FOR_TABLE,
 } from 'src/components/FilterableTable/FilterableTable';

--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopoverTitle_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopoverTitle_spec.jsx
@@ -20,7 +20,7 @@
 import React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 
 import AdhocMetricEditPopoverTitle from 'src/explore/components/AdhocMetricEditPopoverTitle';
 

--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopoverTitle_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopoverTitle_spec.jsx
@@ -20,7 +20,7 @@
 import React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
-import { OverlayTrigger } from 'react-bootstrap';
+import Tooltip from 'src/common/components/Tooltip';
 
 import AdhocMetricEditPopoverTitle from 'src/explore/components/AdhocMetricEditPopoverTitle';
 
@@ -43,16 +43,18 @@ function setup(overrides) {
 describe('AdhocMetricEditPopoverTitle', () => {
   it('renders an OverlayTrigger wrapper with the title', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(OverlayTrigger)).toExist();
-    expect(wrapper.find(OverlayTrigger).find('span').text()).toBe(
-      'My Metric\xa0',
-    );
+    expect(wrapper.find(Tooltip)).toExist();
+    expect(
+      wrapper.find('[data-test="AdhocMetricEditTitle#trigger"]').text(),
+    ).toBe('My Metric\xa0');
   });
 
   it('transfers to edit mode when clicked', () => {
     const { wrapper } = setup();
     expect(wrapper.state('isEditable')).toBe(false);
-    wrapper.simulate('click');
+    wrapper
+      .find('[data-test="AdhocMetricEditTitle#trigger"]')
+      .simulate('click');
     expect(wrapper.state('isEditable')).toBe(true);
   });
 });

--- a/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
@@ -22,6 +22,7 @@ import { OverlayTrigger, Radio } from 'react-bootstrap';
 import sinon from 'sinon';
 import { styledMount as mount } from 'spec/helpers/theming';
 
+import Tooltip from 'src/common/components/Tooltip';
 import Popover from 'src/common/components/Popover';
 import Tabs from 'src/common/components/Tabs';
 import Label from 'src/components/Label';
@@ -115,17 +116,19 @@ describe('DateFilterControl', () => {
     const popoverContent = wrapper.find(Popover).first().props().content;
     const popoverContentWrapper = mount(popoverContent);
     const defaultTab = popoverContentWrapper.find(Tabs.TabPane).first();
-    const radioTrigger = defaultTab.find(OverlayTrigger);
+    const radioTooltip = defaultTab.find(Tooltip);
 
-    expect(radioTrigger).toExist();
-    expect(radioTrigger).toHaveLength(6);
+    expect(radioTooltip).toExist();
+    expect(radioTooltip).toHaveLength(6);
   });
 
   it('renders the correct time range in tooltip', () => {
     const popoverContent = wrapper.find(Popover).first().props().content;
     const popoverContentWrapper = mount(popoverContent);
     const defaultTab = popoverContentWrapper.find(Tabs.TabPane).first();
-    const triggers = defaultTab.find(OverlayTrigger);
+    const tooltips = defaultTab.find(Tooltip);
+
+    expect(tooltips).toHaveLength(6);
 
     const expectedLabels = {
       'Last day': '2020-09-06 < col < 2020-09-07',
@@ -136,13 +139,10 @@ describe('DateFilterControl', () => {
       'No filter': '-∞ < col < ∞',
     };
 
-    triggers.forEach(trigger => {
-      const { props } = trigger.props().overlay;
-      const label = props.id.split('tooltip-')[1];
+    tooltips.forEach(tooltip => {
+      const label = tooltip.props().id.split('tooltip-')[1];
 
-      expect(trigger.props().overlay.props.children).toEqual(
-        expectedLabels[label],
-      );
+      expect(tooltip.props().title).toEqual(expectedLabels[label]);
     });
   });
 });

--- a/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
@@ -22,7 +22,7 @@ import { Radio } from 'react-bootstrap';
 import sinon from 'sinon';
 import { styledMount as mount } from 'spec/helpers/theming';
 
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import Popover from 'src/common/components/Popover';
 import Tabs from 'src/common/components/Tabs';
 import Label from 'src/components/Label';

--- a/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DateFilterControl_spec.jsx
@@ -18,7 +18,7 @@
  */
 /* eslint-disable no-unused-expressions */
 import React from 'react';
-import { OverlayTrigger, Radio } from 'react-bootstrap';
+import { Radio } from 'react-bootstrap';
 import sinon from 'sinon';
 import { styledMount as mount } from 'spec/helpers/theming';
 

--- a/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import { supersetTheme, ThemeProvider } from '@superset-ui/core';
 import Popover from 'src/common/components/Popover';
 import sinon from 'sinon';
 import { Provider } from 'react-redux';
@@ -50,12 +51,17 @@ describe('EmbedCodeButton', () => {
     const spy1 = sinon.spy(exploreUtils, 'getExploreLongUrl');
     const spy2 = sinon.spy(common, 'getShortUrl');
 
-    const wrapper = mount(<EmbedCodeButton {...defaultProps} />, {
-      wrappingComponent: Provider,
-      wrappingComponentProps: {
-        store,
+    const wrapper = mount(
+      <ThemeProvider theme={supersetTheme}>
+        <EmbedCodeButton {...defaultProps} />
+      </ThemeProvider>,
+      {
+        wrappingComponent: Provider,
+        wrappingComponentProps: {
+          store,
+        },
       },
-    });
+    ).find(EmbedCodeButton);
     wrapper.setState({
       height: '1000',
       width: '2000',

--- a/superset-frontend/spec/javascripts/sqllab/ColumnElement_spec.tsx
+++ b/superset-frontend/spec/javascripts/sqllab/ColumnElement_spec.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { mount } from 'enzyme';
+import { styledMount as mount } from 'spec/helpers/theming';
 import ColumnElement from 'src/SqlLab/components/ColumnElement';
 
 import { mockedActions, table } from './fixtures';

--- a/superset-frontend/src/CRUD/Field.jsx
+++ b/superset-frontend/src/CRUD/Field.jsx
@@ -18,14 +18,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  FormGroup,
-  HelpBlock,
-  FormControl,
-  OverlayTrigger,
-  Tooltip,
-} from 'react-bootstrap';
+import { FormGroup, HelpBlock, FormControl } from 'react-bootstrap';
 
+import Tooltip from 'src/common/components/Tooltip';
 import FormLabel from 'src/components/FormLabel';
 import './crud.less';
 
@@ -72,16 +67,9 @@ export default class Field extends React.PureComponent {
         <FormLabel className="m-r-5">
           {label || fieldKey}
           {compact && description && (
-            <OverlayTrigger
-              placement="right"
-              overlay={
-                <Tooltip id="field-descr" bsSize="lg">
-                  {description}
-                </Tooltip>
-              }
-            >
+            <Tooltip id="field-descr" placement="right" title={description}>
               <i className="fa fa-info-circle m-l-5" />
-            </OverlayTrigger>
+            </Tooltip>
           )}
         </FormLabel>{' '}
         {hookedControl}

--- a/superset-frontend/src/CRUD/Field.jsx
+++ b/superset-frontend/src/CRUD/Field.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, HelpBlock, FormControl } from 'react-bootstrap';
 
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import FormLabel from 'src/components/FormLabel';
 import './crud.less';
 

--- a/superset-frontend/src/SqlLab/components/ColumnElement.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement.tsx
@@ -18,12 +18,41 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '@superset-ui/core';
+import { ClassNames } from '@emotion/core';
+import { styled, useTheme } from '@superset-ui/core';
 
 import { Tooltip } from 'src/common/components/Tooltip';
 
 const propTypes = {
   column: PropTypes.object.isRequired,
+};
+
+const StyledTooltip = props => {
+  const theme = useTheme();
+  return (
+    <ClassNames>
+      {({ css }) => (
+        <Tooltip
+          overlayClassName={css`
+            .ant-tooltip-inner {
+              max-width: ${theme.gridUnit * 125}px;
+              word-wrap: break-word;
+              text-align: center;
+
+              pre {
+                background: transparent;
+                border: none;
+                text-align: left;
+                color: ${theme.colors.grayscale.light5};
+                font-size: ${theme.typography.sizes.xs}px;
+              }
+            }
+          `}
+          {...props}
+        />
+      )}
+    </ClassNames>
+  );
 };
 
 const Hr = styled.hr`
@@ -58,7 +87,7 @@ export default function ColumnElement({ column }: ColumnElementProps) {
     columnName = <strong>{column.name}</strong>;
     icons = column.keys.map((key, i) => (
       <span key={i} className="ColumnElement">
-        <Tooltip
+        <StyledTooltip
           placement="right"
           title={
             <>
@@ -71,7 +100,7 @@ export default function ColumnElement({ column }: ColumnElementProps) {
           }
         >
           <i className={`fa text-muted m-l-2 ${iconMap[key.type]}`} />
-        </Tooltip>
+        </StyledTooltip>
       </span>
     ));
   }

--- a/superset-frontend/src/SqlLab/components/ColumnElement.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement.tsx
@@ -18,8 +18,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { OverlayTrigger } from 'react-bootstrap';
 
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import Tooltip from 'src/common/components/Tooltip';
 
 const propTypes = {
   column: PropTypes.object.isRequired,
@@ -53,20 +54,20 @@ export default function ColumnElement({ column }: ColumnElementProps) {
     columnName = <strong>{column.name}</strong>;
     icons = column.keys.map((key, i) => (
       <span key={i} className="ColumnElement">
-        <OverlayTrigger
+        <Tooltip
           placement="right"
-          overlay={
-            <Tooltip id="idx-json" bsSize="lg">
+          title={
+            <>
               <strong>{tooltipTitleMap[key.type]}</strong>
               <hr />
               <pre className="text-small">
                 {JSON.stringify(key, null, '  ')}
               </pre>
-            </Tooltip>
+            </>
           }
         >
           <i className={`fa text-muted m-l-2 ${iconMap[key.type]}`} />
-        </OverlayTrigger>
+        </Tooltip>
       </span>
     ));
   }

--- a/superset-frontend/src/SqlLab/components/ColumnElement.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@superset-ui/core';
 
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 
 const propTypes = {
   column: PropTypes.object.isRequired,

--- a/superset-frontend/src/SqlLab/components/ColumnElement.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement.tsx
@@ -18,7 +18,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { OverlayTrigger } from 'react-bootstrap';
 
 import Tooltip from 'src/common/components/Tooltip';
 

--- a/superset-frontend/src/SqlLab/components/ColumnElement.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement.tsx
@@ -27,7 +27,7 @@ const propTypes = {
   column: PropTypes.object.isRequired,
 };
 
-const StyledTooltip = props => {
+const StyledTooltip = (props: any) => {
   const theme = useTheme();
   return (
     <ClassNames>

--- a/superset-frontend/src/SqlLab/components/ColumnElement.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement.tsx
@@ -18,12 +18,17 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { styled } from '@superset-ui/core';
 
 import Tooltip from 'src/common/components/Tooltip';
 
 const propTypes = {
   column: PropTypes.object.isRequired,
 };
+
+const Hr = styled.hr`
+  margin-top: ${({ theme }) => theme.gridUnit * 1.5}px;
+`;
 
 const iconMap = {
   pk: 'fa-key',
@@ -58,7 +63,7 @@ export default function ColumnElement({ column }: ColumnElementProps) {
           title={
             <>
               <strong>{tooltipTitleMap[key.type]}</strong>
-              <hr />
+              <Hr />
               <pre className="text-small">
                 {JSON.stringify(key, null, '  ')}
               </pre>

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -25,7 +25,7 @@ import { t } from '@superset-ui/core';
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import Label from 'src/components/Label';
 import Button from 'src/components/Button';
 import Checkbox from 'src/components/Checkbox';

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -19,19 +19,13 @@
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 import PropTypes from 'prop-types';
-import {
-  FormGroup,
-  InputGroup,
-  Form,
-  FormControl,
-  OverlayTrigger,
-  Tooltip,
-} from 'react-bootstrap';
+import { FormGroup, InputGroup, Form, FormControl } from 'react-bootstrap';
 import Split from 'react-split';
 import { t } from '@superset-ui/core';
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 
+import Tooltip from 'src/common/components/Tooltip';
 import Label from 'src/components/Label';
 import Button from 'src/components/Button';
 import Checkbox from 'src/components/Checkbox';
@@ -455,20 +449,19 @@ class SqlEditor extends React.PureComponent {
       this.props.latestQuery.results &&
       this.props.latestQuery.results.displayLimitReached
     ) {
-      const tooltip = (
-        <Tooltip id="tooltip">
-          {t(
+      limitWarning = (
+        <Tooltip
+          id="tooltip"
+          placement="left"
+          title={t(
             `It appears that the number of rows in the query results displayed
            was limited on the server side to
            the %s limit.`,
             this.props.latestQuery.rows,
           )}
-        </Tooltip>
-      );
-      limitWarning = (
-        <OverlayTrigger placement="left" overlay={tooltip}>
+        >
           <Label bsStyle="warning">LIMIT</Label>
-        </OverlayTrigger>
+        </Tooltip>
       );
     }
     const successful =

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -484,7 +484,7 @@ a.Link {
   margin: 3px 5px;
 }
 
-.tooltip pre {
+.ant-tooltip pre {
   background: transparent;
   border: none;
   text-align: left;
@@ -492,9 +492,10 @@ a.Link {
   font-size: @font-size-xs;
 }
 
-.tooltip-inner {
+.ant-tooltip-inner {
   max-width: 500px;
   word-wrap: break-word;
+  text-align: center;
 }
 
 .SouthPane {

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -484,20 +484,6 @@ a.Link {
   margin: 3px 5px;
 }
 
-.ant-tooltip pre {
-  background: transparent;
-  border: none;
-  text-align: left;
-  color: @lightest;
-  font-size: @font-size-xs;
-}
-
-.ant-tooltip-inner {
-  max-width: 500px;
-  word-wrap: break-word;
-  text-align: center;
-}
-
 .SouthPane {
   width: 100%;
 

--- a/superset-frontend/src/common/components/InfoTooltip.tsx
+++ b/superset-frontend/src/common/components/InfoTooltip.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { styled } from '@superset-ui/core';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import Icon from 'src/components/Icon';
 
 interface InfoTooltipProps {

--- a/superset-frontend/src/common/components/Tooltip.tsx
+++ b/superset-frontend/src/common/components/Tooltip.tsx
@@ -22,7 +22,7 @@ import { TooltipProps } from 'antd/lib/tooltip';
 
 const Tooltip = (props: TooltipProps) => (
   <BaseTooltip
-    overlayStyle={{ fontSize: '12px' }}
+    overlayStyle={{ fontSize: '12px', lineHeight: '1.6' }}
     color="rgba(0, 0, 0, 0.9)"
     {...props}
   />

--- a/superset-frontend/src/common/components/Tooltip.tsx
+++ b/superset-frontend/src/common/components/Tooltip.tsx
@@ -17,15 +17,17 @@
  * under the License.
  */
 import React from 'react';
+import { useTheme } from '@superset-ui/core';
 import { Tooltip as BaseTooltip } from 'src/common/components';
 import { TooltipProps } from 'antd/lib/tooltip';
 
-const Tooltip = (props: TooltipProps) => (
-  <BaseTooltip
-    overlayStyle={{ fontSize: '12px', lineHeight: '1.6' }}
-    color="rgba(0, 0, 0, 0.9)"
-    {...props}
-  />
-);
-
-export default Tooltip;
+export const Tooltip = (props: TooltipProps) => {
+  const theme = useTheme();
+  return (
+    <BaseTooltip
+      overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6' }}
+      color={`${theme.colors.grayscale.dark2}e6`}
+      {...props}
+    />
+  );
+};

--- a/superset-frontend/src/common/components/Tooltip.tsx
+++ b/superset-frontend/src/common/components/Tooltip.tsx
@@ -21,7 +21,11 @@ import { Tooltip as BaseTooltip } from 'src/common/components';
 import { TooltipProps } from 'antd/lib/tooltip';
 
 const Tooltip = (props: TooltipProps) => (
-  <BaseTooltip overlayStyle={{ fontSize: '12px' }} {...props} />
+  <BaseTooltip
+    overlayStyle={{ fontSize: '12px' }}
+    color="rgba(0, 0, 0, 0.9)"
+    {...props}
+  />
 );
 
 export default Tooltip;

--- a/superset-frontend/src/common/components/common.stories.tsx
+++ b/superset-frontend/src/common/components/common.stories.tsx
@@ -23,7 +23,7 @@ import Button from 'src/components/Button';
 import Modal from './Modal';
 import Tabs, { EditableTabs } from './Tabs';
 import AntdPopover from './Popover';
-import AntdTooltip from './Tooltip';
+import { Tooltip as AntdTooltip } from './Tooltip';
 import { Menu } from '.';
 import { Dropdown } from './Dropdown';
 import InfoTooltip from './InfoTooltip';

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -20,12 +20,9 @@ import React, { CSSProperties } from 'react';
 import { kebabCase } from 'lodash';
 import { mix } from 'polished';
 import cx from 'classnames';
-import {
-  Button as BootstrapButton,
-  Tooltip,
-  OverlayTrigger,
-} from 'react-bootstrap';
+import { Button as BootstrapButton } from 'react-bootstrap';
 import { styled } from '@superset-ui/core';
+import Tooltip from 'src/common/components/Tooltip';
 import { Menu } from 'src/common/components';
 
 export type OnClickHandler = React.MouseEventHandler<BootstrapButton>;
@@ -302,14 +299,13 @@ export default function Button({
 
   if (tooltip) {
     return (
-      <OverlayTrigger
+      <Tooltip
         placement={placement}
-        overlay={
-          <Tooltip id={`${kebabCase(tooltip)}-tooltip`}>{tooltip}</Tooltip>
-        }
+        id={`${kebabCase(tooltip)}-tooltip`}
+        title={tooltip}
       >
         {button}
-      </OverlayTrigger>
+      </Tooltip>
     );
   }
 

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -22,7 +22,7 @@ import { mix } from 'polished';
 import cx from 'classnames';
 import { Button as BootstrapButton } from 'react-bootstrap';
 import { styled } from '@superset-ui/core';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import { Menu } from 'src/common/components';
 
 export type OnClickHandler = React.MouseEventHandler<BootstrapButton>;

--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -36,7 +36,19 @@ export interface DropdownItemProps {
 export interface ButtonProps {
   className?: string;
   tooltip?: string;
-  placement?: string;
+  placement?:
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'topLeft'
+    | 'topRight'
+    | 'bottomLeft'
+    | 'bottomRight'
+    | 'leftTop'
+    | 'leftBottom'
+    | 'rightTop'
+    | 'rightBottom';
   onClick?: OnClickHandler;
   disabled?: boolean;
   buttonStyle?: string;

--- a/superset-frontend/src/components/CopyToClipboard.jsx
+++ b/superset-frontend/src/components/CopyToClipboard.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { t } from '@superset-ui/core';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 
 const propTypes = {

--- a/superset-frontend/src/components/CopyToClipboard.jsx
+++ b/superset-frontend/src/components/CopyToClipboard.jsx
@@ -18,8 +18,8 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 import { t } from '@superset-ui/core';
+import Tooltip from 'src/common/components/Tooltip';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 
 const propTypes = {
@@ -68,6 +68,18 @@ class CopyToClipboard extends React.Component {
     } else {
       this.copyToClipboard(this.props.text);
     }
+  }
+
+  getDecoratedCopyNode() {
+    return React.cloneElement(
+      this.props.copyNode,
+      {
+        style: { cursor: 'pointer' },
+        onClick: this.onClick,
+        onMouseOut: this.onMouseOut,
+      },
+      null,
+    );
   }
 
   resetTooltipText() {
@@ -119,19 +131,18 @@ class CopyToClipboard extends React.Component {
   }
 
   renderNotWrapped() {
-    const { copyNode } = this.props;
     return (
-      <OverlayTrigger
+      <Tooltip
+        id="copy-to-clipboard-tooltip"
         placement="top"
         style={{ cursor: 'pointer' }}
-        overlay={this.renderTooltip()}
+        title={this.tooltipText()}
         trigger={['hover']}
-        bsStyle="link"
         onClick={this.onClick}
         onMouseOut={this.onMouseOut}
       >
-        {copyNode}
-      </OverlayTrigger>
+        {this.getDecoratedCopyNode()}
+      </Tooltip>
     );
   }
 
@@ -143,24 +154,15 @@ class CopyToClipboard extends React.Component {
             {this.props.text}
           </span>
         )}
-        <OverlayTrigger
+        <Tooltip
+          id="copy-to-clipboard-tooltip"
           placement="top"
-          style={{ cursor: 'pointer' }}
-          overlay={this.renderTooltip()}
+          title={this.tooltipText()}
           trigger={['hover']}
-          bsStyle="link"
-          onClick={this.onClick}
-          onMouseOut={this.onMouseOut}
         >
-          {this.props.copyNode}
-        </OverlayTrigger>
+          {this.getDecoratedCopyNode()}
+        </Tooltip>
       </span>
-    );
-  }
-
-  renderTooltip() {
-    return (
-      <Tooltip id="copy-to-clipboard-tooltip">{this.tooltipText()}</Tooltip>
     );
   }
 

--- a/superset-frontend/src/components/FacePile/index.tsx
+++ b/superset-frontend/src/components/FacePile/index.tsx
@@ -18,7 +18,8 @@
  */
 import React from 'react';
 import { getCategoricalSchemeRegistry, styled } from '@superset-ui/core';
-import { Avatar, Tooltip } from 'src/common/components';
+import { Tooltip } from 'src/common/components/Tooltip';
+import { Avatar } from 'src/common/components';
 import { getRandomColor } from './utils';
 
 interface FacePileProps {

--- a/superset-frontend/src/components/Link.tsx
+++ b/superset-frontend/src/components/Link.tsx
@@ -24,7 +24,19 @@ interface Props {
   className?: string;
   href?: string;
   onClick?: () => void;
-  placement?: string;
+  placement?:
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'topLeft'
+    | 'topRight'
+    | 'bottomLeft'
+    | 'bottomRight'
+    | 'leftTop'
+    | 'leftBottom'
+    | 'rightTop'
+    | 'rightBottom';
   style?: object;
   tooltip?: string | null;
 }

--- a/superset-frontend/src/components/Link.tsx
+++ b/superset-frontend/src/components/Link.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { ReactNode } from 'react';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 
 interface Props {
   children?: ReactNode;

--- a/superset-frontend/src/components/Link.tsx
+++ b/superset-frontend/src/components/Link.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { ReactNode } from 'react';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import Tooltip from 'src/common/components/Tooltip';
 
 interface Props {
   children?: ReactNode;
@@ -50,14 +50,15 @@ const Link = ({
   );
   if (tooltip) {
     return (
-      <OverlayTrigger
-        overlay={<Tooltip id="tooltip">{tooltip}</Tooltip>}
+      <Tooltip
+        id="tooltip"
+        title={tooltip}
         placement={placement}
-        delayShow={300}
-        delayHide={150}
+        mouseEnterDelay={0.3}
+        mouseLeaveDelay={0.15}
       >
         {link}
-      </OverlayTrigger>
+      </Tooltip>
     );
   }
   return link;

--- a/superset-frontend/src/components/TooltipWrapper.jsx
+++ b/superset-frontend/src/components/TooltipWrapper.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { kebabCase } from 'lodash';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 
 const propTypes = {
   label: PropTypes.string.isRequired,

--- a/superset-frontend/src/components/TooltipWrapper.jsx
+++ b/superset-frontend/src/components/TooltipWrapper.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { kebabCase } from 'lodash';
-import { Tooltip, OverlayTrigger } from 'react-bootstrap';
+import Tooltip from 'src/common/components/Tooltip';
 
 const propTypes = {
   label: PropTypes.string.isRequired,
@@ -44,13 +44,14 @@ export default function TooltipWrapper({
   trigger,
 }) {
   return (
-    <OverlayTrigger
+    <Tooltip
+      id={`${kebabCase(label)}-tooltip`}
       placement={placement}
-      overlay={<Tooltip id={`${kebabCase(label)}-tooltip`}>{tooltip}</Tooltip>}
+      title={tooltip}
       trigger={trigger}
     >
       {children}
-    </OverlayTrigger>
+    </Tooltip>
   );
 }
 

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopoverTitle.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopoverTitle.jsx
@@ -18,7 +18,8 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormControl, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { FormControl } from 'react-bootstrap';
+import Tooltip from 'src/common/components/Tooltip';
 
 const propTypes = {
   title: PropTypes.shape({
@@ -70,10 +71,6 @@ export default class AdhocMetricEditPopoverTitle extends React.Component {
   render() {
     const { title, onChange } = this.props;
 
-    const editPrompt = (
-      <Tooltip id="edit-metric-label-tooltip">Click to edit label</Tooltip>
-    );
-
     return this.state.isEditable ? (
       <FormControl
         className="metric-edit-popover-label-input"
@@ -86,18 +83,16 @@ export default class AdhocMetricEditPopoverTitle extends React.Component {
         data-test="AdhocMetricEditTitle#input"
       />
     ) : (
-      <OverlayTrigger
-        placement="top"
-        overlay={editPrompt}
-        onMouseOver={this.onMouseOver}
-        onMouseOut={this.onMouseOut}
-        onClick={this.onClick}
-        onBlur={this.onBlur}
-        className="AdhocMetricEditPopoverTitle"
-      >
+      <Tooltip placement="top" title="Click to edit label">
         <span
-          className="inline-editable"
+          className="AdhocMetricEditPopoverTitle inline-editable"
           data-test="AdhocMetricEditTitle#trigger"
+          onMouseOver={this.onMouseOver}
+          onMouseOut={this.onMouseOut}
+          onClick={this.onClick}
+          onBlur={this.onBlur}
+          role="button"
+          tabIndex={0}
         >
           {title.hasCustomLabel ? title.label : 'My Metric'}
           &nbsp;
@@ -106,7 +101,7 @@ export default class AdhocMetricEditPopoverTitle extends React.Component {
             style={{ color: this.state.isHovered ? 'black' : 'grey' }}
           />
         </span>
-      </OverlayTrigger>
+      </Tooltip>
     );
   }
 }

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopoverTitle.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopoverTitle.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormControl } from 'react-bootstrap';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 
 const propTypes = {
   title: PropTypes.shape({

--- a/superset-frontend/src/explore/components/ControlHeader.jsx
+++ b/superset-frontend/src/explore/components/ControlHeader.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { t } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import Tooltip from 'src/common/components/Tooltip';
 import FormLabel from 'src/components/FormLabel';
 
 const propTypes = {
@@ -98,40 +98,35 @@ export default class ControlHeader extends React.Component {
             </span>{' '}
             {this.props.warning && (
               <span>
-                <OverlayTrigger
+                <Tooltip
+                  id="error-tooltip"
                   placement="top"
-                  overlay={
-                    <Tooltip id="error-tooltip">{this.props.warning}</Tooltip>
-                  }
+                  title={this.props.warning}
                 >
                   <i className="fa fa-exclamation-circle text-warning" />
-                </OverlayTrigger>{' '}
+                </Tooltip>{' '}
               </span>
             )}
             {this.props.danger && (
               <span>
-                <OverlayTrigger
+                <Tooltip
+                  id="error-tooltip"
                   placement="top"
-                  overlay={
-                    <Tooltip id="error-tooltip">{this.props.danger}</Tooltip>
-                  }
+                  title={this.props.danger}
                 >
                   <i className="fa fa-exclamation-circle text-danger" />
-                </OverlayTrigger>{' '}
+                </Tooltip>{' '}
               </span>
             )}
             {this.props.validationErrors.length > 0 && (
               <span>
-                <OverlayTrigger
+                <Tooltip
+                  id="error-tooltip"
                   placement="top"
-                  overlay={
-                    <Tooltip id="error-tooltip">
-                      {this.props.validationErrors.join(' ')}
-                    </Tooltip>
-                  }
+                  title={this.props.validationErrors.join(' ')}
                 >
                   <i className="fa fa-exclamation-circle text-danger" />
-                </OverlayTrigger>{' '}
+                </Tooltip>{' '}
               </span>
             )}
             {this.renderOptionalIcons()}

--- a/superset-frontend/src/explore/components/ControlHeader.jsx
+++ b/superset-frontend/src/explore/components/ControlHeader.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { t } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import FormLabel from 'src/components/FormLabel';
 
 const propTypes = {

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -18,9 +18,10 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ButtonGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { ButtonGroup } from 'react-bootstrap';
 import { t, styled } from '@superset-ui/core';
 
+import Tooltip from 'src/common/components/Tooltip';
 import Button from 'src/components/Button';
 import Hotkeys from '../../components/Hotkeys';
 
@@ -123,14 +124,13 @@ export default function QueryAndSaveBtns({
         {errorMessage && (
           <span>
             {' '}
-            <OverlayTrigger
+            <Tooltip
+              id="query-error-tooltip"
               placement="right"
-              overlay={
-                <Tooltip id="query-error-tooltip">{errorMessage}</Tooltip>
-              }
+              title={errorMessage}
             >
               <i className="fa fa-exclamation-circle text-danger fa-lg" />
-            </OverlayTrigger>
+            </Tooltip>
           </span>
         )}
       </div>

--- a/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
+++ b/superset-frontend/src/explore/components/QueryAndSaveBtns.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import { ButtonGroup } from 'react-bootstrap';
 import { t, styled } from '@superset-ui/core';
 
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import Button from 'src/components/Button';
 import Hotkeys from '../../components/Hotkeys';
 

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -23,7 +23,7 @@ import { t, styled } from '@superset-ui/core';
 import { ColumnOption, MetricOption } from '@superset-ui/chart-controls';
 
 import { Dropdown, Menu } from 'src/common/components';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import Icon from 'src/components/Icon';
 import ChangeDatasourceModal from 'src/datasource/ChangeDatasourceModal';
 import DatasourceModal from 'src/datasource/DatasourceModal';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -18,14 +18,8 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  FormControl,
-  FormGroup,
-  InputGroup,
-  OverlayTrigger,
-  Radio,
-  Tooltip,
-} from 'react-bootstrap';
+import { FormControl, FormGroup, InputGroup, Radio } from 'react-bootstrap';
+import Tooltip from 'src/common/components/Tooltip';
 import Popover from 'src/common/components/Popover';
 import { Select, Input } from 'src/common/components';
 import Button from 'src/components/Button';
@@ -427,14 +421,11 @@ class DateFilterControl extends React.Component {
 
       return (
         <TimeFramesStyles key={timeFrame}>
-          <OverlayTrigger
+          <Tooltip
+            id={`tooltip-${timeFrame}`}
             key={timeFrame}
             placement="right"
-            overlay={
-              <Tooltip id={`tooltip-${timeFrame}`}>
-                {formatTimeRange(timeRange, this.props.endpoints)}
-              </Tooltip>
-            }
+            title={formatTimeRange(timeRange, this.props.endpoints)}
           >
             <div style={{ display: 'inline-block' }}>
               <Radio
@@ -445,7 +436,7 @@ class DateFilterControl extends React.Component {
                 {timeFrame}
               </Radio>
             </div>
-          </OverlayTrigger>
+          </Tooltip>
         </TimeFramesStyles>
       );
     });

--- a/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormControl, FormGroup, InputGroup, Radio } from 'react-bootstrap';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import Popover from 'src/common/components/Popover';
 import { Select, Input } from 'src/common/components';
 import Button from 'src/components/Button';

--- a/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
@@ -20,7 +20,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col, FormControl } from 'react-bootstrap';
 import { t, getChartMetadataRegistry } from '@superset-ui/core';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import Modal from 'src/common/components/Modal';
 import Label from 'src/components/Label';
 import ControlHeader from '../ControlHeader';

--- a/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl.jsx
@@ -18,14 +18,9 @@
  */
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Row,
-  Col,
-  FormControl,
-  OverlayTrigger,
-  Tooltip,
-} from 'react-bootstrap';
+import { Row, Col, FormControl } from 'react-bootstrap';
 import { t, getChartMetadataRegistry } from '@superset-ui/core';
+import Tooltip from 'src/common/components/Tooltip';
 import Modal from 'src/common/components/Modal';
 import Label from 'src/components/Label';
 import ControlHeader from '../ControlHeader';
@@ -181,13 +176,10 @@ const VizTypeControl = props => {
   return (
     <div>
       <ControlHeader {...props} />
-      <OverlayTrigger
+      <Tooltip
+        id="error-tooltip"
         placement="right"
-        overlay={
-          <Tooltip id="error-tooltip">
-            {t('Click to change visualization type')}
-          </Tooltip>
-        }
+        title={t('Click to change visualization type')}
       >
         <>
           <Label onClick={toggleModal} bsStyle={labelBsStyle}>
@@ -200,7 +192,7 @@ const VizTypeControl = props => {
             </div>
           )}
         </>
-      </OverlayTrigger>
+      </Tooltip>
       <Modal
         show={showModal}
         onHide={toggleModal}

--- a/superset-frontend/src/views/CRUD/data/query/QueryList.tsx
+++ b/superset-frontend/src/views/CRUD/data/query/QueryList.tsx
@@ -27,7 +27,7 @@ import { Popover } from 'src/common/components';
 import { commonMenuData } from 'src/views/CRUD/data/common';
 import ListView, { Filters, ListViewProps } from 'src/components/ListView';
 import Icon, { IconName } from 'src/components/Icon';
-import Tooltip from 'src/common/components/Tooltip';
+import { Tooltip } from 'src/common/components/Tooltip';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
 import sql from 'react-syntax-highlighter/dist/cjs/languages/hljs/sql';
 import github from 'react-syntax-highlighter/dist/cjs/styles/hljs/github';


### PR DESCRIPTION
### SUMMARY
Replaces usages of Tooltip and OverlayTrigger from `react-bootstrap` witht Tooltip from `Antd`.
The following components are affected by this PR:
ColumnElement, Button, SqlEditor, Link, AdhocMetrticPopoverTitle, ControlHeader, DateFilterControl, VizTypeControl, QueryAndSaveBtns, CopyToClipboard, TooltipWrapper, Field.
Components that use `InfoTooltipWithTrigger` (e.g. controls on Explore view) are not affected by this PR as `InfoTooltipWithTrigger` is defined in `superset-ui` library.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The changes affect almost every view. Here's an example from SqlLab's `ColumnElement`. Visually they're very similar, what's different is that you can hover and select text in the new Antd tooltip; before the tooltip disappeared when you stopped hovering the trigger.

Before:
![image](https://user-images.githubusercontent.com/15073128/99572434-f4b15500-29d4-11eb-9f42-33652c3a11a8.png)

After:
![image](https://user-images.githubusercontent.com/15073128/99572200-9be1bc80-29d4-11eb-86ad-b910367a6df5.png)

### TEST PLAN
Manually test the affected components.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@adam-stasiak Can you please do some manual testing?