### PR TITLE
fix: (re)upgrade react-split

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -30618,7 +30618,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -152,7 +152,7 @@
     "react-select": "^3.1.0",
     "react-select-async-paginate": "^0.4.1",
     "react-sortable-hoc": "^1.11.0",
-    "react-split": "^2.0.4",
+    "react-split": "^2.0.9",
     "react-sticky": "^6.0.3",
     "react-syntax-highlighter": "^15.3.0",
     "react-table": "^7.2.1",


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Oops! 😬 I managed to _downgrade_ the package by accident (due to lack of rebase, most likely) when merging https://github.com/apache/incubator-superset/pull/11957. This PR restores it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
CI passes and nobody notices this even happened 🙈 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
