### PR TITLE
fix: remove keys in dashboard export

### DIFF
--- a/superset/dashboards/commands/export.py
+++ b/superset/dashboards/commands/export.py
@@ -20,7 +20,7 @@ import json
 import logging
 import random
 import string
-from typing import Any, Dict, Iterator, List, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import yaml
 from werkzeug.utils import secure_filename
@@ -108,8 +108,8 @@ class ExportDashboardsCommand(ExportModelsCommand):
         # TODO (betodealmeida): move this logic to export_to_dict once this
         # becomes the default export endpoint
         for key, new_name in JSON_KEYS.items():
-            if payload.get(key):
-                value = payload.pop(key)
+            value: Optional[str] = payload.pop(key, None)
+            if value:
                 try:
                     payload[new_name] = json.loads(value)
                 except (TypeError, json.decoder.JSONDecodeError):

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -54,7 +54,7 @@ def update_id_refs(config: Dict[str, Any], chart_ids: Dict[str, int]) -> Dict[st
     id_map = {old_id: chart_ids[uuid] for uuid, old_id in old_ids.items()}
 
     # fix metadata
-    metadata = fixed["metadata"]
+    metadata = fixed.get("metadata", {})
     if "timed_refresh_immune_slices" in metadata:
         metadata["timed_refresh_immune_slices"] = [
             id_map[old_id] for old_id in metadata["timed_refresh_immune_slices"]
@@ -82,7 +82,7 @@ def update_id_refs(config: Dict[str, Any], chart_ids: Dict[str, int]) -> Dict[st
         }
 
     # fix position
-    position = fixed["position"]
+    position = fixed.get("position", {})
     for child in position.values():
         if (
             isinstance(child, dict)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

While testing dashboard import I found a small bug in the export. In the export we rename the columns `position_json` to `position` (since we load the JSON) and `json_metadata` to `metadata` (same). If the values were empty we were not renaming them, causing a schema validation error on import.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Exported and imported dashboard.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
