### PR TITLE
feat: add hook for dataset health check

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
@@ -24,6 +24,7 @@ import { Menu } from 'src/common/components';
 import DatasourceModal from 'src/datasource/DatasourceModal';
 import ChangeDatasourceModal from 'src/datasource/ChangeDatasourceModal';
 import DatasourceControl from 'src/explore/components/controls/DatasourceControl';
+import Icon from 'src/components/Icon';
 
 const defaultProps = {
   name: 'datasource',
@@ -40,6 +41,7 @@ const defaultProps = {
       backend: 'mysql',
       name: 'main',
     },
+    health_check_message: 'Warning message!',
   },
   actions: {
     setDatasource: sinon.spy(),
@@ -90,5 +92,11 @@ describe('DatasourceControl', () => {
       </div>,
     );
     expect(menuWrapper.find(Menu.Item)).toHaveLength(2);
+  });
+
+  it('should render health check message', () => {
+    const wrapper = setup();
+    const icons = wrapper.find(Icon);
+    expect(icons.first().prop('name')).toBe('alert-solid');
   });
 });

--- a/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DatasourceControl_spec.jsx
@@ -25,6 +25,7 @@ import DatasourceModal from 'src/datasource/DatasourceModal';
 import ChangeDatasourceModal from 'src/datasource/ChangeDatasourceModal';
 import DatasourceControl from 'src/explore/components/controls/DatasourceControl';
 import Icon from 'src/components/Icon';
+import { Tooltip } from 'src/common/components/Tooltip';
 
 const defaultProps = {
   name: 'datasource',
@@ -96,7 +97,11 @@ describe('DatasourceControl', () => {
 
   it('should render health check message', () => {
     const wrapper = setup();
-    const icons = wrapper.find(Icon);
-    expect(icons.first().prop('name')).toBe('alert-solid');
+    const alert = wrapper.find(Icon).first();
+    expect(alert.prop('name')).toBe('alert-solid');
+    const tooltip = wrapper.find(Tooltip).at(1);
+    expect(tooltip.prop('title')).toBe(
+      defaultProps.datasource.health_check_message,
+    );
   });
 });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -213,13 +213,8 @@ class DatasourceControl extends React.PureComponent {
       </Menu>
     );
 
-    let healthCheckMessage = '';
-    const { extra: rawExtra } = datasource;
-    if (rawExtra) {
-      const extra = JSON.parse(rawExtra) || {};
-      // eslint-disable-next-line camelcase
-      healthCheckMessage = extra?.health_check?.message;
-    }
+    // eslint-disable-next-line camelcase
+    const { health_check_message: healthCheckMessage } = datasource;
 
     return (
       <Styles className="DatasourceControl">

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, Collapse, Row, Well } from 'react-bootstrap';
-import { t, styled } from '@superset-ui/core';
+import { t, styled, supersetTheme } from '@superset-ui/core';
 import { ColumnOption, MetricOption } from '@superset-ui/chart-controls';
 
 import { Dropdown, Menu } from 'src/common/components';
@@ -213,10 +213,18 @@ class DatasourceControl extends React.PureComponent {
       </Menu>
     );
 
+    let healthCheckMessage = '';
+    const { extra: rawExtra } = datasource;
+    if (rawExtra) {
+      const extra = JSON.parse(rawExtra) || {};
+      // eslint-disable-next-line camelcase
+      healthCheckMessage = extra?.health_check?.message;
+    }
+
     return (
       <Styles className="DatasourceControl">
         <ControlHeader {...this.props} />
-        <div>
+        <div style={{ display: 'flex' }}>
           <Tooltip title={t('Expand/collapse dataset configuration')}>
             <Label
               style={{ textTransform: 'none' }}
@@ -230,6 +238,14 @@ class DatasourceControl extends React.PureComponent {
               />
             </Label>
           </Tooltip>
+          {healthCheckMessage && (
+            <Tooltip title={healthCheckMessage}>
+              <Icon
+                name="alert-solid"
+                color={supersetTheme.colors.warning.base}
+              />
+            </Tooltip>
+          )}
           <Dropdown
             overlay={datasourceMenu}
             trigger={['click']}

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -73,6 +73,10 @@ const Styles = styled.div`
     vertical-align: middle;
     cursor: pointer;
   }
+
+  .datasource-controls {
+    display: flex;
+  }
 `;
 
 /**
@@ -219,7 +223,7 @@ class DatasourceControl extends React.PureComponent {
     return (
       <Styles className="DatasourceControl">
         <ControlHeader {...this.props} />
-        <div style={{ display: 'flex' }}>
+        <div className="datasource-controls">
           <Tooltip title={t('Expand/collapse dataset configuration')}>
             <Label
               style={{ textTransform: 'none' }}

--- a/superset/config.py
+++ b/superset/config.py
@@ -991,3 +991,8 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     except Exception:
         logger.exception("Found but failed to import local superset_config")
         raise
+
+
+# It's possible to add a dataset health check logic which is specific to your system.
+# It will get executed each time when user open a chart's explore view.
+DATASET_HEALTH_CHECK = None

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -687,6 +687,10 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         )
 
     @property
+    def health_check_message(self) -> Optional[str]:
+        return self.extra_dict.get("health_check", {}).get("message")
+
+    @property
     def data(self) -> Dict[str, Any]:
         data_ = super().data
         if self.type == "table":
@@ -699,7 +703,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
             data_["fetch_values_predicate"] = self.fetch_values_predicate
             data_["template_params"] = self.template_params
             data_["is_sqllab_view"] = self.is_sqllab_view
-            data_["extra"] = self.extra
+            data_["health_check_message"] = self.health_check_message
         return data_
 
     @property

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1474,7 +1474,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         return extra_cache_keys
 
     def health_check(self, commit: bool = False, force: bool = False) -> None:
-        check = config["DATASET_HEALTH_CHECK"]
+        check = config.get("DATASET_HEALTH_CHECK")
         if check is None:
             return
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1483,13 +1483,10 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
         if force or extra.get("health_check", {}).get("version") != check.version:
             with event_logger.log_context(action="dataset_health_check"):
                 message = check(self)
-                if message:
-                    extra["health_check"] = {
-                        "version": check.version,
-                        "message": message,
-                    }
-                else:
-                    extra.pop("health_check", None)
+                extra["health_check"] = {
+                    "version": check.version,
+                    "message": message,
+                }
                 self.extra = json.dumps(extra)
 
                 db.session.merge(self)

--- a/superset/datasets/dao.py
+++ b/superset/datasets/dao.py
@@ -186,6 +186,8 @@ class DatasetDAO(BaseDAO):
             super().update(model, properties, commit=commit)
             properties["columns"] = original_properties
 
+        super().update(model, properties, commit=False)
+        model.health_check(force=True, commit=False)
         return super().update(model, properties, commit=commit)
 
     @classmethod

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -651,7 +651,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             )
 
         # if feature enabled, run some health check rules for sqla datasource
-        if hasattr(datasource, "health_check") and conf["DATASET_HEALTH_CHECK"]:
+        if hasattr(datasource, "health_check"):
             datasource.health_check()
 
         viz_type = form_data.get("viz_type")

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -650,6 +650,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 f"datasource_id={datasource_id}&"
             )
 
+        # if feature enabled, run some health check rules for sqla datasource
+        if hasattr(datasource, "health_check") and conf["DATASET_HEALTH_CHECK"]:
+            datasource.health_check()
+
         viz_type = form_data.get("viz_type")
         if not viz_type and datasource.default_endpoint:
             return redirect(datasource.default_endpoint)

--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -70,6 +70,8 @@ class Datasource(BaseSupersetView):
                 f"Duplicate column name(s): {','.join(duplicates)}", status=409
             )
         orm_datasource.update_from_object(datasource_dict)
+        if hasattr(orm_datasource, "health_check"):
+            orm_datasource.health_check(force=True, commit=False)
         data = orm_datasource.data
         db.session.commit()
 


### PR DESCRIPTION
### SUMMARY
Inside airbnb, we spent a lot of time on Superset dashboard and query performance issues. We create some guidelines for airbnb users, to help them write better queries to create virtual dataset. So we want to **_add a dataset health check logic_** when user explore a chart, and show some warning message if health check returns any message.

To decide whether a dataset is good or bad, this logic is probably very specific to each corporation. Some rules applied in airbnb may totally not relevant for Dropbox. So in the open source codebase, we only add an entry point, 
```DATASET_HEALTH_CHECK = _your function to check dataset quality_```
which allow each company to implement and hook their own rules.

For example, after implements a rule that checks if the chart is using a virtual dataset:
```
def my_check(datasource: SqlaTable) -> str:
    message = None # pass the check no warning
    if datasource.type == "table" and datasource.sql:
        message = "You should replace this virtual datasource with physical table."
    return message

DATASET_HEALTH_CHECK = my_check
DATASET_HEALTH_CHECK.version = 0.1
```
I will see a warning message like this:

<img width="1406" alt="Screen Shot 2020-12-08 at 8 31 33 PM" src="https://user-images.githubusercontent.com/27990562/101587949-1f6e4800-399a-11eb-88a1-84c13ff1ddae.png">

**Note**
The health_check result will be saved with datasource record `extra` column. _When user update datasource, or `DATASET_HEALTH_CHECK.version` is changed_, health_check function will be triggered again and update the record in the database. Please see how we discussed [different ideas for this feature](https://github.com/apache-superset/superset-ui/pull/856#discussion_r539673938). 


### TEST PLAN
CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

cc @ktmud @etr2460 