### PR TITLE
fix: removing dashboard scrollbars

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/components/chart.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/chart.less
@@ -118,6 +118,8 @@
   height: calc(100% - 32px);
   overflow: auto;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .dot {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In order to fix the random scrollbars on dashboard charts, I added a flex layout to the `.chart-slice` div. This seems to remove some "phantom" spacing between the chart header and the chart body that was causing the overflow. From what I can tell this leaves scrollbars where we need them, e.g. the short filter box in the screenshot below.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

https://user-images.githubusercontent.com/812905/104388567-3ef31600-54ee-11eb-8923-aaab82c73fa8.mp4


After:


https://user-images.githubusercontent.com/812905/104388578-44e8f700-54ee-11eb-9f06-b17ac11464c7.mp4



### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Manual/visual tire kicking.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
