### PR TITLE
fix(explore): time table control panel

### DIFF
--- a/superset-frontend/src/explore/controlPanels/TimeTable.js
+++ b/superset-frontend/src/explore/controlPanels/TimeTable.js
@@ -17,9 +17,11 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
+import { sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -59,14 +61,6 @@ export default {
   controlOverrides: {
     groupby: {
       multiple: false,
-    },
-  },
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
     },
   },
 };


### PR DESCRIPTION
### SUMMARY

Currently Time Table is broken because recent updates on the Time Column control  ( https://github.com/apache-superset/superset-ui/pull/869 ) didn't apply to the actual Time Table plugin code used in `superset-frontend`.

This is because Time Table vis hasn't been fully migrated to `superset-ui`. This PR ports the necessary change to the control panel to `superset-frontend`. Tried to do the full migration, but the viz is broken in a separate way. Obviously the migrated plugin `@superset-ui/legacy-plugin-chart-time-table` doesn't really work.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

![image](https://user-images.githubusercontent.com/335541/104673169-07bf6900-5696-11eb-9399-bd06edb3f050.png)

Time controls are not visible for viz type "Time Table", and an error:

```
Datetime column not provided as part table configuration and is required by this type of chart
```

#### After

![image](https://user-images.githubusercontent.com/335541/104673194-1574ee80-5696-11eb-8b3a-14fb314c4e90.png)

Time table works as expected.

### TEST PLAN

Try create or edit a time table chart.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12147  #12091 (when the regression is actually merged) apache-superset/superset-ui#869
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
