### PR TITLE
fix: Added message flash when chart with missing dataset is accessed.

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -702,8 +702,14 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             datasource_id, datasource_type = get_datasource_info(
                 datasource_id, datasource_type, form_data
             )
-        except SupersetException:
-            flash("The dataset associated with this chart no longer exists", "danger")
+        except SupersetException as ex:
+            flash(
+                _(
+                    "Error occurred when opening the chart: %(error)s",
+                    error=utils.error_msg_from_exception(ex),
+                ),
+                "danger",
+            )
             return redirect(error_redirect)
 
         datasource = ConnectorRegistry.get_datasource(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -702,8 +702,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             datasource_id, datasource_type = get_datasource_info(
                 datasource_id, datasource_type, form_data
             )
-        except SupersetException as e:
-            flash(e.message, "danger")
+        except SupersetException:
+            flash("The dataset associated with this chart no longer exists", "danger")
             return redirect(error_redirect)
 
         datasource = ConnectorRegistry.get_datasource(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -702,7 +702,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             datasource_id, datasource_type = get_datasource_info(
                 datasource_id, datasource_type, form_data
             )
-        except SupersetException:
+        except SupersetException as e:
+            flash(e.message, "danger")
             return redirect(error_redirect)
 
         datasource = ConnectorRegistry.get_datasource(

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -220,7 +220,7 @@ def get_datasource_info(
 
     if not datasource_id:
         raise SupersetException(
-            "The datasource associated with this chart no longer exists"
+            "The dataset associated with this chart no longer exists"
         )
 
     datasource_id = int(datasource_id)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -863,7 +863,7 @@ class TestCore(SupersetTestCase):
 
         self.assertEqual(
             data["errors"][0]["message"],
-            "The datasource associated with this chart no longer exists",
+            "The dataset associated with this chart no longer exists",
         )
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")

--- a/tests/tasks/async_queries_tests.py
+++ b/tests/tasks/async_queries_tests.py
@@ -124,5 +124,5 @@ class TestAsyncQueries(SupersetTestCase):
         with pytest.raises(SupersetException):
             load_explore_json_into_cache(job_metadata, form_data)
 
-        errors = ["The datasource associated with this chart no longer exists"]
+        errors = ["The dataset associated with this chart no longer exists"]
         mock_update_job.assert_called_with(job_metadata, "error", errors=errors)


### PR DESCRIPTION
### SUMMARY
Chart with deleted dataset is still available on charts list. While trying to access its explore view page redirects to charts list page. As discussed in issue #12464, I added flash notification message in right bottom corner.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
[Link to previous behaviour video] (https://user-images.githubusercontent.com/25153919/104351996-6655dd00-5506-11eb-929d-a7c1593098e0.mov)

After:
![Large GIF (1366x756)](https://user-images.githubusercontent.com/2536609/104362538-357ca480-5514-11eb-9e76-961aaca0d0bf.gif)


### TEST PLAN
1. Go to charts list and remember choose chart by dataset
2. Go to list of datasets
3. Delete chosen dataset
4. Come back to charts list and try access charts previously chosen (it will have empty dataset name)
5. It should redirect to charts list and show notification of missing chart and dataset:
`The datasource associated with this chart no longer exists`


### ADDITIONAL INFORMATION
- [x] Has associated issue: #12464
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
