### PR TITLE
build: remove parallelization for E2E tests

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -3,16 +3,10 @@ name: E2E
 on: [push, pull_request]
 
 jobs:
-  cypress-matrix:
+  Cypress:
     runs-on: ubuntu-18.04
     strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving the Dashboard hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
-      fail-fast: false
       matrix:
-        containers: [1, 2, 3]
         browser: ["chrome"]
     env:
       FLASK_ENV: development
@@ -42,7 +36,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
-          ref: 'refs/pull/${{ github.event.number }}/merge'
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -96,12 +90,3 @@ jobs:
         with:
           name: screenshots
           path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots
-  Cypress:
-    if: ${{ always() }}
-    name: Cypress (chrome)
-    runs-on: ubuntu-18.04
-    needs: cypress-matrix
-    steps:
-      - name: Check build matrix status
-        if: ${{ needs.cypress-matrix.result != 'success' }}
-        run: exit 1


### PR DESCRIPTION
### SUMMARY

Follow up for #12241 

Clean up Cypress parallelization for now since CI has been slow and multi-container runs are not really working anyway.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI must pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
