### PR TITLE
fix: tests errors and warnings - iteration 5 (#12212)

### DIFF
--- a/superset-frontend/spec/javascripts/datasource/DatasourceModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/datasource/DatasourceModal_spec.jsx
@@ -39,6 +39,7 @@ const datasource = mockDatasource['7__table'];
 
 const SAVE_ENDPOINT = 'glob:*/api/v1/dataset/7';
 const SAVE_PAYLOAD = { new: 'data' };
+const SAVE_DATASOURCE_ENDPOINT = 'glob:*/datasource/save/';
 
 const mockedProps = {
   datasource,
@@ -94,6 +95,7 @@ describe('DatasourceModal', () => {
 
   it('saves on confirm', async () => {
     const callsP = fetchMock.post(SAVE_ENDPOINT, SAVE_PAYLOAD);
+    fetchMock.post(SAVE_DATASOURCE_ENDPOINT, {});
     act(() => {
       wrapper
         .find('button[data-test="datasource-modal-save"]')

--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
@@ -51,7 +51,7 @@ function setup(overrides) {
   const onClose = sinon.spy();
   const props = {
     adhocMetric: sumValueAdhocMetric,
-    savedMetric: {},
+    savedMetric: { metric_name: 'foo', expression: 'COUNT(*)' },
     savedMetrics: [],
     onChange,
     onClose,

--- a/superset-frontend/spec/javascripts/explore/components/ColorPickerControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/ColorPickerControl_spec.jsx
@@ -34,7 +34,7 @@ const defaultProps = {
 describe('ColorPickerControl', () => {
   let wrapper;
   let inst;
-  beforeEach(() => {
+  beforeAll(() => {
     getCategoricalSchemeRegistry()
       .registerValue(
         'test',

--- a/superset-frontend/spec/javascripts/explore/components/DatasourcePanel_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/DatasourcePanel_spec.jsx
@@ -45,7 +45,7 @@ describe('datasourcepanel', () => {
         datasource,
       },
     },
-    actions: null,
+    actions: {},
   };
   it('should render', () => {
     const { container } = render(

--- a/superset-frontend/spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
@@ -44,8 +44,10 @@ const mockProps = {
   },
   timeout: 1000,
   chart: {
+    id: 0,
     queryResponse: {},
   },
+  chartHeight: '30px',
 };
 
 describe('ExploreChartHeader', () => {

--- a/superset-frontend/spec/javascripts/explore/components/MetricDefinitionOption_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/MetricDefinitionOption_spec.jsx
@@ -33,7 +33,9 @@ describe('MetricDefinitionOption', () => {
   }
 
   it('renders a MetricOption given a saved metric', () => {
-    const wrapper = setup({ option: { metric_name: 'a_saved_metric' } });
+    const wrapper = setup({
+      option: { metric_name: 'a_saved_metric', expression: 'COUNT(*)' },
+    });
     expect(wrapper.find(MetricOption)).toExist();
   });
 

--- a/superset-frontend/spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
@@ -33,7 +33,11 @@ const sumValueAdhocMetric = new AdhocMetric({
 describe('MetricDefinitionValue', () => {
   it('renders a MetricOption given a saved metric', () => {
     const wrapper = shallow(
-      <MetricDefinitionValue option={{ metric_name: 'a_saved_metric' }} />,
+      <MetricDefinitionValue
+        onMetricEdit={() => {}}
+        option={{ metric_name: 'a_saved_metric', expression: 'COUNT(*)' }}
+        index={1}
+      />,
     );
     expect(wrapper.find('AdhocMetricOption')).toExist();
   });
@@ -43,6 +47,7 @@ describe('MetricDefinitionValue', () => {
       <MetricDefinitionValue
         onMetricEdit={() => {}}
         option={sumValueAdhocMetric}
+        index={1}
       />,
     );
     expect(wrapper.find(AdhocMetricOption)).toExist();

--- a/superset-frontend/spec/javascripts/sqllab/SqlEditor_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/SqlEditor_spec.jsx
@@ -55,6 +55,7 @@ describe('SqlEditor', () => {
     dataPreviewQueries: [],
     defaultQueryLimit: 1000,
     maxRow: 100000,
+    displayLimit: 100,
   };
 
   const buildWrapper = (props = {}) =>


### PR DESCRIPTION
### SUMMARY
Remove tests errors and warnings to improve results readability.

The following errors and warnings have been removed:

```
Unmatched <HTTP_METHOD> to <URL>

spec/javascripts/datasource/DatasourceModal_spec.jsx
```

```
Warning: Failed prop type: The prop `savedMetric.metric_name` is marked as required, 
but its value is `undefined`.

spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
```

```
Item with key "test" already exists. You are assigning a new value.

spec/javascripts/explore/components/ColorPickerControl_spec.jsx
```

```
Warning: Failed prop type: The prop `actions` is marked as required, but its value is `null`.

spec/javascripts/explore/components/DatasourcePanel_spec.jsx
```

```
Warning: Failed prop type: The prop `chartHeight` is marked as required, 
but its value is `undefined`.

spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
```

```
Warning: Failed prop type: The prop `chart.id` is marked as required, 
but its value is `undefined`.

spec/javascripts/explore/components/ExploreChartHeader_spec.jsx
```

```
Warning: Failed prop type: Invalid prop `option` supplied to `MetricDefinitionOption`.

spec/javascripts/explore/components/MetricDefinitionOption_spec.jsx
spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
```

```
Warning: Failed prop type: The prop `index` is marked as required, 
but its value is `undefined`.

spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
```

```
Warning: Failed prop type: The prop `onMetricEdit` is marked as required, 
but its value is `undefined`.

spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
```

```
Warning: Failed prop type: The prop `savedMetric.expression` is marked as required, 
but its value is `undefined`.

spec/javascripts/explore/components/MetricDefinitionValue_spec.jsx
```

```
Warning: Failed prop type: The prop `displayLimit` is marked as required, 
but its value is `undefined`.

spec/javascripts/sqllab/SqlEditor_spec.jsx
```

#12212

@rusackas @junlincc @villebro

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
