### PR TITLE
fix(explore): adhoc metric label and control value not consistent

### DIFF
--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -122,8 +122,7 @@ export default class AdhocMetricEditPopover extends React.Component {
     this.setState({
       adhocMetric: this.props.adhocMetric,
       savedMetric: this.props.savedMetric,
-    });
-    this.props.onClose();
+    }, this.props.onClose);
   }
 
   onColumnChange(columnId) {

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -119,10 +119,13 @@ export default class AdhocMetricEditPopover extends React.Component {
   }
 
   onRestStateAndClose() {
-    this.setState({
-      adhocMetric: this.props.adhocMetric,
-      savedMetric: this.props.savedMetric,
-    }, this.props.onClose);
+    this.setState(
+      {
+        adhocMetric: this.props.adhocMetric,
+        savedMetric: this.props.savedMetric,
+      },
+      this.props.onClose,
+    );
   }
 
   onColumnChange(columnId) {

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -67,6 +67,7 @@ export default class AdhocMetricEditPopover extends React.Component {
   constructor(props) {
     super(props);
     this.onSave = this.onSave.bind(this);
+    this.onRestStateAndClose = this.onRestStateAndClose.bind(this);
     this.onColumnChange = this.onColumnChange.bind(this);
     this.onAggregateChange = this.onAggregateChange.bind(this);
     this.onSavedMetricChange = this.onSavedMetricChange.bind(this);
@@ -114,6 +115,14 @@ export default class AdhocMetricEditPopover extends React.Component {
       },
       oldMetric,
     );
+    this.props.onClose();
+  }
+
+  onRestStateAndClose() {
+    this.setState({
+      adhocMetric: this.props.adhocMetric,
+      savedMetric: this.props.savedMetric,
+    });
     this.props.onClose();
   }
 
@@ -390,7 +399,7 @@ export default class AdhocMetricEditPopover extends React.Component {
         <div>
           <Button
             buttonSize="small"
-            onClick={this.props.onClose}
+            onClick={this.onRestStateAndClose}
             data-test="AdhocMetricEdit#cancel"
             cta
           >


### PR DESCRIPTION
### SUMMARY
fix  #12367
Closes #12367
- adhoc metric control must reset state when close Popover

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
add e2e in future

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
