### PR TITLE
fix(explore): overflow issue with metric options

### DIFF
--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -41,7 +41,8 @@ const Label = styled.div`
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;  align-items: center;
+  text-overflow: ellipsis;
+  align-items: center;
   white-space: nowrap;
   padding-left: ${({ theme }) => theme.gridUnit}px;
   svg {

--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -38,8 +38,11 @@ const OptionControlContainer = styled.div<{ isAdhoc?: boolean }>`
 `;
 
 const Label = styled.div`
-  display: flex;
-  align-items: center;
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;  align-items: center;
+  white-space: nowrap;
   padding-left: ${({ theme }) => theme.gridUnit}px;
   svg {
     margin-right: ${({ theme }) => theme.gridUnit}px;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes text overflow display issues with new metric labels in Explore controls

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
![before](https://user-images.githubusercontent.com/812905/102653185-79ea6f80-4123-11eb-93d0-b2fc66e09c71.gif)

After:
![after](https://user-images.githubusercontent.com/812905/102653219-88388b80-4123-11eb-9d98-bc34e184693a.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
