### PR TITLE
fix(setup): disallow python 3.6 for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ import sys
 
 from setuptools import find_packages, setup
 
-if sys.version_info < (3, 6):
-    sys.exit("Sorry, Python < 3.6 is not supported")
-
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 PACKAGE_JSON = os.path.join(BASE_DIR, "superset-frontend", "package.json")

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ setup(
         "thumbnails": ["Pillow>=7.0.0, <8.0.0"],
         "vertica": ["sqlalchemy-vertica-python>=0.5.9, < 0.6"],
     },
-    python_requires="~=3.6",
+    python_requires="~=3.7",
     author="Apache Software Foundation",
     author_email="dev@superset.incubator.apache.org",
     url="https://superset.apache.org/",


### PR DESCRIPTION
### SUMMARY
Disallow python 3.6 for pip install: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
