### PR TITLE
fix(explore): explore window replace wrong standalone slice url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 *.swp
 __pycache__
 
+.local
+.cache
 .bento*
 .cache-loader
 .coverage

--- a/superset-frontend/spec/javascripts/explore/utils_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/utils_spec.jsx
@@ -199,6 +199,16 @@ describe('exploreUtils', () => {
         URI('/superset/explore/').search({ form_data: sFormData }),
       );
     });
+
+    it('generates url with standalone', () => {
+      compareURI(
+        URI(getExploreLongUrl(formData, 'standalone')),
+        URI('/superset/explore/').search({
+          form_data: sFormData,
+          standalone: 'true',
+        }),
+      );
+    });
   });
 
   describe('buildV1ChartDataPayload', () => {

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -167,7 +167,11 @@ function ExploreViewContainer(props) {
 
   function addHistory({ isReplace = false, title } = {}) {
     const payload = { ...props.form_data };
-    const longUrl = getExploreLongUrl(props.form_data, null, false);
+    const longUrl = getExploreLongUrl(
+      props.form_data,
+      props.standalone ? 'standalone' : null,
+      false,
+    );
     try {
       if (isReplace) {
         window.history.replaceState(payload, title, longUrl);


### PR DESCRIPTION
### SUMMARY
Fix the issue with standalone slice in explore component. When it replace browser url, it doesn't consider standalone parameter

### TEST PLAN
- Go to standalone slice url, example http://localhost:9000/superset/slice/23/?standalone=true
- Waiting chart is render fully
- Refresh the browser (Or going URL and enter again)
- Make sure standalone chart is rendered again.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12358
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
