### PR TITLE
fix: SQL Lab height

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -19,7 +19,7 @@
 @import '../../stylesheets/less/variables.less';
 
 body {
-  min-height: 500px; // Set a min height so the gutter is always visible when resizing
+  min-height: ~'max(100vh, 500px)'; // Set a min height so the gutter is always visible when resizing
   overflow: hidden;
 }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

SQL Lab height is currently broken, fixed at 500px because in `SqlLab/main.less` we set:

```css
body {
  min-height: 500px;
}
```

Overriding the default value of:

```css
/* superset-frontend/stylesheets/less/index.less */
body {
  min-height: 100vh;
}
```

We want the minimum width to be `100vh`, so that SQL Lab takes the whole screen, but we also want it to be at least 500px tall so that the resize handle appears (https://github.com/apache/incubator-superset/pull/8716). So this PR sets it to:

```css
body {
  min-height: ~"max(100vh, 500px)"
}
```

Note that Less doesn't like the use of `max` with different units, raising "error evaluating function `max`: incompatible types", so I had to [escape the expression](https://github.com/SomMeri/less4j/wiki/Less-Language-Escaping).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


https://user-images.githubusercontent.com/1534870/102934715-89d2be00-4459-11eb-8671-bb5c4dfd02b8.mov



### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/incubator-superset/issues/12167
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
