### PR TITLE
fix: missing key when verifying adhoc filters in merge_extra_filters

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1025,8 +1025,8 @@ def merge_extra_filters(  # pylint: disable=too-many-branches
         for existing in adhoc_filters:
             if (
                 existing["expressionType"] == "SIMPLE"
-                and existing["comparator"] is not None
-                and existing["subject"] is not None
+                and "comparator" in existing
+                and "subject" in existing
             ):
                 existing_filters[get_filter_key(existing)] = existing["comparator"]
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1025,8 +1025,8 @@ def merge_extra_filters(  # pylint: disable=too-many-branches
         for existing in adhoc_filters:
             if (
                 existing["expressionType"] == "SIMPLE"
-                and "comparator" in existing
-                and "subject" in existing
+                and existing.get("comparator") is not None
+                and existing.get("subject") is not None
             ):
                 existing_filters[get_filter_key(existing)] = existing["comparator"]
 


### PR DESCRIPTION
### SUMMARY
This fixes an error I encountered on a dashboard after I modified a Big Number chart type. It appears the code is checking if a key exists in a dict, which will throw an exception in Python, so I made a change to use the `in` operator instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![Screen Shot 2021-01-19 at 5 52 58 PM](https://user-images.githubusercontent.com/5475421/105185958-081c9180-5ae6-11eb-9f37-fd1ca9094390.png)

### TEST PLAN

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
