### PR TITLE
docs(release): add vote thread to result template

### DIFF
--- a/RELEASING/email_templates/result_pmc.j2
+++ b/RELEASING/email_templates/result_pmc.j2
@@ -52,6 +52,8 @@ Negative votes:
 {% endfor -%}
 {%- endif %}
 
+Link to vote thread: {{ vote_thread }}
+
 We will work to complete the release process.
 
 Thanks,

--- a/RELEASING/send_email.py
+++ b/RELEASING/send_email.py
@@ -193,9 +193,21 @@ def vote_pmc(base_parameters, receiver_email):
     type=str,
     prompt="A List of people with -1 vote (ex: John)",
 )
+@click.option(
+    "--vote_thread",
+    default="",
+    type=str,
+    prompt="Permalink to the vote thread "
+    "(see https://lists.apache.org/list.html?dev@superset.apache.org)",
+)
 @click.pass_obj
 def result_pmc(
-    base_parameters, receiver_email, vote_bindings, vote_nonbindings, vote_negatives
+    base_parameters,
+    receiver_email,
+    vote_bindings,
+    vote_nonbindings,
+    vote_negatives,
+    vote_thread,
 ):
     template_file = "email_templates/result_pmc.j2"
     base_parameters.template_arguments["receiver_email"] = receiver_email
@@ -208,6 +220,7 @@ def result_pmc(
     base_parameters.template_arguments["vote_negatives"] = string_comma_to_list(
         vote_negatives
     )
+    base_parameters.template_arguments["vote_thread"] = vote_thread
     message = render_template(template_file, **base_parameters.template_arguments)
     inter_send_email(
         base_parameters.username,


### PR DESCRIPTION
### SUMMARY
Add placeholder for email vote thread to to result email template.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
