### PR TITLE
fix: tests errors and warnings - iteration 4 (#12212)

### DIFF
--- a/superset-frontend/spec/fixtures/mockDashboardState.js
+++ b/superset-frontend/spec/fixtures/mockDashboardState.js
@@ -28,4 +28,5 @@ export default {
   isPublished: true,
   css: '',
   focusedFilterField: null,
+  refreshFrequency: 0,
 };

--- a/superset-frontend/spec/fixtures/mockState.js
+++ b/superset-frontend/spec/fixtures/mockState.js
@@ -24,11 +24,11 @@ import { dashboardLayout } from './mockDashboardLayout';
 import dashboardInfo from './mockDashboardInfo';
 import { emptyFilters } from './mockDashboardFilters';
 import dashboardState from './mockDashboardState';
-import sliceEntities from './mockSliceEntities';
+import { sliceEntitiesForChart } from './mockSliceEntities';
 
 export default {
   datasources,
-  sliceEntities,
+  sliceEntities: sliceEntitiesForChart,
   charts: chartQueries,
   nativeFilters: nativeFiltersInfo,
   dashboardInfo,

--- a/superset-frontend/spec/javascripts/components/AlteredSliceTag_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/AlteredSliceTag_spec.jsx
@@ -160,9 +160,13 @@ describe('AlteredSliceTag', () => {
       );
       const rows = getTableWrapperFromModalBody(modalBody).find('tr');
       expect(rows).toHaveLength(8);
-      const fakeRow = mount(<div>{rows.get(1)}</div>);
-      expect(fakeRow.find('tr')).toHaveLength(1);
-      expect(fakeRow.find('td')).toHaveLength(3);
+      const slice = mount(
+        <table>
+          <tbody>{rows.get(1)}</tbody>
+        </table>,
+      );
+      expect(slice.find('tr')).toHaveLength(1);
+      expect(slice.find('td')).toHaveLength(3);
     });
   });
 

--- a/superset-frontend/spec/javascripts/components/ConfirmStatusChange_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/ConfirmStatusChange_spec.jsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Button from 'src/components/Button';
+import { act } from 'react-dom/test-utils';
 import { supersetTheme, ThemeProvider } from '@superset-ui/core';
 import ConfirmStatusChange from 'src/components/ConfirmStatusChange';
 import Modal from 'src/common/components/Modal';
@@ -44,7 +45,9 @@ describe('ConfirmStatusChange', () => {
   );
 
   it('opens a confirm modal', () => {
-    wrapper.find('#btn1').first().props().onClick('foo');
+    act(() => {
+      wrapper.find('#btn1').first().props().onClick('foo');
+    });
 
     wrapper.update();
 
@@ -52,7 +55,9 @@ describe('ConfirmStatusChange', () => {
   });
 
   it('calls the function on confirm', () => {
-    wrapper.find(Button).last().props().onClick();
+    act(() => {
+      wrapper.find(Button).last().props().onClick();
+    });
 
     expect(mockedProps.onConfirm).toHaveBeenCalledWith('foo');
   });

--- a/superset-frontend/spec/javascripts/components/ListView/ListView_spec.jsx
+++ b/superset-frontend/spec/javascripts/components/ListView/ListView_spec.jsx
@@ -150,37 +150,40 @@ describe('ListView', () => {
 
   it('calls fetchData on mount', () => {
     expect(wrapper.find(ListView)).toExist();
-    expect(mockedProps.fetchData.mock.calls[0]).toMatchInlineSnapshot(`
-                                                      Array [
-                                                        Object {
-                                                          "filters": Array [],
-                                                          "pageIndex": 0,
-                                                          "pageSize": 1,
-                                                          "sortBy": Array [],
-                                                        },
-                                                      ]
-                                    `);
+    expect(mockedProps.fetchData.mock.calls[0]).toMatchInlineSnapshot(
+      `
+        Array [
+          Object {
+            "filters": Array [],
+            "pageIndex": 0,
+            "pageSize": 1,
+            "sortBy": Array [],
+          },
+        ]
+      `,
+    );
   });
 
   it('calls fetchData on sort', () => {
     wrapper.find('[data-test="sort-header"]').at(1).simulate('click');
-
     expect(mockedProps.fetchData).toHaveBeenCalled();
-    expect(mockedProps.fetchData.mock.calls[0]).toMatchInlineSnapshot(`
-                                                      Array [
-                                                        Object {
-                                                          "filters": Array [],
-                                                          "pageIndex": 0,
-                                                          "pageSize": 1,
-                                                          "sortBy": Array [
-                                                            Object {
-                                                              "desc": false,
-                                                              "id": "id",
-                                                            },
-                                                          ],
-                                                        },
-                                                      ]
-                                    `);
+    expect(mockedProps.fetchData.mock.calls[0]).toMatchInlineSnapshot(
+      `
+        Array [
+          Object {
+            "filters": Array [],
+            "pageIndex": 0,
+            "pageSize": 1,
+            "sortBy": Array [
+              Object {
+                "desc": false,
+                "id": "id",
+              },
+            ],
+          },
+        ]
+      `,
+    );
   });
 
   it('renders pagination controls', () => {
@@ -363,13 +366,14 @@ describe('ListView', () => {
     );
   });
 
-  it('renders and empty state when there is no data', () => {
+  it('renders and empty state when there is no data', async () => {
     const props = {
       ...mockedProps,
       data: [],
     };
 
     const wrapper2 = factory(props);
+    await waitForComponentToPaint(wrapper2);
     expect(wrapper2.find(Empty)).toExist();
   });
 
@@ -461,7 +465,7 @@ describe('ListView', () => {
       initialSort: [{ id: 'something' }],
     });
 
-    act(() => {
+    await act(async () => {
       wrapper2.find('[data-test="card-sort-select"]').first().props().onChange({
         desc: false,
         id: 'something',
@@ -470,7 +474,6 @@ describe('ListView', () => {
       });
     });
 
-    wrapper2.update();
     expect(mockedProps.fetchData).toHaveBeenCalled();
   });
 });

--- a/superset-frontend/spec/javascripts/components/SupersetResourceSelect_spec.tsx
+++ b/superset-frontend/spec/javascripts/components/SupersetResourceSelect_spec.tsx
@@ -23,9 +23,12 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import SupersetResourceSelect from 'src/components/SupersetResourceSelect';
 import { supersetTheme, ThemeProvider } from '@superset-ui/core';
+import fetchMock from 'fetch-mock';
 
 describe('SupersetResourceSelect', () => {
   const NOOP = () => {};
+
+  fetchMock.get('glob:*/api/v1/dataset/?q=*', {});
 
   it('is a valid element', () => {
     // @ts-ignore

--- a/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
@@ -20,7 +20,7 @@ import { Provider } from 'react-redux';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
-
+import fetchMock from 'fetch-mock';
 import { ParentSize } from '@vx/responsive';
 import { supersetTheme, ThemeProvider } from '@superset-ui/core';
 import { Sticky, StickyContainer } from 'react-sticky';
@@ -43,6 +43,8 @@ import WithDragDropContext from 'spec/helpers/WithDragDropContext';
 
 const dashboardLayout = undoableDashboardLayout.present;
 const layoutWithTabs = undoableDashboardLayoutWithTabs.present;
+
+fetchMock.get('glob:*/csstemplateasyncmodelview/api/read', {});
 
 describe('DashboardBuilder', () => {
   let favStarStub;
@@ -67,6 +69,7 @@ describe('DashboardBuilder', () => {
     colorScheme: undefined,
     handleComponentDrop() {},
     setDirectPathToChild: sinon.spy(),
+    setMountedTab() {},
   };
 
   function setup(overrideProps, useProvider = false, store = mockStore) {

--- a/superset-frontend/spec/javascripts/dashboard/components/DashboardGrid_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/DashboardGrid_spec.jsx
@@ -39,6 +39,8 @@ describe('DashboardGrid', () => {
     handleComponentDrop() {},
     resizeComponent() {},
     width: 500,
+    isComponentVisible: true,
+    setDirectPathToChild() {},
   };
 
   function setup(overrideProps) {

--- a/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
@@ -22,7 +22,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import { LineEditableTabs } from 'src/common/components/Tabs';
 import { Modal } from 'src/common/components';
-
+import fetchMock from 'fetch-mock';
 import { styledMount as mount } from 'spec/helpers/theming';
 import DashboardComponent from 'src/dashboard/containers/DashboardComponent';
 import DeleteComponentButton from 'src/dashboard/components/DeleteComponentButton';
@@ -35,6 +35,8 @@ import { dashboardLayoutWithTabs } from 'spec/fixtures/mockDashboardLayout';
 import { mockStoreWithTabs } from 'spec/fixtures/mockStore';
 
 describe('Tabs', () => {
+  fetchMock.post('glob:*/r/shortner/', {});
+
   const props = {
     id: 'TABS_ID',
     parentId: DASHBOARD_ROOT_ID,

--- a/superset-frontend/src/components/Menu/LanguagePicker.tsx
+++ b/superset-frontend/src/components/Menu/LanguagePicker.tsx
@@ -43,6 +43,7 @@ export default function LanguagePicker({
     <NavDropdown
       onMouseEnter={() => setDropdownOpen(true)}
       onMouseLeave={() => setDropdownOpen(false)}
+      onToggle={value => setDropdownOpen(value)}
       open={dropdownOpen}
       id="locale-dropdown"
       title={


### PR DESCRIPTION
### SUMMARY
Remove tests errors and warnings to improve results readability.

The following errors and warnings have been removed:

```
Warning: Failed prop type: The prop `refreshFrequency` is marked as required, 
but its value is `undefined`.

spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
```

```
Warning: validateDOMNesting(...): <tr> cannot appear as a child of <div>.

spec/javascripts/components/AlteredSliceTag_spec.jsx
```

```
When testing, code that causes React state updates should be wrapped into act(...)

spec/javascripts/components/ConfirmStatusChange_spec.jsx
spec/javascripts/components/ListView/ListView_spec.jsx
```

```
Unmatched <HTTP_METHOD> to <URL>

spec/javascripts/components/SupersetResourceSelect_spec.tsx
spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
```

```
Warning: Failed prop type: The prop `setMountedTab` is marked as required, 
but its value is `undefined`.

spec/javascripts/dashboard/components/DashboardBuilder_spec.jsx
```

```
Warning: Failed prop type: The prop `isComponentVisible` is marked as required in 
`DashboardGrid`, but its value is `undefined`.

spec/javascripts/dashboard/components/DashboardGrid_spec.jsx
```

```
Warning: Failed prop type: The prop `setDirectPathToChild` is marked as required in 
`DashboardGrid`, but its value is `undefined`.

spec/javascripts/dashboard/components/DashboardGrid_spec.jsx
```

```
Warning: Failed prop type: The prop `slice` is marked as required, but its value is `undefined`.

spec/javascripts/dashboard/components/gridComponents/Tabs_spec.jsx
```

```
Warning: Failed prop type: You have provided a `open` prop to `Dropdown` 
without an `onToggle` handler prop. This will render a read-only field. 
If the field should be mutable use `defaultOpen`. Otherwise, set `onToggle`.

src/components/Menu/LanguagePicker.tsx
```

#12212

@rusackas @junlincc @villebro

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
