### PR TITLE
fix: annotation layers: remove redirect on layer edit

### DIFF
--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx
@@ -122,10 +122,6 @@ const AnnotationLayerModal: FunctionComponent<AnnotationLayerModalProps> = ({
         delete currentLayer.id;
         delete currentLayer.created_by;
         updateResource(update_id, currentLayer).then(() => {
-          if (onLayerAdd) {
-            onLayerAdd();
-          }
-
           hide();
         });
       }


### PR DESCRIPTION
### SUMMARY
On annotation layer create, the user is redirected to the annotations list for that layer. A similar redirect was occurring on edit that brought the user to an invalid page. This fix removes that edit redirect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/11817
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
