### PR TITLE
build(cypress): Add Cypress parallelization with obfuscated record key

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -164,9 +164,10 @@ cypress-run() {
   export TERM="xterm"
 
   say "::group::Run Cypress for [$page]"
-  if [[ -z $CYPRESS_RECORD_KEY ]]; then
+  if [[ -z $CYPRESS_KEY ]]; then
     $cypress --spec "cypress/integration/$page" --browser "$browser"
   else
+    export CYPRESS_RECORD_KEY=`echo $CYPRESS_KEY | base64 --decode`
     # additional flags for Cypress dashboard recording
     $cypress --spec "cypress/integration/$page" --browser "$browser" \
       --record --group "$group" --tag "${GITHUB_REPOSITORY},${GITHUB_EVENT_NAME}" \

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -9,10 +9,16 @@ on:
   pull_request:
 
 jobs:
-  Cypress:
+  cypress-matrix:
     runs-on: ubuntu-18.04
     strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving the Dashboard hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
       matrix:
+        containers: [1, 2, 3]
         browser: ["chrome"]
     env:
       FLASK_ENV: development
@@ -87,7 +93,7 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         env:
           CYPRESS_BROWSER: ${{ matrix.browser }}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_KEY: YjljODE2MzAtODcwOC00NTA3LWE4NmMtMTU3YmFmMjIzOTRhCg==
         with:
           run: cypress-run-all
       - name: Upload Artifacts
@@ -96,3 +102,12 @@ jobs:
         with:
           name: screenshots
           path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots
+  Cypress:
+    if: ${{ always() }}
+    name: Cypress (chrome)
+    runs-on: ubuntu-18.04
+    needs: cypress-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.cypress-matrix.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
### SUMMARY
Let's try again on Cypress parallelization, this time with an obfuscated record key that runs on `pull_request` events.

### TEST PLAN
Cypress should run tests concurrently.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
