### PR TITLE
fix(explore): preserve metric column order in bar chart

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -162,7 +162,7 @@ class BaseViz:
         return self._force_cached
 
     def process_metrics(self) -> None:
-        # metrics in TableViz is order sensitive, so metric_dict should be
+        # metrics in Viz is order sensitive, so metric_dict should be
         # OrderedDict
         self.metric_dict = OrderedDict()
         fd = self.form_data
@@ -1671,6 +1671,9 @@ class DistributionBarViz(BaseViz):
             pt = pt.T
             pt = (pt / pt.sum()).T
         pt = pt.reindex(row.index)
+
+        # Re-order the columns adhering to the metric ordering.
+        pt = pt[metrics]
         chart_data = []
         for name, ys in pt.items():
             if pt[name].dtype.kind not in "biufc" or name in self.groupby:

--- a/superset/viz_sip38.py
+++ b/superset/viz_sip38.py
@@ -1629,6 +1629,10 @@ class DistributionBarViz(DistributionPieViz):
             pt = pt.T
             pt = (pt / pt.sum()).T
         pt = pt.reindex(row.index)
+
+        # Re-order the columns adhering to the metric ordering.
+        pt = pt[metrics]
+
         chart_data = []
         for name, ys in pt.items():
             if pt[name].dtype.kind not in "biufc" or name in groupby:

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -79,10 +79,10 @@ class TestBaseViz(SupersetTestCase):
         datasource.type = "table"
         test_viz = viz.BaseViz(datasource, form_data)
         expect_metric_labels = [
-            u"sum__SP_POP_TOTL",
-            u"SUM(SE_PRM_NENR_MA)",
-            u"SUM(SP_URB_TOTL)",
-            u"count",
+            "sum__SP_POP_TOTL",
+            "SUM(SE_PRM_NENR_MA)",
+            "SUM(SP_URB_TOTL)",
+            "count",
         ]
         self.assertEqual(test_viz.metric_labels, expect_metric_labels)
         self.assertEqual(test_viz.all_metrics, expect_metric_labels)
@@ -500,6 +500,7 @@ class TestDistBarViz(SupersetTestCase):
             {"x": "2.0", "y": 29},
             {"x": NULL_STRING, "y": 3},
         ]
+
         self.assertEqual(expected_values, data["values"])
 
     def test_column_nulls(self):
@@ -590,7 +591,7 @@ class TestDistBarViz(SupersetTestCase):
 
         expected = [
             {
-                "key": "z_column, {}".format(NULL_STRING),
+                "key": f"z_column, {NULL_STRING}",
                 "values": [{"x": "pepperoni", "y": 2}, {"x": "cheese", "y": 1}],
             },
             {
@@ -598,7 +599,7 @@ class TestDistBarViz(SupersetTestCase):
                 "values": [{"x": "pepperoni", "y": 5}, {"x": "cheese", "y": 3}],
             },
             {
-                "key": "votes, {}".format(NULL_STRING),
+                "key": f"votes, {NULL_STRING}",
                 "values": [{"x": "pepperoni", "y": 2}, {"x": "cheese", "y": 1}],
             },
             {
@@ -606,7 +607,7 @@ class TestDistBarViz(SupersetTestCase):
                 "values": [{"x": "pepperoni", "y": 5}, {"x": "cheese", "y": 3}],
             },
             {
-                "key": "a_column, {}".format(NULL_STRING),
+                "key": f"a_column, {NULL_STRING}",
                 "values": [{"x": "pepperoni", "y": 2}, {"x": "cheese", "y": 1}],
             },
             {
@@ -1265,18 +1266,18 @@ class TestTimeSeriesViz(SupersetTestCase):
         viz_data = test_viz.get_data(df)
         expected = [
             {
-                u"values": [
-                    {u"y": 4, u"x": u"2018-02-20T00:00:00"},
-                    {u"y": 4, u"x": u"2018-03-09T00:00:00"},
+                "values": [
+                    {"y": 4, "x": "2018-02-20T00:00:00"},
+                    {"y": 4, "x": "2018-03-09T00:00:00"},
                 ],
-                u"key": (u"Real Madrid Basket",),
+                "key": ("Real Madrid Basket",),
             },
             {
-                u"values": [
-                    {u"y": 2, u"x": u"2018-02-20T00:00:00"},
-                    {u"y": 2, u"x": u"2018-03-09T00:00:00"},
+                "values": [
+                    {"y": 2, "x": "2018-02-20T00:00:00"},
+                    {"y": 2, "x": "2018-03-09T00:00:00"},
                 ],
-                u"key": (u"Real Madrid C.F.\U0001f1fa\U0001f1f8\U0001f1ec\U0001f1e7",),
+                "key": ("Real Madrid C.F.\U0001f1fa\U0001f1f8\U0001f1ec\U0001f1e7",),
             },
         ]
         self.assertEqual(expected, viz_data)

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -531,6 +531,92 @@ class TestDistBarViz(SupersetTestCase):
         ]
         self.assertEqual(expected, data)
 
+    def test_column_metrics_in_order(self):
+        form_data = {
+            "metrics": ["z_column", "votes", "a_column"],
+            "adhoc_filters": [],
+            "groupby": ["toppings"],
+            "columns": [],
+        }
+        datasource = self.get_datasource_mock()
+        df = pd.DataFrame(
+            {
+                "toppings": ["cheese", "pepperoni", "cheese", "pepperoni"],
+                "role": ["engineer", "engineer", None, None],
+                "votes": [3, 5, 1, 2],
+                "a_column": [3, 5, 1, 2],
+                "z_column": [3, 5, 1, 2],
+            }
+        )
+        test_viz = viz.DistributionBarViz(datasource, form_data)
+        data = test_viz.get_data(df)
+
+        expected = [
+            {
+                "key": "z_column",
+                "values": [{"x": "pepperoni", "y": 3.5}, {"x": "cheese", "y": 2.0}],
+            },
+            {
+                "key": "votes",
+                "values": [{"x": "pepperoni", "y": 3.5}, {"x": "cheese", "y": 2.0}],
+            },
+            {
+                "key": "a_column",
+                "values": [{"x": "pepperoni", "y": 3.5}, {"x": "cheese", "y": 2.0}],
+            },
+        ]
+
+        self.assertEqual(expected, data)
+
+    def test_column_metrics_in_order_with_breakdowns(self):
+        form_data = {
+            "metrics": ["z_column", "votes", "a_column"],
+            "adhoc_filters": [],
+            "groupby": ["toppings"],
+            "columns": ["role"],
+        }
+        datasource = self.get_datasource_mock()
+        df = pd.DataFrame(
+            {
+                "toppings": ["cheese", "pepperoni", "cheese", "pepperoni"],
+                "role": ["engineer", "engineer", None, None],
+                "votes": [3, 5, 1, 2],
+                "a_column": [3, 5, 1, 2],
+                "z_column": [3, 5, 1, 2],
+            }
+        )
+        test_viz = viz.DistributionBarViz(datasource, form_data)
+        data = test_viz.get_data(df)
+
+        expected = [
+            {
+                "key": "z_column, {}".format(NULL_STRING),
+                "values": [{"x": "pepperoni", "y": 2}, {"x": "cheese", "y": 1}],
+            },
+            {
+                "key": "z_column, engineer",
+                "values": [{"x": "pepperoni", "y": 5}, {"x": "cheese", "y": 3}],
+            },
+            {
+                "key": "votes, {}".format(NULL_STRING),
+                "values": [{"x": "pepperoni", "y": 2}, {"x": "cheese", "y": 1}],
+            },
+            {
+                "key": "votes, engineer",
+                "values": [{"x": "pepperoni", "y": 5}, {"x": "cheese", "y": 3}],
+            },
+            {
+                "key": "a_column, {}".format(NULL_STRING),
+                "values": [{"x": "pepperoni", "y": 2}, {"x": "cheese", "y": 1}],
+            },
+            {
+                "key": "a_column, engineer",
+                "values": [{"x": "pepperoni", "y": 5}, {"x": "cheese", "y": 3}],
+            },
+        ]
+
+        self.assertEqual(expected, data)
+
 
 class TestPairedTTest(SupersetTestCase):
     def test_get_data_transforms_dataframe(self):


### PR DESCRIPTION
### SUMMARY
Reindex pivot table by using metric columns

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Create metrics with different name and re-order them, the column in bar chart should reflect those orders

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12416
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
