### PR TITLE
fix: uneven list header padding (#12029)

### DIFF
--- a/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
+++ b/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
@@ -52,6 +52,7 @@ export const Table = styled.table`
     background: ${({ theme }) => theme.colors.grayscale.light5};
     position: sticky;
     top: 0;
+
     &:first-of-type {
       padding-left: ${({ theme }) => theme.gridUnit * 4}px;
     }
@@ -77,11 +78,14 @@ export const Table = styled.table`
 
     span {
       white-space: nowrap;
+      display: flex;
+      align-items: center;
+      line-height: 2;
     }
 
     svg {
       display: inline-block;
-      top: 6px;
+      top: 2px;
       position: relative;
     }
   }


### PR DESCRIPTION
### SUMMARY
Adjust list header padding.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1118" alt="Screen Shot 2021-01-11 at 11 58 16 AM" src="https://user-images.githubusercontent.com/70410625/104216234-8ad38b80-5418-11eb-9ca7-65cd87024a36.png">
<img width="1113" alt="Screen Shot 2021-01-11 at 2 21 52 PM" src="https://user-images.githubusercontent.com/70410625/104216252-91620300-5418-11eb-98d2-0b867205a049.png">

Closes #12029 

@junlincc 

### TEST PLAN
1 - Go to any major list (charts, dashboards, databases, etc)
2 - Check header padding

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
