### PR TITLE
feat: alert/report execution log list view

### DIFF
--- a/superset-frontend/spec/javascripts/views/CRUD/alert/AlertList_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/alert/AlertList_spec.jsx
@@ -16,17 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import thunk from 'redux-thunk';
-import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import { styledMount as mount } from 'spec/helpers/theming';
-
-import AlertList from 'src/views/CRUD/alert/AlertList';
+import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
+import { Switch } from 'src/common/components/Switch';
 import ListView from 'src/components/ListView';
 import SubMenu from 'src/components/Menu/SubMenu';
-import { Switch } from 'src/common/components/Switch';
-import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
+import AlertList from 'src/views/CRUD/alert/AlertList';
 
 // store needed for withToasts(AlertList)
 const mockStore = configureStore([thunk]);
@@ -35,6 +34,7 @@ const store = mockStore({});
 const alertsEndpoint = 'glob:*/api/v1/report/?*';
 const alertEndpoint = 'glob:*/api/v1/report/*';
 const alertsInfoEndpoint = 'glob:*/api/v1/report/_info*';
+const alertsCreatedByEndpoint = 'glob:*/api/v1/report/related/created_by*';
 
 const mockalerts = [...new Array(3)].map((_, i) => ({
   active: true,
@@ -74,6 +74,7 @@ fetchMock.get(alertsEndpoint, {
 fetchMock.get(alertsInfoEndpoint, {
   permissions: ['can_delete', 'can_edit'],
 });
+fetchMock.get(alertsCreatedByEndpoint, { result: [] });
 fetchMock.put(alertEndpoint, { ...mockalerts[0], active: false });
 fetchMock.put(alertsEndpoint, { ...mockalerts[0], active: false });
 

--- a/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
@@ -88,8 +88,8 @@ describe('ExecutionLog', () => {
 
   it('fetches report/alert', () => {
     const callsQ = fetchMock.calls(/report\/1/);
-    expect(callsQ).toHaveLength(2);
-    expect(callsQ[1][0]).toMatchInlineSnapshot(
+    expect(callsQ).toHaveLength(4);
+    expect(callsQ[0][0]).toMatchInlineSnapshot(
       `"http://localhost/api/v1/report/1"`,
     );
   });

--- a/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import fetchMock from 'fetch-mock';
+import { styledMount as mount } from 'spec/helpers/theming';
+
+import ExecutionLog from 'src/views/CRUD/alert/ExecutionLog';
+import ListView from 'src/components/ListView';
+
+import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
+
+// store needed for withToasts(ExecutionLog)
+const mockStore = configureStore([thunk]);
+const store = mockStore({});
+
+const executionLogsEndpoint = 'glob:*/api/v1/report/*/log*';
+const reportEndpoint = 'glob:*/api/v1/report/*';
+
+fetchMock.delete(executionLogsEndpoint, {});
+
+const mockannotations = [...new Array(3)].map((_, i) => ({
+  end_dttm: new Date().toISOString,
+  error_message: `report ${i} error message`,
+  id: i,
+  scheduled_dttm: new Date().toISOString,
+  start_dttm: new Date().toISOString,
+  state: 'Success',
+  value: `report ${i} value`,
+}));
+
+fetchMock.get(executionLogsEndpoint, {
+  ids: [2, 0, 1],
+  result: mockannotations,
+  count: 3,
+});
+
+fetchMock.get(reportEndpoint, {
+  id: 1,
+  result: { name: 'Test 0' },
+});
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
+  useParams: () => ({ alertId: '1' }),
+}));
+
+async function mountAndWait(props) {
+  const mounted = mount(<ExecutionLog {...props} />, {
+    context: { store },
+  });
+  await waitForComponentToPaint(mounted);
+
+  return mounted;
+}
+
+describe('ExecutionLog', () => {
+  let wrapper;
+
+  beforeAll(async () => {
+    wrapper = await mountAndWait();
+  });
+
+  it('renders', () => {
+    expect(wrapper.find(ExecutionLog)).toExist();
+  });
+
+  it('renders a ListView', () => {
+    expect(wrapper.find(ListView)).toExist();
+  });
+
+  it('fetches report/alert', () => {
+    const callsQ = fetchMock.calls(/report\/1/);
+    expect(callsQ).toHaveLength(2);
+    expect(callsQ[1][0]).toMatchInlineSnapshot(
+      `"http://localhost/api/v1/report/1"`,
+    );
+  });
+
+  it('fetches execution logs', () => {
+    const callsQ = fetchMock.calls(/report\/1\/log/);
+    expect(callsQ).toHaveLength(1);
+    expect(callsQ[0][0]).toMatchInlineSnapshot(
+      `"http://localhost/api/v1/report/1/log/?q=(order_column:start_dttm,order_direction:desc,page:0,page_size:25)"`,
+    );
+  });
+});

--- a/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/alert/ExecutionLog_spec.jsx
@@ -16,16 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import thunk from 'redux-thunk';
-import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import { styledMount as mount } from 'spec/helpers/theming';
-
-import ExecutionLog from 'src/views/CRUD/alert/ExecutionLog';
-import ListView from 'src/components/ListView';
-
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
+import ListView from 'src/components/ListView';
+import ExecutionLog from 'src/views/CRUD/alert/ExecutionLog';
 
 // store needed for withToasts(ExecutionLog)
 const mockStore = configureStore([thunk]);
@@ -63,9 +62,11 @@ jest.mock('react-router-dom', () => ({
 }));
 
 async function mountAndWait(props) {
-  const mounted = mount(<ExecutionLog {...props} />, {
-    context: { store },
-  });
+  const mounted = mount(
+    <Provider store={store}>
+      <ExecutionLog {...props} />
+    </Provider>,
+  );
   await waitForComponentToPaint(mounted);
 
   return mounted;
@@ -88,8 +89,8 @@ describe('ExecutionLog', () => {
 
   it('fetches report/alert', () => {
     const callsQ = fetchMock.calls(/report\/1/);
-    expect(callsQ).toHaveLength(4);
-    expect(callsQ[0][0]).toMatchInlineSnapshot(
+    expect(callsQ).toHaveLength(2);
+    expect(callsQ[1][0]).toMatchInlineSnapshot(
       `"http://localhost/api/v1/report/1"`,
     );
   });

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -29,6 +29,7 @@ import ErrorBoundary from 'src/components/ErrorBoundary';
 import Menu from 'src/components/Menu/Menu';
 import FlashProvider from 'src/components/FlashProvider';
 import AlertList from 'src/views/CRUD/alert/AlertList';
+import ExecutionLog from 'src/views/CRUD/alert/ExecutionLog';
 import AnnotationLayersList from 'src/views/CRUD/annotationlayers/AnnotationLayersList';
 import AnnotationList from 'src/views/CRUD/annotation/AnnotationList';
 import ChartList from 'src/views/CRUD/chart/ChartList';
@@ -133,6 +134,16 @@ const App = () => (
               <Route path="/report/list/">
                 <ErrorBoundary>
                   <AlertList user={user} isReportEnabled />
+                </ErrorBoundary>
+              </Route>
+              <Route path="/alert/:alertId/log">
+                <ErrorBoundary>
+                  <ExecutionLog user={user} />
+                </ErrorBoundary>
+              </Route>
+              <Route path="/report/:alertId/log">
+                <ErrorBoundary>
+                  <ExecutionLog user={user} isReportEnabled />
                 </ErrorBoundary>
               </Route>
             </Switch>

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -17,25 +17,23 @@
  * under the License.
  */
 
-import React, { useMemo, useEffect } from 'react';
-
 import { t } from '@superset-ui/core';
-import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
-import Button from 'src/components/Button';
-import Icon, { IconName } from 'src/components/Icon';
+import React, { useEffect, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Switch } from 'src/common/components/Switch';
-import AlertStatusIcon from 'src/views/CRUD/alert/components/AlertStatusIcon';
+import Button from 'src/components/Button';
 import FacePile from 'src/components/FacePile';
-import ListView, { Filters, FilterOperators } from 'src/components/ListView';
+import Icon, { IconName } from 'src/components/Icon';
+import ListView, { FilterOperators, Filters } from 'src/components/ListView';
+import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
-import { createFetchRelated, createErrorHandler } from 'src/views/CRUD/utils';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
-
+import AlertStatusIcon from 'src/views/CRUD/alert/components/AlertStatusIcon';
 import {
   useListViewResource,
-  useSingleViewResource,
+  useSingleViewResource
 } from 'src/views/CRUD/hooks';
-
+import { createErrorHandler, createFetchRelated } from 'src/views/CRUD/utils';
 import { AlertObject } from './types';
 
 const PAGE_SIZE = 25;
@@ -105,9 +103,6 @@ function AlertList({
     refreshData();
   }, [isReportEnabled]);
 
-  const gotoExecutionLog = (id: number, type: string) => {
-    window.location.href = `/${type.toLowerCase()}/${id}/log`;
-  };
   const columns = useMemo(
     () => [
       {
@@ -172,10 +167,11 @@ function AlertList({
       },
       {
         Cell: ({ row: { original } }: any) => {
+          const history = useHistory();
           const handleEdit = () => {}; // handleAnnotationEdit(original);
           const handleDelete = () => {}; // setAlertCurrentlyDeleting(original);
           const hanldGotoExecutionLog = () =>
-            gotoExecutionLog(original.id, original.type);
+            history.push(`/${original.type.toLowerCase()}/${original.id}/log`);
 
           const actions = [
             canEdit

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -31,7 +31,7 @@ import withToasts from 'src/messageToasts/enhancers/withToasts';
 import AlertStatusIcon from 'src/views/CRUD/alert/components/AlertStatusIcon';
 import {
   useListViewResource,
-  useSingleViewResource,
+  useSingleViewResource
 } from 'src/views/CRUD/hooks';
 import { createErrorHandler, createFetchRelated } from 'src/views/CRUD/utils';
 import { AlertObject } from './types';
@@ -170,7 +170,7 @@ function AlertList({
           const history = useHistory();
           const handleEdit = () => {}; // handleAnnotationEdit(original);
           const handleDelete = () => {}; // setAlertCurrentlyDeleting(original);
-          const hanldeGotoExecutionLog = () =>
+          const handleGotoExecutionLog = () =>
             history.push(`/${original.type.toLowerCase()}/${original.id}/log`);
 
           const actions = [
@@ -180,7 +180,7 @@ function AlertList({
                   tooltip: t('Execution Log'),
                   placement: 'bottom',
                   icon: 'note' as IconName,
-                  onClick: hanldeGotoExecutionLog,
+                  onClick: handleGotoExecutionLog,
                 }
               : null,
             canEdit

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -23,18 +23,19 @@ import { useHistory } from 'react-router-dom';
 import { Switch } from 'src/common/components/Switch';
 import Button from 'src/components/Button';
 import FacePile from 'src/components/FacePile';
-import Icon, { IconName } from 'src/components/Icon';
+import { IconName } from 'src/components/Icon';
 import ListView, { FilterOperators, Filters } from 'src/components/ListView';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
 import SubMenu, { SubMenuProps } from 'src/components/Menu/SubMenu';
 import withToasts from 'src/messageToasts/enhancers/withToasts';
 import AlertStatusIcon from 'src/views/CRUD/alert/components/AlertStatusIcon';
+import RecipientIcon from 'src/views/CRUD/alert/components/RecipientIcon';
 import {
   useListViewResource,
-  useSingleViewResource
+  useSingleViewResource,
 } from 'src/views/CRUD/hooks';
 import { createErrorHandler, createFetchRelated } from 'src/views/CRUD/utils';
-import { AlertObject } from './types';
+import { AlertObject, AlertState } from './types';
 
 const PAGE_SIZE = 25;
 
@@ -126,7 +127,7 @@ function AlertList({
           },
         }: any) =>
           recipients.map((r: any) => (
-            <Icon key={r.id} name={r.type as IconName} />
+            <RecipientIcon key={r.id} type={r.type} />
           )),
         accessor: 'recipients',
         Header: t('Notification Method'),
@@ -264,9 +265,11 @@ function AlertList({
         operator: FilterOperators.equals,
         unfilteredLabel: 'Any',
         selects: [
-          { label: t('Success'), value: 'Success' },
-          { label: t('Working'), value: 'Working' },
-          { label: t('Error'), value: 'Error' },
+          { label: t(`${AlertState.success}`), value: AlertState.success },
+          { label: t(`${AlertState.working}`), value: AlertState.working },
+          { label: t(`${AlertState.error}`), value: AlertState.error },
+          { label: t(`${AlertState.noop}`), value: AlertState.noop },
+          { label: t(`${AlertState.grace}`), value: AlertState.grace },
         ],
       },
       {

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -174,16 +174,17 @@ function AlertList({
         Cell: ({ row: { original } }: any) => {
           const handleEdit = () => {}; // handleAnnotationEdit(original);
           const handleDelete = () => {}; // setAlertCurrentlyDeleting(original);
-          const hanldView = () => gotoExecutionLog(original.id, original.type);
+          const hanldGotoExecutionLog = () =>
+            gotoExecutionLog(original.id, original.type);
 
           const actions = [
             canEdit
               ? {
-                  label: 'preview-action',
+                  label: 'execution-log-action',
                   tooltip: t('Execution Log'),
                   placement: 'bottom',
                   icon: 'note' as IconName,
-                  onClick: hanldView,
+                  onClick: hanldGotoExecutionLog,
                 }
               : null,
             canEdit

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -31,7 +31,7 @@ import withToasts from 'src/messageToasts/enhancers/withToasts';
 import AlertStatusIcon from 'src/views/CRUD/alert/components/AlertStatusIcon';
 import {
   useListViewResource,
-  useSingleViewResource
+  useSingleViewResource,
 } from 'src/views/CRUD/hooks';
 import { createErrorHandler, createFetchRelated } from 'src/views/CRUD/utils';
 import { AlertObject } from './types';

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -310,6 +310,49 @@ function AlertList({
         operator: FilterOperators.equals,
         unfilteredLabel: 'Any',
         selects: [
+          { label: t('Ok'), value: 'ok' },
+          { label: t('Alerting'), value: 'alerting' },
+          { label: t('Failed'), value: 'failed' },
+        ],
+      },
+      {
+        Header: t('Search'),
+        id: 'name',
+        input: 'search',
+        operator: 'ct',
+      },
+    ],
+    [],
+  );
+
+  const filters: Filters = useMemo(
+    () => [
+      {
+        Header: t('Created By'),
+        id: 'created_by',
+        input: 'select',
+        operator: 'rel_o_m',
+        unfilteredLabel: 'All',
+        fetchSelects: createFetchRelated(
+          'report',
+          'created_by',
+          createErrorHandler(errMsg =>
+            t(
+              'An error occurred while fetching dataset datasource values: %s',
+              errMsg,
+            ),
+          ),
+          user.userId,
+        ),
+        paginate: true,
+      },
+      {
+        Header: t('Status'),
+        id: 'last_state',
+        input: 'select',
+        operator: 'eq',
+        unfilteredLabel: 'Any',
+        selects: [
           { label: t('Success'), value: 'Success' },
           { label: t('Working'), value: 'Working' },
           { label: t('Error'), value: 'Error' },

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -170,7 +170,7 @@ function AlertList({
           const history = useHistory();
           const handleEdit = () => {}; // handleAnnotationEdit(original);
           const handleDelete = () => {}; // setAlertCurrentlyDeleting(original);
-          const hanldGotoExecutionLog = () =>
+          const hanldeGotoExecutionLog = () =>
             history.push(`/${original.type.toLowerCase()}/${original.id}/log`);
 
           const actions = [
@@ -180,7 +180,7 @@ function AlertList({
                   tooltip: t('Execution Log'),
                   placement: 'bottom',
                   icon: 'note' as IconName,
-                  onClick: hanldGotoExecutionLog,
+                  onClick: hanldeGotoExecutionLog,
                 }
               : null,
             canEdit

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -19,7 +19,7 @@
 
 import { styled, t } from '@superset-ui/core';
 import moment from 'moment';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import ListView from 'src/components/ListView';
 import SubMenu from 'src/components/Menu/SubMenu';
@@ -73,9 +73,11 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
     addDangerToast,
   );
 
-  if (alertId !== null && !alertLoading) {
-    fetchResource(alertId);
-  }
+  useEffect(() => {
+    if (alertId !== null && !alertLoading) {
+      fetchResource(alertId);
+    }
+  }, [alertId]);
 
   const initialSort = [{ id: 'start_dttm', desc: true }];
   const columns = useMemo(

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useMemo, useEffect, useCallback, useState } from 'react';
+import { useParams, Link, useHistory } from 'react-router-dom';
+import moment from 'moment';
+import { styled, t, SupersetClient } from '@superset-ui/core';
+
+import AlertStatusIcon from 'src/views/CRUD/alert/components/AlertStatusIcon';
+import ListView from 'src/components/ListView';
+import SubMenu from 'src/components/Menu/SubMenu';
+import getClientErrorObject from 'src/utils/getClientErrorObject';
+import withToasts from 'src/messageToasts/enhancers/withToasts';
+import { fDuration } from 'src/modules/dates';
+import { useListViewResource } from 'src/views/CRUD/hooks';
+
+import { LogObject } from './types';
+
+const PAGE_SIZE = 25;
+
+interface ExecutionLogProps {
+  addDangerToast: (msg: string) => void;
+  addSuccessToast: (msg: string) => void;
+  isReportEnabled: boolean;
+}
+
+function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
+  const { alertId }: any = useParams();
+  const title = isReportEnabled ? t('Report') : t('Alert');
+  const {
+    state: { loading, resourceCount: LogCount, resourceCollection: logs },
+    fetchData,
+  } = useListViewResource<LogObject>(
+    `report/${alertId}/log`,
+    t('log'),
+    addDangerToast,
+    false,
+  );
+  const [alertName, setAlertName] = useState<string>('');
+  const StyledHeader = styled.div`
+    display: flex;
+    flex-direction: row;
+
+    a,
+    Link {
+      margin-left: 16px;
+      font-size: 12px;
+      font-weight: normal;
+      text-decoration: underline;
+    }
+  `;
+
+  let hasHistory = true;
+
+  try {
+    useHistory();
+  } catch (err) {
+    // If error is thrown, we know not to use <Link> in render
+    hasHistory = false;
+  }
+
+  const fetchAlert = useCallback(
+    async function fetchAlert() {
+      try {
+        const response = await SupersetClient.get({
+          endpoint: `/api/v1/report/${alertId}`,
+        });
+        setAlertName(response.json.result.name);
+      } catch (response) {
+        await getClientErrorObject(response).then(({ message }: any) => {
+          addDangerToast(message || t('Sorry, An error occurred'));
+        });
+      }
+    },
+    [alertId],
+  );
+
+  useEffect(() => {
+    fetchAlert();
+  }, [fetchAlert]);
+
+  const initialSort = [{ id: 'start_dttm', desc: true }];
+  const columns = useMemo(
+    () => [
+      {
+        Cell: ({
+          row: {
+            original: { state },
+          },
+        }: any) => <AlertStatusIcon state={state} />,
+        accessor: 'state',
+        Header: t('State'),
+        size: 'xs',
+        disableSortBy: true,
+      },
+      {
+        accessor: 'scheduled_dttm',
+        Header: t('Scheduled at'),
+      },
+      {
+        Cell: ({
+          row: {
+            original: { start_dttm: startDttm },
+          },
+        }: any) => moment(new Date(startDttm)).format('ll'),
+        Header: t('Start At'),
+        accessor: 'start_dttm',
+      },
+      {
+        Cell: ({
+          row: {
+            original: { start_dttm: startDttm, end_dttm: endDttm },
+          },
+        }: any) => fDuration(endDttm - startDttm),
+        Header: t('Duration'),
+        disableSortBy: true,
+      },
+      {
+        accessor: 'value',
+        Header: t('Value'),
+      },
+      {
+        accessor: 'error_message',
+        Header: t('Error Message'),
+      },
+    ],
+    [],
+  );
+  const path = `/${isReportEnabled ? 'report' : 'alert'}/list/`;
+  return (
+    <>
+      <SubMenu
+        name={
+          <StyledHeader>
+            <span>{t(`${title} ${alertName}`)}</span>
+            <span>
+              {hasHistory ? (
+                <Link to={path}>Back to all</Link>
+              ) : (
+                <a href={path}>Back to all</a>
+              )}
+            </span>
+          </StyledHeader>
+        }
+      />
+      <ListView<LogObject>
+        className="execution-log-list-view"
+        columns={columns}
+        count={LogCount}
+        data={logs}
+        fetchData={fetchData}
+        initialSort={initialSort}
+        loading={loading}
+        pageSize={PAGE_SIZE}
+      />
+    </>
+  );
+}
+
+export default withToasts(ExecutionLog);

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -28,7 +28,7 @@ import { fDuration } from 'src/modules/dates';
 import AlertStatusIcon from 'src/views/CRUD/alert/components/AlertStatusIcon';
 import {
   useListViewResource,
-  useSingleViewResource
+  useSingleViewResource,
 } from 'src/views/CRUD/hooks';
 import { AlertObject, LogObject } from './types';
 

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -19,7 +19,7 @@
 
 import { styled, t } from '@superset-ui/core';
 import moment from 'moment';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import ListView from 'src/components/ListView';
 import SubMenu from 'src/components/Menu/SubMenu';
@@ -73,12 +73,8 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
     addDangerToast,
   );
 
-  const [alert, setAlert] = useState<AlertObject | null>(null);
-
-  if (alertId !== null && !alert && !alertLoading) {
-    fetchResource(alertId).then(() => {
-      setAlert(alertResource);
-    });
+  if (alertId !== null && !alertLoading) {
+    fetchResource(alertId);
   }
 
   const initialSort = [{ id: 'start_dttm', desc: true }];
@@ -135,7 +131,7 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
         name={
           <StyledHeader>
             <span>
-              {t(`${alert?.type}`)} {alert?.name}
+              {t(`${alertResource?.type}`)} {alertResource?.name}
             </span>
             <span>
               <Link to={path}>Back to all</Link>

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -42,7 +42,6 @@ interface ExecutionLogProps {
 
 function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
   const { alertId }: any = useParams();
-  const title = isReportEnabled ? t('Report') : t('Alert');
   const {
     state: { loading, resourceCount: LogCount, resourceCollection: logs },
     fetchData,
@@ -53,6 +52,9 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
     false,
   );
   const [alertName, setAlertName] = useState<string>('');
+  const [executionLogType, setExecutionLogType] = useState<'Report' | 'Alert'>(
+    'Report',
+  );
   const StyledHeader = styled.div`
     display: flex;
     flex-direction: row;
@@ -82,6 +84,7 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
           endpoint: `/api/v1/report/${alertId}`,
         });
         setAlertName(response.json.result.name);
+        setExecutionLogType(response.json.result.type);
       } catch (response) {
         await getClientErrorObject(response).then(({ message }: any) => {
           addDangerToast(message || t('Sorry, An error occurred'));
@@ -148,7 +151,9 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
       <SubMenu
         name={
           <StyledHeader>
-            <span>{t(`${title} ${alertName}`)}</span>
+            <span>
+              {t(`${executionLogType}`)} {alertName}
+            </span>
             <span>
               {hasHistory ? (
                 <Link to={path}>Back to all</Link>

--- a/superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { t, styled } from '@superset-ui/core';
+
+import Icon, { IconName } from 'src/components/Icon';
+import { Tooltip } from 'src/common/components/Tooltip';
+
+const StatusIcon = styled(Icon)<{ status: string }>`
+  color: ${({ status, theme }) => {
+    switch (status) {
+      case 'Working':
+        return theme.colors.alert.base;
+      case 'Error':
+        return theme.colors.error.base;
+      case 'Success':
+        return theme.colors.success.base;
+      default:
+        return theme.colors.grayscale.base;
+    }
+  }};
+`;
+
+export default function AlertStatusIcon({ state }: { state: string }) {
+  const lastStateConfig = {
+    name: '',
+    label: '',
+    status: '',
+  };
+  switch (state) {
+    case 'Success':
+      lastStateConfig.name = 'check';
+      lastStateConfig.label = t('Success');
+      lastStateConfig.status = 'Success';
+      break;
+    case 'Working':
+      lastStateConfig.name = 'exclamation';
+      lastStateConfig.label = t('Working');
+      lastStateConfig.status = 'Working';
+      break;
+    case 'Error':
+      lastStateConfig.name = 'x-small';
+      lastStateConfig.label = t('Error');
+      lastStateConfig.status = 'Error';
+      break;
+    default:
+      lastStateConfig.name = 'exclamation';
+      lastStateConfig.label = t('Working');
+      lastStateConfig.status = 'Working';
+  }
+  return (
+    <Tooltip title={lastStateConfig.label} placement="bottom">
+      <StatusIcon
+        name={lastStateConfig.name as IconName}
+        status={lastStateConfig.status}
+      />
+    </Tooltip>
+  );
+}

--- a/superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/AlertStatusIcon.tsx
@@ -16,20 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { styled, t } from '@superset-ui/core';
 import React from 'react';
-import { t, styled } from '@superset-ui/core';
-
-import Icon, { IconName } from 'src/components/Icon';
 import { Tooltip } from 'src/common/components/Tooltip';
+import Icon, { IconName } from 'src/components/Icon';
+import { AlertState } from '../types';
 
 const StatusIcon = styled(Icon)<{ status: string }>`
   color: ${({ status, theme }) => {
     switch (status) {
-      case 'Working':
+      case AlertState.working:
         return theme.colors.alert.base;
-      case 'Error':
+      case AlertState.error:
         return theme.colors.error.base;
-      case 'Success':
+      case AlertState.success:
         return theme.colors.success.base;
       default:
         return theme.colors.grayscale.base;
@@ -44,25 +44,25 @@ export default function AlertStatusIcon({ state }: { state: string }) {
     status: '',
   };
   switch (state) {
-    case 'Success':
+    case AlertState.success:
       lastStateConfig.name = 'check';
-      lastStateConfig.label = t('Success');
-      lastStateConfig.status = 'Success';
+      lastStateConfig.label = t(`${AlertState.success}`);
+      lastStateConfig.status = AlertState.success;
       break;
-    case 'Working':
+    case AlertState.working:
       lastStateConfig.name = 'exclamation';
-      lastStateConfig.label = t('Working');
-      lastStateConfig.status = 'Working';
+      lastStateConfig.label = t(`${AlertState.working}`);
+      lastStateConfig.status = AlertState.working;
       break;
-    case 'Error':
+    case AlertState.error:
       lastStateConfig.name = 'x-small';
-      lastStateConfig.label = t('Error');
-      lastStateConfig.status = 'Error';
+      lastStateConfig.label = t(`${AlertState.error}`);
+      lastStateConfig.status = AlertState.error;
       break;
     default:
       lastStateConfig.name = 'exclamation';
-      lastStateConfig.label = t('Working');
-      lastStateConfig.status = 'Working';
+      lastStateConfig.label = t(`${AlertState.working}`);
+      lastStateConfig.status = AlertState.working;
   }
   return (
     <Tooltip title={lastStateConfig.label} placement="bottom">

--- a/superset-frontend/src/views/CRUD/alert/components/RecipientIcon.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/RecipientIcon.tsx
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t } from '@superset-ui/core';
+import React from 'react';
+import { Tooltip } from 'src/common/components/Tooltip';
+import Icon, { IconName } from 'src/components/Icon';
+import { RecipientIconName } from '../types';
+
+export default function RecipientIcon({ type }: { type: string }) {
+  const recipientIconConfig = {
+    name: '',
+    label: '',
+  };
+  switch (type) {
+    case RecipientIconName.email:
+      recipientIconConfig.name = 'email';
+      recipientIconConfig.label = t(`${RecipientIconName.email}`);
+      break;
+    case RecipientIconName.slack:
+      recipientIconConfig.name = 'slack';
+      recipientIconConfig.label = t(`${RecipientIconName.slack}`);
+      break;
+    default:
+      recipientIconConfig.name = '';
+      recipientIconConfig.label = '';
+  }
+  return recipientIconConfig.name.length ? (
+    <Tooltip title={recipientIconConfig.label} placement="bottom">
+      <Icon name={recipientIconConfig.name as IconName} />
+    </Tooltip>
+  ) : null;
+}

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -51,6 +51,14 @@ export type LogObject = {
   id: number;
   scheduled_dttm: string;
   start_dttm: string;
-  state: string;
+  state: 'Success' | 'Working' | 'Error' | 'Not triggered' | 'On Grace';
   value: string;
 };
+
+export enum AlertState {
+  success = 'Success',
+  working = 'Working',
+  error = 'Error',
+  noop = 'Not triggered',
+  grace = 'On Grace',
+}

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -38,7 +38,7 @@ export type AlertObject = {
   created_on?: string;
   id?: number;
   last_eval_dttm?: number;
-  last_state?: string;
+  last_state?: 'Success' | 'Working' | 'Error' | 'Not triggered' | 'On Grace';
   name?: string;
   owners?: Array<Owner>;
   recipients?: recipients;
@@ -51,7 +51,7 @@ export type LogObject = {
   id: number;
   scheduled_dttm: string;
   start_dttm: string;
-  state: 'Success' | 'Working' | 'Error' | 'Not triggered' | 'On Grace';
+  state: string;
   value: string;
 };
 
@@ -61,4 +61,9 @@ export enum AlertState {
   error = 'Error',
   noop = 'Not triggered',
   grace = 'On Grace',
+}
+
+export enum RecipientIconName {
+  email = 'Email',
+  slack = 'Slack',
 }

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -44,3 +44,13 @@ export type AlertObject = {
   recipients?: recipients;
   type?: string;
 };
+
+export type LogObject = {
+  end_dttm: string;
+  error_message: string;
+  id: number;
+  scheduled_dttm: string;
+  start_dttm: string;
+  state: string;
+  value: string;
+};

--- a/superset/reports/logs/api.py
+++ b/superset/reports/logs/api.py
@@ -50,6 +50,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
     ]
     list_columns = [
         "id",
+        "scheduled_dttm",
         "end_dttm",
         "start_dttm",
         "value",

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -71,7 +71,7 @@ class AlertObservationModelView(
 class AlertReportModelView(SupersetModelView):
     datamodel = SQLAInterface(ReportSchedule)
     route_base = "/report"
-    include_route_methods = RouteMethod.CRUD_SET
+    include_route_methods = RouteMethod.CRUD_SET | {"log"}
 
     @expose("/list/")
     @has_access
@@ -84,11 +84,22 @@ class AlertReportModelView(SupersetModelView):
 
         return super().render_app_template()
 
+    @expose("/<pk>/log/", methods=["GET"])
+    @has_access
+    def log(self, pk: int) -> FlaskResponse:  # pylint: disable=unused-argument
+        if not (
+            is_feature_enabled("ENABLE_REACT_CRUD_VIEWS")
+            and is_feature_enabled("SIP_34_ALERTS_UI")
+        ):
+            return super().list()
+
+        return super().render_app_template()
+
 
 class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
     datamodel = SQLAInterface(Alert)
     route_base = "/alert"
-    include_route_methods = RouteMethod.CRUD_SET
+    include_route_methods = RouteMethod.CRUD_SET | {"log"}
 
     list_columns = (
         "label",
@@ -189,6 +200,17 @@ class AlertModelView(SupersetModelView):  # pylint: disable=too-many-ancestors
     @expose("/list/")
     @has_access
     def list(self) -> FlaskResponse:
+        if not (
+            is_feature_enabled("ENABLE_REACT_CRUD_VIEWS")
+            and is_feature_enabled("SIP_34_ALERTS_UI")
+        ):
+            return super().list()
+
+        return super().render_app_template()
+
+    @expose("/<pk>/log/", methods=["GET"])
+    @has_access
+    def log(self, pk: int) -> FlaskResponse:  # pylint: disable=unused-argument
         if not (
             is_feature_enabled("ENABLE_REACT_CRUD_VIEWS")
             and is_feature_enabled("SIP_34_ALERTS_UI")


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- implement execution log for each alert/report  
- `Back to all` redirect back to alert/report list

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Alert Execution Log
![Screen Shot 2020-12-08 at 2 31 39 PM](https://user-images.githubusercontent.com/5705598/101549290-43ae3280-3962-11eb-8eb5-b4d9c1b74580.png)
Report Execution Log
![Screen Shot 2020-12-08 at 2 31 55 PM](https://user-images.githubusercontent.com/5705598/101549299-4577f600-3962-11eb-8ca1-b80f0618a688.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- unit test for execution log

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
