### PR TITLE
feat(alert/report): add 'not null' condition option to modal

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -578,8 +578,8 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
         delete data.last_value;
         delete data.last_value_row_json;
 
-        updateResource(update_id, data).then(() => {
-          if (fetchError) {
+        updateResource(update_id, data).then(result => {
+          if (!result) {
             return;
           }
 

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -578,8 +578,8 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
         delete data.last_value;
         delete data.last_value_row_json;
 
-        updateResource(update_id, data).then(result => {
-          if (!result) {
+        updateResource(update_id, data).then(response => {
+          if (!response) {
             return;
           }
 
@@ -593,6 +593,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     } else if (currentAlert) {
       // Create
       createResource(data).then(response => {
+        if (!response) {
+          return;
+        }
+
         if (onAdd) {
           onAdd(response);
         }

--- a/superset-frontend/src/views/CRUD/alert/types.ts
+++ b/superset-frontend/src/views/CRUD/alert/types.ts
@@ -38,7 +38,7 @@ export type MetaObject = {
   value?: number | string;
 };
 
-export type Operator = '<' | '>' | '<=' | '>=' | '==' | '!=';
+export type Operator = '<' | '>' | '<=' | '>=' | '==' | '!=' | 'not null';
 
 export type AlertObject = {
   active?: boolean;

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -257,15 +257,19 @@ export function useSingleViewResource<D extends object = any>(
           });
           return json.id;
         },
-        createErrorHandler(errMsg =>
+        createErrorHandler(errMsg => {
           handleErrorMsg(
             t(
               'An error occurred while creating %ss: %s',
               resourceLabel,
               JSON.stringify(errMsg),
             ),
-          ),
-        ),
+          );
+
+          updateState({
+            error: errMsg,
+          });
+        }),
       )
       .finally(() => {
         updateState({ loading: false });
@@ -290,15 +294,19 @@ export function useSingleViewResource<D extends object = any>(
           });
           return json.result;
         },
-        createErrorHandler(errMsg =>
+        createErrorHandler(errMsg => {
           handleErrorMsg(
             t(
               'An error occurred while fetching %ss: %s',
               resourceLabel,
               JSON.stringify(errMsg),
             ),
-          ),
-        ),
+          );
+
+          updateState({
+            error: errMsg,
+          });
+        }),
       )
       .finally(() => {
         updateState({ loading: false });

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -254,6 +254,7 @@ export function useSingleViewResource<D extends object = any>(
         ({ json = {} }) => {
           updateState({
             resource: json.result,
+            error: null,
           });
           return json.id;
         },
@@ -291,6 +292,7 @@ export function useSingleViewResource<D extends object = any>(
         ({ json = {} }) => {
           updateState({
             resource: json.result,
+            error: null,
           });
           return json.result;
         },
@@ -303,9 +305,13 @@ export function useSingleViewResource<D extends object = any>(
             ),
           );
 
+          console.log('error', errMsg);
+
           updateState({
             error: errMsg,
           });
+
+          return errMsg;
         }),
       )
       .finally(() => {

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -305,8 +305,6 @@ export function useSingleViewResource<D extends object = any>(
             ),
           );
 
-          console.log('error', errMsg);
-
           updateState({
             error: errMsg,
           });


### PR DESCRIPTION
### SUMMARY
- [x] Add 'Not Null' option to `ALERT IF...` input
- [x] When selected, disable `VALUE` input
- [x] Fix `validator_config` field to send `operator` when selected and `not null` only when corresponding option is selected 
- [x] Update `useSingleViewResource` hook to add error handling on `updateResource`/`createResource` methods
- [x] Update error handling on edit/create so modal does not close 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="383" alt="Screen Shot 2020-12-15 at 4 04 30 PM" src="https://user-images.githubusercontent.com/8216382/102287494-6ce53a80-3eef-11eb-93ef-8012dd464f6b.png">

### TEST PLAN

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API