### PR TITLE
fix(charts): screenshot API declaring an unnecessary rison arg

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -607,7 +607,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
 
     @expose("/<pk>/screenshot/<digest>/", methods=["GET"])
     @protect()
-    @rison(screenshot_query_schema)
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(log_to_statsd=False)


### PR DESCRIPTION
### SUMMARY
Fix chart screenshot API endpoint, issue has more detail

### ADDITIONAL INFORMATION
- [ ] Has associated issue: #11929
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
