### PR TITLE
build: improve webpack configs for npm link

### DIFF
--- a/superset-frontend/tsconfig.json
+++ b/superset-frontend/tsconfig.json
@@ -17,6 +17,14 @@
     "outDir": "./dist",
     "pretty": true,
     "paths": {
+      "@superset-ui/core": [
+        "./node_modules/@superset-ui/core/src",
+        "./node_modules/@superset-ui/core"
+      ],
+      "@superset-ui/chart-controls": [
+        "./node_modules/@superset-ui/chart-controls/src",
+        "./node_modules/@superset-ui/chart-controls"
+      ],
       // for supressing errors caused by incompatible @types/react when `npm link`
       // Ref: https://github.com/Microsoft/typescript/issues/6496#issuecomment-384786222
       "*": ["./node_modules/@types/*", "*"]

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -459,6 +459,7 @@ if (isDevMode) {
       // only allow exact match so imports like `@superset-ui/plugin-name/lib`
       // and `@superset-ui/plugin-name/esm` can still work.
       config.resolve.alias[`${pkg}$`] = `${pkg}/src`;
+      delete config.resolve.alias[pkg];
       hasSymlink = true;
     }
   });


### PR DESCRIPTION
### SUMMARY

I noticed that sometimes Webpack will not use the source files of `@superset-ui/core` when is it installed via `npm link`.

This change should fix it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

Test locally.

1. `npm link` both the core package and a plugin package.
2. Start `npm dev-server`.
4. Go to Chrome Dev Tools "Sources" panal, use `Cmd + p` to search for files.
3. You should see files from `superset-ui/core/src` instead of `superset-ui/core/esm`.
