### PR TITLE
ci(docker): build image on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,10 @@
 name: Docker
 
-on: [push, pull_request, release]
+on:
+  push
+  pull_request
+  release
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   release:
     types: [published]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Docker
 
-on: [push, pull_request]
+on: [push, pull_request, release]
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,12 @@
 name: Docker
 
 on:
-  push
-  pull_request
-  release
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+  release:
     types: [published]
 
 jobs:

--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -25,7 +25,7 @@ if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
   PR_NUM=$(echo "${GITHUB_REF}" | sed 's:refs/pull/::' | sed 's:/merge::')
   LATEST_TAG="pr-${PR_NUM}"
 else
-  REFSPEC=$(echo "${GITHUB_REF}" | sed 's:refs/heads/::' | sed 's/[^a-zA-Z0-9]/-/')
+  REFSPEC=$(echo "${GITHUB_REF}" | sed 's:refs/heads/::' | sed 's/[^.a-zA-Z0-9]/-/')
   LATEST_TAG="${REFSPEC}"
 fi
 

--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -24,8 +24,11 @@ if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
   REFSPEC="${GITHUB_HEAD_REF/[^a-zA-Z0-9]/-}"
   PR_NUM=$(echo "${GITHUB_REF}" | sed 's:refs/pull/::' | sed 's:/merge::')
   LATEST_TAG="pr-${PR_NUM}"
+elif [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+  REFSPEC="${GITHUB_REF}"
+  LATEST_TAG="${REFSPEC}"
 else
-  REFSPEC=$(echo "${GITHUB_REF}" | sed 's:refs/heads/::' | sed 's/[^.a-zA-Z0-9]/-/')
+  REFSPEC=$(echo "${GITHUB_REF}" | sed 's:refs/heads/::' | sed 's/[^a-zA-Z0-9]/-/')
   LATEST_TAG="${REFSPEC}"
 fi
 


### PR DESCRIPTION
### SUMMARY
Create a specific build when a GH release is published. Tag the image with the release tag has is.

Also limits to master branch and PR's

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
