### PR TITLE
fix: add default position to dash export

### DIFF
--- a/superset/dashboards/commands/export.py
+++ b/superset/dashboards/commands/export.py
@@ -18,7 +18,9 @@
 
 import json
 import logging
-from typing import Iterator, Tuple
+import random
+import string
+from typing import Any, Dict, Iterator, List, Tuple
 
 import yaml
 from werkzeug.utils import secure_filename
@@ -28,6 +30,7 @@ from superset.dashboards.commands.exceptions import DashboardNotFoundError
 from superset.dashboards.dao import DashboardDAO
 from superset.commands.export import ExportModelsCommand
 from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
 from superset.utils.dict_import_export import EXPORT_VERSION
 
 logger = logging.getLogger(__name__)
@@ -35,6 +38,53 @@ logger = logging.getLogger(__name__)
 
 # keys stored as JSON are loaded and the prefix/suffix removed
 JSON_KEYS = {"position_json": "position", "json_metadata": "metadata"}
+
+
+def suffix(length: int = 8) -> str:
+    return "".join(
+        random.SystemRandom().choice(string.ascii_uppercase + string.digits)
+        for _ in range(length)
+    )
+
+
+def default_position(title: str, charts: List[Slice]) -> Dict[str, Any]:
+    chart_hashes = [f"CHART-{suffix()}" for _ in charts]
+    row_hash = f"ROW-N-{suffix()}"
+    position = {
+        "DASHBOARD_VERSION_KEY": "v2",
+        "ROOT_ID": {"children": ["GRID_ID"], "id": "ROOT_ID", "type": "ROOT",},
+        "GRID_ID": {
+            "children": [row_hash],
+            "id": "GRID_ID",
+            "parents": ["ROOT_ID"],
+            "type": "GRID",
+        },
+        "HEADER_ID": {"id": "HEADER_ID", "meta": {"text": title,}, "type": "HEADER",},
+        row_hash: {
+            "children": chart_hashes,
+            "id": row_hash,
+            "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT",},
+            "parents": ["ROOT_ID", "GRID_ID"],
+            "type": "ROW",
+        },
+    }
+
+    for chart_hash, chart in zip(chart_hashes, charts):
+        position[chart_hash] = {
+            "children": [],
+            "id": chart_hash,
+            "meta": {
+                "chartId": chart.id,
+                "height": 50,
+                "sliceName": chart.slice_name,
+                "uuid": str(chart.uuid),
+                "width": 4,
+            },
+            "parents": ["ROOT_ID", "GRID_ID", row_hash],
+            "type": "CHART",
+        }
+
+    return position
 
 
 class ExportDashboardsCommand(ExportModelsCommand):
@@ -63,6 +113,11 @@ class ExportDashboardsCommand(ExportModelsCommand):
                 except (TypeError, json.decoder.JSONDecodeError):
                     logger.info("Unable to decode `%s` field: %s", key, value)
                     payload[new_name] = {}
+
+        # the mapping between dashboard -> charts is inferred from the position
+        # attributes, so if it's not present we need to add a default config
+        if not payload.get("position"):
+            payload["position"] = default_position(model.dashboard_title, model.slices)
 
         payload["version"] = EXPORT_VERSION
 

--- a/superset/dashboards/commands/export.py
+++ b/superset/dashboards/commands/export.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 # keys stored as JSON are loaded and the prefix/suffix removed
 JSON_KEYS = {"position_json": "position", "json_metadata": "metadata"}
+DEFAULT_CHART_HEIGHT = 50
+DEFAULT_CHART_WIDTH = 4
 
 
 def suffix(length: int = 8) -> str:
@@ -52,18 +54,18 @@ def default_position(title: str, charts: List[Slice]) -> Dict[str, Any]:
     row_hash = f"ROW-N-{suffix()}"
     position = {
         "DASHBOARD_VERSION_KEY": "v2",
-        "ROOT_ID": {"children": ["GRID_ID"], "id": "ROOT_ID", "type": "ROOT",},
+        "ROOT_ID": {"children": ["GRID_ID"], "id": "ROOT_ID", "type": "ROOT"},
         "GRID_ID": {
             "children": [row_hash],
             "id": "GRID_ID",
             "parents": ["ROOT_ID"],
             "type": "GRID",
         },
-        "HEADER_ID": {"id": "HEADER_ID", "meta": {"text": title,}, "type": "HEADER",},
+        "HEADER_ID": {"id": "HEADER_ID", "meta": {"text": title}, "type": "HEADER"},
         row_hash: {
             "children": chart_hashes,
             "id": row_hash,
-            "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT",},
+            "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"},
             "parents": ["ROOT_ID", "GRID_ID"],
             "type": "ROW",
         },
@@ -75,10 +77,10 @@ def default_position(title: str, charts: List[Slice]) -> Dict[str, Any]:
             "id": chart_hash,
             "meta": {
                 "chartId": chart.id,
-                "height": 50,
+                "height": DEFAULT_CHART_HEIGHT,
                 "sliceName": chart.slice_name,
                 "uuid": str(chart.uuid),
-                "width": 4,
+                "width": DEFAULT_CHART_WIDTH,
             },
             "parents": ["ROOT_ID", "GRID_ID", row_hash],
             "type": "CHART",


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The layout of dashboards is stored in the `position_json` attribute, containing the position and ID of charts. When a dashboard layout hasn't been modified the attribute is empty, and the relationship between which charts are contained in a given dashboard exists only in the `dashboard_slices` table and **is not exported**.

With this PR, if `position_json` is empty we add a default position to the attribute, so that the relationship between dashboards and charts is present in the export bundle. This doesn't change the layout, but allows us to extract the relationship when importing the dashboard together with the charts.

One alternative to this PR would be explicitly listing the UUIDs of charts when we export a dashboard, eg:

```yaml
# dashboards/some_dashboard.yaml
dashboard_title: Test Import [copy]
description: null
css: ''
slug: null
uuid: a1a7dd04-d113-46b8-8cb9-29b9eef280f4
chart_uuids:
- foo
- bar
```

But since most dashboards will have the `position_json` attribute set, it seems more efficient to populate it when it's empty.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Exported dash, verified the YAML file, and imported again, ensuring that layout was not altered.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
