### PR TITLE
fix: list filters vertical alignment

### DIFF
--- a/superset-frontend/src/components/ListView/Filters/Base.ts
+++ b/superset-frontend/src/components/ListView/Filters/Base.ts
@@ -28,10 +28,10 @@ export const FilterContainer = styled.div`
   display: inline-flex;
   margin-right: 2em;
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
+  align-items: center;
 `;
 
 export const FilterTitle = styled.label`
   font-weight: bold;
-  line-height: 27px;
   margin: 0 0.4em 0 0;
 `;


### PR DESCRIPTION
### SUMMARY
Fix list filters vertical alignment.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="783" alt="Screen Shot 2021-01-13 at 11 36 42 AM" src="https://user-images.githubusercontent.com/70410625/104467223-d90d9980-5594-11eb-89fb-8dfa84368d4f.png">
<img width="810" alt="Screen Shot 2021-01-13 at 4 39 48 PM" src="https://user-images.githubusercontent.com/70410625/104501069-002c9100-55be-11eb-8668-33d6c021c781.png">

### TEST PLAN
1 - Go to main lists (databases, datasets, charts and dashboards)
2 - All filters labels should be vertically aligned with values

@junlincc 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
