### PR TITLE
fix(explore): refine previous calendar range

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1502,19 +1502,19 @@ def get_since_until(
         and time_range.startswith("previous calendar week")
         and separator not in time_range
     ):
-        time_range = "DATETRUNC(DATEADD(DATETIME('today'), -1, WEEK), WEEK) : LASTDAY(DATEADD(DATETIME('today'), -1, WEEK), WEEK)"  # pylint: disable=line-too-long
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), -1, WEEK), WEEK) : DATETRUNC(DATETIME('today'), WEEK)"  # pylint: disable=line-too-long
     if (
         time_range
         and time_range.startswith("previous calendar month")
         and separator not in time_range
     ):
-        time_range = "DATETRUNC(DATEADD(DATETIME('today'), -1, MONTH), MONTH) : LASTDAY(DATEADD(DATETIME('today'), -1, MONTH), MONTH)"  # pylint: disable=line-too-long
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), -1, MONTH), MONTH) : DATETRUNC(DATETIME('today'), MONTH)"  # pylint: disable=line-too-long
     if (
         time_range
         and time_range.startswith("previous calendar year")
         and separator not in time_range
     ):
-        time_range = "DATETRUNC(DATEADD(DATETIME('today'), -1, YEAR), YEAR) : LASTDAY(DATEADD(DATETIME('today'), -1, YEAR), YEAR)"  # pylint: disable=line-too-long
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), -1, YEAR), YEAR) : DATETRUNC(DATETIME('today'), YEAR)"  # pylint: disable=line-too-long
 
     if time_range and separator in time_range:
         time_range_lookup = [

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -762,15 +762,15 @@ class TestUtils(SupersetTestCase):
         self.assertEqual(result, expected)
 
         result = get_since_until("previous calendar week")
-        expected = datetime(2016, 10, 31, 0, 0, 0), datetime(2016, 11, 6, 0, 0, 0)
+        expected = datetime(2016, 10, 31, 0, 0, 0), datetime(2016, 11, 7, 0, 0, 0)
         self.assertEqual(result, expected)
 
         result = get_since_until("previous calendar month")
-        expected = datetime(2016, 10, 1, 0, 0, 0), datetime(2016, 10, 31, 0, 0, 0)
+        expected = datetime(2016, 10, 1, 0, 0, 0), datetime(2016, 11, 1, 0, 0, 0)
         self.assertEqual(result, expected)
 
         result = get_since_until("previous calendar year")
-        expected = datetime(2015, 1, 1, 0, 0, 0), datetime(2015, 12, 31, 0, 0, 0)
+        expected = datetime(2015, 1, 1, 0, 0, 0), datetime(2016, 1, 1, 0, 0, 0)
         self.assertEqual(result, expected)
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
### SUMMARY
fix #12283 
refine `previous calendar range` in new timepicker

for example: 
current date is: 2021-01-06
```
previous calendar week == 2020-12-28 ≤ col < 2021-01-04
previous calendar month == 2020-12-01 ≤ col < 2021-01-01
previous calendar year == 2020-01-01 ≤ col < 2021-01-01
```

### TEST PLAN
changed UT

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
