### PR TITLE
fix: Pull databaseIds for TabbedSqlEditor Component II

### DIFF
--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -32,6 +32,22 @@ import * as Actions from '../actions/sqlLab';
 import SqlEditor from './SqlEditor';
 import TabStatusIcon from './TabStatusIcon';
 
+
+import { makeApi } from '@superset-ui/core';
+import rison from 'rison';
+
+
+const getDatabasesIds = async () => {
+  const queryParams = rison.encode({});
+  const response = await makeApi({
+    method: 'GET',
+    endpoint: '/api/v1/database',
+  })(`q=${queryParams}`);
+
+  console.log(response.ids);
+  return response;
+};
+
 const propTypes = {
   actions: PropTypes.object.isRequired,
   defaultDbId: PropTypes.number,
@@ -76,6 +92,7 @@ class TabbedSqlEditors extends React.PureComponent {
       queriesArray: [],
       dataPreviewQueries: [],
       hideLeftBar: false,
+      databaseIds: getDatabasesIds(),
     };
     this.removeQueryEditor = this.removeQueryEditor.bind(this);
     this.renameTab = this.renameTab.bind(this);
@@ -164,7 +181,6 @@ class TabbedSqlEditors extends React.PureComponent {
       this.popNewTab();
     } else if (query.new || this.props.queryEditors.length === 0) {
       this.newQueryEditor();
-
       if (query.new) {
         window.history.replaceState({}, document.title, this.state.sqlLabUrl);
       }
@@ -240,11 +256,10 @@ class TabbedSqlEditors extends React.PureComponent {
   }
 
   newQueryEditor() {
+    console.log(this.state.databaseIds);
     queryCount += 1;
     const activeQueryEditor = this.activeQueryEditor();
-    const firstDbId = Math.min(
-      ...Object.values(this.props.databases).map(database => database.id),
-    );
+    const firstDbId = Math.min(this.state.databaseIds);
     const warning = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)
       ? ''
       : `${t(

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -34,11 +34,10 @@ import SqlEditor from './SqlEditor';
 import TabStatusIcon from './TabStatusIcon';
 
 const getDatabasesIds = async () => {
-  const queryParams = rison.encode({});
   const response = await makeApi({
     method: 'GET',
     endpoint: '/api/v1/database',
-  })(`q=${queryParams}`);
+  })();
 
   return response;
 };

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -38,7 +38,7 @@ const getDatabasesIds = async () => {
     endpoint: '/api/v1/database',
   })();
 
-  return response;
+  return response.ids;
 };
 
 const propTypes = {

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -24,18 +24,14 @@ import { Menu } from 'src/common/components';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import URI from 'urijs';
-import { styled, t } from '@superset-ui/core';
+import { makeApi, styled, t } from '@superset-ui/core';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 import { areArraysShallowEqual } from 'src/reduxUtils';
+import rison from 'rison';
 import * as Actions from '../actions/sqlLab';
 import SqlEditor from './SqlEditor';
 import TabStatusIcon from './TabStatusIcon';
-
-
-import { makeApi } from '@superset-ui/core';
-import rison from 'rison';
-
 
 const getDatabasesIds = async () => {
   const queryParams = rison.encode({});
@@ -44,7 +40,6 @@ const getDatabasesIds = async () => {
     endpoint: '/api/v1/database',
   })(`q=${queryParams}`);
 
-  console.log(response.ids);
   return response;
 };
 
@@ -256,7 +251,6 @@ class TabbedSqlEditors extends React.PureComponent {
   }
 
   newQueryEditor() {
-    console.log(this.state.databaseIds);
     queryCount += 1;
     const activeQueryEditor = this.activeQueryEditor();
     const firstDbId = Math.min(this.state.databaseIds);

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -28,7 +28,6 @@ import { makeApi, styled, t } from '@superset-ui/core';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 import { areArraysShallowEqual } from 'src/reduxUtils';
-import rison from 'rison';
 import * as Actions from '../actions/sqlLab';
 import SqlEditor from './SqlEditor';
 import TabStatusIcon from './TabStatusIcon';


### PR DESCRIPTION
### SUMMARY
DatabaseSelector is missing a default value whenever the user refreshes on an empty tab page in sqllab. Now we've added a request to get all the available databaseIds in the constructor.

fixes #11914

https://loom.com/share/3944f97db5f442858fd20635a1030c83
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
