### PR TITLE
fix(dashboard): Refresh Interval Modal dropdown

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/RefreshIntervalModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/RefreshIntervalModal_spec.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import ModalTrigger from 'src/components/ModalTrigger';
 import RefreshIntervalModal from 'src/dashboard/components/RefreshIntervalModal';
@@ -66,11 +66,15 @@ describe('RefreshIntervalModal', () => {
       refreshWarning: 'Show warning',
     };
 
-    const wrapper = shallow(<RefreshIntervalModal {...props} />);
+    const wrapper = getMountWrapper(props);
+    wrapper.find('span[role="button"]').simulate('click');
+
     wrapper.instance().handleFrequencyChange({ value: 30 });
-    expect(wrapper.find(ModalTrigger).dive().find(Alert)).toExist();
+    wrapper.update();
+    expect(wrapper.find(ModalTrigger).find(Alert)).toExist();
 
     wrapper.instance().handleFrequencyChange({ value: 3601 });
-    expect(wrapper.find(ModalTrigger).dive().find(Alert)).not.toExist();
+    wrapper.update();
+    expect(wrapper.find(ModalTrigger).find(Alert)).not.toExist();
   });
 });

--- a/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
+++ b/superset-frontend/src/dashboard/components/RefreshIntervalModal.tsx
@@ -38,6 +38,12 @@ export const options = [
   [86400, t('24 hours')],
 ].map(o => ({ value: o[0], label: o[1] }));
 
+const StyledModalTrigger = styled(ModalTrigger)`
+  .ant-modal-body {
+    overflow: visible;
+  }
+`;
+
 const RefreshWarningContainer = styled.div`
   margin-top: ${({ theme }) => theme.gridUnit * 6}px;
 `;
@@ -103,7 +109,7 @@ class RefreshIntervalModal extends React.PureComponent<
       !!refreshFrequency && !!refreshWarning && refreshFrequency < refreshLimit;
 
     return (
-      <ModalTrigger
+      <StyledModalTrigger
         ref={this.modalRef}
         triggerNode={this.props.triggerNode}
         modalTitle={t('Refresh Interval')}


### PR DESCRIPTION
### SUMMARY
In Refresh Interval modal, dropdown overflow was hidden.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1166" alt="refresh_interval_dropdown_before" src="https://user-images.githubusercontent.com/47450693/104175040-f7de2580-5406-11eb-9ac8-5f5970008e16.png">

After:
<img width="1112" alt="refresh_interval_dropdown_after" src="https://user-images.githubusercontent.com/47450693/104175119-fca2d980-5406-11eb-96ca-4697bc77328b.png">

### TEST PLAN
Go to Dashboards and choose one. Click More button ( "3 dots" on the right) and choose _Set auto-refresh interval_. You will see Refresh Interval Modal. Please check if you can see all of the Refresh frequency options and choose them easily.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #12310
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @junlincc @rusackas @adam-stasiak 