### PR TITLE
fix(native-filters): Improve UI for long native filters names

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -161,6 +161,9 @@ const StyledFilterControlTitle = styled.h4`
   color: ${({ theme }) => theme.colors.grayscale.dark1};
   margin: 0;
   text-transform: uppercase;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 `;
 
 const StyledFilterControlTitleBox = styled.div`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -157,10 +157,11 @@ const StyledCascadeChildrenList = styled.ul`
 `;
 
 const StyledFilterControlTitle = styled.h4`
+  width: 100%;
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
   color: ${({ theme }) => theme.colors.grayscale.dark1};
   margin: 0;
-  white-space: normal;
+  overflow-wrap: break-word;
 `;
 
 const StyledFilterControlTitleBox = styled.div`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -160,10 +160,7 @@ const StyledFilterControlTitle = styled.h4`
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
   color: ${({ theme }) => theme.colors.grayscale.dark1};
   margin: 0;
-  text-transform: uppercase;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+  white-space: normal;
 `;
 
 const StyledFilterControlTitleBox = styled.div`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -34,6 +34,7 @@ import { CancelConfirmationAlert } from './CancelConfirmationAlert';
 
 // how long to show the "undo" button when removing a filter
 const REMOVAL_DELAY_SECS = 5;
+const FILTER_WIDTH = 200;
 
 const StyledModalBody = styled.div`
   display: flex;
@@ -59,7 +60,7 @@ const StyledSpan = styled.span`
 const FilterTabs = styled(LineEditableTabs)`
   // extra selector specificity:
   &.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab {
-    min-width: 200px;
+    min-width: ${FILTER_WIDTH}px;
     margin-left: 0;
     padding: 0 ${({ theme }) => theme.gridUnit * 2}px
       ${({ theme }) => theme.gridUnit}px;
@@ -82,7 +83,7 @@ const FilterTabs = styled(LineEditableTabs)`
 const FilterTabTitle = styled.span`
   transition: color ${({ theme }) => theme.transitionTiming}s;
   width: 100%;
-  max-width: 200px;
+  max-width: ${FILTER_WIDTH}px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -82,6 +82,7 @@ const FilterTabs = styled(LineEditableTabs)`
 const FilterTabTitle = styled.span`
   transition: color ${({ theme }) => theme.transitionTiming}s;
   width: 100%;
+  max-width: 200px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -105,6 +106,12 @@ const FilterTabTitle = styled.span`
     animation-name: tabTitleRemovalAnimation;
     animation-duration: ${REMOVAL_DELAY_SECS}s;
   }
+`;
+
+const StyledFilterTitle = styled.div`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 `;
 
 const StyledAddFilterBox = styled.div`
@@ -523,11 +530,11 @@ export function FilterConfigModal({
                     <FilterTabTitle
                       className={removedFilters[id] ? 'removed' : ''}
                     >
-                      <div>
+                      <StyledFilterTitle>
                         {removedFilters[id]
                           ? t('(Removed)')
                           : getFilterTitle(id)}
-                      </div>
+                      </StyledFilterTitle>
                       {removedFilters[id] && (
                         <StyledSpan
                           role="button"

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -19,7 +19,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { findLastIndex, uniq } from 'lodash';
 import shortid from 'shortid';
-import { DeleteFilled, PlusOutlined } from '@ant-design/icons';
+import { PlusOutlined } from '@ant-design/icons';
+import Icon from 'src/components/Icon';
 import { styled, t } from '@superset-ui/core';
 import { Form } from 'src/common/components';
 import { StyledModal } from 'src/common/components/Modal';
@@ -61,15 +62,20 @@ const FilterTabs = styled(LineEditableTabs)`
   // extra selector specificity:
   &.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab {
     min-width: ${FILTER_WIDTH}px;
-    margin-left: 0;
-    padding: 0 ${({ theme }) => theme.gridUnit * 2}px
-      ${({ theme }) => theme.gridUnit}px;
+    margin: 0 ${({ theme }) => theme.gridUnit * 2}px 0 0;
+    padding: ${({ theme }) => theme.gridUnit}px
+      ${({ theme }) => theme.gridUnit * 2}px;
 
     &:hover,
     &-active {
       color: ${({ theme }) => theme.colors.grayscale.dark1};
       border-radius: ${({ theme }) => theme.borderRadius}px;
-      background-color: ${({ theme }) => theme.colors.grayscale.light2};
+      background-color: ${({ theme }) => theme.colors.secondary.light4};
+
+      .ant-tabs-tab-remove > svg {
+        color: ${({ theme }) => theme.colors.grayscale.base};
+        transition: all 0.3s;
+      }
     }
   }
 
@@ -83,12 +89,9 @@ const FilterTabs = styled(LineEditableTabs)`
 const FilterTabTitle = styled.span`
   transition: color ${({ theme }) => theme.transitionTiming}s;
   width: 100%;
-  max-width: ${FILTER_WIDTH}px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  padding: ${({ theme }) => theme.gridUnit}px
-    ${({ theme }) => theme.gridUnit * 2}px 0 0;
 
   @keyframes tabTitleRemovalAnimation {
     0%,
@@ -109,10 +112,10 @@ const FilterTabTitle = styled.span`
   }
 `;
 
-const StyledFilterTitle = styled.div`
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+const StyledFilterTitle = styled.span`
+  width: ${FILTER_WIDTH}px;
+  white-space: normal;
+  color: ${({ theme }) => theme.colors.grayscale.dark1};
 `;
 
 const StyledAddFilterBox = styled.div`
@@ -126,6 +129,10 @@ const StyledAddFilterBox = styled.div`
   &:hover {
     color: ${({ theme }) => theme.colors.primary.base};
   }
+`;
+
+const StyledTrashIcon = styled(Icon)`
+  color: ${({ theme }) => theme.colors.grayscale.light3};
 `;
 
 type FilterRemoval =
@@ -548,7 +555,13 @@ export function FilterConfigModal({
                     </FilterTabTitle>
                   }
                   key={id}
-                  closeIcon={removedFilters[id] ? <></> : <DeleteFilled />}
+                  closeIcon={
+                    removedFilters[id] ? (
+                      <></>
+                    ) : (
+                      <StyledTrashIcon name="trash" />
+                    )
+                  }
                 >
                   <FilterConfigForm
                     form={form}


### PR DESCRIPTION
### SUMMARY
Long native filter names destroy UI of Filter Configuration modal and Filter Bar.
Described in issue #12458

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="552" alt="long_names_before_fb" src="https://user-images.githubusercontent.com/47450693/104615477-924d9b80-5689-11eb-94a9-884d50008fe7.png">
<img width="660" alt="long_names_after_modal" src="https://user-images.githubusercontent.com/47450693/104615495-9679b900-5689-11eb-84f2-993520884c4f.png">

After:
<img width="557" alt="long_names_after_fb" src="https://user-images.githubusercontent.com/47450693/104615513-9b3e6d00-5689-11eb-9178-2d4edcc293de.png">
<img width="660" alt="long_names_after_modal" src="https://user-images.githubusercontent.com/47450693/104615529-9ed1f400-5689-11eb-9e30-ae15dbbc7b31.png">

### TEST PLAN
Set `"DASHBOARD_NATIVE_FILTERS": True`
Go to dashboards and create native filter with long name

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12458
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@junlincc @rusackas @villebro @adam-stasiak 