### PR TITLE
fix(explore): long metric name display

### DIFF
--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -58,6 +58,12 @@ const ResizeIcon = styled.i`
   margin-left: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
+const ColumnOptionStyle = styled.span`
+  .option-label {
+    display: inline;
+  }
+`;
+
 const SAVED_TAB_KEY = 'SAVED';
 
 const startingWidth = 320;
@@ -220,7 +226,11 @@ export default class AdhocMetricEditPopover extends React.Component {
     if (column.metric_name && !column.verbose_name) {
       column.verbose_name = column.metric_name;
     }
-    return <ColumnOption column={column} showType />;
+    return (
+      <ColumnOptionStyle>
+        <ColumnOption column={column} showType />
+      </ColumnOptionStyle>
+    );
   }
 
   render() {

--- a/superset-frontend/src/explore/components/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricOption.jsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tooltip } from 'src/common/components/Tooltip';
 import AdhocMetric from '../AdhocMetric';
 import columnType from '../propTypes/columnType';
 import savedMetricType from '../propTypes/savedMetricType';
@@ -70,17 +71,22 @@ class AdhocMetricOption extends React.PureComponent {
         savedMetric={savedMetric}
         datasourceType={datasourceType}
       >
-        <DraggableOptionControlLabel
-          savedMetric={savedMetric}
-          label={adhocMetric.label}
-          onRemove={this.onRemoveMetric}
-          onMoveLabel={onMoveLabel}
-          onDropLabel={onDropLabel}
-          index={index}
-          type={OPTION_TYPES.metric}
-          isAdhoc
-          isFunction
-        />
+        <Tooltip
+          placement="top"
+          title={savedMetric.expression || adhocMetric.label}
+        >
+          <DraggableOptionControlLabel
+            savedMetric={savedMetric}
+            label={adhocMetric.label}
+            onRemove={this.onRemoveMetric}
+            onMoveLabel={onMoveLabel}
+            onDropLabel={onDropLabel}
+            index={index}
+            type={OPTION_TYPES.metric}
+            isAdhoc
+            isFunction
+          />
+        </Tooltip>
       </AdhocMetricPopoverTrigger>
     );
   }

--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -60,6 +60,9 @@ const Label = styled.div`
   svg {
     margin-right: ${({ theme }) => theme.gridUnit}px;
   }
+  .option-label {
+    display: inline;
+  }
 `;
 
 const CaretContainer = styled.div`


### PR DESCRIPTION
### SUMMARY
fix: #12363
- allow the long metric name to be displayed in the pill
- allow the long metric name to be displayed in the dropdown menu

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Pasted_Image_2021_1_9__10_03_PM](https://user-images.githubusercontent.com/2016594/104093628-a595eb00-52c6-11eb-9c69-be2f3101e57d.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Manual test on my local browser.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
