### PR TITLE
fix(timepicker): make pyparsing thread safe

### DIFF
--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -32,6 +32,7 @@ from pyparsing import (
     Group,
     Optional as ppOptional,
     ParseException,
+    ParserElement,
     ParseResults,
     pyparsing_common,
     quotedString,
@@ -39,6 +40,8 @@ from pyparsing import (
 )
 
 from .core import memoized
+
+ParserElement.enablePackrat()
 
 logger = logging.getLogger(__name__)
 

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -378,7 +378,7 @@ class EvalHolidayFunc:  # pylint: disable=too-few-public-methods
         raise ValueError(_("Unable to find such a holiday: [{}]").format(holiday))
 
 
-@memoized()
+@memoized
 def datetime_parser() -> ParseResults:  # pylint: disable=too-many-locals
     (  # pylint: disable=invalid-name
         DATETIME,


### PR DESCRIPTION
### SUMMARY
make `pyparsing` thread-safe

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. run superset with below
```
 gunicorn -w 1 --threads 64 -b "0.0.0.0:8088" "superset.app:create_app()"
```
2. open `world bank's data` dashboard without error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
