### PR TITLE
fix(explore): improve filter translation

### DIFF
--- a/superset-frontend/spec/javascripts/explore/utils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/utils_spec.jsx
@@ -301,28 +301,38 @@ describe('exploreUtils', () => {
   });
 
   describe('getSimpleSQLExpression', () => {
-    const subject = 'subject';
-    const operator = '=';
-    const comparator = 'comparator';
     it('returns empty string when subject is undefined', () => {
       expect(getSimpleSQLExpression(undefined, '=', 10)).toBe('');
       expect(getSimpleSQLExpression()).toBe('');
     });
-    it('returns subject when its provided and operator is undefined', () => {
-      expect(getSimpleSQLExpression(subject, undefined, 10)).toBe(subject);
-      expect(getSimpleSQLExpression(subject)).toBe(subject);
+    it("returns subject when it's provided and operator is undefined", () => {
+      expect(getSimpleSQLExpression('col', undefined, 10)).toBe('col');
+      expect(getSimpleSQLExpression('col')).toBe('col');
     });
-    it('returns subject and operator when theyre provided and comparator is undefined', () => {
-      expect(getSimpleSQLExpression(subject, operator)).toBe(
-        `${subject} ${operator}`,
-      );
+    it("returns subject and operator when they're provided and comparator is undefined", () => {
+      expect(getSimpleSQLExpression('col', '=')).toBe('col =');
+      expect(getSimpleSQLExpression('col', 'IN')).toBe('col IN');
+      expect(getSimpleSQLExpression('col', 'IN', [])).toBe('col IN ()');
     });
     it('returns full expression when subject, operator and comparator are provided', () => {
-      expect(getSimpleSQLExpression(subject, operator, comparator)).toBe(
-        `${subject} ${operator} ${comparator}`,
+      expect(getSimpleSQLExpression('col', '=', 'comp')).toBe("col = 'comp'");
+      expect(getSimpleSQLExpression('col', '=', "it's an apostrophe")).toBe(
+        "col = 'it''s an apostrophe'",
       );
-      expect(getSimpleSQLExpression(subject, operator, comparator, true)).toBe(
-        `${subject} ${operator} ('${comparator}')`,
+      expect(getSimpleSQLExpression('col', '=', 0)).toBe('col = 0');
+      expect(getSimpleSQLExpression('col', '=', '0')).toBe('col = 0');
+      expect(getSimpleSQLExpression('col', 'IN', 'foo')).toBe("col IN ('foo')");
+      expect(getSimpleSQLExpression('col', 'NOT IN', ['foo'])).toBe(
+        "col NOT IN ('foo')",
+      );
+      expect(getSimpleSQLExpression('col', 'IN', ['foo', 'bar'])).toBe(
+        "col IN ('foo', 'bar')",
+      );
+      expect(getSimpleSQLExpression('col', 'IN', ['0', '1', '2'])).toBe(
+        'col IN (0, 1, 2)',
+      );
+      expect(getSimpleSQLExpression('col', 'NOT IN', [0, 1, 2])).toBe(
+        'col NOT IN (0, 1, 2)',
       );
     });
   });

--- a/superset-frontend/spec/javascripts/explore/utils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/utils_spec.jsx
@@ -312,7 +312,7 @@ describe('exploreUtils', () => {
     it("returns subject and operator when they're provided and comparator is undefined", () => {
       expect(getSimpleSQLExpression('col', '=')).toBe('col =');
       expect(getSimpleSQLExpression('col', 'IN')).toBe('col IN');
-      expect(getSimpleSQLExpression('col', 'IN', [])).toBe('col IN ()');
+      expect(getSimpleSQLExpression('col', 'IN', [])).toBe('col IN');
     });
     it('returns full expression when subject, operator and comparator are provided', () => {
       expect(getSimpleSQLExpression('col', '=', 'comp')).toBe("col = 'comp'");

--- a/superset-frontend/src/explore/AdhocFilter.js
+++ b/superset-frontend/src/explore/AdhocFilter.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { MULTI_OPERATORS, CUSTOM_OPERATORS } from './constants';
+import { CUSTOM_OPERATORS } from './constants';
 import { getSimpleSQLExpression } from './exploreUtils';
 
 export const EXPRESSION_TYPES = {
@@ -48,22 +48,13 @@ const OPERATORS_TO_SQL = {
 };
 
 function translateToSql(adhocMetric, { useSimple } = {}) {
-  if (
-    (adhocMetric.expressionType === EXPRESSION_TYPES.SIMPLE &&
-      adhocMetric.comparator &&
-      adhocMetric.operator) ||
-    useSimple
-  ) {
-    const isMulti = MULTI_OPERATORS.has(adhocMetric.operator);
-    const { subject } = adhocMetric;
+  if (adhocMetric.expressionType === EXPRESSION_TYPES.SIMPLE || useSimple) {
+    const { subject, comparator } = adhocMetric;
     const operator =
       adhocMetric.operator && CUSTOM_OPERATORS.has(adhocMetric.operator)
         ? OPERATORS_TO_SQL[adhocMetric.operator](adhocMetric)
         : OPERATORS_TO_SQL[adhocMetric.operator];
-    const comparator = Array.isArray(adhocMetric.comparator)
-      ? adhocMetric.comparator.join("','")
-      : adhocMetric.comparator || '';
-    return getSimpleSQLExpression(subject, operator, comparator, isMulti);
+    return getSimpleSQLExpression(subject, operator, comparator);
   }
   if (adhocMetric.expressionType === EXPRESSION_TYPES.SQL) {
     return adhocMetric.sqlExpression;

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -27,6 +27,7 @@ import {
 } from '@superset-ui/core';
 import { availableDomains } from 'src/utils/hostNamesConfig';
 import { safeStringify } from 'src/utils/safeStringify';
+import { MULTI_OPERATORS } from './constants';
 
 const MAX_URL_LENGTH = 8000;
 
@@ -309,19 +310,28 @@ export const useDebouncedEffect = (effect, delay) => {
   }, [callback, delay]);
 };
 
-export const getSimpleSQLExpression = (
-  subject,
-  operator,
-  comparator,
-  isMulti,
-) => {
+export const getSimpleSQLExpression = (subject, operator, comparator) => {
+  const isMulti = MULTI_OPERATORS.has(operator);
   let expression = subject ?? '';
   if (subject && operator) {
     expression += ` ${operator}`;
-    if (comparator) {
-      expression += ` ${isMulti ? "('" : ''}${comparator}${
-        isMulti ? "')" : ''
-      }`;
+    const firstValue =
+      isMulti && Array.isArray(comparator) ? comparator[0] : comparator;
+    const comparatorArray =
+      comparator === undefined ||
+      comparator === null ||
+      Array.isArray(comparator)
+        ? comparator
+        : [comparator];
+    const isString =
+      firstValue !== undefined && Number.isNaN(Number(firstValue));
+    const quote = isString ? "'" : '';
+    const [prefix, suffix] = isMulti ? ['(', ')'] : ['', ''];
+    const formattedComparators = (comparatorArray || []).map(
+      val => `${quote}${isString ? val.replace("'", "''") : val}${quote}`,
+    );
+    if (comparatorArray) {
+      expression += ` ${prefix}${formattedComparators.join(', ')}${suffix}`;
     }
   }
   return expression;

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -317,20 +317,22 @@ export const getSimpleSQLExpression = (subject, operator, comparator) => {
     expression += ` ${operator}`;
     const firstValue =
       isMulti && Array.isArray(comparator) ? comparator[0] : comparator;
-    const comparatorArray =
-      comparator === undefined ||
-      comparator === null ||
-      Array.isArray(comparator)
-        ? comparator
-        : [comparator];
+    let comparatorArray;
+    if (comparator === undefined || comparator === null) {
+      comparatorArray = [];
+    } else if (Array.isArray(comparator)) {
+      comparatorArray = comparator;
+    } else {
+      comparatorArray = [comparator];
+    }
     const isString =
       firstValue !== undefined && Number.isNaN(Number(firstValue));
     const quote = isString ? "'" : '';
     const [prefix, suffix] = isMulti ? ['(', ')'] : ['', ''];
-    const formattedComparators = (comparatorArray || []).map(
+    const formattedComparators = comparatorArray.map(
       val => `${quote}${isString ? val.replace("'", "''") : val}${quote}`,
     );
-    if (comparatorArray) {
+    if (comparatorArray.length > 0) {
       expression += ` ${prefix}${formattedComparators.join(', ')}${suffix}`;
     }
   }


### PR DESCRIPTION
### SUMMARY
Currently simple filters aren't always translated to valid custom SQL:
- strings aren't enclosed in quotes (quotes were only added in the case of set operators)
- all set operator clauses were enclosed in quotes (should not be the case for numeric values)
- single quotes aren't doubly quoted as per ANSI SQL (`it's a word` -> `col = 'it''s a word'`)
- when only a subject or subject and operator are given, the custom filter is left empty

Some test cases are added and code slightly refactored.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
New tests added and old tests updated accordingly. The variables in the tests are replaced with explicit values to make them easier to read.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #12340, closes #12293
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
