### PR TITLE
fix(explore): clear custom label if removed

### DIFF
--- a/superset-frontend/src/explore/components/AdhocMetricEditPopoverTitle.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopoverTitle.jsx
@@ -62,7 +62,6 @@ export default class AdhocMetricEditPopoverTitle extends React.Component {
 
   onInputBlur(e) {
     if (e.target.value === '') {
-      e.target.value = this.props.defaultLabel;
       this.props.onChange(e);
     }
     this.onBlur();


### PR DESCRIPTION
### SUMMARY
When clearing the custom label, it should be reverted to the default label.

### AFTER SCREENSHOTS OR ANIMATED GIF
![metric_label](https://user-images.githubusercontent.com/33317356/104087705-5ae68580-526a-11eb-878b-9542624064a8.gif)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #12380 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
