### PR TITLE
fix: Null error when deleting the last owner label in DatasourceEditor/settings

### DIFF
--- a/superset-frontend/src/explore/components/controls/SelectAsyncControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectAsyncControl.jsx
@@ -60,9 +60,9 @@ const SelectAsyncControl = props => {
   const onSelectionChange = options => {
     let val;
     if (multi) {
-      val = options?.map(option => option.value) || null;
+      val = options?.map(option => option.value) ?? null;
     } else {
-      val = options?.value || null;
+      val = options?.value ?? null;
     }
     onChange(val);
   };

--- a/superset-frontend/src/explore/components/controls/SelectAsyncControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectAsyncControl.jsx
@@ -60,11 +60,9 @@ const SelectAsyncControl = props => {
   const onSelectionChange = options => {
     let val;
     if (multi) {
-      val = options.map(option => option.value);
-    } else if (options) {
-      val = options.value;
+      val = options?.map(option => option.value) || null;
     } else {
-      val = null;
+      val = options?.value || null;
     }
     onChange(val);
   };


### PR DESCRIPTION
### SUMMARY
In Settings tab of DatasourceEditor, we couldn't delete all owner labels - when deleting the last one, there was a null error. This PR adds some null checks to SelectAsyncControl.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/99711965-b5513a00-2aa2-11eb-8a3e-94a93c40df70.png)
After:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/15073128/99712311-28f34700-2aa3-11eb-94f1-cedfe6af376f.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @graceguo-supercat 