### PR TITLE
ci(e2e): replace pull_request_target trigger

### DIFF
--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -13,10 +13,6 @@ jobs:
     name: build
     runs-on: ubuntu-18.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: npm install

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -1,6 +1,6 @@
 name: E2E
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   cypress-matrix:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -35,10 +35,6 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout code (push)
         if: github.event_name == 'push'
         uses: actions/checkout@v2

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -6,10 +6,6 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -10,10 +10,6 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python
@@ -37,10 +33,6 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python
@@ -63,10 +55,6 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python

--- a/.github/workflows/superset-python-mysql.yml
+++ b/.github/workflows/superset-python-mysql.yml
@@ -28,10 +28,6 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/superset-python-postgres.yml
+++ b/.github/workflows/superset-python-postgres.yml
@@ -29,10 +29,6 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -40,10 +40,6 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -94,10 +90,6 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Create csv upload directory
         run: sudo mkdir -p /tmp/.superset/uploads

--- a/.github/workflows/superset-python-sqlite.yml
+++ b/.github/workflows/superset-python-sqlite.yml
@@ -21,10 +21,6 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -6,10 +6,6 @@ jobs:
   frontend-check:
     runs-on: ubuntu-18.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install dependencies
@@ -27,10 +23,6 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- switched back to use `pull_request` trigger for e2e tests. 
- 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A 

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
- CI
- 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
