### PR TITLE
fix(dashboard): nested rows and columns with hovered menu

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -93,7 +93,7 @@ const StyledDashboardContent = styled.div`
     width: 100%;
     flex-grow: 1;
     position: relative;
-    margin: ${({ theme }) => theme.gridUnit * 2}px
+    margin: ${({ theme }) => theme.gridUnit * 6}px
       ${({ theme }) => theme.gridUnit * 8}px
       ${({ theme }) => theme.gridUnit * 6}px
       ${({ theme, dashboardFiltersOpen }) => {

--- a/superset-frontend/src/dashboard/stylesheets/hover-menu.less
+++ b/superset-frontend/src/dashboard/stylesheets/hover-menu.less
@@ -28,6 +28,7 @@
   top: 50%;
   transform: translate(0, -50%);
   left: -28px;
+  padding: 8px 0;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
### SUMMARY
When we have nested rows and columns in the dashboard the hovered menu is not visible or have not enough space. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
<img width="1406" alt="Screen_Shot_2021-01-19_at_6_52_10_AM" src="https://user-images.githubusercontent.com/2536609/105064986-a88a9b80-5a7d-11eb-9eee-df1137a58040.png">

After
![Screenshot 2021-01-19 at 17 00 30](https://user-images.githubusercontent.com/2536609/105060485-c0abec00-5a78-11eb-9316-4d0245eb4df6.png)

closes #12601 

### TEST PLAN
1. Go to Dashboard and pick World's Bank Data
2. Go to edit mode
3. Check mouse over various charts

or
Create own dashboard and nest a lot of charts and rows.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #12601
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
