### PR TITLE
fix: FilterBox select lose focus when focused

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -65,27 +65,21 @@ describe('Dashboard filter', () => {
       cy.wait(aliases);
     });
   });
-  xit('should apply filter', () => {
-    cy.get('.Select__control input[type=text]')
-      .first()
-      .should('be.visible')
-      .focus();
+
+  it('should apply filter', () => {
+    cy.get('.Select__placeholder:first').click();
 
     // should open the filter indicator
-    cy.get('[data-test="filter"]')
-      .should('be.visible', { timeout: 10000 })
+    cy.get('svg[data-test="filter"]')
+      .should('be.visible')
       .should(nodes => {
-        expect(nodes).to.have.length(9); // this part was not working, xit-ed
+        expect(nodes).to.have.length(9);
       });
 
-    cy.get('[data-test="chart-container"]').find('svg').should('be.visible');
-
-    cy.get('.Select__control input[type=text]').first().focus().blur();
-
-    cy.get('.Select__control input[type=text]')
-      .first()
-      .focus()
-      .type('So', { force: true, delay: 100 });
+    cy.get('.Select__control:first input[type=text]').type('So', {
+      force: true,
+      delay: 100,
+    });
 
     cy.get('.Select__menu').first().contains('South Asia').click();
 

--- a/superset-frontend/cypress-base/package.json
+++ b/superset-frontend/cypress-base/package.json
@@ -19,6 +19,9 @@
     "eslint-plugin-cypress": "^2.11.1"
   },
   "nyc": {
-    "reporter": ["html", "json"]
+    "reporter": [
+      "html",
+      "json"
+    ]
   }
 }

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -102,7 +102,7 @@ const Styles = styled.div`
   overflow: visible;
 `;
 
-class FilterBox extends React.Component {
+class FilterBox extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -424,7 +424,6 @@ class FilterBox extends React.Component {
 
   render() {
     const { instantFiltering } = this.props;
-
     return (
       <Styles>
         {this.renderDateFilter()}


### PR DESCRIPTION
### SUMMARY

After recent upgrades of Redux (#11967 ), FilterBox selects would lose focus once users focused on it, making it impossible to type to search filter values. This is caused by some unnecessary rendering. Fixed by moving FilterBox component to `React.PureComponent`. Didn't dig deep, but my guess is this is because new Redux now will re-render components even if props are all the same.

Fixes #12107. 

This should have been caught by the FilterBox test case had it been enabled. Maybe previously it was flaky because of the same reason. Let's see if re-enable it gives us any luck this time.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


cc @junlincc @graceguo-supercat @zuzana-vej 