### PR TITLE
fix: Remove uppercase for tab names

### DIFF
--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -65,6 +65,7 @@ const TabTitleWrapper = styled.div`
 
 const TabTitle = styled.span`
   margin-right: ${({ theme }) => theme.gridUnit * 2}px;
+  text-transform: none;
 `;
 
 class TabbedSqlEditors extends React.PureComponent {
@@ -364,7 +365,6 @@ class TabbedSqlEditors extends React.PureComponent {
           </Menu.Item>
         </Menu>
       );
-
       const tabHeader = (
         <TabTitleWrapper>
           <div data-test="dropdown-toggle-button">


### PR DESCRIPTION
### SUMMARY
Disable uppercase for tab names

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
![image](https://user-images.githubusercontent.com/8277264/103221354-17674f80-492b-11eb-9400-3259f4e0822f.png)
AFTER
![image](https://user-images.githubusercontent.com/8277264/103221335-0ae2f700-492b-11eb-85de-ffaaa15e2a94.png)


### TEST PLAN
Go to SQL Lab, add more tabs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] fix: https://github.com/apache/incubator-superset/issues/12134
