### PR TITLE
Restore pull_request_target trigger for e2e tests

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -1,6 +1,6 @@
 name: E2E
 
-on: [push, pull_request]
+on: [push, pull_request, pull_request_target]
 
 jobs:
   cypress-matrix:


### PR DESCRIPTION
### SUMMARY
Restores `pull_request_target` trigger for e2e tests, recently changed in https://github.com/apache/incubator-superset/pull/12241

NOTE: this will require a second PR to remove the `pull_request` action once this PR is merged.

### TEST PLAN
e2e tests should run successfully (without parallelization in this branch)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
