### PR TITLE
feat: Add Saved Metrics tab to metrics popover

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
@@ -49,6 +49,8 @@ function setup(overrides) {
   const onClose = sinon.spy();
   const props = {
     adhocMetric: sumValueAdhocMetric,
+    savedMetric: {},
+    savedMetrics: [],
     onChange,
     onClose,
     onResize: () => {},
@@ -62,7 +64,7 @@ function setup(overrides) {
 describe('AdhocMetricEditPopover', () => {
   it('renders a popover with edit metric form contents', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(FormGroup)).toHaveLength(3);
+    expect(wrapper.find(FormGroup)).toHaveLength(4);
     expect(wrapper.find(Button)).toHaveLength(2);
   });
 

--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricOption_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricOption_spec.jsx
@@ -41,11 +41,15 @@ function setup(overrides) {
   const onMetricEdit = sinon.spy();
   const props = {
     adhocMetric: sumValueAdhocMetric,
+    savedMetric: {},
+    savedMetrics: [],
     onMetricEdit,
     columns,
     ...overrides,
   };
-  const wrapper = shallow(<AdhocMetricOption {...props} />);
+  const wrapper = shallow(<AdhocMetricOption {...props} />)
+    .find('AdhocMetricPopoverTrigger')
+    .shallow();
   return { wrapper, onMetricEdit };
 }
 
@@ -54,13 +58,6 @@ describe('AdhocMetricOption', () => {
     const { wrapper } = setup();
     expect(wrapper.find(Popover)).toExist();
     expect(wrapper.find('OptionControlLabel')).toExist();
-  });
-
-  it('overlay should open if metric is new', () => {
-    const { wrapper } = setup({
-      adhocMetric: sumValueAdhocMetric.duplicateWith({ isNew: true }),
-    });
-    expect(wrapper.find(Popover).props().defaultVisible).toBe(true);
   });
 
   it('overwrites the adhocMetric in state with onLabelChange', () => {

--- a/superset-frontend/spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
@@ -35,7 +35,7 @@ describe('MetricDefinitionValue', () => {
     const wrapper = shallow(
       <MetricDefinitionValue option={{ metric_name: 'a_saved_metric' }} />,
     );
-    expect(wrapper.find('OptionControlLabel')).toExist();
+    expect(wrapper.find('AdhocMetricOption')).toExist();
   });
 
   it('renders an AdhocMetricOption given an adhoc metric', () => {

--- a/superset-frontend/spec/javascripts/explore/components/MetricsControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/MetricsControl_spec.jsx
@@ -169,7 +169,7 @@ describe('MetricsControl', () => {
       const editedMetric = sumValueAdhocMetric.duplicateWith({
         aggregate: AGGREGATES.AVG,
       });
-      component.instance().onMetricEdit(editedMetric);
+      component.instance().onMetricEdit(editedMetric, sumValueAdhocMetric);
 
       expect(onChange.lastCall.args).toEqual([[editedMetric]]);
     });

--- a/superset-frontend/src/common/components/Tabs/Tabs.tsx
+++ b/superset-frontend/src/common/components/Tabs/Tabs.tsx
@@ -23,15 +23,18 @@ import Icon from 'src/components/Icon';
 
 interface TabsProps {
   fullWidth?: boolean;
+  allowOverflow?: boolean;
 }
 
-const notForwardedProps = ['fullWidth'];
+const notForwardedProps = ['fullWidth', 'allowOverflow'];
 
 const StyledTabs = styled(AntdTabs, {
   shouldForwardProp: prop => !notForwardedProps.includes(prop),
 })<TabsProps>`
+  overflow: ${({ allowOverflow }) => (allowOverflow ? 'visible' : 'hidden')};
+
   .ant-tabs-content-holder {
-    overflow: auto;
+    overflow: ${({ allowOverflow }) => (allowOverflow ? 'visible' : 'auto')};
   }
 
   .ant-tabs-tab {

--- a/superset-frontend/src/explore/AdhocMetric.js
+++ b/superset-frontend/src/explore/AdhocMetric.js
@@ -92,9 +92,12 @@ export default class AdhocMetric {
 
   translateToSql() {
     if (this.expressionType === EXPRESSION_TYPES.SIMPLE) {
-      return `${this.aggregate || ''}(${
-        (this.column && this.column.column_name) || ''
-      })`;
+      const aggregate = this.aggregate || '';
+      // eslint-disable-next-line camelcase
+      const column = this.column?.column_name
+        ? `(${this.column.column_name})`
+        : '';
+      return aggregate + column;
     }
     if (this.expressionType === EXPRESSION_TYPES.SQL) {
       return this.sqlExpression;

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
@@ -150,6 +150,7 @@ export default class AdhocFilterEditPopover extends React.Component {
           className="adhoc-filter-edit-tabs"
           data-test="adhoc-filter-edit-tabs"
           style={{ height: this.state.height, width: this.state.width }}
+          allowOverflow
         >
           <Tabs.TabPane
             className="adhoc-filter-edit-tab"

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
@@ -155,7 +155,7 @@ export default class AdhocFilterEditPopover extends React.Component {
           <Tabs.TabPane
             className="adhoc-filter-edit-tab"
             key={EXPRESSION_TYPES.SIMPLE}
-            tab="Simple"
+            tab={t('Simple')}
           >
             <AdhocFilterEditPopoverSimpleTabContent
               adhocFilter={this.state.adhocFilter}
@@ -170,7 +170,7 @@ export default class AdhocFilterEditPopover extends React.Component {
           <Tabs.TabPane
             className="adhoc-filter-edit-tab"
             key={EXPRESSION_TYPES.SQL}
-            tab="Custom SQL"
+            tab={t('Custom SQL')}
           >
             {!this.props.datasource ||
             this.props.datasource.type !== 'druid' ? (

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -305,10 +305,10 @@ export default class AdhocMetricEditPopover extends React.Component {
           onChange={this.refreshAceEditor}
           allowOverflow
         >
-          <Tabs.TabPane key={EXPRESSION_TYPES.SIMPLE} tab="Simple">
+          <Tabs.TabPane key={EXPRESSION_TYPES.SIMPLE} tab={t('Simple')}>
             <FormGroup>
               <FormLabel>
-                <strong>column</strong>
+                <strong>{t('column')}</strong>
               </FormLabel>
               <Select name="select-column" {...columnSelectProps}>
                 {columns.map(column => (
@@ -324,7 +324,7 @@ export default class AdhocMetricEditPopover extends React.Component {
             </FormGroup>
             <FormGroup>
               <FormLabel>
-                <strong>aggregate</strong>
+                <strong>{t('aggregate')}</strong>
               </FormLabel>
               <Select name="select-aggregate" {...aggregateSelectProps}>
                 {AGGREGATES_OPTIONS.map(option => (
@@ -335,10 +335,10 @@ export default class AdhocMetricEditPopover extends React.Component {
               </Select>
             </FormGroup>
           </Tabs.TabPane>
-          <Tabs.TabPane key={SAVED_TAB_KEY} tab="Saved">
+          <Tabs.TabPane key={SAVED_TAB_KEY} tab={t('Saved')}>
             <FormGroup>
               <FormLabel>
-                <strong>Saved metric</strong>
+                <strong>{t('Saved metric')}</strong>
               </FormLabel>
               <Select name="select-saved" {...savedSelectProps}>
                 {Array.isArray(savedMetrics) &&
@@ -358,7 +358,7 @@ export default class AdhocMetricEditPopover extends React.Component {
           </Tabs.TabPane>
           <Tabs.TabPane
             key={EXPRESSION_TYPES.SQL}
-            tab="Custom SQL"
+            tab={t('Custom SQL')}
             data-test="adhoc-metric-edit-tab#custom"
           >
             {this.props.datasourceType !== 'druid' ? (
@@ -394,7 +394,7 @@ export default class AdhocMetricEditPopover extends React.Component {
             data-test="AdhocMetricEdit#cancel"
             cta
           >
-            Close
+            {t('Close')}
           </Button>
           <Button
             disabled={!stateIsValid}
@@ -406,7 +406,7 @@ export default class AdhocMetricEditPopover extends React.Component {
             onClick={this.onSave}
             cta
           >
-            Save
+            {t('Save')}
           </Button>
           <ResizeIcon
             role="button"

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -32,6 +32,7 @@ import sqlKeywords from 'src/SqlLab/utils/sqlKeywords';
 
 import { AGGREGATES_OPTIONS } from '../constants';
 import columnType from '../propTypes/columnType';
+import savedMetricType from '../propTypes/savedMetricType';
 import AdhocMetric, { EXPRESSION_TYPES } from '../AdhocMetric';
 
 const propTypes = {
@@ -40,8 +41,8 @@ const propTypes = {
   onClose: PropTypes.func.isRequired,
   onResize: PropTypes.func.isRequired,
   columns: PropTypes.arrayOf(columnType),
-  savedMetrics: PropTypes.arrayOf(PropTypes.object),
-  savedMetric: PropTypes.object,
+  savedMetrics: PropTypes.arrayOf(savedMetricType),
+  savedMetric: savedMetricType,
   datasourceType: PropTypes.string,
   title: PropTypes.shape({
     label: PropTypes.string,
@@ -339,7 +340,7 @@ export default class AdhocMetricEditPopover extends React.Component {
               <FormLabel>
                 <strong>Saved metric</strong>
               </FormLabel>
-              <Select name="select-column" {...savedSelectProps}>
+              <Select name="select-saved" {...savedSelectProps}>
                 {Array.isArray(savedMetrics) &&
                   savedMetrics.map(savedMetric => (
                     <Select.Option

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -204,7 +204,11 @@ export default class AdhocMetricEditPopover extends React.Component {
   }
 
   renderColumnOption(option) {
-    return <ColumnOption column={option} showType />;
+    const column = { ...option };
+    if (column.metric_name && !column.verbose_name) {
+      column.verbose_name = column.metric_name;
+    }
+    return <ColumnOption column={column} showType />;
   }
 
   render() {
@@ -298,6 +302,7 @@ export default class AdhocMetricEditPopover extends React.Component {
           className="adhoc-metric-edit-tabs"
           style={{ height: this.state.height, width: this.state.width }}
           onChange={this.refreshAceEditor}
+          allowOverflow
         >
           <Tabs.TabPane key={EXPRESSION_TYPES.SIMPLE} tab="Simple">
             <FormGroup>

--- a/superset-frontend/src/explore/components/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricOption.jsx
@@ -18,53 +18,25 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Popover from 'src/common/components/Popover';
-import AdhocMetricEditPopoverTitle from 'src/explore/components/AdhocMetricEditPopoverTitle';
-import AdhocMetricEditPopover from './AdhocMetricEditPopover';
 import AdhocMetric from '../AdhocMetric';
 import columnType from '../propTypes/columnType';
 import { OptionControlLabel } from './OptionControls';
+import AdhocMetricPopoverTrigger from './AdhocMetricPopoverTrigger';
 
 const propTypes = {
   adhocMetric: PropTypes.instanceOf(AdhocMetric),
   onMetricEdit: PropTypes.func.isRequired,
   onRemoveMetric: PropTypes.func,
   columns: PropTypes.arrayOf(columnType),
+  savedMetrics: PropTypes.arrayOf(PropTypes.object),
+  savedMetric: PropTypes.object,
   datasourceType: PropTypes.string,
 };
 
 class AdhocMetricOption extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.onPopoverResize = this.onPopoverResize.bind(this);
-    this.onLabelChange = this.onLabelChange.bind(this);
     this.onRemoveMetric = this.onRemoveMetric.bind(this);
-    this.closePopover = this.closePopover.bind(this);
-    this.togglePopover = this.togglePopover.bind(this);
-    this.state = {
-      popoverVisible: undefined,
-      title: {
-        label: props.adhocMetric.label,
-        hasCustomLabel: props.adhocMetric.hasCustomLabel,
-      },
-    };
-  }
-
-  componentWillUnmount() {
-    // isNew is used to auto-open the popup. Once popup is viewed, it's not
-    // considered new anymore. We mutate the prop directly because we don't
-    // want excessive rerenderings.
-    this.props.adhocMetric.isNew = false;
-  }
-
-  onLabelChange(e) {
-    const label = e.target.value;
-    this.setState({
-      title: {
-        label: label || this.props.adhocMetric.label,
-        hasCustomLabel: !!label,
-      },
-    });
   }
 
   onRemoveMetric(e) {
@@ -72,64 +44,32 @@ class AdhocMetricOption extends React.PureComponent {
     this.props.onRemoveMetric();
   }
 
-  onPopoverResize() {
-    this.forceUpdate();
-  }
-
-  closePopover() {
-    this.togglePopover(false);
-  }
-
-  togglePopover(visible) {
-    this.setState(({ popoverVisible }) => {
-      this.props.adhocMetric.isNew = false;
-      return {
-        popoverVisible: visible === undefined ? !popoverVisible : visible,
-      };
-    });
-  }
-
   render() {
-    const { adhocMetric } = this.props;
-
-    const overlayContent = (
-      <AdhocMetricEditPopover
-        adhocMetric={adhocMetric}
-        title={this.state.title}
-        columns={this.props.columns}
-        datasourceType={this.props.datasourceType}
-        onResize={this.onPopoverResize}
-        onClose={this.closePopover}
-        onChange={this.props.onMetricEdit}
-      />
-    );
-
-    const popoverTitle = (
-      <AdhocMetricEditPopoverTitle
-        title={this.state.title}
-        defaultLabel={adhocMetric.label}
-        onChange={this.onLabelChange}
-      />
-    );
-
+    const {
+      adhocMetric,
+      onMetricEdit,
+      columns,
+      savedMetrics,
+      savedMetric,
+      datasourceType,
+    } = this.props;
     return (
-      <Popover
-        placement="right"
-        trigger="click"
-        disabled
-        content={overlayContent}
-        defaultVisible={this.state.popoverVisible || adhocMetric.isNew}
-        visible={this.state.popoverVisible}
-        onVisibleChange={this.togglePopover}
-        title={popoverTitle}
+      <AdhocMetricPopoverTrigger
+        adhocMetric={adhocMetric}
+        onMetricEdit={onMetricEdit}
+        columns={columns}
+        savedMetrics={savedMetrics}
+        savedMetric={savedMetric}
+        datasourceType={datasourceType}
       >
         <OptionControlLabel
+          savedMetric={savedMetric}
           label={adhocMetric.label}
           onRemove={this.onRemoveMetric}
           isAdhoc
           isFunction
         />
-      </Popover>
+      </AdhocMetricPopoverTrigger>
     );
   }
 }

--- a/superset-frontend/src/explore/components/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricOption.jsx
@@ -20,6 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import AdhocMetric from '../AdhocMetric';
 import columnType from '../propTypes/columnType';
+import savedMetricType from '../propTypes/savedMetricType';
 import { OptionControlLabel } from './OptionControls';
 import AdhocMetricPopoverTrigger from './AdhocMetricPopoverTrigger';
 
@@ -28,8 +29,8 @@ const propTypes = {
   onMetricEdit: PropTypes.func.isRequired,
   onRemoveMetric: PropTypes.func,
   columns: PropTypes.arrayOf(columnType),
-  savedMetrics: PropTypes.arrayOf(PropTypes.object),
-  savedMetric: PropTypes.object,
+  savedMetrics: PropTypes.arrayOf(savedMetricType),
+  savedMetric: savedMetricType,
   datasourceType: PropTypes.string,
 };
 

--- a/superset-frontend/src/explore/components/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/AdhocMetricPopoverTrigger.tsx
@@ -21,12 +21,8 @@ import Popover from 'src/common/components/Popover';
 import AdhocMetricEditPopoverTitle from 'src/explore/components/AdhocMetricEditPopoverTitle';
 import AdhocMetricEditPopover from './AdhocMetricEditPopover';
 import AdhocMetric from '../AdhocMetric';
+import { savedMetricType } from '../types';
 
-type savedMetricType = {
-  metric_name: string;
-  verbose_name: string;
-  expression: string;
-};
 export type AdhocMetricPopoverTriggerProps = {
   adhocMetric: AdhocMetric;
   onMetricEdit: () => void;

--- a/superset-frontend/src/explore/components/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/AdhocMetricPopoverTrigger.tsx
@@ -22,12 +22,17 @@ import AdhocMetricEditPopoverTitle from 'src/explore/components/AdhocMetricEditP
 import AdhocMetricEditPopover from './AdhocMetricEditPopover';
 import AdhocMetric from '../AdhocMetric';
 
+type savedMetricType = {
+  metric_name: string;
+  verbose_name: string;
+  expression: string;
+};
 export type AdhocMetricPopoverTriggerProps = {
   adhocMetric: AdhocMetric;
   onMetricEdit: () => void;
   columns: { column_name: string; type: string }[];
-  savedMetrics: Record<string, any>[];
-  savedMetric: any;
+  savedMetrics: savedMetricType[];
+  savedMetric: savedMetricType;
   datasourceType: string;
   children: ReactNode;
   createNew?: boolean;

--- a/superset-frontend/src/explore/components/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/AdhocMetricPopoverTrigger.tsx
@@ -21,12 +21,13 @@ import Popover from 'src/common/components/Popover';
 import AdhocMetricEditPopoverTitle from 'src/explore/components/AdhocMetricEditPopoverTitle';
 import AdhocMetricEditPopover from './AdhocMetricEditPopover';
 import AdhocMetric from '../AdhocMetric';
-import columnType from '../propTypes/columnType';
 
 export type AdhocMetricPopoverTriggerProps = {
   adhocMetric: AdhocMetric;
   onMetricEdit: () => void;
-  columns: typeof columnType[];
+  columns: { column_name: string; type: string }[];
+  savedMetrics: Record<string, any>[];
+  savedMetric: any;
   datasourceType: string;
   children: ReactNode;
   createNew?: boolean;
@@ -88,6 +89,8 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
         adhocMetric={adhocMetric}
         title={this.state.title}
         columns={this.props.columns}
+        savedMetrics={this.props.savedMetrics}
+        savedMetric={this.props.savedMetric}
         datasourceType={this.props.datasourceType}
         onResize={this.onPopoverResize}
         onClose={this.closePopover}

--- a/superset-frontend/src/explore/components/MetricDefinitionValue.jsx
+++ b/superset-frontend/src/explore/components/MetricDefinitionValue.jsx
@@ -31,7 +31,7 @@ const propTypes = {
   onMetricEdit: PropTypes.func,
   onRemoveMetric: PropTypes.func,
   columns: PropTypes.arrayOf(columnType),
-  savedMetrics: PropTypes.arrayOf(PropTypes.object),
+  savedMetrics: PropTypes.arrayOf(savedMetricType),
   multi: PropTypes.bool,
   datasourceType: PropTypes.string,
 };

--- a/superset-frontend/src/explore/components/MetricDefinitionValue.jsx
+++ b/superset-frontend/src/explore/components/MetricDefinitionValue.jsx
@@ -18,7 +18,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MetricOption } from '@superset-ui/chart-controls';
 
 import AdhocMetricOption from './AdhocMetricOption';
 import AdhocMetric from '../AdhocMetric';
@@ -32,6 +31,7 @@ const propTypes = {
   onMetricEdit: PropTypes.func,
   onRemoveMetric: PropTypes.func,
   columns: PropTypes.arrayOf(columnType),
+  savedMetrics: PropTypes.arrayOf(PropTypes.object),
   multi: PropTypes.bool,
   datasourceType: PropTypes.string,
 };
@@ -41,27 +41,34 @@ export default function MetricDefinitionValue({
   onMetricEdit,
   onRemoveMetric,
   columns,
+  savedMetrics,
   datasourceType,
 }) {
+  const getSavedMetricByName = metricName =>
+    savedMetrics.find(metric => metric.metric_name === metricName);
+
+  let savedMetric;
   if (option.metric_name) {
-    return (
-      <OptionControlLabel
-        label={<MetricOption metric={option} />}
-        onRemove={onRemoveMetric}
-        isFunction
-      />
-    );
+    savedMetric = option;
+  } else if (typeof option === 'string') {
+    savedMetric = getSavedMetricByName(option);
   }
-  if (option instanceof AdhocMetric) {
-    return (
-      <AdhocMetricOption
-        adhocMetric={option}
-        onMetricEdit={onMetricEdit}
-        onRemoveMetric={onRemoveMetric}
-        columns={columns}
-        datasourceType={datasourceType}
-      />
-    );
+
+  if (option instanceof AdhocMetric || savedMetric) {
+    const adhocMetric =
+      option instanceof AdhocMetric ? option : new AdhocMetric({});
+
+    const metricOptionProps = {
+      onMetricEdit,
+      onRemoveMetric,
+      columns,
+      savedMetrics,
+      datasourceType,
+      adhocMetric,
+      savedMetric: savedMetric ?? {},
+    };
+
+    return <AdhocMetricOption {...metricOptionProps} />;
   }
   if (typeof option === 'string') {
     return (

--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import { styled, useTheme } from '@superset-ui/core';
+import { ColumnOption } from '@superset-ui/chart-controls';
 import Icon from '../../components/Icon';
 
 const OptionControlContainer = styled.div<{ isAdhoc?: boolean }>`
@@ -109,12 +110,14 @@ export const AddIconButton = styled.button`
 
 export const OptionControlLabel = ({
   label,
+  savedMetric,
   onRemove,
   isAdhoc,
   isFunction,
   ...props
 }: {
   label: string | React.ReactNode;
+  savedMetric?: any;
   onRemove: () => void;
   isAdhoc?: boolean;
   isFunction?: boolean;
@@ -135,7 +138,11 @@ export const OptionControlLabel = ({
       </CloseContainer>
       <Label data-test="control-label">
         {isFunction && <Icon name="function" viewBox="0 0 16 11" />}
-        {label}
+        {savedMetric?.metric_name ? (
+          <ColumnOption column={savedMetric} />
+        ) : (
+          label
+        )}
       </Label>
       {isAdhoc && (
         <CaretContainer>

--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { styled, useTheme } from '@superset-ui/core';
 import { ColumnOption } from '@superset-ui/chart-controls';
 import Icon from '../../components/Icon';
+import { savedMetricType } from '../types';
 
 const OptionControlContainer = styled.div<{ isAdhoc?: boolean }>`
   display: flex;
@@ -117,7 +118,7 @@ export const OptionControlLabel = ({
   ...props
 }: {
   label: string | React.ReactNode;
-  savedMetric?: any;
+  savedMetric?: savedMetricType;
   onRemove: () => void;
   isAdhoc?: boolean;
   isFunction?: boolean;
@@ -125,7 +126,8 @@ export const OptionControlLabel = ({
   const theme = useTheme();
   const getLabelContent = () => {
     if (savedMetric?.metric_name) {
-      const column = { ...savedMetric };
+      // add column_name to fix typescript error
+      const column = { ...savedMetric, column_name: '' };
       if (!column.verbose_name) {
         column.verbose_name = column.metric_name;
       }

--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -123,6 +123,16 @@ export const OptionControlLabel = ({
   isFunction?: boolean;
 }) => {
   const theme = useTheme();
+  const getLabelContent = () => {
+    if (savedMetric?.metric_name) {
+      const column = { ...savedMetric };
+      if (!column.verbose_name) {
+        column.verbose_name = column.metric_name;
+      }
+      return <ColumnOption column={column} />;
+    }
+    return label;
+  };
   return (
     <OptionControlContainer
       isAdhoc={isAdhoc}
@@ -138,11 +148,7 @@ export const OptionControlLabel = ({
       </CloseContainer>
       <Label data-test="control-label">
         {isFunction && <Icon name="function" viewBox="0 0 16 11" />}
-        {savedMetric?.metric_name ? (
-          <ColumnOption column={savedMetric} />
-        ) : (
-          label
-        )}
+        {getLabelContent()}
       </Label>
       {isAdhoc && (
         <CaretContainer>

--- a/superset-frontend/src/explore/components/controls/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricsControl.jsx
@@ -128,6 +128,7 @@ class MetricsControl extends React.PureComponent {
         onMetricEdit={this.onMetricEdit}
         onRemoveMetric={() => this.onRemoveMetric(index)}
         columns={this.props.columns}
+        savedMetrics={this.props.savedMetrics}
         datasourceType={this.props.datasourceType}
       />
     );
@@ -178,17 +179,25 @@ class MetricsControl extends React.PureComponent {
     );
   }
 
-  onMetricEdit(changedMetric) {
-    let newValue = this.state.value.map(value => {
-      if (value.optionName === changedMetric.optionName) {
-        return changedMetric;
-      }
-      return value;
-    });
-    if (!this.props.multi) {
-      newValue = newValue[0];
-    }
-    this.props.onChange(newValue);
+  onMetricEdit(changedMetric, oldMetric) {
+    this.setState(
+      prevState => ({
+        value: prevState.value.map(value => {
+          if (
+            // compare saved metrics
+            value === oldMetric.metric_name ||
+            // compare adhoc metrics
+            value.optionName === oldMetric.optionName
+          ) {
+            return changedMetric;
+          }
+          return value;
+        }),
+      }),
+      () => {
+        this.onChange(this.state.value);
+      },
+    );
   }
 
   onRemoveMetric(index) {
@@ -242,6 +251,8 @@ class MetricsControl extends React.PureComponent {
         adhocMetric={new AdhocMetric({})}
         onMetricEdit={this.onNewMetric}
         columns={this.props.columns}
+        savedMetrics={this.props.savedMetrics}
+        savedMetric={{}}
         datasourceType={this.props.datasourceType}
         createNew
       >

--- a/superset-frontend/src/explore/propTypes/savedMetricType.js
+++ b/superset-frontend/src/explore/propTypes/savedMetricType.js
@@ -20,5 +20,6 @@ import PropTypes from 'prop-types';
 
 export default PropTypes.shape({
   metric_name: PropTypes.string.isRequired,
+  verbose_name: PropTypes.string,
   expression: PropTypes.string.isRequired,
 });

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+export type savedMetricType = {
+  metric_name: string;
+  verbose_name: string;
+  expression: string;
+};


### PR DESCRIPTION
### SUMMARY
This PR adds a possibility of selecting saved metrics (predefined in dataset). Also fixes bugs mentioned in points 1., 2. and 4. in this comment: https://github.com/apache/incubator-superset/pull/12095#issuecomment-747936902

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/102641735-db7b0000-415c-11eb-99f2-104204b9cb3b.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro @ktmud
@adam-stasiak Can you help with testing please?