### PR TITLE
fix: Select options overflowing Save chart modal on Explore view

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SaveModal_spec.jsx
@@ -29,10 +29,9 @@ import Button from 'src/components/Button';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
 
-import Modal from 'src/common/components/Modal';
 import * as exploreUtils from 'src/explore/exploreUtils';
 import * as saveModalActions from 'src/explore/actions/saveModalActions';
-import SaveModal from 'src/explore/components/SaveModal';
+import SaveModal, { StyledModal } from 'src/explore/components/SaveModal';
 
 describe('SaveModal', () => {
   const middlewares = [thunk];
@@ -79,11 +78,11 @@ describe('SaveModal', () => {
 
   it('renders a Modal with the right set of components', () => {
     const wrapper = getWrapper();
-    expect(wrapper.find(Modal)).toExist();
+    expect(wrapper.find(StyledModal)).toExist();
     expect(wrapper.find(FormControl)).toExist();
     expect(wrapper.find(Radio)).toHaveLength(2);
 
-    const footerWrapper = shallow(wrapper.find('Modal').props().footer);
+    const footerWrapper = shallow(wrapper.find(StyledModal).props().footer);
     expect(footerWrapper.find(Button)).toHaveLength(3);
   });
 

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -55,7 +55,7 @@ type SaveModalState = {
   action: ActionType;
 };
 
-const StyledModal = styled(Modal)`
+export const StyledModal = styled(Modal)`
   .ant-modal-body {
     overflow: visible;
   }

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -19,7 +19,7 @@
 /* eslint camelcase: 0 */
 import React from 'react';
 import { Alert, FormControl, FormGroup, Radio } from 'react-bootstrap';
-import { JsonObject, t } from '@superset-ui/core';
+import { JsonObject, t, styled } from '@superset-ui/core';
 import ReactMarkdown from 'react-markdown';
 import Modal from 'src/common/components/Modal';
 import Button from 'src/components/Button';
@@ -54,6 +54,12 @@ type SaveModalState = {
   alert: string | null;
   action: ActionType;
 };
+
+const StyledModal = styled(Modal)`
+  .ant-modal-body {
+    overflow: visible;
+  }
+`;
 
 class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
   constructor(props: SaveModalProps) {
@@ -153,7 +159,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
 
   render() {
     return (
-      <Modal
+      <StyledModal
         show
         onHide={this.props.onHide}
         title={t('Save Chart')}
@@ -261,7 +267,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
             />
           </FormGroup>
         </div>
-      </Modal>
+      </StyledModal>
     );
   }
 }


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/12521

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: see linked issue
After:
![image](https://user-images.githubusercontent.com/15073128/104606770-6548bb00-5680-11eb-97b7-8fddbd3b6129.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12521
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc @eugeniamz 