### PR TITLE
chore: remove double check in scheduler

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -16,7 +16,6 @@
 # under the License.
 
 """Utility functions used across Superset"""
-
 import logging
 import time
 import urllib.request
@@ -494,11 +493,6 @@ def schedule_email_report(
     model_cls = get_scheduler_model(report_type)
     with session_scope(nullpool=True) as session:
         schedule = session.query(model_cls).get(schedule_id)
-
-        # The user may have disabled the schedule. If so, ignore this
-        if not schedule or not schedule.active:
-            logger.info("Ignoring deactivated schedule")
-            return
 
         recipients = recipients or schedule.recipients
         slack_channel = slack_channel or schedule.slack_channel

--- a/superset/views/schedules.py
+++ b/superset/views/schedules.py
@@ -131,16 +131,20 @@ class EmailScheduleView(
 
     def post_add(self, item: "EmailScheduleView") -> None:
         # Schedule a test mail if the user requested for it.
-        if self._extra_data["test_email"]:
-            recipients = self._extra_data["test_email_recipients"] or item.recipients
-            slack_channel = self._extra_data["test_slack_channel"] or item.slack_channel
-            args = (self.schedule_type, item.id)
-            kwargs = dict(recipients=recipients, slack_channel=slack_channel)
-            schedule_email_report.apply_async(args=args, kwargs=kwargs)
-
-        # Notify the user that schedule changes will be activate only in the
-        # next hour
         if item.active:
+            if self._extra_data["test_email"]:
+                recipients = (
+                    self._extra_data["test_email_recipients"] or item.recipients
+                )
+                slack_channel = (
+                    self._extra_data["test_slack_channel"] or item.slack_channel
+                )
+                args = (self.schedule_type, item.id)
+                kwargs = dict(recipients=recipients, slack_channel=slack_channel)
+                schedule_email_report.apply_async(args=args, kwargs=kwargs)
+
+            # Notify the user that schedule changes will be activate only in the
+            # next hour
             flash("Schedule changes will get applied in one hour", "warning")
 
     def post_update(self, item: "EmailScheduleView") -> None:


### PR DESCRIPTION
Remove double check the active scheduler in `email_reports.send` task and `scheduler_windows` method:

email_reports.send task:
```       
  # The user may have disabled the schedule. If so, ignore this
  if not schedule or not schedule.active:
      logger.info("Ignoring deactivated schedule")
      return
```
scheduler_windows :
```
schedules = session.query(model_cls).filter(model_cls.active.is_(True))

for schedule in schedules: