### PR TITLE
fix: save tabs when saving the query bug

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/actions/sqlLab_spec.js
+++ b/superset-frontend/spec/javascripts/sqllab/actions/sqlLab_spec.js
@@ -23,10 +23,9 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import shortid from 'shortid';
 import * as featureFlags from 'src/featureFlags';
-
+import { ADD_TOAST } from 'src/messageToasts/actions';
 import * as actions from 'src/SqlLab/actions/sqlLab';
 import { defaultQueryEditor, query } from '../fixtures';
-import { ADD_TOAST } from 'src/messageToasts/actions';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -139,42 +139,8 @@ export function queryValidationFailed(query, message, error) {
   return { type: QUERY_VALIDATION_FAILED, query, message, error };
 }
 
-export function saveQuery(query) {
-  return dispatch =>
-    SupersetClient.post({
-      endpoint: '/savedqueryviewapi/api/create',
-      postPayload: convertQueryToServer(query),
-      stringify: false,
-    })
-      .then(result => {
-        dispatch({
-          type: QUERY_EDITOR_SAVED,
-          query,
-          result: convertQueryToClient(result.json.item),
-        });
-        dispatch(addSuccessToast(t('Your query was saved')));
-      })
-      .catch(() =>
-        dispatch(addDangerToast(t('Your query could not be saved'))),
-      );
-}
-
 export function updateQueryEditor(alterations) {
   return { type: UPDATE_QUERY_EDITOR, alterations };
-}
-
-export function updateSavedQuery(query) {
-  return dispatch =>
-    SupersetClient.put({
-      endpoint: `/savedqueryviewapi/api/update/${query.remoteId}`,
-      postPayload: convertQueryToServer(query),
-      stringify: false,
-    })
-      .then(() => dispatch(addSuccessToast(t('Your query was updated'))))
-      .catch(() =>
-        dispatch(addDangerToast(t('Your query could not be updated'))),
-      )
-      .then(() => dispatch(updateQueryEditor(query)));
 }
 
 export function scheduleQuery(query) {
@@ -845,6 +811,44 @@ export function queryEditorSetTitle(queryEditor, title) {
         ),
       );
   };
+}
+
+export function saveQuery(query) {
+  return dispatch =>
+    SupersetClient.post({
+      endpoint: '/savedqueryviewapi/api/create',
+      postPayload: convertQueryToServer(query),
+      stringify: false,
+    })
+      .then(result => {
+        dispatch({
+          type: QUERY_EDITOR_SAVED,
+          query,
+          result: convertQueryToClient(result.json.item),
+        });
+        dispatch(addSuccessToast(t('Your query was saved')));
+        dispatch(queryEditorSetTitle(query, query.title));
+      })
+      .catch(() =>
+        dispatch(addDangerToast(t('Your query could not be saved'))),
+      );
+}
+
+export function updateSavedQuery(query) {
+  return dispatch =>
+    SupersetClient.put({
+      endpoint: `/savedqueryviewapi/api/update/${query.remoteId}`,
+      postPayload: convertQueryToServer(query),
+      stringify: false,
+    })
+      .then(() => {
+        dispatch(addSuccessToast(t('Your query was updated')));
+        dispatch(queryEditorSetTitle(query, query.title));
+      })
+      .catch(() =>
+        dispatch(addDangerToast(t('Your query could not be updated'))),
+      )
+      .then(() => dispatch(updateQueryEditor(query)));
 }
 
 export function queryEditorSetSql(queryEditor, sql) {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix small bug with updating the query tab name on query save. This bug only appears specifically when SQLLAB_BACKEND_PERSISTENCE is True.

Reference for #12561

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![saved_tabs](https://user-images.githubusercontent.com/27827808/105076849-a0b90000-5a59-11eb-9d49-0417ad99ceb8.gif)

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. Make sure `SQLLAB_BACKEND_PERSISTENCE` is True in `superset_config.py`
2. Goto sqllab
3. Create a new tab
4. Write a query and save
5. Refresh the page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
