### PR TITLE
fix: Adding __init__.py in superset.commands.importers

### DIFF
--- a/superset/commands/importers/__init__.py
+++ b/superset/commands/importers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/databases/commands/importers/v1/__init__.py
+++ b/superset/databases/commands/importers/v1/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, List
+from typing import Any, Dict, Optional, List
 
 from marshmallow import Schema, validate
 from marshmallow.exceptions import ValidationError
@@ -84,7 +84,7 @@ class ImportDatabasesCommand(BaseCommand):
 
         # verify that the metadata file is present and valid
         try:
-            metadata = load_metadata(self.contents)
+            metadata: Optional[Dict[str, str]] = load_metadata(self.contents)
         except ValidationError as exc:
             exceptions.append(exc)
             metadata = None

--- a/superset/databases/commands/importers/v1/__init__.py
+++ b/superset/databases/commands/importers/v1/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 from marshmallow import Schema, validate
 from marshmallow.exceptions import ValidationError

--- a/superset/datasets/commands/importers/v1/__init__.py
+++ b/superset/datasets/commands/importers/v1/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Optional, Set
 
 from marshmallow import Schema, validate
 from marshmallow.exceptions import ValidationError
@@ -89,7 +89,7 @@ class ImportDatasetsCommand(BaseCommand):
 
         # verify that the metadata file is present and valid
         try:
-            metadata = load_metadata(self.contents)
+            metadata: Optional[Dict[str, str]] = load_metadata(self.contents)
         except ValidationError as exc:
             exceptions.append(exc)
             metadata = None


### PR DESCRIPTION
### SUMMARY
Adds missing __init__.py to superset.commands.importers, which causes app to fail on init


