### PR TITLE
fix: disable keyboard shortcut for running empty query in SQL Lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -199,13 +199,21 @@ class SqlEditor extends React.PureComponent {
         name: 'runQuery1',
         key: 'ctrl+r',
         descr: t('Run query'),
-        func: this.runQuery,
+        func: () => {
+          if (this.state.sql.trim() !== '') {
+            this.runQuery();
+          }
+        },
       },
       {
         name: 'runQuery2',
         key: 'ctrl+enter',
         descr: t('Run query'),
-        func: this.runQuery,
+        func: () => {
+          if (this.state.sql.trim() !== '') {
+            this.runQuery();
+          }
+        },
       },
       {
         name: 'newTab',


### PR DESCRIPTION
### SUMMARY
Using CTRL + R or CTRL + Enter when there is empty input for queries in SQL Lab is disabled and doesn't perform any action.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before it was returning error:
```
Database Error
local variable 'result_set' referenced before assignment
```
After:
hotkey is not doing anything.

### TEST PLAN
1. Go to SQL Lab
2. Delete everything in the text area (including SELECT ...)
3. Press CTRL+R or CTRL+Enter
No error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
Fixes: #11587
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
