### PR TITLE
perf: improve loading speed of recent activities

### DIFF
--- a/superset/extensions.py
+++ b/superset/extensions.py
@@ -30,6 +30,7 @@ from werkzeug.local import LocalProxy
 from superset.utils.async_query_manager import AsyncQueryManager
 from superset.utils.cache_manager import CacheManager
 from superset.utils.feature_flag_manager import FeatureFlagManager
+from superset.utils.log import AbstractEventLogger
 from superset.utils.machine_auth import MachineAuthProviderFactory
 
 
@@ -103,7 +104,7 @@ cache_manager = CacheManager()
 celery_app = celery.Celery()
 csrf = CSRFProtect()
 db = SQLA()
-_event_logger: Dict[str, Any] = {}
+_event_logger: Dict[str, AbstractEventLogger] = {}
 event_logger = LocalProxy(lambda: _event_logger.get("event_logger"))
 feature_flag_manager = FeatureFlagManager()
 machine_auth_provider_factory = MachineAuthProviderFactory()

--- a/superset/extensions.py
+++ b/superset/extensions.py
@@ -16,7 +16,7 @@
 # under the License.
 import json
 import os
-from typing import Any, Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import celery
 from cachelib.base import BaseCache

--- a/superset/migrations/versions/debf575ce1a1_add_index_to_logs.py
+++ b/superset/migrations/versions/debf575ce1a1_add_index_to_logs.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_index_to_logs
+
+Revision ID: debf575ce1a1
+Revises: a8173232b786
+Create Date: 2020-11-25 17:28:39.383290
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "debf575ce1a1"
+down_revision = "a8173232b786"
+
+
+IDX_LOGS_ACTION = "ix_logs_action"
+IDX_LOGS_USER_ID_DTTM = "ix_logs_user_id_dttm"
+
+
+def upgrade():
+    with op.batch_alter_table("logs") as batch_op:
+        batch_op.create_index(
+            op.f(IDX_LOGS_USER_ID_DTTM), ["user_id", "dttm"], unique=False,
+        )
+        batch_op.create_index(
+            op.f(IDX_LOGS_ACTION), ["action"], unique=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("logs") as batch_op:
+        batch_op.drop_index(op.f(IDX_LOGS_USER_ID_DTTM))
+        batch_op.drop_index(op.f(IDX_LOGS_ACTION))


### PR DESCRIPTION
### SUMMARY

Improve the loading speed of `/recent_activity` by streaming the results to remove duplicates at Python side instead of scanning the whole table. With the newly added `logs` table index, this should greatly speed up loading speed for the home page.

Closes #11738 .

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Test on our internal deployment with a lot of Superset logs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
