### PR TITLE
fix(chart): replace viz_type with viz name from registry for list view

### DIFF
--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -63,6 +63,8 @@ const CONFIRM_OVERWRITE_MESSAGE = t(
     'sure you want to overwrite?',
 );
 
+const registry = getChartMetadataRegistry();
+
 const createFetchDatasets = (handleError: (err: Response) => void) => async (
   filterValue = '',
   pageIndex?: number,
@@ -214,7 +216,7 @@ function ChartList(props: ChartListProps) {
           row: {
             original: { viz_type: vizType },
           },
-        }: any) => vizType,
+        }: any) => registry.get(vizType)?.name || vizType,
         Header: t('Visualization Type'),
         accessor: 'viz_type',
         size: 'xxl',
@@ -412,9 +414,9 @@ function ChartList(props: ChartListProps) {
       input: 'select',
       operator: FilterOperators.equals,
       unfilteredLabel: 'All',
-      selects: getChartMetadataRegistry()
+      selects: registry
         .keys()
-        .map(k => ({ label: k, value: k }))
+        .map(k => ({ label: registry.get(k)?.name || k, value: k }))
         .sort((a, b) => {
           if (!a.label || !b.label) {
             return 0;


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- change viz type filter to display viz names instead of internal key. 
- change Visualization Type column to display viz name instead of internal key
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="1671" alt="Screen Shot 2020-12-18 at 9 43 59 PM" src="https://user-images.githubusercontent.com/10255196/102682028-0c6a2d80-417b-11eb-8ff2-3e808fa5b112.png">
<img width="265" alt="Screen Shot 2020-12-18 at 9 44 07 PM" src="https://user-images.githubusercontent.com/10255196/102682031-10964b00-417b-11eb-94b5-b416301505e8.png">
After:
<img width="365" alt="Screen Shot 2020-12-18 at 9 46 01 PM" src="https://user-images.githubusercontent.com/10255196/102682032-112ee180-417b-11eb-83af-1c94dde2e55d.png">
<img width="1678" alt="Screen Shot 2020-12-18 at 9 46 12 PM" src="https://user-images.githubusercontent.com/10255196/102682033-112ee180-417b-11eb-9f83-16902aad4546.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
👀 Chart list no longer displays internal key for viz type, instead displays same name used in explore and addSlice pages.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes #12084
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
