### PR TITLE
fix: Pinot query generation with time granularities: WEEKS/MONTHS/QUARTERS/YEARS

### DIFF
--- a/tests/db_engine_specs/pinot_tests.py
+++ b/tests/db_engine_specs/pinot_tests.py
@@ -23,11 +23,19 @@ from tests.db_engine_specs.base_tests import TestDbEngineSpec
 class TestPinotDbEngineSpec(TestDbEngineSpec):
     """ Tests pertaining to our Pinot database support """
 
+    def test_pinot_time_expression_sec_one_1d_grain(self):
+        col = column("tstamp")
+        expr = PinotEngineSpec.get_timestamp_expr(col, "epoch_s", "P1D")
+        result = str(expr.compile())
+        self.assertEqual(
+            result,
+            "DATETIMECONVERT(tstamp, '1:SECONDS:EPOCH', '1:SECONDS:EPOCH', '1:DAYS')",
+        )  # noqa
+
     def test_pinot_time_expression_sec_one_1m_grain(self):
         col = column("tstamp")
         expr = PinotEngineSpec.get_timestamp_expr(col, "epoch_s", "P1M")
         result = str(expr.compile())
         self.assertEqual(
-            result,
-            "DATETIMECONVERT(tstamp, '1:SECONDS:EPOCH', '1:SECONDS:EPOCH', '1:MONTHS')",
+            result, "DATETRUNC('month', tstamp, 'SECONDS')",
         )  # noqa


### PR DESCRIPTION
### SUMMARY
Fixing the bug that time granularity doesn't work for WEEKS/MONTHS/QUARTERS/YEARS.
Pinot internally has two time converter functions: timeConverter and dateTrunc.
Pinot `timeConverter` has better performance comparing to `dateTrunc` function when querying for granularity `DAYS`/`MINUTES`/`SECONDS`/... as it uses arithmetic ops for it, however, this function doesn't support conversion to `WEEKS`/`MONTHS`/`QUARTERS`/`YEARS`.

So we need to use `dateTrunc` for querying with those granularities.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: error when send queries using granularity: week/month/quarter/year
![image](https://user-images.githubusercontent.com/1202120/104679105-c6cd5180-56a1-11eb-986b-eca4d3a5d17a.png)

Query generated: 
```
SELECT DATETIMECONVERT(SecondsSinceEpoch, '1:SECONDS:EPOCH', '1:SECONDS:EPOCH', '1:WEEKS'),
       count(DepDel15) AS count_1
FROM "airlineStats"
GROUP BY DATETIMECONVERT(SecondsSinceEpoch, '1:SECONDS:EPOCH', '1:SECONDS:EPOCH', '1:WEEKS')
LIMIT 10000;
```

After, query with month:
![image](https://user-images.githubusercontent.com/1202120/104678996-853ca680-56a1-11eb-9644-16980fb661d2.png)

The query generated is:
```
SELECT DATETRUNC('month', DaysSinceEpoch * 86400, 'SECONDS'),
       count(TotalAddGTime) AS count_1
FROM "airlineStats"."airlineStats"
GROUP BY DATETRUNC('month', DaysSinceEpoch * 86400, 'SECONDS')
LIMIT 10000;
```
### TEST PLAN
Unit test and integration tests with Pinot quickstart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
