### PR TITLE
fix: Temporarily disable editing metric title

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/AdhocMetrics.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/AdhocMetrics.test.ts
@@ -27,8 +27,9 @@ describe('AdhocMetrics', () => {
   });
 
   it('Clear metric and set simple adhoc metric', () => {
-    const metric = 'sum(num_girls)';
-    const metricName = 'Sum Girls';
+    // TODO: add support for custom title for saved metrics
+    // const metric = 'sum(num_girls)';
+    // const metricName = 'Sum Girls';
     cy.get('[data-test=metrics]')
       .find('[data-test="remove-control-button"]')
       .click();
@@ -37,20 +38,21 @@ describe('AdhocMetrics', () => {
       .find('[data-test="add-metric-button"]')
       .click();
 
-    cy.get('[data-test="AdhocMetricEditTitle#trigger"]').click();
-    cy.get('[data-test="AdhocMetricEditTitle#input"]').type(metricName);
+    // cy.get('[data-test="AdhocMetricEditTitle#trigger"]').click();
+    // cy.get('[data-test="AdhocMetricEditTitle#input"]').type(metricName);
 
     cy.get('[name="select-column"]').click().type('num_girls{enter}');
     cy.get('[name="select-aggregate"]').click().type('sum{enter}');
 
     cy.get('[data-test="AdhocMetricEdit#save"]').contains('Save').click();
 
-    cy.get('[data-test="control-label"]').contains(metricName);
+    // cy.get('[data-test="control-label"]').contains(metricName);
+    cy.get('[data-test="control-label"]').contains('SUM(num_girls)');
 
     cy.get('button[data-test="run-query-button"]').click();
     cy.verifySliceSuccess({
       waitAlias: '@postJson',
-      querySubstring: `${metric} AS "${metricName}"`, // SQL statement
+      // querySubstring: `${metric} AS "${metricName}"`, // SQL statement
       chartSelector: 'svg',
     });
   });

--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopoverTitle_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopoverTitle_spec.jsx
@@ -20,7 +20,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
-import { Tooltip } from 'src/common/components/Tooltip';
 
 import AdhocMetricEditPopoverTitle from 'src/explore/components/AdhocMetricEditPopoverTitle';
 
@@ -43,18 +42,23 @@ function setup(overrides) {
 describe('AdhocMetricEditPopoverTitle', () => {
   it('renders an OverlayTrigger wrapper with the title', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(Tooltip)).toExist();
+    // TODO: add support for custom title for saved metrics
+    // expect(wrapper.find(Tooltip)).toExist();
+    // expect(
+    //   wrapper.find('[data-test="AdhocMetricEditTitle#trigger"]').text(),
+    // ).toBe('My Metric\xa0');
     expect(
       wrapper.find('[data-test="AdhocMetricEditTitle#trigger"]').text(),
-    ).toBe('My Metric\xa0');
+    ).toBe('My Metric');
   });
 
-  it('transfers to edit mode when clicked', () => {
-    const { wrapper } = setup();
-    expect(wrapper.state('isEditable')).toBe(false);
-    wrapper
-      .find('[data-test="AdhocMetricEditTitle#trigger"]')
-      .simulate('click');
-    expect(wrapper.state('isEditable')).toBe(true);
-  });
+  // TODO: add support for custom title for saved metrics
+  // it('transfers to edit mode when clicked', () => {
+  //   const { wrapper } = setup();
+  //   expect(wrapper.state('isEditable')).toBe(false);
+  //   wrapper
+  //     .find('[data-test="AdhocMetricEditTitle#trigger"]')
+  //     .simulate('click');
+  //   expect(wrapper.state('isEditable')).toBe(true);
+  // });
 });

--- a/superset-frontend/src/explore/components/AdhocMetricEditPopoverTitle.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopoverTitle.jsx
@@ -18,8 +18,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormControl } from 'react-bootstrap';
-import { Tooltip } from 'src/common/components/Tooltip';
 
 const propTypes = {
   title: PropTypes.shape({
@@ -30,77 +28,92 @@ const propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
-export default class AdhocMetricEditPopoverTitle extends React.Component {
-  constructor(props) {
-    super(props);
-    this.onMouseOver = this.onMouseOver.bind(this);
-    this.onMouseOut = this.onMouseOut.bind(this);
-    this.onClick = this.onClick.bind(this);
-    this.onBlur = this.onBlur.bind(this);
-    this.onInputBlur = this.onInputBlur.bind(this);
-    this.state = {
-      isHovered: false,
-      isEditable: false,
-    };
-  }
+// TODO: add support for custom title for saved metrics
+// export default class AdhocMetricEditPopoverTitle extends React.Component {
+//   constructor(props) {
+//     super(props);
+//     this.onMouseOver = this.onMouseOver.bind(this);
+//     this.onMouseOut = this.onMouseOut.bind(this);
+//     this.onClick = this.onClick.bind(this);
+//     this.onBlur = this.onBlur.bind(this);
+//     this.onInputBlur = this.onInputBlur.bind(this);
+//     this.state = {
+//       isHovered: false,
+//       isEditable: false,
+//     };
+//   }
+//
+//   onMouseOver() {
+//     this.setState({ isHovered: true });
+//   }
+//
+//   onMouseOut() {
+//     this.setState({ isHovered: false });
+//   }
+//
+//   onClick() {
+//     this.setState({ isEditable: true });
+//   }
+//
+//   onBlur() {
+//     this.setState({ isEditable: false });
+//   }
+//
+//   onInputBlur(e) {
+//     if (e.target.value === '') {
+//       this.props.onChange(e);
+//     }
+//     this.onBlur();
+//   }
+//
+//   render() {
+//     const { title, onChange } = this.props;
+//
+//     return this.state.isEditable ? (
+//       <FormControl
+//         className="metric-edit-popover-label-input"
+//         type="text"
+//         placeholder={title.label}
+//         value={title.hasCustomLabel ? title.label : ''}
+//         autoFocus
+//         onChange={onChange}
+//         onBlur={this.onInputBlur}
+//         data-test="AdhocMetricEditTitle#input"
+//       />
+//     ) : (
+//       <Tooltip placement="top" title="Click to edit label">
+//         <span
+//           className="AdhocMetricEditPopoverTitle inline-editable"
+//           data-test="AdhocMetricEditTitle#trigger"
+//           onMouseOver={this.onMouseOver}
+//           onMouseOut={this.onMouseOut}
+//           onClick={this.onClick}
+//           onBlur={this.onBlur}
+//           role="button"
+//           tabIndex={0}
+//         >
+//           {title.hasCustomLabel ? title.label : 'My Metric'}
+//           &nbsp;
+//           <i
+//             className="fa fa-pencil"
+//             style={{ color: this.state.isHovered ? 'black' : 'grey' }}
+//           />
+//         </span>
+//       </Tooltip>
+//     );
+//   }
+// }
 
-  onMouseOver() {
-    this.setState({ isHovered: true });
-  }
-
-  onMouseOut() {
-    this.setState({ isHovered: false });
-  }
-
-  onClick() {
-    this.setState({ isEditable: true });
-  }
-
-  onBlur() {
-    this.setState({ isEditable: false });
-  }
-
-  onInputBlur(e) {
-    if (e.target.value === '') {
-      this.props.onChange(e);
-    }
-    this.onBlur();
-  }
-
+export default class AdhocMetricEditPopoverTitle extends React.PureComponent {
   render() {
-    const { title, onChange } = this.props;
-
-    return this.state.isEditable ? (
-      <FormControl
-        className="metric-edit-popover-label-input"
-        type="text"
-        placeholder={title.label}
-        value={title.hasCustomLabel ? title.label : ''}
-        autoFocus
-        onChange={onChange}
-        onBlur={this.onInputBlur}
-        data-test="AdhocMetricEditTitle#input"
-      />
-    ) : (
-      <Tooltip placement="top" title="Click to edit label">
-        <span
-          className="AdhocMetricEditPopoverTitle inline-editable"
-          data-test="AdhocMetricEditTitle#trigger"
-          onMouseOver={this.onMouseOver}
-          onMouseOut={this.onMouseOut}
-          onClick={this.onClick}
-          onBlur={this.onBlur}
-          role="button"
-          tabIndex={0}
-        >
-          {title.hasCustomLabel ? title.label : 'My Metric'}
-          &nbsp;
-          <i
-            className="fa fa-pencil"
-            style={{ color: this.state.isHovered ? 'black' : 'grey' }}
-          />
-        </span>
-      </Tooltip>
+    const { title } = this.props;
+    return (
+      <span
+        className="AdhocMetricEditPopoverTitle inline-editable"
+        data-test="AdhocMetricEditTitle#trigger"
+      >
+        {title.hasCustomLabel ? title.label : 'My Metric'}
+      </span>
     );
   }
 }


### PR DESCRIPTION
### SUMMARY
Temporarily disable editing metric title until displaying custom title is supported.
Closes https://github.com/apache/superset/issues/12375
Closes https://github.com/apache/superset/issues/12379

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/104090968-9c7f2c80-527a-11eb-89e1-69cd7ce486ad.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @villebro 