### PR TITLE
build(cypress): Remove e2e pull_request event trigger

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -1,6 +1,6 @@
 name: E2E
 
-on: [push, pull_request, pull_request_target]
+on: [push, pull_request_target]
 
 jobs:
   cypress-matrix:


### PR DESCRIPTION
### SUMMARY
Remove the `pull_request` event trigger for e2e Cypress tests, in favor of `pull_request_target`, now that https://github.com/apache/incubator-superset/pull/11750 has been merged. The latter should have access to the `CYPRESS_RECORD_KEY` secret in the upstream repo, and Cypress tests should now run in parallel.

### TEST PLAN
Cypress tests in CI should run in parallel.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
