### PR TITLE
fix: missing dim options for deckgl charts

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -6221,9 +6221,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -6257,11 +6257,11 @@
       },
       "dependencies": {
         "math.gl": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.2.2.tgz",
-          "integrity": "sha512-lkM9y3DirpOBMpCCrsOMV3AWkxtwql8fvF98EUN0SLOMWAIjnkQBS9NPleN5uvqpnjSVZd3Y3cn+fbIuA4npmQ==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.3.2.tgz",
+          "integrity": "sha512-33CWhbeiQxl+lzpnKdKijH9mPdZRQUP9TlBILNh6xhnJdMD9D+Kle6Xhfb8dMllE1UUQcPZlQ8/Sd1qSVtNsKQ==",
           "requires": {
-            "@math.gl/core": "3.2.2"
+            "@math.gl/core": "3.3.2"
           }
         }
       }
@@ -6276,11 +6276,11 @@
       },
       "dependencies": {
         "math.gl": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.2.2.tgz",
-          "integrity": "sha512-lkM9y3DirpOBMpCCrsOMV3AWkxtwql8fvF98EUN0SLOMWAIjnkQBS9NPleN5uvqpnjSVZd3Y3cn+fbIuA4npmQ==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.3.2.tgz",
+          "integrity": "sha512-33CWhbeiQxl+lzpnKdKijH9mPdZRQUP9TlBILNh6xhnJdMD9D+Kle6Xhfb8dMllE1UUQcPZlQ8/Sd1qSVtNsKQ==",
           "requires": {
-            "@math.gl/core": "3.2.2"
+            "@math.gl/core": "3.3.2"
           }
         }
       }
@@ -6378,18 +6378,18 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@math.gl/core": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.2.2.tgz",
-      "integrity": "sha512-R1UQwg699pfReLHy0N+ach2KdGqH4XsniEPKM7H0WbeDhEvuoMRWB9oNtIw9qPQV39lBv3Dzplaw5DPscwgMPQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.3.2.tgz",
+      "integrity": "sha512-W0QoVrdjiLs52ivtozrHbCitqWGNsWi4TwdfBckhOaeB5cE/R/pyOXfvLmdwGj2b1TLSg8SwgZLlmkWG776GKw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "gl-matrix": "^3.0.0"
       }
     },
     "@math.gl/web-mercator": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.2.2.tgz",
-      "integrity": "sha512-uZbLlST7gbfJV227Ev1oShpYQGon9Nk/i0AoM81mVoEYtd+XxKuoDBYaRIdPNVkkALwF9xFG1lwxHqblrs3v5w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.3.2.tgz",
+      "integrity": "sha512-84NNnwP97Xwm1ynZzat1BuEU2uLyIw0gzG5uvGMrAzezny2P38+E2cUK8t9eptKa8gjk2MaC7hhcO0saFCZTHw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "gl-matrix": "^3.0.0"
@@ -18709,9 +18709,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-deckgl": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.3.1.tgz",
-      "integrity": "sha512-mHX2vWJH+1Hq5QuQu2wlKstLgql3/ukNU1SVoLyjDX/BdTqeZiISMCumj2UUMbf0cK1zjHPHrVUCLzJwfsQbUQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-deckgl/-/legacy-preset-chart-deckgl-0.3.2.tgz",
+      "integrity": "sha512-6GH1RZmM5jyKTGOnKU9RfavdhIQX5Uv27n0zn/k4uyW/LH/9G/L0QGQbAX6jtYOxuQBASW3pwQWN/lGdZ8vEPQ==",
       "requires": {
         "@math.gl/web-mercator": "^3.2.2",
         "@types/d3-array": "^2.0.0",
@@ -30618,7 +30618,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
@@ -31479,9 +31479,9 @@
       }
     },
     "h3-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.6.4.tgz",
-      "integrity": "sha512-wMu0Y+vdh4xx2WT1jqy4QDBgJupjBfHsGaMtMsFocdZdIsfxLFufzjGcmReOSfKQ+twRO2XjXAmDY9h1nq99EA=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.7.0.tgz",
+      "integrity": "sha512-EcH/qGU4khZsAEG39Uu8MvaCing0JFcuoe3K4Xmg5MofDIu1cNJl7z2AQS8ggvXGxboiLJqsGirhEqFKdd2gAA=="
     },
     "hammerjs": {
       "version": "2.0.8",
@@ -50709,9 +50709,9 @@
       }
     },
     "underscore": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
-      "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
     },
     "unfetch": {
       "version": "4.1.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -87,7 +87,7 @@
     "@superset-ui/legacy-plugin-chart-treemap": "^0.15.17",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.15.17",
     "@superset-ui/legacy-preset-chart-big-number": "^0.15.17",
-    "@superset-ui/legacy-preset-chart-deckgl": "^0.3.1",
+    "@superset-ui/legacy-preset-chart-deckgl": "^0.3.2",
     "@superset-ui/legacy-preset-chart-nvd3": "^0.15.17",
     "@superset-ui/plugin-chart-echarts": "^0.15.17",
     "@superset-ui/plugin-chart-table": "^0.15.17",


### PR DESCRIPTION
### SUMMARY

This brings in the fix in https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/21

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/21

### TEST PLAN

Manual. See https://github.com/apache-superset/superset-ui-plugins-deckgl/pull/21 on how to reproduce.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
