### PR TITLE
fix: append ID to filename when exporting chart

### DIFF
--- a/superset/charts/commands/export.py
+++ b/superset/charts/commands/export.py
@@ -45,7 +45,7 @@ class ExportChartsCommand(ExportModelsCommand):
     @staticmethod
     def _export(model: Slice) -> Iterator[Tuple[str, str]]:
         chart_slug = secure_filename(model.slice_name)
-        file_name = f"charts/{chart_slug}.yaml"
+        file_name = f"charts/{chart_slug}_{model.id}.yaml"
 
         payload = model.export_to_dict(
             recursive=False,

--- a/tests/charts/commands_tests.py
+++ b/tests/charts/commands_tests.py
@@ -49,20 +49,22 @@ class TestExportChartsCommand(SupersetTestCase):
         mock_g.user = security_manager.find_user("admin")
 
         example_chart = (
-            db.session.query(Slice).filter_by(slice_name="Energy Sankey").one_or_none()
+            db.session.query(Slice).filter_by(slice_name="Energy Sankey").one()
         )
         command = ExportChartsCommand([example_chart.id])
         contents = dict(command.run())
 
         expected = [
             "metadata.yaml",
-            "charts/Energy_Sankey.yaml",
+            f"charts/Energy_Sankey_{example_chart.id}.yaml",
             "datasets/examples/energy_usage.yaml",
             "databases/examples.yaml",
         ]
         assert expected == list(contents.keys())
 
-        metadata = yaml.safe_load(contents["charts/Energy_Sankey.yaml"])
+        metadata = yaml.safe_load(
+            contents[f"charts/Energy_Sankey_{example_chart.id}.yaml"]
+        )
         assert metadata == {
             "slice_name": "Energy Sankey",
             "viz_type": "sankey",
@@ -107,12 +109,14 @@ class TestExportChartsCommand(SupersetTestCase):
         mock_g.user = security_manager.find_user("admin")
 
         example_chart = (
-            db.session.query(Slice).filter_by(slice_name="Energy Sankey").one_or_none()
+            db.session.query(Slice).filter_by(slice_name="Energy Sankey").one()
         )
         command = ExportChartsCommand([example_chart.id])
         contents = dict(command.run())
 
-        metadata = yaml.safe_load(contents["charts/Energy_Sankey.yaml"])
+        metadata = yaml.safe_load(
+            contents[f"charts/Energy_Sankey_{example_chart.id}.yaml"]
+        )
         assert list(metadata.keys()) == [
             "slice_name",
             "viz_type",

--- a/tests/dashboards/commands_tests.py
+++ b/tests/dashboards/commands_tests.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from werkzeug.utils import secure_filename
 
 from superset import db, security_manager
 from superset.commands.exceptions import CommandInvalidError
@@ -58,19 +59,12 @@ class TestExportDashboardsCommand(SupersetTestCase):
         expected_paths = {
             "metadata.yaml",
             "dashboards/World_Banks_Data.yaml",
-            "charts/Region_Filter.yaml",
             "datasets/examples/wb_health_population.yaml",
             "databases/examples.yaml",
-            "charts/Worlds_Population.yaml",
-            "charts/Most_Populated_Countries.yaml",
-            "charts/Growth_Rate.yaml",
-            "charts/Rural.yaml",
-            "charts/Life_Expectancy_VS_Rural.yaml",
-            "charts/Rural_Breakdown.yaml",
-            "charts/Worlds_Pop_Growth.yaml",
-            "charts/Box_plot.yaml",
-            "charts/Treemap.yaml",
         }
+        for chart in example_dashboard.slices:
+            chart_slug = secure_filename(chart.slice_name)
+            expected_paths.add(f"charts/{chart_slug}_{chart.id}.yaml")
         assert expected_paths == set(contents.keys())
 
         metadata = yaml.safe_load(contents["dashboards/World_Banks_Data.yaml"])


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When exporting charts we need to include the chart ID in the filename, since it's not guaranteed that slugs will be unique. I ran across this when @srinify created dashboard containing two charts with the same title, and only one of them was present in the export.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Updated unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
