### PR TITLE
style: Restoring menu highlights

### DIFF
--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -100,11 +100,10 @@ const StyledHeader = styled.header`
   }
 
   .navbar-nav > li > a {
+  .navbar-inverse .navbar-nav > li > a {
     color: ${({ theme }) => theme.colors.grayscale.dark1};
     border-bottom: none;
-    &:focus {
-      border-bottom: none;
-    }
+    transition: background-color ${({ theme }) => theme.transitionTiming}s;
     &:after {
       content: '';
       position: absolute;
@@ -115,19 +114,22 @@ const StyledHeader = styled.header`
       opacity: 0;
       transform: translateX(-50%);
       transition: all ${({ theme }) => theme.transitionTiming}s;
+      background-color: ${({ theme }) => theme.colors.primary.base};
     }
-
+    &:focus {
+      border-bottom: none;
+      background-color: transparent;
+      /* background-color: ${({ theme }) => theme.colors.primary.light5}; */
+    }
     &:hover {
       color: ${({ theme }) => theme.colors.grayscale.dark1};
+      background-color: ${({ theme }) => theme.colors.primary.light5};
       border-bottom: none;
+      margin: 0;
       &:after {
         opacity: 1;
         width: 100%;
       }
-    }
-    &:hover,
-    &:focus {
-      margin: 0;
     }
   }
 

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -99,7 +99,6 @@ const StyledHeader = styled.header`
     padding-left: 12px;
   }
 
-  .navbar-nav > li > a {
   .navbar-inverse .navbar-nav > li > a {
     color: ${({ theme }) => theme.colors.grayscale.dark1};
     border-bottom: none;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Following up on https://github.com/apache/incubator-superset/pull/11915
This PR restores the little animated underlines, and the nav link hover backgrounds, which got lost somewhere along the line in a refactor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
![menu](https://user-images.githubusercontent.com/812905/102003952-c287d000-3cc0-11eb-9a59-1fdd0bb8b939.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
