### PR TITLE
fix(dashboard): dropdown indicator in dashboard tabs has proper width and position

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -86,22 +86,6 @@ const StyledTabsContainer = styled.div`
     position: relative;
   }
 
-  .drop-indicator--left {
-    left: ${({ theme }) => -theme.gridUnit * 3}px !important;
-  }
-  .drop-indicator--right {
-    left: ${({ theme }) => `calc(100% + ${theme.gridUnit * 6}px)`} !important;
-  }
-
-  .drop-indicator--bottom,
-  .drop-indicator--top {
-    width: ${({ theme }) => `calc(100% + ${theme.gridUnit * 6}px)`} !important;
-  }
-
-  .drop-indicator--top {
-    top: ${({ theme }) => theme.gridUnit * 2}px;
-  }
-
   .ant-tabs {
     overflow: visible;
 


### PR DESCRIPTION
### SUMMARY
Dropdown indicators were moved several pixels to various direction (depending on indicator's area). 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Large GIF (1068x574)](https://user-images.githubusercontent.com/2536609/105046218-1bd5e280-5a69-11eb-8c62-c1c87083bb52.gif)

After:
![Large GIF (1068x574)](https://user-images.githubusercontent.com/2536609/104946453-59c7fd80-59ba-11eb-8d3b-25b6e586e9d4.gif)

After with open native filters:
![Large GIF (1068x574)](https://user-images.githubusercontent.com/2536609/104946444-55034980-59ba-11eb-81bc-817e6c74563d.gif)


### TEST PLAN
1. Go to dashboards
2. Choose a dashboard (can be `Tabbed Dashboard`
3. Go to edit mode
4. Add chart (or markdown) to the tabs area

### ADDITIONAL INFORMATION
- [x] Has associated issue: #12486
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
