### PR TITLE
fix(reports): don't log user errors and state change has errors

### DIFF
--- a/superset/reports/commands/exceptions.py
+++ b/superset/reports/commands/exceptions.py
@@ -181,3 +181,7 @@ class ReportScheduleUnexpectedError(CommandException):
 
 class ReportScheduleForbiddenError(ForbiddenError):
     message = _("Changing this report is forbidden")
+
+
+class ReportSchedulePruneLogError(CommandException):
+    message = _("An error occurred while pruning logs ")


### PR DESCRIPTION
### SUMMARY
Don't log misconfigure alerts (with bad SQL or unsupported results) has errors on the worker. Also logs information about log pruning

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
