### PR TITLE
fix(explore): fixed table header in chrome

### DIFF
--- a/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
+++ b/superset-frontend/src/components/dataViewCommon/TableCollection.tsx
@@ -37,7 +37,6 @@ export const Table = styled.table`
   background-color: ${({ theme }) => theme.colors.grayscale.light5};
   border-collapse: separate;
   border-radius: ${({ theme }) => theme.borderRadius}px;
-  overflow: hidden;
 
   thead > tr > th {
     border: 0;


### PR DESCRIPTION
### SUMMARY
this pr is to FIX table header in Explore Data section
closes [#12430](https://github.com/apache/superset/issues/12430)

### BEFORE
![ezgif-7-7d0019f43dd3](https://user-images.githubusercontent.com/67837651/104090615-c447a380-522c-11eb-9375-aaab8cc21437.gif)

### AFTER 
![ezgif-3-59346b87046c](https://user-images.githubusercontent.com/67837651/104262963-81a8e580-543d-11eb-910f-7aa39f1c3e92.gif)

cc @kgabryje @ktmud 

### TEST PLAN
1. open Explore in Chrome
2. use wb_health_population as the dataset
3. open Data section 
4. see both tables scroll with header fixed! 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: [#12430](https://github.com/apache/superset/issues/12430)
- [x ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
