### PR TITLE
fix: certification icon order

### DIFF
--- a/superset-frontend/src/components/TableSelector.tsx
+++ b/superset-frontend/src/components/TableSelector.tsx
@@ -253,6 +253,9 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   function renderTableOption(option: any) {
     return (
       <TableLabel title={option.label}>
+        <small className="text-muted">
+          <i className={`fa fa-${option.type === 'view' ? 'eye' : 'table'}`} />
+        </small>
         {option.extra?.certification && (
           <CertifiedIconWithTooltip
             certifiedBy={option.extra.certification.certified_by}
@@ -260,9 +263,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
             size={20}
           />
         )}
-        <small className="text-muted">
-          <i className={`fa fa-${option.type === 'view' ? 'eye' : 'table'}`} />
-        </small>
         {option.label}
       </TableLabel>
     );


### PR DESCRIPTION
### SUMMARY
In the dataset crud view, the table icon comes first, so we should use the same order here

### TEST PLAN
CI
new order:
![image](https://user-images.githubusercontent.com/7409244/100799471-f2d69100-33d9-11eb-9086-b8c71b38d6e8.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

to: @ktmud 