### PR TITLE
fix: docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ WORKDIR /app
 
 USER superset
 
-HEALTHCHECK CMD ["curl", "-f", "http://localhost:$$SUPERSET_PORT/health"]
+HEALTHCHECK CMD curl -f "http://localhost:$SUPERSET_PORT/health"
 
 EXPOSE ${SUPERSET_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ WORKDIR /app
 
 USER superset
 
-HEALTHCHECK CMD ["curl", "-f", "http://localhost:8088/health"]
+HEALTHCHECK CMD ["curl", "-f", "http://localhost:$$SUPERSET_PORT/health"]
 
 EXPOSE ${SUPERSET_PORT}
 


### PR DESCRIPTION
This is tested.
Remove `[]` to run cmd in shell that will fill the `$SUPERSET_PORT` at runtime.

Related  https://github.com/apache/incubator-superset/issues/11747#issuecomment-732711291_