### PR TITLE
fix: Reset All filters button

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -399,6 +399,16 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     });
   };
 
+  const handleResetAll = () => {
+    setFilterData({});
+    const filterIds = Object.keys(filterData);
+    filterIds.forEach(filterId => {
+      if (filterData[filterId]) {
+        setExtraFormData(filterId, {});
+      }
+    });
+  };
+
   return (
     <BarWrapper data-test="filter-bar" className={cx({ open: filtersOpen })}>
       <CollapsedBar
@@ -423,7 +433,11 @@ const FilterBar: React.FC<FiltersBarProps> = ({
           <Icon name="expand" onClick={() => toggleFiltersBar(false)} />
         </TitleArea>
         <ActionButtons>
-          <Button buttonStyle="secondary" buttonSize="sm">
+          <Button
+            buttonStyle="secondary"
+            buttonSize="sm"
+            onClick={handleResetAll}
+          >
             {t('Reset All')}
           </Button>
           <Button


### PR DESCRIPTION
### SUMMARY
"Reset all" button, located in Filter Bar, did not work. Now it is possible to click it - all previously set filters will be removed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![reset_all_before](https://user-images.githubusercontent.com/47450693/102788320-bd064600-43a2-11eb-8b3f-91b64a3350e6.gif)

After:
![reset_all_after](https://user-images.githubusercontent.com/47450693/102788330-c099cd00-43a2-11eb-9936-2771667951b6.gif)

### TEST PLAN
Set feature flag `DASHBOARD_NATIVE_FILTERS` to true.
Go to Dashboards, choose one and set some filters in the Filter Bar.
Click "Reset all" to check if all filters are removed and do not have an impact on charts.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @junlincc @villebro @rusackas 