### PR TITLE
fix: case expression should not have double quotes

### DIFF
--- a/superset/examples/configs/datasets/examples/FCC_2018_Survey.yaml
+++ b/superset/examples/configs/datasets/examples/FCC_2018_Survey.yaml
@@ -45,19 +45,19 @@ columns:
   type: STRING
   groupby: true
   filterable: true
-  expression: "CASE \n  WHEN school_degree = \"no high school (secondary school)\"\
-    \ THEN \"A. No high school (secondary school)\"\n  WHEN school_degree =  \"some\
-    \ high school\" THEN \"B. Some high school\"\n  WHEN school_degree = \"high school\
-    \ diploma or equivalent (GED)\" THEN \"C. High school diploma or equivalent (GED)\"\
-    \n  WHEN school_degree = \"associate's degree\" THEN \"D. Associate's degree\"\
-    \n  WHEN school_degree = \"some college credit, no degree\" THEN \"E. Some college\
-    \ credit, no degree\"\n  WHEN school_degree = \"bachelor's degree\" THEN \"F.\
-    \ Bachelor's degree\"\n  WHEN school_degree = \"trade, technical, or vocational\
-    \ training\" THEN \"G. Trade, technical, or vocational training\"\n  WHEN school_degree\
-    \ = \"master's degree (non-professional)\" THEN \"H. Master's degree (non-professional)\"\
-    \n  WHEN school_degree = \"Ph.D.\" THEN \"I. Ph.D.\"\n  WHEN school_degree = \"\
-    professional degree (MBA, MD, JD, etc.)\" THEN \"J. Professional degree (MBA,\
-    \ MD, JD, etc.)\"\nEND"
+  expression: "CASE \n  WHEN school_degree = 'no high school (secondary school)'\
+    \ THEN 'A. No high school (secondary school)'\n  WHEN school_degree =  'some\
+    \ high school' THEN 'B. Some high school'\n  WHEN school_degree = 'high school\
+    \ diploma or equivalent (GED)' THEN 'C. High school diploma or equivalent (GED)'\
+    \n  WHEN school_degree = 'associate''s degree' THEN 'D. Associate''s degree'\
+    \n  WHEN school_degree = 'some college credit, no degree' THEN 'E. Some college\
+    \ credit, no degree'\n  WHEN school_degree = 'bachelor''s degree' THEN 'F.\
+    \ Bachelor''s degree'\n  WHEN school_degree = 'trade, technical, or vocational\
+    \ training' THEN 'G. Trade, technical, or vocational training'\n  WHEN school_degree\
+    \ = 'master''s degree (non-professional)' THEN 'H. Master''s degree (non-professional)'\
+    \n  WHEN school_degree = 'Ph.D.' THEN 'I. Ph.D.'\n  WHEN school_degree = '\
+    professional degree (MBA, MD, JD, etc.)' THEN 'J. Professional degree (MBA,\
+    \ MD, JD, etc.)'\nEND"
   description: Highest Degree Earned
   python_date_format: null
 - column_name: job_location_preference


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix `CASE` expression so it uses single quotes instead of double.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

In MySQL:

![Screenshot_2021-01-15 Explore - FCC 2018 Survey](https://user-images.githubusercontent.com/1534870/104779846-abf7ed00-5734-11eb-9bea-69766cd41027.png)

![Screenshot_2021-01-15 Explore - FCC 2018 Survey(1)](https://user-images.githubusercontent.com/1534870/104779863-b0240a80-5734-11eb-9180-47c9cfffea40.png)


### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Tested in MySQL, Postgres and Sqlite (see screenshots for MySQL).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/12559
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
