### PR TITLE
fix: specify VARCHAR size when loading examples

### DIFF
--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -37,8 +37,8 @@ JSON_KEYS = {"params", "template_params", "extra"}
 
 
 type_map = {
-    "VARCHAR": String(),
-    "STRING": String(),
+    "VARCHAR": String(255),
+    "STRING": String(255),
     "TEXT": Text(),
     "BIGINT": BigInteger(),
     "FLOAT": Float(),


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`superset load_examples` is failing on Mysql:

```
  File "/Users/max/.pyenv/versions/3.7.7/envs/env37/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 481, in compile
    return self._compiler(dialect, bind=bind, **kw)
  File "/Users/max/.pyenv/versions/3.7.7/envs/env37/lib/python3.7/site-packages/sqlalchemy/sql/ddl.py", line 29, in _compiler
    return dialect.ddl_compiler(dialect, self, **kw)
  File "/Users/max/.pyenv/versions/3.7.7/envs/env37/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 322, in __init__
    self.string = self.process(self.statement, **compile_kwargs)
  File "/Users/max/.pyenv/versions/3.7.7/envs/env37/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 352, in process
    return obj._compiler_dispatch(self, **kwargs)
  File "/Users/max/.pyenv/versions/3.7.7/envs/env37/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 96, in _compiler_dispatch
    return meth(self, **kw)
  File "/Users/max/.pyenv/versions/3.7.7/envs/env37/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2918, in visit_create_table
    from_=ce,
  File "/Users/max/.pyenv/versions/3.7.7/envs/env37/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
sqlalchemy.exc.CompileError: (in table 'video_game_sales', column 'Name'): VARCHAR requires a length on dialect mysql
```

This PR fixes it by adding a default size for `VARCHAR` columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

`superset load_examples` now work on MySQL.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
