### PR TITLE
fix: Save tabs when saving the query

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -139,42 +139,8 @@ export function queryValidationFailed(query, message, error) {
   return { type: QUERY_VALIDATION_FAILED, query, message, error };
 }
 
-export function saveQuery(query) {
-  return dispatch =>
-    SupersetClient.post({
-      endpoint: '/savedqueryviewapi/api/create',
-      postPayload: convertQueryToServer(query),
-      stringify: false,
-    })
-      .then(result => {
-        dispatch({
-          type: QUERY_EDITOR_SAVED,
-          query,
-          result: convertQueryToClient(result.json.item),
-        });
-        dispatch(addSuccessToast(t('Your query was saved')));
-      })
-      .catch(() =>
-        dispatch(addDangerToast(t('Your query could not be saved'))),
-      );
-}
-
 export function updateQueryEditor(alterations) {
   return { type: UPDATE_QUERY_EDITOR, alterations };
-}
-
-export function updateSavedQuery(query) {
-  return dispatch =>
-    SupersetClient.put({
-      endpoint: `/savedqueryviewapi/api/update/${query.remoteId}`,
-      postPayload: convertQueryToServer(query),
-      stringify: false,
-    })
-      .then(() => dispatch(addSuccessToast(t('Your query was updated'))))
-      .catch(() =>
-        dispatch(addDangerToast(t('Your query could not be updated'))),
-      )
-      .then(() => dispatch(updateQueryEditor(query)));
 }
 
 export function scheduleQuery(query) {
@@ -845,6 +811,44 @@ export function queryEditorSetTitle(queryEditor, title) {
         ),
       );
   };
+}
+
+export function saveQuery(query) {
+  return dispatch =>
+    SupersetClient.post({
+      endpoint: '/savedqueryviewapi/api/create',
+      postPayload: convertQueryToServer(query),
+      stringify: false,
+    })
+      .then(result => {
+        dispatch({
+          type: QUERY_EDITOR_SAVED,
+          query,
+          result: convertQueryToClient(result.json.item),
+        });
+        dispatch(addSuccessToast(t('Your query was saved')));
+        dispatch(queryEditorSetTitle(query, query.title));
+      })
+      .catch(() =>
+        dispatch(addDangerToast(t('Your query could not be saved'))),
+      );
+}
+
+export function updateSavedQuery(query) {
+  return dispatch =>
+    SupersetClient.put({
+      endpoint: `/savedqueryviewapi/api/update/${query.remoteId}`,
+      postPayload: convertQueryToServer(query),
+      stringify: false,
+    })
+      .then(() => {
+        dispatch(addSuccessToast(t('Your query was updated')));
+        dispatch(queryEditorSetTitle(query, query.title));
+      })
+      .catch(() =>
+        dispatch(addDangerToast(t('Your query could not be updated'))),
+      )
+      .then(() => dispatch(updateQueryEditor(query)));
 }
 
 export function queryEditorSetSql(queryEditor, sql) {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix small bug with updating the query tab name on query save. This bug only appears specifically when `SQLLAB_BACKEND_PERSISTENCE` is True.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
