### PR TITLE
fix: Rendering standalone chart

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -172,9 +172,8 @@ const ExploreChartPanel = props => {
 
     return (
       <ParentSize>
-        {({ width, height }) =>
-          width > 0 &&
-          height > 0 && (
+        {({ width }) =>
+          width > 0 && (
             <ChartContainer
               width={Math.floor(width)}
               height={chartSectionHeight}

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -50,6 +50,8 @@ import {
 
 const propTypes = {
   ...ExploreChartPanel.propTypes,
+  height: PropTypes.string,
+  width: PropTypes.string,
   actions: PropTypes.object.isRequired,
   datasource_type: PropTypes.string.isRequired,
   dashboardId: PropTypes.number,

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -97,7 +97,9 @@
     </div>
 
     {% block tail_js %}
-      {{ js_bundle('menu') }}
+      {% if not standalone_mode %}
+        {{ js_bundle('menu') }}
+      {% endif %}
       {% if entry %}
         {{ js_bundle(entry) }}
       {% endif %}


### PR DESCRIPTION
### SUMMARY
This PR fixes problem with rendering standalone charts. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1599" alt="standalone" src="https://user-images.githubusercontent.com/47450693/102909927-ffe71d00-4479-11eb-8a3b-539e75764eaf.png">

### TEST PLAN
Go to Charts and click on a chart. When it's loaded add `&standalone=true` to the URL and check if chart is rendered.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #12176 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @villebro 