### PR TITLE
fix: Scroll for big charts

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -87,6 +87,9 @@ const Styles = styled.div`
     opacity: 0.75;
     font-size: ${({ theme }) => theme.typography.sizes.s}px;
   }
+  svg {
+    width: auto !important;
+  }
 `;
 
 class Chart extends React.PureComponent {
@@ -212,6 +215,7 @@ class Chart extends React.PureComponent {
           <div
             className={`slice_container ${isFaded ? ' faded' : ''}`}
             data-test="slice-container"
+            style={{ width, overflow: 'scroll' }}
           >
             <ChartRenderer {...this.props} data-test={this.props.vizType} />
           </div>


### PR DESCRIPTION
### SUMMARY
Add scroll to view entire Time-Series Bar Chart

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
![image](https://user-images.githubusercontent.com/8277264/101888423-c7586100-3ba6-11eb-8210-fc2657bcf09c.png)
AFTER
![Kapture 2020-12-11 at 11 48 57](https://user-images.githubusercontent.com/8277264/101888634-0d152980-3ba7-11eb-9377-ca48c232feed.gif)


### TEST PLAN
Add a new chart
Select Time-series Bar Chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] https://github.com/apache/incubator-superset/issues/11859
