### PR TITLE
fix: height on grid results

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.tsx
@@ -463,43 +463,45 @@ export default class FilterableTable extends PureComponent<
 
     // fix height of filterable table
     return (
-      <ScrollSync>
-        {({ onScroll, scrollTop }) => (
-          <div
-            style={{ height }}
-            className="filterable-table-container Table"
-            data-test="filterable-table-container"
-            ref={this.container}
-          >
-            <div className="LeftColumn">
-              <Grid
-                cellRenderer={this.renderGridCellHeader}
-                columnCount={orderedColumnKeys.length}
-                columnWidth={getColumnWidth}
-                height={rowHeight}
-                rowCount={1}
-                rowHeight={rowHeight}
-                scrollTop={scrollTop}
-                width={this.totalTableWidth}
-              />
+      <StyledFilterableTable>
+        <ScrollSync>
+          {({ onScroll, scrollTop }) => (
+            <div
+              style={{ height }}
+              className="filterable-table-container Table"
+              data-test="filterable-table-container"
+              ref={this.container}
+            >
+              <div className="LeftColumn">
+                <Grid
+                  cellRenderer={this.renderGridCellHeader}
+                  columnCount={orderedColumnKeys.length}
+                  columnWidth={getColumnWidth}
+                  height={rowHeight}
+                  rowCount={1}
+                  rowHeight={rowHeight}
+                  scrollTop={scrollTop}
+                  width={this.totalTableWidth}
+                />
+              </div>
+              <div className="RightColumn">
+                <Grid
+                  cellRenderer={this.renderGridCell}
+                  columnCount={orderedColumnKeys.length}
+                  columnWidth={getColumnWidth}
+                  height={totalTableHeight - rowHeight}
+                  onScroll={onScroll}
+                  overscanColumnCount={overscanColumnCount}
+                  overscanRowCount={overscanRowCount}
+                  rowCount={this.list.size}
+                  rowHeight={rowHeight}
+                  width={this.totalTableWidth}
+                />
+              </div>
             </div>
-            <div className="RightColumn">
-              <Grid
-                cellRenderer={this.renderGridCell}
-                columnCount={orderedColumnKeys.length}
-                columnWidth={getColumnWidth}
-                height={totalTableHeight - rowHeight}
-                onScroll={onScroll}
-                overscanColumnCount={overscanColumnCount}
-                overscanRowCount={overscanRowCount}
-                rowCount={this.list.size}
-                rowHeight={rowHeight}
-                width={this.totalTableWidth}
-              />
-            </div>
-          </div>
-        )}
-      </ScrollSync>
+          )}
+        </ScrollSync>
+      </StyledFilterableTable>
     );
   }
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Results with 50+ (`MAX_COLUMNS_FOR_TABLE`) columns in SQL Lab are currently broken. The `<FilterableTable>` component has two different render options, one for <50 columns and another for 50+. Recently (?), the component was styled, but the styling was applied only to the <50 columns render method.

I fixed it by wrapping the grid element (`<SyncScroll>`) in `<StyledFilterableTable>` as well.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot_2021-01-15 Superset(1)](https://user-images.githubusercontent.com/1534870/104770351-4cdeac00-5725-11eb-8cfe-f2489e4f28ac.png)

After:

![Screenshot_2021-01-15 Superset](https://user-images.githubusercontent.com/1534870/104770359-50723300-5725-11eb-8c14-898972568c67.png)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

See screenshots.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/12538
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
