### PR TITLE
fix(report): fix start date format and paginated query

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -33,6 +33,8 @@ import Owner from 'src/types/Owner';
 import { AlertReportCronScheduler } from './components/AlertReportCronScheduler';
 import { AlertObject, Operator, Recipient, MetaObject } from './types';
 
+const SELECT_PAGE_SIZE = 2000; // temporary fix for paginated query
+
 type SelectValue = {
   value: string;
   label: string;
@@ -616,7 +618,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
 
   // Fetch data to populate form dropdowns
   const loadOwnerOptions = (input = '') => {
-    const query = rison.encode({ filter: input });
+    const query = rison.encode({ filter: input, page_size: SELECT_PAGE_SIZE });
     return SupersetClient.get({
       endpoint: `/api/v1/report/related/owners?q=${query}`,
     }).then(
@@ -633,7 +635,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   };
 
   const loadSourceOptions = (input = '') => {
-    const query = rison.encode({ filter: input });
+    const query = rison.encode({ filter: input, page_size: SELECT_PAGE_SIZE });
     return SupersetClient.get({
       endpoint: `/api/v1/report/related/database?q=${query}`,
     }).then(
@@ -682,7 +684,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   };
 
   const loadDashboardOptions = (input = '') => {
-    const query = rison.encode({ filter: input });
+    const query = rison.encode({ filter: input, page_size: SELECT_PAGE_SIZE });
     return SupersetClient.get({
       endpoint: `/api/v1/report/related/dashboard?q=${query}`,
     }).then(
@@ -731,7 +733,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   };
 
   const loadChartOptions = (input = '') => {
-    const query = rison.encode({ filter: input });
+    const query = rison.encode({ filter: input, page_size: SELECT_PAGE_SIZE });
     return SupersetClient.get({
       endpoint: `/api/v1/report/related/chart?q=${query}`,
     }).then(

--- a/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
+++ b/superset-frontend/src/views/CRUD/alert/ExecutionLog.tsx
@@ -104,7 +104,7 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
           row: {
             original: { start_dttm: startDttm },
           },
-        }: any) => moment(new Date(startDttm)).format('ll'),
+        }: any) => moment(new Date(startDttm)).format('MM/DD/YYYY hh:mm:ss a'),
         Header: t('Start At'),
         accessor: 'start_dttm',
       },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- `chart`, `dashboard`, `owners`, `database` endpoints are paginated with page_size 20 by default and setting page size to `2000` to get the full list of result
-  change format for start date from `Dec 18, 2020` to `12/18/2020 01:03:44 pm`
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://www.loom.com/share/c673550e95164e1882e9d770a91da237
### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- manual testing
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
