### PR TITLE
chore(dashboard): Add ErrorBoudary for AdhocFilter components

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopover_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopover_spec.jsx
@@ -22,6 +22,7 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import Button from 'src/components/Button';
 
+import ErrorBoundary from 'src/components/ErrorBoundary';
 import Tabs from 'src/common/components/Tabs';
 import AdhocFilter, {
   EXPRESSION_TYPES,
@@ -44,6 +45,14 @@ const simpleAdhocFilter = new AdhocFilter({
 const sqlAdhocFilter = new AdhocFilter({
   expressionType: EXPRESSION_TYPES.SQL,
   sqlExpression: 'value > 10',
+  clause: CLAUSES.WHERE,
+});
+
+const faultiAdhocFilter = new AdhocFilter({
+  expressionType: null,
+  subject: null,
+  operator: '>',
+  comparator: '10',
   clause: CLAUSES.WHERE,
 });
 
@@ -95,6 +104,14 @@ describe('AdhocFilterEditPopover', () => {
     expect(wrapper.find(Tabs.TabPane)).toHaveLength(2);
     expect(wrapper.find(Button)).toHaveLength(2);
     expect(wrapper.find(AdhocFilterEditPopoverSqlTabContent)).toExist();
+  });
+
+  it('renders simple and sql tabs with ErrorBoundary instead of content', () => {
+    const { wrapper } = setup({ adhocFilter: faultiAdhocFilter });
+    expect(wrapper.find(Tabs)).toExist();
+    expect(wrapper.find(Tabs.TabPane)).toHaveLength(2);
+    expect(wrapper.find(Button)).toHaveLength(2);
+    expect(wrapper.find(ErrorBoundary)).toHaveLength(2);
   });
 
   it('overwrites the adhocFilter in state with onAdhocFilterChange', () => {

--- a/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopover_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocFilterEditPopover_spec.jsx
@@ -48,7 +48,7 @@ const sqlAdhocFilter = new AdhocFilter({
   clause: CLAUSES.WHERE,
 });
 
-const faultiAdhocFilter = new AdhocFilter({
+const faultyAdhocFilter = new AdhocFilter({
   expressionType: null,
   subject: null,
   operator: '>',
@@ -107,7 +107,7 @@ describe('AdhocFilterEditPopover', () => {
   });
 
   it('renders simple and sql tabs with ErrorBoundary instead of content', () => {
-    const { wrapper } = setup({ adhocFilter: faultiAdhocFilter });
+    const { wrapper } = setup({ adhocFilter: faultyAdhocFilter });
     expect(wrapper.find(Tabs)).toExist();
     expect(wrapper.find(Tabs.TabPane)).toHaveLength(2);
     expect(wrapper.find(Button)).toHaveLength(2);

--- a/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocFilterEditPopover.jsx
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import Button from 'src/components/Button';
 import { styled, t } from '@superset-ui/core';
 
+import ErrorBoundary from 'src/components/ErrorBoundary';
 import Tabs from 'src/common/components/Tabs';
 import columnType from '../propTypes/columnType';
 import adhocMetricType from '../propTypes/adhocMetricType';
@@ -157,34 +158,38 @@ export default class AdhocFilterEditPopover extends React.Component {
             key={EXPRESSION_TYPES.SIMPLE}
             tab={t('Simple')}
           >
-            <AdhocFilterEditPopoverSimpleTabContent
-              adhocFilter={this.state.adhocFilter}
-              onChange={this.onAdhocFilterChange}
-              options={options}
-              datasource={datasource}
-              onHeightChange={this.adjustHeight}
-              partitionColumn={partitionColumn}
-              popoverRef={this.popoverContentRef.current}
-            />
+            <ErrorBoundary>
+              <AdhocFilterEditPopoverSimpleTabContent
+                adhocFilter={this.state.adhocFilter}
+                onChange={this.onAdhocFilterChange}
+                options={options}
+                datasource={datasource}
+                onHeightChange={this.adjustHeight}
+                partitionColumn={partitionColumn}
+                popoverRef={this.popoverContentRef.current}
+              />
+            </ErrorBoundary>
           </Tabs.TabPane>
           <Tabs.TabPane
             className="adhoc-filter-edit-tab"
             key={EXPRESSION_TYPES.SQL}
             tab={t('Custom SQL')}
           >
-            {!this.props.datasource ||
-            this.props.datasource.type !== 'druid' ? (
-              <AdhocFilterEditPopoverSqlTabContent
-                adhocFilter={this.state.adhocFilter}
-                onChange={this.onAdhocFilterChange}
-                options={this.props.options}
-                height={this.state.height}
-              />
-            ) : (
-              <div className="custom-sql-disabled-message">
-                Custom SQL Filters are not available on druid datasources
-              </div>
-            )}
+            <ErrorBoundary>
+              {!this.props.datasource ||
+              this.props.datasource.type !== 'druid' ? (
+                <AdhocFilterEditPopoverSqlTabContent
+                  adhocFilter={this.state.adhocFilter}
+                  onChange={this.onAdhocFilterChange}
+                  options={this.props.options}
+                  height={this.state.height}
+                />
+              ) : (
+                <div className="custom-sql-disabled-message">
+                  Custom SQL Filters are not available on druid datasources
+                </div>
+              )}
+            </ErrorBoundary>
           </Tabs.TabPane>
         </Tabs>
         <div>


### PR DESCRIPTION
### SUMMARY
Wrap AdhocFilter components in ErrorBoundary component to preserve the rest of the page in case if error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before/After:
- **Simple Tab**
![Screenshot 2021-01-08 at 13 50 39](https://user-images.githubusercontent.com/26679866/104017850-24046700-51b9-11eb-9945-118f8ac08b6a.png)
=======
![Screenshot 2021-01-08 at 13 46 14](https://user-images.githubusercontent.com/26679866/104017872-2f579280-51b9-11eb-9dc8-ab127db79b9b.png)

- **Custom SQL Tab**
![Screenshot 2021-01-08 at 13 46 25](https://user-images.githubusercontent.com/26679866/104017899-3e3e4500-51b9-11eb-8932-4ab4b9175112.png)
=======
![Screenshot 2021-01-08 at 13 50 47](https://user-images.githubusercontent.com/26679866/104017929-45fde980-51b9-11eb-8480-8f035225756a.png)

### TEST PLAN
1. Go to **Dashboards**
2. Choose a dashboards that has **FILTERS** option (e.g. **deck.gl Demo > Scatterplot**)
3. Click on **FILTERS**
Note: This change will show only in case of an error in the code for **AdhocFilterEditPopoverSimpleTabContent** or **AdhocFilterEditPopoverSqlTabContent** components.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
