### PR TITLE
feat: add title to dashboard tabbed panel

### DIFF
--- a/superset-frontend/src/common/components/Tabs/Tabs.tsx
+++ b/superset-frontend/src/common/components/Tabs/Tabs.tsx
@@ -144,8 +144,9 @@ EditableTabs.TabPane.defaultProps = {
 
 export const StyledLineEditableTabs = styled(EditableTabs)`
   &.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab {
-    margin: 0 ${({ theme }) => theme.gridUnit * 4}px;
+    margin-right: ${({ theme }) => theme.gridUnit * 4}px;
     padding: ${({ theme }) => `${theme.gridUnit * 3}px ${theme.gridUnit}px`};
+    background: ${({ theme }) => theme.colors.grayscale.light4};
     background: transparent;
     border: none;
   }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -24,6 +24,7 @@ import DragDroppable from '../dnd/DragDroppable';
 import EditableTitle from '../../../components/EditableTitle';
 import AnchorLink from '../../../components/AnchorLink';
 import { componentShape } from '../../util/propShapes';
+import { styled } from '@superset-ui/core';
 
 export const RENDER_TAB = 'RENDER_TAB';
 export const RENDER_TAB_CONTENT = 'RENDER_TAB_CONTENT';
@@ -52,6 +53,11 @@ const propTypes = {
   updateComponents: PropTypes.func.isRequired,
   setDirectPathToChild: PropTypes.func.isRequired,
 };
+
+const StyledTab = styled.div`
+  background-color: ${({ theme }) => theme.colors.grayscale.light4};
+  padding: ${({ theme }) => theme.gridUnit * 4}px;
+`;
 
 const defaultProps = {
   availableColumnCount: 0,
@@ -123,7 +129,7 @@ export default class Tab extends React.PureComponent {
     } = this.props;
 
     return (
-      <div className="dashboard-component-tabs-content">
+      <StyledTab className="dashboard-component-tabs-content">
         {/* Make top of tab droppable */}
         {editMode && (
           <DragDroppable
@@ -179,7 +185,7 @@ export default class Tab extends React.PureComponent {
             }
           </DragDroppable>
         )}
-      </div>
+      </StyledTab>
     );
   }
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -18,13 +18,12 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import { styled } from '@superset-ui/core';
 import DashboardComponent from '../../containers/DashboardComponent';
 import DragDroppable from '../dnd/DragDroppable';
 import EditableTitle from '../../../components/EditableTitle';
 import AnchorLink from '../../../components/AnchorLink';
 import { componentShape } from '../../util/propShapes';
-import { styled } from '@superset-ui/core';
 
 export const RENDER_TAB = 'RENDER_TAB';
 export const RENDER_TAB_CONTENT = 'RENDER_TAB_CONTENT';

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -318,7 +318,7 @@ class Tabs extends React.PureComponent {
           >
             <StyledHeader>
               <EditableTitle
-                title={meta.text || typeToDefaultMetaData[TABS_TYPE].text}
+                title={meta?.text || typeToDefaultMetaData[TABS_TYPE].text}
                 canEdit={editMode}
                 onSaveTitle={this.handleChangeText}
                 showTooltip={false}

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -34,6 +34,7 @@ import { componentShape } from '../../util/propShapes';
 import { NEW_TAB_ID, DASHBOARD_ROOT_ID } from '../../util/constants';
 import { RENDER_TAB, RENDER_TAB_CONTENT } from './Tab';
 import { TAB_TYPE } from '../../util/componentTypes';
+import EditableTitle from '../../../components/EditableTitle';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -77,6 +78,10 @@ const defaultProps = {
 };
 
 const StyledTabsContainer = styled.div`
+  &&& {
+    padding: ${({ theme }) => theme.gridUnit * 4}px;
+    padding-left: ${({ theme }) => theme.gridUnit * 4}px;
+  }
   width: 100%;
   background-color: ${({ theme }) => theme.colors.grayscale.light5};
 
@@ -112,6 +117,12 @@ const StyledTabsContainer = styled.div`
 
   div .ant-tabs-tab-btn {
     text-transform: none;
+  }
+`;
+
+const StyledHeader = styled.div`
+  &&& .editable-title {
+    font-weight: ${({ theme }) => theme.typography.weights.bold};
   }
 `;
 
@@ -248,6 +259,21 @@ class Tabs extends React.PureComponent {
     }
   }
 
+  handleChangeText = nextText => {
+    const { updateComponents, component } = this.props;
+    if (nextText && nextText !== component.meta.text) {
+      updateComponents({
+        [component.id]: {
+          ...component,
+          meta: {
+            ...component.meta,
+            text: nextText,
+          },
+        },
+      });
+    }
+  };
+
   render() {
     const {
       depth,
@@ -267,7 +293,7 @@ class Tabs extends React.PureComponent {
     } = this.props;
 
     const { tabIndex: selectedTabIndex } = this.state;
-    const { children: tabIds } = tabsComponent;
+    const { children: tabIds, meta } = tabsComponent;
 
     const activeKey = tabIds[selectedTabIndex];
 
@@ -289,6 +315,14 @@ class Tabs extends React.PureComponent {
             className="dashboard-component dashboard-component-tabs"
             data-test="dashboard-component-tabs"
           >
+            <StyledHeader>
+              <EditableTitle
+                title={meta.text}
+                canEdit={editMode}
+                onSaveTitle={this.handleChangeText}
+                showTooltip={false}
+              />
+            </StyledHeader>
             {editMode && renderHoverMenu && (
               <HoverMenu innerRef={tabsDragSourceRef} position="left">
                 <DragHandle position="left" />

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -33,8 +33,9 @@ import getLeafComponentIdFromPath from '../../util/getLeafComponentIdFromPath';
 import { componentShape } from '../../util/propShapes';
 import { NEW_TAB_ID, DASHBOARD_ROOT_ID } from '../../util/constants';
 import { RENDER_TAB, RENDER_TAB_CONTENT } from './Tab';
-import { TAB_TYPE } from '../../util/componentTypes';
+import { TAB_TYPE, TABS_TYPE } from '../../util/componentTypes';
 import EditableTitle from '../../../components/EditableTitle';
+import { typeToDefaultMetaData } from '../../util/newComponentFactory';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -174,6 +175,21 @@ class Tabs extends React.PureComponent {
     }
   }
 
+  handleChangeText = nextText => {
+    const { updateComponents, component } = this.props;
+    if (nextText && nextText !== component.meta.text) {
+      updateComponents({
+        [component.id]: {
+          ...component,
+          meta: {
+            ...component.meta,
+            text: nextText,
+          },
+        },
+      });
+    }
+  };
+
   showDeleteConfirmModal = key => {
     const { component, deleteComponent } = this.props;
     Modal.confirm({
@@ -259,21 +275,6 @@ class Tabs extends React.PureComponent {
     }
   }
 
-  handleChangeText = nextText => {
-    const { updateComponents, component } = this.props;
-    if (nextText && nextText !== component.meta.text) {
-      updateComponents({
-        [component.id]: {
-          ...component,
-          meta: {
-            ...component.meta,
-            text: nextText,
-          },
-        },
-      });
-    }
-  };
-
   render() {
     const {
       depth,
@@ -317,7 +318,7 @@ class Tabs extends React.PureComponent {
           >
             <StyledHeader>
               <EditableTitle
-                title={meta.text}
+                title={meta.text || typeToDefaultMetaData[TABS_TYPE].text}
                 canEdit={editMode}
                 onSaveTitle={this.handleChangeText}
                 showTooltip={false}

--- a/superset-frontend/src/dashboard/util/newComponentFactory.js
+++ b/superset-frontend/src/dashboard/util/newComponentFactory.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 import shortid from 'shortid';
-
+import { t } from '@superset-ui/core';
 import {
   CHART_TYPE,
   COLUMN_TYPE,
@@ -43,14 +43,14 @@ export const typeToDefaultMetaData = {
   },
   [DIVIDER_TYPE]: null,
   [HEADER_TYPE]: {
-    text: 'New header',
+    text: t('New header'),
     headerSize: MEDIUM_HEADER,
     background: BACKGROUND_TRANSPARENT,
   },
   [MARKDOWN_TYPE]: { width: GRID_DEFAULT_CHART_WIDTH, height: 50 },
   [ROW_TYPE]: { background: BACKGROUND_TRANSPARENT },
-  [TABS_TYPE]: { text: 'New Tabs' },
-  [TAB_TYPE]: { text: 'New Tab' },
+  [TABS_TYPE]: { text: t('New Tabs') },
+  [TAB_TYPE]: { text: t('New Tab') },
 };
 
 function uuid(type) {

--- a/superset-frontend/src/dashboard/util/newComponentFactory.js
+++ b/superset-frontend/src/dashboard/util/newComponentFactory.js
@@ -49,7 +49,7 @@ const typeToDefaultMetaData = {
   },
   [MARKDOWN_TYPE]: { width: GRID_DEFAULT_CHART_WIDTH, height: 50 },
   [ROW_TYPE]: { background: BACKGROUND_TRANSPARENT },
-  [TABS_TYPE]: null,
+  [TABS_TYPE]: { text: 'New Tabs' },
   [TAB_TYPE]: { text: 'New Tab' },
 };
 

--- a/superset-frontend/src/dashboard/util/newComponentFactory.js
+++ b/superset-frontend/src/dashboard/util/newComponentFactory.js
@@ -35,7 +35,7 @@ import {
   GRID_DEFAULT_CHART_WIDTH,
 } from './constants';
 
-const typeToDefaultMetaData = {
+export const typeToDefaultMetaData = {
   [CHART_TYPE]: { width: GRID_DEFAULT_CHART_WIDTH, height: 50 },
   [COLUMN_TYPE]: {
     width: GRID_DEFAULT_CHART_WIDTH,


### PR DESCRIPTION
### SUMMARY
- Add title to dashboard tabbed panel according design: https://www.figma.com/file/Z75uj6W6n0A6nfK3Mvawqi/Dashboard-Filters---P1?node-id=59%3A12625
- Add paddings to tabbed panels

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

1. No grey paddings inside Tabbed panel
2. No title for Tabbed panel

![Screen Shot 2020-12-01 at 9 09 33](https://user-images.githubusercontent.com/56388545/100708451-03c0db80-33b5-11eb-94ec-cd85e4fda83a.png)

After:

1. Grey paddings inside Tabbed panel
2. Title for Tabbed panel (See `Tabbed panel` name)

![Screen Shot 2020-11-25 at 12 00 55](https://user-images.githubusercontent.com/56388545/100212379-ec49a480-2f15-11eb-8b90-4a7975e94588.png)


### TEST PLAN
1. Go to dashboards
2. Check that tabbed panel have title

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
