### PR TITLE
fix: Fix style for error modal

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -119,7 +119,7 @@ export default function ErrorAlert({
           </a>
         )}
       </div>
-      {!isExpandable ? (
+      {isExpandable ? (
         <div className="error-body">
           <p>{subtitle}</p>
           {body && (
@@ -152,7 +152,7 @@ export default function ErrorAlert({
       ) : (
         <ErrorModal
           level={level}
-          show
+          show={isModalOpen}
           onHide={() => setIsModalOpen(false)}
           title={
             <div className="header">

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -59,6 +59,11 @@ const ErrorModal = styled(Modal)<{ level: ErrorLevel }>`
   color: ${({ level, theme }) => theme.colors[level].dark2};
   overflow-wrap: break-word;
 
+  .ant-modal-header {
+    background-color: ${({ level, theme }) => theme.colors[level].light2};
+    padding: ${({ theme }) => 4 * theme.gridUnit}px;
+  }
+
   .icon {
     margin-right: ${({ theme }) => 2 * theme.gridUnit}px;
   }
@@ -66,7 +71,6 @@ const ErrorModal = styled(Modal)<{ level: ErrorLevel }>`
   .header {
     display: flex;
     align-items: center;
-    background-color: ${({ level, theme }) => theme.colors[level].light2};
     font-size: ${({ theme }) => theme.typography.sizes.l}px;
   }
 `;
@@ -115,7 +119,7 @@ export default function ErrorAlert({
           </a>
         )}
       </div>
-      {isExpandable ? (
+      {!isExpandable ? (
         <div className="error-body">
           <p>{subtitle}</p>
           {body && (
@@ -148,7 +152,7 @@ export default function ErrorAlert({
       ) : (
         <ErrorModal
           level={level}
-          show={isModalOpen}
+          show
           onHide={() => setIsModalOpen(false)}
           title={
             <div className="header">


### PR DESCRIPTION
### SUMMARY
Fix style for error modal
https://trello.com/c/CjAlWauS/35-bug-with-coloration-of-error-modal-header

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
![image](https://user-images.githubusercontent.com/8277264/101752556-58153b00-3ada-11eb-9fc7-9ee31278b20a.png)
AFTER
![image](https://user-images.githubusercontent.com/8277264/101752416-27cd9c80-3ada-11eb-8745-b76f83f5997a.png)


### TEST PLAN
Got to SQL Lab, generate a wrong SQL

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
