### PR TITLE
fix: Download non english csv filename

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -22,6 +22,7 @@ from contextlib import closing
 from datetime import datetime
 from typing import Any, cast, Dict, List, Optional, Union
 from urllib import parse
+from unidecode import unidecode
 
 import backoff
 import pandas as pd
@@ -2395,10 +2396,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             df = query.database.get_df(sql, query.schema)
             # TODO(bkyryliuk): add compression=gzip for big files.
             csv = df.to_csv(index=False, **config["CSV_EXPORT"])
+        csv = csv.encode(config.get('CSV_EXPORT')['encoding'])
         response = Response(csv, mimetype="text/csv")
-        response.headers[
-            "Content-Disposition"
-        ] = f"attachment; filename={query.name}.csv"
+        response.headers['Content-Disposition'] = (
+             'attachment; filename={}.csv'.format(unidecode(query.name)))
         event_info = {
             "event_type": "data_export",
             "client_id": client_id,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enables download transliterated filename for non-en csv
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
