### PR TITLE
fix(reports): log duration and sort columns

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -111,7 +111,8 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
           row: {
             original: { start_dttm: startDttm, end_dttm: endDttm },
           },
-        }: any) => fDuration(endDttm - startDttm),
+        }: any) =>
+          fDuration(new Date(startDttm).getTime(), new Date(endDttm).getTime()),
         Header: t('Duration'),
         disableSortBy: true,
       },

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -145,6 +145,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "changed_on",
         "changed_on_delta_humanized",
         "created_on",
+        "crontab",
         "name",
         "type",
     ]
@@ -200,7 +201,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         try:
             DeleteReportScheduleCommand(g.user, pk).run()
             return self.response(200, message="OK")
-        except ReportScheduleNotFoundError as ex:
+        except ReportScheduleNotFoundError:
             return self.response_404()
         except ReportScheduleDeleteFailedError as ex:
             logger.error(

--- a/superset/reports/logs/api.py
+++ b/superset/reports/logs/api.py
@@ -64,6 +64,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
         "error_message",
         "end_dttm",
         "start_dttm",
+        "scheduled_dttm",
     ]
     openapi_spec_tag = "Report Schedules"
     openapi_spec_methods = openapi_spec_methods_override

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -199,6 +199,7 @@ class ReportSchedulePutSchema(Schema):
         description=sql_description,
         example="SELECT value FROM time_series_table",
         required=False,
+        allow_none=True,
     )
     chart = fields.Integer(required=False)
     dashboard = fields.Integer(required=False)
@@ -209,6 +210,7 @@ class ReportSchedulePutSchema(Schema):
         validate=validate.OneOf(
             choices=tuple(key.value for key in ReportScheduleValidatorType)
         ),
+        allow_none=True,
         required=False,
     )
     validator_config_json = fields.Nested(ValidatorConfigJSONSchema, required=False)
@@ -219,6 +221,9 @@ class ReportSchedulePutSchema(Schema):
         description=grace_period_description, example=60 * 60 * 4, required=False
     )
     working_timeout = fields.Integer(
-        description=working_timeout_description, example=60 * 60 * 1, required=False
+        description=working_timeout_description,
+        example=60 * 60 * 1,
+        allow_none=True,
+        required=False,
     )
     recipients = fields.List(fields.Nested(ReportRecipientSchema), required=False)


### PR DESCRIPTION
### SUMMARY
Fix various small bugs:

- Sort error for field `crontab` on alerts/reports list.
- Sort error for field `scheduled_dttm` on execution log list
- Not possible to insert/update reports
- Duration field was showing `invalid date`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
