### PR TITLE
fix: wrong key used  FEATURE_FLAGS[LISTVIEW_DEFAULT_CARD_VIEW] 

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -316,7 +316,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "SIP_38_VIZ_REARCHITECTURE": False,
     "TAGGING_SYSTEM": False,
     "SQLLAB_BACKEND_PERSISTENCE": False,
-    "LISTVIEW_DEFAULT_CARD_VIEW": False,
+    "LISTVIEWS_DEFAULT_CARD_VIEW": False,
     # Enables the replacement React views for all the FAB views (list, edit, show) with
     # designs introduced in https://github.com/apache/incubator-superset/issues/8976
     # (SIP-34). This is a work in progress so not all features available in FAB have
@@ -344,7 +344,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
 # Setting LISTVIEW_DEFAULT_CARD_VIEW to False will force the default view to
 # always be the table layout
 if DEFAULT_FEATURE_FLAGS["THUMBNAILS"]:
-    DEFAULT_FEATURE_FLAGS["LISTVIEW_DEFAULT_CARD_VIEW"] = True
+    DEFAULT_FEATURE_FLAGS["LISTVIEWS_DEFAULT_CARD_VIEW"] = True
 
 # This is merely a default.
 FEATURE_FLAGS: Dict[str, bool] = {}

--- a/superset/config.py
+++ b/superset/config.py
@@ -341,7 +341,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
 }
 
 # Set the default view to card/grid view if thumbnail support is enabled.
-# Setting LISTVIEW_DEFAULT_CARD_VIEW to False will force the default view to
+# Setting LISTVIEWS_DEFAULT_CARD_VIEW to False will force the default view to
 # always be the table layout
 if DEFAULT_FEATURE_FLAGS["THUMBNAILS"]:
     DEFAULT_FEATURE_FLAGS["LISTVIEWS_DEFAULT_CARD_VIEW"] = True

--- a/superset/config.py
+++ b/superset/config.py
@@ -316,7 +316,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "SIP_38_VIZ_REARCHITECTURE": False,
     "TAGGING_SYSTEM": False,
     "SQLLAB_BACKEND_PERSISTENCE": False,
-    "LISTVIEWS_DEFAULT_CARD_VIEW": False,
+    "LISTVIEW_DEFAULT_CARD_VIEW": False,
     # Enables the replacement React views for all the FAB views (list, edit, show) with
     # designs introduced in https://github.com/apache/incubator-superset/issues/8976
     # (SIP-34). This is a work in progress so not all features available in FAB have


### PR DESCRIPTION
### SUMMARY
key name was incorrect rename from  LISTVIEW_DEFAULT_CARD_VIEW--LISTVIEW**S**_DEFAULT_CARD_VIEW 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
