### PR TITLE
fix: Spinning loader indicator overlaying dashboard header

### DIFF
--- a/superset-frontend/src/components/Loading.tsx
+++ b/superset-frontend/src/components/Loading.tsx
@@ -24,7 +24,7 @@ interface Props {
 }
 
 const LoaderImg = styled.img`
-  z-index: 1000;
+  z-index: 99;
   width: 50px;
   position: relative;
   margin: 10px;


### PR DESCRIPTION
### SUMMARY
Fixes an excessive z-index of the spinning loader indicator which was causing the loading indicator to appear over the header.
The z-index was increased in this PR  #10105 to avoid the spinner showing up under the filters. Testing shows the new z-index is high enough to prevent that issue from presenting itself again.

Closes #12298 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![before-Sales-Dashboard](https://user-images.githubusercontent.com/60598000/103928810-a68b1900-511c-11eb-93b8-3e92774bf528.gif)

After:
![after-Sales-Dashboard](https://user-images.githubusercontent.com/60598000/103928830-abe86380-511c-11eb-8455-eb7de8100ec2.gif)


### TEST PLAN
1. Go to a dashboard 
2. Scroll while charts are loading
3. Make sure the spinner does not appear over the header

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12298 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
