### PR TITLE
chore: Refetch samples on Explore view only when filters change

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane.tsx
@@ -137,11 +137,18 @@ export const DataTablesPane = ({
   );
 
   useEffect(() => {
-    setIsRequestPending({
+    setIsRequestPending(prevState => ({
+      ...prevState,
       [RESULT_TYPES.results]: true,
-      [RESULT_TYPES.samples]: true,
-    });
+    }));
   }, [queryFormData]);
+
+  useEffect(() => {
+    setIsRequestPending(prevState => ({
+      ...prevState,
+      [RESULT_TYPES.samples]: true,
+    }));
+  }, [queryFormData.adhoc_filters]);
 
   useEffect(() => {
     if (panelOpen && isRequestPending[RESULT_TYPES.results]) {


### PR DESCRIPTION
### SUMMARY
This PR optimizes fetching samples. The goal is not to refetch on every change in controls panel, but only when filters change, because only filters affect the response of samples endpoint.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Verify that we refetch samples only when filters change either in Networking tab of browser console or visually, by seeing that there's no spinner that indicates fetching data.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Closes https://github.com/apache/incubator-superset/issues/11968
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @mistercrunch @rusackas @junlincc @adam-stasiak 