### PR TITLE
fix(alerts/reports): modal submit button, copy changes, select apis

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -101,6 +101,7 @@ const RETENTION_OPTIONS = [
 
 const DEFAULT_RETENTION = 90;
 const DEFAULT_WORKING_TIMEOUT = 3600;
+const DEFAULT_CRON_VALUE = '* * * * *'; // every minute
 
 const StyledIcon = styled(Icon)`
   margin: auto ${({ theme }) => theme.gridUnit * 2}px auto 0;
@@ -958,7 +959,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   ) {
     setCurrentAlert({
       active: true,
-      crontab: '',
+      crontab: DEFAULT_CRON_VALUE,
       log_retention: DEFAULT_RETENTION,
       working_timeout: DEFAULT_WORKING_TIMEOUT,
       name: '',
@@ -1194,7 +1195,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               </h4>
             </StyledSectionTitle>
             <AlertReportCronScheduler
-              value={(currentAlert && currentAlert.crontab) || undefined}
+              value={
+                (currentAlert && currentAlert.crontab) || DEFAULT_CRON_VALUE
+              }
               onChange={newVal => updateAlertState('crontab', newVal)}
             />
             <StyledSectionTitle>

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -613,7 +613,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   const loadOwnerOptions = (input = '') => {
     const query = rison.encode({ filter: input });
     return SupersetClient.get({
-      endpoint: `/api/v1/dashboard/related/owners?q=${query}`,
+      endpoint: `/api/v1/report/related/owners?q=${query}`,
     }).then(
       response => {
         return response.json.result.map((item: any) => ({
@@ -630,7 +630,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   const loadSourceOptions = (input = '') => {
     const query = rison.encode({ filter: input });
     return SupersetClient.get({
-      endpoint: `/api/v1/dataset/related/database?q=${query}`,
+      endpoint: `/api/v1/report/related/database?q=${query}`,
     }).then(
       response => {
         const list = response.json.result.map((item: any) => ({
@@ -679,12 +679,12 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   const loadDashboardOptions = (input = '') => {
     const query = rison.encode({ filter: input });
     return SupersetClient.get({
-      endpoint: `/api/v1/dashboard?q=${query}`,
+      endpoint: `/api/v1/report/related/dashboard?q=${query}`,
     }).then(
       response => {
         const list = response.json.result.map((item: any) => ({
-          value: item.id,
-          label: item.dashboard_title,
+          value: item.value,
+          label: item.text,
         }));
 
         setDashboardOptions(list);
@@ -728,12 +728,12 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   const loadChartOptions = (input = '') => {
     const query = rison.encode({ filter: input });
     return SupersetClient.get({
-      endpoint: `/api/v1/chart?q=${query}`,
+      endpoint: `/api/v1/report/related/chart?q=${query}`,
     }).then(
       response => {
         const list = response.json.result.map((item: any) => ({
-          value: item.id,
-          label: item.slice_name,
+          value: item.value,
+          label: item.text,
         }));
 
         setChartOptions(list);

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -771,12 +771,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
 
   // Updating alert/report state
   const updateAlertState = (name: string, value: any) => {
-    const data = {
-      ...currentAlert,
+    setCurrentAlert(currentAlertData => ({
+      ...currentAlertData,
       [name]: value,
-    };
-
-    setCurrentAlert(data);
+    }));
   };
 
   // Handle input/textarea updates
@@ -1047,7 +1045,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
         <div className="header-section">
           <StyledInputContainer>
             <div className="control-label">
-              {t('Alert Name')}
+              {isReport ? t('Report Name') : t('Alert Name')}
               <span className="required">*</span>
             </div>
             <div className="input-container">
@@ -1055,7 +1053,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 type="text"
                 name="name"
                 value={currentAlert ? currentAlert.name : ''}
-                placeholder={t('Alert Name')}
+                placeholder={isReport ? t('Report Name') : t('Alert Name')}
                 onChange={onTextChange}
               />
             </div>
@@ -1189,7 +1187,11 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
           )}
           <div className="column schedule">
             <StyledSectionTitle>
-              <h4>{t('Alert Condition Schedule')}</h4>
+              <h4>
+                {isReport
+                  ? t('Report Schedule')
+                  : t('Alert Condition Schedule')}
+              </h4>
             </StyledSectionTitle>
             <AlertReportCronScheduler
               value={(currentAlert && currentAlert.crontab) || undefined}

--- a/superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx
@@ -24,9 +24,8 @@ import { Radio } from 'src/common/components/Radio';
 import { CronPicker, CronError } from 'src/common/components/CronPicker';
 import { StyledInputContainer } from '../AlertReportModal';
 
-const DEFAULT_CRON_VALUE = '* * * * *'; // every minute
 interface AlertReportCronSchedulerProps {
-  value?: string;
+  value: string;
   onChange: (change: string) => any;
 }
 
@@ -58,7 +57,7 @@ export const AlertReportCronScheduler: FunctionComponent<AlertReportCronSchedule
           <Radio value="picker" />
           <CronPicker
             clearButton={false}
-            value={value || DEFAULT_CRON_VALUE}
+            value={value}
             setValue={customSetValue}
             disabled={scheduleFormat !== 'picker'}
             displayError={scheduleFormat === 'picker'}

--- a/superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx
@@ -24,13 +24,14 @@ import { Radio } from 'src/common/components/Radio';
 import { CronPicker, CronError } from 'src/common/components/CronPicker';
 import { StyledInputContainer } from '../AlertReportModal';
 
+const DEFAULT_CRON_VALUE = '* * * * *'; // every minute
 interface AlertReportCronSchedulerProps {
   value?: string;
   onChange: (change: string) => any;
 }
 
 export const AlertReportCronScheduler: FunctionComponent<AlertReportCronSchedulerProps> = ({
-  value = '* * * * *',
+  value,
   onChange,
 }) => {
   const theme = useTheme();
@@ -57,7 +58,7 @@ export const AlertReportCronScheduler: FunctionComponent<AlertReportCronSchedule
           <Radio value="picker" />
           <CronPicker
             clearButton={false}
-            value={value}
+            value={value || DEFAULT_CRON_VALUE}
             setValue={customSetValue}
             disabled={scheduleFormat !== 'picker'}
             displayError={scheduleFormat === 'picker'}

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -161,7 +161,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     ]
     search_columns = ["name", "active", "created_by", "type", "last_state"]
     search_filters = {"name": [ReportScheduleAllTextFilter]}
-    allowed_rel_fields = {"owners", "chart", "dashboard", "database"}
+    allowed_rel_fields = {"owners", "chart", "dashboard", "database", "created_by"}
     filter_rel_fields = {
         "chart": [["id", ChartFilter, lambda: []]],
         "dashboard": [["id", DashboardFilter, lambda: []]],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a few issues with alerts:
- Add button is disabled for both the alerts and reports modal when all required fields are filled
- The "Add Report" modal field has label and helper text "Add Alert" and section header "Alert Condition Schedule". Let's change these to "Add Report" and "Report Schedule"
- Switch over select apis to use `/api/v1/related/<chart|dashboard|database|owners>`
- expose `api/v1/report/related/created_by` api

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
<img width="838" alt="Screen Shot 2020-12-17 at 10 10 44 PM" src="https://user-images.githubusercontent.com/10255196/102581143-d06c9500-40b4-11eb-91e5-9bd920b40e9b.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- manual test:
  - Modal submit button is enabled after all required fields have been filled
  - Report modal has copy updated `alert -> report`
  - select values are fetched from `/api/v1/report/related/*` endpoints.
  
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
