### PR TITLE
fix: update chart doesn't remove all connections to dashboards

### DIFF
--- a/superset/charts/commands/update.py
+++ b/superset/charts/commands/update.py
@@ -59,7 +59,7 @@ class UpdateChartCommand(BaseCommand):
 
     def validate(self) -> None:
         exceptions: List[ValidationError] = list()
-        dashboard_ids = self._properties.get("dashboards", [])
+        dashboard_ids = self._properties.get("dashboards")
         owner_ids: Optional[List[int]] = self._properties.get("owners")
 
         # Validate if datasource_id is provided datasource_type is required
@@ -87,11 +87,12 @@ class UpdateChartCommand(BaseCommand):
             except ValidationError as ex:
                 exceptions.append(ex)
 
-        # Validate/Populate dashboards
-        dashboards = DashboardDAO.find_by_ids(dashboard_ids)
-        if len(dashboards) != len(dashboard_ids):
-            exceptions.append(DashboardsNotFoundValidationError())
-        self._properties["dashboards"] = dashboards
+        # Validate/Populate dashboards only if it's a list
+        if dashboard_ids is not None:
+            dashboards = DashboardDAO.find_by_ids(dashboard_ids)
+            if len(dashboards) != len(dashboard_ids):
+                exceptions.append(DashboardsNotFoundValidationError())
+            self._properties["dashboards"] = dashboards
 
         # Validate/Populate owner
         try:


### PR DESCRIPTION
### SUMMARY
Updating chart's properties was removing all existing connection to dashboards where chart was added. Right now it is checked if list of chart's dashboards is updated as well.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot 2020-11-26 at 20 03 08](https://user-images.githubusercontent.com/2536609/100385314-8dbe1c80-3022-11eb-9fac-64f1ec5432ef.png)

After:
![Screenshot 2020-11-26 at 19 55 42](https://user-images.githubusercontent.com/2536609/100385320-931b6700-3022-11eb-96a2-2901c8937d9a.png) 
It's possible to change title into:
![Screenshot 2020-11-26 at 20 02 20](https://user-images.githubusercontent.com/2536609/100385335-99a9de80-3022-11eb-8e18-fc3d0175dcc7.png)

### TEST PLAN
1. Add chart to a dashboard and save
2. Go to chart's details and click burger -> Edit properties
3. Change something ex. title
4. Go back to the dashboard and refresh, chart should be there with new title

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
Fixes: #10528
- [ ] Has associated issue: 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
