### PR TITLE
feat: Debounce TextControl if change handler runs immediately after user input

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl.tsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import { FormGroup, FormControl } from 'react-bootstrap';
 import { legacyValidateNumber, legacyValidateInteger } from '@superset-ui/core';
+import debounce from 'lodash/debounce';
 import ControlHeader from '../ControlHeader';
 
 interface TextControlProps {
@@ -30,10 +31,12 @@ interface TextControlProps {
   placeholder?: string;
   value?: string | number;
   controlId?: string;
+  renderTrigger?: boolean;
 }
 
 interface TextControlState {
   controlId: string;
+  value?: string | number;
 }
 
 const generateControlId = (controlId?: string) =>
@@ -43,42 +46,59 @@ export default class TextControl extends React.Component<
   TextControlProps,
   TextControlState
 > {
+  debouncedOnChange = debounce((inputValue: string) => {
+    this.onChange(inputValue);
+  }, 500);
+
   constructor(props: TextControlProps) {
     super(props);
-    this.onChange = this.onChange.bind(this);
+
     // if there's no control id provided, generate a random
     // number to prevent rendering elements with same ids
     this.state = {
       controlId: generateControlId(props.controlId),
+      value: props.value,
     };
   }
 
-  onChange(event: any) {
-    let { value } = event.target;
-
+  onChange = (inputValue: string) => {
+    let parsedValue: string | number = inputValue;
     // Validation & casting
     const errors = [];
-    if (value !== '' && this.props.isFloat) {
-      const error = legacyValidateNumber(value);
+    if (inputValue !== '' && this.props.isFloat) {
+      const error = legacyValidateNumber(inputValue);
       if (error) {
         errors.push(error);
       } else {
-        value = value.match(/.*([.0])$/g) ? value : parseFloat(value);
+        parsedValue = inputValue.match(/.*([.0])$/g)
+          ? inputValue
+          : parseFloat(inputValue);
       }
     }
-    if (value !== '' && this.props.isInt) {
-      const error = legacyValidateInteger(value);
+    if (inputValue !== '' && this.props.isInt) {
+      const error = legacyValidateInteger(inputValue);
       if (error) {
         errors.push(error);
       } else {
-        value = parseInt(value, 10);
+        parsedValue = parseInt(inputValue, 10);
       }
     }
-    this.props.onChange?.(value, errors);
-  }
+    this.props.onChange?.(parsedValue, errors);
+  };
 
-  render() {
-    const { value: rawValue } = this.props;
+  onChangeWrapper = (event: any) => {
+    const { value } = event.target;
+    this.setState({ value });
+
+    // use debounce when change takes effect immediately after user starts typing
+    const onChange = this.props.renderTrigger
+      ? this.debouncedOnChange
+      : this.onChange;
+    onChange(value);
+  };
+
+  render = () => {
+    const { value: rawValue } = this.state;
     const value =
       typeof rawValue !== 'undefined' && rawValue !== null
         ? rawValue.toString()
@@ -92,7 +112,7 @@ export default class TextControl extends React.Component<
             type="text"
             data-test="inline-name"
             placeholder={this.props.placeholder}
-            onChange={this.onChange}
+            onChange={this.onChangeWrapper}
             onFocus={this.props.onFocus}
             value={value}
             disabled={this.props.disabled}
@@ -100,5 +120,5 @@ export default class TextControl extends React.Component<
         </FormGroup>
       </div>
     );
-  }
+  };
 }


### PR DESCRIPTION
### SUMMARY
This PR adds a 500ms debounce to TextControl on Explore control panel, if `renderTrigger` is true - that means that change handler fires immediately when user types input. If `renderTrigger` is false, there are no changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/15073128/101663801-68caa000-3a4b-11eb-9406-631bc8355649.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11938
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @rusackas 
@adam-stasiak Can you help with testing?