### PR TITLE
fix(dashboard): CSS injection order (#12265)

### DIFF
--- a/superset-frontend/src/dashboard/util/injectCustomCss.js
+++ b/superset-frontend/src/dashboard/util/injectCustomCss.js
@@ -25,11 +25,24 @@ export default function injectCustomCss(css) {
     style = document.createElement('style');
     style.className = className;
     style.type = 'text/css';
-    head.appendChild(style);
   }
+
   if (style.styleSheet) {
     style.styleSheet.cssText = css;
   } else {
     style.innerHTML = css;
   }
+
+  /**
+   * Ensures that the style applied is always the last.
+   *
+   * from: https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild
+   * The Node.appendChild() method adds a node to the end of the list of children
+   * of a specified parent node. If the given child is a reference to an existing
+   * node in the document, appendChild() moves it from its current position to the
+   * new position (there is no requirement to remove the node from its parent node
+   * before appending it to some other node).
+   */
+
+  head.appendChild(style);
 }


### PR DESCRIPTION
### SUMMARY
`CSS` templates were being overridden by other styles loaded by the application. This fix ensures that `CSS` templates are always the last child of `<head>`.

### AFTER FIX (before can be seen in #12265)
![after](https://user-images.githubusercontent.com/70410625/104023929-1e028c00-51a1-11eb-9329-5aba73edd337.gif)

### TEST PLAN
1. Go to 'Any dashboard'
2. Click on 'Edit dashboard > Edit CSS'
3. Save CSS template
4. Refresh browser
5. Should keep CSS template

Closes #12265 

@junlincc 

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
