### PR TITLE
fix: improve Avatar text size consistency

### DIFF
--- a/superset-frontend/src/components/FacePile/index.tsx
+++ b/superset-frontend/src/components/FacePile/index.tsx
@@ -17,7 +17,11 @@
  * under the License.
  */
 import React from 'react';
-import { getCategoricalSchemeRegistry, styled } from '@superset-ui/core';
+import {
+  getCategoricalSchemeRegistry,
+  styled,
+  SupersetTheme,
+} from '@superset-ui/core';
 import { Tooltip } from 'src/common/components/Tooltip';
 import { Avatar } from 'src/common/components';
 import { getRandomColor } from './utils';
@@ -29,20 +33,21 @@ interface FacePileProps {
 
 const colorList = getCategoricalSchemeRegistry().get()?.colors ?? [];
 
+const customAvatarStyler = (theme: SupersetTheme) => `
+  width: ${theme.gridUnit * 6}px;
+  height: ${theme.gridUnit * 6}px;
+  line-height: ${theme.gridUnit * 6}px;
+  font-size: ${theme.typography.sizes.m}px;
+`;
+
 const StyledAvatar = styled(Avatar)`
-  width: ${({ theme }) => theme.gridUnit * 6}px;
-  height: ${({ theme }) => theme.gridUnit * 6}px;
-  line-height: ${({ theme }) => theme.gridUnit * 6}px;
-  font-size: ${({ theme }) => theme.typography.sizes.xl}px;
+  ${({ theme }) => customAvatarStyler(theme)}
 `;
 
 // to apply styling to the maxCount avatar
 const StyledGroup = styled(Avatar.Group)`
   .ant-avatar {
-    width: ${({ theme }) => theme.gridUnit * 6}px;
-    height: ${({ theme }) => theme.gridUnit * 6}px;
-    line-height: ${({ theme }) => theme.gridUnit * 6}px;
-    font-size: ${({ theme }) => theme.typography.sizes.xl}px;
+    ${({ theme }) => customAvatarStyler(theme)}
   }
 `;
 


### PR DESCRIPTION
### SUMMARY
In https://github.com/apache/incubator-superset/issues/11813 I noticed that the avatar text sizes weren't very consistent due to the varying size of 2 characters in English ("II" is much thinner than "WW"). After playing around more with the Avatar component, I realized this was because we were setting a much larger size than necessary for the Avatar text (21px). I reduced this to 14px, what seemed to be a happy medium between the 21px that "II" could fit in and the tiny 9px that "WW" needed to fully fit. It doesn't entirely fix the problem, but I think it's the best we'll get, unless we decided to make these monospaced (something that I considered a worse option).

I also refactored the style application code a bit to adhere to DRY

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screen Shot 2020-11-29 at 7 24 23 PM](https://user-images.githubusercontent.com/7409244/100566006-bc820000-3279-11eb-8de0-d136f78881a2.png)

After:
![Screen Shot 2020-11-29 at 7 23 22 PM](https://user-images.githubusercontent.com/7409244/100566010-c0158700-3279-11eb-99e5-6800f234a493.png)

### TEST PLAN
Test in storybook with initials `II` and `WW`. Also ensure the width and height of the avatars match before and after the code refactor
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/incubator-superset/issues/11813
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @nytai 