### PR TITLE
fix: chart disappears in standalone slice when resizing

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -203,6 +203,11 @@ const ExploreChartPanel = props => {
     [chartRef, renderChart],
   );
 
+  const standaloneChartBody = useMemo(
+    () => <div ref={chartRef}>{renderChart()}</div>,
+    [chartRef, renderChart],
+  );
+
   if (props.standalone) {
     // dom manipulation hack to get rid of the boostrap theme's body background
     const standaloneClass = 'background-transparent';
@@ -210,7 +215,7 @@ const ExploreChartPanel = props => {
     if (!bodyClasses.includes(standaloneClass)) {
       document.body.className += ` ${standaloneClass}`;
     }
-    return renderChart();
+    return standaloneChartBody;
   }
 
   const header = (

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -557,7 +557,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             try:
                 json_body = json.loads(request.form["form_data"])
             except (TypeError, json.JSONDecodeError):
-                json_body = None
+                pass
 
         if json_body is None:
             return self.response_400(message=_("Request is not JSON"))


### PR DESCRIPTION
### SUMMARY
Add `ref` to standalone chart render

### TEST PLAN
- Go to standalone chart url; verify that chart is rendered properly
- Go to explore window; resize panels and verify everything is rendered properly

### ADDITIONAL INFORMATION

- [x] Has associated issue: #12557
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
