### PR TITLE
feat(native-filters): Show alert for unsaved filters after cancelling Filter Config Modal

### DIFF
--- a/superset-frontend/spec/javascripts/dashboard/components/nativeFilters/NativeFiltersModal_spec.tsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/nativeFilters/NativeFiltersModal_spec.tsx
@@ -20,9 +20,11 @@ import React from 'react';
 import { styledMount as mount } from 'spec/helpers/theming';
 import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
+import Alert from 'react-bootstrap/lib/Alert';
 import { FilterConfigModal } from 'src/dashboard/components/nativeFilters/FilterConfigModal';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { mockStore } from 'spec/fixtures/mockStore';
+import { ReactWrapper } from 'enzyme';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -73,5 +75,49 @@ describe('FiltersConfigModal', () => {
     });
     await waitForComponentToPaint(wrapper);
     expect(onSave.mock.calls).toHaveLength(0);
+  });
+
+  describe('when click cancel', () => {
+    let onCancel: jest.Mock;
+    let wrapper: ReactWrapper;
+
+    beforeEach(() => {
+      onCancel = jest.fn();
+      wrapper = setup({ onCancel, createNewOnOpen: false });
+    })
+
+    async function clickCancel() {
+      act(() => {
+        wrapper.find('.ant-modal-footer button').at(0).simulate('click');
+      });
+      await waitForComponentToPaint(wrapper);
+    }
+
+    function addFilter() {
+      act(() => {
+        wrapper.find('button[aria-label="Add tab"]').at(0).simulate('click');
+      });
+    }
+
+    it('does not show alert when there is no unsaved filters', async () => {
+      await clickCancel();
+      expect(onCancel.mock.calls).toHaveLength(1);
+    });
+
+    it('shows correct alert message for an unsaved filter', async () => {
+      addFilter();
+      await clickCancel();
+      expect(onCancel.mock.calls).toHaveLength(0);
+      expect(wrapper.find(Alert).text()).toContain('Are you sure you want to cancel? "New Filter" will not be saved.');
+    });
+
+
+    it('shows correct alert message for 2 unsaved filters', async () => {
+      addFilter();
+      addFilter();
+      await clickCancel();
+      expect(onCancel.mock.calls).toHaveLength(0);
+      expect(wrapper.find(Alert).text()).toContain('Are you sure you want to cancel? "New Filter" and "New Filter" will not be saved.');
+    });
   });
 });

--- a/superset-frontend/spec/javascripts/dashboard/components/nativeFilters/NativeFiltersModal_spec.tsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/nativeFilters/NativeFiltersModal_spec.tsx
@@ -19,12 +19,12 @@
 import React from 'react';
 import { styledMount as mount } from 'spec/helpers/theming';
 import { act } from 'react-dom/test-utils';
+import { ReactWrapper } from 'enzyme';
 import { Provider } from 'react-redux';
 import Alert from 'react-bootstrap/lib/Alert';
 import { FilterConfigModal } from 'src/dashboard/components/nativeFilters/FilterConfigModal';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { mockStore } from 'spec/fixtures/mockStore';
-import { ReactWrapper } from 'enzyme';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -84,7 +84,7 @@ describe('FiltersConfigModal', () => {
     beforeEach(() => {
       onCancel = jest.fn();
       wrapper = setup({ onCancel, createNewOnOpen: false });
-    })
+    });
 
     async function clickCancel() {
       act(() => {
@@ -108,16 +108,19 @@ describe('FiltersConfigModal', () => {
       addFilter();
       await clickCancel();
       expect(onCancel.mock.calls).toHaveLength(0);
-      expect(wrapper.find(Alert).text()).toContain('Are you sure you want to cancel? "New Filter" will not be saved.');
+      expect(wrapper.find(Alert).text()).toContain(
+        'Are you sure you want to cancel? "New Filter" will not be saved.',
+      );
     });
-
 
     it('shows correct alert message for 2 unsaved filters', async () => {
       addFilter();
       addFilter();
       await clickCancel();
       expect(onCancel.mock.calls).toHaveLength(0);
-      expect(wrapper.find(Alert).text()).toContain('Are you sure you want to cancel? "New Filter" and "New Filter" will not be saved.');
+      expect(wrapper.find(Alert).text()).toContain(
+        'Are you sure you want to cancel? "New Filter" and "New Filter" will not be saved.',
+      );
     });
   });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/CancelConfirmationAlert.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/CancelConfirmationAlert.tsx
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { styled, t } from '@superset-ui/core';
+import Alert from 'react-bootstrap/lib/Alert';
+import Button from 'src/components/Button';
+import Icon from 'src/components/Icon';
+
+const StyledAlert = styled(Alert)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
+  padding: ${({ theme }) => theme.gridUnit * 2}px;
+`;
+
+const StyledTextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  margin-right: ${({ theme }) => theme.gridUnit}px;
+`;
+
+const StyledTitleBox = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledAlertTitle = styled.span`
+  font-weight: ${({ theme }) => theme.typography.weights.bold};
+`;
+
+const StyledAlertText = styled.p`
+  margin-left: ${({ theme }) => theme.gridUnit * 9}px;
+`;
+
+const StyledButtonsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const StyledAlertIcon = styled(Icon)`
+  color: ${({ theme }) => theme.colors.alert.base};
+  margin-right: ${({ theme }) => theme.gridUnit * 3}px;
+`;
+
+export interface ConfirmationAlertProps {
+  title: string;
+  children: React.ReactNode;
+  onConfirm: () => void;
+  onDismiss: () => void;
+}
+
+export function CancelConfirmationAlert({
+  title,
+  onConfirm,
+  onDismiss,
+  children,
+}: ConfirmationAlertProps) {
+  return (
+    <StyledAlert bsStyle="warning" key="alert">
+      <StyledTextContainer>
+        <StyledTitleBox>
+          <StyledAlertIcon name="alert-solid" />
+          <StyledAlertTitle>{title}</StyledAlertTitle>
+        </StyledTitleBox>
+        <StyledAlertText>{children}</StyledAlertText>
+      </StyledTextContainer>
+      <StyledButtonsContainer>
+        <Button
+          key="submit"
+          buttonSize="small"
+          buttonStyle="primary"
+          onClick={onConfirm}
+        >
+          {t('Yes, cancel')}
+        </Button>
+        <Button
+          key="cancel"
+          buttonSize="small"
+          buttonStyle="secondary"
+          onClick={onDismiss}
+        >
+          {t('Keep editing')}
+        </Button>
+      </StyledButtonsContainer>
+    </StyledAlert>
+  );
+}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -442,7 +442,24 @@ export function FilterConfigModal({
   };
 
   const unsavedFiltersIds = newFilterIds.filter(id => !removedFilters[id]);
-  const unsavedFiltersNames = unsavedFiltersIds.map(getFilterTitle).join(', ');
+
+  const getUnsavedFilterNames = (): string => {
+    const unsavedFiltersNames = unsavedFiltersIds.map(
+      id => `"${getFilterTitle(id)}"`,
+    );
+
+    if (unsavedFiltersNames.length === 0) {
+      return '';
+    }
+
+    if (unsavedFiltersNames.length === 1) {
+      return unsavedFiltersNames[0];
+    }
+
+    const lastFilter = unsavedFiltersNames.pop();
+
+    return `${unsavedFiltersNames.join(', ')} ${t('and')} ${lastFilter}`;
+  };
 
   const handleCancel = () => {
     if (unsavedFiltersIds.length > 0) {
@@ -468,8 +485,8 @@ export function FilterConfigModal({
               <StyledAlertText>
                 <i className="fa fa-exclamation-triangle" />{' '}
                 <span>
-                  {t(`Are you sure you want to cancel?`)} {unsavedFiltersNames}{' '}
-                  {t(`will not be saved.`)}
+                  {t(`Are you sure you want to cancel?`)}{' '}
+                  {getUnsavedFilterNames()} {t(`will not be saved.`)}
                 </span>
               </StyledAlertText>
               <div>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -479,34 +479,32 @@ export function FilterConfigModal({
       centered
       data-test="filter-modal"
       footer={[
-        <>
-          {saveAlertVisible && (
-            <StyledAlert bsStyle="warning">
-              <StyledAlertText>
-                <i className="fa fa-exclamation-triangle" />{' '}
-                <span>
-                  {t(`Are you sure you want to cancel?`)}{' '}
-                  {getUnsavedFilterNames()} {t(`will not be saved.`)}
-                </span>
-              </StyledAlertText>
-              <div>
-                <Button
-                  key="submit"
-                  buttonStyle="primary"
-                  onClick={confirmCancel}
-                >
-                  {t('Confirm')}
-                </Button>
-              </div>
-            </StyledAlert>
-          )}
-          <Button key="cancel" buttonStyle="secondary" onClick={handleCancel}>
-            {t('Cancel')}
-          </Button>
-          <Button key="submit" buttonStyle="primary" onClick={onOk}>
-            {t('Save')}
-          </Button>
-        </>,
+        saveAlertVisible && (
+          <StyledAlert bsStyle="warning" key="alert">
+            <StyledAlertText>
+              <i className="fa fa-exclamation-triangle" />{' '}
+              <span>
+                {t(`Are you sure you want to cancel?`)}{' '}
+                {getUnsavedFilterNames()} {t(`will not be saved.`)}
+              </span>
+            </StyledAlertText>
+            <div>
+              <Button
+                key="submit"
+                buttonStyle="primary"
+                onClick={confirmCancel}
+              >
+                {t('Confirm')}
+              </Button>
+            </div>
+          </StyledAlert>
+        ),
+        <Button key="cancel" buttonStyle="secondary" onClick={handleCancel}>
+          {t('Cancel')}
+        </Button>,
+        <Button key="submit" buttonStyle="primary" onClick={onOk}>
+          {t('Save')}
+        </Button>,
       ]}
     >
       <ErrorBoundary>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -125,11 +125,12 @@ const StyledAlert = styled(Alert)`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: ${({ theme }) => theme.gridUnit}px;
+  margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
 const StyledAlertText = styled.div`
   text-align: left;
+  margin-right: ${({ theme }) => theme.gridUnit}px;
 `;
 
 type FilterRemoval =
@@ -246,6 +247,7 @@ export function FilterConfigModal({
     const newFilterId = generateFilterId();
     setNewFilterIds([...newFilterIds, newFilterId]);
     setCurrentFilterId(newFilterId);
+    setSaveAlertVisible(false);
   }, [newFilterIds, setCurrentFilterId]);
 
   // if this is a "create" modal rather than an "edit" modal,
@@ -434,18 +436,16 @@ export function FilterConfigModal({
     validateForm,
   ]);
 
-  const newFiltersNames = newFilterIds.map(getFilterTitle).join(', ');
-
   const confirmCancel = () => {
     resetForm();
     onCancel();
   };
 
+  const unsavedFiltersIds = newFilterIds.filter(id => !removedFilters[id]);
+  const unsavedFiltersNames = unsavedFiltersIds.map(getFilterTitle).join(', ');
+
   const handleCancel = () => {
-    const savedFilterIds = getFilterIds(filterConfig);
-    if (
-      !newFilterIds.every(newFilterId => savedFilterIds.includes(newFilterId))
-    ) {
+    if (unsavedFiltersIds.length > 0) {
       setSaveAlertVisible(true);
     } else {
       confirmCancel();
@@ -468,7 +468,7 @@ export function FilterConfigModal({
               <StyledAlertText>
                 <i className="fa fa-exclamation-triangle" />{' '}
                 <span>
-                  {t(`Are you sure you want to cancel?`)} {newFiltersNames}{' '}
+                  {t(`Are you sure you want to cancel?`)} {unsavedFiltersNames}{' '}
                   {t(`will not be saved.`)}
                 </span>
               </StyledAlertText>
@@ -477,7 +477,6 @@ export function FilterConfigModal({
                   key="submit"
                   buttonStyle="primary"
                   onClick={confirmCancel}
-                  style={{ marginLeft: 16 }}
                 >
                   {t('Confirm')}
                 </Button>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -21,7 +21,6 @@ import { findLastIndex, uniq } from 'lodash';
 import shortid from 'shortid';
 import { DeleteFilled, PlusOutlined } from '@ant-design/icons';
 import { styled, t } from '@superset-ui/core';
-import Alert from 'react-bootstrap/lib/Alert';
 import { Form } from 'src/common/components';
 import { StyledModal } from 'src/common/components/Modal';
 import Button from 'src/components/Button';
@@ -32,6 +31,7 @@ import ErrorBoundary from 'src/components/ErrorBoundary';
 import { useFilterConfigMap, useFilterConfiguration } from './state';
 import FilterConfigForm from './FilterConfigForm';
 import { FilterConfiguration, NativeFiltersForm } from './types';
+import { CancelConfirmationAlert } from './CancelConfirmationAlert';
 
 // how long to show the "undo" button when removing a filter
 const REMOVAL_DELAY_SECS = 5;
@@ -119,18 +119,6 @@ const StyledAddFilterBox = styled.div`
   &:hover {
     color: ${({ theme }) => theme.colors.primary.base};
   }
-`;
-
-const StyledAlert = styled(Alert)`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
-`;
-
-const StyledAlertText = styled.div`
-  text-align: left;
-  margin-right: ${({ theme }) => theme.gridUnit}px;
 `;
 
 type FilterRemoval =
@@ -469,6 +457,30 @@ export function FilterConfigModal({
     }
   };
 
+  const renderFooterElements = (): React.ReactNode[] => {
+    if (saveAlertVisible) {
+      return [
+        <CancelConfirmationAlert
+          title={`${unsavedFiltersIds.length} ${t('unsaved filters')}`}
+          onConfirm={confirmCancel}
+          onDismiss={() => setSaveAlertVisible(false)}
+        >
+          {t(`Are you sure you want to cancel?`)} {getUnsavedFilterNames()}{' '}
+          {t(`will not be saved.`)}
+        </CancelConfirmationAlert>,
+      ];
+    }
+
+    return [
+      <Button key="cancel" buttonStyle="secondary" onClick={handleCancel}>
+        {t('Cancel')}
+      </Button>,
+      <Button key="submit" buttonStyle="primary" onClick={onOk}>
+        {t('Save')}
+      </Button>,
+    ];
+  };
+
   return (
     <StyledModal
       visible={isOpen}
@@ -478,34 +490,7 @@ export function FilterConfigModal({
       onOk={onOk}
       centered
       data-test="filter-modal"
-      footer={[
-        saveAlertVisible && (
-          <StyledAlert bsStyle="warning" key="alert">
-            <StyledAlertText>
-              <i className="fa fa-exclamation-triangle" />{' '}
-              <span>
-                {t(`Are you sure you want to cancel?`)}{' '}
-                {getUnsavedFilterNames()} {t(`will not be saved.`)}
-              </span>
-            </StyledAlertText>
-            <div>
-              <Button
-                key="submit"
-                buttonStyle="primary"
-                onClick={confirmCancel}
-              >
-                {t('Confirm')}
-              </Button>
-            </div>
-          </StyledAlert>
-        ),
-        <Button key="cancel" buttonStyle="secondary" onClick={handleCancel}>
-          {t('Cancel')}
-        </Button>,
-        <Button key="submit" buttonStyle="primary" onClick={onOk}>
-          {t('Save')}
-        </Button>,
-      ]}
+      footer={renderFooterElements()}
     >
       <ErrorBoundary>
         <StyledModalBody>


### PR DESCRIPTION
### SUMMARY
The aim was to show info at the bottom of Native Filter Config Modal when users clicks 'cancel'.
Now we want the user to confirm this decision when there are unsaved filters.
Fixes #12459

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Confirming cancel:
![canceling_filters](https://user-images.githubusercontent.com/47450693/104759548-5afdee00-5760-11eb-9419-ee69df2e7ce6.gif)

Remove incorrect 
![removing_incorrect_alert](https://user-images.githubusercontent.com/47450693/104759593-6c46fa80-5760-11eb-8341-c117d2127ebf.gif)

Alert with long filter names:
<img width="978" alt="long_filters" src="https://user-images.githubusercontent.com/47450693/104760233-5d147c80-5761-11eb-921c-bcae16917906.png">

### TEST PLAN
Set `"DASHBOARD_NATIVE_FILTERS": True`
Create native filter
Click Cancel

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12459
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

cc @junlincc @rusackas @villebro 
@adam-stasiak please test it 