### PR TITLE
feat: add invisible layer on loading chart

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -19,6 +19,8 @@
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { styled } from '@superset-ui/core';
+
 import { exploreChart, exportChart } from '../../../explore/exploreUtils';
 import SliceHeader from '../SliceHeader';
 import ChartContainer from '../../../chart/ChartContainer';
@@ -80,6 +82,13 @@ const SHOULD_UPDATE_ON_PROP_CHANGES = Object.keys(propTypes).filter(
 );
 const OVERFLOWABLE_VIZ_TYPES = new Set(['filter_box']);
 const DEFAULT_HEADER_HEIGHT = 22;
+
+const ChartOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 5;
+`;
 
 export default class Chart extends React.Component {
   constructor(props) {
@@ -257,7 +266,8 @@ export default class Chart extends React.Component {
       return <MissingChart height={this.getChartHeight()} />;
     }
 
-    const { queryResponse, chartUpdateEndTime } = chart;
+    const { queryResponse, chartUpdateEndTime, chartStatus } = chart;
+    const isLoading = chartStatus === 'loading';
     const isCached = queryResponse && queryResponse.is_cached;
     const cachedDttm = queryResponse && queryResponse.cached_dttm;
     const isOverflowable = OVERFLOWABLE_VIZ_TYPES.has(slice.viz_type);
@@ -319,6 +329,15 @@ export default class Chart extends React.Component {
             isOverflowable && 'dashboard-chart--overflowable',
           )}
         >
+          {isLoading && (
+            <ChartOverlay
+              style={{
+                width,
+                height: this.getChartHeight(),
+              }}
+            />
+          )}
+
           <ChartContainer
             width={width}
             height={this.getChartHeight()}
@@ -328,7 +347,7 @@ export default class Chart extends React.Component {
             annotationData={chart.annotationData}
             chartAlert={chart.chartAlert}
             chartId={id}
-            chartStatus={chart.chartStatus}
+            chartStatus={chartStatus}
             datasource={datasource}
             dashboardId={dashboardId}
             initialValues={initialValues}

--- a/superset-frontend/src/dashboard/stylesheets/components/chart.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/chart.less
@@ -59,6 +59,7 @@
 
 .dashboard-chart {
   overflow: hidden;
+  position: relative;
 }
 
 .dashboard-chart.dashboard-chart--overflowable {


### PR DESCRIPTION
### SUMMARY
When chart is loading, we show a spinner icon on top of chart, but it won't block user interact with chart. This will cause some issue for filter box: In large dashboard with many filter box, user applies a filter, other filter may update accordingly. If user interact with filter box while it is waiting for query results, it will make dashboard stuck in a wired state or show errors.

This PR is to add an invisible layer on top of chart.  When chart is loading, user can not interact with the chart. There is no visible UI change for loading chart, but user can not change filter dropdown:

<img width="576" alt="Screen Shot 2020-12-09 at 11 34 02 PM" src="https://user-images.githubusercontent.com/27990562/101735724-215a0900-3a77-11eb-82de-250b5a7d8f8b.png">


### TEST PLAN
- CI
- Manual test:
1. open dashboard with multiple filter boxes: both dashboard and filter box should aligned as before.
1. apply one filter, 
1. when filter box is loading, you can not select dropdown anymore.

cc @zuzana-vej @etr2460 @ktmud 