### PR TITLE
fix(explore): Don't run a query on every change in chart controls

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -265,7 +265,6 @@ function ExploreViewContainer(props) {
     }
   }, [isDynamicPluginLoading]);
 
-  // effect to run when controls change
   useEffect(() => {
     const hasError = Object.values(props.controls).some(
       control =>
@@ -274,7 +273,10 @@ function ExploreViewContainer(props) {
     if (!hasError) {
       props.actions.triggerQuery(true, props.chart.id);
     }
+  }, []);
 
+  // effect to run when controls change
+  useEffect(() => {
     if (previousControls) {
       if (props.controls.viz_type.value !== previousControls.viz_type.value) {
         props.actions.resetControls();


### PR DESCRIPTION
### SUMMARY
Closes https://github.com/apache/superset/issues/12207
Closes https://github.com/apache/superset/issues/12317

As you can see on video below, no request is triggered until user click Run query.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issues
After:
https://user-images.githubusercontent.com/15073128/104059464-b4609d00-51f5-11eb-95c5-0c3b9f368f23.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12207, https://github.com/apache/superset/issues/12317
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro @ktmud 