### PR TITLE
fix: Filter Bar scrolling

### DIFF
--- a/superset-frontend/src/dashboard/components/StickyVerticalBar.tsx
+++ b/superset-frontend/src/dashboard/components/StickyVerticalBar.tsx
@@ -73,8 +73,28 @@ export const StickyVerticalBar: React.FC<SVBProps> = ({
     <Wrapper className={cx({ open: filtersOpen })}>
       <StickyContainer>
         <Sticky topOffset={-topOffset} bottomOffset={Infinity}>
-          {({ style, isSticky }: { style: any; isSticky: boolean }) => (
-            <Contents style={isSticky ? { ...style, top: topOffset } : null}>
+          {({
+            style,
+            isSticky,
+            distanceFromTop,
+          }: {
+            style: any;
+            isSticky: boolean;
+            distanceFromTop: number;
+          }) => (
+            <Contents
+              style={
+                isSticky
+                  ? {
+                      ...style,
+                      top: topOffset,
+                      height: `calc(100vh - ${topOffset}px)`,
+                    }
+                  : {
+                      height: `calc(100vh - ${distanceFromTop}px)`,
+                    }
+              }
+            >
               {children}
             </Contents>
           )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -61,8 +61,7 @@ const Bar = styled.div`
   width: ${barWidth}; // arbitrary...
   background: ${({ theme }) => theme.colors.grayscale.light5};
   border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
-  height: 100%;
-  max-height: 100%;
+  min-height: 100%;
   display: none;
   /* &.animated {
     display: flex;


### PR DESCRIPTION
### SUMMARY
This PR fixes bug in Filter Bar. When there was many filters added, Filter Bar scrolling did not work properly, as presented below.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![filter_bar_scrolling_before](https://user-images.githubusercontent.com/47450693/102779517-ab1da680-4394-11eb-8ba4-90e4fc688c9d.gif)
 
After:
![filter_bar_scrolling_after](https://user-images.githubusercontent.com/47450693/102779531-b07af100-4394-11eb-922e-d598b34e2a66.gif)

### TEST PLAN
Set feature flag `DASHBOARD_NATIVE_FILTERS` to true. 
Go to Dashboards, choose one and create a bunch of Filters. Try to scroll Filter Bar up and down.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @rusackas @villebro @junlincc 