### PR TITLE
refactor: Migrate react-select to Antd Select in Metrics and Filters popovers

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopoverSimpleTabContent_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopoverSimpleTabContent_spec.jsx
@@ -59,10 +59,10 @@ const simpleCustomFilter = new AdhocFilter({
 });
 
 const options = [
-  { type: 'VARCHAR(255)', column_name: 'source' },
-  { type: 'VARCHAR(255)', column_name: 'target' },
-  { type: 'DOUBLE', column_name: 'value' },
-  { saved_metric_name: 'my_custom_metric' },
+  { type: 'VARCHAR(255)', column_name: 'source', id: 1 },
+  { type: 'VARCHAR(255)', column_name: 'target', id: 2 },
+  { type: 'DOUBLE', column_name: 'value', id: 3 },
+  { saved_metric_name: 'my_custom_metric', id: 4 },
   sumValueAdhocMetric,
 ];
 
@@ -91,9 +91,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
 
   it('passes the new adhocFilter to onChange after onSubjectChange', () => {
     const { wrapper, onChange } = setup();
-    wrapper
-      .instance()
-      .onSubjectChange({ type: 'VARCHAR(255)', column_name: 'source' });
+    wrapper.instance().onSubjectChange(1);
     expect(onChange.calledOnce).toBe(true);
     expect(onChange.lastCall.args[0]).toEqual(
       simpleAdhocFilter.duplicateWith({ subject: 'source' }),
@@ -102,7 +100,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
 
   it('may alter the clause in onSubjectChange if the old clause is not appropriate', () => {
     const { wrapper, onChange } = setup();
-    wrapper.instance().onSubjectChange(sumValueAdhocMetric);
+    wrapper.instance().onSubjectChange(sumValueAdhocMetric.optionName);
     expect(onChange.calledOnce).toBe(true);
     expect(onChange.lastCall.args[0]).toEqual(
       simpleAdhocFilter.duplicateWith({

--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
@@ -28,9 +28,9 @@ import AdhocMetricEditPopover from 'src/explore/components/AdhocMetricEditPopove
 import { AGGREGATES } from 'src/explore/constants';
 
 const columns = [
-  { type: 'VARCHAR(255)', column_name: 'source' },
-  { type: 'VARCHAR(255)', column_name: 'target' },
-  { type: 'DOUBLE', column_name: 'value' },
+  { type: 'VARCHAR(255)', column_name: 'source', id: 1 },
+  { type: 'VARCHAR(255)', column_name: 'target', id: 2 },
+  { type: 'DOUBLE', column_name: 'value', id: 3 },
 ];
 
 const sumValueAdhocMetric = new AdhocMetric({
@@ -68,7 +68,7 @@ describe('AdhocMetricEditPopover', () => {
 
   it('overwrites the adhocMetric in state with onColumnChange', () => {
     const { wrapper } = setup();
-    wrapper.instance().onColumnChange(columns[0]);
+    wrapper.instance().onColumnChange(columns[0].id);
     expect(wrapper.state('adhocMetric')).toEqual(
       sumValueAdhocMetric.duplicateWith({ column: columns[0] }),
     );
@@ -95,7 +95,7 @@ describe('AdhocMetricEditPopover', () => {
     expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
     wrapper.instance().onColumnChange(null);
     expect(wrapper.find(Button).find({ disabled: true })).toExist();
-    wrapper.instance().onColumnChange({ column: columns[0] });
+    wrapper.instance().onColumnChange(columns[0].id);
     expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
     wrapper.instance().onAggregateChange(null);
     expect(wrapper.find(Button).find({ disabled: true })).toExist();
@@ -104,7 +104,7 @@ describe('AdhocMetricEditPopover', () => {
   it('highlights save if changes are present', () => {
     const { wrapper } = setup();
     expect(wrapper.find(Button).find({ buttonStyle: 'primary' })).not.toExist();
-    wrapper.instance().onColumnChange({ column: columns[1] });
+    wrapper.instance().onColumnChange(columns[1].id);
     expect(wrapper.find(Button).find({ buttonStyle: 'primary' })).toExist();
   });
 

--- a/superset-frontend/src/common/components/Select.tsx
+++ b/superset-frontend/src/common/components/Select.tsx
@@ -20,6 +20,10 @@ import { styled } from '@superset-ui/core';
 import { Select as BaseSelect } from 'src/common/components';
 
 const StyledSelect = styled(BaseSelect)`
+  display: block;
+`;
+
+const StyledGraySelect = styled(StyledSelect)`
   &.ant-select-single {
     .ant-select-selector {
       height: 36px;
@@ -42,5 +46,9 @@ const StyledSelect = styled(BaseSelect)`
 const StyledOption = BaseSelect.Option;
 
 export const Select = Object.assign(StyledSelect, {
+  Option: StyledOption,
+});
+
+export const GraySelect = Object.assign(StyledGraySelect, {
   Option: StyledOption,
 });

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSqlTabContent.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'react-bootstrap';
-import Select from 'src/components/Select';
+import { Select } from 'src/common/components/Select';
 import { t } from '@superset-ui/core';
 import { SQLEditor } from 'src/components/AsyncAceEditor';
 import sqlKeywords from 'src/SqlLab/utils/sqlKeywords';
@@ -51,11 +51,7 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
     this.handleAceEditorRef = this.handleAceEditorRef.bind(this);
 
     this.selectProps = {
-      isMulti: false,
       name: 'select-column',
-      labelKey: 'label',
-      autosize: false,
-      clearable: false,
     };
   }
 
@@ -94,7 +90,6 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
 
     const clauseSelectProps = {
       placeholder: t('choose WHERE or HAVING...'),
-      options: Object.keys(CLAUSES),
       value: adhocFilter.clause,
       onChange: this.onSqlExpressionClauseChange,
     };
@@ -121,7 +116,13 @@ export default class AdhocFilterEditPopoverSqlTabContent extends React.Component
             {...this.selectProps}
             {...clauseSelectProps}
             className="filter-edit-clause-dropdown"
-          />
+          >
+            {Object.keys(CLAUSES).map(clause => (
+              <Select.Option value={clause} key={clause}>
+                {clause}
+              </Select.Option>
+            ))}
+          </Select>
           <span className="filter-edit-clause-info">
             <strong>WHERE</strong> {t('filters by columns')}
             <br />

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -203,7 +203,6 @@ export default class AdhocMetricEditPopover extends React.Component {
         (adhocMetric.column && adhocMetric.column.column_name) ||
         adhocMetric.inferSqlExpressionColumn(),
       onChange: this.onColumnChange,
-      optionRenderer: this.renderColumnOption,
       allowClear: true,
       showSearch: true,
       filterOption: (input, option) =>
@@ -254,7 +253,8 @@ export default class AdhocMetricEditPopover extends React.Component {
                 {columns.map(column => (
                   <Select.Option
                     value={column.id}
-                    filterBy={column.column_name}
+                    filterBy={column.verbose_name || column.column_name}
+                    key={column.id}
                   >
                     {this.renderColumnOption(column)}
                   </Select.Option>
@@ -267,7 +267,9 @@ export default class AdhocMetricEditPopover extends React.Component {
               </FormLabel>
               <Select name="select-aggregate" {...aggregateSelectProps}>
                 {AGGREGATES_OPTIONS.map(option => (
-                  <Select.Option value={option}>{option}</Select.Option>
+                  <Select.Option value={option} key={option}>
+                    {option}
+                  </Select.Option>
                 ))}
               </Select>
             </FormGroup>

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import { FormGroup } from 'react-bootstrap';
 import Tabs from 'src/common/components/Tabs';
 import Button from 'src/components/Button';
-import Select from 'src/components/Select';
+import { Select } from 'src/common/components/Select';
 import { styled, t } from '@superset-ui/core';
 import { ColumnOption } from '@superset-ui/chart-controls';
 
@@ -70,25 +70,10 @@ export default class AdhocMetricEditPopover extends React.Component {
     this.handleAceEditorRef = this.handleAceEditorRef.bind(this);
     this.refreshAceEditor = this.refreshAceEditor.bind(this);
 
-    this.popoverRef = React.createRef();
-
     this.state = {
       adhocMetric: this.props.adhocMetric,
       width: startingWidth,
       height: startingHeight,
-    };
-
-    this.selectProps = {
-      labelKey: 'label',
-      isMulti: false,
-      autosize: false,
-      clearable: true,
-    };
-
-    this.menuPortalProps = {
-      menuPosition: 'fixed',
-      menuPlacement: 'bottom',
-      menuPortalTarget: this.popoverRef.current,
     };
 
     document.addEventListener('mouseup', this.onMouseUp);
@@ -118,7 +103,8 @@ export default class AdhocMetricEditPopover extends React.Component {
     this.props.onClose();
   }
 
-  onColumnChange(column) {
+  onColumnChange(columnId) {
+    const column = this.props.columns.find(column => column.id === columnId);
     this.setState(prevState => ({
       adhocMetric: prevState.adhocMetric.duplicateWith({
         column,
@@ -213,20 +199,24 @@ export default class AdhocMetricEditPopover extends React.Component {
 
     const columnSelectProps = {
       placeholder: t('%s column(s)', columns.length),
-      options: columns,
       value:
         (adhocMetric.column && adhocMetric.column.column_name) ||
         adhocMetric.inferSqlExpressionColumn(),
       onChange: this.onColumnChange,
       optionRenderer: this.renderColumnOption,
-      valueKey: 'column_name',
+      allowClear: true,
+      showSearch: true,
+      filterOption: (input, option) =>
+        option.filterBy.toLowerCase().indexOf(input.toLowerCase()) >= 0,
     };
 
     const aggregateSelectProps = {
       placeholder: t('%s aggregates(s)', AGGREGATES_OPTIONS.length),
-      options: AGGREGATES_OPTIONS,
       value: adhocMetric.aggregate || adhocMetric.inferSqlExpressionAggregate(),
       onChange: this.onAggregateChange,
+      allowClear: true,
+      autoFocus: true,
+      showSearch: true,
     };
 
     if (this.props.datasourceType === 'druid') {
@@ -241,7 +231,6 @@ export default class AdhocMetricEditPopover extends React.Component {
       <div
         id="metrics-edit-popover"
         data-test="metrics-edit-popover"
-        ref={this.popoverRef}
         {...popoverProps}
       >
         <Tabs
@@ -261,24 +250,26 @@ export default class AdhocMetricEditPopover extends React.Component {
               <FormLabel>
                 <strong>column</strong>
               </FormLabel>
-              <Select
-                name="select-column"
-                {...this.selectProps}
-                {...this.menuPortalProps}
-                {...columnSelectProps}
-              />
+              <Select name="select-column" {...columnSelectProps}>
+                {columns.map(column => (
+                  <Select.Option
+                    value={column.id}
+                    filterBy={column.column_name}
+                  >
+                    {this.renderColumnOption(column)}
+                  </Select.Option>
+                ))}
+              </Select>
             </FormGroup>
             <FormGroup>
               <FormLabel>
                 <strong>aggregate</strong>
               </FormLabel>
-              <Select
-                name="select-aggregate"
-                {...this.selectProps}
-                {...this.menuPortalProps}
-                {...aggregateSelectProps}
-                autoFocus
-              />
+              <Select name="select-aggregate" {...aggregateSelectProps}>
+                {AGGREGATES_OPTIONS.map(option => (
+                  <Select.Option value={option}>{option}</Select.Option>
+                ))}
+              </Select>
             </FormGroup>
           </Tabs.TabPane>
           <Tabs.TabPane

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -24,7 +24,7 @@ import { useSingleViewResource } from 'src/views/CRUD/hooks';
 import Icon from 'src/components/Icon';
 import Modal from 'src/common/components/Modal';
 import { Switch } from 'src/common/components/Switch';
-import { Select } from 'src/common/components/Select';
+import { GraySelect as Select } from 'src/common/components/Select';
 import { Radio } from 'src/common/components/Radio';
 import { AsyncSelect } from 'src/components/Select';
 import withToasts from 'src/messageToasts/enhancers/withToasts';


### PR DESCRIPTION
### SUMMARY
As a first part of https://github.com/apache/incubator-superset/issues/11916, I migrated react-select components in Filters and Metrics popovers to Antd. Next step will be refactoring MetricsControl and AdhocFiltersControl according to designs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
As you can see on the before/after screenshot, there is 1 difference - in the bottom select input we no longer display placeholder that says how many options are left when there's at least 1 option selected. Antd doesn't support displaying such label.

Before:
![image](https://user-images.githubusercontent.com/15073128/102120398-c6436000-3e42-11eb-9232-60e9d19d0c85.png)
After: 
![image](https://user-images.githubusercontent.com/15073128/102120349-b592ea00-3e42-11eb-9215-c195e7ef89c1.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro @adam-stasiak 