### PR TITLE
feat: move keyboard shortcut hints to tooltips

### DIFF
--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton.tsx
@@ -55,7 +55,12 @@ const RunQueryActionButton = ({
 
   if (shouldShowStopBtn) {
     return (
-      <Button {...commonBtnProps} cta onClick={stopQuery}>
+      <Button
+        {...commonBtnProps}
+        cta
+        onClick={stopQuery}
+        tooltip={t('Stop running (Ctrl + x)')}
+      >
         <i className="fa fa-stop" /> {t('Stop')}
       </Button>
     );
@@ -67,7 +72,7 @@ const RunQueryActionButton = ({
         cta
         onClick={() => runQuery(true)}
         key="run-async-btn"
-        tooltip={t('Run query asynchronously (Ctrl + ↵)')}
+        tooltip={t('Run query (Ctrl + Return)')}
         disabled={!sql.trim()}
       >
         <i className="fa fa-bolt" /> {runBtnText}
@@ -80,7 +85,7 @@ const RunQueryActionButton = ({
       cta
       onClick={() => runQuery(false)}
       key="run-btn"
-      tooltip={t('Run query synchronously (Ctrl + ↵)')}
+      tooltip={t('Run query (Ctrl + Return)')}
       disabled={!sql.trim()}
     >
       <i className="fa fa-refresh" /> {runBtnText}

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -26,12 +26,12 @@ import Split from 'react-split';
 import { t, styled } from '@superset-ui/core';
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
+import Mousetrap from 'mousetrap';
 
 import { Tooltip } from 'src/common/components/Tooltip';
 import Label from 'src/components/Label';
 import Button from 'src/components/Button';
 import Timer from 'src/components/Timer';
-import Hotkeys from 'src/components/Hotkeys';
 import {
   Dropdown,
   Menu as AntdMenu,
@@ -155,6 +155,12 @@ class SqlEditor extends React.PureComponent {
     this.setState({ height: this.getSqlEditorHeight() });
 
     window.addEventListener('resize', this.handleWindowResize);
+
+    // setup hotkeys
+    const hotkeys = this.getHotkeyConfig();
+    hotkeys.forEach(keyConfig => {
+      Mousetrap.bind([keyConfig.key], keyConfig.func);
+    });
   }
 
   componentWillUnmount() {
@@ -487,7 +493,7 @@ class SqlEditor extends React.PureComponent {
     return menuDropdown;
   }
 
-  renderEditorBottomBar(hotkeys) {
+  renderEditorBottomBar() {
     let ctasControls;
     if (
       this.props.database &&
@@ -614,9 +620,6 @@ class SqlEditor extends React.PureComponent {
                   </a>
                 </Dropdown>
               </LimitSelectStyled>
-            </span>
-            <span>
-              <Hotkeys header={t('Keyboard shortcuts')} hotkeys={hotkeys} />
             </span>
           </Form>
         </div>

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -28,6 +28,7 @@ import { styled, t } from '@superset-ui/core';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 import { areArraysShallowEqual } from 'src/reduxUtils';
+import { Tooltip } from 'src/common/components/Tooltip';
 import * as Actions from '../actions/sqlLab';
 import SqlEditor from './SqlEditor';
 import TabStatusIcon from './TabStatusIcon';
@@ -409,7 +410,11 @@ class TabbedSqlEditors extends React.PureComponent {
         fullWidth={false}
         hideAdd={this.props.offline}
         onEdit={this.handleEdit}
-        addIcon={<i data-test="add-tab-icon" className="fa fa-plus-circle" />}
+        addIcon={
+          <Tooltip id="add-tab" placement="bottom" title="New tab (Ctrl + t)">
+            <i data-test="add-tab-icon" className="fa fa-plus-circle" />
+          </Tooltip>
+        }
       >
         {editors}
       </EditableTabs>


### PR DESCRIPTION
### SUMMARY
#### Updated Keyboard Shortcuts Interface
Remove existing keyboard shortcuts button
Hover tooltips should show up on the following:
- New tab button
- Run query
- Stop running

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
<img width="1501" alt="Screenshot_12_16_20__5_18_PM" src="https://user-images.githubusercontent.com/5186919/102574311-4ff26800-40a5-11eb-9f71-ae121c195b84.png">

After: 
<img width="575" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/102574291-436e0f80-40a5-11eb-9500-447a27c646f2.png">
<img width="621" alt="_DEV__Superset" src="https://user-images.githubusercontent.com/5186919/102574297-48cb5a00-40a5-11eb-9333-7d61b0ffb4a9.png">


### TEST PLAN
Jest tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
