### PR TITLE
fix: Check if annotation type is supported by the given chart type

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
@@ -197,7 +197,7 @@ export default class AnnotationLayer extends React.PureComponent {
         label: chartMetadata.name,
       }));
     // Prepend native source if applicable
-    if (ANNOTATION_TYPES_METADATA[annotationType].supportNativeSource) {
+    if (ANNOTATION_TYPES_METADATA[annotationType]?.supportNativeSource) {
       sources.unshift(ANNOTATION_SOURCE_TYPES_METADATA.NATIVE);
     }
     return sources;

--- a/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayer.jsx
@@ -118,6 +118,7 @@ export default class AnnotationLayer extends React.PureComponent {
       descriptionColumns,
       timeColumn,
       intervalEndColumn,
+      vizType,
     } = props;
 
     // Only allow override whole time_range
@@ -127,10 +128,19 @@ export default class AnnotationLayer extends React.PureComponent {
       delete overrides.until;
     }
 
+    // Check if annotationType is supported by this chart
+    const metadata = getChartMetadataRegistry().get(vizType);
+    const supportedAnnotationTypes = metadata?.supportedAnnotationTypes || [];
+    const validAnnotationType = supportedAnnotationTypes.includes(
+      annotationType,
+    )
+      ? annotationType
+      : supportedAnnotationTypes[0];
+
     this.state = {
       // base
       name,
-      annotationType,
+      annotationType: validAnnotationType,
       sourceType,
       value,
       overrides,
@@ -724,6 +734,7 @@ export default class AnnotationLayer extends React.PureComponent {
                   options={supportedSourceTypes}
                   value={sourceType}
                   onChange={this.handleAnnotationSourceType}
+                  validationErrors={!sourceType ? [t('Mandatory')] : []}
                 />
               )}
               {this.renderValueConfiguration()}


### PR DESCRIPTION
### SUMMARY
This PR checks if annotation type, that user wants to use, is supported by this kind of chart. 
For example, time-line bar chart does not support FORMULA annotation. As specified in `superset-ui`, time-line bar chart should support only interval or event annotations. The problem was that the default annotation type was set to FORMULA for all of the charts. 
In my PR, we first check, which annotation types are supported - if Formula is one of them, we set it as a default one, showing when we open the Annotation Modal. If not, we take the first annotation from Supported Annotations array.
It also impacts issue #11790.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![formula_before](https://user-images.githubusercontent.com/47450693/100742370-f6b6e300-33da-11eb-9452-f4089e174d2d.gif)

after:
![bar_chart_supported_annotations_after](https://user-images.githubusercontent.com/47450693/100742374-fae30080-33da-11eb-9d37-9a98df1c7045.gif)

### TEST PLAN
Verify manually.
Create time-series bar chart and try to add annotation layer.
Try also with some chart, which Formula is a supported annotation type, for example line chart.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #11790
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@kgabryje or @adam-stasiak could you test?
cc @junlincc