### PR TITLE
fix(viz): remove orderby from sample request

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -246,6 +246,7 @@ class BaseViz:
             {
                 "groupby": [],
                 "metrics": [],
+                "orderby": [],
                 "row_limit": config["SAMPLES_ROW_LIMIT"],
                 "columns": [o.column_name for o in self.datasource.columns],
             }


### PR DESCRIPTION
### SUMMARY
If a query object has specified an orderby referencing a metric, requesting a sample payload will fail due to the samples request only selecting individual columns without aggregates. This bug was already fixed in the V1 chart data endpoint in #11656, so this is essentially a backport of that fix. 

# Before
![image](https://user-images.githubusercontent.com/33317356/102189905-ff6de580-3ebf-11eb-9393-3a8d8c93ed55.png)

# After
![image](https://user-images.githubusercontent.com/33317356/102189828-e9602500-3ebf-11eb-856f-93d3bd311010.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
