### PR TITLE
build: cancel previous github action runs

### DIFF
--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -3,27 +3,31 @@ name: Docs
 on:
   push:
     paths:
-      - 'docs/**'
+      - "docs/**"
   pull_request:
     paths:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   docs:
     name: build
     runs-on: ubuntu-18.04
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: npm install
-      working-directory: ./docs
-      run: |
-        npm install
-    - name: lint
-      working-directory: ./docs
-      run: |
-        npm run lint
-    - name: gatsby build
-      working-directory: ./docs
-      run: |
-        npm run build
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: npm install
+        working-directory: ./docs
+        run: |
+          npm install
+      - name: lint
+        working-directory: ./docs
+        run: |
+          npm run lint
+      - name: gatsby build
+        working-directory: ./docs
+        run: |
+          npm run build

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        browser: ['chrome']
+        browser: ["chrome"]
     env:
       FLASK_ENV: development
       ENABLE_REACT_CRUD_VIEWS: true
@@ -30,58 +30,62 @@ jobs:
         ports:
           - 16379:6379
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
-    - name: OS dependencies
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: |
-          apt-get-install
-    - name: Install python dependencies
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: |
-          pip-upgrade
-          pip install -r requirements/testing.txt
-    - name: Setup postgres
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: |
-          setup-postgres
-    - name: Import test data
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: |
-          testdata
-    - name: Install npm dependencies
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: |
-          npm-install
-    - name: Build javascript packages
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: |
-          build-instrumented-assets
-    - name: Install cypress
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: |
-          cypress-install
-    - name: Run Cypress
-      uses: apache-superset/cached-dependencies@b90713b
-      env:
-        CYPRESS_BROWSER: ${{ matrix.browser }}
-        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-      with:
-        run: cypress-run-all
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: screenshots
-        path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: OS dependencies
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: |
+            apt-get-install
+      - name: Install python dependencies
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: |
+            pip-upgrade
+            pip install -r requirements/testing.txt
+      - name: Setup postgres
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: |
+            setup-postgres
+      - name: Import test data
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: |
+            testdata
+      - name: Install npm dependencies
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: |
+            npm-install
+      - name: Build javascript packages
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: |
+            build-instrumented-assets
+      - name: Install cypress
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: |
+            cypress-install
+      - name: Run Cypress
+        uses: apache-superset/cached-dependencies@b90713b
+        env:
+          CYPRESS_BROWSER: ${{ matrix.browser }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        with:
+          run: cypress-run-all
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -6,22 +6,26 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Install dependencies
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: npm-install
-    - name: lint
-      working-directory: ./superset-frontend
-      run: |
-        npm run lint
-        npm run prettier-check
-    - name: unit tests
-      working-directory: ./superset-frontend
-      run: |
-        npm run test -- --coverage
-    - name: Upload code coverage
-      working-directory: ./superset-frontend
-      run: |
-        bash <(curl -s https://codecov.io/bash) -cF javascript
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: npm-install
+      - name: lint
+        working-directory: ./superset-frontend
+        run: |
+          npm run lint
+          npm run prettier-check
+      - name: unit tests
+        working-directory: ./superset-frontend
+        run: |
+          npm run test -- --coverage
+      - name: Upload code coverage
+        working-directory: ./superset-frontend
+        run: |
+          bash <(curl -s https://codecov.io/bash) -cF javascript

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -10,6 +10,10 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python
@@ -33,6 +37,10 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python
@@ -55,6 +63,10 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python

--- a/.github/workflows/superset-python-mysql.yml
+++ b/.github/workflows/superset-python-mysql.yml
@@ -28,6 +28,10 @@ jobs:
         ports:
           - 16379:6379
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/superset-python-postgres.yml
+++ b/.github/workflows/superset-python-postgres.yml
@@ -29,6 +29,10 @@ jobs:
         ports:
           - 16379:6379
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -40,6 +40,10 @@ jobs:
         ports:
           - 16379:6379
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -90,6 +94,10 @@ jobs:
         ports:
           - 16379:6379
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Create csv upload directory
         run: sudo mkdir -p /tmp/.superset/uploads

--- a/.github/workflows/superset-python-sqlite.yml
+++ b/.github/workflows/superset-python-sqlite.yml
@@ -21,6 +21,10 @@ jobs:
         ports:
           - 16379:6379
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -6,16 +6,20 @@ jobs:
   frontend-check:
     runs-on: ubuntu-18.04
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Install dependencies
-      uses: apache-superset/cached-dependencies@b90713b
-      with:
-        run: npm-install
-    - name: lint
-      working-directory: ./superset-frontend
-      run: |
-        npm run check-translation
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: apache-superset/cached-dependencies@b90713b
+        with:
+          run: npm-install
+      - name: lint
+        working-directory: ./superset-frontend
+        run: |
+          npm run check-translation
 
   babel-extract:
     runs-on: ubuntu-18.04
@@ -23,6 +27,10 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
### SUMMARY

CI has been slow recently, partly because of [long running queue](https://github.com/apache/incubator-superset/actions?query=is%3Aqueued).

Each new commits to an open PR triggers a new CI job. Let's see if cancelling previous runs helps speed things up.

Ref: https://github.com/styfle/cancel-workflow-action 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI should work

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
