### PR TITLE
fix: remove autoscroll for filter box

### DIFF
--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -423,7 +423,7 @@ class FilterBox extends React.PureComponent {
   render() {
     const { instantFiltering, width, height } = this.props;
     return (
-      <div style={{ width, height }}>
+      <div style={{ width, height, overflowY: 'auto' }}>
         {this.renderDateFilter()}
         {this.renderDatasourceFilters()}
         {this.renderFilters()}

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -423,7 +423,7 @@ class FilterBox extends React.PureComponent {
   render() {
     const { instantFiltering, width, height } = this.props;
     return (
-      <div style={{ width, height, overflowY: 'auto' }}>
+      <div style={{ width, height }}>
         {this.renderDateFilter()}
         {this.renderDatasourceFilters()}
         {this.renderFilters()}

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -423,7 +423,7 @@ class FilterBox extends React.PureComponent {
   render() {
     const { instantFiltering, width, height } = this.props;
     return (
-      <div style={{ width, height, overflow: 'auto' }}>
+      <div style={{ width, height }}>
         {this.renderDateFilter()}
         {this.renderDatasourceFilters()}
         {this.renderFilters()}


### PR DESCRIPTION
### SUMMARY
The FilterBox visualization renders an unnecessary horizontal scroll bar when a time range filter control is present. On some browsers (e.g. Safari), this scroll bar can get in the way of the drop down if the drop down is near the scroll bar. This PR removes the overflow CSS property causing this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
![Screen Shot 2021-01-20 at 6 19 06 AM](https://user-images.githubusercontent.com/5475421/105187388-95acb100-5ae7-11eb-909f-fd5448ae1587.png)

After:
![Screen Shot 2021-01-20 at 6 19 24 AM](https://user-images.githubusercontent.com/5475421/105187417-9e04ec00-5ae7-11eb-8f8a-0f23e7c1d81e.png)

### TEST PLAN
Create a filter box and check the `Date filter` option. An unneeded horizontal scroll bar should show up. This happens both in the chart explore and if on a dashboard.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [*] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
