### PR TITLE
fix(CI): properly configure cancel duplicates

### DIFF
--- a/.github/workflows/cancel_duplicates.yml
+++ b/.github/workflows/cancel_duplicates.yml
@@ -1,25 +1,34 @@
 name: Cancel Duplicates
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: ["requested"]
+  # Checks for duplicate jobs on every push (merge) and every 10 minutes
+  push:
+  schedule:
+    - cron: "*/10 * * * *"
 
 jobs:
-  cancel-duplicate-workflow-runs:
-    name: "Cancel duplicate workflow runs"
-    runs-on: ubuntu-latest
+  cancel-duplicate-runs:
+    name: Cancel duplicate workflow runs
+    runs-on: ubuntu-20.04
     steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-          submodules: recursive
-      - uses: ./.github/actions/cancel-workflow-runs/
+      - name: Check number of queued tasks
+        id: check_queued
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          get_count() {
+            echo $(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                    "https://api.github.com/repos/$GITHUB_REPO/actions/runs?status=$1" | \
+                    jq ".total_count")
+          }
+          count=$(( `get_count queued` + `get_count in_progress` ))
+          echo "Found $count unfinished jobs."
+          echo "::set-output name=count::$count"
+
+      - uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
         name: "Cancel duplicate workflow runs"
+        if: steps.check_queued.outputs.count >= 20
         with:
-          cancelMode: duplicates
-          cancelFutureDuplicates: true
+          cancelMode: allDuplicates
           token: ${{ secrets.GITHUB_TOKEN }}
-          sourceRunId: ${{ github.event.workflow_run.id }}
-          notifyPRCancel: true
-          skipEventTypes: '["push", "pull_request", "pull_request_target"]'
+          notifyPRCancel: false

--- a/.github/workflows/cancel_duplicates.yml
+++ b/.github/workflows/cancel_duplicates.yml
@@ -1,9 +1,10 @@
 name: Cancel Duplicates
 on:
-  # Checks for duplicate jobs on every push (merge) and every 10 minutes
-  push:
-  schedule:
-    - cron: "*/10 * * * *"
+  workflow_run:
+    workflows:
+      - "Miscellaneous"
+    types:
+      - requested
 
 jobs:
   cancel-duplicate-runs:
@@ -25,9 +26,16 @@ jobs:
           echo "Found $count unfinished jobs."
           echo "::set-output name=count::$count"
 
-      - uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        name: "Cancel duplicate workflow runs"
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         if: steps.check_queued.outputs.count >= 20
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Cancel duplicate workflow runs
+        if: steps.check_queued.outputs.count >= 20
+        uses: ./.github/actions/cancel-workflow-runs
         with:
           cancelMode: allDuplicates
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cancel_duplicates.yml
+++ b/.github/workflows/cancel_duplicates.yml
@@ -29,15 +29,12 @@ jobs:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         if: steps.check_queued.outputs.count >= 20
         uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-          submodules: recursive
 
       - name: Cancel duplicate workflow runs
         if: steps.check_queued.outputs.count >= 20
-        uses: ./.github/actions/cancel-workflow-runs
-        with:
-          cancelMode: allDuplicates
-          sourceRunId: ${{ github.event.workflow_run.id }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notifyPRCancel: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          pip install click requests typing_extensions python-dateutil
+          python ./scripts/cancel_github_workflows.py

--- a/.github/workflows/cancel_duplicates.yml
+++ b/.github/workflows/cancel_duplicates.yml
@@ -38,5 +38,6 @@ jobs:
         uses: ./.github/actions/cancel-workflow-runs
         with:
           cancelMode: allDuplicates
+          sourceRunId: ${{ github.event.workflow_run.id }}
           token: ${{ secrets.GITHUB_TOKEN }}
           notifyPRCancel: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,12 +24,12 @@
 [submodule ".github/actions/file-changes-action"]
 	path = .github/actions/file-changes-action
 	url = https://github.com/trilom/file-changes-action
-[submodule ".github/actions/cancel-workflow-action"]
-	path = .github/actions/cancel-workflow-action
-	url = https://github.com/styfle/cancel-workflow-action
 [submodule ".github/actions/cached-dependencies"]
 	path = .github/actions/cached-dependencies
 	url = https://github.com/apache-superset/cached-dependencies
 [submodule ".github/actions/comment-on-pr"]
 	path = .github/actions/comment-on-pr
 	url = https://github.com/unsplash/comment-on-pr
+[submodule ".github/actions/cancel-workflow-runs"]
+	path = .github/actions/cancel-workflow-runs
+	url = https://github.com/potiuk/cancel-workflow-runs

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,6 +30,3 @@
 [submodule ".github/actions/comment-on-pr"]
 	path = .github/actions/comment-on-pr
 	url = https://github.com/unsplash/comment-on-pr
-[submodule ".github/actions/cancel-workflow-runs"]
-	path = .github/actions/cancel-workflow-runs
-	url = https://github.com/potiuk/cancel-workflow-runs

--- a/scripts/cancel_github_workflows.py
+++ b/scripts/cancel_github_workflows.py
@@ -203,10 +203,11 @@ def cancel_github_workflows(
         seen = set()
         dups = []
         for item in reversed(runs):
-            if item["workflow_id"] in seen:
+            key = f'{item["event"]}_{item["head_branch"]}_{item["workflow_id"]}'
+            if key in seen:
                 dups.append(item)
             else:
-                seen.add(item["workflow_id"])
+                seen.add(key)
         if not dups:
             print(
                 "Only the latest runs are in queue. "

--- a/scripts/cancel_github_workflows.py
+++ b/scripts/cancel_github_workflows.py
@@ -98,7 +98,7 @@ def get_runs(
     ]
 
 
-def print_commit(commit):
+def print_commit(commit, branch):
     """Print out commit message for verification"""
     indented_message = "    \n".join(commit["message"].split("\n"))
     date_str = (
@@ -107,7 +107,7 @@ def print_commit(commit):
         .strftime("%a, %d %b %Y %H:%M:%S")
     )
     print(
-        f"""HEAD {commit["id"]}
+        f"""HEAD {commit["id"]} ({branch})
 Author: {commit["author"]["name"]} <{commit["author"]["email"]}>
 Date:   {date_str}
 
@@ -223,7 +223,8 @@ def cancel_github_workflows(
         head_commit = entry["head_commit"]
         if head_commit["id"] != last_sha:
             last_sha = head_commit["id"]
-            print_commit(head_commit)
+            print("")
+            print_commit(head_commit, entry["head_branch"])
         try:
             print(f"[{entry['status']}] {entry['name']}", end="\r")
             cancel_run(repo, entry["id"])

--- a/scripts/cancel_github_workflows.py
+++ b/scripts/cancel_github_workflows.py
@@ -23,13 +23,13 @@ Example:
   export GITHUB_TOKEN=394ba3b48494ab8f930fbc93
   export GITHUB_REPOSITORY=apache/superset
 
-  # cancel previous jobs for a PR
+  # cancel previous jobs for a PR, will even cancel the running ones
   ./cancel_github_workflows.py 1042
 
   # cancel previous jobs for a branch
   ./cancel_github_workflows.py my-branch
 
-  # cancel all jobs
+  # cancel all jobs of a PR, including the latest runs
   ./cancel_github_workflows.py 1024 --include-last
 """
 import os
@@ -58,7 +58,18 @@ def request(method: Literal["GET", "POST", "DELETE", "PUT"], endpoint: str, **kw
 
 
 def list_runs(repo: str, params=None):
-    return request("GET", f"/repos/{repo}/actions/runs", params=params)
+    page = 1
+    total_count = 10000
+    while page * 100 < total_count:
+        result = request(
+            "GET",
+            f"/repos/{repo}/actions/runs",
+            params={**params, "per_page": 100, "page": page},
+        )
+        total_count = result["total_count"]
+        for item in result["workflow_runs"]:
+            yield item
+        page += 1
 
 
 def cancel_run(repo: str, run_id: Union[str, int]):
@@ -69,9 +80,9 @@ def get_pull_request(repo: str, pull_number: Union[str, int]):
     return request("GET", f"/repos/{repo}/pulls/{pull_number}")
 
 
-def get_runs_by_branch(
+def get_runs(
     repo: str,
-    branch: str,
+    branch: Optional[str] = None,
     user: Optional[str] = None,
     statuses: Iterable[str] = ("queued", "in_progress"),
     events: Iterable[str] = ("pull_request", "push"),
@@ -81,10 +92,8 @@ def get_runs_by_branch(
         item
         for event in events
         for status in statuses
-        for item in list_runs(
-            repo, {"event": event, "status": status, "per_page": 100}
-        )["workflow_runs"]
-        if item["head_branch"] == branch
+        for item in list_runs(repo, {"event": event, "status": status})
+        if (branch is None or (branch == item["head_branch"]))
         and (user is None or (user == item["head_repository"]["owner"]["login"]))
     ]
 
@@ -132,10 +141,10 @@ Date:   {date_str}
     show_default=True,
     help="Whether to also cancel running workflows.",
 )
-@click.argument("branch_or_pull")
+@click.argument("branch_or_pull", required=False)
 def cancel_github_workflows(
-    branch_or_pull: str,
-    repo,
+    branch_or_pull: Optional[str],
+    repo: str,
     event: List[str],
     include_last: bool,
     include_running: bool,
@@ -145,24 +154,25 @@ def cancel_github_workflows(
         raise ClickException("Please provide GITHUB_TOKEN as an env variable")
 
     statuses = ("queued", "in_progress") if include_running else ("queued",)
+    events = event
     pr = None
 
-    if branch_or_pull.isdigit():
+    if branch_or_pull is None:
+        title = "all jobs" if include_last else "all duplicate jobs"
+    elif branch_or_pull.isdigit():
         pr = get_pull_request(repo, pull_number=branch_or_pull)
-        target_type = "pull request"
-        title = f"#{pr['number']} - {pr['title']}"
+        title = f"pull request #{pr['number']} - {pr['title']}"
     else:
         target_type = "branch"
-        title = branch_or_pull
+        title = f"branch [{branch_or_pull}]"
 
     print(
         f"\nCancel {'active' if include_running else 'previous'} "
-        f"workflow runs for {target_type}\n\n    {title}\n"
+        f"workflow runs for {title}\n"
     )
 
     if pr:
-        # full branch name
-        runs = get_runs_by_branch(
+        runs = get_runs(
             repo,
             statuses=statuses,
             events=event,
@@ -172,19 +182,22 @@ def cancel_github_workflows(
     else:
         user = None
         branch = branch_or_pull
-        if ":" in branch:
+        if branch and ":" in branch:
             [user, branch] = branch.split(":", 2)
-        runs = get_runs_by_branch(
-            repo, statuses=statuses, events=event, branch=branch_or_pull, user=user
+        runs = get_runs(
+            repo, branch=branch, user=user, statuses=statuses, events=events,
         )
 
+    # sort old jobs to the front, so to cancel older jobs first
     runs = sorted(runs, key=lambda x: x["created_at"])
-    if not runs:
+    if runs:
+        print(f"Found {len(runs)} potential runs of\n   status: {statuses}\n   event: {events}\n")
+    else:
         print(f"No {' or '.join(statuses)} workflow runs found.\n")
         return
 
     if not include_last:
-        # Only keep one item for each workflow
+        # Keep the latest run for each workflow and cancel all others
         seen = set()
         dups = []
         for item in reversed(runs):

--- a/scripts/cancel_github_workflows.py
+++ b/scripts/cancel_github_workflows.py
@@ -58,6 +58,9 @@ def request(method: Literal["GET", "POST", "DELETE", "PUT"], endpoint: str, **kw
 
 
 def list_runs(repo: str, params=None):
+    """List all github workflow runs.
+    Returns:
+      An iterator that will iterate through all pages of matching runs."""
     page = 1
     total_count = 10000
     while page * 100 < total_count:

--- a/scripts/cancel_github_workflows.py
+++ b/scripts/cancel_github_workflows.py
@@ -163,7 +163,6 @@ def cancel_github_workflows(
         pr = get_pull_request(repo, pull_number=branch_or_pull)
         title = f"pull request #{pr['number']} - {pr['title']}"
     else:
-        target_type = "branch"
         title = f"branch [{branch_or_pull}]"
 
     print(
@@ -191,7 +190,10 @@ def cancel_github_workflows(
     # sort old jobs to the front, so to cancel older jobs first
     runs = sorted(runs, key=lambda x: x["created_at"])
     if runs:
-        print(f"Found {len(runs)} potential runs of\n   status: {statuses}\n   event: {events}\n")
+        print(
+            f"Found {len(runs)} potential runs of\n"
+            f"   status: {statuses}\n   event: {events}\n"
+        )
     else:
         print(f"No {' or '.join(statuses)} workflow runs found.\n")
         return


### PR DESCRIPTION
### SUMMARY

Updating the "Cancel Duplicates" job to use our own Python script, which will try to cancel all duplicate jobs of all workflows:

1. For each workflow, we keep only the latest run for a given branch + event type (`pull_request` or `push`).
2. Older runs will be cancelled even if they are already running.

The benefit of using a custom Python script instead of a black-box like 3rd party action is that even if the cancel workflow is blocked be other long-running jobs scheduled before it, committers can still run the script locally to trigger the cancellation.

Tried to use https://github.com/potiuk/cancel-workflow-runs#most-often-used-canceling-example
but it's not very easy to configure.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

The job should start correctly and duplicate runs should be properly cancelled. 

Tested on my personal fork.

Check https://github.com/ktmud/superset/actions?query=workflow%3A%22Cancel+Duplicates%22 or verification.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12090  #12394 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
