### PR TITLE
feat(chart-data-api): ignore unknown fields on QueryObject

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -17,7 +17,7 @@
 from typing import Any, Dict
 
 from flask_babel import gettext as _
-from marshmallow import fields, post_load, Schema, validate
+from marshmallow import EXCLUDE, fields, post_load, Schema, validate
 from marshmallow.validate import Length, Range
 
 from superset.common.query_context import QueryContext
@@ -857,6 +857,9 @@ class AnnotationLayerSchema(Schema):
 
 
 class ChartDataQueryObjectSchema(Schema):
+    class Meta:  # pylint: disable=too-few-public-methods
+        unknown = EXCLUDE
+
     annotation_layers = fields.List(
         fields.Nested(AnnotationLayerSchema),
         description="Annotation layers to apply to chart",


### PR DESCRIPTION
### SUMMARY
Currently the V1 chart data API expects all fields on the `QueryObject` to be explicitly defined - any unexpected fields will raise an exception. This changes the default behavior to exclude unknown fields, thus making the backend more resilient to requests including redundant metadata. Needed for #10288

Relevant Marshmallow docs: https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields

### TEST PLAN
CI + added test that would have failed previously.
