### PR TITLE
fix(explore): Select shows behind Antd popover

### DIFF
--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -279,6 +279,10 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
         : 'padding: 0; flex: 1 1 auto;'};
     `,
   ],
+  menuPortal: base => ({
+    ...base,
+    zIndex: 1030, // must be same or higher of antd popover
+  }),
 };
 
 const INPUT_TAG_BASE_STYLES = {


### PR DESCRIPTION
### SUMMARY
The Antd Popover has a z-index at 1030. By adding the option `menuPortalTarget` as `document.body` to the Select, the dropdowns (both single-choice and multi-choice) show behind the Popover. One fix could have been to reduce the default z-index of the Antd Popover but we don't know what side effects this might cause. This PR instead raises the z-index of the outer div of the dropdowns to be the same as the Antd Popover. This should be a safer approach as dropdowns must usually appear over elements.

Closes #12309 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![Explore---cases_ts](https://user-images.githubusercontent.com/60598000/103912985-4c805880-5108-11eb-8906-29bdc9450293.gif)

After:

![Explore---FCC-2018-Survey](https://user-images.githubusercontent.com/60598000/103911218-0c1fdb00-5106-11eb-90fe-16432273d6d5.gif)


### TEST PLAN
1. Create a new Scatterplot chart
2. Click to set latitude and longitude under "Query"
3. Click on "Latitude" and "Longitude" Select. The. dropdowns should be visible

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12309 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
