### PR TITLE
fix(viz): missing groupby and broken adhoc metrics for boxplot

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -166,6 +166,7 @@ class QueryContext:
         if self.result_type == utils.ChartDataResultType.SAMPLES:
             row_limit = query_obj.row_limit or math.inf
             query_obj = copy.copy(query_obj)
+            query_obj.is_timeseries = False
             query_obj.orderby = []
             query_obj.groupby = []
             query_obj.metrics = []

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -142,7 +142,7 @@ class QueryContext:
     def df_metrics_to_num(df: pd.DataFrame, query_object: QueryObject) -> None:
         """Converting metrics to numeric when pandas.read_sql cannot"""
         for col, dtype in df.dtypes.items():
-            if dtype.type == np.object_ and col in query_object.metrics:
+            if dtype.type == np.object_ and col in query_object.metric_names:
                 df[col] = pd.to_numeric(df[col], errors="coerce")
 
     def get_data(self, df: pd.DataFrame,) -> Union[str, List[Dict[str, Any]]]:

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -28,7 +28,7 @@ from superset import app, is_feature_enabled
 from superset.exceptions import QueryObjectValidationError
 from superset.typing import Metric
 from superset.utils import pandas_postprocessing
-from superset.utils.core import DTTM_ALIAS, json_int_dttm_ser
+from superset.utils.core import DTTM_ALIAS, get_metric_names, json_int_dttm_ser
 from superset.utils.date_parser import get_since_until, parse_human_timedelta
 from superset.views.utils import get_time_range_endpoints
 
@@ -211,6 +211,10 @@ class QueryObject:
                             field.old_name,
                         )
                     self.extras[field.new_name] = value
+
+    @property
+    def metric_names(self) -> List[str]:
+        return get_metric_names(self.metrics)
 
     def to_dict(self) -> Dict[str, Any]:
         query_object_dict = {

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -993,6 +993,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
 
         time_range_endpoints = extras.get("time_range_endpoints")
         groupby_exprs_with_timestamp = OrderedDict(groupby_exprs_sans_timestamp.items())
+
         if granularity:
             dttm_col = columns_by_name[granularity]
             time_grain = extras.get("time_grain_sqla")
@@ -1032,7 +1033,7 @@ class SqlaTable(  # pylint: disable=too-many-public-methods,too-many-instance-at
 
         tbl = self.get_from_clause(template_processor)
 
-        if (is_sip_38 and metrics) or (not is_sip_38 and not columns):
+        if groupby_exprs_with_timestamp:
             qry = qry.group_by(*groupby_exprs_with_timestamp.values())
 
         where_clause_and = []


### PR DESCRIPTION
### SUMMARY

Fix two bugs in Box Plot Viz:

1.  when select "Series" and "Distributed by", `SqalTable` generates invalid SQL queries
   ![image](https://user-images.githubusercontent.com/335541/104763787-4c411800-571b-11eb-9a66-380c1a5f1722.png)
2. when applying adhoc metrics, post processing fails:
   ![image](https://user-images.githubusercontent.com/335541/104765385-ac38be00-571d-11eb-838b-37cc4334c8b9.png)

Not sure when did these bugs occur, but they seem to be related to either #9366 or #12091 .

Anyway, the related logics in the new chart data API were not robust enough. Both issues were actually fixed in #10270 as well, but I'm creating a separate PR here to fix BoxPlot first.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See summary for BEFORE.

### TEST PLAN

Manual verification.

1. Go to Box Plot
2. Select both "Series" and "Distributed By"
3. To test Bug 2, make sure to use an adhoc metric

This is a hotfix. I'm going to create a separate task to add tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: see SUMMARY  closes #12553 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
