### PR TITLE
fix: test errors and warnings - iteration 2 (#12212)

### DIFF
--- a/superset-frontend/spec/fixtures/mockStore.js
+++ b/superset-frontend/spec/fixtures/mockStore.js
@@ -26,8 +26,12 @@ import { dashboardLayoutWithTabs } from './mockDashboardLayout';
 import { sliceId } from './mockChartQueries';
 import { dashboardFilters } from './mockDashboardFilters';
 
-export const getMockStore = () =>
-  createStore(rootReducer, mockState, compose(applyMiddleware(thunk)));
+export const getMockStore = overrideState =>
+  createStore(
+    rootReducer,
+    { ...mockState, ...overrideState },
+    compose(applyMiddleware(thunk)),
+  );
 
 export const mockStore = getMockStore();
 

--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
@@ -29,14 +29,17 @@ import DragDroppable from 'src/dashboard/components/dnd/DragDroppable';
 import HoverMenu from 'src/dashboard/components/menu/HoverMenu';
 import ResizableContainer from 'src/dashboard/components/resizable/ResizableContainer';
 
-import { mockStore } from 'spec/fixtures/mockStore';
+import { getMockStore } from 'spec/fixtures/mockStore';
 import { sliceId } from 'spec/fixtures/mockChartQueries';
+import dashboardInfo from 'spec/fixtures/mockDashboardInfo';
 import { dashboardLayout as mockLayout } from 'spec/fixtures/mockDashboardLayout';
 import WithDragDropContext from 'spec/helpers/WithDragDropContext';
+import { sliceEntitiesForChart } from 'spec/fixtures/mockSliceEntities';
 
 describe('ChartHolder', () => {
   const props = {
     id: String(sliceId),
+    dashboardId: dashboardInfo.id,
     parentId: 'ROW_ID',
     component: mockLayout.present.CHART_ID,
     depth: 2,
@@ -54,6 +57,10 @@ describe('ChartHolder', () => {
   };
 
   function setup(overrideProps) {
+    const mockStore = getMockStore({
+      sliceEntities: sliceEntitiesForChart,
+    });
+
     // We have to wrap provide DragDropContext for the underlying DragDroppable
     // otherwise we cannot assert on DragDroppable children
     const wrapper = mount(

--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Tab_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Tab_spec.jsx
@@ -42,6 +42,8 @@ describe('Tabs', () => {
     depth: 1,
     editMode: false,
     renderType: RENDER_TAB,
+    filters: {},
+    setDirectPathToChild: jest.fn(),
     onDropOnTab() {},
     onDeleteTab() {},
     availableColumnCount: 12,

--- a/superset-frontend/spec/javascripts/datasource/ChangeDatasourceModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/ChangeDatasourceModal_spec.jsx
@@ -52,8 +52,11 @@ const DATASOURCES_ENDPOINT =
 const DATASOURCE_ENDPOINT = `glob:*/datasource/get/${datasourceData.type}/${datasourceData.id}`;
 const DATASOURCE_PAYLOAD = { new: 'data' };
 
+const INFO_ENDPOINT = 'glob:*/api/v1/dataset/_info?*';
+
 fetchMock.get(DATASOURCES_ENDPOINT, { result: [mockDatasource['7__table']] });
 fetchMock.get(DATASOURCE_ENDPOINT, DATASOURCE_PAYLOAD);
+fetchMock.get(INFO_ENDPOINT, {});
 
 async function mountAndWait(props = mockedProps) {
   const mounted = mount(<ChangeDatasourceModal store={store} {...props} />, {

--- a/superset-frontend/spec/javascripts/explore/components/AdhocFilterControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocFilterControl_spec.jsx
@@ -55,7 +55,7 @@ const columns = [
 
 const formData = {
   metric: undefined,
-  metrics: [sumValueAdhocMetric, savedMetric.saved_metric_name],
+  metrics: [sumValueAdhocMetric, savedMetric.metric_name],
 };
 
 function setup(overrides) {

--- a/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/EmbedCodeButton_spec.jsx
@@ -23,10 +23,14 @@ import Popover from 'src/common/components/Popover';
 import sinon from 'sinon';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-
+import fetchMock from 'fetch-mock';
 import EmbedCodeButton from 'src/explore/components/EmbedCodeButton';
 import * as exploreUtils from 'src/explore/exploreUtils';
 import * as common from 'src/utils/common';
+
+const ENDPOINT = 'glob:*/r/shortner/';
+
+fetchMock.post(ENDPOINT, {});
 
 describe('EmbedCodeButton', () => {
   const mockStore = configureStore([]);

--- a/superset-frontend/spec/javascripts/explore/components/MetricsControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/MetricsControl_spec.jsx
@@ -131,7 +131,6 @@ describe('MetricsControl', () => {
             label: 'SUM(value)',
             optionName: 'blahblahblah',
           },
-          'avg__value',
         ],
       });
 
@@ -149,7 +148,6 @@ describe('MetricsControl', () => {
           sqlExpression: null,
           isNew: false,
         },
-        'avg__value',
       ]);
     });
   });
@@ -157,7 +155,10 @@ describe('MetricsControl', () => {
   describe('onChange', () => {
     it('handles creating a new metric', () => {
       const { component, onChange } = setup();
-      component.instance().onNewMetric({ metric_name: 'sum__value' });
+      component.instance().onNewMetric({
+        metric_name: 'sum__value',
+        expression: 'SUM(energy_usage.value)',
+      });
       expect(onChange.lastCall.args).toEqual([['sum__value']]);
     });
   });

--- a/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -71,6 +71,17 @@ describe('SaveModal', () => {
     value: 10,
   };
 
+  const mockDashboardData = {
+    pks: ['id'],
+    result: [{ id: 'id', dashboard_title: 'dashboard title' }],
+  };
+
+  const saveEndpoint = `glob:*/dashboardasync/api/read?_flt_0_owners=${1}`;
+
+  beforeAll(() => fetchMock.get(saveEndpoint, mockDashboardData));
+
+  afterAll(() => fetchMock.restore());
+
   const getWrapper = () =>
     shallow(<SaveModal {...defaultProps} store={store} />)
       .dive()
@@ -183,21 +194,21 @@ describe('SaveModal', () => {
     });
 
     describe('should always reload or redirect', () => {
+      const originalLocation = window.location;
+      delete window.location;
+      window.location = { assign: jest.fn() };
+      const stub = sinon.stub(window.location, 'assign');
+
+      afterAll(() => {
+        delete window.location;
+        window.location = originalLocation;
+      });
+
       let wrapper;
-      let windowLocation;
 
       beforeEach(() => {
+        stub.resetHistory();
         wrapper = getWrapper();
-        windowLocation = window.location;
-        // To bypass "TypeError: Cannot redefine property: assign"
-        Object.defineProperty(window, 'location', {
-          value: { ...windowLocation, assign: () => {} },
-        });
-        sinon.stub(window.location, 'assign');
-      });
-      afterEach(() => {
-        window.location.assign.restore();
-        Object.defineProperty(window, 'location', windowLocation);
       });
 
       it('Save & go to dashboard', () =>
@@ -248,25 +259,9 @@ describe('SaveModal', () => {
     let actionThunk;
     const userID = 1;
 
-    const mockDashboardData = {
-      pks: ['id'],
-      result: [{ id: 'id', dashboard_title: 'dashboard title' }],
-    };
-
-    const saveEndpoint = `glob:*/dashboardasync/api/read?_flt_0_owners=${1}`;
-
-    beforeAll(() => {
-      fetchMock.get(saveEndpoint, mockDashboardData);
-    });
-
-    afterAll(fetchMock.restore);
-
     beforeEach(() => {
-      dispatch = sinon.spy();
-    });
-
-    afterEach(() => {
       fetchMock.resetHistory();
+      dispatch = sinon.spy();
     });
 
     const makeRequest = () => {

--- a/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
@@ -155,7 +155,7 @@ describe('SelectControl', () => {
           <SelectControl
             {...defaultProps}
             multi
-            value={50}
+            value={['today']}
             placeholder="add something"
           />,
         );

--- a/superset-frontend/spec/javascripts/messageToasts/components/Toast_spec.jsx
+++ b/superset-frontend/spec/javascripts/messageToasts/components/Toast_spec.jsx
@@ -20,7 +20,7 @@ import { Alert } from 'react-bootstrap';
 import React from 'react';
 import { mount } from 'enzyme';
 import Toast from 'src/messageToasts/components/Toast';
-
+import { act } from 'react-dom/test-utils';
 import mockMessageToasts from '../mockMessageToasts';
 
 const props = {
@@ -43,19 +43,23 @@ describe('Toast', () => {
     expect(alert.childAt(0).childAt(1).text()).toBe(props.toast.text);
   });
 
-  it('should call onCloseToast upon alert dismissal', () =>
-    new Promise(done => {
-      const onCloseToast = id => {
-        expect(id).toBe(props.toast.id);
-        done();
-      };
+  it('should call onCloseToast upon alert dismissal', async () => {
+    await act(
+      () =>
+        new Promise(done => {
+          const onCloseToast = id => {
+            expect(id).toBe(props.toast.id);
+            done();
+          };
 
-      const wrapper = setup({ onCloseToast });
-      const handleClosePress = wrapper.find('[label="Close alert"]').props()
-        .onClick;
+          const wrapper = setup({ onCloseToast });
+          const handleClosePress = wrapper.find('[label="Close alert"]').props()
+            .onClick;
 
-      const alertProps = wrapper.find(Alert).props();
-      expect(alertProps.onDismiss).toBe(handleClosePress);
-      handleClosePress(); // there is a timeout for onCloseToast to be called
-    }));
+          const alertProps = wrapper.find(Alert).props();
+          expect(alertProps.onDismiss).toBe(handleClosePress);
+          handleClosePress(); // there is a timeout for onCloseToast to be called
+        }),
+    );
+  });
 });

--- a/superset-frontend/spec/javascripts/sqllab/QuerySearch_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/QuerySearch_spec.jsx
@@ -20,14 +20,18 @@ import React from 'react';
 import Button from 'src/components/Button';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
-
+import fetchMock from 'fetch-mock';
 import Select from 'src/components/Select';
 import QuerySearch from 'src/SqlLab/components/QuerySearch';
+
+const SEARCH_ENDPOINT = 'glob:*/superset/search_queries?*';
+
+fetchMock.get(SEARCH_ENDPOINT, []);
 
 describe('QuerySearch', () => {
   const search = sinon.spy(QuerySearch.prototype, 'refreshQueries');
   const mockedProps = {
-    actions: {},
+    actions: { addDangerToast: jest.fn() },
     height: 0,
     displayLimit: 50,
   };

--- a/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
@@ -20,10 +20,11 @@ import React from 'react';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { styledMount as mount } from 'spec/helpers/theming';
-
 import DatabaseModal from 'src/views/CRUD/data/database/DatabaseModal';
 import Modal from 'src/common/components/Modal';
 import Tabs from 'src/common/components/Tabs';
+import fetchMock from 'fetch-mock';
+import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 
 // store needed for withToasts(DatabaseModal)
 const mockStore = configureStore([thunk]);
@@ -42,9 +43,12 @@ const dbProps = {
   },
 };
 
+const DATABASE_ENDPOINT = 'glob:*/api/v1/database/*';
+
+fetchMock.get(DATABASE_ENDPOINT, {});
+
 describe('DatabaseModal', () => {
   const wrapper = mount(<DatabaseModal store={store} {...mockedProps} />);
-  const editWrapper = mount(<DatabaseModal store={store} {...dbProps} />);
 
   it('renders', () => {
     expect(wrapper.find(DatabaseModal)).toExist();
@@ -54,11 +58,13 @@ describe('DatabaseModal', () => {
     expect(wrapper.find(Modal)).toExist();
   });
 
-  it('renders "Add Database" header when no database is included', () => {
+  it('renders "Add database" header when no database is included', () => {
     expect(wrapper.find('h4').text()).toEqual('Add database');
   });
 
-  it('renders "Edit Database" header when database prop is included', () => {
+  it('renders "Edit database" header when database prop is included', () => {
+    const editWrapper = mount(<DatabaseModal store={store} {...dbProps} />);
+    waitForComponentToPaint(editWrapper);
     expect(editWrapper.find('h4').text()).toEqual('Edit database');
   });
 


### PR DESCRIPTION
### SUMMARY
Remove tests errors and warnings to improve results readability.

The following errors and warnings have been removed:

```
Warning: Failed prop type: Invalid prop `option` supplied to `MetricDefinitionValue`.

spec/javascripts/explore/components/MetricsControl_spec.jsx
```

```
Error: Not implemented: navigation (except hash changes)

spec/javascripts/components/AlteredSliceTag_spec.jsx
```

```
Warning: Unmatched <HTTP_METHOD> to <URL>

spec/javascripts/explore/components/SaveModal_spec.jsx
spec/javascripts/datasource/ChangeDatasourceModal_spec.jsx
```

```
Warning: Each child in a list should have a unique "key" prop.

spec/javascripts/explore/components/SelectControl_spec.jsx
spec/javascripts/explore/components/SelectControl_spec.jsx
```

```
Warning: Failed prop type: The prop `dashboardId` is marked as required in `ChartHolder`, 
but its value is `undefined`.

spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
```

```
Warning: Failed prop type: The prop `slice` is marked as required in `Chart`, but its value is `undefined`.

spec/javascripts/dashboard/components/gridComponents/ChartHolder_spec.jsx
```

```
Warning: Failed prop type: The prop `filters` is marked as required in `Tab`, but its value is `undefined`.

spec/javascripts/dashboard/components/gridComponents/Tab_spec.jsx
```

```
Warning: Failed prop type: The prop `setDirectPathToChild` is marked as required in `Tab`, 
but its value is `undefined`.

spec/javascripts/dashboard/components/gridComponents/Tab_spec.jsx
```

```
Error: fetch-mock: No fallback response defined for <HTTP_METHOD> to <URL>

spec/javascripts/datasource/ChangeDatasourceModal_spec.jsx
spec/javascripts/explore/components/EmbedCodeButton_spec
spec/javascripts/explore/components/SaveModal_spec.jsx
spec/javascripts/sqllab/QuerySearch_spec.jsx
spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
```

```
Warning: Failed prop type: The prop `savedMetric.metric_name` is marked as required 
in `AdhocMetricEditPopover`,  but its value is `undefined`.

spec/javascripts/explore/components/AdhocFilterControl_spec.jsx
```

```
UnhandledPromiseRejection: This error originated either by throwing inside of an async function
without a catch block, or by rejecting a promise which was not handled with .catch().

spec/javascripts/explore/components/EmbedCodeButton_spec
```

```
When testing, code that causes React state updates should be wrapped into act(...)

spec/javascripts/explore/components/EmbedCodeButton_spec
spec/javascripts/messageToasts/components/Toast_spec.jsx
spec/javascripts/views/CRUD/data/database/DatabaseModal_spec.jsx
```

```
Warning: Failed prop type: Invalid prop `option` supplied to `MetricDefinitionValue`.

spec/javascripts/explore/components/MetricsControl_spec.jsx
```

#12212 

@rusackas @junlincc @villebro 

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
