### PR TITLE
fix: remove SIP_34_ALERTS_UI from config

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -339,7 +339,6 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     "ROW_LEVEL_SECURITY": False,
     # Enables Alerts and reports new implementation
     "ALERT_REPORTS": False,
-    "SIP_34_ALERTS_UI": False,
 }
 
 # Set the default view to card/grid view if thumbnail support is enabled.


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/apache/incubator-superset/pull/12085 removed all usage of the flag, but left a reference in config.py. This PR removes it to avoid confusion. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
- N/A
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- Nothing should change

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
