### PR TITLE
feat: add modal to import datasets

### DIFF
--- a/superset-frontend/src/datasource/components/ImportModal/ImportModal.test.tsx
+++ b/superset-frontend/src/datasource/components/ImportModal/ImportModal.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { styledMount as mount } from 'spec/helpers/theming';
+import { ReactWrapper } from 'enzyme';
+
+import ImportDatasetModal from 'src/datasource/components/ImportModal';
+import Modal from 'src/common/components/Modal';
+
+const mockStore = configureStore([thunk]);
+const store = mockStore({});
+
+const requiredProps = {
+  addDangerToast: () => {},
+  addSuccessToast: () => {},
+  onDatasetImport: () => {},
+  show: true,
+  onHide: () => {},
+};
+
+describe('ImportDatasetModal', () => {
+  let wrapper: ReactWrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<ImportDatasetModal {...requiredProps} />, {
+      context: { store },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders', () => {
+    expect(wrapper.find(ImportDatasetModal)).toExist();
+  });
+
+  it('renders a Modal', () => {
+    expect(wrapper.find(Modal)).toExist();
+  });
+
+  it('renders "Import Dataset" header', () => {
+    expect(wrapper.find('h4').text()).toEqual('Import Dataset');
+  });
+
+  it('renders a label and a file input field', () => {
+    expect(wrapper.find('input[type="file"]')).toExist();
+    expect(wrapper.find('label')).toExist();
+  });
+
+  it('should attach the label to the input field', () => {
+    const id = 'datasetFile';
+    expect(wrapper.find('label').prop('htmlFor')).toBe(id);
+    expect(wrapper.find('input').prop('id')).toBe(id);
+  });
+
+  it('should render the close, import and cancel buttons', () => {
+    expect(wrapper.find('button')).toHaveLength(3);
+  });
+
+  it('should render the import button initially disabled', () => {
+    expect(wrapper.find('button[children="Import"]').prop('disabled')).toBe(
+      true,
+    );
+  });
+
+  it('should render the import button enabled when a file is selected', () => {
+    const file = new File([new ArrayBuffer(1)], 'dataset_export.zip');
+    wrapper.find('input').simulate('change', { target: { files: [file] } });
+
+    expect(wrapper.find('button[children="Import"]').prop('disabled')).toBe(
+      false,
+    );
+  });
+
+  it('should render password fields when needed for import', () => {
+    const wrapperWithPasswords = mount(
+      <ImportDatasetModal
+        {...requiredProps}
+        passwordFields={['datasets/examples.yaml']}
+      />,
+      {
+        context: { store },
+      },
+    );
+    expect(wrapperWithPasswords.find('input[type="password"]')).toExist();
+  });
+});

--- a/superset-frontend/src/datasource/components/ImportModal/index.tsx
+++ b/superset-frontend/src/datasource/components/ImportModal/index.tsx
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { FunctionComponent, useRef, useState } from 'react';
+import { t } from '@superset-ui/core';
+
+import Modal from 'src/common/components/Modal';
+import {
+  StyledIcon,
+  StyledInputContainer,
+} from 'src/views/CRUD/data/database/DatabaseModal';
+import { useSingleViewResource } from 'src/views/CRUD/hooks';
+import { DatasetObject } from 'src/views/CRUD/data/dataset/types';
+
+export interface ImportDatasetModalProps {
+  addDangerToast: (msg: string) => void;
+  addSuccessToast: (msg: string) => void;
+  onDatasetImport: () => void;
+  show: boolean;
+  onHide: () => void;
+  passwordFields?: string[];
+  setPasswordFields?: (passwordFields: string[]) => void;
+}
+
+const ImportDatasetModal: FunctionComponent<ImportDatasetModalProps> = ({
+  addDangerToast,
+  addSuccessToast,
+  onDatasetImport,
+  show,
+  onHide,
+  passwordFields = [],
+  setPasswordFields = () => {},
+}) => {
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [isHidden, setIsHidden] = useState<boolean>(true);
+  const [passwords, setPasswords] = useState<Record<string, string>>({});
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { importResource } = useSingleViewResource<DatasetObject>(
+    'dataset',
+    t('dataset'),
+    addDangerToast,
+  );
+
+  // Functions
+  const hide = () => {
+    setIsHidden(true);
+    onHide();
+  };
+
+  const clearModal = () => {
+    setUploadFile(null);
+    setPasswordFields([]);
+    setPasswords({});
+    if (fileInputRef && fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const onUpload = () => {
+    if (uploadFile === null) {
+      return;
+    }
+
+    importResource(uploadFile, passwords).then(result => {
+      if (result === true) {
+        // Success
+        addSuccessToast(t('The datasets have been imported'));
+        clearModal();
+        onDatasetImport();
+      } else if (result) {
+        // Need passwords
+        setPasswordFields(result);
+      } else {
+        // Failure
+        clearModal();
+      }
+    });
+  };
+
+  const changeFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target as HTMLInputElement;
+    setUploadFile((files && files[0]) || null);
+  };
+
+  const renderPasswordFields = () => {
+    if (passwordFields.length === 0) {
+      return null;
+    }
+
+    return (
+      <>
+        <h5>Database passwords</h5>
+        <StyledInputContainer>
+          <div className="helper">
+            {t(
+              'The password for the databases below is needed in order to ' +
+                'import them together with the datasets. Please note that the ' +
+                '"Secure Extra" and "Certificate" sections of ' +
+                'the database configuration are not present in export files, and ' +
+                'should be added manually after the import if they are needed.',
+            )}
+          </div>
+        </StyledInputContainer>
+        {passwordFields.map(fileName => (
+          <StyledInputContainer key={`password-for-${fileName}`}>
+            <div className="control-label">
+              {fileName}
+              <span className="required">*</span>
+            </div>
+            <input
+              name={`password-${fileName}`}
+              type="password"
+              value={passwords[fileName]}
+              onChange={event =>
+                setPasswords({ ...passwords, [fileName]: event.target.value })
+              }
+            />
+          </StyledInputContainer>
+        ))}
+      </>
+    );
+  };
+
+  // Show/hide
+  if (isHidden && show) {
+    setIsHidden(false);
+  }
+
+  return (
+    <Modal
+      name="dataset"
+      className="dataset-modal"
+      disablePrimaryButton={uploadFile === null}
+      onHandledPrimaryAction={onUpload}
+      onHide={hide}
+      primaryButtonName={t('Import')}
+      width="750px"
+      show={show}
+      title={
+        <h4>
+          <StyledIcon name="table" />
+          {t('Import Dataset')}
+        </h4>
+      }
+    >
+      <StyledInputContainer>
+        <div className="control-label">
+          <label htmlFor="datasetFile">
+            {t('File')}
+            <span className="required">*</span>
+          </label>
+        </div>
+        <input
+          ref={fileInputRef}
+          data-test="dataset-file-input"
+          name="datasetFile"
+          id="datasetFile"
+          type="file"
+          accept=".yaml,.json,.yml,.zip"
+          onChange={changeFile}
+        />
+      </StyledInputContainer>
+      {renderPasswordFields()}
+    </Modal>
+  );
+};
+
+export default ImportDatasetModal;

--- a/superset-frontend/src/datasource/components/ImportModal/index.tsx
+++ b/superset-frontend/src/datasource/components/ImportModal/index.tsx
@@ -109,7 +109,7 @@ const ImportDatasetModal: FunctionComponent<ImportDatasetModalProps> = ({
         <StyledInputContainer>
           <div className="helper">
             {t(
-              'The password for the databases below is needed in order to ' +
+              'The passwords for the databases below are needed in order to ' +
                 'import them together with the datasets. Please note that the ' +
                 '"Secure Extra" and "Certificate" sections of ' +
                 'the database configuration are not present in export files, and ' +

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
@@ -27,7 +27,7 @@ import { createErrorHandler } from 'src/views/CRUD/utils';
 
 type DatasetAddObject = {
   id: number;
-  databse: number;
+  database: number;
   schema: string;
   table_name: string;
 };

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -45,6 +45,8 @@ import TooltipWrapper from 'src/components/TooltipWrapper';
 import Icon from 'src/components/Icon';
 import FacePile from 'src/components/FacePile';
 import CertifiedIconWithTooltip from 'src/components/CertifiedIconWithTooltip';
+import ImportDatasetModal from 'src/datasource/components/ImportModal/index';
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 import AddDatasetModal from './AddDatasetModal';
 
 const PAGE_SIZE = 25;
@@ -113,6 +115,22 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
     datasetCurrentlyEditing,
     setDatasetCurrentlyEditing,
   ] = useState<Dataset | null>(null);
+
+  const [importingDataset, showImportModal] = useState<boolean>(false);
+  const [passwordFields, setPasswordFields] = useState<string[]>([]);
+
+  function openDatasetImportModal() {
+    showImportModal(true);
+  }
+
+  function closeDatasetImportModal() {
+    showImportModal(false);
+  }
+
+  const handleDatasetImport = () => {
+    showImportModal(false);
+    refreshData();
+  };
 
   const canEdit = hasPerm('can_edit');
   const canDelete = hasPerm('can_delete');
@@ -452,6 +470,14 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
     });
   }
 
+  if (isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT)) {
+    buttonArr.push({
+      name: <Icon name="import" />,
+      buttonStyle: 'link',
+      onClick: openDatasetImportModal,
+    });
+  }
+
   menuData.buttons = buttonArr;
 
   const closeDatasetDeleteModal = () => {
@@ -618,6 +644,16 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           );
         }}
       </ConfirmStatusChange>
+
+      <ImportDatasetModal
+        show={importingDataset}
+        onHide={closeDatasetImportModal}
+        addDangerToast={addDangerToast}
+        addSuccessToast={addSuccessToast}
+        onDatasetImport={handleDatasetImport}
+        passwordFields={passwordFields}
+        setPasswordFields={setPasswordFields}
+      />
     </>
   );
 };

--- a/superset-frontend/src/views/CRUD/data/dataset/types.ts
+++ b/superset-frontend/src/views/CRUD/data/dataset/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+type ColumnObject = {
+  id: number;
+  column_name: string;
+  type: string;
+  verbose_name?: string;
+  description?: string;
+  expression?: string;
+  filterable: boolean;
+  groupby: boolean;
+  is_active: boolean;
+  is_dttm: boolean;
+  python_date_format?: string;
+  uuid?: string;
+};
+
+type MetricObject = {
+  id: number;
+  expression?: string;
+  description?: string;
+  metric_name: string;
+  metric_type: string;
+  d3format?: string;
+  warning_text?: string;
+};
+
+export type DatasetObject = {
+  table_name?: string;
+  sql?: string;
+  filter_select_enabled?: boolean;
+  fetch_values_predicate?: string;
+  schema?: string;
+  description?: string;
+  main_dttm_col?: string;
+  offset?: number;
+  default_endpoint?: string;
+  cache_timeout?: number;
+  is_sqllab_view?: boolean;
+  template_params?: string;
+  owners: number[];
+  columns: ColumnObject[];
+  metrics: MetricObject[];
+  extra?: string;
+};

--- a/superset/databases/commands/importers/v1/__init__.py
+++ b/superset/databases/commands/importers/v1/__init__.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import urllib.parse
 from typing import Any, Dict, List, Optional
 
 from marshmallow import Schema, validate
@@ -48,11 +47,9 @@ class ImportDatabasesCommand(BaseCommand):
     """Import databases"""
 
     # pylint: disable=unused-argument
-    def __init__(
-        self, contents: Dict[str, str], *args: Any, **kwargs: Any,
-    ):
+    def __init__(self, contents: Dict[str, str], *args: Any, **kwargs: Any):
         self.contents = contents
-        self.passwords = kwargs.get("passwords") or {}
+        self.passwords: Dict[str, str] = kwargs.get("passwords") or {}
         self._configs: Dict[str, Any] = {}
 
     def _import_bundle(self, session: Session) -> None:
@@ -87,6 +84,14 @@ class ImportDatabasesCommand(BaseCommand):
     def validate(self) -> None:
         exceptions: List[ValidationError] = []
 
+        # load existing databases so we can apply the password validation
+        db_passwords = {
+            str(uuid): password
+            for uuid, password in db.session.query(
+                Database.uuid, Database.password
+            ).all()
+        }
+
         # verify that the metadata file is present and valid
         try:
             metadata: Optional[Dict[str, str]] = load_metadata(self.contents)
@@ -94,14 +99,20 @@ class ImportDatabasesCommand(BaseCommand):
             exceptions.append(exc)
             metadata = None
 
+        # validate databases and dataset
         for file_name, content in self.contents.items():
             prefix = file_name.split("/")[0]
             schema = schemas.get(f"{prefix}/")
             if schema:
                 try:
                     config = load_yaml(file_name, content)
+
+                    # populate passwords from the request or from existing DBs
                     if file_name in self.passwords:
                         config["password"] = self.passwords[file_name]
+                    elif prefix == "databases" and config["uuid"] in db_passwords:
+                        config["password"] = db_passwords[config["uuid"]]
+
                     schema.load(config)
                     self._configs[file_name] = config
                 except ValidationError as exc:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import json
 import logging
 from datetime import datetime
 from io import BytesIO
@@ -644,7 +645,13 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                 for file_name in bundle.namelist()
             }
 
-        command = ImportDatasetsCommand(contents)
+        passwords = (
+            json.loads(request.form["passwords"])
+            if "passwords" in request.form
+            else None
+        )
+
+        command = ImportDatasetsCommand(contents, passwords=passwords)
         try:
             command.run()
             return self.response(200, message="OK")

--- a/superset/datasets/commands/importers/dispatcher.py
+++ b/superset/datasets/commands/importers/dispatcher.py
@@ -46,12 +46,14 @@ class ImportDatasetsCommand(BaseCommand):
     # pylint: disable=unused-argument
     def __init__(self, contents: Dict[str, str], *args: Any, **kwargs: Any):
         self.contents = contents
+        self.args = args
+        self.kwargs = kwargs
 
     def run(self) -> None:
         # iterate over all commands until we find a version that can
         # handle the contents
         for version in command_versions:
-            command = version(self.contents)
+            command = version(self.contents, *self.args, **self.kwargs)
             try:
                 command.run()
                 return

--- a/superset/datasets/commands/importers/v0.py
+++ b/superset/datasets/commands/importers/v0.py
@@ -288,6 +288,8 @@ class ImportDatasetsCommand(BaseCommand):
         contents: Dict[str, str],
         sync_columns: bool = False,
         sync_metrics: bool = False,
+        *args: Any,
+        **kwargs: Any,
     ):
         self.contents = contents
         self._configs: Dict[str, Any] = {}

--- a/superset/datasets/commands/importers/v1/__init__.py
+++ b/superset/datasets/commands/importers/v1/__init__.py
@@ -35,6 +35,7 @@ from superset.databases.schemas import ImportV1DatabaseSchema
 from superset.datasets.commands.exceptions import DatasetImportError
 from superset.datasets.commands.importers.v1.utils import import_dataset
 from superset.datasets.schemas import ImportV1DatasetSchema
+from superset.models.core import Database
 
 schemas: Dict[str, Schema] = {
     "databases/": ImportV1DatabaseSchema(),
@@ -49,6 +50,7 @@ class ImportDatasetsCommand(BaseCommand):
     # pylint: disable=unused-argument
     def __init__(self, contents: Dict[str, str], *args: Any, **kwargs: Any):
         self.contents = contents
+        self.passwords: Dict[str, str] = kwargs.get("passwords") or {}
         self._configs: Dict[str, Any] = {}
 
     def _import_bundle(self, session: Session) -> None:
@@ -88,6 +90,14 @@ class ImportDatasetsCommand(BaseCommand):
     def validate(self) -> None:
         exceptions: List[ValidationError] = []
 
+        # load existing databases so we can apply the password validation
+        db_passwords = {
+            str(uuid): password
+            for uuid, password in db.session.query(
+                Database.uuid, Database.password
+            ).all()
+        }
+
         # verify that the metadata file is present and valid
         try:
             metadata: Optional[Dict[str, str]] = load_metadata(self.contents)
@@ -95,12 +105,20 @@ class ImportDatasetsCommand(BaseCommand):
             exceptions.append(exc)
             metadata = None
 
+        # validate datasets and databases
         for file_name, content in self.contents.items():
             prefix = file_name.split("/")[0]
             schema = schemas.get(f"{prefix}/")
             if schema:
                 try:
                     config = load_yaml(file_name, content)
+
+                    # populate passwords from the request or from existing DBs
+                    if file_name in self.passwords:
+                        config["password"] = self.passwords[file_name]
+                    elif prefix == "databases" and config["uuid"] in db_passwords:
+                        config["password"] = db_passwords[config["uuid"]]
+
                     schema.load(config)
                     self._configs[file_name] = config
                 except ValidationError as exc:

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -126,20 +126,20 @@ class DatasetRelatedObjectsResponse(Schema):
 
 class ImportV1ColumnSchema(Schema):
     column_name = fields.String(required=True)
-    verbose_name = fields.String()
+    verbose_name = fields.String(allow_none=True)
     is_dttm = fields.Boolean()
     is_active = fields.Boolean(allow_none=True)
     type = fields.String(required=True)
     groupby = fields.Boolean()
     filterable = fields.Boolean()
-    expression = fields.String()
+    expression = fields.String(allow_none=True)
     description = fields.String(allow_none=True)
     python_date_format = fields.String(allow_none=True)
 
 
 class ImportV1MetricSchema(Schema):
     metric_name = fields.String(required=True)
-    verbose_name = fields.String()
+    verbose_name = fields.String(allow_none=True)
     metric_type = fields.String(allow_none=True)
     expression = fields.String(required=True)
     description = fields.String(allow_none=True)
@@ -151,12 +151,12 @@ class ImportV1MetricSchema(Schema):
 class ImportV1DatasetSchema(Schema):
     table_name = fields.String(required=True)
     main_dttm_col = fields.String(allow_none=True)
-    description = fields.String()
-    default_endpoint = fields.String()
+    description = fields.String(allow_none=True)
+    default_endpoint = fields.String(allow_none=True)
     offset = fields.Integer()
-    cache_timeout = fields.Integer()
-    schema = fields.String()
-    sql = fields.String()
+    cache_timeout = fields.Integer(allow_none=True)
+    schema = fields.String(allow_none=True)
+    sql = fields.String(allow_none=True)
     params = fields.String(allow_none=True)
     template_params = fields.String(allow_none=True)
     filter_select_enabled = fields.Boolean()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Similar to https://github.com/apache/incubator-superset/pull/11884, this adds a modal to import datasets.

If the database doesn't exist and needs a password the user will be prompted for it; see the screenshot below.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

![Screenshot_2020-12-02 Superset](https://user-images.githubusercontent.com/1534870/100943740-a743e600-34b2-11eb-825f-f09695f3330a.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested importing virtual and physical datasets, both with the database already there as well as importing the database together with the dataset.

Added tests as well.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/incubator-superset/issues/11167
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
