### PR TITLE
fix: south pane scrolling issues

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/sqllab/sourcePanel.index.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/sourcePanel.index.test.js
@@ -34,9 +34,7 @@ describe('SqlLab datasource panel', () => {
     cy.get('.sql-toolbar .Select').should('have.length', 3);
 
     cy.get('.sql-toolbar .table-schema').should('not.exist');
-    cy.get('.SouthPane .tab-content .filterable-table-container').should(
-      'not.exist',
-    );
+    cy.get('[data-test="filterable-table-container"]').should('not.exist');
 
     cy.get('.sql-toolbar .Select')
       .eq(0) // database select

--- a/superset-frontend/src/SqlLab/components/SouthPane.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane.jsx
@@ -37,7 +37,7 @@ import {
   LOCALSTORAGE_MAX_QUERY_AGE_MS,
 } from '../constants';
 
-const TAB_HEIGHT = 44;
+const TAB_HEIGHT = 64;
 
 /*
     editorQueries are queries executed by users passed from SqlEditor component
@@ -61,8 +61,25 @@ const defaultProps = {
 };
 
 const StyledPane = styled.div`
-  .div {
-    overflow: none;
+  width: 100%;
+
+  .ant-tabs .ant-tabs-content-holder {
+    overflow: visible;
+  }
+
+  .SouthPaneTabs {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .tab-content {
+    .alert {
+      margin-top: 10px;
+    }
+
+    button.fetch {
+      margin-top: 10px;
+    }
   }
 `;
 

--- a/superset-frontend/src/SqlLab/components/SouthPane.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane.jsx
@@ -23,7 +23,8 @@ import { Alert } from 'react-bootstrap';
 import Tabs from 'src/common/components/Tabs';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { t } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
+
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 import Label from 'src/components/Label';
@@ -58,6 +59,12 @@ const defaultProps = {
   activeSouthPaneTab: 'Results',
   offline: false,
 };
+
+const StyledPane = styled.div`
+  .div {
+    overflow: none;
+  }
+`;
 
 export class SouthPane extends React.PureComponent {
   constructor(props) {
@@ -158,7 +165,7 @@ export class SouthPane extends React.PureComponent {
     ));
 
     return (
-      <div className="SouthPane" ref={this.southPaneRef}>
+      <StyledPane className="SouthPane" ref={this.southPaneRef}>
         <Tabs
           activeKey={this.props.activeSouthPaneTab}
           className="SouthPaneTabs"
@@ -178,7 +185,7 @@ export class SouthPane extends React.PureComponent {
           </Tabs.TabPane>
           {dataPreviewTabs}
         </Tabs>
-      </div>
+      </StyledPane>
     );
   }
 }

--- a/superset-frontend/src/SqlLab/components/SouthPane.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane.jsx
@@ -78,7 +78,7 @@ const StyledPane = styled.div`
     }
 
     button.fetch {
-      margin-top: 10px;
+      margin-top: ${({ theme }) => theme.gridUnit * 2}px;
     }
   }
 `;

--- a/superset-frontend/src/SqlLab/components/SouthPane.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane.jsx
@@ -74,7 +74,7 @@ const StyledPane = styled.div`
   }
   .tab-content {
     .alert {
-      margin-top: 10px;
+      margin-top: ${({ theme }) => theme.gridUnit * 2}px;
     }
 
     button.fetch {

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -235,10 +235,6 @@ div.Workspace {
   .ace_content {
     height: 100%;
   }
-
-  .SouthPane {
-    height: 100%;
-  }
 }
 
 .SqlEditorTabs li {
@@ -318,7 +314,7 @@ div.Workspace {
   .queryPane {
     flex: 1 1 auto;
     padding-left: 10px;
-    overflow: auto;
+    overflow: visible;
   }
 
   .schemaPane-enter-done,
@@ -493,16 +489,6 @@ a.Link {
   margin: 3px 5px;
 }
 
-.SouthPane {
-  width: 100%;
-
-  .SouthPaneTabs {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-  }
-}
-
 .nav-tabs .ddbtn-tab {
   padding: 0;
   border: none;
@@ -531,14 +517,6 @@ a.Link {
   .Select {
     margin-right: 3px;
   }
-}
-
-.SouthPane .tab-content .alert {
-  margin-top: 10px;
-}
-
-.SouthPane .tab-content button.fetch {
-  margin-top: 10px;
 }
 
 .cost-estimate {

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -401,10 +401,6 @@ div.tablePopover {
   padding-top: 16px;
 }
 
-.filterable-table-container {
-  margin-top: 48px;
-}
-
 .ace_editor.ace_editor {
   //double class is better than !important
   border: 1px solid @gray-light;

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -501,10 +501,6 @@ a.Link {
     display: flex;
     flex-direction: column;
   }
-
-  .ant-tabs-tabpane {
-    overflow-y: auto; // scroll the query history pane
-  }
 }
 
 .nav-tabs .ddbtn-tab {

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -29,7 +29,7 @@ import {
   SortIndicator,
   Table,
 } from 'react-virtualized';
-import { getMultipleTextDimensions, t } from '@superset-ui/core';
+import { getMultipleTextDimensions, t, css } from '@superset-ui/core';
 
 import Button from '../Button';
 import CopyToClipboard from '../CopyToClipboard';
@@ -82,6 +82,10 @@ const JSON_TREE_THEME = {
   base0E: '#ae81ff',
   base0F: '#cc6633',
 };
+
+const filterableTableStyles = css`
+  overflow-x: auto;
+`;
 
 // when more than MAX_COLUMNS_FOR_TABLE are returned, switch from table to grid view
 export const MAX_COLUMNS_FOR_TABLE = 50;
@@ -463,6 +467,7 @@ export default class FilterableTable extends PureComponent<
           <div
             style={{ height }}
             className="filterable-table-container Table"
+            data-test="filterable-table-container"
             ref={this.container}
           >
             <div className="LeftColumn">
@@ -555,6 +560,7 @@ export default class FilterableTable extends PureComponent<
         style={{ height }}
         className="filterable-table-container"
         ref={this.container}
+        css={filterableTableStyles}
       >
         {this.state.fitted && (
           <Table

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -29,7 +29,7 @@ import {
   SortIndicator,
   Table,
 } from 'react-virtualized';
-import { getMultipleTextDimensions, t, css } from '@superset-ui/core';
+import { getMultipleTextDimensions, t, styled } from '@superset-ui/core';
 
 import Button from '../Button';
 import CopyToClipboard from '../CopyToClipboard';
@@ -83,8 +83,9 @@ const JSON_TREE_THEME = {
   base0F: '#cc6633',
 };
 
-const filterableTableStyles = css`
+const StyledFilterableTable = styled.div`
   overflow-x: auto;
+  margin-top: ${({ theme }) => theme.gridUnit * 12}px;
 `;
 
 // when more than MAX_COLUMNS_FOR_TABLE are returned, switch from table to grid view
@@ -556,11 +557,10 @@ export default class FilterableTable extends PureComponent<
     const rowGetter = ({ index }: { index: number }) =>
       this.getDatum(sortedAndFilteredList, index);
     return (
-      <div
+      <StyledFilterableTable
         style={{ height }}
         className="filterable-table-container"
         ref={this.container}
-        css={filterableTableStyles}
       >
         {this.state.fitted && (
           <Table
@@ -592,7 +592,7 @@ export default class FilterableTable extends PureComponent<
             ))}
           </Table>
         )}
-      </div>
+      </StyledFilterableTable>
     );
   }
 


### PR DESCRIPTION
### SUMMARY
Fixes scrolling issues where the tabs were overlapping the table and also where the last row was being cut off.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/5186919/103837719-445ce600-5040-11eb-96f1-abc5ea58ba1c.mov


### TEST PLAN
manual visual testing.. all other tests should still pass





### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/9869, https://github.com/apache/superset/issues/11966, https://github.com/apache/superset/issues/12046
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
