### PR TITLE
fix: always fetch database list on bootstrap payload

### DIFF
--- a/superset/dao/base.py
+++ b/superset/dao/base.py
@@ -77,6 +77,19 @@ class BaseDAO:
         return query.all()
 
     @classmethod
+    def find_all(cls) -> List[Model]:
+        """
+        Get all that fit the `base_filter`
+        """
+        query = db.session.query(cls.model_cls)
+        if cls.base_filter:
+            data_model = SQLAInterface(cls.model_cls, db.session)
+            query = cls.base_filter(  # pylint: disable=not-callable
+                "id", data_model
+            ).apply(query, None)
+        return query.all()
+
+    @classmethod
     def create(cls, properties: Dict[str, Any], commit: bool = True) -> Model:
         """
         Generic for creating models

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -63,6 +63,7 @@ from superset.connectors.sqla.models import (
 )
 from superset.dashboards.commands.importers.v0 import ImportDashboardsCommand
 from superset.dashboards.dao import DashboardDAO
+from superset.databases.dao import DatabaseDAO
 from superset.databases.filters import DatabaseFilter
 from superset.exceptions import (
     CertificateException,
@@ -2720,17 +2721,16 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             .first()
         )
 
-        databases: Dict[int, Any] = {}
+        databases: Dict[int, Any] = {
+            database.id: {
+                k: v for k, v in database.to_json().items() if k in DATABASE_KEYS
+            }
+            for database in DatabaseDAO.find_all()
+        }
         queries: Dict[str, Any] = {}
 
         # These are unnecessary if sqllab backend persistence is disabled
         if is_feature_enabled("SQLLAB_BACKEND_PERSISTENCE"):
-            databases = {
-                database.id: {
-                    k: v for k, v in database.to_json().items() if k in DATABASE_KEYS
-                }
-                for database in db.session.query(Database).all()
-            }
             # return all user queries associated with existing SQL editors
             user_queries = (
                 db.session.query(Query)


### PR DESCRIPTION
There was this weird bug happening only when `SQLLAB_BACKEND_PERSISTENCE
= False` where if no database had been selected, there would be some
issue.

This makes sure that the store is populated consistently with the list
of database connections regardless of `SQLLAB_BACKEND_PERSISTENCE`. It
also uses the DAO to fetch database and will apply the RBAC-related
filters if any, the same way that the API does.

@dpgaspar @hughhhh @betodealmeida 