### PR TITLE
fix: Set width to pseudoelement to wrap filter box

### DIFF
--- a/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
@@ -149,7 +149,7 @@ export default class AdhocFilterEditPopover extends React.Component {
           defaultActiveKey={adhocFilter.expressionType}
           className="adhoc-filter-edit-tabs"
           data-test="adhoc-filter-edit-tabs"
-          style={{ height: this.state.height, width: this.state.width }}
+          style={{ minHeight: this.state.height, width: this.state.width }}
           allowOverflow
         >
           <Tabs.TabPane

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -44,6 +44,7 @@ const SelectWithLabel = styled(Select)`
     display: inline-block;
     white-space: nowrap;
     color: ${({ theme }) => theme.colors.grayscale.light1};
+    width: max-content;
   }
 `;
 


### PR DESCRIPTION
### SUMMARY
Set width to pseudoelement to wrap filter box

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
![Kapture 2021-01-06 at 14 32 07](https://user-images.githubusercontent.com/8277264/103768903-ffc74f80-502b-11eb-8dfc-644ebe2cef82.gif)

AFTER
![Kapture 2021-01-06 at 14 28 22](https://user-images.githubusercontent.com/8277264/103768628-862f6180-502b-11eb-9050-45581c10ed22.gif)


### TEST PLAN
Select any chart to explore
Expand Query section
Click Filters
Select "NOT IN" or "IN"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Fixes https://github.com/apache/superset/issues/12139 
