### PR TITLE
fix: docker-compose file to fix EMPTY UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-x-superset-image: &superset-image apache/incubator-superset:latest-dev
 x-superset-depends-on: &superset-depends-on
   - db
   - redis
@@ -49,7 +48,7 @@ services:
 
   superset:
     env_file: docker/.env
-    image: *superset-image
+    build: .
     container_name: superset_app
     command: ["/app/docker/docker-bootstrap.sh", "app"]
     restart: unless-stopped
@@ -62,7 +61,7 @@ services:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
 
   superset-init:
-    image: *superset-image
+    build: .
     container_name: superset_init
     command: ["/app/docker/docker-init.sh"]
     env_file: docker/.env
@@ -81,7 +80,7 @@ services:
     volumes: *superset-volumes
 
   superset-worker:
-    image: *superset-image
+    build: .
     container_name: superset_worker
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
     env_file: docker/.env
@@ -91,7 +90,7 @@ services:
     volumes: *superset-volumes
 
   superset-tests-worker:
-    image: *superset-image
+    build: .
     container_name: superset_tests_worker
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
     env_file: docker/.env


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Taking the latest clone of the project and starting the containers would cause superset-node.
This was because the docker hub image is not aligned with the code.

### TEST PLAN
Run docker-compose up

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: UI Not loading

