### PR TITLE
fix: handle context-dependent feature flags in CLI

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -46,7 +46,12 @@ feature_flags.update(config.FEATURE_FLAGS)
 feature_flags_func = config.GET_FEATURE_FLAGS_FUNC
 if feature_flags_func:
     # pylint: disable=not-callable
-    feature_flags = feature_flags_func(feature_flags)
+    try:
+        feature_flags = feature_flags_func(feature_flags)
+    except Exception:  # pylint: disable=broad-except
+        # bypass any feature flags that depend on context
+        # that's not available
+        pass
 
 
 def normalize_token(token_name: str) -> str:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

@ktmud pointed out in #11803 that `GET_FEATURE_FLAG_FUNC` might use the app context, breaking the CLI. This PR fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added this to my `superset_config.py`:

```python
# pylint: disable=invalid-name
def GET_FEATURE_FLAGS_FUNC(feature_flags_dict: Dict[str, bool]) -> Dict[str, bool]:
    from flask import g

    if hasattr(g, "user") and g.user.is_active:
        feature_flags_dict["some_feature"] = g.user and g.user.id == 5
    return feature_flags_dict
```

The CLI works as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
