### PR TITLE
fix(reports): make name unique between alerts and reports

### DIFF
--- a/superset/migrations/versions/c878781977c6_alert_reports_shared_uniqueness.py
+++ b/superset/migrations/versions/c878781977c6_alert_reports_shared_uniqueness.py
@@ -57,6 +57,7 @@ report_schedule = sa.Table(
     sa.Column("validator_config_json", sa.Text(), default="{}", nullable=True),
     sa.Column("log_retention", sa.Integer(), nullable=True, default=90),
     sa.Column("grace_period", sa.Integer(), nullable=True, default=60 * 60 * 4),
+    sa.Column("working_timeout", sa.Integer(), nullable=True, default=60 * 60 * 1),
     # Audit Mixin
     sa.Column("created_on", sa.DateTime(), nullable=True),
     sa.Column("changed_on", sa.DateTime(), nullable=True),

--- a/superset/migrations/versions/c878781977c6_alert_reports_shared_uniqueness.py
+++ b/superset/migrations/versions/c878781977c6_alert_reports_shared_uniqueness.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""alert reports shared uniqueness
+
+Revision ID: c878781977c6
+Revises: 73fd22e742ab
+Create Date: 2020-12-23 11:34:53.882200
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "c878781977c6"
+down_revision = "73fd22e742ab"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    try:
+        op.drop_constraint("uq_report_schedule_name", "report_schedule", type_="unique")
+        op.drop_constraint(
+            "report_schedule_name_key", "report_schedule", type_="unique"
+        )
+    except Exception:
+        # Expected to fail on SQLite
+        pass
+
+    try:
+        op.create_unique_constraint(
+            "uq_report_schedule_name_type", "report_schedule", ["name", "type"]
+        )
+    except Exception:
+        # Expected to fail on SQLite
+        pass
+
+
+def downgrade():
+    try:
+        op.drop_constraint(
+            "uq_report_schedule_name_type", "report_schedule", type_="unique"
+        )
+    except Exception:
+        # Expected to fail on SQLite
+        pass
+    try:
+        op.create_unique_constraint(
+            "uq_report_schedule_name", "report_schedule", ["name"]
+        )
+    except Exception:
+        # Expected to fail on SQLite and if there are already non unique values on names
+        pass

--- a/superset/models/reports.py
+++ b/superset/models/reports.py
@@ -92,9 +92,11 @@ class ReportSchedule(Model, AuditMixinNullable):
     """
 
     __tablename__ = "report_schedule"
+    __table_args__ = (UniqueConstraint("name", "type"),)
+
     id = Column(Integer, primary_key=True)
     type = Column(String(50), nullable=False)
-    name = Column(String(150), nullable=False, unique=True)
+    name = Column(String(150), nullable=False)
     description = Column(Text)
     context_markdown = Column(Text)
     active = Column(Boolean, default=True, index=True)

--- a/superset/reports/commands/create.py
+++ b/superset/reports/commands/create.py
@@ -64,8 +64,10 @@ class CreateReportScheduleCommand(BaseReportScheduleCommand):
         if not report_type:
             exceptions.append(ReportScheduleRequiredTypeValidationError())
 
-        # Validate name uniqueness
-        if not ReportScheduleDAO.validate_update_uniqueness(name):
+        # Validate name type uniqueness
+        if report_type and not ReportScheduleDAO.validate_update_uniqueness(
+            name, report_type
+        ):
             exceptions.append(ReportScheduleNameUniquenessValidationError())
 
         # validate relation by report type

--- a/superset/reports/commands/exceptions.py
+++ b/superset/reports/commands/exceptions.py
@@ -126,7 +126,7 @@ class ReportScheduleWorkingTimeoutError(CommandException):
 
 class ReportScheduleNameUniquenessValidationError(ValidationError):
     """
-    Marshmallow validation error for Report Schedule name already exists
+    Marshmallow validation error for Report Schedule name and type already exists
     """
 
     def __init__(self) -> None:

--- a/superset/reports/commands/update.py
+++ b/superset/reports/commands/update.py
@@ -80,15 +80,16 @@ class UpdateReportScheduleCommand(BaseReportScheduleCommand):
         ):
             self._properties["last_state"] = ReportState.NOOP
 
-        # Validate name uniqueness
-        if not ReportScheduleDAO.validate_update_uniqueness(
-            name, report_schedule_id=self._model_id
-        ):
-            exceptions.append(ReportScheduleNameUniquenessValidationError())
-
         # validate relation by report type
         if not report_type:
             report_type = self._model.type
+
+        # Validate name type uniqueness
+        if not ReportScheduleDAO.validate_update_uniqueness(
+            name, report_type, report_schedule_id=self._model_id
+        ):
+            exceptions.append(ReportScheduleNameUniquenessValidationError())
+
         if report_type == ReportScheduleType.ALERT:
             database_id = self._properties.get("database")
             # If database_id was sent let's validate it exists

--- a/superset/reports/dao.py
+++ b/superset/reports/dao.py
@@ -111,17 +111,20 @@ class ReportScheduleDAO(BaseDAO):
 
     @staticmethod
     def validate_update_uniqueness(
-        name: str, report_schedule_id: Optional[int] = None
+        name: str, report_type: str, report_schedule_id: Optional[int] = None
     ) -> bool:
         """
-        Validate if this name is unique.
+        Validate if this name and type is unique.
 
         :param name: The report schedule name
+        :param report_type: The report schedule type
         :param report_schedule_id: The report schedule current id
         (only for validating on updates)
         :return: bool
         """
-        query = db.session.query(ReportSchedule).filter(ReportSchedule.name == name)
+        query = db.session.query(ReportSchedule).filter(
+            ReportSchedule.name == name, ReportSchedule.type == report_type
+        )
         if report_schedule_id:
             query = query.filter(ReportSchedule.id != report_schedule_id)
         return not db.session.query(query.exists()).scalar()

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -14,10 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Union
+from typing import Any, Dict, Union
 
 from croniter import croniter
-from marshmallow import fields, Schema, validate
+from marshmallow import fields, Schema, validate, validates_schema
 from marshmallow.validate import Length, ValidationError
 
 from superset.models.reports import (
@@ -169,6 +169,16 @@ class ReportSchedulePostSchema(Schema):
     )
 
     recipients = fields.List(fields.Nested(ReportRecipientSchema))
+
+    @validates_schema
+    def validate_report_references(  # pylint: disable=unused-argument,no-self-use
+        self, data: Dict[str, Any], **kwargs: Any
+    ) -> None:
+        if data["type"] == ReportScheduleType.REPORT:
+            if "database" in data:
+                raise ValidationError(
+                    {"database": ["Database reference is not allowed on a report"]}
+                )
 
 
 class ReportSchedulePutSchema(Schema):


### PR DESCRIPTION
### SUMMARY
Uniqueness was being imposed on Alerts/Report names, preventing user's from creating an Alert name "X" and a Report with the same name "X". This allows it while still enforcing name uniqueness on Alerts and Reports separately

Also guarantees that a database reference is not sent when creating a report

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
