### PR TITLE
fix(explore): Filter popover is covered by data table on Explore

### DIFF
--- a/superset-frontend/src/explore/components/AdhocFilterPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/AdhocFilterPopoverTrigger.tsx
@@ -104,7 +104,6 @@ class AdhocFilterPopoverTrigger extends React.PureComponent<
           defaultVisible={this.state.popoverVisible}
           visible={this.state.popoverVisible}
           onVisibleChange={this.togglePopover}
-          overlayStyle={{ zIndex: 1 }}
           destroyTooltipOnHide={this.props.createNew}
         >
           {this.props.children}


### PR DESCRIPTION
### SUMMARY
Closes https://github.com/apache/superset/issues/12373

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
![image](https://user-images.githubusercontent.com/15073128/104085864-ee13c100-5252-11eb-8342-a92ffab0fcf2.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12373
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @rusackas 