### PR TITLE
build: fix typescript errors with npm link

### DIFF
--- a/superset-frontend/tsconfig.json
+++ b/superset-frontend/tsconfig.json
@@ -16,6 +16,11 @@
     "noUnusedLocals": true,
     "outDir": "./dist",
     "pretty": true,
+    "paths": {
+      // for supressing errors caused by incompatible @types/react when `npm link`
+      // Ref: https://github.com/Microsoft/typescript/issues/6496#issuecomment-384786222
+      "*": ["./node_modules/@types/*", "*"]
+    },
     "skipLibCheck": true,
     "sourceMap": true,
     "strictNullChecks": true,


### PR DESCRIPTION
### SUMMARY

Sometimes when `@superset-ui/core` or `@superset-ui/chart-controls` install an incompatible version of `@types/react` (from dependency chains), builds with `npm link` will throw typing errors. 

This tsconfig update fixes these errors following the advice from https://github.com/Microsoft/typescript/issues/6496#issuecomment-384786222

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

`npm link /source/code/to/superset-ui-core` and `npm run dev` should not throw typing errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
