### PR TITLE
fix(dataset): fetch metadata on dataset creation may raise broad exceptions

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -666,7 +666,9 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                         col["type"] = db_engine_spec.column_datatype_to_string(
                             col["type"], db_dialect
                         )
-                except CompileError:
+                # Broad exception catch, because there are multiple possible exceptions
+                # from different drivers that fall outside CompileError
+                except Exception:
                     col["type"] = "UNKNOWN"
         return cols
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -45,7 +45,6 @@ from sqlalchemy import (
     Table,
     Text,
 )
-from sqlalchemy.exc import CompileError
 from sqlalchemy.orm import backref, Query, relationship, RelationshipProperty, Session
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql import column, ColumnElement, literal_column, table, text
@@ -668,7 +667,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
                         )
                 # Broad exception catch, because there are multiple possible exceptions
                 # from different drivers that fall outside CompileError
-                except Exception:
+                except Exception:  # pylint: disable=broad-except
                     col["type"] = "UNKNOWN"
         return cols
 

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -47,16 +47,8 @@ class CreateDatasetCommand(BaseCommand):
         self.validate()
         # Creates SqlaTable (Dataset)
         dataset = DatasetDAO.create(self._properties, commit=False)
-
-        try:
-            # Updates columns and metrics from the dataset
-            dataset.fetch_metadata(commit=False)
-        # Broad exception catch, because there are multiple possible exceptions
-        # from different drivers
-        except Exception as ex:
-            logger.exception(ex)
-            db.session.rollback()
-
+        # Updates columns and metrics from the dataset
+        dataset.fetch_metadata(commit=False)
         # Add datasource access permission
         security_manager.add_permission_view_menu(
             "datasource_access", dataset.get_perm()
@@ -68,7 +60,7 @@ class CreateDatasetCommand(BaseCommand):
             )
         try:
             db.session.commit()
-        except (SQLAlchemyError, DAOCreateFailedError) as ex:
+        except Exception as ex:
             logger.exception(ex)
             db.session.rollback()
             raise DatasetCreateFailedError()

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -57,7 +57,7 @@ class CreateDatasetCommand(BaseCommand):
                 security_manager.add_permission_view_menu(
                     "schema_access", dataset.schema_perm
                 )
-                db.session.commit()
+            db.session.commit()
         except Exception as ex:
             logger.exception(ex)
             db.session.rollback()

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -20,9 +20,11 @@ from typing import Any, Dict, List, Optional
 from flask_appbuilder.models.sqla import Model
 from flask_appbuilder.security.sqla.models import User
 from marshmallow import ValidationError
+from sqlalchemy.exc import SQLAlchemyError
 
 from superset.commands.base import BaseCommand
 from superset.commands.utils import populate_owners
+from superset.dao.exceptions import DAOCreateFailedError
 from superset.datasets.commands.exceptions import (
     DatabaseNotFoundValidationError,
     DatasetCreateFailedError,
@@ -58,7 +60,7 @@ class CreateDatasetCommand(BaseCommand):
                     "schema_access", dataset.schema_perm
                 )
             db.session.commit()
-        except Exception as ex:
+        except (SQLAlchemyError, DAOCreateFailedError) as ex:
             logger.exception(ex)
             db.session.rollback()
             raise DatasetCreateFailedError()

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -43,8 +43,8 @@ class CreateDatasetCommand(BaseCommand):
 
     def run(self) -> Model:
         self.validate()
-        # Creates SqlaTable (Dataset)
         try:
+            # Creates SqlaTable (Dataset)
             dataset = DatasetDAO.create(self._properties, commit=False)
             # Updates columns and metrics from the dataset
             dataset.fetch_metadata(commit=False)


### PR DESCRIPTION
### SUMMARY
`fetch_metadata` may raise broad exceptions from database drivers, the try/catch block was too narrow

Example pydruid can raise when a column type is not supported:
```
pydruid.db.exceptions.NotSupportedError: Type BLOB is not supported
```



### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
