### PR TITLE
fix(native-filters): incorrect queriesData state

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -19101,16 +19101,6 @@
         }
       }
     },
-    "@superset-ui/plugin-filter-antd": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/@superset-ui/plugin-filter-antd/-/plugin-filter-antd-0.16.4.tgz",
-      "integrity": "sha512-c1EZZukUvppeb7gYL4h69Jscz+BdLQJNqx/EbIJM865zfuO1EdZXVR5tYs2LNpPKvNNh8SRO+f+fS485gWcN0A==",
-      "requires": {
-        "@superset-ui/chart-controls": "0.16.4",
-        "@superset-ui/core": "0.16.4",
-        "antd": "^4.9.1"
-      }
-    },
     "@superset-ui/preset-chart-xy": {
       "version": "0.16.4",
       "resolved": "https://registry.npmjs.org/@superset-ui/preset-chart-xy/-/preset-chart-xy-0.16.4.tgz",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -92,7 +92,6 @@
     "@superset-ui/plugin-chart-echarts": "^0.16.4",
     "@superset-ui/plugin-chart-table": "^0.16.4",
     "@superset-ui/plugin-chart-word-cloud": "^0.16.4",
-    "@superset-ui/plugin-filter-antd": "^0.16.4",
     "@superset-ui/preset-chart-xy": "^0.16.4",
     "@vx/responsive": "^0.0.195",
     "abortcontroller-polyfill": "^1.1.9",

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -276,7 +276,7 @@ const FilterValue: React.FC<FilterProps> = ({
           height={20}
           width={220}
           formData={getFormData()}
-          queriesData={[state]}
+          queriesData={state}
           chartType="filter_select"
           hooks={{ setExtraFormData }}
         />


### PR DESCRIPTION
### SUMMARY
The migration of native filters from `superset-ui` to main repo in #12154 introduced an error when implementing support for multi-query results. Also removing dependency on now deprecated `@superset-ui/plugin-filter-antd` package (now in main `superset` repo).

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
