### PR TITLE
fix: Set a unique savedMetricId when adding a new saved metric to controls

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/MetricsControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/MetricsControl_spec.jsx
@@ -158,7 +158,7 @@ describe('MetricsControl', () => {
     it('handles creating a new metric', () => {
       const { component, onChange } = setup();
       component.instance().onNewMetric({ metric_name: 'sum__value' });
-      expect(onChange.lastCall.args).toEqual([['sum__value']]);
+      expect(onChange.lastCall.args).toEqual([[{ metric_name: 'sum__value' }]]);
     });
   });
 

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -361,12 +361,17 @@ export function exploreJSON(
     };
     if (dashboardId) requestParams.dashboard_id = dashboardId;
 
-    formData.metrics = formData.metrics.map(metric => {
-      if (metric.metric_name) {
-        return metric.metric_name;
-      }
-      return metric;
-    });
+    if (formData.metric && formData.metric.metric_name) {
+      formData.metric = formData.metric.metric_name;
+    }
+    if (Array.isArray(formData.metrics)) {
+      formData.metrics = formData.metrics.map(metric => {
+        if (metric.metric_name) {
+          return metric.metric_name;
+        }
+        return metric;
+      });
+    }
 
     const chartDataRequest = getChartDataRequest({
       formData,

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -361,18 +361,6 @@ export function exploreJSON(
     };
     if (dashboardId) requestParams.dashboard_id = dashboardId;
 
-    if (formData.metric && formData.metric.metric_name) {
-      formData.metric = formData.metric.metric_name;
-    }
-    if (Array.isArray(formData.metrics)) {
-      formData.metrics = formData.metrics.map(metric => {
-        if (metric.metric_name) {
-          return metric.metric_name;
-        }
-        return metric;
-      });
-    }
-
     const chartDataRequest = getChartDataRequest({
       formData,
       resultFormat: 'json',

--- a/superset-frontend/src/chart/chartAction.js
+++ b/superset-frontend/src/chart/chartAction.js
@@ -361,6 +361,13 @@ export function exploreJSON(
     };
     if (dashboardId) requestParams.dashboard_id = dashboardId;
 
+    formData.metrics = formData.metrics.map(metric => {
+      if (metric.metric_name) {
+        return metric.metric_name;
+      }
+      return metric;
+    });
+
     const chartDataRequest = getChartDataRequest({
       formData,
       resultFormat: 'json',

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
@@ -125,7 +125,15 @@ export default class AdhocMetricEditPopover extends React.Component {
       label = metricLabel;
     }
 
-    const metric = savedMetric?.metric_name ? savedMetric : adhocMetric;
+    // if saved metric, generate a unique savedMetricId
+    const metric = savedMetric?.metric_name
+      ? {
+          ...savedMetric,
+          savedMetricId: `${Math.random()
+            .toString(36)
+            .substring(2, 15)}_${Math.random().toString(36).substring(2, 15)}`,
+        }
+      : adhocMetric;
     const oldMetric = this.props.savedMetric?.metric_name
       ? this.props.savedMetric
       : this.props.adhocMetric;

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricsControl.jsx
@@ -184,15 +184,29 @@ class MetricsControl extends React.PureComponent {
   }
 
   onMetricEdit(changedMetric, oldMetric) {
+    // if saved metric, use savedMetricId if available, otherwise use metric_name
+    // required for compatibility with metrics added before implementing savedMetricId
+    const oldMetricKey = oldMetric.metric_name
+      ? oldMetric.savedMetricId || oldMetric.metric_name
+      : oldMetric.optionName;
     this.setState(
       prevState => ({
         value: prevState.value.map(value => {
+          let valueKey;
+          if (typeof value === 'string') {
+            valueKey = value;
+          } else if (value.metric_name) {
+            valueKey = value.savedMetricId || value.metric_name;
+          } else {
+            valueKey = value.optionName;
+          }
+
           if (
             // compare saved metrics
-            value === oldMetric.metric_name ||
+            valueKey === oldMetricKey ||
             // compare adhoc metrics
-            typeof value.optionName !== 'undefined'
-              ? value.optionName === oldMetric.optionName
+            typeof valueKey !== 'undefined'
+              ? valueKey === oldMetricKey
               : false
           ) {
             return changedMetric;
@@ -232,15 +246,7 @@ class MetricsControl extends React.PureComponent {
     } else {
       transformedOpts = opts ? [opts] : [];
     }
-    const optionValues = transformedOpts
-      .map(option => {
-        // pre-defined metric
-        if (option.metric_name) {
-          return option.metric_name;
-        }
-        return option;
-      })
-      .filter(option => option);
+    const optionValues = transformedOpts.filter(option => option);
     this.props.onChange(this.props.multi ? optionValues : optionValues[0]);
   }
 

--- a/superset-frontend/src/explore/controlUtils.js
+++ b/superset-frontend/src/explore/controlUtils.js
@@ -27,6 +27,20 @@ export function getFormDataFromControls(controlsState) {
     const control = controlsState[controlName];
     formData[controlName] = control.value;
   });
+
+  // extract metric_name from saved metric object
+  if (formData.metric && formData.metric.metric_name) {
+    formData.metric = formData.metric.metric_name;
+  }
+  if (Array.isArray(formData.metrics)) {
+    formData.metrics = formData.metrics.map(metric => {
+      if (metric.metric_name) {
+        return metric.metric_name;
+      }
+      return metric;
+    });
+  }
+
   return formData;
 }
 


### PR DESCRIPTION
### SUMMARY
Saved metrics added to controls did not have a unique id - we distinguished them only by their names. If we added the same saved metric twice and then tried to edit 1, both items were being edited, because their names were equal.
This PR introduces a `savedMetricId`, which is added to a metric when it's added to controls via the metrics popover.
The saved metrics that had been added before this PR will not have this param until they are removed and added again, however everything should still work as expected.
**_The only case when the bug will still happen is if 2 or more exactly the same saved metrics are already in controls panel before this change is introduced. In such case, removing the metric and adding it again in control panel will fix the issue._**


Fixes https://github.com/apache/superset/issues/12611
Closes https://github.com/apache/superset/issues/12611
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/105178344-2c995d80-5b28-11eb-88e3-2e55f0f4a63a.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/12611
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @rusackas  @john-bodley @adam-stasiak