### PR TITLE
fix(presto): check for valid datasource types when fetching ds names

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -58,6 +58,12 @@ class DatasourceKind(str, Enum):
     PHYSICAL = "physical"
 
 
+class DatasourceType(str, Enum):
+    TABLE = "table"
+    DRUID = "druid"
+    VIEW = "view"
+
+
 class BaseDatasource(
     AuditMixinNullable, ImportExportMixin
 ):  # pylint: disable=too-many-public-methods

--- a/superset/connectors/druid/models.py
+++ b/superset/connectors/druid/models.py
@@ -50,7 +50,12 @@ from sqlalchemy.sql import expression
 from sqlalchemy_utils import EncryptedType
 
 from superset import conf, db, is_feature_enabled, security_manager
-from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
+from superset.connectors.base.models import (
+    BaseColumn,
+    BaseDatasource,
+    BaseMetric,
+    DatasourceType,
+)
 from superset.constants import NULL_STRING
 from superset.exceptions import SupersetException
 from superset.models.core import Database
@@ -126,7 +131,7 @@ class DruidCluster(Model, AuditMixinNullable, ImportExportMixin):
     """ORM object referencing the Druid clusters"""
 
     __tablename__ = "clusters"
-    type = "druid"
+    type = DatasourceType.DRUID.value
 
     id = Column(Integer, primary_key=True)
     verbose_name = Column(String(250), unique=True)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -53,7 +53,12 @@ from sqlalchemy.sql.expression import Label, Select, TextAsFrom
 from sqlalchemy.types import TypeEngine
 
 from superset import app, db, is_feature_enabled, security_manager
-from superset.connectors.base.models import BaseColumn, BaseDatasource, BaseMetric
+from superset.connectors.base.models import (
+    BaseColumn,
+    BaseDatasource,
+    BaseMetric,
+    DatasourceType,
+)
 from superset.constants import NULL_STRING
 from superset.db_engine_specs.base import TimestampExpression
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -435,7 +440,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
 
     """An ORM object for SqlAlchemy table references"""
 
-    type = "table"
+    type = DatasourceType.TABLE.value
     query_language = "sql"
     is_rls_supported = True
     columns: List[TableColumn] = []

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -38,9 +38,10 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import ColumnClause, Select
 
 from superset import app, cache_manager, is_feature_enabled, security_manager
+from superset.connectors.base.models import DatasourceType
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetTemplateException
+from superset.exceptions import SupersetException, SupersetTemplateException
 from superset.models.sql_lab import Query
 from superset.models.sql_types.presto_sql_types import (
     Array,
@@ -595,6 +596,9 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
     def get_all_datasource_names(
         cls, database: "Database", datasource_type: str
     ) -> List[utils.DatasourceName]:
+        if datasource_type not in [item.value for item in DatasourceType]:
+            raise SupersetException("Found an unknown datasource type")
+
         datasource_df = database.get_df(
             "SELECT table_schema, table_name FROM INFORMATION_SCHEMA.{}S "
             "ORDER BY concat(table_schema, '.', table_name)".format(


### PR DESCRIPTION
### SUMMARY
Make sure we have a valid `datasource_type` before performing Presto query to fetch all tables or views

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
