### PR TITLE
chore(chart): Save modal select placeholder value

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -152,8 +152,8 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
   }
 
   render() {
-    const selectValue =
-      this.state.newDashboardName || this.state.saveToDashboardId || null;
+    const dashboardSelectValue =
+      this.state.newDashboardName || this.state.saveToDashboardId;
     return (
       <Modal
         show
@@ -249,7 +249,9 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
               creatable
               onChange={this.onDashboardSelectChange}
               autoSize={false}
-              value={selectValue ? { value: selectValue } : null}
+              value={
+                dashboardSelectValue ? { value: dashboardSelectValue } : null
+              }
               placeholder={
                 // Using markdown to allow for good i18n
                 <ReactMarkdown

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -29,7 +29,7 @@ import { connect } from 'react-redux';
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
-const SELECT_PLACEHOLDER = t('**Select** a dashboard OR **create** a new one');
+const SELECT_PLACEHOLDER = t('Select dashboard');
 
 type SaveModalProps = {
   can_overwrite?: boolean;
@@ -152,6 +152,8 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
   }
 
   render() {
+    const selectValue =
+      this.state.newDashboardName || this.state.saveToDashboardId || null;
     return (
       <Modal
         show
@@ -247,10 +249,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
               creatable
               onChange={this.onDashboardSelectChange}
               autoSize={false}
-              value={{
-                value:
-                  this.state.saveToDashboardId || this.state.newDashboardName,
-              }}
+              value={selectValue ? { value: selectValue } : null}
               placeholder={
                 // Using markdown to allow for good i18n
                 <ReactMarkdown

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -29,7 +29,7 @@ import { connect } from 'react-redux';
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
-const SELECT_PLACEHOLDER = t('Select dashboard');
+const SELECT_PLACEHOLDER = t('**Select** a dashboard OR **create** a new one');
 
 type SaveModalProps = {
   can_overwrite?: boolean;
@@ -153,7 +153,10 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
 
   render() {
     const dashboardSelectValue =
-      this.state.newDashboardName || this.state.saveToDashboardId;
+      this.state.saveToDashboardId || this.state.newDashboardName;
+    const valueObj = dashboardSelectValue
+      ? { value: dashboardSelectValue }
+      : null;
     return (
       <Modal
         show
@@ -244,14 +247,13 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
             <CreatableSelect
               id="dashboard-creatable-select"
               className="save-modal-selector"
+              menuPosition="fixed"
               options={this.props.dashboards}
               clearable
               creatable
               onChange={this.onDashboardSelectChange}
               autoSize={false}
-              value={
-                dashboardSelectValue ? { value: dashboardSelectValue } : null
-              }
+              value={valueObj}
               placeholder={
                 // Using markdown to allow for good i18n
                 <ReactMarkdown


### PR DESCRIPTION
### SUMMARY
Fix SaveModal dashboard select placeholder value and clear button.
https://github.com/apache/superset/issues/12366

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![104073894-b578d680-51c3-11eb-81c3-d2714db4bef6](https://user-images.githubusercontent.com/26679866/104220221-748cf600-543f-11eb-83b6-1a3a12ba7db3.png)
After:
![Screenshot 2021-01-11 at 19 02 48](https://user-images.githubusercontent.com/26679866/104220362-abfba280-543f-11eb-91c2-27e14e3f19bd.png)

### TEST PLAN
1. **Open** or **create** any chart
2. Click on **Save** button to save the chart

**Expected result**: Under **ADD TO DASHBOARD** label, select dropdown should have a placeholder text with no clear button. If the value is selected, the value should be displayed instead of placeholder and clear button should appear.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
