### PR TITLE
feat: initial custom error messages for SQL Lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -28,7 +28,6 @@ import { styled, t } from '@superset-ui/core';
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import { getByUser, put as updateDatset } from 'src/api/dataset';
-import { ErrorTypeEnum } from 'src/components/ErrorMessage/types';
 import Loading from '../../components/Loading';
 import ExploreCtasResultsButton from './ExploreCtasResultsButton';
 import ExploreResultsButton from './ExploreResultsButton';
@@ -490,17 +489,10 @@ export default class ResultSet extends React.PureComponent<
       return <Alert bsStyle="warning">Query was stopped</Alert>;
     }
     if (query.state === 'failed') {
-      // TODO (betodealmeida): handle this logic through the error component
-      // registry
-      const title =
-        query?.errors?.[0].error_type ===
-        ErrorTypeEnum.MISSING_TEMPLATE_PARAMS_ERROR
-          ? t('Parameter Error')
-          : t('Database Error');
       return (
         <div className="result-set-error-message">
           <ErrorMessageWithStackTrace
-            title={title}
+            title={t('Database Error')}
             error={query?.errors?.[0]}
             subtitle={<MonospaceDiv>{query.errorMessage}</MonospaceDiv>}
             copyText={query.errorMessage || undefined}

--- a/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { t } from '@superset-ui/core';
+
+import { ErrorMessageComponentProps } from './types';
+import IssueCode from './IssueCode';
+import ErrorAlert from './ErrorAlert';
+
+interface ParameterErrorExtra {
+  undefined_parameters?: string[];
+  template_parameters?: object;
+  issue_codes: {
+    code: number;
+    message: string;
+  }[];
+}
+
+const triggerMessage = t('This may be triggered by:');
+
+function ParameterErrorMessage({
+  error,
+  source = 'sqllab',
+}: ErrorMessageComponentProps<ParameterErrorExtra>) {
+  const { extra, level, message } = error;
+
+  const body = (
+    <>
+      <p>
+        {triggerMessage}
+        <br />
+        {extra.issue_codes
+          .map<React.ReactNode>(issueCode => <IssueCode {...issueCode} />)
+          .reduce((prev, curr) => [prev, <br />, curr])}
+      </p>
+    </>
+  );
+
+  const copyText = `${message}
+${triggerMessage}
+${extra.issue_codes.map(issueCode => issueCode.message).join('\n')}`;
+
+  return (
+    <ErrorAlert
+      title={t('Parameter Error')}
+      subtitle={message}
+      level={level}
+      source={source}
+      copyText={copyText}
+      body={body}
+    />
+  );
+}
+
+export default ParameterErrorMessage;

--- a/superset-frontend/src/setup/setupErrorMessages.ts
+++ b/superset-frontend/src/setup/setupErrorMessages.ts
@@ -20,6 +20,7 @@ import getErrorMessageComponentRegistry from 'src/components/ErrorMessage/getErr
 import { ErrorTypeEnum } from 'src/components/ErrorMessage/types';
 import TimeoutErrorMessage from 'src/components/ErrorMessage/TimeoutErrorMessage';
 import DatabaseErrorMessage from 'src/components/ErrorMessage/DatabaseErrorMessage';
+import ParameterErrorMessage from 'src/components/ErrorMessage/ParameterErrorMessage';
 
 import setupErrorMessagesExtra from './setupErrorMessagesExtra';
 
@@ -45,6 +46,10 @@ export default function setupErrorMessages() {
   errorMessageComponentRegistry.registerValue(
     ErrorTypeEnum.TABLE_DOES_NOT_EXIST_ERROR,
     DatabaseErrorMessage,
+  );
+  errorMessageComponentRegistry.registerValue(
+    ErrorTypeEnum.MISSING_TEMPLATE_PARAMS_ERROR,
+    ParameterErrorMessage,
   );
   setupErrorMessagesExtra();
 }

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -38,19 +38,51 @@ class SupersetException(Exception):
         return self._exception
 
 
-class SupersetTimeoutException(SupersetException):
-    status = 408
+class SupersetErrorException(SupersetException):
+    """Exceptions with a single SupersetErrorType associated with them"""
 
     def __init__(
         self,
         error_type: SupersetErrorType,
         message: str,
         level: ErrorLevel,
-        extra: Optional[Dict[str, Any]],
+        extra: Optional[Dict[str, Any]] = None,
     ) -> None:
-        super(SupersetTimeoutException, self).__init__(message)
+        super().__init__(message)
         self.error = SupersetError(
-            error_type=error_type, message=message, level=level, extra=extra
+            error_type=error_type, message=message, level=level, extra=extra or {}
+        )
+
+
+class SupersetTimeoutException(SupersetErrorException):
+    status = 408
+
+
+class SupersetGenericDBErrorException(SupersetErrorException):
+    status = 500
+
+    def __init__(
+        self,
+        message: str,
+        level: ErrorLevel = ErrorLevel.ERROR,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(
+            SupersetErrorType.GENERIC_DB_ENGINE_ERROR, message, level, extra,
+        )
+
+
+class SupersetTemplateParamsErrorException(SupersetErrorException):
+    status = 400
+
+    def __init__(
+        self,
+        message: str,
+        level: ErrorLevel = ErrorLevel.ERROR,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(
+            SupersetErrorType.MISSING_TEMPLATE_PARAMS_ERROR, message, level, extra,
         )
 
 
@@ -60,7 +92,7 @@ class SupersetSecurityException(SupersetException):
     def __init__(
         self, error: SupersetError, payload: Optional[Dict[str, Any]] = None
     ) -> None:
-        super(SupersetSecurityException, self).__init__(error.message)
+        super().__init__(error.message)
         self.error = error
         self.payload = payload
 
@@ -69,7 +101,7 @@ class SupersetVizException(SupersetException):
     status = 400
 
     def __init__(self, errors: List[SupersetError]) -> None:
-        super(SupersetVizException, self).__init__(str(errors))
+        super().__init__(str(errors))
         self.errors = errors
 
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -49,9 +49,9 @@ from superset import (
 from superset.connectors.sqla import models
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
+    SupersetErrorException,
     SupersetException,
     SupersetSecurityException,
-    SupersetTimeoutException,
 )
 from superset.models.helpers import ImportExportMixin
 from superset.translations.utils import get_language_pack
@@ -183,7 +183,7 @@ def handle_api_exception(
             return json_errors_response(
                 errors=[ex.error], status=ex.status, payload=ex.payload
             )
-        except SupersetTimeoutException as ex:
+        except SupersetErrorException as ex:
             logger.warning(ex)
             return json_errors_response(errors=[ex.error], status=ex.status)
         except SupersetException as ex:

--- a/tests/sqllab_tests.py
+++ b/tests/sqllab_tests.py
@@ -24,10 +24,10 @@ from unittest import mock
 
 import prison
 
-import tests.test_app
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.db_engine_specs import BaseEngineSpec
+from superset.errors import ErrorLevel, SupersetErrorType
 from superset.models.sql_lab import Query, SavedQuery
 from superset.result_set import SupersetResultSet
 from superset.sql_parse import CtasMethod
@@ -69,7 +69,18 @@ class TestSqlLab(SupersetTestCase):
         self.assertLess(0, len(data["data"]))
 
         data = self.run_sql("SELECT * FROM unexistant_table", "2")
-        self.assertLess(0, len(data["error"]))
+        assert (
+            data["errors"][0]["error_type"] == SupersetErrorType.GENERIC_DB_ENGINE_ERROR
+        )
+        assert data["errors"][0]["level"] == ErrorLevel.ERROR
+        assert data["errors"][0]["extra"] == {
+            "issue_codes": [
+                {
+                    "code": 1002,
+                    "message": "Issue 1002 - The database returned an unexpected error.",
+                }
+            ]
+        }
 
     def test_sql_json_to_saved_query_info(self):
         """
@@ -592,6 +603,18 @@ class TestSqlLab(SupersetTestCase):
         assert data["status"] == "success"
 
         data = self.run_sql(
-            "SELECT * FROM birth_names WHERE state = '{{ state }}' LIMIT 10", "2"
+            "SELECT * FROM birth_names WHERE state = '{{ stat }}' LIMIT 10",
+            "2",
+            template_params=json.dumps({"state": "CA"}),
         )
         assert data["errors"][0]["error_type"] == "MISSING_TEMPLATE_PARAMS_ERROR"
+        assert data["errors"][0]["extra"] == {
+            "issue_codes": [
+                {
+                    "code": 1006,
+                    "message": "Issue 1006 - One or more parameters specified in the query are missing.",
+                }
+            ],
+            "template_parameters": {"state": "CA"},
+            "undefined_parameters": ["stat"],
+        }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds the exception `SupersetGenericDBErrorException`, so we can start showing custom errors in SQL Lab. I still need to replace calls to `json_response_error` with throwing the exception in many parts of the view, but it already works for some errors (see screenshots).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

![Screenshot_2020-12-16 Superset(1)](https://user-images.githubusercontent.com/1534870/102406158-0a4b7780-3f9f-11eb-91df-7f06eb734449.png)
![Screenshot_2020-12-16 Superset(2)](https://user-images.githubusercontent.com/1534870/102406168-0d466800-3f9f-11eb-8219-9257b672160d.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
