### PR TITLE
fix: correct null check for condition threshold to allow 0 values

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -1201,8 +1201,11 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                       name="threshold"
                       disabled={conditionNotNull}
                       value={
-                        currentAlert && currentAlert.validator_config_json
-                          ? currentAlert.validator_config_json.threshold || ''
+                        currentAlert &&
+                        currentAlert.validator_config_json &&
+                        currentAlert.validator_config_json.threshold !==
+                          undefined
+                          ? currentAlert.validator_config_json.threshold
                           : ''
                       }
                       placeholder={t('Value')}


### PR DESCRIPTION
### SUMMARY
- [x] Add an extra `!== undefined` check to condition threshold to allow falsey values (0) to display in edit mode

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
Manual test:
1. Create an alert with condition threshold of `0`
2. Save
3. Edit same alert and ensure that threshold displays properly

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
