### PR TITLE
fix: incorrect cursor position Firefox

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -378,9 +378,9 @@ div.tablePopover {
   //double class is better than !important
   border: 1px solid @gray-light;
   font-feature-settings: @font-feature-settings;
-  // Fire Code causes problem with Ace under Firefox
-  font-family: 'Menlo', 'Courier New', 'Ubuntu Mono', 'Consolas',
-    'source-code-pro', monospace;
+  // Fira Code causes problem with Ace under Firefox
+  font-family: 'Menlo', 'Lucida Console', 'Courier New', 'Ubuntu Mono',
+    'Consolas', 'source-code-pro', monospace;
 
   &.ace_autocomplete {
     // Use !important because Ace Editor applies extra CSS at the last second

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -208,6 +208,10 @@ div.Workspace {
   .ace_content {
     height: 100%;
   }
+
+  .ace_editor * {
+    font: inherit!important;
+  }
 }
 
 .SqlEditorTabs li {

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -379,7 +379,8 @@ div.tablePopover {
   border: 1px solid @gray-light;
   font-feature-settings: @font-feature-settings;
   // Fire Code causes problem with Ace under Firefox
-  font-family: 'Menlo', 'Courier New', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+  font-family: 'Menlo', 'Courier New', 'Ubuntu Mono', 'Consolas',
+    'source-code-pro', monospace;
 
   &.ace_autocomplete {
     // Use !important because Ace Editor applies extra CSS at the last second

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -208,10 +208,6 @@ div.Workspace {
   .ace_content {
     height: 100%;
   }
-
-  .ace_editor * {
-    font: inherit!important;
-  }
 }
 
 .SqlEditorTabs li {
@@ -382,7 +378,8 @@ div.tablePopover {
   //double class is better than !important
   border: 1px solid @gray-light;
   font-feature-settings: @font-feature-settings;
-  font-family: @font-family-monospace;
+  // Fire Code causes problem with Ace under Firefox
+  font-family: 'Menlo', 'Courier New', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 
   &.ace_autocomplete {
     // Use !important because Ace Editor applies extra CSS at the last second


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When using SQL Lab in Firefox, the position of the cursor will drift to the left progressively along the row. As the cursor moves to the right, it's shifted more and more to the left, to a point where it shows up in the incorrect position.

This seems to be a known bug: https://stackoverflow.com/questions/20931029/ace-editor-monospace-fonts-issues-with-cursor-spacing

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Here's a query in Firefox, with the cursor moved to the end of the line:

![Screenshot_2021-01-11 Superset(1)](https://user-images.githubusercontent.com/1534870/104246558-15b58580-541b-11eb-8307-b27f8ae84aa7.png)

Note how it looks like the cursor is to the left of the semi-colon — **it's not**, and if the user presses <kbd>delete</kbd> the semi-colon will be deleted instead!

Here's the same query with this fix:

![Screenshot_2021-01-11 Superset](https://user-images.githubusercontent.com/1534870/104246614-2f56cd00-541b-11eb-9d6e-6274e8ab6727.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
