### PR TITLE
fix(native-filters): Reset column field for removed dataset

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
@@ -29,6 +29,7 @@ const StyledContainer = styled.div<{ level: ErrorLevel }>`
   border: 1px solid ${({ level, theme }) => theme.colors[level].base};
   color: ${({ level, theme }) => theme.colors[level].dark2};
   padding: ${({ theme }) => theme.gridUnit * 2}px;
+  margin-bottom: ${({ theme }) => theme.gridUnit}px;
   width: 100%;
 `;
 

--- a/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { styled, supersetTheme } from '@superset-ui/core';
+import Icon from '../Icon';
+import { ErrorLevel } from './types';
+
+const StyledContainer = styled.div<{ level: ErrorLevel }>`
+  display: flex;
+  flex-direction: row;
+  background-color: ${({ level, theme }) => theme.colors[level].light2};
+  border-radius: ${({ theme }) => theme.borderRadius}px;
+  border: 1px solid ${({ level, theme }) => theme.colors[level].base};
+  color: ${({ level, theme }) => theme.colors[level].dark2};
+  padding: ${({ theme }) => theme.gridUnit * 2}px;
+  width: 100%;
+`;
+
+const StyledContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: ${({ theme }) => theme.gridUnit * 2}px;
+`;
+
+const StyledTitle = styled.span`
+  font-weight: ${({ theme }) => theme.typography.weights.bold};
+`;
+
+interface BasicErrorAlertProps {
+  title: string;
+  body: string;
+  level: ErrorLevel;
+}
+
+export default function BasicErrorAlert({
+  body,
+  level,
+  title,
+}: BasicErrorAlertProps) {
+  return (
+    <StyledContainer level={level}>
+      <Icon
+        name={level === 'error' ? 'error-solid' : 'warning-solid'}
+        color={supersetTheme.colors[level].base}
+      />
+      <StyledContent>
+        <StyledTitle>{title}</StyledTitle>
+        <p>{body}</p>
+      </StyledContent>
+    </StyledContainer>
+  );
+}

--- a/superset-frontend/src/components/SupersetResourceSelect.tsx
+++ b/superset-frontend/src/components/SupersetResourceSelect.tsx
@@ -31,7 +31,7 @@ export type Value<V> = { value: V; label: string };
 export interface SupersetResourceSelectProps<T = unknown, V = string> {
   value?: Value<V> | null;
   initialId?: number | string;
-  onChange?: (value: Value<V>) => void;
+  onChange?: (value?: Value<V>) => void;
   isMulti?: boolean;
   searchColumn?: string;
   resource?: string; // e.g. "dataset", "dashboard/related/owners"
@@ -74,11 +74,15 @@ export default function SupersetResourceSelect<T, V>({
     if (initialId == null) return;
     cachedSupersetGet({
       endpoint: `/api/v1/${resource}/${initialId}`,
-    }).then(response => {
-      const { result } = response.json;
-      const value = transformItem ? transformItem(result) : result;
-      if (onChange) onChange(value);
-    });
+    })
+      .then(response => {
+        const { result } = response.json;
+        const value = transformItem ? transformItem(result) : result;
+        if (onChange) onChange(value);
+      })
+      .catch(response => {
+        if (response?.status === 404 && onChange) onChange(undefined);
+      });
   }, [resource, initialId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function loadOptions(input: string) {

--- a/superset-frontend/src/dashboard/components/nativeFilters/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ColumnSelect.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { FormInstance } from 'antd/lib/form';
 import { SupersetClient, t } from '@superset-ui/core';
 import { useChangeEffect } from 'src/common/hooks/useChangeEffect';
@@ -62,11 +62,18 @@ export function ColumnSelect({
       { name: ['filters', filterId, 'column'], touched: false, value: null },
     ]);
   }, [form, filterId]);
+
   useChangeEffect(datasetId, previous => {
     if (previous != null) {
       resetColumnField();
     }
   });
+
+  useEffect(() => {
+    if (datasetId == null) {
+      resetColumnField();
+    }
+  }, [datasetId, resetColumnField]);
 
   function loadOptions() {
     if (datasetId == null) return [];

--- a/superset-frontend/src/dashboard/components/nativeFilters/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ColumnSelect.tsx
@@ -69,21 +69,20 @@ export function ColumnSelect({
     }
   });
 
-  useEffect(() => {
-    if (datasetId == null) {
-      resetColumnField();
-    }
-  }, [datasetId, resetColumnField]);
-
   function loadOptions() {
     if (datasetId == null) return [];
     return cachedSupersetGet({
       endpoint: `/api/v1/dataset/${datasetId}`,
     }).then(
-      ({ json: { result } }) =>
-        result.columns
+      ({ json: { result } }) => {
+        const columns = result.columns
           .map((col: any) => col.column_name)
-          .sort((a: string, b: string) => a.localeCompare(b)),
+          .sort((a: string, b: string) => a.localeCompare(b));
+        if (!columns.includes(value)) {
+          resetColumnField();
+        }
+        return columns;
+      },
       async badResponse => {
         const { error, message } = await getClientErrorObject(badResponse);
         let errorText = message || error || t('An error has occurred');

--- a/superset-frontend/src/dashboard/components/nativeFilters/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ColumnSelect.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { FormInstance } from 'antd/lib/form';
 import { SupersetClient, t } from '@superset-ui/core';
 import { useChangeEffect } from 'src/common/hooks/useChangeEffect';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -260,7 +260,7 @@ const FilterValue: React.FC<FilterProps> = ({
           setLoading(false);
         });
     }
-  }, [cascadingFilters]);
+  }, [cascadingFilters, datasetId, groupby]);
 
   const setExtraFormData = (extraFormData: ExtraFormData) =>
     onExtraFormDataChange(filter, extraFormData);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -32,6 +32,7 @@ import Icon from 'src/components/Icon';
 import { getChartDataRequest } from 'src/chart/chartAction';
 import { areObjectsEqual } from 'src/reduxUtils';
 import Loading from 'src/components/Loading';
+import BasicErrorAlert from 'src/components/ErrorMessage/BasicErrorAlert';
 import FilterConfigurationLink from './FilterConfigurationLink';
 // import FilterScopeModal from 'src/dashboard/components/filterscope/FilterScopeModal';
 
@@ -273,7 +274,13 @@ const FilterValue: React.FC<FilterProps> = ({
   }
 
   if (error) {
-    return <span>{t('Cannot load this filter. Check configuration.')}</span>;
+    return (
+      <BasicErrorAlert
+        title={t('Cannot load filter')}
+        body={t('Check configuration')}
+        level="error"
+      />
+    );
   }
 
   return (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -215,6 +215,7 @@ const FilterValue: React.FC<FilterProps> = ({
   const cascadingFilters = useCascadingFilters(id);
   const [loading, setLoading] = useState<boolean>(true);
   const [state, setState] = useState([]);
+  const [error, setError] = useState<boolean>(false);
   const [formData, setFormData] = useState<Partial<QueryFormData>>({});
   const [target] = targets;
   const { datasetId = 18, column } = target;
@@ -247,10 +248,16 @@ const FilterValue: React.FC<FilterProps> = ({
         formData: newFormData,
         force: false,
         requestParams: { dashboardId: 0 },
-      }).then(response => {
-        setState(response.result);
-        setLoading(false);
-      });
+      })
+        .then(response => {
+          setState(response.result);
+          setError(false);
+          setLoading(false);
+        })
+        .catch(() => {
+          setError(true);
+          setLoading(false);
+        });
     }
   }, [cascadingFilters]);
 
@@ -263,6 +270,10 @@ const FilterValue: React.FC<FilterProps> = ({
         <Loading />
       </StyledLoadingBox>
     );
+  }
+
+  if (error) {
+    return <span>{t('Cannot load this filter. Check configuration.')}</span>;
   }
 
   return (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigForm.tsx
@@ -98,7 +98,11 @@ export const FilterConfigForm: React.FC<FilterConfigFormProps> = ({
   form,
   parentFilters,
 }) => {
-  const [dataset, setDataset] = useState<Value<number> | undefined>();
+  const [dataset, setDataset] = useState<Value<number> | undefined>(
+    filterToEdit?.targets[0].datasetId
+      ? { label: '', value: filterToEdit?.targets[0].datasetId }
+      : undefined,
+  );
 
   const onDatasetSelectError = useCallback(
     ({ error, message }: ClientErrorObject) => {


### PR DESCRIPTION
### SUMMARY
After removing dataset, which is used in some native filter, it was still possible to see field from this dataset. Dataset was removed, but field value was not removed from Filter Config Modal.
Described in #12457

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
First we set some native filter
<img width="1643" alt="remove_dataset_before" src="https://user-images.githubusercontent.com/47450693/104583731-ca40e880-5661-11eb-8988-8c18e7dda510.png">
Then we remove used dataset and come back to native filter config
![dataset_remove](https://user-images.githubusercontent.com/47450693/104583846-ee042e80-5661-11eb-98a1-b5710b0e9041.gif)

After:
<img width="1615" alt="remove_dataset_after" src="https://user-images.githubusercontent.com/47450693/104583752-d036c980-5661-11eb-9a4c-245b356be4c6.png">
![dataset_remove_after](https://user-images.githubusercontent.com/47450693/104583823-e6dd2080-5661-11eb-8d8f-2575b1c397d7.gif)

### TEST PLAN
Set `"DASHBOARD_NATIVE_FILTERS": True`
Create new native filter with given dataset
Go to datasets and remove this dataset
Come back to native filter you have just created and check if you see 'Select' placeholder instead of field value from removed dataset

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #12457
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@junlincc @rusackas @adam-stasiak 
