### PR TITLE
feat(bigquery): implement custom minute time grains

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -245,6 +245,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                 date_trunc_function = cls._date_trunc_functions.get(type_)
                 if date_trunc_function:
                     time_expr = time_expr.replace("{func}", date_trunc_function)
+            if type_ and "{type}" in time_expr:
+                date_trunc_function = cls._date_trunc_functions.get(type_)
+                if date_trunc_function:
+                    time_expr = time_expr.replace("{type}", type_)
         else:
             time_expr = "{col}"
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -66,6 +66,18 @@ class BigQueryEngineSpec(BaseEngineSpec):
         None: "{col}",
         "PT1S": "{func}({col}, SECOND)",
         "PT1M": "{func}({col}, MINUTE)",
+        "PT5M": "CAST(TIMESTAMP_SECONDS("
+        "5*60 * DIV(UNIX_SECONDS(CAST({col} AS TIMESTAMP)), 5*60)"
+        ") AS {type})",
+        "PT10M": "CAST(TIMESTAMP_SECONDS("
+        "10*60 * DIV(UNIX_SECONDS(CAST({col} AS TIMESTAMP)), 10*60)"
+        ") AS {type})",
+        "PT15M": "CAST(TIMESTAMP_SECONDS("
+        "15*60 * DIV(UNIX_SECONDS(CAST({col} AS TIMESTAMP)), 15*60)"
+        ") AS {type})",
+        "PT0.5H": "CAST(TIMESTAMP_SECONDS("
+        "30*60 * DIV(UNIX_SECONDS(CAST({col} AS TIMESTAMP)), 30*60)"
+        ") AS {type})",
         "PT1H": "{func}({col}, HOUR)",
         "P1D": "{func}({col}, DAY)",
         "P1W": "{func}({col}, WEEK)",

--- a/tests/db_engine_specs/bigquery_tests.py
+++ b/tests/db_engine_specs/bigquery_tests.py
@@ -74,6 +74,28 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
             )
             self.assertEqual(str(actual), expected)
 
+    def test_custom_minute_timegrain_expressions(self):
+        """
+        DB Eng Specs (bigquery): Test time grain expressions
+        """
+        col = column("temporal")
+        test_cases = {
+            "DATE": "CAST(TIMESTAMP_SECONDS("
+            "5*60 * DIV(UNIX_SECONDS(CAST(temporal AS TIMESTAMP)), 5*60)"
+            ") AS DATE)",
+            "DATETIME": "CAST(TIMESTAMP_SECONDS("
+            "5*60 * DIV(UNIX_SECONDS(CAST(temporal AS TIMESTAMP)), 5*60)"
+            ") AS DATETIME)",
+            "TIMESTAMP": "CAST(TIMESTAMP_SECONDS("
+            "5*60 * DIV(UNIX_SECONDS(CAST(temporal AS TIMESTAMP)), 5*60)"
+            ") AS TIMESTAMP)",
+        }
+        for type_, expected in test_cases.items():
+            actual = BigQueryEngineSpec.get_timestamp_expr(
+                col=col, pdf=None, time_grain="PT5M", type_=type_
+            )
+            self.assertEqual(str(actual), expected)
+
     def test_fetch_data(self):
         """
         DB Eng Specs (bigquery): Test fetch data

--- a/tests/db_engine_specs/bigquery_tests.py
+++ b/tests/db_engine_specs/bigquery_tests.py
@@ -94,7 +94,7 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
             actual = BigQueryEngineSpec.get_timestamp_expr(
                 col=col, pdf=None, time_grain="PT5M", type_=type_
             )
-            self.assertEqual(str(actual), expected)
+            assert str(actual) == expected
 
     def test_fetch_data(self):
         """


### PR DESCRIPTION
### SUMMARY
Currently the BigQuery engine spec only supports full seconds/minutes/hours due to the dialect not natively supporting custom intervals. This PR adds support for the missing default 5, 10, 15 and 30 min grains by utilizing some custom timestamp handling functions:

### Screenshot
![image](https://user-images.githubusercontent.com/33317356/104903270-75b2ab80-5988-11eb-8251-6be14582d4c2.png)

### TEST PLAN
Verified to work on `TIMESTAMP`, `DATETIME` and `DATE` types + added new unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
