### PR TITLE
fix: Chart select borders in BuilderComponentPane

### DIFF
--- a/superset-frontend/src/dashboard/components/BuilderComponentPane.jsx
+++ b/superset-frontend/src/dashboard/components/BuilderComponentPane.jsx
@@ -23,7 +23,7 @@ import Tabs from 'src/common/components/Tabs';
 import { StickyContainer, Sticky } from 'react-sticky';
 import { ParentSize } from '@vx/responsive';
 
-import { t } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 
 import NewColumn from './gridComponents/new/NewColumn';
 import NewDivider from './gridComponents/new/NewDivider';
@@ -43,14 +43,18 @@ const defaultProps = {
 
 const SUPERSET_HEADER_HEIGHT = 59;
 
+const BuilderComponentPaneTabs = styled(Tabs)`
+  line-height: inherit;
+  margin-top: ${({ theme }) => theme.gridUnit * 2}px;
+`;
+
 class BuilderComponentPane extends React.PureComponent {
   renderTabs(height) {
     const { isSticky } = this.props;
     return (
-      <Tabs
+      <BuilderComponentPaneTabs
         id="tabs"
         className="tabs-components"
-        style={{ marginTop: '10px' }}
         data-test="dashboard-builder-component-pane-tabs-navigation"
       >
         <Tabs.TabPane key={1} tab={t('Components')}>
@@ -66,7 +70,7 @@ class BuilderComponentPane extends React.PureComponent {
             height={height + (isSticky ? SUPERSET_HEADER_HEIGHT : 0)}
           />
         </Tabs.TabPane>
-      </Tabs>
+      </BuilderComponentPaneTabs>
     );
   }
 


### PR DESCRIPTION
### SUMMARY
Span elements of chart select in BuilderComponentPane were inheriting line-height from `.ant-tabs` class and it increased the total height of SliceCard. In result, cards overlapped each other and the last card was overflowing from cards container.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
![image](https://user-images.githubusercontent.com/15073128/99830036-67e5d300-2b5d-11eb-9c2a-38cadfe1ee67.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/incubator-superset/issues/11756
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
