### PR TITLE
feat(explore): add tooltip to timepicker label

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterControl.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterControl.tsx
@@ -209,13 +209,12 @@ export default function DateFilterControl(props: DateFilterLabelProps) {
           valueToLower.startsWith('previous')
         ) {
           setActualTimeRange(value);
-          setValidTimeRange(true);
           setTooltipTitle(actualRange || '');
         } else {
           setActualTimeRange(actualRange || '');
-          setValidTimeRange(true);
           setTooltipTitle(value || '');
         }
+        setValidTimeRange(true);
       }
     });
   }, [value]);

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterControl.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterControl.tsx
@@ -37,6 +37,7 @@ import Popover from 'src/common/components/Popover';
 import { Divider } from 'src/common/components';
 import Icon from 'src/components/Icon';
 import { Select } from 'src/components/Select';
+import { Tooltip } from 'src/common/components/Tooltip';
 import { SelectOptionType, FrameType } from './types';
 import {
   COMMON_RANGE_VALUES_SET,
@@ -181,27 +182,42 @@ export default function DateFilterControl(props: DateFilterLabelProps) {
   const [timeRangeValue, setTimeRangeValue] = useState(value);
   const [validTimeRange, setValidTimeRange] = useState<boolean>(false);
   const [evalResponse, setEvalResponse] = useState<string>(value);
+  const [tooltipTitle, setTooltipTitle] = useState<string>(value);
 
   useEffect(() => {
-    const valueToLower = value.toLowerCase();
-    if (
-      valueToLower.startsWith('last') ||
-      valueToLower.startsWith('next') ||
-      valueToLower.startsWith('previous')
-    ) {
-      setActualTimeRange(value);
-      setValidTimeRange(true);
-    } else {
-      fetchTimeRange(value, endpoints).then(({ value, error }) => {
-        if (error) {
-          setEvalResponse(error || '');
-          setValidTimeRange(false);
-        } else {
-          setActualTimeRange(value || '');
+    fetchTimeRange(value, endpoints).then(({ value: actualRange, error }) => {
+      if (error) {
+        setEvalResponse(error || '');
+        setValidTimeRange(false);
+        setTooltipTitle(value || '');
+      } else {
+        /*
+          HRT == human readable text
+          ADR == actual datetime range
+          +--------------+------+----------+--------+----------+-----------+
+          |              | Last | Previous | Custom | Advanced | No Filter |
+          +--------------+------+----------+--------+----------+-----------+
+          | control pill | HRT  | HRT      | ADR    | ADR      |   ADR     |
+          +--------------+------+----------+--------+----------+-----------+
+          | tooltip      | ADR  | ADR      | HRT    | HRT      |   HRT     |
+          +--------------+------+----------+--------+----------+-----------+
+        */
+        const valueToLower = value.toLowerCase();
+        if (
+          valueToLower.startsWith('last') ||
+          valueToLower.startsWith('next') ||
+          valueToLower.startsWith('previous')
+        ) {
+          setActualTimeRange(value);
           setValidTimeRange(true);
+          setTooltipTitle(actualRange || '');
+        } else {
+          setActualTimeRange(actualRange || '');
+          setValidTimeRange(true);
+          setTooltipTitle(value || '');
         }
-      });
-    }
+      }
+    });
   }, [value]);
 
   useEffect(() => {
@@ -327,13 +343,15 @@ export default function DateFilterControl(props: DateFilterLabelProps) {
         onVisibleChange={togglePopover}
         overlayStyle={overlayStyle}
       >
-        <Label
-          className="pointer"
-          data-test="time-range-trigger"
-          onClick={() => setShow(true)}
-        >
-          {actualTimeRange}
-        </Label>
+        <Tooltip placement="top" title={tooltipTitle}>
+          <Label
+            className="pointer"
+            data-test="time-range-trigger"
+            onClick={() => setShow(true)}
+          >
+            {actualTimeRange}
+          </Label>
+        </Tooltip>
       </StyledPopover>
     </>
   );


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The user should get both human readable text and actual datetime range, so Add tooltip to timepicker control pill

          HRT == human readable text
          ADR == actual datetime range
          +--------------+------+----------+--------+----------+-----------+
          |              | Last | Previous | Custom | Advanced | No Filter |
          +--------------+------+----------+--------+----------+-----------+
          | control pill | HRT  | HRT      | ADR    | ADR      |   ADR     |
          +--------------+------+----------+--------+----------+-----------+
          | tooltip      | ADR  | ADR      | HRT    | HRT      |   HRT     |
          +--------------+------+----------+--------+----------+-----------+

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

1. last / previous frame
![image](https://user-images.githubusercontent.com/2016594/104125265-954a4280-5390-11eb-91cf-2190217a4167.png)

2. custom / Advanced / no filter frame
![image](https://user-images.githubusercontent.com/2016594/104125283-b743c500-5390-11eb-96b1-4e165ca3cd8a.png)

### TEST PLAN
tested in my local browser

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
