### PR TITLE
fix: add related field filter to queries/user

### DIFF
--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -111,6 +111,7 @@ class QueryRestApi(BaseSupersetModelRestApi):
 
     related_field_filters = {
         "created_by": RelatedFieldFilter("first_name", FilterRelatedOwners),
+        "user": RelatedFieldFilter("first_name", FilterRelatedOwners),
     }
 
     search_columns = ["changed_on", "database", "sql", "status", "user", "start_time"]


### PR DESCRIPTION
### SUMMARY
- [x] Add `user` to `related_field_filters` for query history api
- [x] Subsequently fix the User filter autocomplete dropdown

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="559" alt="Screen Shot 2021-01-04 at 3 45 50 PM" src="https://user-images.githubusercontent.com/8216382/103591094-fe6b1b00-4ea3-11eb-878f-4ce42e94e171.png">
<img width="561" alt="Screen Shot 2021-01-04 at 3 46 00 PM" src="https://user-images.githubusercontent.com/8216382/103591097-ff9c4800-4ea3-11eb-85c1-001a4a71e54f.png">

### TEST PLAN
Manual Test:
1. Go to Query History page
2. Click into User filter dropdown
3. Type filter query
4. Ensure that the user list filters

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/incubator-superset/issues/12047
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
