### PR TITLE
fix: remove root dir from ZIP bundle

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -861,7 +861,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        upload = request.files.get("file")
+        upload = request.files.get("formData")
         if not upload:
             return self.response_400()
         with ZipFile(upload) as bundle:

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -61,6 +61,7 @@ from superset.charts.schemas import (
     thumbnail_query_schema,
 )
 from superset.commands.exceptions import CommandInvalidError
+from superset.commands.importers.v1.utils import remove_root
 from superset.constants import RouteMethod
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import event_logger
@@ -865,7 +866,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             return self.response_400()
         with ZipFile(upload) as bundle:
             contents = {
-                file_name: bundle.read(file_name).decode()
+                remove_root(file_name): bundle.read(file_name).decode()
                 for file_name in bundle.namelist()
             }
 

--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -14,7 +14,6 @@
 # under the License.
 
 import logging
-import os.path
 from pathlib import Path
 from typing import Any, Dict
 

--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -14,6 +14,8 @@
 # under the License.
 
 import logging
+import os.path
+from pathlib import Path
 from typing import Any, Dict
 
 import yaml
@@ -28,6 +30,13 @@ IMPORT_VERSION = "1.0.0"
 logger = logging.getLogger(__name__)
 
 
+def remove_root(file_path: str) -> str:
+    """Remove the first directory of a path"""
+    full_path = Path(file_path)
+    relative_path = Path(*full_path.parts[1:])
+    return str(relative_path)
+
+
 class MetadataSchema(Schema):
     version = fields.String(required=True, validate=validate.Equal(IMPORT_VERSION))
     type = fields.String(required=True)
@@ -39,14 +48,14 @@ def load_yaml(file_name: str, content: str) -> Dict[str, Any]:
     try:
         return yaml.safe_load(content)
     except yaml.parser.ParserError:
-        logger.exception("Invalid YAML in %s", METADATA_FILE_NAME)
+        logger.exception("Invalid YAML in %s", file_name)
         raise ValidationError({file_name: "Not a valid YAML file"})
 
 
 def load_metadata(contents: Dict[str, str]) -> Dict[str, str]:
     """Apply validation and load a metadata file"""
     if METADATA_FILE_NAME not in contents:
-        # if the contents ahve no METADATA_FILE_NAME this is probably
+        # if the contents have no METADATA_FILE_NAME this is probably
         # a original export without versioning that should not be
         # handled by this command
         raise IncorrectVersionError(f"Missing {METADATA_FILE_NAME}")

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -30,6 +30,7 @@ from werkzeug.wsgi import FileWrapper
 
 from superset import is_feature_enabled, thumbnail_cache
 from superset.commands.exceptions import CommandInvalidError
+from superset.commands.importers.v1.utils import remove_root
 from superset.constants import RouteMethod
 from superset.dashboards.commands.bulk_delete import BulkDeleteDashboardCommand
 from superset.dashboards.commands.create import CreateDashboardCommand
@@ -679,12 +680,12 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        upload = request.files.get("file")
+        upload = request.files.get("formData")
         if not upload:
             return self.response_400()
         with ZipFile(upload) as bundle:
             contents = {
-                file_name: bundle.read(file_name).decode()
+                remove_root(file_name): bundle.read(file_name).decode()
                 for file_name in bundle.namelist()
             }
 

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -36,6 +36,7 @@ from sqlalchemy.exc import (
 
 from superset import event_logger
 from superset.commands.exceptions import CommandInvalidError
+from superset.commands.importers.v1.utils import remove_root
 from superset.constants import RouteMethod
 from superset.databases.commands.create import CreateDatabaseCommand
 from superset.databases.commands.delete import DeleteDatabaseCommand
@@ -760,12 +761,12 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        upload = request.files.get("file")
+        upload = request.files.get("formData")
         if not upload:
             return self.response_400()
         with ZipFile(upload) as bundle:
             contents = {
-                file_name: bundle.read(file_name).decode()
+                remove_root(file_name): bundle.read(file_name).decode()
                 for file_name in bundle.namelist()
             }
 

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -628,7 +628,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        upload = request.files.get("file")
+        upload = request.files.get("formData")
         if not upload:
             return self.response_400()
         with ZipFile(upload) as bundle:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -29,6 +29,7 @@ from marshmallow import ValidationError
 
 from superset import is_feature_enabled
 from superset.commands.exceptions import CommandInvalidError
+from superset.commands.importers.v1.utils import remove_root
 from superset.connectors.sqla.models import SqlaTable
 from superset.constants import RouteMethod
 from superset.databases.filters import DatabaseFilter
@@ -632,7 +633,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             return self.response_400()
         with ZipFile(upload) as bundle:
             contents = {
-                file_name: bundle.read(file_name).decode()
+                remove_root(file_name): bundle.read(file_name).decode()
                 for file_name in bundle.namelist()
             }
 

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -1187,18 +1187,18 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("metadata.yaml", "w") as fp:
+            with bundle.open("root/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(chart_metadata_config).encode())
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
-            with bundle.open("charts/imported_chart.yaml", "w") as fp:
+            with bundle.open("root/charts/imported_chart.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(chart_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "chart_export.zip"),
+            "formData": (buf, "chart_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))
@@ -1233,18 +1233,18 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("metadata.yaml", "w") as fp:
+            with bundle.open("root/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_metadata_config).encode())
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
-            with bundle.open("charts/imported_chart.yaml", "w") as fp:
+            with bundle.open("root/charts/imported_chart.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(chart_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "chart_export.zip"),
+            "formData": (buf, "chart_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))

--- a/tests/charts/api_tests.py
+++ b/tests/charts/api_tests.py
@@ -1187,13 +1187,15 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("root/metadata.yaml", "w") as fp:
+            with bundle.open("chart_export/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(chart_metadata_config).encode())
-            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "chart_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("chart_export/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
-            with bundle.open("root/charts/imported_chart.yaml", "w") as fp:
+            with bundle.open("chart_export/charts/imported_chart.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(chart_config).encode())
         buf.seek(0)
 
@@ -1233,13 +1235,15 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("root/metadata.yaml", "w") as fp:
+            with bundle.open("chart_export/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_metadata_config).encode())
-            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "chart_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("chart_export/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
-            with bundle.open("root/charts/imported_chart.yaml", "w") as fp:
+            with bundle.open("chart_export/charts/imported_chart.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(chart_config).encode())
         buf.seek(0)
 

--- a/tests/dashboards/api_tests.py
+++ b/tests/dashboards/api_tests.py
@@ -1096,20 +1096,26 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("metadata.yaml", "w") as fp:
+            with bundle.open("dashboard_export/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dashboard_metadata_config).encode())
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "dashboard_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open(
+                "dashboard_export/datasets/imported_dataset.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
-            with bundle.open("charts/imported_chart.yaml", "w") as fp:
+            with bundle.open("dashboard_export/charts/imported_chart.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(chart_config).encode())
-            with bundle.open("dashboards/imported_dashboard.yaml", "w") as fp:
+            with bundle.open(
+                "dashboard_export/dashboards/imported_dashboard.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dashboard_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "dashboard_export.zip"),
+            "formData": (buf, "dashboard_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))
@@ -1147,20 +1153,26 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("metadata.yaml", "w") as fp:
+            with bundle.open("dashboard_export/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_metadata_config).encode())
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "dashboard_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open(
+                "dashboard_export/datasets/imported_dataset.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
-            with bundle.open("charts/imported_chart.yaml", "w") as fp:
+            with bundle.open("dashboard_export/charts/imported_chart.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(chart_config).encode())
-            with bundle.open("dashboards/imported_dashboard.yaml", "w") as fp:
+            with bundle.open(
+                "dashboard_export/dashboards/imported_dashboard.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dashboard_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "dashboard_export.zip"),
+            "formData": (buf, "dashboard_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -836,11 +836,15 @@ class TestDatabaseApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("root/metadata.yaml", "w") as fp:
+            with bundle.open("database_export/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_metadata_config).encode())
-            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "database_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open(
+                "database_export/datasets/imported_dataset.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 
@@ -876,11 +880,15 @@ class TestDatabaseApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("root/metadata.yaml", "w") as fp:
+            with bundle.open("database_export/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_metadata_config).encode())
-            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "database_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open(
+                "database_export/datasets/imported_dataset.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 

--- a/tests/databases/api_tests.py
+++ b/tests/databases/api_tests.py
@@ -836,16 +836,16 @@ class TestDatabaseApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("metadata.yaml", "w") as fp:
+            with bundle.open("root/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_metadata_config).encode())
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "database_export.zip"),
+            "formData": (buf, "database_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))
@@ -876,16 +876,16 @@ class TestDatabaseApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("metadata.yaml", "w") as fp:
+            with bundle.open("root/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_metadata_config).encode())
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "database_export.zip"),
+            "formData": (buf, "database_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -1185,16 +1185,16 @@ class TestDatasetApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("metadata.yaml", "w") as fp:
+            with bundle.open("root/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_metadata_config).encode())
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "dataset_export.zip"),
+            "formData": (buf, "dataset_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))
@@ -1225,16 +1225,16 @@ class TestDatasetApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("metadata.yaml", "w") as fp:
+            with bundle.open("root/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_metadata_config).encode())
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "dataset_export.zip"),
+            "formData": (buf, "dataset_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))
@@ -1253,14 +1253,14 @@ class TestDatasetApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("databases/imported_database.yaml", "w") as fp:
+            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 
         form_data = {
-            "file": (buf, "dataset_export.zip"),
+            "formData": (buf, "dataset_export.zip"),
         }
         rv = self.client.post(uri, data=form_data, content_type="multipart/form-data")
         response = json.loads(rv.data.decode("utf-8"))

--- a/tests/datasets/api_tests.py
+++ b/tests/datasets/api_tests.py
@@ -1185,11 +1185,15 @@ class TestDatasetApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("root/metadata.yaml", "w") as fp:
+            with bundle.open("dataset_export/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(dataset_metadata_config).encode())
-            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "dataset_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open(
+                "dataset_export/datasets/imported_dataset.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 
@@ -1225,11 +1229,15 @@ class TestDatasetApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("root/metadata.yaml", "w") as fp:
+            with bundle.open("dataset_export/metadata.yaml", "w") as fp:
                 fp.write(yaml.safe_dump(database_metadata_config).encode())
-            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "dataset_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open(
+                "dataset_export/datasets/imported_dataset.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 
@@ -1253,9 +1261,13 @@ class TestDatasetApi(SupersetTestCase):
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:
-            with bundle.open("root/databases/imported_database.yaml", "w") as fp:
+            with bundle.open(
+                "dataset_export/databases/imported_database.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(database_config).encode())
-            with bundle.open("root/datasets/imported_dataset.yaml", "w") as fp:
+            with bundle.open(
+                "dataset_export/datasets/imported_dataset.yaml", "w"
+            ) as fp:
                 fp.write(yaml.safe_dump(dataset_config).encode())
         buf.seek(0)
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In the new import files, we have a ZIP file called `exported_$object_$timestamp.zip`, with the files inside all prefixed with the ZIP name without the extension:

- `exported_$object_$timestamp/metadata.yaml`
- `exported_$object_$timestamp/databases/example.yaml`
- etc.

The import commands (eg, `ImportDatabasesCommand`) expect the file names to be **without** the prefix, ie:

- `metadata.yaml`
- `databases/example.yaml`
- etc.

I modified the API to remove the prefix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested a database import, it now works as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
