### PR TITLE
fix: Button storybook component size knob

### DIFF
--- a/superset-frontend/src/components/Button/Button.stories.jsx
+++ b/superset-frontend/src/components/Button/Button.stories.jsx
@@ -113,7 +113,7 @@ export const InteractiveButton = args => {
 
 InteractiveButton.args = {
   buttonStyle: STYLES.defaultValue,
-  size: SIZES.defaultValue,
+  buttonSize: SIZES.defaultValue,
   type: TYPES.defaultValue,
   target: TARGETS.defaultValue,
   href: HREFS.defaultValue,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The "Interactive" Button in Storybook wasn't changing size with the controls... because the knob was bound to an incorrect prop! This fixes that. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Tested in storybook. Now it works :D

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
