### PR TITLE
fix(native-filters): Setting default value

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
@@ -99,6 +99,7 @@ export function DefaultValueSelect({
       loadOptions={loadOptions}
       defaultOptions // load options on render
       cacheOptions
+      isClearable
     />
   );
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { FormInstance } from 'antd/lib/form';
 import { useChangeEffect } from 'src/common/hooks/useChangeEffect';
 import { AsyncSelect } from 'src/components/Select';
@@ -67,12 +67,6 @@ export function DefaultValueSelect({
       resetFieldValue();
     }
   });
-
-  useEffect(() => {
-    if (datasetId == null || column == null) {
-      resetFieldValue();
-    }
-  }, [datasetId, column, resetFieldValue]);
 
   async function loadOptions() {
     if (datasetId == null || !column) return [];

--- a/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { FormInstance } from 'antd/lib/form';
 import { useChangeEffect } from 'src/common/hooks/useChangeEffect';
 import { AsyncSelect } from 'src/components/Select';
@@ -67,6 +67,12 @@ export function DefaultValueSelect({
       resetFieldValue();
     }
   });
+
+  useEffect(() => {
+    if (datasetId == null || column == null) {
+      resetFieldValue();
+    }
+  }, [datasetId, column, resetFieldValue]);
 
   async function loadOptions() {
     if (datasetId == null || !column) return [];

--- a/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useCallback } from 'react';
+import { FormInstance } from 'antd/lib/form';
+import { useChangeEffect } from 'src/common/hooks/useChangeEffect';
+import { AsyncSelect } from 'src/components/Select';
+import { getChartDataRequest } from 'src/chart/chartAction';
+import { NativeFiltersForm } from './types';
+
+type SelectOption = {
+  label: string;
+  value: string;
+};
+
+interface DefaultValueSelectProps {
+  form: FormInstance<NativeFiltersForm>;
+  filterId: string;
+  datasetId?: number | null | undefined;
+  column?: SelectOption | string | null;
+  value?: SelectOption | null;
+  onChange?: (value: SelectOption | null) => void;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export function DefaultValueSelect({
+  form,
+  filterId,
+  datasetId,
+  column,
+  value,
+  onChange,
+}: DefaultValueSelectProps) {
+  const resetFieldValue = useCallback(() => {
+    form.setFields([
+      {
+        name: ['filters', filterId, 'defaultValue'],
+        touched: false,
+        value: null,
+      },
+    ]);
+  }, [form, filterId]);
+
+  useChangeEffect(datasetId, previous => {
+    if (previous != null) {
+      resetFieldValue();
+    }
+  });
+
+  useChangeEffect(column, previous => {
+    if (previous != null) {
+      resetFieldValue();
+    }
+  });
+
+  async function loadOptions() {
+    if (datasetId == null || !column) return [];
+
+    const formData = {
+      datasource: `${datasetId}__table`,
+      groupby: [column],
+      metrics: ['count'],
+      row_limit: 10000,
+      viz_type: 'filter_select',
+    };
+
+    const response = await getChartDataRequest({
+      formData,
+      force: false,
+      requestParams: { dashboardId: 0 },
+    });
+
+    return response.result[0].data.map((el: any) => el[column as string]);
+  }
+
+  return (
+    <AsyncSelect
+      // "key" prop makes react render a new instance of the select whenever the dataset changes
+      key={`${datasetId}-${column}`}
+      isDisabled={datasetId == null}
+      value={value}
+      onChange={onChange}
+      isMulti={false}
+      loadOptions={loadOptions}
+      defaultOptions // load options on render
+      cacheOptions
+    />
+  );
+}

--- a/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/DefaultValueSelect.tsx
@@ -57,13 +57,13 @@ export function DefaultValueSelect({
   }, [form, filterId]);
 
   useChangeEffect(datasetId, previous => {
-    if (previous != null) {
+    if (previous !== undefined) {
       resetFieldValue();
     }
   });
 
   useChangeEffect(column, previous => {
-    if (previous != null) {
+    if (previous !== undefined) {
       resetFieldValue();
     }
   });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -24,6 +24,7 @@ import {
   ExtraFormData,
 } from '@superset-ui/core';
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { mapValues } from 'lodash';
 import { useSelector } from 'react-redux';
 import cx from 'classnames';
 import { Form } from 'src/common/components';
@@ -39,6 +40,7 @@ import FilterConfigurationLink from './FilterConfigurationLink';
 import {
   useCascadingFilters,
   useFilterConfiguration,
+  useFiltersState,
   useSetExtraFormData,
 } from './state';
 import { Filter, CascadeFilter } from './types';
@@ -68,14 +70,18 @@ const Bar = styled.div`
   /* &.animated {
     display: flex;
     transform: translateX(-100%);
-    transition: transform ${({ theme }) => theme.transitionTiming}s;
+    transition: transform ${({
+    theme,
+  }) => theme.transitionTiming}s;
     transition-delay: 0s;
   }  */
   &.open {
     display: flex;
     /* &.animated {
       transform: translateX(0);
-      transition-delay: ${({ theme }) => theme.transitionTiming * 2}s;
+      transition-delay: ${({
+      theme,
+    }) => theme.transitionTiming * 2}s;
     } */
   }
 `;
@@ -92,7 +98,9 @@ const CollapsedBar = styled.div`
   /* &.animated {
     display: block;
     transform: translateX(-100%);
-    transition: transform ${({ theme }) => theme.transitionTiming}s;
+    transition: transform ${({
+    theme,
+  }) => theme.transitionTiming}s;
     transition-delay: 0s;
   } */
   &.open {
@@ -102,7 +110,9 @@ const CollapsedBar = styled.div`
     padding: ${({ theme }) => theme.gridUnit * 2}px;
     /* &.animated {
       transform: translateX(0);
-      transition-delay: ${({ theme }) => theme.transitionTiming * 3}s;
+      transition-delay: ${({
+      theme,
+    }) => theme.transitionTiming * 3}s;
     } */
   }
   svg {
@@ -212,7 +222,6 @@ const FilterValue: React.FC<FilterProps> = ({
     inverseSelection,
     targets,
     currentValue,
-    defaultValue,
   } = filter;
   const cascadingFilters = useCascadingFilters(id);
   const [loading, setLoading] = useState<boolean>(true);
@@ -239,7 +248,7 @@ const FilterValue: React.FC<FilterProps> = ({
     time_range_endpoints: ['inclusive', 'exclusive'],
     url_params: {},
     viz_type: 'filter_select',
-    defaultValues: currentValue || defaultValue || [],
+    defaultValues: currentValue || [],
   });
 
   useEffect(() => {
@@ -364,6 +373,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   );
   const setExtraFormData = useSetExtraFormData();
   const filterConfigs = useFilterConfiguration();
+  const filtersState = useFiltersState();
   const canEdit = useSelector<any, boolean>(
     ({ dashboardInfo }) => dashboardInfo.dash_edit_perm,
   );
@@ -373,7 +383,16 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     if (filterConfigs.length === 0 && filtersOpen) {
       toggleFiltersBar(false);
     }
+    setFilterData({});
   }, [filterConfigs]);
+
+  useEffect(() => {
+    const extraFormData = mapValues(
+      filtersState,
+      filter => filter.extraFormData || {},
+    );
+    setFilterData(filterData => ({ ...extraFormData, ...filterData }));
+  }, [filtersState]);
 
   const getFilterValue = useCallback(
     (filter: Filter): (string | number | boolean)[] | null => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -70,18 +70,14 @@ const Bar = styled.div`
   /* &.animated {
     display: flex;
     transform: translateX(-100%);
-    transition: transform ${({
-    theme,
-  }) => theme.transitionTiming}s;
+    transition: transform ${({ theme }) => theme.transitionTiming}s;
     transition-delay: 0s;
   }  */
   &.open {
     display: flex;
     /* &.animated {
       transform: translateX(0);
-      transition-delay: ${({
-      theme,
-    }) => theme.transitionTiming * 2}s;
+      transition-delay: ${({ theme }) => theme.transitionTiming * 2}s;
     } */
   }
 `;
@@ -98,9 +94,7 @@ const CollapsedBar = styled.div`
   /* &.animated {
     display: block;
     transform: translateX(-100%);
-    transition: transform ${({
-    theme,
-  }) => theme.transitionTiming}s;
+    transition: transform ${({ theme }) => theme.transitionTiming}s;
     transition-delay: 0s;
   } */
   &.open {
@@ -110,9 +104,7 @@ const CollapsedBar = styled.div`
     padding: ${({ theme }) => theme.gridUnit * 2}px;
     /* &.animated {
       transform: translateX(0);
-      transition-delay: ${({
-      theme,
-    }) => theme.transitionTiming * 3}s;
+      transition-delay: ${({ theme }) => theme.transitionTiming * 3}s;
     } */
   }
   svg {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigForm.tsx
@@ -33,6 +33,7 @@ import SupersetResourceSelect, {
 import { addDangerToast } from 'src/messageToasts/actions';
 import { ClientErrorObject } from 'src/utils/getClientErrorObject';
 import { ColumnSelect } from './ColumnSelect';
+import { DefaultValueSelect } from './DefaultValueSelect';
 import { Filter, NativeFiltersForm } from './types';
 import FilterScope from './FilterScope';
 
@@ -102,6 +103,9 @@ export const FilterConfigForm: React.FC<FilterConfigFormProps> = ({
     filterToEdit?.targets[0].datasetId
       ? { label: '', value: filterToEdit?.targets[0].datasetId }
       : undefined,
+  );
+  const [column, setColumn] = useState<Value<string> | string | null>(
+    filterToEdit?.targets[0]?.column?.name || null,
   );
 
   const onDatasetSelectError = useCallback(
@@ -177,6 +181,19 @@ export const FilterConfigForm: React.FC<FilterConfigFormProps> = ({
           form={form}
           filterId={filterId}
           datasetId={dataset?.value}
+          onChange={setColumn}
+        />
+      </StyledFormItem>
+      <StyledFormItem
+        name={['filters', filterId, 'defaultValue']}
+        label={<StyledLabel>{t('Default Value')}</StyledLabel>}
+        initialValue={filterToEdit?.defaultValue}
+      >
+        <DefaultValueSelect
+          form={form}
+          filterId={filterId}
+          datasetId={dataset?.value}
+          column={column}
         />
       </StyledFormItem>
       <StyledFormItem

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -62,6 +62,12 @@ export function useFilterConfigMap() {
   );
 }
 
+export function useFiltersState() {
+  return useSelector<any, { [id: string]: FilterState }>(
+    state => state.nativeFilters.filtersState,
+  );
+}
+
 export function useFilterState(id: string) {
   return useSelector<any, FilterState>(
     state => state.nativeFilters.filtersState[id] || getInitialFilterState(id),

--- a/superset-frontend/src/dashboard/reducers/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/reducers/nativeFilters.ts
@@ -29,22 +29,27 @@ import {
 } from 'src/dashboard/components/nativeFilters/types';
 import { getSelectExtraFormData } from 'src/filters/utils';
 
-export function getInitialFilterState(filter: Filter): FilterState {
-  let extraFormData = {};
+export function getInitialFilterState(
+  id: string,
+  extraFormData = {},
+): FilterState {
+  return {
+    id,
+    extraFormData,
+  };
+}
 
-  if (filter.defaultValue) {
+function getInitialExtraFormData(filter: Filter) {
+  if (filter?.defaultValue) {
     const [target] = filter.targets;
-    extraFormData = getSelectExtraFormData(
+    return getSelectExtraFormData(
       target.column.name,
       [filter.defaultValue],
       false,
       filter.inverseSelection,
     );
   }
-  return {
-    id: filter.id,
-    extraFormData,
-  };
+  return {};
 }
 
 export function getInitialState(
@@ -57,7 +62,9 @@ export function getInitialState(
   filterConfig.forEach(filter => {
     const { id } = filter;
     filters[id] = filter;
-    filtersState[id] = prevFiltersState?.[id] || getInitialFilterState(filter);
+    filtersState[id] =
+      prevFiltersState?.[id] ||
+      getInitialFilterState(id, getInitialExtraFormData(filter));
   });
   return state;
 }

--- a/superset-frontend/src/dashboard/reducers/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/reducers/nativeFilters.ts
@@ -39,7 +39,7 @@ export function getInitialFilterState(
   };
 }
 
-function getInitialExtraFormData(filter: Filter) {
+function getInitialExtraFormData(filter: Filter, prevState?: FilterState) {
   if (filter?.defaultValue) {
     const [target] = filter.targets;
     return getSelectExtraFormData(
@@ -48,6 +48,9 @@ function getInitialExtraFormData(filter: Filter) {
       false,
       filter.inverseSelection,
     );
+  }
+  if (prevState?.extraFormData) {
+    return prevState.extraFormData;
   }
   return {};
 }
@@ -62,9 +65,10 @@ export function getInitialState(
   filterConfig.forEach(filter => {
     const { id } = filter;
     filters[id] = filter;
-    filtersState[id] =
-      prevFiltersState?.[id] ||
-      getInitialFilterState(id, getInitialExtraFormData(filter));
+    filtersState[id] = getInitialFilterState(
+      id,
+      getInitialExtraFormData(filter, prevFiltersState?.[id]),
+    );
   });
   return state;
 }

--- a/superset-frontend/src/dashboard/reducers/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/reducers/nativeFilters.ts
@@ -22,15 +22,28 @@ import {
   SET_FILTER_CONFIG_COMPLETE,
 } from 'src/dashboard/actions/nativeFilters';
 import {
+  Filter,
   FilterConfiguration,
   FilterState,
   NativeFiltersState,
 } from 'src/dashboard/components/nativeFilters/types';
+import { getSelectExtraFormData } from 'src/filters/utils';
 
-export function getInitialFilterState(id: string): FilterState {
+export function getInitialFilterState(filter: Filter): FilterState {
+  let extraFormData = {};
+
+  if (filter.defaultValue) {
+    const [target] = filter.targets;
+    extraFormData = getSelectExtraFormData(
+      target.column.name,
+      [filter.defaultValue],
+      false,
+      filter.inverseSelection,
+    );
+  }
   return {
-    id,
-    extraFormData: {},
+    id: filter.id,
+    extraFormData,
   };
 }
 
@@ -44,7 +57,7 @@ export function getInitialState(
   filterConfig.forEach(filter => {
     const { id } = filter;
     filters[id] = filter;
-    filtersState[id] = prevFiltersState?.[id] || getInitialFilterState(id);
+    filtersState[id] = prevFiltersState?.[id] || getInitialFilterState(filter);
   });
   return state;
 }


### PR DESCRIPTION
### SUMMARY
The aim of this PR was to improve setting default value for Native Filters. 
The new Default Value Select component was created, which enables to choose default value based on dataset and field.
Now it is possible to set default value for a given filter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
![default_values_before](https://user-images.githubusercontent.com/47450693/104353026-b1242480-5507-11eb-913f-6c5a223dec0e.gif)

**After:
for native filter without children (including editing)**
![defalult_value_normal_edit](https://user-images.githubusercontent.com/47450693/104353069-c13c0400-5507-11eb-9978-d4cc593afe35.gif)

**for native filters child**
![default_value_children](https://user-images.githubusercontent.com/47450693/104353089-ca2cd580-5507-11eb-9d64-16e4994c225d.gif)

### TEST PLAN
Go to `config.py` and set  `"DASHBOARD_NATIVE_FILTERS": True`
Go to dashboards, choose one and create filter or use existing one.
Set default value.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes one of the issues mentioned in #12148
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @junlincc @villebro @rusackas 
@adam-stasiak could you test it?