### PR TITLE
style: WIP: Using the ThemeProvider instead of supersetTheme

### DIFF
--- a/superset-frontend/src/components/CertifiedIconWithTooltip.tsx
+++ b/superset-frontend/src/components/CertifiedIconWithTooltip.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { t, supersetTheme } from '@superset-ui/core';
+import { t, useTheme } from '@superset-ui/core';
 import Icon from 'src/components/Icon';
 import TooltipWrapper from 'src/components/TooltipWrapper';
 
@@ -32,6 +32,7 @@ function CertifiedIconWithTooltip({
   details,
   size = 24,
 }: CertifiedIconWithTooltipProps) {
+  const theme = useTheme();
   return (
     <TooltipWrapper
       label="certified-details"
@@ -43,7 +44,7 @@ function CertifiedIconWithTooltip({
       }
     >
       <Icon
-        color={supersetTheme.colors.primary.base}
+        color={theme.colors.primary.base}
         height={size}
         width={size}
         name="certified"

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useState, ReactNode } from 'react';
-import { styled, supersetTheme, t } from '@superset-ui/core';
+import { styled, useTheme, t } from '@superset-ui/core';
 import { noOp } from 'src/utils/common';
 import Modal from 'src/common/components/Modal';
 import Button from 'src/components/Button';
@@ -98,6 +98,8 @@ export default function ErrorAlert({
 
   const isExpandable = ['explore', 'sqllab'].includes(source);
 
+  const theme = useTheme();
+
   return (
     <ErrorAlertDiv level={level}>
       <div className="top-row">
@@ -105,7 +107,7 @@ export default function ErrorAlert({
           <Icon
             className="icon"
             name={level === 'error' ? 'error-solid' : 'warning-solid'}
-            color={supersetTheme.colors[level].base}
+            color={theme.colors[level].base}
           />
           <strong>{title}</strong>
         </LeftSideContent>
@@ -155,7 +157,7 @@ export default function ErrorAlert({
               <Icon
                 className="icon"
                 name={level === 'error' ? 'error-solid' : 'warning-solid'}
-                color={supersetTheme.colors[level].base}
+                color={theme.colors[level].base}
               />
               <div className="title">{title}</div>
             </div>

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -18,7 +18,7 @@
  */
 import React, { CSSProperties, ComponentType, ReactNode } from 'react';
 import { css, SerializedStyles, ClassNames } from '@emotion/core';
-import { supersetTheme } from '@superset-ui/core';
+import { useTheme } from '@superset-ui/core';
 import {
   Styles,
   Theme,
@@ -39,6 +39,8 @@ export const DEFAULT_CLASS_NAME_PREFIX = 'Select';
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
+
+const theme = useTheme();
 
 export type ThemeConfig = {
   borderRadius: number;
@@ -67,7 +69,7 @@ export type ThemeConfig = {
 export type PartialThemeConfig = RecursivePartial<ThemeConfig>;
 
 export const DEFAULT_THEME: PartialThemeConfig = {
-  borderRadius: supersetTheme.borderRadius,
+  borderRadius: theme.borderRadius,
   zIndex: 11,
   colors: {
     ...supersetColors,

--- a/superset-frontend/src/datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/datasource/DatasourceEditor.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Badge, Col, Radio, Well } from 'react-bootstrap';
 import shortid from 'shortid';
-import { styled, SupersetClient, t, supersetTheme } from '@superset-ui/core';
+import { styled, SupersetClient, t, useTheme } from '@superset-ui/core';
 
 import Tabs from 'src/common/components/Tabs';
 import Button from 'src/components/Button';
@@ -69,7 +69,7 @@ const FlexRowContainer = styled.div`
 `;
 
 const EditLockContainer = styled.div`
-  font-size: ${supersetTheme.typography.sizes.s}px;
+  font-size: ${({ theme }) => theme.typography.sizes.s}px;
   display: flex;
   align-items: center;
   a {
@@ -649,6 +649,7 @@ class DatasourceEditor extends React.PureComponent {
 
   renderSourceFieldset() {
     const { datasource } = this.state;
+    const theme = useTheme();
     return (
       <div>
         <div className="m-l-10 m-t-20 m-b-10">
@@ -791,7 +792,7 @@ class DatasourceEditor extends React.PureComponent {
           <EditLockContainer>
             <a href="#" onClick={this.onChangeEditMode}>
               <Icon
-                color={supersetTheme.colors.grayscale.base}
+                color={theme.colors.grayscale.base}
                 name={this.state.isEditMode ? 'lock-unlocked' : 'lock-locked'}
               />
             </a>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I happened to notice a few files were directly using the `supersetTheme` from `superset-ui` directly. It's better to use the theme inherited via the `ThemeProvider` at the top of the React apps, so that we can mutate/override/append that base `supersetTheme` at the provider level, and have all the react components inherit that theme properly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
(should be no visible change at this point)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
@junlincc and I will poke around to make sure nothing looks out of place. And CI should pass, of course.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
