### PR TITLE
fix: properly render booleans in FilterBox and explore page data preview

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -70,11 +70,7 @@ describe('Dashboard filter', () => {
     cy.get('.Select__placeholder:first').click();
 
     // should open the filter indicator
-    cy.get('svg[data-test="filter"]')
-      .should('be.visible')
-      .should(nodes => {
-        expect(nodes).to.have.length(9);
-      });
+    cy.get('svg[data-test="filter"]').should('be.visible');
 
     cy.get('.Select__control:first input[type=text]').type('So', {
       force: true,
@@ -82,6 +78,12 @@ describe('Dashboard filter', () => {
     });
 
     cy.get('.Select__menu').first().contains('South Asia').click();
+
+    // should still have all filter indicators
+    // and since the select is closed, all filter indicators should be visible
+    cy.get('svg[data-test="filter"]:visible').should(nodes => {
+      expect(nodes).to.have.length(9);
+    });
 
     cy.get('.filter_box button').click({ force: true });
     cy.wait(aliases.filter(x => x !== getAlias(filterId))).then(requests => {

--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -19,3 +19,6 @@
 export const DATETIME_WITH_TIME_ZONE = 'YYYY-MM-DD HH:mm:ssZ';
 
 export const TIME_WITH_MS = 'HH:mm:ss.SSS';
+
+export const BOOL_TRUE_DISPLAY = 'True';
+export const BOOL_FALSE_DISPLAY = 'False';

--- a/superset-frontend/src/explore/components/DataTableControl.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl.tsx
@@ -21,6 +21,8 @@ import { styled, t } from '@superset-ui/core';
 import { FormControl } from 'react-bootstrap';
 import { Column } from 'react-table';
 import debounce from 'lodash/debounce';
+
+import { BOOL_FALSE_DISPLAY, BOOL_TRUE_DISPLAY } from 'src/constants';
 import Button from 'src/components/Button';
 import {
   applyFormattingToTabularData,
@@ -110,10 +112,10 @@ export const useTableColumns = (
                 Header: key,
                 Cell: ({ value }) => {
                   if (value === true) {
-                    return t('True');
+                    return BOOL_TRUE_DISPLAY;
                   }
                   if (value === false) {
-                    return t('False');
+                    return BOOL_FALSE_DISPLAY;
                   }
                   return String(value);
                 },

--- a/superset-frontend/src/explore/components/DataTableControl.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl.tsx
@@ -19,6 +19,7 @@
 import React, { useMemo } from 'react';
 import { styled, t } from '@superset-ui/core';
 import { FormControl } from 'react-bootstrap';
+import { Column } from 'react-table';
 import debounce from 'lodash/debounce';
 import Button from 'src/components/Button';
 import {
@@ -95,11 +96,30 @@ export const useFilteredTableData = (
     );
   }, [data, filterText]);
 
-export const useTableColumns = (data?: Record<string, any>[]) =>
+export const useTableColumns = (
+  data?: Record<string, any>[],
+  moreConfigs?: { [key: string]: Partial<Column> },
+) =>
   useMemo(
     () =>
       data?.length
-        ? Object.keys(data[0]).map(key => ({ accessor: key, Header: key }))
+        ? Object.keys(data[0]).map(
+            key =>
+              ({
+                accessor: key,
+                Header: key,
+                Cell: ({ value }) => {
+                  if (value === true) {
+                    return t('True');
+                  }
+                  if (value === false) {
+                    return t('False');
+                  }
+                  return String(value);
+                },
+                ...moreConfigs?.[key],
+              } as Column),
+          )
         : [],
-    [data],
+    [data, moreConfigs],
   );

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -235,28 +235,34 @@ const ExploreChartPanel = props => {
     };
   };
 
+  const panelBody = <div className="panel-body">{renderChart()}</div>;
+
   return (
     <Styles className="panel panel-default chart-container">
       <div className="panel-heading" ref={panelHeadingRef}>
         {header}
       </div>
-      <Split
-        sizes={splitSizes}
-        minSize={MIN_SIZES}
-        direction="vertical"
-        gutterSize={gutterHeight}
-        onDragStart={onDragStart}
-        onDragEnd={onDragEnd}
-        elementStyle={elementStyle}
-      >
-        <div className="panel-body">{renderChart()}</div>
-        <DataTablesPane
-          queryFormData={props.chart.latestQueryFormData}
-          tableSectionHeight={tableSectionHeight}
-          onCollapseChange={onCollapseChange}
-          displayBackground={displaySouthPaneBackground}
-        />
-      </Split>
+      {props.vizType === 'filter_box' ? (
+        panelBody
+      ) : (
+        <Split
+          sizes={splitSizes}
+          minSize={MIN_SIZES}
+          direction="vertical"
+          gutterSize={gutterHeight}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          elementStyle={elementStyle}
+        >
+          {panelBody}
+          <DataTablesPane
+            queryFormData={props.chart.latestQueryFormData}
+            tableSectionHeight={tableSectionHeight}
+            onCollapseChange={onCollapseChange}
+            displayBackground={displaySouthPaneBackground}
+          />
+        </Split>
+      )}
     </Styles>
   );
 };

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -24,8 +24,8 @@ import { AsyncCreatableSelect, CreatableSelect } from 'src/components/Select';
 import Button from 'src/components/Button';
 import { t, styled, SupersetClient } from '@superset-ui/core';
 
+import { BOOL_FALSE_DISPLAY, BOOL_TRUE_DISPLAY } from 'src/constants';
 import FormLabel from 'src/components/FormLabel';
-
 import DateFilterControl from 'src/explore/components/controls/DateFilterControl';
 import ControlRow from 'src/explore/components/ControlRow';
 import Control from 'src/explore/components/Control';
@@ -218,9 +218,9 @@ class FilterBox extends React.PureComponent {
       const style = { backgroundImage };
       let label = opt.id;
       if (label === true) {
-        label = t('True');
+        label = BOOL_TRUE_DISPLAY;
       } else if (label === false) {
-        label = t('False');
+        label = BOOL_FALSE_DISPLAY;
       }
       return { value: opt.id, label, style };
     });

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -216,7 +216,13 @@ class FilterBox extends React.PureComponent {
       const color = 'lightgrey';
       const backgroundImage = `linear-gradient(to right, ${color}, ${color} ${perc}%, rgba(0,0,0,0) ${perc}%`;
       const style = { backgroundImage };
-      return { value: opt.id, label: opt.id, style };
+      let label = opt.id;
+      if (label === true) {
+        label = t('True');
+      } else if (label === false) {
+        label = t('False');
+      }
+      return { value: opt.id, label, style };
     });
   }
 


### PR DESCRIPTION
### SUMMARY

Fixes #12106 #12105 

Also hides the data preview pane for FilterBox.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### After Fix

In FilterBox:

<img src="https://user-images.githubusercontent.com/335541/102593086-40851600-40c9-11eb-8c4e-5b3210e0fadd.png" width="400">

In data preview:

<img src="https://user-images.githubusercontent.com/335541/102592828-e71ce700-40c8-11eb-89d5-ee9c5ba2b850.png" width="600">

### TEST PLAN

Manual verification.

1. Try create a calculated column that returns boolean values in the `wb_health_population` dataset

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
