### PR TITLE
fix(releasing): svn dockerfile requirements path

### DIFF
--- a/RELEASING/Dockerfile.from_svn_tarball
+++ b/RELEASING/Dockerfile.from_svn_tarball
@@ -56,7 +56,7 @@ RUN cd superset-frontend \
 
 WORKDIR /home/superset/apache-superset-$VERSION
 RUN pip install --upgrade setuptools pip \
-    && pip install -r requirements.txt \
+    && pip install -r requirements/base.txt \
     && pip install --no-cache-dir .
 
 RUN flask fab babel-compile --target superset/translations


### PR DESCRIPTION
### SUMMARY
The dockerfile for testing the SVN build is referencing the old `requirements.txt` path. This fixes that.

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
