### PR TITLE
refactor: Replace SqlLab components' styles using Emotion & theme variables

### DIFF
--- a/superset-frontend/src/SqlLab/components/QuerySearch.jsx
+++ b/superset-frontend/src/SqlLab/components/QuerySearch.jsx
@@ -58,6 +58,10 @@ const TableStyles = styled.div`
   }
 `;
 
+const StyledTableStylesContainer = styled.div`
+  overflow: auto;
+`;
+
 class QuerySearch extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -293,11 +297,11 @@ class QuerySearch extends React.PureComponent {
             </Button>
           </div>
         </div>
-        <div className="scrollbar-container">
+        <StyledTableStylesContainer>
           {this.state.queriesLoading ? (
             <Loading />
           ) : (
-            <TableStyles className="scrollbar-content">
+            <TableStyles>
               <QueryTable
                 columns={[
                   'state',
@@ -317,7 +321,7 @@ class QuerySearch extends React.PureComponent {
               />
             </TableStyles>
           )}
-        </div>
+        </StyledTableStylesContainer>
       </TableWrapper>
     );
   }

--- a/superset-frontend/src/SqlLab/components/QueryTable.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { ProgressBar, Well } from 'react-bootstrap';
 import Label from 'src/components/Label';
-import { t, styled } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 
 import TableView from 'src/components/TableView';
 import Button from 'src/components/Button';
@@ -46,18 +46,6 @@ const defaultProps = {
   onUserClicked: () => {},
   onDbClicked: () => {},
 };
-
-const StyledButtonContainer = styled.div`
-  width: 100px;
-`;
-
-const StyledLinksContainer = styled.div`
-  width: 75px;
-`;
-
-const StyledProgressBar = styled(ProgressBar)`
-  width: 75px;
-`;
 
 const openQuery = id => {
   const url = `/superset/sqllab?queryId=${id}`;
@@ -130,16 +118,14 @@ const QueryTable = props => {
         );
         q.started = moment(q.startDttm).format('HH:mm:ss');
         q.querylink = (
-          <StyledButtonContainer>
-            <Button
-              buttonSize="small"
-              buttonStyle="link"
-              onClick={() => openQuery(q.queryId)}
-            >
-              <i className="fa fa-external-link m-r-3" />
-              {t('Edit')}
-            </Button>
-          </StyledButtonContainer>
+          <Button
+            buttonSize="small"
+            buttonStyle="link"
+            onClick={() => openQuery(q.queryId)}
+          >
+            <i className="fa fa-external-link m-r-3" />
+            {t('Edit')}
+          </Button>
         );
         q.sql = (
           <Well>
@@ -183,7 +169,7 @@ const QueryTable = props => {
           q.output = [schemaUsed, q.tempTable].filter(v => v).join('.');
         }
         q.progress = (
-          <StyledProgressBar
+          <ProgressBar
             striped
             now={q.progress}
             label={`${q.progress.toFixed(0)}%`}
@@ -204,7 +190,7 @@ const QueryTable = props => {
           </div>
         );
         q.actions = (
-          <StyledLinksContainer>
+          <div>
             <Link
               className="fa fa-pencil m-r-3"
               onClick={() => restoreSql(query)}
@@ -224,7 +210,7 @@ const QueryTable = props => {
               tooltip={t('Remove query from log')}
               onClick={() => removeQuery(query)}
             />
-          </StyledLinksContainer>
+          </div>
         );
         return q;
       })

--- a/superset-frontend/src/SqlLab/components/QueryTable.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { ProgressBar, Well } from 'react-bootstrap';
 import Label from 'src/components/Label';
-import { t } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 
 import TableView from 'src/components/TableView';
 import Button from 'src/components/Button';
@@ -46,6 +46,18 @@ const defaultProps = {
   onUserClicked: () => {},
   onDbClicked: () => {},
 };
+
+const StyledButtonContainer = styled.div`
+  width: 100px;
+`;
+
+const StyledLinksContainer = styled.div`
+  width: 75px;
+`;
+
+const StyledProgressBar = styled(ProgressBar)`
+  width: 75px;
+`;
 
 const openQuery = id => {
   const url = `/superset/sqllab?queryId=${id}`;
@@ -118,7 +130,7 @@ const QueryTable = props => {
         );
         q.started = moment(q.startDttm).format('HH:mm:ss');
         q.querylink = (
-          <div style={{ width: '100px' }}>
+          <StyledButtonContainer>
             <Button
               buttonSize="small"
               buttonStyle="link"
@@ -127,7 +139,7 @@ const QueryTable = props => {
               <i className="fa fa-external-link m-r-3" />
               {t('Edit')}
             </Button>
-          </div>
+          </StyledButtonContainer>
         );
         q.sql = (
           <Well>
@@ -171,8 +183,7 @@ const QueryTable = props => {
           q.output = [schemaUsed, q.tempTable].filter(v => v).join('.');
         }
         q.progress = (
-          <ProgressBar
-            style={{ width: '75px' }}
+          <StyledProgressBar
             striped
             now={q.progress}
             label={`${q.progress.toFixed(0)}%`}
@@ -193,7 +204,7 @@ const QueryTable = props => {
           </div>
         );
         q.actions = (
-          <div style={{ width: '75px' }}>
+          <StyledLinksContainer>
             <Link
               className="fa fa-pencil m-r-3"
               onClick={() => restoreSql(query)}
@@ -213,7 +224,7 @@ const QueryTable = props => {
               tooltip={t('Remove query from log')}
               onClick={() => removeQuery(query)}
             />
-          </div>
+          </StyledLinksContainer>
         );
         return q;
       })

--- a/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
@@ -93,7 +93,7 @@ const defaultProps = {
 };
 
 const StyledRow = styled(Row)`
-  padding-bottom: ${({ theme }) => theme.gridUnit * 2.5}px;
+  padding-bottom: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
 class ScheduleQueryButton extends React.PureComponent {

--- a/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
+++ b/superset-frontend/src/SqlLab/components/ScheduleQueryButton.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import Form from 'react-jsonschema-form';
 import chrono from 'chrono-node';
 import { Col, FormControl, FormGroup, Row } from 'react-bootstrap';
-import { t } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 
 import Button from 'src/components/Button';
 import ModalTrigger from 'src/components/ModalTrigger';
@@ -92,6 +92,10 @@ const defaultProps = {
   tooltip: null,
 };
 
+const StyledRow = styled(Row)`
+  padding-bottom: ${({ theme }) => theme.gridUnit * 2.5}px;
+`;
+
 class ScheduleQueryButton extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -139,7 +143,7 @@ class ScheduleQueryButton extends React.PureComponent {
   renderModalBody() {
     return (
       <FormGroup>
-        <Row style={{ paddingBottom: '10px' }}>
+        <StyledRow>
           <Col md={12}>
             <FormLabel className="control-label" htmlFor="embed-height">
               {t('Label')}
@@ -151,8 +155,8 @@ class ScheduleQueryButton extends React.PureComponent {
               onChange={this.onLabelChange}
             />
           </Col>
-        </Row>
-        <Row style={{ paddingBottom: '10px' }}>
+        </StyledRow>
+        <StyledRow>
           <Col md={12}>
             <FormLabel className="control-label" htmlFor="embed-height">
               {t('Description')}
@@ -164,7 +168,7 @@ class ScheduleQueryButton extends React.PureComponent {
               onChange={this.onDescriptionChange}
             />
           </Col>
-        </Row>
+        </StyledRow>
         <Row>
           <Col md={12}>
             <div className="json-schema">

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from 'src/components/Button';
-import { t } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 import TableElement from './TableElement';
 import TableSelector from '../../components/TableSelector';
 
@@ -38,6 +38,15 @@ const defaultProps = {
   offline: false,
   tables: [],
 };
+
+const StyledScrollbarContainer = styled.div`
+  flex: 1 1 auto;
+  overflow: auto;
+`;
+
+const StyledScrollbarContent = styled.div`
+  height: ${props => props.contentHeight}px;
+`;
 
 export default class SqlEditorLeftBar extends React.PureComponent {
   constructor(props) {
@@ -130,11 +139,8 @@ export default class SqlEditorLeftBar extends React.PureComponent {
           tableNameSticky={false}
         />
         <div className="divider" />
-        <div className="scrollbar-container">
-          <div
-            className="scrollbar-content"
-            style={{ height: tableMetaDataHeight }}
-          >
+        <StyledScrollbarContainer>
+          <StyledScrollbarContent contentHeight={tableMetaDataHeight}>
             {this.props.tables.map(table => (
               <TableElement
                 table={table}
@@ -142,8 +148,8 @@ export default class SqlEditorLeftBar extends React.PureComponent {
                 actions={this.props.actions}
               />
             ))}
-          </div>
-        </div>
+          </StyledScrollbarContent>
+        </StyledScrollbarContainer>
         {shouldShowReset && (
           <Button
             buttonSize="small"

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge } from 'react-bootstrap';
-import { t } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 
 import Button from 'src/components/Button';
@@ -36,6 +36,12 @@ const defaultProps = {
   onChange: () => {},
   code: '{}',
 };
+
+const StyledConfigEditor = styled(ConfigEditor)`
+  &.ace_editor {
+    border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+  }
+`;
 
 export default class TemplateParamsEditor extends React.Component {
   constructor(props) {
@@ -96,10 +102,9 @@ export default class TemplateParamsEditor extends React.Component {
     return (
       <div>
         {this.renderDoc()}
-        <ConfigEditor
+        <StyledConfigEditor
           keywords={[]}
           mode={this.props.language}
-          style={{ border: '1px solid #CCC' }}
           minLines={25}
           maxLines={50}
           onChange={this.onChange}

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -239,10 +239,6 @@ div.Workspace {
   .SouthPane {
     height: 100%;
   }
-
-  .scrollbar-container {
-    overflow: auto;
-  }
 }
 
 .SqlEditorTabs li {
@@ -370,11 +366,6 @@ div.Workspace {
   .divider {
     border-bottom: 1px solid @gray-bg;
     margin: 15px 0;
-  }
-
-  .scrollbar-container {
-    flex: 1 1 auto;
-    overflow: auto;
   }
 }
 


### PR DESCRIPTION
### SUMMARY
Refactor covers changes in SqlLab components with inline or less classname styles implementation. They were replaced with Emotion based components using Superset UI Theme variables in some cases. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
In all cases, only one thing has slightly changed regarding UI. Template Parameters modal's border color was changed from inline style color `#CCC` to light grey color provided in Theme. 
Before:
<img width="600" alt="#ccc" src="https://user-images.githubusercontent.com/47450693/99983101-bc7e8d80-2dab-11eb-948c-32f2e719e7a9.png">

Now: 
<img width="600" alt="lightgrey" src="https://user-images.githubusercontent.com/47450693/99983329-02d3ec80-2dac-11eb-83be-abbfa5fe7452.png">

### TEST PLAN
Verify manually if SqlLab tab looks correct. 
Changes concern following SqlLab components:
Query Search, QueryTable, Query Schedule Button, Sql Editor Left bar and Template params editor. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @rusackas @mistercrunch @adam-stasiak 