### PR TITLE
fix: Stabilize and deprecate legacy alerts module

### DIFF
--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -538,11 +538,10 @@ def schedule_email_report(
 @celery_app.task(
     name="alerts.run_query",
     bind=True,
-    soft_time_limit=config["EMAIL_ASYNC_TIME_LIMIT_SEC"],
     # TODO: find cause of https://github.com/apache/superset/issues/10530
     # and remove retry
     autoretry_for=(NoSuchColumnError, ResourceClosedError,),
-    retry_kwargs={"max_retries": 5},
+    retry_kwargs={"max_retries": 1},
     retry_backoff=True,
 )
 def schedule_alert_query(
@@ -847,8 +846,8 @@ def schedule_alerts() -> None:
     resolution = 0
     now = datetime.utcnow()
     start_at = now - timedelta(
-        seconds=3600
-    )  # process any missed tasks in the past hour
+        seconds=300
+    )  # process any missed tasks in the past few minutes
     stop_at = now + timedelta(seconds=1)
     with session_scope(nullpool=True) as session:
         schedule_window(ScheduleType.alert, start_at, stop_at, resolution, session)

--- a/superset/tasks/schedules.py
+++ b/superset/tasks/schedules.py
@@ -14,8 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-"""Utility functions used across Superset"""
+"""
+DEPRECATION NOTICE: this module is deprecated as of v1.0.0.
+It will be removed in future versions of Superset. Please
+migrate to the new scheduler: `superset.tasks.scheduler`.
+"""
 
 import logging
 import time


### PR DESCRIPTION
### SUMMARY
We are seeing exponential growth of `alert.run_query` tasks in our Celery queues, likely due to the permissive scheduling window combined with multiple task retries. This PR 1) reduces the schedule window from 1hr to a few minutes, 2) reduces the retry count from 5 to 1, and 3) removes the arbitrary `soft_time_limit` value.

Also adding a deprecation notice to this module, as it's been replaced by https://github.com/apache/superset/pull/11711

### TEST PLAN
Alert scheduling should function without exponential growth of celery task queues.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
