### PR TITLE
fix: css templates modal cleanup: keep modal open on error, utilize useEffect

### DIFF
--- a/superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx
+++ b/superset-frontend/src/views/CRUD/csstemplates/CssTemplateModal.tsx
@@ -110,7 +110,11 @@ const CssTemplateModal: FunctionComponent<CssTemplateModalProps> = ({
         const update_id = currentCssTemplate.id;
         delete currentCssTemplate.id;
         delete currentCssTemplate.created_by;
-        updateResource(update_id, currentCssTemplate).then(() => {
+        updateResource(update_id, currentCssTemplate).then(response => {
+          if (!response) {
+            return;
+          }
+
           if (onCssTemplateAdd) {
             onCssTemplateAdd();
           }
@@ -120,7 +124,11 @@ const CssTemplateModal: FunctionComponent<CssTemplateModalProps> = ({
       }
     } else if (currentCssTemplate) {
       // Create
-      createResource(currentCssTemplate).then(() => {
+      createResource(currentCssTemplate).then(response => {
+        if (!response) {
+          return;
+        }
+
         if (onCssTemplateAdd) {
           onCssTemplateAdd();
         }
@@ -166,29 +174,35 @@ const CssTemplateModal: FunctionComponent<CssTemplateModalProps> = ({
   };
 
   // Initialize
-  if (
-    isEditMode &&
-    (!currentCssTemplate ||
-      !currentCssTemplate.id ||
-      (cssTemplate && cssTemplate.id !== currentCssTemplate.id) ||
-      (isHidden && show))
-  ) {
-    if (cssTemplate && cssTemplate.id !== null && !loading) {
-      const id = cssTemplate.id || 0;
+  useEffect(() => {
+    if (
+      isEditMode &&
+      (!currentCssTemplate ||
+        !currentCssTemplate.id ||
+        (cssTemplate && cssTemplate.id !== currentCssTemplate.id) ||
+        (isHidden && show))
+    ) {
+      if (cssTemplate && cssTemplate.id !== null && !loading) {
+        const id = cssTemplate.id || 0;
 
-      fetchResource(id).then(() => {
-        setCurrentCssTemplate(resource);
+        fetchResource(id);
+      }
+    } else if (
+      !isEditMode &&
+      (!currentCssTemplate || currentCssTemplate.id || (isHidden && show))
+    ) {
+      setCurrentCssTemplate({
+        template_name: '',
+        css: '',
       });
     }
-  } else if (
-    !isEditMode &&
-    (!currentCssTemplate || currentCssTemplate.id || (isHidden && show))
-  ) {
-    setCurrentCssTemplate({
-      template_name: '',
-      css: '',
-    });
-  }
+  }, [cssTemplate]);
+
+  useEffect(() => {
+    if (resource) {
+      setCurrentCssTemplate(resource);
+    }
+  }, [resource]);
 
   // Validation
   useEffect(() => {


### PR DESCRIPTION
### SUMMARY
- [x] Handles errors on save/update so modal does not close when an error is encountered
- [x] utilizes `useEffect` hook for initialization to reduce API requests

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
Manual Test:
1. Create or update css template without network connectivity
2. Attempt to save
3. Confirm that an error toast is thrown and the modal does not close

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
