### PR TITLE
fix(explore): Prevent duplicated query by data table

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane.tsx
@@ -73,16 +73,21 @@ export const DataTablesPane = ({
   queryFormData,
   tableSectionHeight,
   onCollapseChange,
+  chartStatus,
 }: {
   queryFormData: Record<string, any>;
   tableSectionHeight: number;
   onCollapseChange: (openPanelName: string) => void;
+  chartStatus: string;
 }) => {
   const [data, setData] = useState<{
     [RESULT_TYPES.results]?: Record<string, any>[];
     [RESULT_TYPES.samples]?: Record<string, any>[];
   }>(NULLISH_RESULTS_STATE);
-  const [isLoading, setIsLoading] = useState(NULLISH_RESULTS_STATE);
+  const [isLoading, setIsLoading] = useState({
+    [RESULT_TYPES.results]: true,
+    [RESULT_TYPES.samples]: true,
+  });
   const [error, setError] = useState(NULLISH_RESULTS_STATE);
   const [filterText, setFilterText] = useState('');
   const [activeTabKey, setActiveTabKey] = useState<string>(
@@ -150,11 +155,18 @@ export const DataTablesPane = ({
 
   useEffect(() => {
     if (panelOpen && isRequestPending[RESULT_TYPES.results]) {
-      setIsRequestPending(prevState => ({
-        ...prevState,
-        [RESULT_TYPES.results]: false,
-      }));
-      getData(RESULT_TYPES.results);
+      if (chartStatus === 'loading') {
+        setIsLoading(prevIsLoading => ({
+          ...prevIsLoading,
+          [RESULT_TYPES.results]: true,
+        }));
+      } else {
+        setIsRequestPending(prevState => ({
+          ...prevState,
+          [RESULT_TYPES.results]: false,
+        }));
+        getData(RESULT_TYPES.results);
+      }
     }
     if (
       panelOpen &&
@@ -167,7 +179,7 @@ export const DataTablesPane = ({
       }));
       getData(RESULT_TYPES.samples);
     }
-  }, [panelOpen, isRequestPending, getData, activeTabKey]);
+  }, [panelOpen, isRequestPending, getData, activeTabKey, chartStatus]);
 
   const filteredData = {
     [RESULT_TYPES.results]: useFilteredTableData(

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -248,6 +248,7 @@ const ExploreChartPanel = props => {
             queryFormData={props.chart.latestQueryFormData}
             tableSectionHeight={tableSectionHeight}
             onCollapseChange={onCollapseChange}
+            chartStatus={props.chart.chartStatus}
           />
         </Split>
       )}


### PR DESCRIPTION
### SUMMARY
In Explore view, right now we have chart section and data table. Chart and results table are from different API response, but they actually are generated from same query and same data frame.

In airbnb Presto resources are limited. If query engine detects a same user running the same query in the multiple requests, query engine will drop one of the duplicated queries. This rule might impact the explore view user: when chart is loading, if user open data table, Explore will send another request to query engine, which is actually the same query. As the result, one of query request will be dropped and error returned.

This PR will try to fix this issue by delaying the results table request:
- When chart is still loading, if user clicks on data, Explore will show a spinner, but won't trigger new request
- When chart is done loading and results panel is open, Explore will trigger 2nd request (with `results=true` parameter). At this moment, query's results data is cached, so the 2nd request won't reach query engine, and return cached results data to frontend. 

Even this issue probably only happens in airbnb not other companies, it is a good practice that should never send duplicated queries to engine. And since the deferred request always have cached results, it should only take ~1 second for roundtrip.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**: when user open results table while chart loading, Explore view sends 2 queries at the same time:
![7Jek16ZC1K](https://user-images.githubusercontent.com/27990562/104144720-447b1f80-5379-11eb-845a-30ad6621b762.gif)

**After**: when user open results table while chart loading, Explore view will show spinner but not sending another request. But once the chart request is completed, data request will be triggered:
![dbxXDoH8Ox](https://user-images.githubusercontent.com/27990562/104149435-f707ae00-538a-11eb-8482-5dd41a110c33.gif)



### TEST PLAN
1. open explore view with a slow query
2. when chart is loading, open data table, just see results tab
3. check browser console, check how many requests running at the same time


cc @ktmud @zuzana-vej @junlincc @zhaoyongjie @kgabryje 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
