### PR TITLE
fix(dashboard): artefacts shown while drag and dropping deck.gl charts

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/dnd.less
+++ b/superset-frontend/src/dashboard/stylesheets/dnd.less
@@ -27,7 +27,6 @@
   }
 }
 
-
 .dragdroppable--dragging {
   opacity: 0.2;
 }

--- a/superset-frontend/src/dashboard/stylesheets/dnd.less
+++ b/superset-frontend/src/dashboard/stylesheets/dnd.less
@@ -20,6 +20,14 @@
   position: relative;
 }
 
+// Fixes ISSUE-12181 - before in chart's contract-trigger breaks drag and drop mode
+.dashboard--editing {
+  .contract-trigger:before {
+    display: none;
+  }
+}
+
+
 .dragdroppable--dragging {
   opacity: 0.2;
 }


### PR DESCRIPTION
### SUMMARY
Disables `:before` in charts while drag'n'drop which caused artefacts in chart preview.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
![Large GIF (1298x860)](https://user-images.githubusercontent.com/2536609/104224861-d5b7c800-5445-11eb-996d-bdbaaf4de0b0.gif)

After
![Large GIF (1300x860)](https://user-images.githubusercontent.com/2536609/104224367-2e3a9580-5445-11eb-9948-4628b583f26e.gif)


### TEST PLAN
1. Go to deck.gl dashboard
2. Go to edit mode
3. Try drag and drop one of charts

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
Fixes #12181 
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
