### PR TITLE
fix (SQL Lab): disappearing results on tab switch

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/SouthPane_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/SouthPane_spec.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { styledShallow as shallow } from 'spec/helpers/theming';
-import SouthPaneContainer, { SouthPane } from 'src/SqlLab/components/SouthPane';
+import SouthPaneContainer from 'src/SqlLab/components/SouthPane';
 import ResultSet from 'src/SqlLab/components/ResultSet';
 import { STATUS_OPTIONS } from 'src/SqlLab/constants';
 import { initialState } from './fixtures';
@@ -79,12 +79,6 @@ describe('SouthPane', () => {
     shallow(<SouthPaneContainer store={store} {...mockedProps} />).dive();
 
   let wrapper;
-
-  beforeAll(() => {
-    jest
-      .spyOn(SouthPane.prototype, 'getSouthPaneHeight')
-      .mockImplementation(() => 500);
-  });
 
   it('should render offline when the state is offline', () => {
     wrapper = getWrapper();

--- a/superset-frontend/src/SqlLab/components/SouthPane.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane.jsx
@@ -90,20 +90,11 @@ export class SouthPane extends React.PureComponent {
       height: props.height,
     };
     this.southPaneRef = React.createRef();
-    this.getSouthPaneHeight = this.getSouthPaneHeight.bind(this);
     this.switchTab = this.switchTab.bind(this);
   }
 
-  UNSAFE_componentWillReceiveProps() {
-    // south pane expands the entire height of the tab content on mount
-    this.setState({ height: this.getSouthPaneHeight() });
-  }
-
-  // One layer of abstraction for easy spying in unit tests
-  getSouthPaneHeight() {
-    return this.southPaneRef.current
-      ? this.southPaneRef.current.clientHeight
-      : 0;
+  UNSAFE_componentWillReceiveProps(props) {
+    this.setState({ height: props.height });
   }
 
   switchTab(id) {

--- a/superset-frontend/src/SqlLab/components/SouthPane.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane.jsx
@@ -86,15 +86,8 @@ const StyledPane = styled.div`
 export class SouthPane extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = {
-      height: props.height,
-    };
     this.southPaneRef = React.createRef();
     this.switchTab = this.switchTab.bind(this);
-  }
-
-  UNSAFE_componentWillReceiveProps(props) {
-    this.setState({ height: props.height });
   }
 
   switchTab(id) {
@@ -112,7 +105,7 @@ export class SouthPane extends React.PureComponent {
         </Label>
       );
     }
-    const innerTabContentHeight = this.state.height - TAB_HEIGHT;
+    const innerTabContentHeight = this.props.height - TAB_HEIGHT;
     let latestQuery;
     const { props } = this;
     if (props.editorQueries.length > 0) {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When switching away from a SQL tab with results and back again, the results don't show up because the height of the component is computed incorrectly.

I fixed it by simply reusing the height passed as props.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

How to repro:

1. Go to SQL Lab and run a query with results
2. Switch to another tab
3. Switch back
4. No results are displayed

With this PR, it works as expected:


https://user-images.githubusercontent.com/1534870/104369922-fed26a00-54d2-11eb-8a67-078f0bc377a1.mov



### TEST PLAN
<!--- What steps should be taken to verify the changes -->

See above.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
