### PR TITLE
fix: Displaying filter indicators

### DIFF
--- a/superset-frontend/src/dashboard/containers/FiltersBadge.tsx
+++ b/superset-frontend/src/dashboard/containers/FiltersBadge.tsx
@@ -22,6 +22,7 @@ import { setDirectPathToChild } from 'src/dashboard/actions/dashboardState';
 import {
   selectIndicatorsForChart,
   IndicatorStatus,
+  selectNativeIndicatorsForChart,
 } from 'src/dashboard/components/FiltersBadge/selectors';
 import FiltersBadge from 'src/dashboard/components/FiltersBadge';
 
@@ -38,15 +39,28 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
   );
 
 const mapStateToProps = (
-  { datasources, dashboardFilters, charts }: any,
+  { datasources, dashboardFilters, nativeFilters, charts }: any,
   { chartId }: FiltersBadgeProps,
 ) => {
-  const indicators = selectIndicatorsForChart(
+  const dashboardIndicators = selectIndicatorsForChart(
     chartId,
     dashboardFilters,
     datasources,
     charts,
   );
+
+  const nativeIndicators = selectNativeIndicatorsForChart(nativeFilters);
+
+  const indicators = nativeIndicators.reduce((acc, indicator) => {
+    const sameColumnIndicator = acc.find(
+      ({ column }) => column === indicator.column,
+    );
+    // deduplicate unapplied filters for the same column
+    if (sameColumnIndicator?.status !== IndicatorStatus.Applied) {
+      return [...acc.filter(ind => ind !== sameColumnIndicator), indicator];
+    }
+    return [...acc, indicator];
+  }, dashboardIndicators);
 
   const appliedIndicators = indicators.filter(
     indicator => indicator.status === IndicatorStatus.Applied,


### PR DESCRIPTION
### SUMMARY
The problem was that chart indicator did not match native filter indicator and this PR fixes that.
Be aware that there is still filter component next to the charts. It is separated from the native filters, but has impact on the same charts. It also counts as "Applied filter".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1388" alt="indicator_1_before" src="https://user-images.githubusercontent.com/47450693/103547414-aa146b00-4ea4-11eb-932c-1e5cee5f2ae1.png">
![image](https://user-images.githubusercontent.com/47450693/103547374-9cf77c00-4ea4-11eb-87d3-1c746e49b629.png)

After: 
<img width="1388" alt="indicator_1_after" src="https://user-images.githubusercontent.com/47450693/103546888-f3b08600-4ea3-11eb-9a85-b52a89110fce.png">
<img width="1391" alt="indicator_2_after" src="https://user-images.githubusercontent.com/47450693/103546897-f6ab7680-4ea3-11eb-9980-78eb0451c479.png">

### TEST PLAN
Verify manually. Go to `config.py` and set `"DASHBOARD_NATIVE_FILTERS": True`
Go to a dashboard and create Native Filter. 
Click an indicator presented on the charts (dark gray pill with a number). See if the information matches your filter.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @junlincc @villebro 
@adam-stasiak could you please test?