### PR TITLE
fix: Update Limit Control with SQL_ROW_MAX value

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -539,7 +539,15 @@ class SqlEditor extends React.PureComponent {
   }
 
   renderQueryLimit() {
-    const menuDropdown = (
+    // Update the limit dropdown with SQL_ROW_MAX value
+    const { maxRow } = this.props;
+    let currentLimit = LIMIT_DROPDOWN[LIMIT_DROPDOWN.length - 1];
+    while (currentLimit < maxRow) {
+      currentLimit *= 10;
+      LIMIT_DROPDOWN.push(currentLimit);
+    }
+    
+    return (
       <AntdMenu>
         {LIMIT_DROPDOWN.map(limit => (
           <AntdMenu.Item onClick={() => this.setQueryLimit(limit)}>
@@ -551,8 +559,6 @@ class SqlEditor extends React.PureComponent {
         ))}
       </AntdMenu>
     );
-
-    return menuDropdown;
   }
 
   renderEditorBottomBar() {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update dropdown with sql_row_max value, we'll only be supporting multiples of 10.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![Screen Shot 2021-01-14 at 6 28 20 PM](https://user-images.githubusercontent.com/27827808/104661321-49e8aa80-5696-11eb-9278-9ce225f0b0ce.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
