### PR TITLE
refactor: move async calls to api layer

### DIFF
--- a/superset-frontend/src/api/chart.ts
+++ b/superset-frontend/src/api/chart.ts
@@ -16,31 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { User } from 'src/types/bootstrapTypes';
-import Dashboard from 'src/types/Dashboard';
 
-export type FavoriteStatus = {
-  [id: number]: boolean;
+import { SupersetClient } from '@superset-ui/core';
+import rison from 'rison';
+import Chart from 'src/types/Chart';
+
+export const importChart = async (chartFile: File) => {
+  const endpoint = encodeURI(`/api/v1/chart/import/`);
+  const formData = new FormData();
+  formData.append('formData', chartFile);
+  await SupersetClient.post({
+    endpoint,
+    body: formData,
+  });
+  return Promise.resolve();
 };
 
-export interface DashboardTableProps {
-  addDangerToast: (message: string) => void;
-  addSuccessToast: (message: string) => void;
-  search: string;
-  user?: User;
-  mine: Array<Dashboard>;
-}
-
-export type SavedQueryObject = {
-  database: {
-    database_name: string;
-    id: number;
-  };
-  db_id: number;
-  description?: string;
-  id: number;
-  label: string;
-  schema: string;
-  sql: string | null;
-  sql_tables?: { catalog?: string; schema: string; table: string }[];
+export const destroyBulk = async (charts: Chart[]) => {
+  const endpoint = `/api/v1/chart/?q=${rison.encode(
+    charts.map(({ id }: { id: number }) => id),
+  )}`;
+  const {
+    json: {
+      json: { message },
+    },
+  } = await SupersetClient.delete({ endpoint });
+  return Promise.resolve(message);
 };

--- a/superset-frontend/src/api/dashboard.ts
+++ b/superset-frontend/src/api/dashboard.ts
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SupersetClient } from '@superset-ui/core';
+import rison from 'rison';
+import Dashboard from 'src/types/Dashboard';
+
+export const importDashboard = async (dashboardFile: File) => {
+  const endpoint = encodeURI(`/api/v1/dashboard/import/`);
+  const formData = new FormData();
+  formData.append('formData', dashboardFile);
+  await SupersetClient.post({
+    endpoint,
+    body: formData,
+  });
+  return Promise.resolve();
+};
+
+export const get = async () => {
+  const queryParams = rison.encode({
+    order_column: 'changed_on_delta_humanized',
+    order_direction: 'desc',
+    page: 0,
+    page_size: 10,
+  });
+  const endpoint = `/api/v1/dashboard?q=${queryParams}`;
+  const {
+    json: {
+      json: { result },
+    },
+  } = await SupersetClient.get({
+    endpoint,
+  });
+  return Promise.resolve(result);
+};
+
+export const show = async (id: number) => {
+  const endpoint = `/api/v1/dashboard/${id}`;
+  const json = await SupersetClient.get({ endpoint });
+  return Promise.resolve(json.json);
+};
+
+export const destroyBulk = async (dashboards: Dashboard[]) => {
+  const endpoint = `/api/v1/dashboard/?q=${rison.encode(
+    dashboards.map(({ id }: { id: number }) => id),
+  )}`;
+  const {
+    json: {
+      json: { message },
+    },
+  } = await SupersetClient.delete({ endpoint });
+  return Promise.resolve(message);
+};

--- a/superset-frontend/src/api/database.ts
+++ b/superset-frontend/src/api/database.ts
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SupersetClient, JsonResponse } from '@superset-ui/core';
+import rison from 'rison';
+import Dataset from 'src/types/Dataset';
+
+const returnResult = async (endpoint: string) => {
+  const json = await SupersetClient.get({
+    endpoint,
+  });
+  return json.json;
+};
+
+export const importDataset = async (datasetFile: File) => {
+  const endpoint = encodeURI(`/api/v1/database/import/`);
+  const formData = new FormData();
+  formData.append('formData', datasetFile);
+  const response: JsonResponse = await SupersetClient.post({
+    endpoint,
+    body: formData,
+  });
+  return Promise.resolve(response);
+};
+
+export const get = async () => {
+  const queryParams = rison.encode({
+    order_column: 'changed_on_delta_humanized',
+    order_direction: 'desc',
+    page: 0,
+    page_size: 10,
+  });
+  const endpoint = `/api/v1/database?q=${queryParams}`;
+  const result = await returnResult(endpoint);
+  return Promise.resolve(result);
+};
+
+export const show = async (id: number) => {
+  const endpoint = `/api/v1/database${id}`;
+  const result = await returnResult(endpoint);
+  return Promise.resolve(result);
+};
+
+export const getRelated = async (id: number) => {
+  const endpoint = `/api/v1/database/${id}/related_objects`;
+  const result = await returnResult(endpoint);
+  return Promise.resolve(result);
+};
+
+export const destroy = async (id: number) => {
+  return SupersetClient.delete({
+    endpoint: `/api/v1/database/${id}`,
+  });
+};
+
+export const bulkDestroy = async (datasets: Dataset[]) => {
+  const {
+    json: {
+      json: { message },
+    },
+  } = await SupersetClient.delete({
+    endpoint: `/api/v1/database/?q=${rison.encode(
+      datasets.map(({ id }) => id),
+    )}`,
+  });
+  return Promise.resolve(message);
+};

--- a/superset-frontend/src/api/dataset.ts
+++ b/superset-frontend/src/api/dataset.ts
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SupersetClient, JsonResponse } from '@superset-ui/core';
+import rison from 'rison';
+import Dataset from 'src/types/Dataset';
+
+const returnResult = async (endpoint: string) => {
+  const {
+    json: {
+      json: { result },
+    },
+  } = await SupersetClient.get({
+    endpoint,
+  });
+  return result;
+};
+
+export const importDataset = async (datasetFile: File) => {
+  const endpoint = encodeURI(`/api/v1/dataset/import/`);
+  const formData = new FormData();
+  formData.append('formData', datasetFile);
+  const response: JsonResponse = await SupersetClient.post({
+    endpoint,
+    body: formData,
+  });
+  return Promise.resolve(response);
+};
+
+export const get = async () => {
+  const queryParams = rison.encode({
+    order_column: 'changed_on_delta_humanized',
+    order_direction: 'desc',
+    page: 0,
+    page_size: 10,
+  });
+  const endpoint = `/api/v1/dataset?q=${queryParams}`;
+  const result = await returnResult(endpoint);
+  return Promise.resolve(result);
+};
+
+export const show = async (id: number) => {
+  const endpoint = `/api/v1/dataset${id}`;
+  const result = await returnResult(endpoint);
+  return Promise.resolve(result);
+};
+
+export const getRelated = async (id: number) => {
+  const endpoint = `/api/v1/dataset/${id}/related_objects`;
+  const result = await returnResult(endpoint);
+  return Promise.resolve(result);
+};
+
+export const destroy = async (id: number) => {
+  return SupersetClient.delete({
+    endpoint: `/api/v1/dataset/${id}`,
+  });
+};
+
+export const bulkDestroy = async (datasets: Dataset[]) => {
+  const {
+    json: {
+      json: { message },
+    },
+  } = await SupersetClient.delete({
+    endpoint: `/api/v1/dataset/?q=${rison.encode(
+      datasets.map(({ id }) => id),
+    )}`,
+  });
+  return Promise.resolve(message);
+};

--- a/superset-frontend/src/types/Dashboard.ts
+++ b/superset-frontend/src/types/Dashboard.ts
@@ -16,31 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { User } from 'src/types/bootstrapTypes';
-import Dashboard from 'src/types/Dashboard';
 
-export type FavoriteStatus = {
-  [id: number]: boolean;
-};
+/**
+ * The Dashboard model as returned from the API
+ */
 
-export interface DashboardTableProps {
-  addDangerToast: (message: string) => void;
-  addSuccessToast: (message: string) => void;
-  search: string;
-  user?: User;
-  mine: Array<Dashboard>;
-}
+import Owner from './Owner';
 
-export type SavedQueryObject = {
-  database: {
-    database_name: string;
-    id: number;
-  };
-  db_id: number;
-  description?: string;
+export default interface Dashboard {
+  changed_by_name: string;
+  changed_by_url: string;
+  changed_by: string;
+  changed_on_delta_humanized: string;
+  created_by: object;
+  dashboard_title: string;
   id: number;
-  label: string;
-  schema: string;
-  sql: string | null;
-  sql_tables?: { catalog?: string; schema: string; table: string }[];
-};
+  loading?: boolean;
+  owners: Owner[];
+  published: boolean;
+  slice_name?: string;
+  thumbnail_url: string;
+  url: string;
+}

--- a/superset-frontend/src/types/Dataset.ts
+++ b/superset-frontend/src/types/Dataset.ts
@@ -16,31 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { User } from 'src/types/bootstrapTypes';
-import Dashboard from 'src/types/Dashboard';
 
-export type FavoriteStatus = {
-  [id: number]: boolean;
-};
+/**
+ * The Dataset model as returned from the API
+ */
+import Owner from './Owner';
 
-export interface DashboardTableProps {
-  addDangerToast: (message: string) => void;
-  addSuccessToast: (message: string) => void;
-  search: string;
-  user?: User;
-  mine: Array<Dashboard>;
-}
-
-export type SavedQueryObject = {
+export default interface Dataset {
+  changed_by_name: string;
+  changed_by_url: string;
+  changed_by: string;
+  changed_on_delta_humanized: string;
   database: {
+    id: string;
     database_name: string;
-    id: number;
   };
-  db_id: number;
-  description?: string;
+  kind: string;
+  explore_url: string;
   id: number;
-  label: string;
+  owners: Array<Owner>;
   schema: string;
-  sql: string | null;
-  sql_tables?: { catalog?: string; schema: string; table: string }[];
-};
+  table_name: string;
+}

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -45,6 +45,7 @@ import withToasts from 'src/messageToasts/enhancers/withToasts';
 import PropertiesModal from 'src/explore/components/PropertiesModal';
 import Chart from 'src/types/Chart';
 import TooltipWrapper from 'src/components/TooltipWrapper';
+import { destroyBulk as bulkDeleteCharts } from 'src/api/chart';
 import ChartCard from './ChartCard';
 
 const PAGE_SIZE = 25;
@@ -128,22 +129,18 @@ function ChartList(props: ChartListProps) {
     hasPerm('can_mulexport') && isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT);
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
-  function handleBulkChartDelete(chartsToDelete: Chart[]) {
-    SupersetClient.delete({
-      endpoint: `/api/v1/chart/?q=${rison.encode(
-        chartsToDelete.map(({ id }) => id),
-      )}`,
-    }).then(
-      ({ json = {} }) => {
-        refreshData();
-        props.addSuccessToast(json.message);
-      },
+  async function handleBulkChartDelete(chartsToDelete: Chart[]) {
+    try {
+      const message = await bulkDeleteCharts(chartsToDelete);
+      refreshData();
+      props.addSuccessToast(message);
+    } catch (e) {
       createErrorHandler(errMsg =>
         props.addDangerToast(
           t('There was an issue deleting the selected charts: %s', errMsg),
         ),
-      ),
-    );
+      );
+    }
   }
 
   const columns = useMemo(

--- a/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
+++ b/superset-frontend/src/views/CRUD/dashboard/DashboardCard.tsx
@@ -30,7 +30,7 @@ import Icon from 'src/components/Icon';
 import Label from 'src/components/Label';
 import FacePile from 'src/components/FacePile';
 import FaveStar from 'src/components/FaveStar';
-import { Dashboard } from 'src/views/CRUD/types';
+import Dashboard from 'src/types/Dashboard';
 
 interface DashboardCardProps {
   isChart?: boolean;

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -27,7 +27,7 @@ import Chart from 'src/types/Chart';
 import rison from 'rison';
 import getClientErrorObject from 'src/utils/getClientErrorObject';
 import { FetchDataConfig } from 'src/components/ListView';
-import { Dashboard } from './types';
+import Dashboard from 'src/types/Dashboard';
 
 const createFetchResourceMethod = (method: string) => (
   resource: string,

--- a/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/DashboardTable.tsx
@@ -19,7 +19,8 @@
 import React, { useState, useMemo } from 'react';
 import { SupersetClient, t } from '@superset-ui/core';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
-import { Dashboard, DashboardTableProps } from 'src/views/CRUD/types';
+import { DashboardTableProps } from 'src/views/CRUD/types';
+import Dashboard from 'src/types/Dashboard';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import PropertiesModal from 'src/dashboard/components/PropertiesModal';
 import DashboardCard from 'src/views/CRUD/dashboard/DashboardCard';


### PR DESCRIPTION
### SUMMARY
In preparation for import/export functionality and with discussions with a few other people @suddjian and @rusackas about having an api layer abstraction, I decided to start to move existing logic into a separate file that we can decide upon later what this abstraction should look like. It's a very rough v1 just to have the logic in one place. I started with most of the import/export models, namely charts, dashboards, datasets, and databases and the corresponding list views

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
existing tests should pass; TODO: add unit tests for the new api files

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
