### PR TITLE
fix(explore): save chart not working

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -145,10 +145,8 @@ describe('SaveModal', () => {
 
       sinon.stub(defaultProps.actions, 'saveSlice').callsFake(() =>
         Promise.resolve({
-          data: {
-            dashboard_url: 'http://localhost/mock_dashboard/',
-            slice: { slice_url: '/mock_slice/' },
-          },
+          dashboard_url: 'http://localhost/mock_dashboard/',
+          slice: { slice_url: '/mock_slice/' },
         }),
       );
     });

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -73,7 +73,7 @@ export function saveSlice(formData, requestParams) {
     return SupersetClient.post({ url, postPayload: { form_data: formData } })
       .then(response => {
         dispatch(saveSliceSuccess(response.json));
-        return response;
+        return response.json;
       })
       .catch(() => dispatch(saveSliceFailed()));
   };

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -131,7 +131,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
 
     this.props.actions
       .saveSlice(this.props.form_data, sliceParams)
-      .then(({ data }: JsonObject) => {
+      .then((data: JsonObject) => {
         if (data.dashboard_id === null) {
           sessionStorage.removeItem(SK_DASHBOARD_ID);
         } else {


### PR DESCRIPTION
### SUMMARY
Saving a chart is currently broken due to the save action returning an incorrect object, likely caused by #11997.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #12177
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
