### PR TITLE
build: fix emotion theme errors when npm link @superset-ui/core

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -274,8 +274,12 @@ const config = {
     modules: [APP_DIR, 'node_modules'],
     alias: {
       'react-dom': '@hot-loader/react-dom',
-      // force using absolute import path of the @superset-ui/core and @superset-ui/chart-controls
-      // so that we can `npm link` viz plugins without linking these two base packages
+      // Force using absolute import path of some packages in the root node_modules,
+      // as they can be dependencies of other packages via `npm link`.
+      // Both `@emotion/core` and `@superset-ui/core` remember some globals within
+      // module after imported, which will not be available everywhere if two
+      // different copies of the same module are imported in different places.
+      '@emotion/core': path.resolve(APP_DIR, './node_modules/@emotion/core'),
       '@superset-ui/core': path.resolve(
         APP_DIR,
         './node_modules/@superset-ui/core',


### PR DESCRIPTION
### SUMMARY

Fix a new build error from `npm link @superset-ui/core`, which is caused by duplicate copies of `@emotion/core` registering themes separately. See code comments for details.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

1. Run `npm link @superset-ui/core` and `npm run dev-server`
2. Go to a page with Superset style select (e.g., Explore page for table viz)
3. You may see following JS error:
   <img src="https://user-images.githubusercontent.com/335541/104548323-67117080-55e5-11eb-93d4-5010c9b0448d.png" width="500">
   This PR should fix that.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
