### PR TITLE
fix: adjust width for non multi select inputs

### DIFF
--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -257,12 +257,14 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   ],
 };
 
-const inputTagStyles = {
-  background: 'none',
-  border: 'none',
-  outline: 'none',
-  padding: 0,
-  width: '100%',
+const inputTagStyles = (isMultiWithValue: boolean | undefined) => {
+  const styles = {
+    background: 'none',
+    border: 'none',
+    outline: 'none',
+    padding: 0,
+  };
+  return isMultiWithValue ? { ...styles, width: '100%' } : styles;
 };
 
 export type SelectComponentsType = Omit<
@@ -323,14 +325,14 @@ export const DEFAULT_COMPONENTS: SelectComponentsType = {
       selectProps: { isMulti, value, placeholder },
       getStyles,
     } = props;
-    const isMultiWithValue = isMulti && Array.isArray(value) && value.length;
+    const isMultiWithValue = isMulti && Array.isArray(value) && !!value.length;
     return (
       <Input
         {...props}
         placeholder={isMultiWithValue ? placeholder : undefined}
         css={getStyles('input', props)}
         autocomplete="chrome-off"
-        inputStyle={inputTagStyles}
+        inputStyle={inputTagStyles(isMultiWithValue)}
       />
     );
   },

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -257,14 +257,11 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   ],
 };
 
-const inputTagStyles = (isMultiWithValue: boolean | undefined) => {
-  const styles = {
-    background: 'none',
-    border: 'none',
-    outline: 'none',
-    padding: 0,
-  };
-  return isMultiWithValue ? { ...styles, width: '100%' } : styles;
+const INPUT_TAG_BASE_STYLES = {
+  background: 'none',
+  border: 'none',
+  outline: 'none',
+  padding: 0,
 };
 
 export type SelectComponentsType = Omit<
@@ -332,7 +329,11 @@ export const DEFAULT_COMPONENTS: SelectComponentsType = {
         placeholder={isMultiWithValue ? placeholder : undefined}
         css={getStyles('input', props)}
         autocomplete="chrome-off"
-        inputStyle={inputTagStyles(isMultiWithValue)}
+        inputStyle={
+          isMultiWithValue
+            ? { ...INPUT_TAG_BASE_STYLES, width: '100%' }
+            : INPUT_TAG_BASE_STYLES
+        }
       />
     );
   },


### PR DESCRIPTION
### SUMMARY
slight formatting fix for selects when used as filters on the CRUD pages for example that was introduced in https://github.com/apache/incubator-superset/pull/11732

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="1333" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/100959836-fa7a6080-34d3-11eb-8426-c3e0973b5064.png">


AFTER:
<img width="817" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/100959742-c737d180-34d3-11eb-9cca-b69578d79013.png">


### TEST PLAN
visual comparisons

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
