### PR TITLE
docs: Document move of helm chart from ./install/helm to ./helm

### DIFF
--- a/docs/src/pages/docs/installation/installing_scratch.mdx
+++ b/docs/src/pages/docs/installation/installing_scratch.mdx
@@ -120,12 +120,13 @@ locally by default at `localhost:8088`) and login using the username and passwor
 ### Installing Superset with Helm in Kubernetes
 
 You can install Superset into Kubernetes with [Helm](https://helm.sh/). The chart is located in
-`install/helm`.
+`helm/`.
 
 To install Superset in Kubernetes, run:
 
 ```
-helm upgrade --install superset ./install/helm/superset
+helm dependency update ./helm/superset
+helm upgrade --install superset ./helm/superset
 ```
 
 Note that the above command will install Superset into `default` namespace of your Kubernetes


### PR DESCRIPTION
### SUMMARY
Since ./install/helm has been moved, reflect that in documentation.
Additionally document how to pull dependencies first to fix an error which happens when dependencies are not pulled yet.

### ADDITIONAL INFORMATION
* See https://github.com/apache/incubator-superset/issues/11363#issuecomment-716175968
* and https://github.com/apache/incubator-superset/issues/9622#issuecomment-617923948
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
