### PR TITLE
fix: Show copy icon

### DIFF
--- a/superset-frontend/src/components/CopyToClipboard.jsx
+++ b/superset-frontend/src/components/CopyToClipboard.jsx
@@ -77,8 +77,7 @@ class CopyToClipboard extends React.Component {
         style: { cursor: 'pointer' },
         onClick: this.onClick,
         onMouseOut: this.onMouseOut,
-      },
-      null,
+      }
     );
   }
 

--- a/superset-frontend/src/components/CopyToClipboard.jsx
+++ b/superset-frontend/src/components/CopyToClipboard.jsx
@@ -71,14 +71,11 @@ class CopyToClipboard extends React.Component {
   }
 
   getDecoratedCopyNode() {
-    return React.cloneElement(
-      this.props.copyNode,
-      {
-        style: { cursor: 'pointer' },
-        onClick: this.onClick,
-        onMouseOut: this.onMouseOut,
-      }
-    );
+    return React.cloneElement(this.props.copyNode, {
+      style: { cursor: 'pointer' },
+      onClick: this.onClick,
+      onMouseOut: this.onMouseOut,
+    });
   }
 
   resetTooltipText() {

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -75,6 +75,10 @@ const CopyButton = styled(Button)`
   && {
     margin-left: ${({ theme }) => theme.gridUnit * 2}px;
   }
+
+  i {
+    padding: 0;
+  }
 `;
 
 export const DisplayQueryButton = props => {

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -207,9 +207,6 @@ export const DisplayQueryButton = props => {
               <CopyButtonViewQuery>
                 <i className="fa fa-clipboard" />
               </CopyButtonViewQuery>
-              // <Button style={{ position: 'absolute', right: 20}}>
-              //   <i className="fa fa-clipboard" style={{ padding: 0 }}/>
-              // </Button>
             }
           />
           <SyntaxHighlighter language={language} style={github}>

--- a/superset-frontend/src/explore/components/DisplayQueryButton.jsx
+++ b/superset-frontend/src/explore/components/DisplayQueryButton.jsx
@@ -81,6 +81,20 @@ const CopyButton = styled(Button)`
   }
 `;
 
+const CopyButtonViewQuery = styled(Button)`
+  padding: ${({ theme }) => theme.gridUnit / 2}px
+    ${({ theme }) => theme.gridUnit * 2.5}px;
+  font-size: ${({ theme }) => theme.typography.sizes.s}px;
+
+  && {
+    margin-bottom: 5px;
+  }
+
+  i {
+    padding: 0;
+  }
+`;
+
 export const DisplayQueryButton = props => {
   const { datasource } = props.latestQueryFormData;
 
@@ -190,9 +204,12 @@ export const DisplayQueryButton = props => {
             text={query}
             shouldShowText={false}
             copyNode={
-              <Button style={{ position: 'absolute', right: 20 }}>
+              <CopyButtonViewQuery>
                 <i className="fa fa-clipboard" />
-              </Button>
+              </CopyButtonViewQuery>
+              // <Button style={{ position: 'absolute', right: 20}}>
+              //   <i className="fa fa-clipboard" style={{ padding: 0 }}/>
+              // </Button>
             }
           />
           <SyntaxHighlighter language={language} style={github}>


### PR DESCRIPTION
### SUMMARY
Fix issue to display the correct copy to clipboard icon

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
![image](https://user-images.githubusercontent.com/8277264/100445064-29986880-30b5-11eb-8fb8-ecef1ce3b7df.png)
AFTER
![image](https://user-images.githubusercontent.com/8277264/100445117-3ddc6580-30b5-11eb-838a-4028e7e56e5b.png)


### TEST PLAN
Log into Superset
Navigate to Datasets
Select on Dataset
Click on the View Results in the right corner (menu)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Fixes https://github.com/apache/incubator-superset/issues/11807
