### PR TITLE
chore(home): add ErrorBoundary to Charts section

### DIFF
--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -30,7 +30,7 @@ import { User } from 'src/types/bootstrapTypes';
 import Icon from 'src/components/Icon';
 import ChartCard from 'src/views/CRUD/chart/ChartCard';
 import Chart from 'src/types/Chart';
-import ErrorBoundary from 'src/components/ErrorBoundary'
+import ErrorBoundary from 'src/components/ErrorBoundary';
 import SubMenu from 'src/components/Menu/SubMenu';
 import EmptyState from './EmptyState';
 import { CardContainer, IconContainer } from '../utils';

--- a/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ChartTable.tsx
@@ -30,6 +30,7 @@ import { User } from 'src/types/bootstrapTypes';
 import Icon from 'src/components/Icon';
 import ChartCard from 'src/views/CRUD/chart/ChartCard';
 import Chart from 'src/types/Chart';
+import ErrorBoundary from 'src/components/ErrorBoundary'
 import SubMenu from 'src/components/Menu/SubMenu';
 import EmptyState from './EmptyState';
 import { CardContainer, IconContainer } from '../utils';
@@ -114,7 +115,7 @@ function ChartTable({
   };
 
   return (
-    <>
+    <ErrorBoundary>
       {sliceCurrentlyEditing && (
         <PropertiesModal
           onHide={closeChartEditModal}
@@ -188,7 +189,7 @@ function ChartTable({
       ) : (
         <EmptyState tableName="CHARTS" tab={chartFilter} />
       )}
-    </>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
### SUMMARY
Hello, I am interested in contributing to Superset. Found issue #12149 and thought it would be a good way to learn the system.  If you would like me to create a separate issue for this, I can do that.

#12149 wants to add an ErrorBoundary to specific components. I picked the ChartTable on the Welcome component, which I believe is the same as the **2nd item** under the **5. Home Page** mentioned in the issue. I replaced the root `React.Fragment (<>)` with an `ErrorBoundary`. I found the router logic and some other components using the `ErrorBoundary` this way.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TEST PLAN
I wasn't sure how to proceed with testing or if it was desired. I didn't find any tests that tested the ErrorBoundary itself or any components that import it. The superset-ui repo has [some tests](https://github.com/apache-superset/superset-ui/blob/master/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx#L49) I can take cues from. I'm more than happy to add tests, unless the ErrorBoundary is enough. Advice would be great!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Progresses #12149 Fixes 5.2. Charts
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
