### PR TITLE
fix(explore): Data tables styling issues on Explore view

### DIFF
--- a/superset-frontend/src/components/TableView/TableView.tsx
+++ b/superset-frontend/src/components/TableView/TableView.tsx
@@ -41,13 +41,17 @@ export interface TableViewProps {
   emptyWrapperType?: EmptyWrapperType;
   noDataText?: string;
   className?: string;
+  isPaginationSticky?: boolean;
+  showRowCount?: boolean;
 }
 
 const EmptyWrapper = styled.div`
   margin: ${({ theme }) => theme.gridUnit * 40}px 0;
 `;
 
-const TableViewStyles = styled.div`
+const TableViewStyles = styled.div<{
+  isPaginationSticky?: boolean;
+}>`
   .table-cell.table-cell {
     vertical-align: top;
   }
@@ -57,6 +61,15 @@ const TableViewStyles = styled.div`
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    background-color: ${({ theme }) => theme.colors.grayscale.light5};
+
+    ${({ theme, isPaginationSticky }) =>
+      isPaginationSticky &&
+      `
+        position: sticky;
+        bottom: ${theme.gridUnit * 4}px;
+        left: 0;
+    `};
   }
 
   .row-count-container {
@@ -75,6 +88,7 @@ const TableView = ({
   withPagination = true,
   emptyWrapperType = EmptyWrapperType.Default,
   noDataText,
+  showRowCount = true,
   ...props
 }: TableViewProps) => {
   const initialState = {
@@ -151,15 +165,17 @@ const TableView = ({
             onChange={(p: number) => gotoPage(p - 1)}
             hideFirstAndLastPageLinks
           />
-          <div className="row-count-container">
-            {!loading &&
-              t(
-                '%s-%s of %s',
-                pageSize * pageIndex + (page.length && 1),
-                pageSize * pageIndex + page.length,
-                data.length,
-              )}
-          </div>
+          {showRowCount && (
+            <div className="row-count-container">
+              {!loading &&
+                t(
+                  '%s-%s of %s',
+                  pageSize * pageIndex + (page.length && 1),
+                  pageSize * pageIndex + page.length,
+                  data.length,
+                )}
+            </div>
+          )}
         </div>
       )}
     </TableViewStyles>

--- a/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
+++ b/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
@@ -75,6 +75,10 @@ export const Table = styled.table`
       min-width: 200px;
     }
 
+    span {
+      white-space: nowrap;
+    }
+
     svg {
       display: inline-block;
       top: 6px;

--- a/superset-frontend/src/explore/components/DataTableControl.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl.tsx
@@ -80,8 +80,14 @@ export const FilterInput = ({
   );
 };
 
-export const RowCount = ({ data }: { data?: Record<string, any>[] }) => (
-  <RowCountLabel rowcount={data?.length ?? 0} suffix={t('rows retrieved')} />
+export const RowCount = ({
+  data,
+  loading,
+}: {
+  data?: Record<string, any>[];
+  loading: boolean;
+}) => (
+  <RowCountLabel rowcount={data?.length ?? 0} loading={loading} suffix={t('rows retrieved')} />
 );
 
 export const useFilteredTableData = (

--- a/superset-frontend/src/explore/components/DataTableControl.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl.tsx
@@ -87,7 +87,11 @@ export const RowCount = ({
   data?: Record<string, any>[];
   loading: boolean;
 }) => (
-  <RowCountLabel rowcount={data?.length ?? 0} loading={loading} suffix={t('rows retrieved')} />
+  <RowCountLabel
+    rowcount={data?.length ?? 0}
+    loading={loading}
+    suffix={t('rows retrieved')}
+  />
 );
 
 export const useFilteredTableData = (

--- a/superset-frontend/src/explore/components/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane.tsx
@@ -201,6 +201,8 @@ export const DataTablesPane = ({
           noDataText={t('No data')}
           emptyWrapperType={EmptyWrapperType.Small}
           className="table-condensed"
+          isPaginationSticky
+          showRowCount={false}
         />
       );
     }

--- a/superset-frontend/src/explore/components/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane.tsx
@@ -211,7 +211,7 @@ export const DataTablesPane = ({
 
   const TableControls = (
     <TableControlsWrapper>
-      <RowCount data={data[activeTabKey]} />
+      <RowCount data={data[activeTabKey]} loading={isLoading[activeTabKey]} />
       <CopyToClipboardButton data={data[activeTabKey]} />
       <FilterInput onChangeHandler={setFilterText} />
     </TableControlsWrapper>

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -93,6 +93,8 @@ const Styles = styled.div`
     border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   }
   .main-explore-content {
+    flex: 1;
+    min-width: ${({ theme }) => theme.gridUnit * 128}px;
     border-left: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   }
   .controls-column {

--- a/superset-frontend/src/explore/components/RowCountLabel.jsx
+++ b/superset-frontend/src/explore/components/RowCountLabel.jsx
@@ -28,26 +28,28 @@ const propTypes = {
   limit: PropTypes.number,
   rows: PropTypes.string,
   suffix: PropTypes.string,
+  loading: PropTypes.bool,
 };
 
 const defaultProps = {
   suffix: t('rows'),
 };
 
-export default function RowCountLabel({ rowcount, limit, suffix }) {
+export default function RowCountLabel({ rowcount, limit, suffix, loading }) {
   const limitReached = rowcount === limit;
-  const bsStyle = limitReached || rowcount === 0 ? 'danger' : 'default';
+  const bsStyle =
+    limitReached || (rowcount === 0 && !loading) ? 'danger' : 'default';
   const formattedRowCount = getNumberFormatter()(rowcount);
   const tooltip = (
     <span>
       {limitReached && <div>{t('Limit reached')}</div>}
-      {rowcount}
+      {loading ? 'Loading' : rowcount}
     </span>
   );
   return (
     <TooltipWrapper label="tt-rowcount" tooltip={tooltip}>
       <Label bsStyle={bsStyle}>
-        {formattedRowCount} {suffix}
+        {loading ? 'Loading...' : `${formattedRowCount} ${suffix}`}
       </Label>
     </TooltipWrapper>
   );


### PR DESCRIPTION
### SUMMARY
Closes https://github.com/apache/superset/issues/12371
Closes https://github.com/apache/superset/issues/12370
Fixes an issue with wide tables stretching the chart section container, resulting in some components being cut off (described in comment https://github.com/apache/superset/pull/12257#issuecomment-756967446)
Fixes displaying "0 rows retrieved" with "error" style when data is still loading

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/104090226-9d618f80-5275-11eb-8b83-5c9d63ac6888.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12370, https://github.com/apache/superset/issues/12371
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc, @ktmud, @villebro 