### PR TITLE
docs: fix redirect from bad find/replace

### DIFF
--- a/docs/.htaccess
+++ b/docs/.htaccess
@@ -19,5 +19,5 @@ RewriteEngine On
 RewriteCond %{SERVER_PORT} 80
 RewriteRule ^(.*)$ https://superset.apache.org/$1 [R,L]
 
-RewriteCond %{HTTP_HOST} ^superset.apache.org$ [NC]
+RewriteCond %{HTTP_HOST} ^superset.incubator.apache.org$ [NC]
 RewriteRule ^(.*)$ https://superset.apache.org/$1 [R=301,L]


### PR DESCRIPTION
https://github.com/apache/superset/pull/12289 did a find/replace across the board to remove all reference to the incubator/incubation/incubating and sent the Apache server's .htaccess file into a infinite redirect loop. This fixes that. 

Tested in production here https://github.com/apache/superset-site/commit/b22c82dcf553576225eac8d42fc5fc9aafd46405