### PR TITLE
fix(reports): dashboard references aren't clear

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -145,6 +145,9 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
     def __repr__(self) -> str:
         return f"Dashboard<{self.id or self.slug}>"
 
+    def __str__(self) -> str:
+        return self.dashboard_title
+
     @property
     def table_names(self) -> str:
         # pylint: disable=no-member


### PR DESCRIPTION
### SUMMARY
The dropdown in the report creation view are not intelligible to users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="541" alt="Screen Shot 2020-11-21 at 5 48 57 PM" src="https://user-images.githubusercontent.com/487433/99891753-31be5700-2c22-11eb-97e6-a294b6612113.png">
<img width="561" alt="Screen Shot 2020-11-21 at 5 47 56 PM" src="https://user-images.githubusercontent.com/487433/99891754-3256ed80-2c22-11eb-9175-7cc7ca5a8ec6.png">
