### PR TITLE
chore: Change subtabs order for Data tab

### DIFF
--- a/superset-frontend/src/views/CRUD/data/common.ts
+++ b/superset-frontend/src/views/CRUD/data/common.ts
@@ -23,15 +23,15 @@ export const commonMenuData = {
   name: t('Data'),
   tabs: [
     {
-      name: 'Datasets',
-      label: t('Datasets'),
-      url: '/tablemodelview/list/',
-      usesRouter: true,
-    },
-    {
       name: 'Databases',
       label: t('Databases'),
       url: '/databaseview/list/',
+      usesRouter: true,
+    },
+    {
+      name: 'Datasets',
+      label: t('Datasets'),
+      url: '/tablemodelview/list/',
       usesRouter: true,
     },
     {


### PR DESCRIPTION
### SUMMARY
The task was to change order of Data tab subtabs: "Datasets" and "Databases"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/47450693/100464871-a5eb7580-30ce-11eb-9ea4-68eb8af2bb02.png)

After:
![image](https://user-images.githubusercontent.com/47450693/100465912-61f97000-30d0-11eb-9ec9-583b9b76f045.png)


### TEST PLAN
Verify manually:
Click "Data" tab in top navigation bar and choose one of the subtabs from the dropdown menu (i.e. Databases).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @junlincc @rusackas 
@adam-stasiak or @kgabryje could you test it please?