### PR TITLE
feat: add new dashboard with video game sales

### DIFF
--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -81,6 +81,15 @@ def update_id_refs(config: Dict[str, Any], chart_ids: Dict[str, int]) -> Dict[st
             for old_id, value in metadata["expanded_slices"].items()
         }
 
+    if "default_filters" in metadata:
+        default_filters = json.loads(metadata["default_filters"])
+        metadata["default_filters"] = json.dumps(
+            {
+                str(id_map[int(old_id)]): value
+                for old_id, value in default_filters.items()
+            }
+        )
+
     # fix position
     position = fixed.get("position", {})
     for child in position.values():

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -37,11 +37,15 @@ JSON_KEYS = {"params", "template_params", "extra"}
 
 
 type_map = {
+    "VARCHAR": String(),
+    "STRING": String(),
+    "TEXT": Text(),
     "BIGINT": BigInteger(),
     "FLOAT": Float(),
+    "FLOAT64": Float(),
+    "DOUBLE PRECISION": Float(),
     "DATE": Date(),
-    "DOUBLE PRECISION": Float(precision=32),
-    "TEXT": Text(),
+    "DATETIME": DateTime(),
     "TIMESTAMP WITHOUT TIME ZONE": DateTime(timezone=False),
     "TIMESTAMP WITH TIME ZONE": DateTime(timezone=True),
 }

--- a/superset/examples/configs/charts/Games.yaml
+++ b/superset/examples/configs/charts/Games.yaml
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Games
+viz_type: table
+params:
+  adhoc_filters: []
+  all_columns:
+  - Name
+  - Global_Sales
+  - Platform
+  - Genre
+  - Publisher
+  - Year
+  color_pn: false
+  datasource: 21__table
+  granularity_sqla: Year
+  groupby:
+  - Name
+  include_search: true
+  metrics:
+  - aggregate: SUM
+    column:
+      column_name: Global_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 887
+      is_dttm: false
+      optionName: _col_Global_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: false
+    isNew: false
+    label: SUM(Global_Sales)
+    optionName: metric_pkpvgdsf70d_pnqv77v0x2p
+    sqlExpression: null
+  order_by_cols:
+  - '["Global_Sales", false]'
+  order_desc: true
+  page_length: '15'
+  percent_metrics: []
+  queryFields:
+    groupby: groupby
+    metrics: metrics
+  query_mode: raw
+  row_limit: null
+  show_cell_bars: false
+  slice_id: 1394
+  table_filter: false
+  table_timestamp_format: smart_date
+  time_grain_sqla: P1D
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params: {}
+  viz_type: table
+cache_timeout: null
+uuid: 2a5e562b-ab37-1b9b-1de3-1be4335c8e83
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Games_per_Genre.yaml
+++ b/superset/examples/configs/charts/Games_per_Genre.yaml
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Games per Genre
+viz_type: treemap
+params:
+  adhoc_filters: []
+  color_scheme: supersetColors
+  datasource: 1559__table
+  granularity_sqla: Year
+  groupby:
+  - Genre
+  label_colors:
+    '0': '#1FA8C9'
+    '1': '#454E7C'
+    '2600': '#666666'
+    3DO: '#B2B2B2'
+    3DS: '#D1C6BC'
+    Action: '#1FA8C9'
+    Adventure: '#454E7C'
+    DC: '#A38F79'
+    DS: '#8FD3E4'
+    Europe: '#5AC189'
+    Fighting: '#5AC189'
+    GB: '#FDE380'
+    GBA: '#ACE1C4'
+    GC: '#5AC189'
+    GEN: '#3CCCCB'
+    GG: '#EFA1AA'
+    Japan: '#FF7F44'
+    Microsoft Game Studios: '#D1C6BC'
+    Misc: '#FF7F44'
+    N64: '#1FA8C9'
+    NES: '#9EE5E5'
+    NG: '#A1A6BD'
+    Nintendo: '#D3B3DA'
+    North America: '#666666'
+    Other: '#E04355'
+    PC: '#EFA1AA'
+    PCFX: '#FDE380'
+    PS: '#A1A6BD'
+    PS2: '#FCC700'
+    PS3: '#3CCCCB'
+    PS4: '#B2B2B2'
+    PSP: '#FEC0A1'
+    PSV: '#FCC700'
+    Platform: '#666666'
+    Puzzle: '#E04355'
+    Racing: '#FCC700'
+    Role-Playing: '#A868B7'
+    SAT: '#A868B7'
+    SCD: '#8FD3E4'
+    SNES: '#454E7C'
+    Shooter: '#3CCCCB'
+    Simulation: '#A38F79'
+    Sports: '#8FD3E4'
+    Strategy: '#A1A6BD'
+    TG16: '#FEC0A1'
+    Take-Two Interactive: '#9EE5E5'
+    WS: '#ACE1C4'
+    Wii: '#A38F79'
+    WiiU: '#E04355'
+    X360: '#A868B7'
+    XB: '#D3B3DA'
+    XOne: '#FF7F44'
+  metrics:
+  - count
+  number_format: SMART_NUMBER
+  queryFields:
+    groupby: groupby
+    metrics: metrics
+  row_limit: null
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  treemap_ratio: 1.618033988749895
+  url_params:
+    preselect_filters: '{"1389": {"Platform": ["PS", "PS2", "PS3", "PS4"], "Genre":
+      null, "__time_range": "No filter"}}'
+  viz_type: treemap
+cache_timeout: null
+uuid: 0499bdec-0837-44f3-ae8a-8c670de81afd
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Games_per_Genre_over_time.yaml
+++ b/superset/examples/configs/charts/Games_per_Genre_over_time.yaml
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Games per Genre over time
+viz_type: line
+params:
+  adhoc_filters: []
+  annotation_layers: []
+  bottom_margin: auto
+  color_scheme: supersetColors
+  comparison_type: values
+  contribution: false
+  datasource: 21__table
+  granularity_sqla: Year
+  groupby:
+  - Genre
+  label_colors:
+    '0': '#1FA8C9'
+    '1': '#454E7C'
+    '2600': '#666666'
+    3DO: '#B2B2B2'
+    3DS: '#D1C6BC'
+    Action: '#1FA8C9'
+    Adventure: '#454E7C'
+    DC: '#A38F79'
+    DS: '#8FD3E4'
+    Europe: '#5AC189'
+    Fighting: '#5AC189'
+    GB: '#FDE380'
+    GBA: '#ACE1C4'
+    GC: '#5AC189'
+    GEN: '#3CCCCB'
+    GG: '#EFA1AA'
+    Japan: '#FF7F44'
+    Microsoft Game Studios: '#D1C6BC'
+    Misc: '#FF7F44'
+    N64: '#1FA8C9'
+    NES: '#9EE5E5'
+    NG: '#A1A6BD'
+    Nintendo: '#D3B3DA'
+    North America: '#666666'
+    Other: '#E04355'
+    PC: '#EFA1AA'
+    PCFX: '#FDE380'
+    PS: '#A1A6BD'
+    PS2: '#FCC700'
+    PS3: '#3CCCCB'
+    PS4: '#B2B2B2'
+    PSP: '#FEC0A1'
+    PSV: '#FCC700'
+    Platform: '#666666'
+    Puzzle: '#E04355'
+    Racing: '#FCC700'
+    Role-Playing: '#A868B7'
+    SAT: '#A868B7'
+    SCD: '#8FD3E4'
+    SNES: '#454E7C'
+    Shooter: '#3CCCCB'
+    Simulation: '#A38F79'
+    Sports: '#8FD3E4'
+    Strategy: '#A1A6BD'
+    TG16: '#FEC0A1'
+    Take-Two Interactive: '#9EE5E5'
+    WS: '#ACE1C4'
+    Wii: '#A38F79'
+    WiiU: '#E04355'
+    X360: '#A868B7'
+    XB: '#D3B3DA'
+    XOne: '#FF7F44'
+  left_margin: auto
+  line_interpolation: linear
+  metrics:
+  - count
+  order_desc: true
+  queryFields:
+    groupby: groupby
+    metrics: metrics
+  rich_tooltip: true
+  rolling_type: None
+  row_limit: null
+  show_brush: auto
+  show_legend: true
+  show_markers: false
+  slice_id: 3544
+  time_grain_sqla: null
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params:
+    preselect_filters: '{"1389": {"Platform": ["PS", "PS2", "PS3", "PS4"], "Genre":
+      null, "__time_range": "No filter"}}'
+  viz_type: line
+  x_axis_format: smart_date
+  x_axis_label: Year Published
+  x_axis_showminmax: true
+  x_ticks_layout: auto
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: SMART_NUMBER
+  y_axis_label: '# of Games Published'
+  y_axis_showminmax: true
+cache_timeout: null
+uuid: 0f8976aa-7bb4-40c7-860b-64445a51aaaf
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Most_Dominant_Platforms.yaml
+++ b/superset/examples/configs/charts/Most_Dominant_Platforms.yaml
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Most Dominant Platforms
+viz_type: pie
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: '25'
+    expressionType: SIMPLE
+    filterOptionName: filter_znxs4o61aod_n5blgxo29r
+    isExtra: false
+    isNew: false
+    operator: <=
+    sqlExpression: null
+    subject: Rank
+  color_scheme: supersetColors
+  datasource: 21__table
+  donut: true
+  granularity_sqla: Year
+  groupby:
+  - Publisher
+  innerRadius: 45
+  label_line: true
+  labels_outside: true
+  metric:
+    aggregate: SUM
+    column:
+      column_name: Global_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 887
+      is_dttm: false
+      optionName: _col_Global_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: false
+    isNew: false
+    label: SUM(Global_Sales)
+    optionName: metric_k2rqz0zqhkf_49hu4kq9h3u
+    sqlExpression: null
+  number_format: SMART_NUMBER
+  outerRadius: 67
+  pie_label_type: key
+  queryFields:
+    groupby: groupby
+    metric: metrics
+  row_limit: null
+  show_labels: true
+  show_legend: false
+  slice_id: 658
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params: {}
+  viz_type: pie
+cache_timeout: null
+uuid: 1810975a-f6d4-07c3-495c-c3b535d01f21
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Number_of_Games_That_Hit_100k_in_Sales_By_Release_Year.yaml
+++ b/superset/examples/configs/charts/Number_of_Games_That_Hit_100k_in_Sales_By_Release_Year.yaml
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: '# of Games That Hit 100k in Sales By Release Year'
+viz_type: treemap
+params:
+  adhoc_filters: []
+  color_scheme: supersetColors
+  datasource: 21__table
+  granularity_sqla: Year
+  groupby:
+  - Platform
+  label_colors:
+    '2600': '#D1C6BC'
+    3DO: '#A38F79'
+    3DS: '#B2B2B2'
+    Action: '#ACE1C4'
+    Adventure: '#5AC189'
+    COUNT(*): '#1FA8C9'
+    DC: '#666666'
+    DS: '#E04355'
+    Fighting: '#D1C6BC'
+    GB: '#A1A6BD'
+    GBA: '#A868B7'
+    GC: '#D3B3DA'
+    GEN: '#FF7F44'
+    GG: '#8FD3E4'
+    Microsoft Game Studios: '#FCC700'
+    Misc: '#D3B3DA'
+    N64: '#EFA1AA'
+    NES: '#FEC0A1'
+    NG: '#FCC700'
+    Nintendo: '#666666'
+    PC: '#8FD3E4'
+    PCFX: '#A1A6BD'
+    PS: '#FCC700'
+    PS2: '#454E7C'
+    PS3: '#FF7F44'
+    PS4: '#A38F79'
+    PSP: '#3CCCCB'
+    PSV: '#454E7C'
+    Platform: '#FDE380'
+    Puzzle: '#454E7C'
+    Racing: '#9EE5E5'
+    Role-Playing: '#EFA1AA'
+    SAT: '#5AC189'
+    SCD: '#E04355'
+    SNES: '#FDE380'
+    Shooter: '#B2B2B2'
+    Simulation: '#1FA8C9'
+    Sports: '#FEC0A1'
+    Strategy: '#FF7F44'
+    TG16: '#3CCCCB'
+    Take-Two Interactive: '#E04355'
+    WS: '#A868B7'
+    Wii: '#666666'
+    WiiU: '#1FA8C9'
+    X360: '#5AC189'
+    XB: '#ACE1C4'
+    XOne: '#9EE5E5'
+  metrics:
+  - count
+  number_format: SMART_NUMBER
+  queryFields:
+    groupby: groupby
+    metrics: metrics
+  row_limit: 10
+  slice_id: 661
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  treemap_ratio: 1.618033988749895
+  url_params: {}
+  viz_type: treemap
+cache_timeout: null
+uuid: 2b69887b-23e3-b46d-d38c-8ea11856c555
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Popular_Genres_Across_Platforms.yaml
+++ b/superset/examples/configs/charts/Popular_Genres_Across_Platforms.yaml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Popular Genres Across Platforms
+viz_type: heatmap
+params:
+  adhoc_filters: []
+  all_columns_x: Platform
+  all_columns_y: Genre
+  bottom_margin: auto
+  canvas_image_rendering: pixelated
+  datasource: 64__table
+  granularity_sqla: Year
+  left_margin: auto
+  linear_color_scheme: blue_white_yellow
+  metric: count
+  normalize_across: heatmap
+  queryFields:
+    metric: metrics
+  row_limit: 10000
+  show_legend: true
+  show_perc: true
+  show_values: true
+  sort_x_axis: alpha_asc
+  sort_y_axis: alpha_asc
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params: {}
+  viz_type: heatmap
+  xscale_interval: null
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: SMART_NUMBER
+  yscale_interval: null
+cache_timeout: null
+uuid: 326fc7e5-b7f1-448e-8a6f-80d0e7ce0b64
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Publishers_With_Most_Titles.yaml
+++ b/superset/examples/configs/charts/Publishers_With_Most_Titles.yaml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Publishers With Most Titles
+viz_type: table
+params:
+  adhoc_filters: []
+  all_columns:
+  - Rank
+  - Name
+  - Global_Sales
+  - Platform
+  - Genre
+  - Publisher
+  - Year
+  color_pn: false
+  datasource: 21__table
+  granularity_sqla: Year
+  groupby: []
+  metrics:
+  - count
+  order_by_cols: []
+  order_desc: true
+  page_length: null
+  percent_metrics: []
+  queryFields:
+    groupby: groupby
+    metrics: metrics
+  query_mode: raw
+  row_limit: 10
+  show_cell_bars: false
+  slice_id: 657
+  table_timestamp_format: smart_date
+  time_grain_sqla: P1D
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params: {}
+  viz_type: table
+cache_timeout: null
+uuid: d20b7324-3b80-24d4-37e2-3bd583b66713
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Rise__Fall_of_Video_Game_Consoles.yaml
+++ b/superset/examples/configs/charts/Rise__Fall_of_Video_Game_Consoles.yaml
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Rise & Fall of Video Game Consoles
+viz_type: area
+params:
+  adhoc_filters: []
+  annotation_layers: []
+  bottom_margin: auto
+  color_scheme: supersetColors
+  comparison_type: values
+  contribution: false
+  datasource: 21__table
+  granularity_sqla: Year
+  groupby:
+  - Platform
+  label_colors:
+    '0': '#1FA8C9'
+    '1': '#454E7C'
+    '2600': '#666666'
+    3DO: '#B2B2B2'
+    3DS: '#D1C6BC'
+    Action: '#1FA8C9'
+    Adventure: '#454E7C'
+    DC: '#A38F79'
+    DS: '#8FD3E4'
+    Europe: '#5AC189'
+    Fighting: '#5AC189'
+    GB: '#FDE380'
+    GBA: '#ACE1C4'
+    GC: '#5AC189'
+    GEN: '#3CCCCB'
+    GG: '#EFA1AA'
+    Japan: '#FF7F44'
+    Microsoft Game Studios: '#D1C6BC'
+    Misc: '#FF7F44'
+    N64: '#1FA8C9'
+    NES: '#9EE5E5'
+    NG: '#A1A6BD'
+    Nintendo: '#D3B3DA'
+    North America: '#666666'
+    Other: '#E04355'
+    PC: '#EFA1AA'
+    PCFX: '#FDE380'
+    PS: '#A1A6BD'
+    PS2: '#FCC700'
+    PS3: '#3CCCCB'
+    PS4: '#B2B2B2'
+    PSP: '#FEC0A1'
+    PSV: '#FCC700'
+    Platform: '#666666'
+    Puzzle: '#E04355'
+    Racing: '#FCC700'
+    Role-Playing: '#A868B7'
+    SAT: '#A868B7'
+    SCD: '#8FD3E4'
+    SNES: '#454E7C'
+    Shooter: '#3CCCCB'
+    Simulation: '#A38F79'
+    Sports: '#8FD3E4'
+    Strategy: '#A1A6BD'
+    TG16: '#FEC0A1'
+    Take-Two Interactive: '#9EE5E5'
+    WS: '#ACE1C4'
+    Wii: '#A38F79'
+    WiiU: '#E04355'
+    X360: '#A868B7'
+    XB: '#D3B3DA'
+    XOne: '#FF7F44'
+  line_interpolation: linear
+  metrics:
+  - aggregate: SUM
+    column:
+      column_name: Global_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 887
+      is_dttm: false
+      optionName: _col_Global_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: false
+    isNew: false
+    label: SUM(Global_Sales)
+    optionName: metric_ufl75addr8c_oqqhdumirpn
+    sqlExpression: null
+  order_desc: true
+  queryFields:
+    groupby: groupby
+    metrics: metrics
+  rich_tooltip: true
+  rolling_type: None
+  row_limit: null
+  show_brush: auto
+  show_legend: false
+  slice_id: 659
+  stacked_style: stream
+  time_grain_sqla: null
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params:
+    preselect_filters: '{"1389": {"Platform": ["PS", "PS2", "PS3", "PS4"], "Genre":
+      null, "__time_range": "No filter"}}'
+  viz_type: area
+  x_axis_format: smart_date
+  x_axis_label: Year Published
+  x_axis_showminmax: true
+  x_ticks_layout: auto
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: SMART_NUMBER
+cache_timeout: null
+uuid: 83b0e2d0-d38b-d980-ed8e-e1c9846361b6
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Top_10_Games_Proportion_of_Sales_in_Markets.yaml
+++ b/superset/examples/configs/charts/Top_10_Games_Proportion_of_Sales_in_Markets.yaml
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: 'Top 10 Games: Proportion of Sales in Markets'
+viz_type: dist_bar
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: '10'
+    expressionType: SIMPLE
+    filterOptionName: filter_juemdnqji5_d6fm8tuf4rc
+    isExtra: false
+    isNew: false
+    operator: <=
+    sqlExpression: null
+    subject: Rank
+  bar_stacked: true
+  bottom_margin: auto
+  color_scheme: supersetColors
+  columns: []
+  contribution: true
+  datasource: 21__table
+  granularity_sqla: Year
+  groupby:
+  - Name
+  label_colors: {}
+  metrics:
+  - aggregate: SUM
+    column:
+      column_name: NA_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 883
+      is_dttm: false
+      optionName: _col_NA_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    isNew: false
+    label: North America
+    optionName: metric_a943v7wg5g_0mm03hrsmpf
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      column_name: EU_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 884
+      is_dttm: false
+      optionName: _col_EU_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    isNew: false
+    label: Europe
+    optionName: metric_bibau54x0rb_dwrjtqkbyso
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      column_name: JP_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 885
+      is_dttm: false
+      optionName: _col_JP_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    isNew: false
+    label: Japan
+    optionName: metric_06whpr2oyhw_4l88xxu6zvd
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      column_name: Other_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 886
+      is_dttm: false
+      optionName: _col_Other_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    isNew: false
+    label: Other
+    optionName: metric_pcx05ioxums_ibr16zvi74
+    sqlExpression: null
+  queryFields:
+    columns: groupby
+    groupby: groupby
+    metrics: metrics
+  row_limit: null
+  show_legend: true
+  slice_id: 3546
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params: {}
+  viz_type: dist_bar
+  x_ticks_layout: staggered
+  y_axis_format: SMART_NUMBER
+cache_timeout: null
+uuid: a40879d5-653a-42fe-9314-bbe88ad26e92
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Total_Sales_per_Market_Grouped_by_Genre.yaml
+++ b/superset/examples/configs/charts/Total_Sales_per_Market_Grouped_by_Genre.yaml
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Total Sales per Market (Grouped by Genre)
+viz_type: dist_bar
+params:
+  adhoc_filters: []
+  bar_stacked: true
+  bottom_margin: auto
+  color_scheme: supersetColors
+  columns: []
+  contribution: false
+  datasource: 21__table
+  granularity_sqla: Year
+  groupby:
+  - Genre
+  label_colors:
+    '0': '#1FA8C9'
+    '1': '#454E7C'
+    '2600': '#666666'
+    3DO: '#B2B2B2'
+    3DS: '#D1C6BC'
+    Action: '#1FA8C9'
+    Adventure: '#454E7C'
+    DC: '#A38F79'
+    DS: '#8FD3E4'
+    Europe: '#5AC189'
+    Fighting: '#5AC189'
+    GB: '#FDE380'
+    GBA: '#ACE1C4'
+    GC: '#5AC189'
+    GEN: '#3CCCCB'
+    GG: '#EFA1AA'
+    Japan: '#FF7F44'
+    Microsoft Game Studios: '#D1C6BC'
+    Misc: '#FF7F44'
+    N64: '#1FA8C9'
+    NES: '#9EE5E5'
+    NG: '#A1A6BD'
+    Nintendo: '#D3B3DA'
+    North America: '#666666'
+    Other: '#E04355'
+    PC: '#EFA1AA'
+    PCFX: '#FDE380'
+    PS: '#A1A6BD'
+    PS2: '#FCC700'
+    PS3: '#3CCCCB'
+    PS4: '#B2B2B2'
+    PSP: '#FEC0A1'
+    PSV: '#FCC700'
+    Platform: '#666666'
+    Puzzle: '#E04355'
+    Racing: '#FCC700'
+    Role-Playing: '#A868B7'
+    SAT: '#A868B7'
+    SCD: '#8FD3E4'
+    SNES: '#454E7C'
+    Shooter: '#3CCCCB'
+    Simulation: '#A38F79'
+    Sports: '#8FD3E4'
+    Strategy: '#A1A6BD'
+    TG16: '#FEC0A1'
+    Take-Two Interactive: '#9EE5E5'
+    WS: '#ACE1C4'
+    Wii: '#A38F79'
+    WiiU: '#E04355'
+    X360: '#A868B7'
+    XB: '#D3B3DA'
+    XOne: '#FF7F44'
+  metrics:
+  - aggregate: SUM
+    column:
+      column_name: NA_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 883
+      is_dttm: false
+      optionName: _col_NA_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    isNew: false
+    label: North America
+    optionName: metric_3pl6jwmyd72_p9o4j2xxgyp
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      column_name: EU_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 884
+      is_dttm: false
+      optionName: _col_EU_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    isNew: false
+    label: Europe
+    optionName: metric_e8rdyfxxjdu_6dgyhf7xcne
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      column_name: JP_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 885
+      is_dttm: false
+      optionName: _col_JP_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    isNew: false
+    label: Japan
+    optionName: metric_6gesefugzy6_517l3wowdwu
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      column_name: Other_Sales
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 886
+      is_dttm: false
+      optionName: _col_Other_Sales
+      python_date_format: null
+      type: DOUBLE PRECISION
+      verbose_name: null
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    isNew: false
+    label: Other
+    optionName: metric_cf6kbre28f_2sg5b5pfq5a
+    sqlExpression: null
+  order_bars: false
+  queryFields:
+    columns: groupby
+    groupby: groupby
+    metrics: metrics
+  row_limit: null
+  show_bar_value: false
+  show_controls: true
+  show_legend: true
+  slice_id: 3548
+  time_range: No filter
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params:
+    preselect_filters: '{"1389": {"Platform": ["PS", "PS2", "PS3", "PS4"], "Genre":
+      null, "__time_range": "No filter"}}'
+  viz_type: dist_bar
+  x_axis_label: Genre
+  x_ticks_layout: flat
+  y_axis_format: SMART_NUMBER
+cache_timeout: null
+uuid: d8bf948e-46fd-4380-9f9c-a950c34bcc92
+version: 1.0.0
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/charts/Vehicle_Sales_Filter.yaml
+++ b/superset/examples/configs/charts/Vehicle_Sales_Filter.yaml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+slice_name: Vehicle Sales Filter
+viz_type: filter_box
+params:
+  adhoc_filters: []
+  datasource: 23__table
+  date_filter: true
+  filter_configs:
+  - asc: true
+    clearable: true
+    column: ProductLine
+    key: 7oUjq15eQ
+    multiple: true
+    searchAllOptions: false
+  - asc: true
+    clearable: true
+    column: DealSize
+    key: c3hO6Eub8
+    multiple: true
+    searchAllOptions: false
+  granularity_sqla: OrderDate
+  queryFields: {}
+  slice_id: 671
+  time_range: '2003-01-01T00:00:00 : 2005-06-01T00:00:00'
+  time_range_endpoints:
+  - inclusive
+  - exclusive
+  url_params: {}
+  viz_type: filter_box
+cache_timeout: null
+uuid: a5689df7-98fc-7c51-602c-ebd92dc3ec70
+version: 1.0.0
+dataset_uuid: e8623bb9-5e00-f531-506a-19607f5f8005

--- a/superset/examples/configs/charts/Video_Game_Sales_Filter.yaml
+++ b/superset/examples/configs/charts/Video_Game_Sales_Filter.yaml
@@ -14,35 +14,42 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-slice_name: Filter
+slice_name: Video Game Sales filter
 viz_type: filter_box
 params:
   adhoc_filters: []
-  datasource: 23__table
+  datasource: 21__table
   date_filter: true
   filter_configs:
   - asc: true
     clearable: true
-    column: ProductLine
-    key: 7oUjq15eQ
+    column: Platform
+    key: s3ItH9vhG
     multiple: true
     searchAllOptions: false
   - asc: true
     clearable: true
-    column: DealSize
-    key: c3hO6Eub8
+    column: Genre
+    key: 202hDeMsG
     multiple: true
     searchAllOptions: false
-  granularity_sqla: OrderDate
+  - asc: true
+    clearable: true
+    column: Publisher
+    key: 5Os6jsJFK
+    multiple: true
+    searchAllOptions: false
+  granularity_sqla: Year
   queryFields: {}
-  slice_id: 671
-  time_range: '2003-01-01T00:00:00 : 2005-06-01T00:00:00'
+  time_range: No filter
   time_range_endpoints:
   - inclusive
   - exclusive
-  url_params: {}
+  url_params:
+    preselect_filters: '{"1389": {"Platform": ["PS", "PS2", "PS3", "PS4"], "Genre":
+      null, "__time_range": "No filter"}}'
   viz_type: filter_box
 cache_timeout: null
-uuid: a5689df7-98fc-7c51-602c-ebd92dc3ec70
+uuid: fd9ce7ec-ae08-4f71-93e0-7c26b132b2e6
 version: 1.0.0
-dataset_uuid: e8623bb9-5e00-f531-506a-19607f5f8005
+dataset_uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283

--- a/superset/examples/configs/dashboards/Video_Game_Sales.yaml
+++ b/superset/examples/configs/dashboards/Video_Game_Sales.yaml
@@ -1,0 +1,443 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+dashboard_title: Video Game Sales
+description: null
+css: ''
+slug: null
+uuid: c7bc10f4-6a2d-7569-caae-bbc91864ee11
+position:
+  CHART-1L7NIcXvVN:
+    children: []
+    id: CHART-1L7NIcXvVN
+    meta:
+      chartId: 3544
+      height: 79
+      sliceName: Games per Genre over time
+      uuid: 0f8976aa-7bb4-40c7-860b-64445a51aaaf
+      width: 6
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    - ROW-fjg6YQBkH
+    type: CHART
+  CHART-7mKdnU7OUJ:
+    children: []
+    id: CHART-7mKdnU7OUJ
+    meta:
+      chartId: 3545
+      height: 80
+      sliceName: Games per Genre
+      uuid: 0499bdec-0837-44f3-ae8a-8c670de81afd
+      width: 3
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    - ROW-yP9SB89PZ
+    type: CHART
+  CHART-8OG3UJX-Tn:
+    children: []
+    id: CHART-8OG3UJX-Tn
+    meta:
+      chartId: 661
+      height: 54
+      sliceName: '# of Games That Hit 100k in Sales By Release Year'
+      sliceNameOverride: 'Top 10 Consoles, by # of Hit Games'
+      uuid: 2b69887b-23e3-b46d-d38c-8ea11856c555
+      width: 6
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    - ROW-7kAf1blYU
+    type: CHART
+  CHART-W02beJK7ms:
+    children: []
+    id: CHART-W02beJK7ms
+    meta:
+      chartId: 657
+      height: 54
+      sliceName: Publishers With Most Titles
+      sliceNameOverride: Top 10 Games (by Global Sales)
+      uuid: d20b7324-3b80-24d4-37e2-3bd583b66713
+      width: 3
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    - ROW-7kAf1blYU
+    type: CHART
+  CHART-XFag0yZdLk:
+    children: []
+    id: CHART-XFag0yZdLk
+    meta:
+      chartId: 658
+      height: 54
+      sliceName: Most Dominant Platforms
+      sliceNameOverride: Publishers of Top 25 Games
+      uuid: 1810975a-f6d4-07c3-495c-c3b535d01f21
+      width: 3
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    - ROW-7kAf1blYU
+    type: CHART
+  CHART-XRvRfsMsaQ:
+    children: []
+    id: CHART-XRvRfsMsaQ
+    meta:
+      chartId: 3546
+      height: 62
+      sliceName: 'Top 10 Games: Proportion of Sales in Markets'
+      uuid: a40879d5-653a-42fe-9314-bbe88ad26e92
+      width: 6
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    - ROW-NuR8GFQTO
+    type: CHART
+  CHART-XVIYTeubZh:
+    children: []
+    id: CHART-XVIYTeubZh
+    meta:
+      chartId: 1394
+      height: 80
+      sliceName: Games
+      uuid: 2a5e562b-ab37-1b9b-1de3-1be4335c8e83
+      width: 5
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    - ROW-yP9SB89PZ
+    type: CHART
+  CHART-_sx22yawJO:
+    children: []
+    id: CHART-_sx22yawJO
+    meta:
+      chartId: 3461
+      height: 62
+      sliceName: Popular Genres Across Platforms
+      uuid: 326fc7e5-b7f1-448e-8a6f-80d0e7ce0b64
+      width: 6
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    - ROW-NuR8GFQTO
+    type: CHART
+  CHART-nYns6xr4Ft:
+    children: []
+    id: CHART-nYns6xr4Ft
+    meta:
+      chartId: 3548
+      height: 79
+      sliceName: Total Sales per Market (Grouped by Genre)
+      uuid: d8bf948e-46fd-4380-9f9c-a950c34bcc92
+      width: 6
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    - ROW-fjg6YQBkH
+    type: CHART
+  CHART-uP9GF0z0rT:
+    children: []
+    id: CHART-uP9GF0z0rT
+    meta:
+      chartId: 3547
+      height: 45
+      sliceName: Filter
+      uuid: fd9ce7ec-ae08-4f71-93e0-7c26b132b2e6
+      width: 4
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    - ROW-yP9SB89PZ
+    - COLUMN-F53B1OSMcz
+    type: CHART
+  CHART-wt6ZO8jRXZ:
+    children: []
+    id: CHART-wt6ZO8jRXZ
+    meta:
+      chartId: 659
+      height: 72
+      sliceName: Rise & Fall of Video Game Consoles
+      sliceNameOverride: Global Sales per Console
+      uuid: 83b0e2d0-d38b-d980-ed8e-e1c9846361b6
+      width: 12
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    - ROW-XT1DsNA_V
+    type: CHART
+  COLUMN-F53B1OSMcz:
+    children:
+    - MARKDOWN-7K5cBNy7qu
+    - CHART-uP9GF0z0rT
+    id: COLUMN-F53B1OSMcz
+    meta:
+      background: BACKGROUND_TRANSPARENT
+      width: 4
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    - ROW-yP9SB89PZ
+    type: COLUMN
+  DASHBOARD_VERSION_KEY: v2
+  GRID_ID:
+    children: []
+    id: GRID_ID
+    parents:
+    - ROOT_ID
+    type: GRID
+  HEADER_ID:
+    id: HEADER_ID
+    meta:
+      text: Video Game Sales
+    type: HEADER
+  MARKDOWN-7K5cBNy7qu:
+    children: []
+    id: MARKDOWN-7K5cBNy7qu
+    meta:
+      code: "# \U0001F93F Explore Trends\n\nDive into data on popular video games\
+        \ using the following dimensions:\n\n- Year\n- Platform\n- Publisher\n- Genre\n\
+        \nTo use the **Filter Games** box below, select values for each dimension\
+        \ you want to zoom in on and then click **Apply**. \n\nThe filter criteria\
+        \ you set in this Filter-box will apply to *all* charts in this tab."
+      height: 33
+      width: 4
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    - ROW-yP9SB89PZ
+    - COLUMN-F53B1OSMcz
+    type: MARKDOWN
+  MARKDOWN-JOZKOjVc3a:
+    children: []
+    id: MARKDOWN-JOZKOjVc3a
+    meta:
+      code: "## \U0001F3AEVideo Game Sales\n\nThis dashboard visualizes sales & platform\
+        \ data on video games that sold more than 100k copies. The data was last updated\
+        \ in early 2017.\n\n[Original dataset](https://www.kaggle.com/gregorut/videogamesales)"
+      height: 18
+      width: 12
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    - ROW-0F99WDC-sz
+    type: MARKDOWN
+  ROOT_ID:
+    children:
+    - TABS-97PVJa11D_
+    id: ROOT_ID
+    type: ROOT
+  ROW-0F99WDC-sz:
+    children:
+    - MARKDOWN-JOZKOjVc3a
+    id: ROW-0F99WDC-sz
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    type: ROW
+  ROW-7kAf1blYU:
+    children:
+    - CHART-W02beJK7ms
+    - CHART-XFag0yZdLk
+    - CHART-8OG3UJX-Tn
+    id: ROW-7kAf1blYU
+    meta:
+      '0': ROOT_ID
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    type: ROW
+  ROW-NuR8GFQTO:
+    children:
+    - CHART-_sx22yawJO
+    - CHART-XRvRfsMsaQ
+    id: ROW-NuR8GFQTO
+    meta:
+      '0': ROOT_ID
+      '1': TABS-97PVJa11D_
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    type: ROW
+  ROW-XT1DsNA_V:
+    children:
+    - CHART-wt6ZO8jRXZ
+    id: ROW-XT1DsNA_V
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-lg-5ymUDgm
+    type: ROW
+  ROW-fjg6YQBkH:
+    children:
+    - CHART-1L7NIcXvVN
+    - CHART-nYns6xr4Ft
+    id: ROW-fjg6YQBkH
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    type: ROW
+  ROW-yP9SB89PZ:
+    children:
+    - COLUMN-F53B1OSMcz
+    - CHART-XVIYTeubZh
+    - CHART-7mKdnU7OUJ
+    id: ROW-yP9SB89PZ
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    - TAB-2_QXp8aNq
+    type: ROW
+  TAB-2_QXp8aNq:
+    children:
+    - ROW-yP9SB89PZ
+    - ROW-fjg6YQBkH
+    id: TAB-2_QXp8aNq
+    meta:
+      text: "\U0001F93F Explore Trends"
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    type: TAB
+  TAB-lg-5ymUDgm:
+    children:
+    - ROW-0F99WDC-sz
+    - ROW-XT1DsNA_V
+    - ROW-7kAf1blYU
+    - ROW-NuR8GFQTO
+    id: TAB-lg-5ymUDgm
+    meta:
+      text: Overview
+    parents:
+    - ROOT_ID
+    - TABS-97PVJa11D_
+    type: TAB
+  TABS-97PVJa11D_:
+    children:
+    - TAB-lg-5ymUDgm
+    - TAB-2_QXp8aNq
+    id: TABS-97PVJa11D_
+    meta: {}
+    parents:
+    - ROOT_ID
+    type: TABS
+metadata:
+  timed_refresh_immune_slices: []
+  expanded_slices: {}
+  refresh_frequency: 0
+  default_filters: '{"3547": {"Platform": ["PS", "PS2", "PS3", "XB", "X360"], "__time_range":
+    "No filter"}}'
+  color_scheme: supersetColors
+  filter_scopes:
+    '3547':
+      Platform:
+        scope:
+        - TAB-2_QXp8aNq
+        immune: []
+      Genre:
+        scope:
+        - ROOT_ID
+        immune: []
+      Publisher:
+        scope:
+        - ROOT_ID
+        immune: []
+      __time_range:
+        scope:
+        - ROOT_ID
+        immune: []
+  label_colors:
+    '0': '#1FA8C9'
+    '1': '#454E7C'
+    '2600': '#666666'
+    Europe: '#5AC189'
+    Japan: '#FF7F44'
+    North America: '#666666'
+    Other: '#E04355'
+    PS2: '#FCC700'
+    X360: '#A868B7'
+    PS3: '#3CCCCB'
+    Wii: '#A38F79'
+    DS: '#8FD3E4'
+    PS: '#A1A6BD'
+    GBA: '#ACE1C4'
+    PSP: '#FEC0A1'
+    PS4: '#B2B2B2'
+    PC: '#EFA1AA'
+    GB: '#FDE380'
+    XB: '#D3B3DA'
+    NES: '#9EE5E5'
+    3DS: '#D1C6BC'
+    N64: '#1FA8C9'
+    SNES: '#454E7C'
+    GC: '#5AC189'
+    XOne: '#FF7F44'
+    WiiU: '#E04355'
+    PSV: '#FCC700'
+    SAT: '#A868B7'
+    GEN: '#3CCCCB'
+    DC: '#A38F79'
+    SCD: '#8FD3E4'
+    NG: '#A1A6BD'
+    WS: '#ACE1C4'
+    TG16: '#FEC0A1'
+    3DO: '#B2B2B2'
+    GG: '#EFA1AA'
+    PCFX: '#FDE380'
+    Nintendo: '#D3B3DA'
+    Take-Two Interactive: '#9EE5E5'
+    Microsoft Game Studios: '#D1C6BC'
+    Action: '#1FA8C9'
+    Adventure: '#454E7C'
+    Fighting: '#5AC189'
+    Misc: '#FF7F44'
+    Platform: '#666666'
+    Puzzle: '#E04355'
+    Racing: '#FCC700'
+    Role-Playing: '#A868B7'
+    Shooter: '#3CCCCB'
+    Simulation: '#A38F79'
+    Sports: '#8FD3E4'
+    Strategy: '#A1A6BD'
+version: 1.0.0

--- a/superset/examples/configs/datasets/examples/video_game_sales.yaml
+++ b/superset/examples/configs/datasets/examples/video_game_sales.yaml
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+table_name: video_game_sales
+main_dttm_col: null
+description: null
+default_endpoint: null
+offset: 0
+cache_timeout: null
+schema: null
+sql: ''
+params:
+  remote_id: 64
+  database_name: examples
+  import_time: 1606677834
+template_params: null
+filter_select_enabled: false
+fetch_values_predicate: null
+extra: null
+uuid: 53d47c0c-c03d-47f0-b9ac-81225f808283
+metrics:
+- metric_name: count
+  verbose_name: COUNT(*)
+  metric_type: null
+  expression: COUNT(*)
+  description: null
+  d3format: null
+  extra: null
+  warning_text: null
+columns:
+- column_name: Year
+  verbose_name: null
+  is_dttm: true
+  is_active: null
+  type: BIGINT
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: '%Y'
+- column_name: NA_Sales
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: FLOAT64
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: EU_Sales
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: FLOAT64
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: Global_Sales
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: FLOAT64
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: JP_Sales
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: FLOAT64
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: Other_Sales
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: FLOAT64
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: Rank
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: BIGINT
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: Genre
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: STRING
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: Name
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: STRING
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: Platform
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: STRING
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+- column_name: Publisher
+  verbose_name: null
+  is_dttm: false
+  is_active: null
+  type: STRING
+  groupby: true
+  filterable: true
+  expression: null
+  description: null
+  python_date_format: null
+version: 1.0.0
+database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
+data: https://raw.githubusercontent.com/apache/incubator-superset/e428e525a05fac3555d3cdc458f68fbb05ce7ce4/superset/examples/new_dashboards/video_game_sales_dashboard/video_game_sales.csv

--- a/superset/examples/utils.py
+++ b/superset/examples/utils.py
@@ -21,6 +21,8 @@ from pkg_resources import resource_isdir, resource_listdir, resource_stream
 
 from superset.commands.importers.v1.examples import ImportExamplesCommand
 
+YAML_EXTENSIONS = {".yaml", ".yml"}
+
 
 def load_from_configs() -> None:
     contents = load_contents()
@@ -43,7 +45,7 @@ def load_contents() -> Dict[str, Any]:
                 path_name / child_name
                 for child_name in resource_listdir("superset", str(path_name))
             )
-        else:
+        elif path_name.suffix.lower() in YAML_EXTENSIONS:
             contents[path_name] = (
                 resource_stream("superset", str(path_name)).read().decode("utf-8")
             )

--- a/tests/datasets/commands_tests.py
+++ b/tests/datasets/commands_tests.py
@@ -270,7 +270,7 @@ class TestImportDatasetsCommand(SupersetTestCase):
         assert len(dataset.metrics) == 2
         assert dataset.main_dttm_col == "ds"
         assert dataset.filter_select_enabled
-        assert [col.column_name for col in dataset.columns] == [
+        assert set(col.column_name for col in dataset.columns) == {
             "num_california",
             "ds",
             "state",
@@ -279,7 +279,7 @@ class TestImportDatasetsCommand(SupersetTestCase):
             "sum_boys",
             "sum_girls",
             "num",
-        ]
+        }
 
         db.session.delete(dataset)
         db.session.commit()


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adding a new dashboard by @srinify, showing sales of video games.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

![Screenshot_2020-12-21 Video Game Sales](https://user-images.githubusercontent.com/1534870/102823084-106e9900-438f-11eb-9af7-a36221238f9f.png)

![Screenshot_2020-12-21 Video Game Sales(2)](https://user-images.githubusercontent.com/1534870/102829507-2171d700-439c-11eb-8f53-266e245b2ead.png)



### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Ran `superset load_examples`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
