### PR TITLE
chore: upgrade CI runner to Ubuntu 20.04

### DIFF
--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   license_check:
     name: License Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Java

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   docs:
     name: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cypress-matrix:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
@@ -105,7 +105,7 @@ jobs:
   Cypress:
     if: ${{ always() }}
     name: Cypress (chrome)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: cypress-matrix
     steps:
       - name: Check build matrix status

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]
@@ -32,7 +32,7 @@ jobs:
         run: pylint -j 0 superset
 
   pre-commit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]
@@ -54,7 +54,7 @@ jobs:
         run: pre-commit run --all-files
 
   babel-extract:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-postgres-presto:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # run unit tests in multiple version just for fun
@@ -67,7 +67,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-postgres-hive:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # run unit tests in multiple version just for fun

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-mysql:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]
@@ -55,7 +55,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-postgres:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7, 3.8]
@@ -102,7 +102,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-sqlite:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   frontend-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
           npm run check-translation
 
   babel-extract:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test-postgres-hive:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # run unit tests in multiple version just for fun

--- a/.github/workflows/test-presto.yml
+++ b/.github/workflows/test-presto.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test-postgres-presto:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       strategy:
         matrix:
           # run unit tests in multiple version just for fun


### PR DESCRIPTION
### SUMMARY

Hope this fixes current broken CI where apt fails to update:

>  E: The repository 'https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04  Release' no longer has a Release file.

E.g. https://github.com/apache/superset/runs/1710882908?check_suite_focus=true

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

CI must pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
