### PR TITLE
fix: select overlap by aggregate button (#12312)

### DIFF
--- a/superset-frontend/src/components/Select/SupersetStyledSelect.tsx
+++ b/superset-frontend/src/components/Select/SupersetStyledSelect.tsx
@@ -216,6 +216,8 @@ function styled<
       Object.assign(restProps, sortableContainerProps);
     }
 
+    stylesConfig.menuPortal = base => ({ ...base, zIndex: 9999 });
+
     // When values are rendered as labels, adjust valueContainer padding
     const valueRenderedAsLabel =
       valueRenderedAsLabel_ === undefined ? isMulti : valueRenderedAsLabel_;


### PR DESCRIPTION
### SUMMARY
Fix select overlap by aggregate button.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="300" alt="Screen Shot 2021-01-07 at 9 36 20 AM" src="https://user-images.githubusercontent.com/70410625/103893324-ed045780-50cb-11eb-9b38-6c0a507a442b.png">
<img width="304" alt="Screen Shot 2021-01-07 at 9 35 54 AM" src="https://user-images.githubusercontent.com/70410625/103893335-f1307500-50cb-11eb-8a25-d5d877cd9ef0.png">

#12312 

@junlincc 

### TEST PLAN
1 - Select a chart with query mode control (Breakdown of Developers Type is an example)
2- Open any select that could overlap the aggregate button
3- The select should be displayed on top

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
