### PR TITLE
fix: Boolean values in react-table (issue #12106)

### DIFF
--- a/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
+++ b/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
@@ -304,7 +304,7 @@ export default function TableCollection({
                       {...columnCellProps}
                     >
                       <span className={cx({ 'loading-bar': loading })}>
-                        <span data-test="cell-text">{cell.render('Cell')}</span>
+                        <span data-test="cell-text">{typeof cell.value === "boolean" ? cell.value.toString() : cell.render('Cell')}</span>
                       </span>
                     </td>
                   );


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Forces boolean values to render as a string instead of using the `react-table` Cell renderer. This feels like it's working around the problem, rather than fixing it. But hey, look: there they are:

Before:
![image](https://user-images.githubusercontent.com/812905/102585541-6f958a80-40bd-11eb-8d67-448bfb73fb78.png)

After:
![image](https://user-images.githubusercontent.com/812905/102584511-715e4e80-40bb-11eb-92ed-6864a4a6efe5.png)

For anyone that needs a boolean column to repro this issue, here's a query you can run in SQL Lab and carry over to Explore:

```
SELECT gender, name , SUM(num) AS sum__num, 
  bool_or(gender = 'boy') over (partition by name) as is_boy
FROM birth_names
WHERE ds >= '1920-08-22 00:00:00.000000'
  AND ds <= '2020-08-22 02:23:48.000000'
GROUP BY gender, name
ORDER BY sum__num DESC;
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Verified in UI, CI should pass, and I'm hoping to get a check on the approach from @kgabryje who wrote a lot of this `react-table` stuff, and from @nikolagigic and/or @geido who are looking at this issue.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #12106 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
