### PR TITLE
fix: impose dataset ownership check on old API

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,7 @@ This file documents any backwards-incompatible changes in Superset and
 assists people when migrating to a new version.
 
 ## Next
+- [11509](https://github.com/apache/superset/pull/12491): Dataset metadata updates check user ownership, only owners or an Admin are allowed.
 - Security simplification (SIP-19), the following permission domains were simplified:
     - [12072](https://github.com/apache/superset/pull/12072): `Query` with `can_read`, `can_write`
     - [12036](https://github.com/apache/superset/pull/12036): `Database` with `can_read`, `can_write`.

--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -69,7 +69,7 @@ class DeleteFailedError(CommandException):
 
 
 class ForbiddenError(CommandException):
-    status = 500
+    status = 403
     message = "Action is forbidden"
 
 

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -172,6 +172,15 @@ class TableColumnInlineView(  # pylint: disable=too-many-ancestors
 
     edit_form_extra_fields = add_form_extra_fields
 
+    def pre_add(self, item: "models.SqlMetric") -> None:
+        check_ownership(item.table)
+
+    def pre_update(self, item: "models.SqlMetric") -> None:
+        check_ownership(item.table)
+
+    def pre_delete(self, item: "models.SqlMetric") -> None:
+        check_ownership(item.table)
+
 
 class SqlMetricInlineView(  # pylint: disable=too-many-ancestors
     CompactCRUDMixin, SupersetModelView
@@ -245,6 +254,15 @@ class SqlMetricInlineView(  # pylint: disable=too-many-ancestors
     }
 
     edit_form_extra_fields = add_form_extra_fields
+
+    def pre_add(self, item: "models.SqlMetric") -> None:
+        check_ownership(item.table)
+
+    def pre_update(self, item: "models.SqlMetric") -> None:
+        check_ownership(item.table)
+
+    def pre_delete(self, item: "models.SqlMetric") -> None:
+        check_ownership(item.table)
 
 
 class RowLevelSecurityListWidget(

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -37,6 +37,7 @@ from superset.constants import MODEL_VIEW_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.typing import FlaskResponse
 from superset.utils import core as utils
 from superset.views.base import (
+    check_ownership,
     create_table_permissions,
     DatasourceFilter,
     DeleteMixin,
@@ -458,6 +459,9 @@ class TableModelView(  # pylint: disable=too-many-ancestors
 
     def pre_add(self, item: "TableModelView") -> None:
         validate_sqlatable(item)
+
+    def pre_update(self, item: "TableModelView") -> None:
+        check_ownership(item)
 
     def post_add(  # pylint: disable=arguments-differ
         self,

--- a/superset/views/datasource.py
+++ b/superset/views/datasource.py
@@ -24,8 +24,10 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from superset import db
 from superset.connectors.connector_registry import ConnectorRegistry
-from superset.exceptions import SupersetException
+from superset.datasets.commands.exceptions import DatasetForbiddenError
+from superset.exceptions import SupersetException, SupersetSecurityException
 from superset.typing import FlaskResponse
+from superset.views.base import check_ownership
 
 from .base import api, BaseSupersetView, handle_api_exception, json_error_response
 
@@ -52,6 +54,14 @@ class Datasource(BaseSupersetView):
         orm_datasource.database_id = database_id
 
         if "owners" in datasource_dict and orm_datasource.owner_class is not None:
+            # Check ownership
+            try:
+                check_ownership(orm_datasource)
+            except SupersetSecurityException:
+                return json_error_response(
+                    f"{DatasetForbiddenError.message}", DatasetForbiddenError.status
+                )
+
             datasource_dict["owners"] = (
                 db.session.query(orm_datasource.owner_class)
                 .filter(orm_datasource.owner_class.id.in_(datasource_dict["owners"]))


### PR DESCRIPTION
### SUMMARY
The old API does not check for ownership, this PR fixes it

When a user tries to changes a dataset they do not own (and their not admins):

<img width="429" alt="Screenshot 2021-01-13 at 10 27 30" src="https://user-images.githubusercontent.com/4025227/104440205-f7ba6300-5589-11eb-840e-da429865fc5a.png">


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
