### PR TITLE
fix: Fixed width for dataset panel

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -398,9 +398,7 @@ function ExploreViewContainer(props) {
       )}
       <div
         className={
-          isCollapsed
-            ? 'no-show'
-            : 'explore-column data-source-selection'
+          isCollapsed ? 'no-show' : 'explore-column data-source-selection'
         }
       >
         <div className="title-container">

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -81,8 +81,10 @@ const Styles = styled.div`
   border-top: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   .explore-column {
     display: flex;
+    flex: 0 0 ${({ theme }) => theme.gridUnit * 80}px;
     flex-direction: column;
     padding: ${({ theme }) => 2 * theme.gridUnit}px 0;
+    max-width: ${({ theme }) => theme.gridUnit * 80}px;
     max-height: 100%;
   }
   .data-source-selection {
@@ -121,9 +123,6 @@ const Styles = styled.div`
     background-color: ${({ theme }) => theme.colors.grayscale.light4};
     padding: ${({ theme }) => 2 * theme.gridUnit}px;
     width: ${({ theme }) => 8 * theme.gridUnit}px;
-  }
-  .data-tab {
-    min-width: 288px;
   }
   .callpase-icon > svg {
     color: ${({ theme }) => theme.colors.primary.base};
@@ -401,7 +400,7 @@ function ExploreViewContainer(props) {
         className={
           isCollapsed
             ? 'no-show'
-            : 'data-tab explore-column data-source-selection'
+            : 'explore-column data-source-selection'
         }
       >
         <div className="title-container">


### PR DESCRIPTION
### SUMMARY
This PR sets a fixed width for dataset panel on Explore view - 320px. The goal was to prevent resizing when datasource changes and it's name is much shorter or longer than the previous one.
Closes https://github.com/apache/incubator-superset/issues/12142

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/103274194-64960080-49c1-11eb-8834-90c384632f8d.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/12142
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @etr2460 