### PR TITLE
fix : adhoc filter dropdown

### DIFF
--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -90,7 +90,7 @@ class AdhocFilterOption extends React.PureComponent {
         onChange={this.props.onFilterEdit}
       />
     );
-    
+
     return (
       <div
         role="button"

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -116,7 +116,7 @@ class AdhocFilterOption extends React.PureComponent {
           defaultVisible={this.state.popoverVisible || adhocFilter.isNew}
           visible={this.state.popoverVisible}
           onVisibleChange={this.togglePopover}
-          overlayStyle={{zIndex: 1}}
+          overlayStyle={{ zIndex: 1 }}
         >
           <Label className="option-label adhoc-option adhoc-filter-option">
             {adhocFilter.getDefaultLabel()}

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -90,7 +90,7 @@ class AdhocFilterOption extends React.PureComponent {
         onChange={this.props.onFilterEdit}
       />
     );
-
+    
     return (
       <div
         role="button"
@@ -115,7 +115,6 @@ class AdhocFilterOption extends React.PureComponent {
           content={overlayContent}
           defaultVisible={this.state.popoverVisible || adhocFilter.isNew}
           visible={this.state.popoverVisible}
-          onVisibleChange={this.togglePopover}
           overlayStyle={{ zIndex: 1 }}
         >
           <Label className="option-label adhoc-option adhoc-filter-option">

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -115,6 +115,7 @@ class AdhocFilterOption extends React.PureComponent {
           content={overlayContent}
           defaultVisible={this.state.popoverVisible || adhocFilter.isNew}
           visible={this.state.popoverVisible}
+          onVisibleChange={() => this.togglePopover(true)}
           overlayStyle={{ zIndex: 1 }}
         >
           <Label className="option-label adhoc-option adhoc-filter-option">

--- a/superset-frontend/src/explore/components/AdhocFilterOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterOption.jsx
@@ -116,6 +116,7 @@ class AdhocFilterOption extends React.PureComponent {
           defaultVisible={this.state.popoverVisible || adhocFilter.isNew}
           visible={this.state.popoverVisible}
           onVisibleChange={this.togglePopover}
+          overlayStyle={{zIndex: 1}}
         >
           <Label className="option-label adhoc-option adhoc-filter-option">
             {adhocFilter.getDefaultLabel()}


### PR DESCRIPTION
### SUMMARY
Fix dropdown on filter popover

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
![image](https://user-images.githubusercontent.com/8277264/101528577-2dbb6480-3998-11eb-86de-8b4b15996143.png)
After
![image](https://user-images.githubusercontent.com/8277264/101528617-357b0900-3998-11eb-9941-150dcc03e0bd.png)

Second fix:
Before
![Kapture 2020-12-08 at 21 36 22](https://user-images.githubusercontent.com/8277264/101532625-7f1a2280-399d-11eb-9f9f-50039588b96f.gif)
After
![Kapture 2020-12-08 at 21 37 34](https://user-images.githubusercontent.com/8277264/101532726-9f49e180-399d-11eb-90c1-d61f783dca77.gif)


### TEST PLAN
1) Log in
2) Go to any chart
3) Add new filter with option "in" or "not in"
4) See next dropdown

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Fix: https://github.com/apache/incubator-superset/issues/11955
- [x] Fix: https://github.com/apache/incubator-superset/issues/11954
