### PR TITLE
fix: Test connection whitelist added for gsheets

### DIFF
--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -35,6 +35,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
         self._actor = user
         self._properties = data.copy()
         self._model: Optional[Database] = None
+        self._whitelist = ["gsheets://"]
 
     def run(self) -> None:
         self.validate()
@@ -55,8 +56,9 @@ class TestConnectionDatabaseCommand(BaseCommand):
                 username = self._actor.username if self._actor is not None else None
                 engine = database.get_sqla_engine(user_name=username)
             with closing(engine.raw_connection()) as conn:
-                if not engine.dialect.do_ping(conn):
-                    raise DBAPIError(None, None, None)
+                if uri not in self._whitelist:
+                    if not engine.dialect.do_ping(conn):
+                        raise DBAPIError(None, None, None)
         except DBSecurityException as ex:
             logger.warning(ex)
             raise DatabaseSecurityUnsafeError()


### PR DESCRIPTION
### SUMMARY
Handles the case of throwing the following error message: `An error occurred while creating databases: "Could not connect to database."` when adding `gsheets://` as a Database.

Fixes #11844

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
