### PR TITLE
fix(dashboard): use datasource id from slice metadata

### DIFF
--- a/superset-frontend/src/dashboard/actions/sliceEntities.js
+++ b/superset-frontend/src/dashboard/actions/sliceEntities.js
@@ -74,17 +74,15 @@ export function fetchAllSlices(userId) {
           const slices = {};
           json.result.forEach(slice => {
             let form_data = JSON.parse(slice.params);
-            let { datasource } = form_data;
-            if (!datasource) {
-              datasource = getDatasourceParameter(
-                slice.datasource_id,
-                slice.datasource_type,
-              );
-              form_data = {
-                ...form_data,
-                datasource,
-              };
-            }
+            form_data = {
+              ...form_data,
+              // force using datasource stored in relational table prop
+              datasource:
+                getDatasourceParameter(
+                  slice.datasource_id,
+                  slice.datasource_type,
+                ) || form_data.datasource,
+            };
             slices[slice.id] = {
               slice_id: slice.id,
               slice_url: slice.url,
@@ -93,6 +91,8 @@ export function fetchAllSlices(userId) {
               form_data,
               datasource_name: slice.datasource_name_text,
               datasource_url: slice.datasource_url,
+              datasource_id: slice.datasource_id,
+              datasource_type: slice.datasource_type,
               changed_on: new Date(slice.changed_on_utc).getTime(),
               description: slice.description,
               description_markdown: slice.description_markeddown,

--- a/tests/charts/commands_tests.py
+++ b/tests/charts/commands_tests.py
@@ -140,10 +140,13 @@ class TestImportChartsCommand(SupersetTestCase):
         command = ImportChartsCommand(contents)
         command.run()
 
-        chart = db.session.query(Slice).filter_by(uuid=chart_config["uuid"]).one()
+        chart: Slice = db.session.query(Slice).filter_by(
+            uuid=chart_config["uuid"]
+        ).one()
+        dataset = chart.datasource
         assert json.loads(chart.params) == {
             "color_picker": {"a": 1, "b": 135, "g": 122, "r": 0},
-            "datasource": "12__table",
+            "datasource": dataset.uid,
             "js_columns": ["color"],
             "js_data_mutator": "data => data.map(d => ({\\n    ...d,\\n    color: colors.hexToRGB(d.extraProps.color)\\n}));",
             "js_onclick_href": "",


### PR DESCRIPTION
### SUMMARY

Fixes #12480 

1. Always use datasource uid (or `parameter`, or `key`, whatever you call it) from the `slice.datasource_id` and `slice.datasource_type`, instead of the `datasource` field stored in `form_data` (`slice.params`), as they can be out of sync.
2. Update the import scripts to account for this and update `datasource` in `slice.params` with real dataset id associated with uuid.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

Adding charts from the new samples data in dashboard edit mode throws an error:

![image](https://user-images.githubusercontent.com/335541/104407733-29461680-5517-11eb-887d-0fb4274c4646.png)

#### After

It does not throw an error

![Snip20210112_122](https://user-images.githubusercontent.com/335541/104407743-382cc900-5517-11eb-8059-256ad48cb2a2.png)


### TEST PLAN

CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12163 #12162 #12480 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
