### PR TITLE
fix: Fix "View in SQLLab" bug

### DIFF
--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -116,8 +116,15 @@ class TabbedSqlEditors extends React.PureComponent {
     }
 
     // merge post form data with GET search params
+    // Hack: this data should be comming from getInitialState
+    // but for some reason this data isn't being passed properly through
+    // the reducer.
+    const appContainer = document.getElementById('app');
+    const bootstrapData = JSON.parse(
+      appContainer?.getAttribute('data-bootstrap') || '{}',
+    );
     const query = {
-      ...this.props.requestedQuery,
+      ...bootstrapData.requested_query,
       ...URI(window.location).search(true),
     };
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`getInitialState` isn't properly setting the `requestedQuery` object in the reducer. Going to make a hotfix for now since this is broken in production, but will come up with a proper fix after.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
