### PR TITLE
refactor: Move Badge to Antdesign

### DIFF
--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Badge } from 'react-bootstrap';
+import Badge from 'src/common/components/Badge';
 import { t, styled } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 
@@ -127,7 +127,7 @@ export default class TemplateParamsEditor extends React.Component {
         triggerNode={
           <Button tooltip={t('Edit template parameters')} buttonSize="small">
             {`${t('parameters')} `}
-            {paramCount > 0 && <Badge>{paramCount}</Badge>}
+            <Badge count={paramCount} />
             {!this.state.isValid && (
               <InfoTooltipWithTrigger
                 icon="exclamation-triangle"

--- a/superset-frontend/src/common/components/Badge.tsx
+++ b/superset-frontend/src/common/components/Badge.tsx
@@ -31,6 +31,7 @@ const Badge = styled((
   { textColor, ...props }: BadgeProps,
 ) => <AntdBadge {...props} />)`
   & > sup {
+    padding: 0 0.35px 0 0;
     background: ${({ theme, color }) => color || theme.colors.primary.base};
     color: ${({ theme, textColor }) =>
       textColor || theme.colors.grayscale.light5};

--- a/superset-frontend/src/common/components/Badge.tsx
+++ b/superset-frontend/src/common/components/Badge.tsx
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { styled } from '@superset-ui/core';
+import { Badge as AntdBadge } from 'src/common/components';
+import { BadgeProps as AntdBadgeProps } from 'antd/lib/badge';
+
+interface BadgeProps extends AntdBadgeProps {
+  textColor?: string;
+}
+
+const Badge = styled((props: BadgeProps) => <AntdBadge {...props} />)`
+  & > sup {
+    background: ${({ theme, color }) => color || theme.colors.primary.base};
+    color: ${({ theme, textColor }) =>
+      textColor || theme.colors.primary.light5};
+  }
+`;
+
+export default Badge;

--- a/superset-frontend/src/common/components/Badge.tsx
+++ b/superset-frontend/src/common/components/Badge.tsx
@@ -18,18 +18,22 @@
  */
 import React from 'react';
 import { styled } from '@superset-ui/core';
-import { Badge as AntdBadge } from 'src/common/components';
+// eslint-disable-next-line no-restricted-imports
+import { Badge as AntdBadge } from 'antd';
 import { BadgeProps as AntdBadgeProps } from 'antd/lib/badge';
 
 interface BadgeProps extends AntdBadgeProps {
   textColor?: string;
 }
 
-const Badge = styled((props: BadgeProps) => <AntdBadge {...props} />)`
+const Badge = styled((
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  { textColor, ...props }: BadgeProps,
+) => <AntdBadge {...props} />)`
   & > sup {
     background: ${({ theme, color }) => color || theme.colors.primary.base};
     color: ${({ theme, textColor }) =>
-      textColor || theme.colors.primary.light5};
+      textColor || theme.colors.grayscale.light5};
   }
 `;
 

--- a/superset-frontend/src/common/components/common.stories.tsx
+++ b/superset-frontend/src/common/components/common.stories.tsx
@@ -32,6 +32,7 @@ import {
   DatePicker as AntdDatePicker,
   RangePicker as AntdRangePicker,
 } from './DatePicker';
+import Badge from './Badge';
 
 export default {
   title: 'Common Components',
@@ -246,3 +247,12 @@ export const Switch = () => (
     <AntdSwitch size="small" defaultChecked />
   </>
 );
+
+export const BadgeDefault = () => <Badge count={100} />;
+export const BadgeColored = () => <Badge color="blue" text="Blue" />;
+export const BadgeTextColored = () => (
+  <Badge textColor="yellow" color="red" text="yellow" />
+);
+export const BadgeSuccess = () => <Badge status="success" text="Success" />;
+export const BadgeError = () => <Badge status="error" text="Error" />;
+export const BadgeSmall = () => <Badge count={100} size="small" />;

--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -21,7 +21,6 @@ import { styled } from '@superset-ui/core';
 // eslint-disable-next-line no-restricted-imports
 import { Dropdown, Skeleton, Menu as AntdMenu } from 'antd';
 import { DropDownProps } from 'antd/lib/dropdown';
-
 /*
   Antd is re-exported from here so we can override components with Emotion as needed.
 
@@ -44,8 +43,9 @@ export {
   Switch,
   Tabs,
   Tooltip,
-  Badge,
 } from 'antd';
+
+export { default as Badge } from 'src/common/components/Badge';
 
 export const MenuItem = styled(AntdMenu.Item)`
   > a {

--- a/superset-frontend/src/common/components/index.tsx
+++ b/superset-frontend/src/common/components/index.tsx
@@ -44,6 +44,7 @@ export {
   Switch,
   Tabs,
   Tooltip,
+  Badge,
 } from 'antd';
 
 export const MenuItem = styled(AntdMenu.Item)`

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -18,7 +18,8 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Alert, Badge, Col, Radio, Well } from 'react-bootstrap';
+import { Alert, Col, Radio, Well } from 'react-bootstrap';
+import Badge from 'src/common/components/Badge';
 import shortid from 'shortid';
 import { styled, SupersetClient, t, supersetTheme } from '@superset-ui/core';
 
@@ -94,7 +95,7 @@ DATASOURCE_TYPES_ARR.forEach(o => {
 function CollectionTabTitle({ title, collection }) {
   return (
     <div data-test={`collection-tab-${title}`}>
-      {title} <Badge>{collection ? collection.length : 0}</Badge>
+      {title} <Badge count={collection ? collection.length : 0} showZero />
     </div>
   );
 }

--- a/superset-frontend/src/profile/components/Security.tsx
+++ b/superset-frontend/src/profile/components/Security.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { Badge } from 'react-bootstrap';
+import Badge from 'src/common/components/Badge';
 import { t } from '@superset-ui/core';
 
 import Label from 'src/components/Label';
@@ -32,7 +32,7 @@ export default function Security({ user }: SecurityProps) {
     <div>
       <div className="roles">
         <h4>
-          {t('Roles')} <Badge>{Object.keys(user.roles).length}</Badge>
+          {t('Roles')} <Badge count={Object.keys(user.roles).length} showZero />
         </h4>
         {Object.keys(user.roles).map(role => (
           <Label key={role}>{role}</Label>
@@ -44,7 +44,7 @@ export default function Security({ user }: SecurityProps) {
           <div>
             <h4>
               {t('Databases')}{' '}
-              <Badge>{user.permissions.database_access.length}</Badge>
+              <Badge count={user.permissions.database_access.length} showZero />
             </h4>
             {user.permissions.database_access.map(role => (
               <Label key={role}>{role}</Label>
@@ -58,7 +58,10 @@ export default function Security({ user }: SecurityProps) {
           <div>
             <h4>
               {t('Datasets')}{' '}
-              <Badge>{user.permissions.datasource_access.length}</Badge>
+              <Badge
+                count={user.permissions.datasource_access.length}
+                showZero
+              />
             </h4>
             {user.permissions.datasource_access.map(role => (
               <Label key={role}>{role}</Label>

--- a/superset-frontend/stylesheets/less/cosmo/variables.less
+++ b/superset-frontend/stylesheets/less/cosmo/variables.less
@@ -751,24 +751,6 @@
 @well-bg: @gray-bg; // superset-var
 @well-border: darken(@well-bg, 7%);
 
-// == Badges
-//
-// ##
-
-@badge-color: @lightest; // superset-var
-// ** Linked badge text color on hover
-@badge-link-hover-color: @lightest; // superset-var
-@badge-bg: @brand-primary;
-
-// ** Badge text color in active nav link
-@badge-active-color: @link-color;
-// ** Badge background color in active nav link
-@badge-active-bg: @lightest; // superset-var
-
-@badge-font-weight: bold;
-@badge-line-height: 1;
-@badge-border-radius: 10px;
-
 // == Breadcrumbs
 //
 // ##

--- a/superset-frontend/stylesheets/less/cosmo/variables.less
+++ b/superset-frontend/stylesheets/less/cosmo/variables.less
@@ -751,6 +751,24 @@
 @well-bg: @gray-bg; // superset-var
 @well-border: darken(@well-bg, 7%);
 
+// == Badges
+//
+// ##
+
+@badge-color: @lightest; // superset-var
+// ** Linked badge text color on hover
+@badge-link-hover-color: @lightest; // superset-var
+@badge-bg: @brand-primary;
+
+// ** Badge text color in active nav link
+@badge-active-color: @link-color;
+// ** Badge background color in active nav link
+@badge-active-bg: @lightest; // superset-var
+
+@badge-font-weight: bold;
+@badge-line-height: 1;
+@badge-border-radius: 10px;
+
 // == Breadcrumbs
 //
 // ##


### PR DESCRIPTION
### SUMMARY
Move the Badge component from react-bootstrap to Antdesign and add the ability to change text color.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![badge-before](https://user-images.githubusercontent.com/60598000/100922223-4fbf6d80-34e6-11eb-95ad-6a1f4af5bfb0.png)
After:
![Screen Shot 2020-12-04 at 17 16 18](https://user-images.githubusercontent.com/60598000/101180782-aea2f500-3654-11eb-95f9-69bc9ed3b493.png)


### TEST PLAN
1. Log into Superset
2. Navigate to Datasets
3. Edit a dataset
4. Look for the badges for METRICS, COLUMNS, and CALCULATED COLUMNS

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
