### PR TITLE
chore: Add Loading icon to Filter Bar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -185,7 +185,7 @@ const StyledCaretIcon = styled(Icon)`
 
 const StyledLoadingBox = styled.div`
   position: relative;
-  height: 32px;
+  height: ${({ theme }) => theme.gridUnit * 8}px;
   margin-bottom: ${({ theme }) => theme.gridUnit * 6}px;
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -31,6 +31,7 @@ import Button from 'src/components/Button';
 import Icon from 'src/components/Icon';
 import { getChartDataRequest } from 'src/chart/chartAction';
 import { areObjectsEqual } from 'src/reduxUtils';
+import Loading from 'src/components/Loading';
 import FilterConfigurationLink from './FilterConfigurationLink';
 // import FilterScopeModal from 'src/dashboard/components/filterscope/FilterScopeModal';
 
@@ -182,6 +183,12 @@ const StyledCaretIcon = styled(Icon)`
   margin-top: ${({ theme }) => -theme.gridUnit}px;
 `;
 
+const StyledLoadingBox = styled.div`
+  position: relative;
+  height: 32px;
+  margin-bottom: ${({ theme }) => theme.gridUnit * 6}px;
+`;
+
 interface FilterProps {
   filter: Filter;
   icon?: React.ReactElement;
@@ -206,6 +213,7 @@ const FilterValue: React.FC<FilterProps> = ({
     defaultValue,
   } = filter;
   const cascadingFilters = useCascadingFilters(id);
+  const [loading, setLoading] = useState<boolean>(true);
   const [state, setState] = useState({ data: undefined });
   const [formData, setFormData] = useState<Partial<QueryFormData>>({});
   const [target] = targets;
@@ -241,12 +249,21 @@ const FilterValue: React.FC<FilterProps> = ({
         requestParams: { dashboardId: 0 },
       }).then(response => {
         setState({ data: response.result[0].data });
+        setLoading(false);
       });
     }
   }, [cascadingFilters]);
 
   const setExtraFormData = (extraFormData: ExtraFormData) =>
     onExtraFormDataChange(filter, extraFormData);
+
+  if (loading) {
+    return (
+      <StyledLoadingBox>
+        <Loading />
+      </StyledLoadingBox>
+    );
+  }
 
   return (
     <Form
@@ -309,7 +326,7 @@ export const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
 
       <StyledCascadeChildrenList>
         {filter.cascadeChildren?.map(childFilter => (
-          <li>
+          <li key={childFilter.id}>
             <CascadeFilterControl
               filter={childFilter}
               onExtraFormDataChange={onExtraFormDataChange}


### PR DESCRIPTION
### SUMMARY
Loading icon were added to Filter Bar. Now, instead of 'No results' while loading, Superset infinite loading icon is used.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![loading_before](https://user-images.githubusercontent.com/47450693/102795960-d1037500-43ad-11eb-935b-ad94659de5cf.gif)

After:
![loading_icon_after](https://user-images.githubusercontent.com/47450693/102795968-d496fc00-43ad-11eb-9113-e0f07dbbe0cb.gif)

### TEST PLAN
Set feature flag `DASHBOARD_NATIVE_FILTERS` to true.
Go to Dashboards, choose one and check if you can see loading icon (instead of 'No results) for filters.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @junlincc @villebro @rusackas 