### PR TITLE
fix(release): add typing-extensions as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
         "sqlalchemy>=1.3.16, <2.0, !=1.3.21",
         "sqlalchemy-utils>=0.36.6,<0.37",
         "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562
+        "typing-extensions>=3.7.4.3,<4",  # needed to support typing.Literal on py37
         "wtforms-json",
         "pyparsing>=2.4.7, <3.0.0",
         "holidays==0.10.3",  # PINNED! https://github.com/dr-prodigy/python-holidays/issues/406


### PR DESCRIPTION
### SUMMARY

When installing and running Superset 1.0.0 on Python 3.8 via `pip`, an exception is raised for a missing module. This due to the [`typing-extensions`](https://pypi.org/project/typing-extensions/) package not being pulled in automatically on Python 3.8, which is needed to support [`typing.Literal`](https://docs.python.org/3/library/typing.html#typing.Literal) on Python 3.7 and being used in `superset/utils/log.py` (introduced in #11927).

### TEST PLAN
Test locally that Superset works on both 3.7 and 3.8

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #12647
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
