### PR TITLE
feat: Global nav menus open on hover

### DIFF
--- a/superset-frontend/src/components/Menu/LanguagePicker.tsx
+++ b/superset-frontend/src/components/Menu/LanguagePicker.tsx
@@ -41,9 +41,9 @@ export default function LanguagePicker({
 
   return (
     <NavDropdown
-      onMouseEnter = { () => setDropdownOpen(true) }
-      onMouseLeave = { () => setDropdownOpen(false) }
-      open={ dropdownOpen }
+      onMouseEnter={() => setDropdownOpen(true)}
+      onMouseLeave={() => setDropdownOpen(false)}
+      open={dropdownOpen}
       id="locale-dropdown"
       title={
         <span className="f16">

--- a/superset-frontend/src/components/Menu/LanguagePicker.tsx
+++ b/superset-frontend/src/components/Menu/LanguagePicker.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { Menu } from 'src/common/components';
 import NavDropdown from 'src/components/NavDropdown';
 
@@ -37,8 +37,13 @@ export default function LanguagePicker({
   locale,
   languages,
 }: LanguagePickerProps) {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
   return (
     <NavDropdown
+      onMouseEnter = { () => setDropdownOpen(true) }
+      onMouseLeave = { () => setDropdownOpen(false) }
+      open={ dropdownOpen }
       id="locale-dropdown"
       title={
         <span className="f16">

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -99,11 +99,7 @@ const StyledHeader = styled.header`
     padding-left: 12px;
   }
 
-  .dropdown-menu {
-    transform: translateY(3px);
-  }
-
-  .navbar-inverse .navbar-nav > li > a {
+  .navbar-nav > li > a {
     color: ${({ theme }) => theme.colors.grayscale.dark1};
     border-bottom: none;
     &:focus {
@@ -178,10 +174,12 @@ export function Menu({
         <Nav className="navbar-right">
           {!navbarRight.user_is_anonymous && <NewMenu />}
           {settings && settings.length > 0 && (
-            <NavDropdown id="settings-dropdown" title={t('Settings')}
-              onMouseEnter = { () => setDropdownOpen(true) }
-              onMouseLeave = { () => setDropdownOpen(false) }
-              open={ dropdownOpen }
+            <NavDropdown
+              id="settings-dropdown"
+              title={t('Settings')}
+              onMouseEnter={() => setDropdownOpen(true)}
+              onMouseLeave={() => setDropdownOpen(false)}
+              open={dropdownOpen}
             >
               <DropdownMenu>
                 {settings.map((section, index) => [

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -99,7 +99,7 @@ const StyledHeader = styled.header`
     padding-left: 12px;
   }
 
-  .navbar-nav > li > a {
+  .navbar-inverse .navbar-nav > li > a {
     color: ${({ theme }) => theme.colors.grayscale.dark1};
     border-bottom: none;
     &:focus {

--- a/superset-frontend/src/components/Menu/Menu.tsx
+++ b/superset-frontend/src/components/Menu/Menu.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { t, styled } from '@superset-ui/core';
 import { Nav, Navbar, NavItem } from 'react-bootstrap';
 import NavDropdown from 'src/components/NavDropdown';
@@ -99,7 +99,11 @@ const StyledHeader = styled.header`
     padding-left: 12px;
   }
 
-  .navbar-nav > li > a {
+  .dropdown-menu {
+    transform: translateY(3px);
+  }
+
+  .navbar-inverse .navbar-nav > li > a {
     color: ${({ theme }) => theme.colors.grayscale.dark1};
     border-bottom: none;
     &:focus {
@@ -153,6 +157,8 @@ const StyledHeader = styled.header`
 export function Menu({
   data: { menu, brand, navbar_right: navbarRight, settings },
 }: MenuProps) {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
   return (
     <StyledHeader className="top" id="main-menu">
       <Navbar inverse fluid staticTop role="navigation">
@@ -172,7 +178,11 @@ export function Menu({
         <Nav className="navbar-right">
           {!navbarRight.user_is_anonymous && <NewMenu />}
           {settings && settings.length > 0 && (
-            <NavDropdown id="settings-dropdown" title={t('Settings')}>
+            <NavDropdown id="settings-dropdown" title={t('Settings')}
+              onMouseEnter = { () => setDropdownOpen(true) }
+              onMouseLeave = { () => setDropdownOpen(false) }
+              open={ dropdownOpen }
+            >
               <DropdownMenu>
                 {settings.map((section, index) => [
                   <DropdownMenu.ItemGroup

--- a/superset-frontend/src/components/Menu/MenuObject.tsx
+++ b/superset-frontend/src/components/Menu/MenuObject.tsx
@@ -55,12 +55,13 @@ export default function MenuObject({
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
   return (
-    <NavDropdown 
-        id={`menu-dropdown-${label}`} 
-        title={label} 
-        onMouseEnter = { () => setDropdownOpen(true) }
-        onMouseLeave = { () => setDropdownOpen(false) }
-        open={ dropdownOpen }>
+    <NavDropdown
+      id={`menu-dropdown-${label}`}
+      title={label}
+      onMouseEnter={() => setDropdownOpen(true)}
+      onMouseLeave={() => setDropdownOpen(false)}
+      open={dropdownOpen}
+    >
       <Menu>
         {childs?.map((child: MenuObjectChildProps | string, index1: number) => {
           if (typeof child === 'string' && child === '-') {

--- a/superset-frontend/src/components/Menu/MenuObject.tsx
+++ b/superset-frontend/src/components/Menu/MenuObject.tsx
@@ -44,6 +44,8 @@ export default function MenuObject({
   url,
   index,
 }: MenuObjectProps) {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
   if (url) {
     return (
       <NavItem eventKey={index} href={url}>
@@ -51,8 +53,6 @@ export default function MenuObject({
       </NavItem>
     );
   }
-
-  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   return (
     <NavDropdown

--- a/superset-frontend/src/components/Menu/MenuObject.tsx
+++ b/superset-frontend/src/components/Menu/MenuObject.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { NavItem } from 'react-bootstrap';
 import { Menu } from 'src/common/components';
 import NavDropdown from '../NavDropdown';
@@ -52,8 +52,15 @@ export default function MenuObject({
     );
   }
 
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
   return (
-    <NavDropdown id={`menu-dropdown-${label}`} title={label}>
+    <NavDropdown 
+        id={`menu-dropdown-${label}`} 
+        title={label} 
+        onMouseEnter = { () => setDropdownOpen(true) }
+        onMouseLeave = { () => setDropdownOpen(false) }
+        open={ dropdownOpen }>
       <Menu>
         {childs?.map((child: MenuObjectChildProps | string, index1: number) => {
           if (typeof child === 'string' && child === '-') {

--- a/superset-frontend/src/components/Menu/NewMenu.tsx
+++ b/superset-frontend/src/components/Menu/NewMenu.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, {useState} from 'react';
 import { t, styled } from '@superset-ui/core';
 import { Menu } from 'src/common/components';
 import NavDropdown from 'src/components/NavDropdown';
@@ -43,8 +43,14 @@ const StyledI = styled.div`
 `;
 
 export default function NewMenu() {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
   return (
-    <NavDropdown id="new-dropdown" title={<StyledI className="fa fa-plus" />}>
+    <NavDropdown id="new-dropdown" title={<StyledI className="fa fa-plus" />}
+      onMouseEnter = { () => setDropdownOpen(true) }
+      onMouseLeave = { () => setDropdownOpen(false) }
+      open={ dropdownOpen }
+    >
       <Menu>
         {dropdownItems.map((menu, i) => (
           <Menu.Item key={i}>

--- a/superset-frontend/src/components/Menu/NewMenu.tsx
+++ b/superset-frontend/src/components/Menu/NewMenu.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import { t, styled } from '@superset-ui/core';
 import { Menu } from 'src/common/components';
 import NavDropdown from 'src/components/NavDropdown';
@@ -46,10 +46,12 @@ export default function NewMenu() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
   return (
-    <NavDropdown id="new-dropdown" title={<StyledI className="fa fa-plus" />}
-      onMouseEnter = { () => setDropdownOpen(true) }
-      onMouseLeave = { () => setDropdownOpen(false) }
-      open={ dropdownOpen }
+    <NavDropdown
+      id="new-dropdown"
+      title={<StyledI className="fa fa-plus" />}
+      onMouseEnter={() => setDropdownOpen(true)}
+      onMouseLeave={() => setDropdownOpen(false)}
+      open={dropdownOpen}
     >
       <Menu>
         {dropdownItems.map((menu, i) => (


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I was fiddling around on the menus in this PR: https://github.com/apache/incubator-superset/pull/12024
I was finding it strangely tedious to have to click the global nav menus to open them. Hover-opening seemed lie it'd be more natural. Not sure others will agree, but if they do, we can merge this PR after that one.

Curious what others think, e.g. @junlincc @ktmud @mihir174

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![hover-open](https://user-images.githubusercontent.com/812905/102004264-fd3f3780-3cc3-11eb-9083-df9c9cf55e5d.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
