### PR TITLE
feat: add modal to import databases

### DIFF
--- a/superset-frontend/src/database/components/ImportModal/ImportModal.test.tsx
+++ b/superset-frontend/src/database/components/ImportModal/ImportModal.test.tsx
@@ -17,16 +17,11 @@
  * under the License.
  */
 import React from 'react';
-import thunk from 'redux-thunk';
-import configureStore from 'redux-mock-store';
 import { styledMount as mount } from 'spec/helpers/theming';
 import { ReactWrapper } from 'enzyme';
 
 import ImportDatabaseModal from 'src/database/components/ImportModal';
 import Modal from 'src/common/components/Modal';
-
-const mockStore = configureStore([thunk]);
-const store = mockStore({});
 
 const requiredProps = {
   addDangerToast: () => {},
@@ -40,9 +35,7 @@ describe('ImportDatabaseModal', () => {
   let wrapper: ReactWrapper;
 
   beforeEach(() => {
-    wrapper = mount(<ImportDatabaseModal {...requiredProps} />, {
-      context: { store },
-    });
+    wrapper = mount(<ImportDatabaseModal {...requiredProps} />);
   });
 
   afterEach(() => {
@@ -97,9 +90,6 @@ describe('ImportDatabaseModal', () => {
         {...requiredProps}
         passwordFields={['databases/examples.yaml']}
       />,
-      {
-        context: { store },
-      },
     );
     expect(wrapperWithPasswords.find('input[type="password"]')).toExist();
   });

--- a/superset-frontend/src/database/components/ImportModal/ImportModal.test.tsx
+++ b/superset-frontend/src/database/components/ImportModal/ImportModal.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { styledMount as mount } from 'spec/helpers/theming';
+import { ReactWrapper } from 'enzyme';
+
+import ImportDatabaseModal from 'src/database/components/ImportModal';
+import Modal from 'src/common/components/Modal';
+
+const mockStore = configureStore([thunk]);
+const store = mockStore({});
+
+const requiredProps = {
+  addDangerToast: () => {},
+  addSuccessToast: () => {},
+  onDatabaseImport: () => {},
+  show: true,
+  onHide: () => {},
+};
+
+describe('ImportDatabaseModal', () => {
+  let wrapper: ReactWrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<ImportDatabaseModal {...requiredProps} />, {
+      context: { store },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders', () => {
+    expect(wrapper.find(ImportDatabaseModal)).toExist();
+  });
+
+  it('renders a Modal', () => {
+    expect(wrapper.find(Modal)).toExist();
+  });
+
+  it('renders "Import Database" header', () => {
+    expect(wrapper.find('h4').text()).toEqual('Import Database');
+  });
+
+  it('renders a label and a file input field', () => {
+    expect(wrapper.find('input[type="file"]')).toExist();
+    expect(wrapper.find('label')).toExist();
+  });
+
+  it('should attach the label to the input field', () => {
+    const id = 'databaseFile';
+    expect(wrapper.find('label').prop('htmlFor')).toBe(id);
+    expect(wrapper.find('input').prop('id')).toBe(id);
+  });
+
+  it('should render the close, import and cancel buttons', () => {
+    expect(wrapper.find('button')).toHaveLength(3);
+  });
+
+  it('should render the import button initially disabled', () => {
+    expect(wrapper.find('button[children="Import"]').prop('disabled')).toBe(
+      true,
+    );
+  });
+
+  it('should render the import button enabled when a file is selected', () => {
+    const file = new File([new ArrayBuffer(1)], 'database_export.zip');
+    wrapper.find('input').simulate('change', { target: { files: [file] } });
+
+    expect(wrapper.find('button[children="Import"]').prop('disabled')).toBe(
+      false,
+    );
+  });
+
+  it('should render password fields when needed for import', () => {
+    const wrapperWithPasswords = mount(
+      <ImportDatabaseModal
+        {...requiredProps}
+        passwordFields={['databases/examples.yaml']}
+      />,
+      {
+        context: { store },
+      },
+    );
+    expect(wrapperWithPasswords.find('input[type="password"]')).toExist();
+  });
+});

--- a/superset-frontend/src/database/components/ImportModal/index.tsx
+++ b/superset-frontend/src/database/components/ImportModal/index.tsx
@@ -1,0 +1,185 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { FunctionComponent, useRef, useState } from 'react';
+import { t } from '@superset-ui/core';
+
+import Modal from 'src/common/components/Modal';
+import {
+  StyledIcon,
+  StyledInputContainer,
+} from 'src/views/CRUD/data/database/DatabaseModal';
+import { useSingleViewResource } from 'src/views/CRUD/hooks';
+import { DatabaseObject } from 'src/views/CRUD/data/database/types';
+
+export interface ImportDatabaseModalProps {
+  addDangerToast: (msg: string) => void;
+  addSuccessToast: (msg: string) => void;
+  onDatabaseImport: () => void;
+  show: boolean;
+  onHide: () => void;
+  passwordFields?: string[];
+  setPasswordFields?: (passwordFields: string[]) => void;
+}
+
+const ImportDatabaseModal: FunctionComponent<ImportDatabaseModalProps> = ({
+  addDangerToast,
+  addSuccessToast,
+  onDatabaseImport,
+  show,
+  onHide,
+  passwordFields = [],
+  setPasswordFields = () => {},
+}) => {
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [isHidden, setIsHidden] = useState<boolean>(true);
+  const [passwords, setPasswords] = useState<Record<string, string>>({});
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { importResource } = useSingleViewResource<DatabaseObject>(
+    'database',
+    t('database'),
+    addDangerToast,
+  );
+
+  // Functions
+  const hide = () => {
+    setIsHidden(true);
+    onHide();
+  };
+
+  const clearModal = () => {
+    setUploadFile(null);
+    setPasswordFields([]);
+    setPasswords({});
+    if (fileInputRef && fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const onUpload = () => {
+    if (uploadFile === null) {
+      return;
+    }
+
+    importResource(uploadFile, passwords).then(result => {
+      if (result === true) {
+        // Success
+        addSuccessToast(t('The databases have been imported'));
+        clearModal();
+        onDatabaseImport();
+      } else if (result) {
+        // Need passwords
+        setPasswordFields(result);
+      } else {
+        // Failure
+        clearModal();
+      }
+    });
+  };
+
+  const changeFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target as HTMLInputElement;
+    setUploadFile((files && files[0]) || null);
+  };
+
+  const renderPasswordFields = () => {
+    if (passwordFields.length === 0) {
+      return null;
+    }
+
+    return (
+      <>
+        <h5>Passwords</h5>
+        <StyledInputContainer>
+          <div className="helper">
+            {t('Please provide the password for the databases below')}
+          </div>
+        </StyledInputContainer>
+        {passwordFields.map(fileName => (
+          <StyledInputContainer key={`password-for-${fileName}`}>
+            <div className="control-label">
+              {fileName}
+              <span className="required">*</span>
+            </div>
+            <input
+              name={`password-${fileName}`}
+              type="password"
+              value={passwords[fileName]}
+              onChange={event =>
+                setPasswords({ ...passwords, [fileName]: event.target.value })
+              }
+            />
+          </StyledInputContainer>
+        ))}
+      </>
+    );
+  };
+
+  // Show/hide
+  if (isHidden && show) {
+    setIsHidden(false);
+  }
+
+  return (
+    <Modal
+      name="database"
+      className="database-modal"
+      disablePrimaryButton={uploadFile === null}
+      onHandledPrimaryAction={onUpload}
+      onHide={hide}
+      primaryButtonName={t('Import')}
+      width="750px"
+      show={show}
+      title={
+        <h4>
+          <StyledIcon name="database" />
+          {t('Import Database')}
+        </h4>
+      }
+    >
+      <StyledInputContainer>
+        <div className="control-label">
+          <label htmlFor="databaseFile">
+            {t('File')}
+            <span className="required">*</span>
+          </label>
+        </div>
+        <input
+          ref={fileInputRef}
+          data-test="database-file-input"
+          name="databaseFile"
+          id="databaseFile"
+          type="file"
+          accept=".yaml,.json,.yml,.zip"
+          onChange={changeFile}
+        />
+        <div className="helper">
+          {t(
+            'Please note that the "Secure Extra" and "Certificate" sections of ' +
+              'the database configuration are not present in export files, and ' +
+              'should be added manually after the import if they are needed.',
+          )}
+        </div>
+      </StyledInputContainer>
+      {renderPasswordFields()}
+    </Modal>
+  );
+};
+
+export default ImportDatabaseModal;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -78,13 +78,13 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
   const [importingDatabase, showImportModal] = useState<boolean>(false);
   const [passwordFields, setPasswordFields] = useState<string[]>([]);
 
-  function openDatabaseImportModal() {
+  const openDatabaseImportModal = () => {
     showImportModal(true);
-  }
+  };
 
-  function closeDatabaseImportModal() {
+  const closeDatabaseImportModal = () => {
     showImportModal(false);
-  }
+  };
 
   const handleDatabaseImport = () => {
     showImportModal(false);

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -29,6 +29,7 @@ import TooltipWrapper from 'src/components/TooltipWrapper';
 import Icon from 'src/components/Icon';
 import ListView, { Filters } from 'src/components/ListView';
 import { commonMenuData } from 'src/views/CRUD/data/common';
+import ImportDatabaseModal from 'src/database/components/ImportModal/index';
 import DatabaseModal from './DatabaseModal';
 import { DatabaseObject } from './types';
 
@@ -74,6 +75,21 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
   const [currentDatabase, setCurrentDatabase] = useState<DatabaseObject | null>(
     null,
   );
+  const [importingDatabase, showImportModal] = useState<boolean>(false);
+  const [passwordFields, setPasswordFields] = useState<string[]>([]);
+
+  function openDatabaseImportModal() {
+    showImportModal(true);
+  }
+
+  function closeDatabaseImportModal() {
+    showImportModal(false);
+  }
+
+  const handleDatabaseImport = () => {
+    showImportModal(false);
+    refreshData();
+  };
 
   const openDatabaseDeleteModal = (database: DatabaseObject) =>
     SupersetClient.get({
@@ -146,6 +162,14 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
         },
       },
     ];
+
+    if (isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT)) {
+      menuData.buttons.push({
+        name: <Icon name="import" />,
+        buttonStyle: 'link',
+        onClick: openDatabaseImportModal,
+      });
+    }
   }
 
   function handleDatabaseExport(database: DatabaseObject) {
@@ -399,6 +423,16 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
         initialSort={initialSort}
         loading={loading}
         pageSize={PAGE_SIZE}
+      />
+
+      <ImportDatabaseModal
+        show={importingDatabase}
+        onHide={closeDatabaseImportModal}
+        addDangerToast={addDangerToast}
+        addSuccessToast={addSuccessToast}
+        onDatabaseImport={handleDatabaseImport}
+        passwordFields={passwordFields}
+        setPasswordFields={setPasswordFields}
       />
     </>
   );

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal.tsx
@@ -39,11 +39,11 @@ interface DatabaseModalProps {
   database?: DatabaseObject | null; // If included, will go into edit mode
 }
 
-const StyledIcon = styled(Icon)`
+export const StyledIcon = styled(Icon)`
   margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
 `;
 
-const StyledInputContainer = styled.div`
+export const StyledInputContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
 
   &.extra-container {

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -378,7 +378,6 @@ export function useImportResource<D extends object = any>(
               });
               return false;
             }
-            console.log(errMsg);
             handleErrorMsg(
               t(
                 'An error occurred while importing %s: %s',

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import json
 import logging
 from datetime import datetime
 from io import BytesIO
@@ -776,7 +777,13 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 for file_name in bundle.namelist()
             }
 
-        command = ImportDatabasesCommand(contents)
+        passwords = (
+            json.loads(request.form["passwords"])
+            if "passwords" in request.form
+            else None
+        )
+
+        command = ImportDatabasesCommand(contents, passwords=passwords)
         try:
             command.run()
             return self.response(200, message="OK")

--- a/superset/databases/commands/importers/dispatcher.py
+++ b/superset/databases/commands/importers/dispatcher.py
@@ -41,12 +41,14 @@ class ImportDatabasesCommand(BaseCommand):
     # pylint: disable=unused-argument
     def __init__(self, contents: Dict[str, str], *args: Any, **kwargs: Any):
         self.contents = contents
+        self.args = args
+        self.kwargs = kwargs
 
     def run(self) -> None:
         # iterate over all commands until we find a version that can
         # handle the contents
         for version in command_versions:
-            command = version(self.contents)
+            command = version(self.contents, *self.args, **self.kwargs)
             try:
                 command.run()
                 return

--- a/superset/databases/commands/importers/v1/__init__.py
+++ b/superset/databases/commands/importers/v1/__init__.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import urllib.parse
 from typing import Any, Dict, List, Optional
 
 from marshmallow import Schema, validate
@@ -47,8 +48,11 @@ class ImportDatabasesCommand(BaseCommand):
     """Import databases"""
 
     # pylint: disable=unused-argument
-    def __init__(self, contents: Dict[str, str], *args: Any, **kwargs: Any):
+    def __init__(
+        self, contents: Dict[str, str], *args: Any, **kwargs: Any,
+    ):
         self.contents = contents
+        self.passwords = kwargs.get("passwords") or {}
         self._configs: Dict[str, Any] = {}
 
     def _import_bundle(self, session: Session) -> None:
@@ -96,6 +100,8 @@ class ImportDatabasesCommand(BaseCommand):
             if schema:
                 try:
                     config = load_yaml(file_name, content)
+                    if file_name in self.passwords:
+                        config["password"] = self.passwords[file_name]
                     schema.load(config)
                     self._configs[file_name] = config
                 except ValidationError as exc:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -155,6 +155,7 @@ class Database(
         "allow_csv_upload",
         "extra",
     ]
+    extra_import_fields = ["password"]
     export_children = ["tables"]
 
     def __repr__(self) -> str:

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -85,6 +85,10 @@ class ImportExportMixin:
     # The names of the attributes
     # that are available for import and export
 
+    extra_import_fields: List[str] = []
+    # Additional fields that should be imported,
+    # even though they were not exported
+
     __mapper__: Mapper
 
     @classmethod
@@ -155,7 +159,12 @@ class ImportExportMixin:
         if sync is None:
             sync = []
         parent_refs = cls.parent_foreign_key_mappings()
-        export_fields = set(cls.export_fields) | set(parent_refs.keys()) | {"uuid"}
+        export_fields = (
+            set(cls.export_fields)
+            | set(cls.extra_import_fields)
+            | set(parent_refs.keys())
+            | {"uuid"}
+        )
         new_children = {c: dict_rep[c] for c in cls.export_children if c in dict_rep}
         unique_constrains = cls._unique_constrains()
 

--- a/tests/databases/commands_tests.py
+++ b/tests/databases/commands_tests.py
@@ -452,6 +452,26 @@ class TestImportDatabasesCommand(SupersetTestCase):
             }
         }
 
+    def test_import_v1_database_masked_password(self):
+        """Test that database imports with masked passwords are rejected"""
+        masked_database_config = database_config.copy()
+        masked_database_config[
+            "sqlalchemy_uri"
+        ] = "postgresql://username:XXXXXXXXXX@host:12345/db"
+        contents = {
+            "metadata.yaml": yaml.safe_dump(database_metadata_config),
+            "databases/imported_database.yaml": yaml.safe_dump(masked_database_config),
+        }
+        command = ImportDatabasesCommand(contents)
+        with pytest.raises(CommandInvalidError) as excinfo:
+            command.run()
+        assert str(excinfo.value) == "Error importing database"
+        assert excinfo.value.normalized_messages() == {
+            "databases/imported_database.yaml": {
+                "sqlalchemy_uri": ["Password cannot be masked"]
+            }
+        }
+
     @patch("superset.databases.commands.importers.v1.import_dataset")
     def test_import_v1_rollback(self, mock_import_dataset):
         """Test than on an exception everything is rolled back"""

--- a/tests/databases/commands_tests.py
+++ b/tests/databases/commands_tests.py
@@ -468,7 +468,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
         assert str(excinfo.value) == "Error importing database"
         assert excinfo.value.normalized_messages() == {
             "databases/imported_database.yaml": {
-                "sqlalchemy_uri": ["Password cannot be masked"]
+                "_schema": ["Must provide a password for the database"]
             }
         }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds a new button to import databases from the UI if the `VERSIONED_EXPORT` feature flag is enabled. It allows users to import databases in the new format proposed in https://github.com/apache/incubator-superset/issues/11167.

The biggest challenge in importing databases is that we export them without passwords, extra security information, nor certificates. When importing database we can inspect the `sqlalchemy_uri` attribute and see if it has a masked password (`XXXXXXXX`), and if true we can prompt the user for the password.

The second biggest challenge is that we don't know how many databases are present in the imported file, since users can export multiple databases at once in a single file. We also don't know how many of those require passwords, since not all databases use them.

To work around this when the user tries to import a file the frontend will upload it to the backend. The backend performs validation on the file, and if there are databases with masked passwords it returns a validation error (422). The frontend will parse the error message, and if the only errors are from missing passwords it will prompt the user for the passwords and resubmit the file, this time with the associated passwords.

This PR adds the backend validation, as well as the import modal. For the API calls I created a new hook similar to `useSingleViewResource` called `useImportResource`, which will be reused for other imports (dataset, chart, dashboard and saved queries).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


![output](https://user-images.githubusercontent.com/1534870/100832445-bd9f6280-341c-11eb-9eaf-aa08cf24986c.gif)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Manually tested importing a database, and confirmed it prompts for the password and the database is configured correctly.

Also added tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/incubator-superset/issues/11167
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
