### PR TITLE
fix(event-flow-viz): handle null metadata selection

### DIFF
--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -102,10 +102,9 @@ export default class SelectControl extends React.PureComponent {
   // Beware: This is acting like an on-click instead of an on-change
   // (firing every time user chooses vs firing only if a new option is chosen).
   onChange(opt) {
-    let optionValue = null;
+    let optionValue = this.props.multi ? [] : null;
     if (opt) {
       if (this.props.multi) {
-        optionValue = [];
         opt.forEach(o => {
           // select all options
           if (o.meta === true) {

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2698,7 +2698,7 @@ class EventFlowViz(BaseViz):
         entity_key = form_data["entity"]
         meta_keys = [
             col
-            for col in form_data["all_columns"]
+            for col in form_data["all_columns"] or []
             if col != event_key and col != entity_key
         ]
 


### PR DESCRIPTION
### SUMMARY
Fix issue when removing additional metadata from the event flow chart. This was caused by the server that returns 500.
To fix that we need to send an empty array instead of null for multiselects.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
![before](https://user-images.githubusercontent.com/8277264/100841575-24a23300-3480-11eb-8d75-ed4f4f8f96e9.gif)
After
![after](https://user-images.githubusercontent.com/8277264/100841580-27048d00-3480-11eb-980b-df9215b21e24.gif)

### TEST PLAN
1) Log In
2) Create a new event flow chart
3) Add additional metadata
4) Run Query
5) Remove all additional metadata

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Fix https://github.com/apache/incubator-superset/issues/11746
