### PR TITLE
fix(explore): deprecated x periods pattern in new time picker value

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterControl.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterControl.tsx
@@ -197,16 +197,17 @@ export default function DateFilterControl(props: DateFilterLabelProps) {
           +--------------+------+----------+--------+----------+-----------+
           |              | Last | Previous | Custom | Advanced | No Filter |
           +--------------+------+----------+--------+----------+-----------+
-          | control pill | HRT  | HRT      | ADR    | ADR      |   ADR     |
+          | control pill | HRT  | HRT      | ADR    | ADR      |   HRT     |
           +--------------+------+----------+--------+----------+-----------+
-          | tooltip      | ADR  | ADR      | HRT    | HRT      |   HRT     |
+          | tooltip      | ADR  | ADR      | HRT    | HRT      |   ADR     |
           +--------------+------+----------+--------+----------+-----------+
         */
         const valueToLower = value.toLowerCase();
         if (
           valueToLower.startsWith('last') ||
           valueToLower.startsWith('next') ||
-          valueToLower.startsWith('previous')
+          valueToLower.startsWith('previous') ||
+          valueToLower === 'no filter'
         ) {
           setActualTimeRange(value);
           setTooltipTitle(actualRange || '');

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterControl.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterControl.tsx
@@ -202,12 +202,10 @@ export default function DateFilterControl(props: DateFilterLabelProps) {
           | tooltip      | ADR  | ADR      | HRT    | HRT      |   ADR     |
           +--------------+------+----------+--------+----------+-----------+
         */
-        const valueToLower = value.toLowerCase();
         if (
-          valueToLower.startsWith('last') ||
-          valueToLower.startsWith('next') ||
-          valueToLower.startsWith('previous') ||
-          valueToLower === 'no filter'
+          frame === 'Common' ||
+          frame === 'Calendar' ||
+          frame === 'No filter'
         ) {
           setActualTimeRange(value);
           setTooltipTitle(actualRange || '');

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/frame/AdvancedFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/frame/AdvancedFrame.tsx
@@ -23,7 +23,11 @@ import { Input } from 'src/common/components';
 import { FrameComponentProps } from '../types';
 
 export function AdvancedFrame(props: FrameComponentProps) {
-  const [since, until] = getAdvancedRange(props.value || '').split(SEPARATOR);
+  const advancedRange = getAdvancedRange(props.value || '');
+  const [since, until] = advancedRange.split(SEPARATOR);
+  if (advancedRange !== props.value) {
+    props.onChange(getAdvancedRange(props.value || ''));
+  }
 
   function getAdvancedRange(value: string): string {
     if (value.includes(SEPARATOR)) {

--- a/superset/migrations/versions/260bf0649a77_migrate_x_dateunit_in_time_range.py
+++ b/superset/migrations/versions/260bf0649a77_migrate_x_dateunit_in_time_range.py
@@ -30,11 +30,11 @@ import json
 import re
 
 import sqlalchemy as sa
-from sqlalchemy.exc import OperationalError
 from alembic import op
 from sqlalchemy import Column, Integer, or_, Text
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db

--- a/superset/migrations/versions/260bf0649a77_migrate_x_dateunit_in_time_range.py
+++ b/superset/migrations/versions/260bf0649a77_migrate_x_dateunit_in_time_range.py
@@ -35,6 +35,7 @@ from alembic import op
 from sqlalchemy import Column, Integer, or_, Text
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect
+from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db

--- a/superset/migrations/versions/260bf0649a77_migrate_x_dateunit_in_time_range.py
+++ b/superset/migrations/versions/260bf0649a77_migrate_x_dateunit_in_time_range.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""migrate [x dateunit] to [x dateunit ago/later]
+
+Revision ID: 260bf0649a77
+Revises: c878781977c6
+Create Date: 2021-01-23 16:25:14.496774
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '260bf0649a77'
+down_revision = 'c878781977c6'
+
+import json
+import re
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Column, Integer, Text, or_
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.dialects.mysql.base import MySQLDialect
+from sqlalchemy.dialects.sqlite.base import SQLiteDialect
+
+from superset import db
+from superset.utils.date_parser import DateRangeMigration
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    slice_name = Column(Text)
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    x_dateunit_in_since = DateRangeMigration.x_dateunit_in_since
+    x_dateunit_in_until = DateRangeMigration.x_dateunit_in_until
+
+    if isinstance(bind.dialect, SQLiteDialect):
+        to_lower = sa.func.LOWER
+        where_clause = or_(
+            sa.func.REGEXP(to_lower(Slice.params), x_dateunit_in_since),
+            sa.func.REGEXP(to_lower(Slice.params), x_dateunit_in_until),
+        )
+    elif isinstance(bind.dialect, MySQLDialect):
+        where_clause = or_(
+            sa.func.REGEXP_LIKE(Slice.params, x_dateunit_in_since, 'i'),
+            sa.func.REGEXP_LIKE(Slice.params, x_dateunit_in_until, 'i'),
+        )
+    else:
+        # default metadata is pg, so: isinstance(bind.dialect, PGDialect):
+        where_clause = or_(
+            Slice.params.op("~*")(x_dateunit_in_since),
+            Slice.params.op("~*")(x_dateunit_in_until),
+        )
+
+    slices = (
+        session
+        .query(Slice)
+        .filter(where_clause)
+        .all()
+    )
+
+    sep = " : "
+    pattern = DateRangeMigration.x_dateunit
+    for idx, slc in enumerate(slices):
+        print(f"Upgrading ({idx + 1}/{len(slices)}): {slc.slice_name}#{slc.id}")
+        params = json.loads(slc.params)
+        time_range = params['time_range']
+        if sep in time_range:
+            start, end = time_range.split(sep)
+            if re.match(pattern, start):
+                start = f"{start.strip()} ago"
+            if re.match(pattern, end):
+                end = f"{end.strip()} later"
+            params['time_range'] = f"{start}{sep}{end}"
+
+            slc.params = json.dumps(params, sort_keys=True, indent=4)
+            session.commit()
+
+    session.close()
+
+
+def downgrade():
+    pass

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -76,11 +76,18 @@ def parse_human_datetime(human_readable: str) -> datetime:
         raise ValueError(
             _(
                 "date string is unclear."
-                " Please specify [{0} ago] or [{0} later]".format(human_readable)
+                " Please specify [%(human_readable)s ago]"
+                " or [%(human_readable)s later]",
+                human_readable=human_readable,
             )
         )
 
-    error_msg = ValueError(_("Couldn't parse date string [{}]".format(human_readable)))
+    error_msg = ValueError(
+        _(
+            "Couldn't parse date string [%{human_readable}s]",
+            human_readable=human_readable,
+        )
+    )
     try:
         dttm = parse(human_readable)
     except Exception:  # pylint: disable=broad-except
@@ -388,7 +395,9 @@ class EvalHolidayFunc:  # pylint: disable=too-few-public-methods
         searched_result = holiday_lookup.get_named(holiday)
         if len(searched_result) == 1:
             return dttm_from_timetuple(searched_result[0].timetuple())
-        raise ValueError(_("Unable to find such a holiday: [{}]").format(holiday))
+        raise ValueError(
+            _("Unable to find such a holiday: [%(holiday)s]", holiday=holiday)
+        )
 
 
 @memoized

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -75,7 +75,7 @@ def parse_human_datetime(human_readable: str) -> datetime:
     if re.search(x_periods, human_readable, re.IGNORECASE):
         raise ValueError(
             _(
-                "date string is unclear."
+                "Date string is unclear."
                 " Please specify [%(human_readable)s ago]"
                 " or [%(human_readable)s later]",
                 human_readable=human_readable,

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -74,7 +74,10 @@ def parse_human_datetime(human_readable: str) -> datetime:
     x_periods = r"^\s*([0-9]+)\s+(second|minute|hour|day|week|month|quarter|year)s?\s*$"
     if re.search(x_periods, human_readable, re.IGNORECASE):
         raise ValueError(
-            _("X periods are used without the look back/forward descriptors.")
+            _(
+                "date string is unclear."
+                " Please specify [{0} ago] or [{0} later]".format(human_readable)
+            )
         )
 
     error_msg = ValueError(_("Couldn't parse date string [{}]".format(human_readable)))

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -84,7 +84,7 @@ def parse_human_datetime(human_readable: str) -> datetime:
         try:
             cal = parsedatetime.Calendar()
             parsed_dttm, parsed_flags = cal.parseDT(human_readable)
-            # 0 = not parsed at all
+            # 0 == not parsed at all
             if parsed_flags == 0:
                 raise error_msg
             # when time is not extracted, we 'reset to midnight'

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -490,7 +490,7 @@ def datetime_eval(datetime_expression: Optional[str] = None) -> Optional[datetim
     return None
 
 
-class DateRangeMigration:
+class DateRangeMigration:  # pylint: disable=too-few-public-methods
     x_dateunit_in_since = (
         r'"time_range":\s"\s*[0-9]+\s(day|week|month|quarter|year)s?\s*\s:\s'
     )

--- a/tests/druid_tests.py
+++ b/tests/druid_tests.py
@@ -176,7 +176,7 @@ class TestDruid(SupersetTestCase):
             "viz_type": "table",
             "granularity": "one+day",
             "druid_time_origin": "",
-            "since": "7+days+ago",
+            "since": "7 days ago",
             "until": "now",
             "row_limit": 5000,
             "include_search": "false",
@@ -193,7 +193,7 @@ class TestDruid(SupersetTestCase):
             "viz_type": "table",
             "granularity": "one+day",
             "druid_time_origin": "",
-            "since": "7+days+ago",
+            "since": "7 days ago",
             "until": "now",
             "row_limit": 5000,
             "include_search": "false",
@@ -535,7 +535,7 @@ class TestDruid(SupersetTestCase):
 
         form_data = {
             "viz_type": "table",
-            "since": "7+days+ago",
+            "since": "7 days ago",
             "until": "now",
             "metrics": ["count"],
             "groupby": [],

--- a/tests/utils/date_parser_tests.py
+++ b/tests/utils/date_parser_tests.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 from superset.utils.date_parser import (
     datetime_eval,
     get_since_until,
+    parse_human_datetime,
     parse_human_timedelta,
     parse_past_timedelta,
 )
@@ -261,3 +262,13 @@ class TestDateParser(SupersetTestCase):
         self.assertEqual(parse_past_timedelta("-1 year"), timedelta(365))
         self.assertEqual(parse_past_timedelta("52 weeks"), timedelta(364))
         self.assertEqual(parse_past_timedelta("1 month"), timedelta(31))
+
+    def test_parse_human_datetime(self):
+        with self.assertRaises(ValueError):
+            parse_human_datetime("  2 days  ")
+
+        with self.assertRaises(ValueError):
+            parse_human_datetime("2 day")
+
+        with self.assertRaises(ValueError):
+            parse_human_datetime("xxxxxxx")

--- a/tests/utils/date_parser_tests.py
+++ b/tests/utils/date_parser_tests.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from superset.utils.date_parser import (
+    DateRangeMigration,
     datetime_eval,
     get_since_until,
     parse_human_datetime,
@@ -272,3 +273,21 @@ class TestDateParser(SupersetTestCase):
 
         with self.assertRaises(ValueError):
             parse_human_datetime("xxxxxxx")
+
+    def test_DateRangeMigration(self):
+        params = '{"time_range": "   8 days     : 2020-03-10T00:00:00"}'
+        self.assertRegex(params, DateRangeMigration.x_dateunit_in_since)
+
+        params = '{"time_range": "2020-03-10T00:00:00 :    8 days    "}'
+        self.assertRegex(params, DateRangeMigration.x_dateunit_in_until)
+
+        params = '{"time_range": "   2 weeks    :    8 days    "}'
+        self.assertRegex(params, DateRangeMigration.x_dateunit_in_since)
+        self.assertRegex(params, DateRangeMigration.x_dateunit_in_until)
+
+        params = '{"time_range": "2 weeks ago : 8 days later"}'
+        self.assertNotRegex(params, DateRangeMigration.x_dateunit_in_since)
+        self.assertNotRegex(params, DateRangeMigration.x_dateunit_in_until)
+
+        field = "   8 days   "
+        self.assertRegex(field, DateRangeMigration.x_dateunit)


### PR DESCRIPTION
### SUMMARY
closes: #12508 

1. changed "No filter" show in the date-picker control pill.
2. deprecated x periods, if user input "x [dateunit][s]" response an error.
3. raise input error when the user input as an arbitrary string.
4. added [x periods] -> [x periods ago/later] DB migration script

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### 1. "No filter" show in the date-picker control pill
![image](https://user-images.githubusercontent.com/2016594/104755508-79caa780-5795-11eb-9fe6-41e471d5fc5e.png)

#### 2. deprecated x periods
![image](https://user-images.githubusercontent.com/2016594/104865618-6f680380-5977-11eb-8558-9495349e6a99.png)

#### 3. catch arbitrary input
![image](https://user-images.githubusercontent.com/2016594/104864260-6ffe9b00-5973-11eb-943c-3558ed50515c.png)


### TEST PLAN
UT covered these case

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12508 
- [ ] Changes UI
- [x] Requires DB Migration.
- [x] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
