### PR TITLE
fix: Download as image not working on Dashboard view

### DIFF
--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -61,6 +61,7 @@ export const MenuItem = styled(AntdMenu.Item)`
       display: inline-block;
       width: 100%;
     }
+    transition-duration: 0s;
   }
 `;
 

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -307,7 +307,9 @@ class HeaderActionsDropdown extends React.PureComponent {
       <NoAnimationDropdown
         overlay={menu}
         trigger={['click']}
-        getPopupContainer={triggerNode => triggerNode.closest(screenshotNodeSelector)}
+        getPopupContainer={triggerNode =>
+          triggerNode.closest(screenshotNodeSelector)
+        }
       >
         <DropdownButton id="save-dash-split-button" role="button">
           <Icon name="more-horiz" />

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -137,6 +137,7 @@ class HeaderActionsDropdown extends React.PureComponent {
   }
 
   handleMenuClick({ key, domEvent }) {
+    const { currentTarget } = domEvent;
     switch (key) {
       case MENU_KEYS.REFRESH_DASHBOARD:
         this.props.forceRefreshAllCharts();
@@ -145,7 +146,14 @@ class HeaderActionsDropdown extends React.PureComponent {
         this.props.showPropertiesModal();
         break;
       case MENU_KEYS.DOWNLOAD_AS_IMAGE:
-        downloadAsImage('.dashboard', this.props.dashboardTitle)(domEvent);
+        setTimeout(
+          () =>
+            downloadAsImage(
+              '.dashboard',
+              this.props.dashboardTitle,
+            )({ currentTarget }),
+          1000,
+        );
         break;
       case MENU_KEYS.TOGGLE_FULLSCREEN: {
         const hasStandalone = window.location.search.includes(
@@ -297,7 +305,7 @@ class HeaderActionsDropdown extends React.PureComponent {
       <NoAnimationDropdown
         overlay={menu}
         trigger={['click']}
-        getPopupContainer={() => document.querySelector('.dashboard')}
+        getPopupContainer={triggerNode => triggerNode.closest('.dashboard')}
       >
         <DropdownButton id="save-dash-split-button" role="button">
           <Icon name="more-horiz" />

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -87,7 +87,7 @@ const DropdownButton = styled.div`
   margin-left: ${({ theme }) => theme.gridUnit * 2.5}px;
 `;
 
-const screenshotNodeSelector = '.dashboard';
+const SCREENSHOT_NODE_SELECTOR = '.dashboard';
 
 class HeaderActionsDropdown extends React.PureComponent {
   static discardChanges() {
@@ -154,7 +154,7 @@ class HeaderActionsDropdown extends React.PureComponent {
         // so that we don't capture it on the screenshot
         menu.style.visibility = 'hidden';
         downloadAsImage(
-          screenshotNodeSelector,
+          SCREENSHOT_NODE_SELECTOR,
           this.props.dashboardTitle,
         )(domEvent).then(() => {
           menu.style.visibility = 'visible';
@@ -311,7 +311,7 @@ class HeaderActionsDropdown extends React.PureComponent {
         overlay={menu}
         trigger={['click']}
         getPopupContainer={triggerNode =>
-          triggerNode.closest(screenshotNodeSelector)
+          triggerNode.closest(SCREENSHOT_NODE_SELECTOR)
         }
       >
         <DropdownButton id="save-dash-split-button" role="button">

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -89,6 +89,8 @@ const DropdownButton = styled.div`
 
 const screenshotNodeSelector = '.dashboard';
 
+const takeScreenshotDelay = 1000;
+
 class HeaderActionsDropdown extends React.PureComponent {
   static discardChanges() {
     window.location.reload();
@@ -148,13 +150,15 @@ class HeaderActionsDropdown extends React.PureComponent {
         this.props.showPropertiesModal();
         break;
       case MENU_KEYS.DOWNLOAD_AS_IMAGE:
+        // menu closes with a delay, we need to wait so
+        // that we don't capture it on the screenshot
         setTimeout(
           () =>
             downloadAsImage(
               screenshotNodeSelector,
               this.props.dashboardTitle,
             )({ currentTarget }),
-          1000,
+          takeScreenshotDelay,
         );
         break;
       case MENU_KEYS.TOGGLE_FULLSCREEN: {

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -87,6 +87,8 @@ const DropdownButton = styled.div`
   margin-left: ${({ theme }) => theme.gridUnit * 2.5}px;
 `;
 
+const screenshotNodeSelector = '.dashboard';
+
 class HeaderActionsDropdown extends React.PureComponent {
   static discardChanges() {
     window.location.reload();
@@ -149,7 +151,7 @@ class HeaderActionsDropdown extends React.PureComponent {
         setTimeout(
           () =>
             downloadAsImage(
-              '.dashboard',
+              screenshotNodeSelector,
               this.props.dashboardTitle,
             )({ currentTarget }),
           1000,
@@ -305,7 +307,7 @@ class HeaderActionsDropdown extends React.PureComponent {
       <NoAnimationDropdown
         overlay={menu}
         trigger={['click']}
-        getPopupContainer={triggerNode => triggerNode.closest('.dashboard')}
+        getPopupContainer={triggerNode => triggerNode.closest(screenshotNodeSelector)}
       >
         <DropdownButton id="save-dash-split-button" role="button">
           <Icon name="more-horiz" />

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -139,9 +139,6 @@ class HeaderActionsDropdown extends React.PureComponent {
   }
 
   handleMenuClick({ key, domEvent }) {
-    const menu = document.querySelector(
-      '.ant-dropdown:not(.ant-dropdown-hidden)',
-    );
     switch (key) {
       case MENU_KEYS.REFRESH_DASHBOARD:
         this.props.forceRefreshAllCharts();
@@ -149,9 +146,12 @@ class HeaderActionsDropdown extends React.PureComponent {
       case MENU_KEYS.EDIT_PROPERTIES:
         this.props.showPropertiesModal();
         break;
-      case MENU_KEYS.DOWNLOAD_AS_IMAGE:
+      case MENU_KEYS.DOWNLOAD_AS_IMAGE: {
         // menu closes with a delay, we need to hide it manually,
         // so that we don't capture it on the screenshot
+        const menu = document.querySelector(
+          '.ant-dropdown:not(.ant-dropdown-hidden)',
+        );
         menu.style.visibility = 'hidden';
         downloadAsImage(
           SCREENSHOT_NODE_SELECTOR,
@@ -160,6 +160,7 @@ class HeaderActionsDropdown extends React.PureComponent {
           menu.style.visibility = 'visible';
         });
         break;
+      }
       case MENU_KEYS.TOGGLE_FULLSCREEN: {
         const hasStandalone = window.location.search.includes(
           'standalone=true',

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -294,7 +294,11 @@ class HeaderActionsDropdown extends React.PureComponent {
       </Menu>
     );
     return (
-      <NoAnimationDropdown overlay={menu} trigger={['click']}>
+      <NoAnimationDropdown
+        overlay={menu}
+        trigger={['click']}
+        getPopupContainer={() => document.querySelector('.dashboard')}
+      >
         <DropdownButton id="save-dash-split-button" role="button">
           <Icon name="more-horiz" />
         </DropdownButton>

--- a/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
+++ b/superset-frontend/src/dashboard/components/HeaderActionsDropdown.jsx
@@ -89,8 +89,6 @@ const DropdownButton = styled.div`
 
 const screenshotNodeSelector = '.dashboard';
 
-const takeScreenshotDelay = 1000;
-
 class HeaderActionsDropdown extends React.PureComponent {
   static discardChanges() {
     window.location.reload();
@@ -141,7 +139,9 @@ class HeaderActionsDropdown extends React.PureComponent {
   }
 
   handleMenuClick({ key, domEvent }) {
-    const { currentTarget } = domEvent;
+    const menu = document.querySelector(
+      '.ant-dropdown:not(.ant-dropdown-hidden)',
+    );
     switch (key) {
       case MENU_KEYS.REFRESH_DASHBOARD:
         this.props.forceRefreshAllCharts();
@@ -150,16 +150,15 @@ class HeaderActionsDropdown extends React.PureComponent {
         this.props.showPropertiesModal();
         break;
       case MENU_KEYS.DOWNLOAD_AS_IMAGE:
-        // menu closes with a delay, we need to wait so
-        // that we don't capture it on the screenshot
-        setTimeout(
-          () =>
-            downloadAsImage(
-              screenshotNodeSelector,
-              this.props.dashboardTitle,
-            )({ currentTarget }),
-          takeScreenshotDelay,
-        );
+        // menu closes with a delay, we need to hide it manually,
+        // so that we don't capture it on the screenshot
+        menu.style.visibility = 'hidden';
+        downloadAsImage(
+          screenshotNodeSelector,
+          this.props.dashboardTitle,
+        )(domEvent).then(() => {
+          menu.style.visibility = 'visible';
+        });
         break;
       case MENU_KEYS.TOGGLE_FULLSCREEN: {
         const hasStandalone = window.location.search.includes(

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -123,6 +123,7 @@ class SliceHeaderControls extends React.PureComponent {
   }
 
   handleMenuClick({ key, domEvent }) {
+    const { currentTarget } = domEvent;
     switch (key) {
       case MENU_KEYS.FORCE_REFRESH:
         this.refreshChart();
@@ -140,10 +141,14 @@ class SliceHeaderControls extends React.PureComponent {
         this.props.handleToggleFullSize();
         break;
       case MENU_KEYS.DOWNLOAD_AS_IMAGE:
-        downloadAsImage(
-          '.dashboard-component-chart-holder',
-          this.props.slice.slice_name,
-        )(domEvent);
+        setTimeout(
+          () =>
+            downloadAsImage(
+              '.dashboard-component-chart-holder',
+              this.props.slice.slice_name,
+            )({ currentTarget }),
+          1000,
+        );
         break;
       default:
         break;
@@ -232,6 +237,9 @@ class SliceHeaderControls extends React.PureComponent {
         dropdownAlign={{
           offset: [-40, 4],
         }}
+        getPopupContainer={triggerNode =>
+          triggerNode.closest('.dashboard-component-chart-holder')
+        }
       >
         <a id={`slice_${slice.slice_id}-controls`} role="button">
           <VerticalDotsTrigger />

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -87,7 +87,7 @@ const RefreshTooltip = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.base};
 `;
 
-const screenshotNodeSelector = '.dashboard-component-chart-holder';
+const SCREENSHOT_NODE_SELECTOR = '.dashboard-component-chart-holder';
 
 const VerticalDotsTrigger = () => (
   <VerticalDotsContainer>
@@ -149,7 +149,7 @@ class SliceHeaderControls extends React.PureComponent {
         // so that we don't capture it on the screenshot
         menu.style.visibility = 'hidden';
         downloadAsImage(
-          screenshotNodeSelector,
+          SCREENSHOT_NODE_SELECTOR,
           this.props.slice.slice_name,
         )(domEvent).then(() => {
           menu.style.visibility = 'visible';
@@ -243,7 +243,7 @@ class SliceHeaderControls extends React.PureComponent {
           offset: [-40, 4],
         }}
         getPopupContainer={triggerNode =>
-          triggerNode.closest(screenshotNodeSelector)
+          triggerNode.closest(SCREENSHOT_NODE_SELECTOR)
         }
       >
         <a id={`slice_${slice.slice_id}-controls`} role="button">

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -87,6 +87,8 @@ const RefreshTooltip = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.base};
 `;
 
+const screenshotNodeSelector = '.dashboard-component-chart-holder';
+
 const VerticalDotsTrigger = () => (
   <VerticalDotsContainer>
     <span className="dot" />
@@ -144,7 +146,7 @@ class SliceHeaderControls extends React.PureComponent {
         setTimeout(
           () =>
             downloadAsImage(
-              '.dashboard-component-chart-holder',
+              screenshotNodeSelector,
               this.props.slice.slice_name,
             )({ currentTarget }),
           1000,
@@ -238,7 +240,7 @@ class SliceHeaderControls extends React.PureComponent {
           offset: [-40, 4],
         }}
         getPopupContainer={triggerNode =>
-          triggerNode.closest('.dashboard-component-chart-holder')
+          triggerNode.closest(screenshotNodeSelector)
         }
       >
         <a id={`slice_${slice.slice_id}-controls`} role="button">

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -125,9 +125,6 @@ class SliceHeaderControls extends React.PureComponent {
   }
 
   handleMenuClick({ key, domEvent }) {
-    const menu = document.querySelector(
-      '.ant-dropdown:not(.ant-dropdown-hidden)',
-    );
     switch (key) {
       case MENU_KEYS.FORCE_REFRESH:
         this.refreshChart();
@@ -144,9 +141,12 @@ class SliceHeaderControls extends React.PureComponent {
       case MENU_KEYS.RESIZE_LABEL:
         this.props.handleToggleFullSize();
         break;
-      case MENU_KEYS.DOWNLOAD_AS_IMAGE:
+      case MENU_KEYS.DOWNLOAD_AS_IMAGE: {
         // menu closes with a delay, we need to hide it manually,
         // so that we don't capture it on the screenshot
+        const menu = document.querySelector(
+          '.ant-dropdown:not(.ant-dropdown-hidden)',
+        );
         menu.style.visibility = 'hidden';
         downloadAsImage(
           SCREENSHOT_NODE_SELECTOR,
@@ -155,6 +155,7 @@ class SliceHeaderControls extends React.PureComponent {
           menu.style.visibility = 'visible';
         });
         break;
+      }
       default:
         break;
     }

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -89,6 +89,8 @@ const RefreshTooltip = styled.div`
 
 const screenshotNodeSelector = '.dashboard-component-chart-holder';
 
+const takeScreenshotDelay = 1000;
+
 const VerticalDotsTrigger = () => (
   <VerticalDotsContainer>
     <span className="dot" />
@@ -143,13 +145,15 @@ class SliceHeaderControls extends React.PureComponent {
         this.props.handleToggleFullSize();
         break;
       case MENU_KEYS.DOWNLOAD_AS_IMAGE:
+        // menu closes with a delay, we need to wait so
+        // that we don't capture it on the screenshot
         setTimeout(
           () =>
             downloadAsImage(
               screenshotNodeSelector,
               this.props.slice.slice_name,
             )({ currentTarget }),
-          1000,
+          takeScreenshotDelay,
         );
         break;
       default:

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls.jsx
@@ -89,8 +89,6 @@ const RefreshTooltip = styled.div`
 
 const screenshotNodeSelector = '.dashboard-component-chart-holder';
 
-const takeScreenshotDelay = 1000;
-
 const VerticalDotsTrigger = () => (
   <VerticalDotsContainer>
     <span className="dot" />
@@ -127,7 +125,9 @@ class SliceHeaderControls extends React.PureComponent {
   }
 
   handleMenuClick({ key, domEvent }) {
-    const { currentTarget } = domEvent;
+    const menu = document.querySelector(
+      '.ant-dropdown:not(.ant-dropdown-hidden)',
+    );
     switch (key) {
       case MENU_KEYS.FORCE_REFRESH:
         this.refreshChart();
@@ -145,16 +145,15 @@ class SliceHeaderControls extends React.PureComponent {
         this.props.handleToggleFullSize();
         break;
       case MENU_KEYS.DOWNLOAD_AS_IMAGE:
-        // menu closes with a delay, we need to wait so
-        // that we don't capture it on the screenshot
-        setTimeout(
-          () =>
-            downloadAsImage(
-              screenshotNodeSelector,
-              this.props.slice.slice_name,
-            )({ currentTarget }),
-          takeScreenshotDelay,
-        );
+        // menu closes with a delay, we need to hide it manually,
+        // so that we don't capture it on the screenshot
+        menu.style.visibility = 'hidden';
+        downloadAsImage(
+          screenshotNodeSelector,
+          this.props.slice.slice_name,
+        )(domEvent).then(() => {
+          menu.style.visibility = 'visible';
+        });
         break;
       default:
         break;

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -90,6 +90,7 @@ export const DisplayQueryButton = props => {
     datasource && datasource.split('__')[1] === 'table',
   );
   const [isPropertiesModalOpen, setIsPropertiesModalOpen] = useState(false);
+  const [menuVisible, setMenuVisible] = useState(false);
 
   const tableData = useMemo(() => {
     if (!data?.length) {
@@ -150,6 +151,7 @@ export const DisplayQueryButton = props => {
 
   const handleMenuClick = ({ key, domEvent }) => {
     const { chartHeight, slice, onOpenInEditor, latestQueryFormData } = props;
+    setMenuVisible(false);
     switch (key) {
       case MENU_KEYS.EDIT_PROPERTIES:
         openPropertiesModal();
@@ -273,6 +275,7 @@ export const DisplayQueryButton = props => {
   const { slice } = props;
   return (
     <DropdownButton
+      open={menuVisible}
       noCaret
       data-test="query-dropdown"
       title={
@@ -284,6 +287,7 @@ export const DisplayQueryButton = props => {
       bsSize="sm"
       pullRight
       id="query"
+      onToggle={setMenuVisible}
     >
       <Menu onClick={handleMenuClick} selectable={false}>
         {slice && [


### PR DESCRIPTION
### SUMMARY
Due to how menu component was mounted (at the end of body), the selector defined in `downloadAsImage` function returned null instead of dashboard component. This PR changes the mount node of Menu to `div.dashboard`.

Another issue was that menu did not close on time before a screenshot was made. I fixed it by using wrapping `downloadAsImage` in `setTimeout` with 1s delay - any suggestion on how to do it better would be greatly appreciated. Using `visible` prop on menu trigger and running `downloadAsImage` in a callback of setState did not work; same as using setTimeout with 0 delay.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Images below are results of running `downloadAsImage` on a chart.

Before - menu is visible and it covers the chart:
![test-2020-11-23T13-52-56 004Z](https://user-images.githubusercontent.com/15073128/99971087-0613ac00-2d9d-11eb-92d4-424020f78232.jpg)

After:
![test-2020-11-23T13-49-35 364Z](https://user-images.githubusercontent.com/15073128/99971129-1166d780-2d9d-11eb-8586-5dd6f68794a7.jpg)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
