### PR TITLE
fix: annotation layer modal err handling

### DIFF
--- a/superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx
@@ -114,6 +114,16 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
   // Functions
   const hide = () => {
     setIsHidden(true);
+
+    // Reset annotation
+    setCurrentAnnotation({
+      short_descr: '',
+      start_dttm: '',
+      end_dttm: '',
+      json_metadata: '',
+      long_descr: '',
+    });
+
     onHide();
   };
 
@@ -127,7 +137,12 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
         delete currentAnnotation.changed_by;
         delete currentAnnotation.changed_on_delta_humanized;
         delete currentAnnotation.layer;
-        updateResource(update_id, currentAnnotation).then(() => {
+        updateResource(update_id, currentAnnotation).then(response => {
+          // No response on error
+          if (!response) {
+            return;
+          }
+
           if (onAnnotationAdd) {
             onAnnotationAdd();
           }
@@ -137,7 +152,11 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
       }
     } else if (currentAnnotation) {
       // Create
-      createResource(currentAnnotation).then(() => {
+      createResource(currentAnnotation).then(response => {
+        if (!response) {
+          return;
+        }
+
         if (onAnnotationAdd) {
           onAnnotationAdd();
         }
@@ -206,32 +225,38 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
   };
 
   // Initialize
-  if (
-    isEditMode &&
-    (!currentAnnotation ||
-      !currentAnnotation.id ||
-      (annotation && annotation.id !== currentAnnotation.id) ||
-      (isHidden && show))
-  ) {
-    if (annotation && annotation.id !== null && !loading) {
-      const id = annotation.id || 0;
+  useEffect(() => {
+    if (
+      isEditMode &&
+      (!currentAnnotation ||
+        !currentAnnotation.id ||
+        (annotation && annotation.id !== currentAnnotation.id) ||
+        (isHidden && show))
+    ) {
+      if (annotation && annotation.id !== null && !loading) {
+        const id = annotation.id || 0;
 
-      fetchResource(id).then(() => {
-        setCurrentAnnotation(resource);
+        fetchResource(id);
+      }
+    } else if (
+      !isEditMode &&
+      (!currentAnnotation || currentAnnotation.id || (isHidden && show))
+    ) {
+      setCurrentAnnotation({
+        short_descr: '',
+        start_dttm: '',
+        end_dttm: '',
+        json_metadata: '',
+        long_descr: '',
       });
     }
-  } else if (
-    !isEditMode &&
-    (!currentAnnotation || currentAnnotation.id || (isHidden && show))
-  ) {
-    setCurrentAnnotation({
-      short_descr: '',
-      start_dttm: '',
-      end_dttm: '',
-      json_metadata: '',
-      long_descr: '',
-    });
-  }
+  }, [annotation]);
+
+  useEffect(() => {
+    if (resource) {
+      setCurrentAnnotation(resource);
+    }
+  }, [resource]);
 
   // Validation
   useEffect(() => {

--- a/superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx
+++ b/superset-frontend/src/views/CRUD/annotation/AnnotationModal.tsx
@@ -111,10 +111,7 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
     addDangerToast,
   );
 
-  // Functions
-  const hide = () => {
-    setIsHidden(true);
-
+  const resetAnnotation = () => {
     // Reset annotation
     setCurrentAnnotation({
       short_descr: '',
@@ -123,6 +120,14 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
       json_metadata: '',
       long_descr: '',
     });
+  };
+
+  // Functions
+  const hide = () => {
+    setIsHidden(true);
+
+    // Reset annotation
+    resetAnnotation();
 
     onHide();
   };
@@ -242,13 +247,7 @@ const AnnotationModal: FunctionComponent<AnnotationModalProps> = ({
       !isEditMode &&
       (!currentAnnotation || currentAnnotation.id || (isHidden && show))
     ) {
-      setCurrentAnnotation({
-        short_descr: '',
-        start_dttm: '',
-        end_dttm: '',
-        json_metadata: '',
-        long_descr: '',
-      });
+      resetAnnotation();
     }
   }, [annotation]);
 

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx
@@ -108,15 +108,20 @@ const AnnotationLayerModal: FunctionComponent<AnnotationLayerModalProps> = ({
     addDangerToast,
   );
 
-  // Functions
-  const hide = () => {
-    setIsHidden(true);
-
+  const resetLayer = () => {
     // Reset layer
     setCurrentLayer({
       name: '',
       descr: '',
     });
+  };
+
+  // Functions
+  const hide = () => {
+    setIsHidden(true);
+
+    // Reset layer
+    resetLayer();
 
     onHide();
   };
@@ -194,10 +199,8 @@ const AnnotationLayerModal: FunctionComponent<AnnotationLayerModalProps> = ({
       !isEditMode &&
       (!currentLayer || currentLayer.id || (isHidden && show))
     ) {
-      setCurrentLayer({
-        name: '',
-        descr: '',
-      });
+      // Reset layer
+      resetLayer();
     }
   }, [layer, show]);
 

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayerModal.tsx
@@ -111,6 +111,13 @@ const AnnotationLayerModal: FunctionComponent<AnnotationLayerModalProps> = ({
   // Functions
   const hide = () => {
     setIsHidden(true);
+
+    // Reset layer
+    setCurrentLayer({
+      name: '',
+      descr: '',
+    });
+
     onHide();
   };
 
@@ -121,13 +128,21 @@ const AnnotationLayerModal: FunctionComponent<AnnotationLayerModalProps> = ({
         const update_id = currentLayer.id;
         delete currentLayer.id;
         delete currentLayer.created_by;
-        updateResource(update_id, currentLayer).then(() => {
+        updateResource(update_id, currentLayer).then(response => {
+          if (!response) {
+            return;
+          }
+
           hide();
         });
       }
     } else if (currentLayer) {
       // Create
       createResource(currentLayer).then(response => {
+        if (!response) {
+          return;
+        }
+
         if (onLayerAdd) {
           onLayerAdd(response);
         }
@@ -162,29 +177,35 @@ const AnnotationLayerModal: FunctionComponent<AnnotationLayerModalProps> = ({
   };
 
   // Initialize
-  if (
-    isEditMode &&
-    (!currentLayer ||
-      !currentLayer.id ||
-      (layer && layer.id !== currentLayer.id) ||
-      (isHidden && show))
-  ) {
-    if (layer && layer.id !== null && !loading) {
-      const id = layer.id || 0;
+  useEffect(() => {
+    if (
+      isEditMode &&
+      (!currentLayer ||
+        !currentLayer.id ||
+        (layer && layer.id !== currentLayer.id) ||
+        (isHidden && show))
+    ) {
+      if (show && layer && layer.id !== null && !loading) {
+        const id = layer.id || 0;
 
-      fetchResource(id).then(() => {
-        setCurrentLayer(resource);
+        fetchResource(id);
+      }
+    } else if (
+      !isEditMode &&
+      (!currentLayer || currentLayer.id || (isHidden && show))
+    ) {
+      setCurrentLayer({
+        name: '',
+        descr: '',
       });
     }
-  } else if (
-    !isEditMode &&
-    (!currentLayer || currentLayer.id || (isHidden && show))
-  ) {
-    setCurrentLayer({
-      name: '',
-      descr: '',
-    });
-  }
+  }, [layer, show]);
+
+  useEffect(() => {
+    if (resource) {
+      setCurrentLayer(resource);
+    }
+  }, [resource]);
 
   // Validation
   useEffect(() => {

--- a/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
+++ b/superset-frontend/src/views/CRUD/annotationlayers/AnnotationLayersList.tsx
@@ -333,6 +333,11 @@ function AnnotationLayersList({
     window.location.href = `/annotationmodelview/${id}/annotation`;
   };
 
+  const onModalHide = () => {
+    refreshData();
+    setAnnotationLayerModalOpen(false);
+  };
+
   return (
     <>
       <SubMenu name={t('Annotation layers')} buttons={subMenuButtons} />
@@ -340,7 +345,7 @@ function AnnotationLayersList({
         addDangerToast={addDangerToast}
         layer={currentAnnotationLayer}
         onLayerAdd={onLayerAdd}
-        onHide={() => setAnnotationLayerModalOpen(false)}
+        onHide={onModalHide}
         show={annotationLayerModalOpen}
       />
       {layerCurrentlyDeleting && (


### PR DESCRIPTION
### SUMMARY
- [x] Handles errors on save/update so modal does not close when an error is encountered
- [x] utilizes `useEffect` hook for initialization to reduce API requests

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
Manual Test:
1. Create or update annotation/annotation layer with duplicate name
2. Attempt to save
3. Confirm that an error toast is thrown and the modal does not close

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
