### PR TITLE
fix: import ZIP files that have been modified

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -63,7 +63,7 @@ from superset.charts.schemas import (
     thumbnail_query_schema,
 )
 from superset.commands.exceptions import CommandInvalidError
-from superset.commands.importers.v1.utils import remove_root
+from superset.commands.importers.v1.utils import is_valid_config, remove_root
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import event_logger
@@ -976,6 +976,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             contents = {
                 remove_root(file_name): bundle.read(file_name).decode()
                 for file_name in bundle.namelist()
+                if is_valid_config(file_name)
             }
 
         passwords = (

--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -73,3 +73,17 @@ def load_metadata(contents: Dict[str, str]) -> Dict[str, str]:
         raise exc
 
     return metadata
+
+
+def is_valid_config(file_name: str) -> bool:
+    path = Path(file_name)
+
+    # ignore system files that might've been added to the bundle
+    if path.name.startswith(".") or path.name.startswith("_"):
+        return False
+
+    # ensure extension is YAML
+    if path.suffix.lower() not in {".yaml", ".yml"}:
+        return False
+
+    return True

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -17,6 +17,7 @@
 # pylint: disable=no-self-use
 
 from superset.commands.exceptions import CommandInvalidError
+from superset.commands.importers.v1.utils import is_valid_config
 from tests.base_tests import SupersetTestCase
 
 
@@ -24,3 +25,13 @@ class TestCommandsExceptions(SupersetTestCase):
     def test_command_invalid_error(self):
         exception = CommandInvalidError("A test")
         assert str(exception) == "A test"
+
+
+class TestImportersV1Utils(SupersetTestCase):
+    def test_is_valid_config(self):
+        assert is_valid_config("metadata.yaml")
+        assert is_valid_config("databases/examples.yaml")
+        assert not is_valid_config(".DS_Store")
+        assert not is_valid_config(
+            "__MACOSX/chart_export_20210111T145253/databases/._examples.yaml"
+        )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If the user modifies the ZIP file from an exported object, Mac OS will add system files to the ZIP, breaking the import.

This PR makes the import mechanism ignore those system files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

1. Exported chart
2. Unzipped file and modified chart YAML
3. Compressed directory into a new ZIP file
4. Import fails; with this PR it succeeds.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
