### PR TITLE
feat: allow user to view their profile again

### DIFF
--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -46,6 +46,7 @@ interface NavBarProps {
   user_info_url: string;
   user_login_url: string;
   user_logout_url: string;
+  user_profile_url: string | null;
   locale: string;
 }
 
@@ -195,8 +196,15 @@ export function Menu({
                 {!navbarRight.user_is_anonymous && [
                   <DropdownMenu.Divider key="user-divider" />,
                   <DropdownMenu.ItemGroup key="user-section" title={t('User')}>
-                    <DropdownMenu.Item key="profile">
-                      <a href={navbarRight.user_info_url}>{t('Profile')}</a>
+                    {navbarRight.user_profile_url && (
+                      <DropdownMenu.Item key="profile">
+                        <a href={navbarRight.user_profile_url}>
+                          {t('Profile')}
+                        </a>
+                      </DropdownMenu.Item>
+                    )}
+                    <DropdownMenu.Item key="info">
+                      <a href={navbarRight.user_info_url}>{t('Info')}</a>
                     </DropdownMenu.Item>
                     <DropdownMenu.Item key="logout">
                       <a href={navbarRight.user_logout_url}>{t('Logout')}</a>

--- a/superset/templates/appbuilder/navbar_right.html
+++ b/superset/templates/appbuilder/navbar_right.html
@@ -106,7 +106,8 @@
         <i class="fa fa-user"></i>&nbsp;<b class="caret"></b>
       </a>
         <ul class="dropdown-menu">
-            <li><a href="{{appbuilder.get_url_for_userinfo}}"><span class="fa fa-fw fa-user"></span>{{_("Profile")}}</a></li>
+            <li><a href="/superset/profile/{{g.user.username}}"><span class="fa fa-fw fa-user"></span>{{_("Profile")}}</a></li>
+            <li><a href="{{appbuilder.get_url_for_userinfo}}"><span class="fa fa-fw fa-user"></span>{{_("Info")}}</a></li>
             <li><a href="{{appbuilder.get_url_for_logout}}"><span class="fa fa-fw fa-sign-out"></span>{{_("Logout")}}</a></li>
             {% if version_string or version_sha %}
               <li class="fineprint">

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -296,6 +296,9 @@ def menu_data() -> Dict[str, Any]:
             "user_info_url": appbuilder.get_url_for_userinfo,
             "user_logout_url": appbuilder.get_url_for_logout,
             "user_login_url": appbuilder.get_url_for_login,
+            "user_profile_url": None
+            if g.user.is_anonymous
+            else f"/superset/profile/{g.user.username}",
             "locale": session.get("locale", "en"),
         },
     }


### PR DESCRIPTION
### SUMMARY
At some point, clicking on the Superset logo was redirected to the "Welcome" page (good!). But because of that, it removed any ability for the user to view their own profile (bad...). This PR adds the Profile link in the settings menu and moves the userinfo link to "Info" (a bit more descriptive of what it does i think).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screen Shot 2020-11-25 at 3 35 53 PM](https://user-images.githubusercontent.com/7409244/100291921-f11d5100-2f33-11eb-90a0-f63700bc10d2.png)
After:
![Screen Shot 2020-11-25 at 3 40 18 PM](https://user-images.githubusercontent.com/7409244/100292223-b49e2500-2f34-11eb-9106-e17c1d450030.png)


### TEST PLAN
CI, ensure the new links work across all pages

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @betodealmeida @nytai @graceguo-supercat @rusackas 