### PR TITLE
fix: Altered button crashing and title not updating on Explore view

### DIFF
--- a/superset-frontend/spec/javascripts/components/AlteredSliceTag_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/AlteredSliceTag_spec.jsx
@@ -23,8 +23,8 @@ import { getChartControlPanelRegistry } from '@superset-ui/core';
 import AlteredSliceTag from 'src/components/AlteredSliceTag';
 import ModalTrigger from 'src/components/ModalTrigger';
 import TooltipWrapper from 'src/components/TooltipWrapper';
-import ListView from 'src/components/ListView';
 import TableCollection from 'src/components/dataViewCommon/TableCollection';
+import TableView from 'src/components/TableView';
 
 import {
   defaultProps,
@@ -34,7 +34,7 @@ import {
 } from './fixtures/AlteredSliceTag';
 
 const getTableWrapperFromModalBody = modalBody =>
-  modalBody.find(ListView).find(TableCollection);
+  modalBody.find(TableView).find(TableCollection);
 
 describe('AlteredSliceTag', () => {
   let wrapper;
@@ -110,7 +110,7 @@ describe('AlteredSliceTag', () => {
       const modalBody = mount(
         <div>{wrapper.instance().renderModalBody()}</div>,
       );
-      expect(modalBody.find(ListView)).toHaveLength(1);
+      expect(modalBody.find(TableView)).toHaveLength(1);
     });
 
     it('renders a thead', () => {

--- a/superset-frontend/src/components/AlteredSliceTag.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag.jsx
@@ -19,12 +19,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual, isEmpty } from 'lodash';
-import ListView from 'src/components/ListView';
-import getControlsForVizType from 'src/utils/getControlsForVizType';
 import { t } from '@superset-ui/core';
+import getControlsForVizType from 'src/utils/getControlsForVizType';
+import { safeStringify } from 'src/utils/safeStringify';
 import TooltipWrapper from './TooltipWrapper';
 import ModalTrigger from './ModalTrigger';
-import { safeStringify } from '../utils/safeStringify';
+import TableView from './TableView';
 
 const propTypes = {
   origFormData: PropTypes.object.isRequired,
@@ -101,30 +101,6 @@ export default class AlteredSliceTag extends React.Component {
     return diffs;
   }
 
-  sortData = ({ sortBy }) => {
-    if (this.state.rows.length > 0 && sortBy.length > 0) {
-      const { id, desc } = sortBy[0];
-      this.setState(({ rows }) => ({
-        rows: this.sortDataByColumn(rows, id, desc),
-      }));
-    }
-  };
-
-  sortDataByColumn(data, sortById, desc) {
-    return data.sort((row1, row2) => {
-      const rows = desc ? [row2, row1] : [row1, row2];
-      const firstVal = rows[0][sortById];
-      const secondVal = rows[1][sortById];
-      if (typeof firstVal === 'string' && typeof secondVal === 'string') {
-        return secondVal.localeCompare(firstVal);
-      }
-      if (typeof firstVal === 'undefined' || firstVal === null) {
-        return 1;
-      }
-      return -1;
-    });
-  }
-
   isEqualish(val1, val2) {
     return isEqual(alterForComparison(val1), alterForComparison(val2));
   }
@@ -187,14 +163,11 @@ export default class AlteredSliceTag extends React.Component {
     ];
 
     return (
-      <ListView
+      <TableView
         columns={columns}
         data={this.state.rows}
-        count={this.state.rows.length}
         pageSize={50}
-        fetchData={this.sortData}
-        loading={false}
-        className="table"
+        className="table-condensed"
       />
     );
   }

--- a/superset-frontend/src/explore/components/PropertiesModal.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal.tsx
@@ -100,6 +100,11 @@ export default function PropertiesModal({
     fetchChartData();
   }, [fetchChartData]);
 
+  // update name after it's changed in another modal
+  useEffect(() => {
+    setName(slice.slice_name || '');
+  }, [slice.slice_name]);
+
   const loadOptions = (input = '') => {
     const query = rison.encode({
       filter: input,

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -165,6 +165,7 @@ export default function exploreReducer(state = {}, action) {
           ...state.slice,
           ...action.slice,
         },
+        sliceName: action.slice.slice_name ?? state.sliceName,
       };
     },
   };


### PR DESCRIPTION
### SUMMARY
Fixes bugs https://github.com/apache/incubator-superset/issues/11623 and https://github.com/apache/incubator-superset/issues/11835. `AlteredSliceTag` was crashing because it was using a `ListView` component, which requires access to React Router to work (which Explore view doesn't have). I replaced it with newer `TableView` to display a table.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/15073128/101471832-1785b800-3948-11eb-9707-39b8e3c96446.gif)

### TEST PLAN
Manually verify that bugs don't occur anymore.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Closes https://github.com/apache/incubator-superset/issues/11623, https://github.com/apache/incubator-superset/issues/11835
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc
@adam-stasiak Can you please test it?