### PR TITLE
fix: remove uniqueness for MySQL

### DIFF
--- a/superset/migrations/versions/73fd22e742ab_add_dynamic_plugins_py.py
+++ b/superset/migrations/versions/73fd22e742ab_add_dynamic_plugins_py.py
@@ -45,7 +45,6 @@ def upgrade():
         sa.ForeignKeyConstraint(["changed_by_fk"], ["ab_user.id"],),
         sa.ForeignKeyConstraint(["created_by_fk"], ["ab_user.id"],),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("bundle_url"),
         sa.UniqueConstraint("key"),
         sa.UniqueConstraint("name"),
     )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `add_dynamic_plugins_py` migration is failing on MySQL because the uniqueness constraint on `bundle_url`:

```
sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (1071, 'Specified key was too long; max key length is 3072 bytes')
```

I fixed it by removing the constraint.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

`superset load_examples` now succeeds on MySQL

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
