### PR TITLE
fix: Add min-height for loading indicator to show up

### DIFF
--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -81,8 +81,10 @@ const defaultProps = {
 };
 
 const Styles = styled.div`
-  position: relative;
   height: 100%;
+  min-height: ${p => p.chartHeight}px;
+  position: relative;
+
   .chart-tooltip {
     opacity: 0.75;
     font-size: ${({ theme }) => theme.typography.sizes.s}px;
@@ -202,7 +204,11 @@ class Chart extends React.PureComponent {
         onError={this.handleRenderContainerFailure}
         showMessage={false}
       >
-        <Styles className="chart-container" data-test="chart-container">
+        <Styles
+          className="chart-container"
+          data-test="chart-container"
+          chartHeight={height}
+        >
           <div
             className={`slice_container ${isFaded ? ' faded' : ''}`}
             data-test="slice-container"

--- a/superset-frontend/src/chart/Chart.jsx
+++ b/superset-frontend/src/chart/Chart.jsx
@@ -81,8 +81,7 @@ const defaultProps = {
 };
 
 const Styles = styled.div`
-  height: 100%;
-  min-height: ${p => p.chartHeight}px;
+  min-height: ${p => p.height}px;
   position: relative;
 
   .chart-tooltip {
@@ -199,6 +198,7 @@ class Chart extends React.PureComponent {
         </Alert>
       );
     }
+
     return (
       <ErrorBoundary
         onError={this.handleRenderContainerFailure}
@@ -207,7 +207,7 @@ class Chart extends React.PureComponent {
         <Styles
           className="chart-container"
           data-test="chart-container"
-          chartHeight={height}
+          height={height}
         >
           <div
             className={`slice_container ${isFaded ? ' faded' : ''}`}


### PR DESCRIPTION
### SUMMARY
Closes #12264. Adds a min-height to the containing div of the loading indicator in order for the component to show up before the chart is rendered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

![USA-Births-Names](https://user-images.githubusercontent.com/60598000/103698082-1d9ba280-4fa1-11eb-9c2c-15b881d58462.gif)


### TEST PLAN
1. Go to a Dashboard
2. Make sure the loading indicator shows up immediately 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12264 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
