### PR TITLE
fix: SIP-15 time_range_endpoints not using default option

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -950,7 +950,7 @@ SSL_CERT_PATH: Optional[str] = None
 # indefinite.
 SIP_15_ENABLED = True
 SIP_15_GRACE_PERIOD_END: Optional[date] = None  # exclusive
-SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS = ["unknown", "inclusive"]
+SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS = ["inclusive", "exclusive"]
 SIP_15_TOAST_MESSAGE = (
     "Action Required: Preview then save your chart using the "
     'new time range endpoints <a target="_blank" href="{url}" '

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -88,8 +88,8 @@ from superset.sql_parse import CtasMethod, ParsedQuery, Table
 from superset.sql_validators import get_validator_by_name
 from superset.typing import FlaskResponse
 from superset.utils import core as utils
-from superset.utils.core import TimeRangeEndpoint
 from superset.utils.cache import etag_cache
+from superset.utils.core import TimeRangeEndpoint
 from superset.utils.dates import now_as_float
 from superset.views.base import (
     api,
@@ -602,10 +602,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             and (
                 not form_data.get("time_range_endpoints")
                 or form_data["time_range_endpoints"]
-                != (
-                    TimeRangeEndpoint(start),
-                    TimeRangeEndpoint(end)
-                )
+                != (TimeRangeEndpoint(start), TimeRangeEndpoint(end))
             )
         ):
             url = Href("/superset/explore/")(
@@ -615,7 +612,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                             "slice_id": slc.id,
                             "time_range_endpoints": (
                                 TimeRangeEndpoint(start),
-                                TimeRangeEndpoint(end)
+                                TimeRangeEndpoint(end),
                             ),
                         }
                     )

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -88,6 +88,7 @@ from superset.sql_parse import CtasMethod, ParsedQuery, Table
 from superset.sql_validators import get_validator_by_name
 from superset.typing import FlaskResponse
 from superset.utils import core as utils
+from superset.utils.core import TimeRangeEndpoint
 from superset.utils.cache import etag_cache
 from superset.utils.dates import now_as_float
 from superset.views.base import (
@@ -593,6 +594,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         # Flash the SIP-15 message if the slice is owned by the current user and has not
         # been updated, i.e., is not using the [start, end) interval.
+        start, end = app.config["SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS"]
         if (
             config["SIP_15_ENABLED"]
             and slc
@@ -601,8 +603,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 not form_data.get("time_range_endpoints")
                 or form_data["time_range_endpoints"]
                 != (
-                    utils.TimeRangeEndpoint.INCLUSIVE,
-                    utils.TimeRangeEndpoint.EXCLUSIVE,
+                    TimeRangeEndpoint(start),
+                    TimeRangeEndpoint(end)
                 )
             )
         ):
@@ -612,8 +614,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                         {
                             "slice_id": slc.id,
                             "time_range_endpoints": (
-                                utils.TimeRangeEndpoint.INCLUSIVE.value,
-                                utils.TimeRangeEndpoint.EXCLUSIVE.value,
+                                TimeRangeEndpoint(start),
+                                TimeRangeEndpoint(end)
                             ),
                         }
                     )

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -256,7 +256,7 @@ def get_time_range_endpoints(
     Note under certain circumstances the slice object may not exist, however the slice
     ID may be defined which serves as a fallback.
 
-    When SIP-15 is enabled all new slices will use the default interval set on 
+    When SIP-15 is enabled all new slices will use the default interval set on
     SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS. If the grace period is defined and has ended
     all slices will adhere to the default interval.
 
@@ -268,11 +268,11 @@ def get_time_range_endpoints(
     if (
         app.config["SIP_15_GRACE_PERIOD_END"]
         and date.today() >= app.config["SIP_15_GRACE_PERIOD_END"]
-    ):  
-        start, end  = app.config["SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS"]
+    ):
+        start, end = app.config["SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS"]
         return (TimeRangeEndpoint(start), TimeRangeEndpoint(end))
 
-    endpoints = form_data.get("time_range_endpoints")	
+    endpoints = form_data.get("time_range_endpoints")
     if (slc or slice_id) and not endpoints:
         try:
             _, datasource_type = get_datasource_info(None, None, form_data)
@@ -292,8 +292,8 @@ def get_time_range_endpoints(
         start, end = endpoints
         return (TimeRangeEndpoint(start), TimeRangeEndpoint(end))
 
-    start, end  = app.config["SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS"]
-    
+    start, end = app.config["SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS"]
+
     return (TimeRangeEndpoint(start), TimeRangeEndpoint(end))
 
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -275,14 +275,12 @@ def get_time_range_endpoints(
 
     
     if (slc or slice_id):
-        print('CHECK')
         try:
             _, datasource_type = get_datasource_info(None, None, form_data)
         except SupersetException:
             return None
 
         if datasource_type == "table":
-            print('TABLE')
             if not slc:
                 slc = db.session.query(Slice).filter_by(id=slice_id).one_or_none()
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -265,7 +265,6 @@ def get_time_range_endpoints(
     :param slice_id: The slice ID
     :returns: The time range endpoints tuple
     """
-    endpoints = None
     if (
         app.config["SIP_15_GRACE_PERIOD_END"]
         and date.today() >= app.config["SIP_15_GRACE_PERIOD_END"]
@@ -273,8 +272,8 @@ def get_time_range_endpoints(
         start, end  = app.config["SIP_15_DEFAULT_TIME_RANGE_ENDPOINTS"]
         return (TimeRangeEndpoint(start), TimeRangeEndpoint(end))
 
-    
-    if (slc or slice_id):
+    endpoints = form_data.get("time_range_endpoints")	
+    if (slc or slice_id) and not endpoints:
         try:
             _, datasource_type = get_datasource_info(None, None, form_data)
         except SupersetException:
@@ -288,8 +287,6 @@ def get_time_range_endpoints(
                 endpoints = slc.datasource.database.get_extra().get(
                     "time_range_endpoints"
                 )
-    if form_data.get("time_range_endpoints"):
-        endpoints = form_data.get("time_range_endpoints")
 
     if endpoints:
         start, end = endpoints

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -924,7 +924,7 @@ class TestUtils(SupersetTestCase):
 
         self.assertEqual(
             get_time_range_endpoints(form_data={"datasource": "1__table"}, slc=slc),
-            (TimeRangeEndpoint.UNKNOWN, TimeRangeEndpoint.INCLUSIVE),
+            (TimeRangeEndpoint.INCLUSIVE, TimeRangeEndpoint.EXCLUSIVE),
         )
 
         slc.datasource.database.get_extra.return_value = {


### PR DESCRIPTION
### SUMMARY
since SIP-15 is enabled, the time_range_endpoints is hardcoded to [start,end), without possibility of taking value set on extra params on database, or on default parameter on conf.py

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![image](https://user-images.githubusercontent.com/25669722/101776241-eb596b00-3af0-11eb-9917-3828d49c86c6.png)

![image](https://user-images.githubusercontent.com/25669722/101776264-f3b1a600-3af0-11eb-96d6-b2157d7c959d.png)



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
