### PR TITLE
chore: Fix typo “Rest” to “Reset”

### DIFF
--- a/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/AdhocMetricEditPopover.jsx
@@ -67,7 +67,7 @@ export default class AdhocMetricEditPopover extends React.Component {
   constructor(props) {
     super(props);
     this.onSave = this.onSave.bind(this);
-    this.onRestStateAndClose = this.onRestStateAndClose.bind(this);
+    this.onResetStateAndClose = this.onResetStateAndClose.bind(this);
     this.onColumnChange = this.onColumnChange.bind(this);
     this.onAggregateChange = this.onAggregateChange.bind(this);
     this.onSavedMetricChange = this.onSavedMetricChange.bind(this);
@@ -118,7 +118,7 @@ export default class AdhocMetricEditPopover extends React.Component {
     this.props.onClose();
   }
 
-  onRestStateAndClose() {
+  onResetStateAndClose() {
     this.setState(
       {
         adhocMetric: this.props.adhocMetric,
@@ -401,7 +401,7 @@ export default class AdhocMetricEditPopover extends React.Component {
         <div>
           <Button
             buttonSize="small"
-            onClick={this.onRestStateAndClose}
+            onClick={this.onResetStateAndClose}
             data-test="AdhocMetricEdit#cancel"
             cta
           >


### PR DESCRIPTION
### SUMMARY
this PR is to fix small typo from 'onRestStateAndClose' to 'onResetStateAndClose' 🤦🏾‍♀️

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
NA
### TEST PLAN
NA

### ADDITIONAL INFORMATION
- [ ] Has associated issue: 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
