### PR TITLE
chore: controls.test supporting v1 charts and added force=true to url when r…

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.js
@@ -18,12 +18,11 @@
  */
 import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
 import readResponseBlob from '../../utils/readResponseBlob';
-import { isLegacyChart } from '../../utils/vizPlugins';
+import { getChartAliases, isLegacyChart } from '../../utils/vizPlugins';
 
 describe('Dashboard top-level controls', () => {
-  const sliceRequests = [];
-  const forceRefreshRequests = [];
   let mapId;
+  let aliases;
 
   beforeEach(() => {
     cy.server();
@@ -33,85 +32,56 @@ describe('Dashboard top-level controls', () => {
     cy.get('#app').then(data => {
       const bootstrapData = JSON.parse(data[0].dataset.bootstrap);
       const dashboard = bootstrapData.dashboard_data;
-      const dashboardId = dashboard.id;
       mapId = dashboard.slices.find(
         slice => slice.form_data.viz_type === 'world_map',
       ).slice_id;
-
-      dashboard.slices.forEach(slice => {
-        // TODO(villebro): enable V1 charts
-        if (isLegacyChart(slice.form_data.viz_type)) {
-          const sliceRequest = `getJson_${slice.slice_id}`;
-          sliceRequests.push(`@${sliceRequest}`);
-          const formData = `{"slice_id":${slice.slice_id}}`;
-          cy.route(
-            'POST',
-            `/superset/explore_json/?form_data=${formData}&dashboard_id=${dashboardId}`,
-          ).as(sliceRequest);
-
-          const forceRefresh = `postJson_${slice.slice_id}_force`;
-          forceRefreshRequests.push(`@${forceRefresh}`);
-          cy.route(
-            'POST',
-            `/superset/explore_json/?form_data={"slice_id":${slice.slice_id}}&force=true&dashboard_id=${dashboardId}`,
-          ).as(forceRefresh);
-        }
-      });
+      aliases = getChartAliases(dashboard.slices);
     });
-  });
-  afterEach(() => {
-    sliceRequests.length = 0;
-    forceRefreshRequests.length = 0;
   });
 
   it('should allow chart level refresh', () => {
-    cy.wait(sliceRequests);
+    cy.wait(aliases);
     cy.get('[data-test="grid-container"]')
       .find('.world_map')
       .should('be.exist');
     cy.get(`#slice_${mapId}-controls`).click();
     cy.get(`[data-test="slice_${mapId}-menu"]`)
-      .find('[data-test="refresh-dashboard-menu-item"]')
+      .should('be.visible')
+      .find('[data-test="refresh-chart-menu-item"]')
       .click({ force: true });
 
-    // not allow dashboard level force refresh when any chart is loading
-    cy.get('[data-test="refresh-dashboard-menu-item"]').should(
-      'have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
     // not allow chart level force refresh when it is loading
     cy.get(`[data-test="slice_${mapId}-menu"]`)
-      .find('[data-test="refresh-dashboard-menu-item"]')
-      .should('have.class', 'ant-dropdown-menu-item-disabled');
+      .find('[data-test="refresh-chart-menu-item"]')
+      .should('be.visible')
+      .and('have.class', 'ant-dropdown-menu-item-disabled');
 
-    cy.wait(`@postJson_${mapId}_force`);
-    cy.get('[data-test="refresh-dashboard-menu-item"]').should(
-      'not.have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
+    cy.wait(`@getJson_${mapId}`);
+    cy.get('[data-test="refresh-chart-menu-item"]')
+      .should('be.visible')
+      .and('not.have.class', 'ant-dropdown-menu-item-disabled');
   });
 
   it('should allow dashboard level force refresh', () => {
     // when charts are not start loading, for example, under a secondary tab,
     // should allow force refresh
     cy.get('[data-test="more-horiz"]').click();
-    cy.get('[data-test="refresh-dashboard-menu-item"]').should(
-      'not.have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
+    cy.get('[data-test="refresh-dashboard-menu-item"]')
+      .should('be.visible')
+      .and('not.have.class', 'ant-dropdown-menu-item-disabled');
 
     // wait the all dash finish loading.
-    cy.wait(sliceRequests);
+    cy.wait(aliases);
     cy.get('[data-test="refresh-dashboard-menu-item"]').click({ force: true });
-    cy.get('[data-test="refresh-dashboard-menu-item"]').should(
-      'have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
+    cy.get('[data-test="refresh-dashboard-menu-item"]')
+      .should('be.visible')
+      .and('have.class', 'ant-dropdown-menu-item-disabled');
 
     // wait all charts force refreshed
-    cy.wait(forceRefreshRequests, { responseTimeout: 15000 }).then(xhrs => {
+    cy.wait(aliases, { responseTimeout: 15000 }).then(xhrs => {
       // is_cached in response should be false
       xhrs.forEach(xhr => {
+        expect(xhr.url).to.have.string('force=true');
         readResponseBlob(xhr.response.body).then(responseBody => {
           expect(responseBody.is_cached).to.equal(false);
         });
@@ -119,9 +89,8 @@ describe('Dashboard top-level controls', () => {
     });
 
     cy.get('[data-test="more-horiz"]').click();
-    cy.get('[data-test="refresh-dashboard-menu-item"]').should(
-      'not.have.class',
-      'ant-dropdown-menu-item-disabled',
-    );
+    cy.get('[data-test="refresh-dashboard-menu-item"]')
+      .should('be.visible')
+      .and('not.have.class', 'ant-dropdown-menu-item-disabled');
   });
 });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.js
@@ -18,12 +18,18 @@
  */
 import { WORLD_HEALTH_DASHBOARD } from './dashboard.helper';
 import readResponseBlob from '../../utils/readResponseBlob';
-import { getChartAliases, isLegacyResponse } from '../../utils/vizPlugins';
+import {
+  getChartAliases,
+  isLegacyResponse,
+  DASHBOARD_CHART_ALIAS_PREFIX,
+} from '../../utils/vizPlugins';
 
 describe('Dashboard top-level controls', () => {
   let mapId;
   let aliases;
-
+  const getAlias = (id: number) => {
+    return `@${DASHBOARD_CHART_ALIAS_PREFIX}${id}`;
+  };
   beforeEach(() => {
     cy.server();
     cy.login();
@@ -50,7 +56,7 @@ describe('Dashboard top-level controls', () => {
         cy.get($el).should('have.class', 'ant-dropdown-menu-item-disabled');
       });
 
-    cy.wait(`@getJson_${mapId}`);
+    cy.wait(getAlias(mapId));
     cy.get('[data-test="refresh-chart-menu-item"]').should(
       'not.have.class',
       'ant-dropdown-menu-item-disabled',

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/controls.test.js
@@ -27,9 +27,7 @@ import {
 describe('Dashboard top-level controls', () => {
   let mapId;
   let aliases;
-  const getAlias = (id: number) => {
-    return `@${DASHBOARD_CHART_ALIAS_PREFIX}${id}`;
-  };
+
   beforeEach(() => {
     cy.server();
     cy.login();
@@ -56,7 +54,7 @@ describe('Dashboard top-level controls', () => {
         cy.get($el).should('have.class', 'ant-dropdown-menu-item-disabled');
       });
 
-    cy.wait(getAlias(mapId));
+    cy.wait(`@${DASHBOARD_CHART_ALIAS_PREFIX}${mapId}`);
     cy.get('[data-test="refresh-chart-menu-item"]').should(
       'not.have.class',
       'ant-dropdown-menu-item-disabled',

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -154,9 +154,11 @@ const v1ChartDataRequest = async (
   // The dashboard id is added to query params for tracking purposes
   const { slice_id: sliceId } = formData;
   const { dashboard_id: dashboardId } = requestParams;
+
   const qs = {};
   if (sliceId !== undefined) qs.form_data = `{"slice_id":${sliceId}}`;
   if (dashboardId !== undefined) qs.dashboard_id = dashboardId;
+  if (force !== false) qs.force = force;
 
   const allowDomainSharding =
     // eslint-disable-next-line camelcase

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -177,7 +177,7 @@ class SliceHeaderControls extends React.PureComponent {
           key={MENU_KEYS.FORCE_REFRESH}
           disabled={this.props.chartStatus === 'loading'}
           style={{ height: 'auto', lineHeight: 'initial' }}
-          data-test="refresh-dashboard-menu-item"
+          data-test="refresh-chart-menu-item"
         >
           {t('Force refresh')}
           <RefreshTooltip data-test="dashboard-slice-refresh-tooltip">


### PR DESCRIPTION
…efreshin chart with force an option

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added support for v1 charts.

Before this change v1 charts did not have force=true in url when user clicks on refresh chart button. For legacy charts it was implemented. Now v1 charts have the same in url. If it was no force refresh operation it is nothing added as before.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x ] Introduces new feature or API
- [ ] Removes existing feature or API
