### PR TITLE
fix(alert/report): remove crontab guru link from add/edit modal

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx
@@ -17,19 +17,13 @@
  * under the License.
  */
 import React, { useState, useCallback, useRef, FunctionComponent } from 'react';
-import { styled, t, useTheme } from '@superset-ui/core';
+import { t, useTheme } from '@superset-ui/core';
 
 import { Input, AntdInput } from 'src/common/components';
 import { Radio } from 'src/common/components/Radio';
 import { CronPicker, CronError } from 'src/common/components/CronPicker';
 import { StyledInputContainer } from '../AlertReportModal';
 
-const HelperText = styled.div`
-  display: block;
-  color: ${({ theme }) => theme.colors.grayscale.base};
-  font-size: ${({ theme }) => theme.typography.sizes.s - 1}px;
-  text-align: left;
-`;
 interface AlertReportCronSchedulerProps {
   value: string;
   onChange: (change: string) => any;
@@ -92,17 +86,6 @@ export const AlertReportCronScheduler: FunctionComponent<AlertReportCronSchedule
             </div>
           </StyledInputContainer>
         </div>
-        <HelperText>
-          {t('Refer to the ')}
-          <a
-            href="https://crontab.guru/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t('crontab guru')}
-          </a>
-          {t(' for more information on how to structure your CRON schedule.')}
-        </HelperText>
       </Radio.Group>
     </>
   );


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- remove crontab guru link from alert/report add/edit modal

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**BEFORE**
Alert Modal:
![Screen Shot 2021-01-12 at 11 21 44 AM](https://user-images.githubusercontent.com/5705598/104362234-69ca7380-54c8-11eb-9d5c-d3f612664f4b.png)
Report Modal:
<img width="1464" alt="Screen Shot 2021-01-12 at 11 22 29 AM" src="https://user-images.githubusercontent.com/5705598/104362267-76e76280-54c8-11eb-96ea-9464f2ad4fd7.png">

**AFTER**
Alert Modal:
<img width="1488" alt="Screen Shot 2021-01-12 at 11 20 35 AM" src="https://user-images.githubusercontent.com/5705598/104362096-34258a80-54c8-11eb-9fa7-a66fa72c050b.png">
Report Modal:
<img width="1463" alt="Screen Shot 2021-01-12 at 11 19 15 AM" src="https://user-images.githubusercontent.com/5705598/104361941-02acbf00-54c8-11eb-95d9-abed50be622a.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
