### PR TITLE
feat:  Create api abstraction layer for dataset network calls

### DIFF
--- a/superset-frontend/src/api/dataset.ts
+++ b/superset-frontend/src/api/dataset.ts
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 import { SupersetClient, JsonResponse } from '@superset-ui/core';
 import rison from 'rison';
 

--- a/superset-frontend/src/api/dataset.ts
+++ b/superset-frontend/src/api/dataset.ts
@@ -1,0 +1,42 @@
+import { SupersetClient, JsonResponse } from '@superset-ui/core';
+import rison from 'rison';
+
+export const get = async (userId: number) => {
+  const queryParams = rison.encode({
+    filters: [
+      {
+        col: 'owners',
+        opr: 'rel_m_m',
+        value: userId,
+      },
+    ],
+    order_column: 'changed_on_delta_humanized',
+    order_direction: 'desc',
+  });
+  const endpoint = `/api/v1/dataset?q=${queryParams}`;
+  const data: JsonResponse = await SupersetClient.get({
+    endpoint,
+  });
+  return data.json.result;
+};
+
+export const put = async (
+  datasetId: number,
+  sql: string,
+  columns: Array<Record<string, any>>,
+  overrideColumns: boolean,
+) => {
+  const endpoint = `api/v1/dataset/${datasetId}?override_columns=${overrideColumns}`;
+  const headers = { 'Content-Type': 'application/json' };
+  const body = JSON.stringify({
+    sql,
+    columns,
+  });
+
+  const data: JsonResponse = await SupersetClient.put({
+    endpoint,
+    headers,
+    body,
+  });
+  return data.json.result;
+};

--- a/superset-frontend/src/api/dataset.ts
+++ b/superset-frontend/src/api/dataset.ts
@@ -1,19 +1,22 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { SupersetClient, JsonResponse } from '@superset-ui/core';
 import rison from 'rison';
 

--- a/superset-frontend/src/api/dataset.ts
+++ b/superset-frontend/src/api/dataset.ts
@@ -20,7 +20,7 @@
 import { SupersetClient, JsonResponse } from '@superset-ui/core';
 import rison from 'rison';
 
-export const get = async (userId: number) => {
+export const getByUser = async (userId: number) => {
   const queryParams = rison.encode({
     filters: [
       {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To help standardize the code, currently moving dataset network calls under the api directory.

Linked to #11755 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
