### PR TITLE
fix: annotation layer crashes when clearing type select

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
@@ -597,6 +597,7 @@ export default class AnnotationLayer extends React.PureComponent {
             { value: 'dotted', label: 'Dotted' },
           ]}
           value={style}
+          clearable={false}
           onChange={v => this.setState({ style: v })}
         />
         <SelectControl
@@ -704,6 +705,7 @@ export default class AnnotationLayer extends React.PureComponent {
                 description={t('Choose the Annotation Layer Type')}
                 label={t('Annotation Layer Type')}
                 name="annotation-layer-type"
+                clearable={false}
                 options={supportedAnnotationTypes}
                 value={annotationType}
                 onChange={this.handleAnnotationType}
@@ -740,6 +742,7 @@ export default class AnnotationLayer extends React.PureComponent {
 
             <Button
               buttonSize="sm"
+              buttonStyle="primary"
               disabled={!isValid}
               onClick={this.submitAnnotation}
             >


### PR DESCRIPTION
### SUMMARY
closes #11759, simply removing the possibility on "clearing" the `<Select>`s
<img width="883" alt="Screen Shot 2020-11-23 at 7 11 31 PM" src="https://user-images.githubusercontent.com/487433/100042260-f48fcb80-2dbf-11eb-8903-9f1af63058b5.png">
