### PR TITLE
fix: mutating input df in viz.py

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1671,6 +1671,7 @@ class DistributionBarViz(BaseViz):
         # pandas will throw away nulls when grouping/pivoting,
         # so we substitute NULL_STRING for any nulls in the necessary columns
         filled_cols = self.groupby + columns
+        df = df.copy()
         df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
 
         row = df.groupby(self.groupby).sum()[metrics[0]].copy()


### PR DESCRIPTION
### SUMMARY
More recent versions of Pandas and PyArrow have started raising exceptions when trying to mutate DataFrames created by PyArrow in-place (see e.g. https://issues.apache.org/jira/browse/ARROW-9772). As it is generally bad practice to mutate objects like this, it is preferable to first make a copy of the `DataFrame` prior to mutating the column values in the `dist_bar` chart. This fixes the following exception seen on current master:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/superset/views/base.py", line 177, in wraps
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/superset/utils/cache.py", line 108, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/superset/views/core.py", line 534, in explore_json
    return self.generate_json(viz_obj, response_type)
  File "/usr/local/lib/python3.7/site-packages/superset/views/core.py", line 430, in generate_json
    payload = viz_obj.get_payload()
  File "/usr/local/lib/python3.7/site-packages/superset/viz.py", line 485, in get_payload
    payload["data"] = self.get_data(df)
  File "/usr/local/lib/python3.7/site-packages/superset/viz.py", line 1674, in get_data
    df[filled_cols] = df[filled_cols].fillna(value=NULL_STRING)
  File "/usr/local/lib/python3.7/site-packages/pandas/core/frame.py", line 3037, in __setitem__
    self._setitem_array(key, value)
  File "/usr/local/lib/python3.7/site-packages/pandas/core/frame.py", line 3065, in _setitem_array
    self[k1] = value[k2]
  File "/usr/local/lib/python3.7/site-packages/pandas/core/frame.py", line 3040, in __setitem__
    self._set_item(key, value)
  File "/usr/local/lib/python3.7/site-packages/pandas/core/frame.py", line 3117, in _set_item
    NDFrame._set_item(self, key, value)
  File "/usr/local/lib/python3.7/site-packages/pandas/core/generic.py", line 3577, in _set_item
    NDFrame._iset_item(self, loc, value)
  File "/usr/local/lib/python3.7/site-packages/pandas/core/generic.py", line 3566, in _iset_item
    self._mgr.iset(loc, value)
  File "/usr/local/lib/python3.7/site-packages/pandas/core/internals/managers.py", line 1096, in iset
    blk.set(blk_locs, value_getitem(val_locs))
  File "/usr/local/lib/python3.7/site-packages/pandas/core/internals/blocks.py", line 330, in set
    self.values[locs] = values
ValueError: assignment destination is read-only
```

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
