### PR TITLE
fix: disable browser autocomplete for DeleteModal

### DIFF
--- a/superset-frontend/src/components/DeleteModal.tsx
+++ b/superset-frontend/src/components/DeleteModal.tsx
@@ -73,6 +73,7 @@ export default function DeleteModal({
           id="delete"
           type="text"
           bsSize="sm"
+          autoComplete="off"
           onChange={(
             event: React.FormEvent<FormControl & FormControlProps>,
           ) => {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See title and linked issue
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="787" alt="Screen Shot 2020-12-14 at 1 12 41 PM" src="https://user-images.githubusercontent.com/10255196/102136327-194ef000-3e0e-11eb-982b-357a3d846d6e.png">

After:
<img width="823" alt="Screen Shot 2020-12-14 at 1 12 13 PM" src="https://user-images.githubusercontent.com/10255196/102136348-1fdd6780-3e0e-11eb-92e3-8c34d09abfa8.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- Ensure no browser autocomplete dropdown appears for the delete modal input 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #11933
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
