### PR TITLE
fix: dashboard iframe to markdown db migration

### DIFF
--- a/superset/migrations/versions/978245563a02_migrate_iframe_to_dash_markdown.py
+++ b/superset/migrations/versions/978245563a02_migrate_iframe_to_dash_markdown.py
@@ -157,7 +157,7 @@ def upgrade():
 
             if keys_to_remove:
                 for key_to_remove in keys_to_remove:
-                    position_dict.pop(key_to_remove)
+                    del position_dict[key_to_remove]
                 dashboard.position_json = json.dumps(
                     position_dict, indent=None, separators=(",", ":"), sort_keys=True,
                 )

--- a/superset/migrations/versions/978245563a02_migrate_iframe_to_dash_markdown.py
+++ b/superset/migrations/versions/978245563a02_migrate_iframe_to_dash_markdown.py
@@ -132,6 +132,7 @@ def upgrade():
             # find iframe chart position in metadata
             # and replace it with markdown component
             position_dict = json.loads(dashboard.position_json or "{}")
+            keys_to_remove = []
             for key, chart_position in position_dict.items():
                 if (
                     chart_position
@@ -145,7 +146,7 @@ def upgrade():
                     markdown = create_new_markdown_component(
                         chart_position, iframe_urls[iframe_id]
                     )
-                    position_dict.pop(key)
+                    keys_to_remove.append(key)
                     position_dict[markdown["id"]] = markdown
 
                     # add markdown to layout tree
@@ -154,13 +155,13 @@ def upgrade():
                     children.remove(key)
                     children.append(markdown["id"])
 
-                    dashboard.position_json = json.dumps(
-                        position_dict,
-                        indent=None,
-                        separators=(",", ":"),
-                        sort_keys=True,
-                    )
-                    session.merge(dashboard)
+            if keys_to_remove:
+                for key_to_remove in keys_to_remove:
+                    position_dict.pop(key_to_remove)
+                dashboard.position_json = json.dumps(
+                    position_dict, indent=None, separators=(",", ":"), sort_keys=True,
+                )
+                session.merge(dashboard)
 
         # remove iframe, separator and markup charts
         slices_to_remove = (


### PR DESCRIPTION
### SUMMARY

Fixing a reported issue on a db migration with the following error:

```
INFO  [alembic.runtime.migration] Running upgrade f2672aa8350a -> 978245563a02, Migrate iframe in dashboard to markdown component
scanning dashboard (1/2) dashboard: 19 >>>>
ERROR [root] dashboard 19 has error: dictionary keys changed during iteration
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/superset/migrations/versions/978245563a02_migrate_iframe_to_dash_markdown.py", line 135, in upgrade
    for key, chart_position in position_dict.items():
RuntimeError: dictionary keys changed during iteration
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
