### PR TITLE
fix: datasets populating after user creation 

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/SaveDatasetModal_spec.tsx
+++ b/superset-frontend/spec/javascripts/sqllab/SaveDatasetModal_spec.tsx
@@ -27,7 +27,6 @@ describe('SaveDatasetModal', () => {
     onOk: () => {},
     onHide: () => {},
     handleDatasetNameChange: () => {},
-    userDatasetsOwned: [],
     handleSaveDatasetRadioBtnState: () => {},
     saveDatasetRadioBtnState: 1,
     handleOverwriteCancel: () => {},
@@ -37,7 +36,7 @@ describe('SaveDatasetModal', () => {
     shouldOverwriteDataset: false,
     userDatasetOptions: [],
     disableSaveAndExploreBtn: false,
-    handleSaveDatasetModalSearch: () => {},
+    handleSaveDatasetModalSearch: (searchText: string) => Promise<void>,
     filterAutocompleteOption: () => false,
     onChangeAutoComplete: () => {},
   };

--- a/superset-frontend/spec/javascripts/sqllab/SaveDatasetModal_spec.tsx
+++ b/superset-frontend/spec/javascripts/sqllab/SaveDatasetModal_spec.tsx
@@ -36,19 +36,22 @@ describe('SaveDatasetModal', () => {
     shouldOverwriteDataset: false,
     userDatasetOptions: [],
     disableSaveAndExploreBtn: false,
-    handleSaveDatasetModalSearch: (searchText: string) => Promise<void>,
+    handleSaveDatasetModalSearch: () => Promise,
     filterAutocompleteOption: () => false,
     onChangeAutoComplete: () => {},
   };
   it('renders a radio group btn', () => {
+    // @ts-ignore
     const wrapper = shallow(<SaveDatasetModal {...mockedProps} />);
     expect(wrapper.find(Radio.Group)).toExist();
   });
   it('renders a autocomplete', () => {
+    // @ts-ignore
     const wrapper = shallow(<SaveDatasetModal {...mockedProps} />);
     expect(wrapper.find(AutoComplete)).toExist();
   });
   it('renders an input form ', () => {
+    // @ts-ignore
     const wrapper = shallow(<SaveDatasetModal {...mockedProps} />);
     expect(wrapper.find(Input)).toExist();
   });

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -43,6 +43,28 @@ import { Query } from '../types';
 
 const SEARCH_HEIGHT = 46;
 
+const debounce = (
+  func: { apply: (arg0: any, arg1: IArguments) => void },
+  wait: number,
+  immediate: number,
+) => {
+  let timeout: NodeJS.Timeout | null;
+  return function () {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const context = this;
+    // eslint-disable-next-line prefer-rest-params
+    const args = arguments;
+    const later = function () {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    const callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+};
+
 enum DatasetRadioState {
   SAVE_NEW = 1,
   OVERWRITE_DATASET = 2,
@@ -86,7 +108,6 @@ interface ResultSetState {
   data: Record<string, any>[];
   showSaveDatasetModal: boolean;
   newSaveDatasetName: string;
-  userDatasetsOwned: DatasetOption[];
   saveDatasetRadioBtnState: number;
   shouldOverwriteDataSet: boolean;
   datasetToOverwrite: Record<string, any>;
@@ -150,8 +171,10 @@ export default class ResultSet extends React.PureComponent<
     this.handleOverwriteDatasetOption = this.handleOverwriteDatasetOption.bind(
       this,
     );
-    this.handleSaveDatasetModalSearch = this.handleSaveDatasetModalSearch.bind(
-      this,
+    this.handleSaveDatasetModalSearch = debounce(
+      this.handleSaveDatasetModalSearch.bind(this),
+      2000,
+      0,
     );
     this.handleFilterAutocompleteOption = this.handleFilterAutocompleteOption.bind(
       this,

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -25,6 +25,7 @@ import Button from 'src/components/Button';
 import shortid from 'shortid';
 import rison from 'rison';
 import { styled, t, makeApi } from '@superset-ui/core';
+import { debounce } from 'lodash';
 
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
@@ -42,28 +43,6 @@ import { CtasEnum } from '../actions/sqlLab';
 import { Query } from '../types';
 
 const SEARCH_HEIGHT = 46;
-
-const debounce = (
-  func: { apply: (arg0: any, arg1: IArguments) => void },
-  wait: number,
-  immediate: number,
-) => {
-  let timeout: NodeJS.Timeout | null;
-  return function () {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const context = this;
-    // eslint-disable-next-line prefer-rest-params
-    const args = arguments;
-    const later = function () {
-      timeout = null;
-      if (!immediate) func.apply(context, args);
-    };
-    const callNow = immediate && !timeout;
-    clearTimeout(timeout);
-    timeout = setTimeout(later, wait);
-    if (callNow) func.apply(context, args);
-  };
-};
 
 enum DatasetRadioState {
   SAVE_NEW = 1,
@@ -173,8 +152,7 @@ export default class ResultSet extends React.PureComponent<
     );
     this.handleSaveDatasetModalSearch = debounce(
       this.handleSaveDatasetModalSearch.bind(this),
-      2000,
-      0,
+      1000,
     );
     this.handleFilterAutocompleteOption = this.handleFilterAutocompleteOption.bind(
       this,

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -29,7 +29,7 @@ import { debounce } from 'lodash';
 
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
-import { getByUser, put as updateDatset } from 'src/api/dataset';
+import { put as updateDatset } from 'src/api/dataset';
 import Loading from '../../components/Loading';
 import ExploreCtasResultsButton from './ExploreCtasResultsButton';
 import ExploreResultsButton from './ExploreResultsButton';
@@ -57,11 +57,6 @@ const EXPLORE_CHART_DEFAULT = {
 };
 
 const LOADING_STYLES: CSSProperties = { position: 'relative', minHeight: 100 };
-
-interface DatasetOption {
-  datasetId: number;
-  datasetName: string;
-}
 
 interface DatasetOptionAutocomplete {
   value: string;

--- a/superset-frontend/src/SqlLab/components/ResultSet.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet.tsx
@@ -23,7 +23,8 @@ import moment from 'moment';
 import { RadioChangeEvent } from 'antd/lib/radio';
 import Button from 'src/components/Button';
 import shortid from 'shortid';
-import { styled, t } from '@superset-ui/core';
+import rison from 'rison';
+import { styled, t, makeApi } from '@superset-ui/core';
 
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
@@ -124,7 +125,6 @@ export default class ResultSet extends React.PureComponent<
       data: [],
       showSaveDatasetModal: false,
       newSaveDatasetName: this.getDefaultDatasetName(),
-      userDatasetsOwned: [],
       saveDatasetRadioBtnState: DatasetRadioState.SAVE_NEW,
       shouldOverwriteDataSet: false,
       datasetToOverwrite: {},
@@ -162,26 +162,9 @@ export default class ResultSet extends React.PureComponent<
     this.handleExploreBtnClick = this.handleExploreBtnClick.bind(this);
   }
 
-  async componentDidMount() {
+  componentDidMount() {
     // only do this the first time the component is rendered/mounted
     this.reRunQueryIfSessionTimeoutErrorOnMount();
-
-    const appContainer = document.getElementById('app');
-    const bootstrapData = JSON.parse(
-      appContainer?.getAttribute('data-bootstrap') || '{}',
-    );
-
-    if (bootstrapData.user && bootstrapData.user.userId) {
-      const datasets = await getByUser(bootstrapData.user.userId);
-      const userDatasetsOwned = datasets.map(
-        (r: { table_name: string; id: number }) => ({
-          datasetName: r.table_name,
-          datasetId: r.id,
-        }),
-      );
-
-      this.setState({ userDatasetsOwned });
-    }
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: ResultSetProps) {
@@ -317,18 +300,46 @@ export default class ResultSet extends React.PureComponent<
     });
   };
 
-  handleSaveDatasetModalSearch = (searchText: string) => {
+  handleSaveDatasetModalSearch = async (searchText: string) => {
     // Making sure that autocomplete input has a value before rendering the dropdown
     // Transforming the userDatasetsOwned data for SaveModalComponent)
-    const { userDatasetsOwned } = this.state;
-    const userDatasets = !searchText
-      ? []
-      : userDatasetsOwned.map(d => ({
-          value: d.datasetName,
-          datasetId: d.datasetId,
-        }));
+    const appContainer = document.getElementById('app');
+    const bootstrapData = JSON.parse(
+      appContainer?.getAttribute('data-bootstrap') || '{}',
+    );
 
-    this.setState({ userDatasetOptions: userDatasets });
+    if (bootstrapData.user && bootstrapData.user.userId) {
+      const queryParams = rison.encode({
+        filters: [
+          {
+            col: 'table_name',
+            opr: 'ct',
+            value: searchText,
+          },
+          {
+            col: 'owners',
+            opr: 'rel_m_m',
+            value: bootstrapData.user.userId,
+          },
+        ],
+        order_column: 'changed_on_delta_humanized',
+        order_direction: 'desc',
+      });
+
+      const response = await makeApi({
+        method: 'GET',
+        endpoint: '/api/v1/dataset',
+      })(`q=${queryParams}`);
+
+      const userDatasetsOwned = response.result.map(
+        (r: { table_name: string; id: number }) => ({
+          value: r.table_name,
+          datasetId: r.id,
+        }),
+      );
+
+      this.setState({ userDatasetOptions: userDatasetsOwned });
+    }
   };
 
   handleFilterAutocompleteOption = (

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal.tsx
@@ -30,7 +30,7 @@ interface SaveDatasetModalProps {
   onOk: () => void;
   onHide: () => void;
   handleDatasetNameChange: (e: React.FormEvent<HTMLInputElement>) => void;
-  handleSaveDatasetModalSearch: (searchText: string) => void;
+  handleSaveDatasetModalSearch: (searchText: string) => Promise<void>;
   filterAutocompleteOption: (
     inputValue: string,
     option: { value: string; datasetId: number },


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before the user would create a new dataset we wouldn't update the dataset owned list. Now with the new pattern we make network calls to the datasets endpoint on users types w/ debouncing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
