### PR TITLE
fix(explore): flaky Change dataset modal 

### DIFF
--- a/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/datasource/ChangeDatasourceModal.tsx
@@ -118,20 +118,24 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
     setConfirmedDataset(datasource);
   }, []);
 
-  useDebouncedEffect(() => {
-    if (filter) {
-      fetchData({
-        ...emptyRequest,
-        filters: [
-          {
-            id: 'table_name',
-            operator: 'ct',
-            value: filter,
-          },
-        ],
-      });
-    }
-  }, 1000);
+  useDebouncedEffect(
+    () => {
+      if (filter) {
+        fetchData({
+          ...emptyRequest,
+          filters: [
+            {
+              id: 'table_name',
+              operator: 'ct',
+              value: filter,
+            },
+          ],
+        });
+      }
+    },
+    1000,
+    [filter],
+  );
 
   useEffect(() => {
     const onEnterModal = async () => {

--- a/superset-frontend/src/explore/exploreUtils.js
+++ b/superset-frontend/src/explore/exploreUtils.js
@@ -288,8 +288,9 @@ export const exploreChart = formData => {
   postForm(url, formData);
 };
 
-export const useDebouncedEffect = (effect, delay) => {
-  const callback = useCallback(effect, [effect]);
+export const useDebouncedEffect = (effect, delay, deps) => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const callback = useCallback(effect, deps);
 
   useEffect(() => {
     const handler = setTimeout(() => {


### PR DESCRIPTION
### SUMMARY
Closes #12389 

The debounce effect was retriggered all the time causing the fetch to be called in an infinite loop.
### BEFORE
![ezgif-3-1f57266d4bcb](https://user-images.githubusercontent.com/67837651/104106462-e3652600-526a-11eb-8381-cde185f62ec7.gif)

### AFTER
![First-Time-Developer-Commute-Time](https://user-images.githubusercontent.com/60598000/104106190-47f8a300-52b4-11eb-97a6-8f07e2e2c96b.gif)


### TEST PLAN
1. Open a chart
2. Change the dataset
3. Search for a dataset
4. Make sure the search does not retrigger all the time

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12389 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
