### PR TITLE
fix: make "DELETE" confirmation work in other languages

### DIFF
--- a/superset-frontend/src/components/DeleteModal.tsx
+++ b/superset-frontend/src/components/DeleteModal.tsx
@@ -65,7 +65,9 @@ export default function DeleteModal({
     >
       <DescriptionContainer>{description}</DescriptionContainer>
       <StyleFormGroup>
-        <FormLabel htmlFor="delete">{t('Type "DELETE" to confirm')}</FormLabel>
+        <FormLabel htmlFor="delete">
+          {t('Type "%s" to confirm', t('DELETE'))}
+        </FormLabel>
         <FormControl
           data-test="delete-modal-input"
           id="delete"

--- a/superset-frontend/src/components/DeleteModal.tsx
+++ b/superset-frontend/src/components/DeleteModal.tsx
@@ -65,7 +65,7 @@ export default function DeleteModal({
     >
       <DescriptionContainer>{description}</DescriptionContainer>
       <StyleFormGroup>
-        <FormLabel htmlFor="delete">{t('type "delete" to confirm')}</FormLabel>
+        <FormLabel htmlFor="delete">{t('Type "DELETE" to confirm')}</FormLabel>
         <FormControl
           data-test="delete-modal-input"
           id="delete"
@@ -75,7 +75,7 @@ export default function DeleteModal({
             event: React.FormEvent<FormControl & FormControlProps>,
           ) => {
             const targetValue = (event.currentTarget?.value as string) ?? '';
-            setDisableChange(targetValue.toUpperCase() !== 'DELETE');
+            setDisableChange(targetValue.toUpperCase() !== t('DELETE'));
           }}
         />
       </StyleFormGroup>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When deleting an asset we ask the user for confirmation with this phrase:

```js
t('type "delete" to confirm')
```

Which in Portuguese, eg, translates to _**digite "apagar" para confirmar**_. But if the user types in "apagar" it won't work. :-P

This PR fixes the bug by comparing the user input with the translated version of "delete".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

There are currently no translations for the strings, so I couldn't test in a different language. But confirmed that it still works in English.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
