### PR TITLE
build: ignore github actions from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,9 @@ updates:
     labels:
       - pip
       - dependabot
+
+  - package-ecosystem: "npm"
+    directory: ".github/actions"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### SUMMARY

Ask Dependabot to ignore `.github/actions` since the dependencies in the local copy of external actions should be manually updated when we update the action.

Related: #12241 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI must pass.