### PR TITLE
feat(chart): Add expression, description and verbose name to search filter

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel.tsx
@@ -175,8 +175,8 @@ const DataSourcePanel = ({
       return;
     }
     setList({
-      columns: matchSorter(columns, value, { keys: ['column_name'] }),
-      metrics: matchSorter(metrics, value, { keys: ['metric_name'] }),
+      columns: matchSorter(columns, value, { keys: ['column_name', 'expression', 'description', 'verbose_name'] }),
+      metrics: matchSorter(metrics, value, { keys: ['metric_name', 'expression', 'description', 'verbose_name'] }),
     });
   };
   useEffect(() => {

--- a/superset-frontend/src/explore/components/DatasourcePanel.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel.tsx
@@ -175,8 +175,12 @@ const DataSourcePanel = ({
       return;
     }
     setList({
-      columns: matchSorter(columns, value, { keys: ['column_name', 'expression', 'description', 'verbose_name'] }),
-      metrics: matchSorter(metrics, value, { keys: ['metric_name', 'expression', 'description', 'verbose_name'] }),
+      columns: matchSorter(columns, value, {
+        keys: ['column_name', 'expression', 'description', 'verbose_name'],
+      }),
+      metrics: matchSorter(metrics, value, {
+        keys: ['metric_name', 'expression', 'description', 'verbose_name'],
+      }),
     });
   };
   useEffect(() => {


### PR DESCRIPTION
### SUMMARY
Explore 2021 Q1 roadmap item https://github.com/apache-superset/superset-roadmap/issues/141
Add **expression**, **description** and **verbose_name** to the search functionality for **metrics** and **columns** in chart **datasource panel** and sort by relevance.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screenshot 2021-01-15 at 15 03 43](https://user-images.githubusercontent.com/26679866/104736240-f2ecdf00-5742-11eb-8ecb-b0406b02f533.png)

### TEST PLAN

1. Go to any **chart**
2. In the **datasource panel** hover over any metric/column **question mark/info icon** and note the text inside if any
3. Search for any portion of the noted text

Search should now filter columns/metrics based on those fields as well.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: roadmap item https://github.com/apache-superset/superset-roadmap/issues/141
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
