### PR TITLE
test(dashboard): fix flaky Cypress test

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/filter.test.ts
@@ -69,8 +69,10 @@ describe('Dashboard filter', () => {
   it('should apply filter', () => {
     cy.get('.Select__placeholder:first').click();
 
-    // should open the filter indicator
-    cy.get('svg[data-test="filter"]').should('be.visible');
+    // should show the filter indicator
+    cy.get('svg[data-test="filter"]:visible').should(nodes => {
+      expect(nodes.length).to.least(9);
+    });
 
     cy.get('.Select__control:first input[type=text]').type('So', {
       force: true,
@@ -80,9 +82,8 @@ describe('Dashboard filter', () => {
     cy.get('.Select__menu').first().contains('South Asia').click();
 
     // should still have all filter indicators
-    // and since the select is closed, all filter indicators should be visible
     cy.get('svg[data-test="filter"]:visible').should(nodes => {
-      expect(nodes).to.have.length(10);
+      expect(nodes.length).to.least(9);
     });
 
     cy.get('.filter_box button').click({ force: true });


### PR DESCRIPTION
### SUMMARY

The dashboard filter test (#12124 ) is still Flaky:

![image](https://user-images.githubusercontent.com/335541/102750398-969cc800-431a-11eb-901c-c9c298f60e76.png)

This error happens most likely because the Select menu closed AFTER Cypress collected the matching elements. 

The fix is to ignore this visibility check by just making sure all other filter indicators are visible.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
