### PR TITLE
build(cypress): ignore unrelated ResizeObserver client errors

### DIFF
--- a/superset-frontend/cypress-base/cypress/support/index.ts
+++ b/superset-frontend/cypress-base/cypress/support/index.ts
@@ -21,6 +21,17 @@ import readResponseBlob from '../utils/readResponseBlob';
 
 const BASE_EXPLORE_URL = '/superset/explore/?form_data=';
 
+/* eslint-disable consistent-return */
+Cypress.on('uncaught:exception', err => {
+  // ignore ResizeObserver client errors, as they are unrelated to operation
+  // and causing flaky test failures in CI
+  if (err.message && /ResizeObserver loop limit exceeded/.test(err.message)) {
+    // returning false here prevents Cypress from failing the test
+    return false;
+  }
+});
+/* eslint-enable consistent-return */
+
 Cypress.Commands.add('login', () => {
   cy.request({
     method: 'POST',


### PR DESCRIPTION
### SUMMARY
The majority of [flaky Cypress tests](https://dashboard.cypress.io/projects/ukwxzo/analytics/flaky-tests) are being caused by an uncaught JS error: `ResizeObserver loop limit exceeded`. All indications are that [this error can be safely ignored](https://github.com/quasarframework/quasar/issues/2233), and should not fail Cypress tests.

Related Cypress docs: https://docs.cypress.io/api/events/catalog-of-events.html#Uncaught-Exceptions

<img width="450" alt="Screen Shot 2021-01-05 at 5 02 27 PM" src="https://user-images.githubusercontent.com/296227/103716611-5e32f600-4f78-11eb-9692-867434852a19.png">

### TEST PLAN
Ensure successful Cypress test suite run.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
