### PR TITLE
fix: explore page style fix, remove unnecessary scroll bars

### DIFF
--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -161,10 +161,8 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   ) => {
     const isPseudoFocused = isFocused && !menuIsOpen;
     let borderColor = colors.grayBorder;
-    if (isPseudoFocused) {
+    if (isPseudoFocused || menuIsOpen) {
       borderColor = colors.grayBorderDark;
-    } else if (menuIsOpen) {
-      borderColor = `${colors.grayBorderDark} ${colors.grayBorder} ${colors.grayBorderLight}`;
     }
     return [
       provider,
@@ -185,22 +183,28 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
       `,
     ];
   },
-  menu: (provider, { theme: { borderRadius, zIndex, colors } }) => [
+  menu: (provider, { theme: { zIndex } }) => [
+    provider,
+    css`
+      padding-bottom: 2em;
+      z-index: ${zIndex}; /* override at least multi-page pagination */
+      width: auto;
+      min-width: 100%;
+      max-width: 80vw;
+      box-shadow: none;
+      border: 0;
+    `,
+  ],
+  menuList: (provider, { theme: { borderRadius, colors } }) => [
     provider,
     css`
       border-radius: 0 0 ${borderRadius}px ${borderRadius}px;
-      border: 1px solid #ccc;
+      border: 1px solid ${colors.grayBorderDark};
       box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
       margin-top: -1px;
       border-top-color: ${colors.grayBorderLight};
       min-width: 100%;
       width: auto;
-      z-index: ${zIndex}; /* override at least multi-page pagination */
-    `,
-  ],
-  menuList: (provider, { theme: { borderRadius } }) => [
-    provider,
-    css`
       border-radius: 0 0 ${borderRadius}px ${borderRadius}px;
       padding-top: 0;
       padding-bottom: 0;

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -46,16 +46,16 @@ const propTypes = {
 
 const Styles = styled.div`
   height: 100%;
-  max-height: 100%;
+  width: 100%;
   overflow: auto;
+  overflow-x: visible;
+  overflow-y: auto;
   .remove-alert {
     cursor: pointer;
   }
   #controlSections {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    max-height: 100%;
+    min-height: 100%;
+    overflow: visible;
   }
   .nav-tabs {
     flex: 0 0 1;
@@ -64,15 +64,18 @@ const Styles = styled.div`
     overflow: auto;
     flex: 1 1 100%;
   }
+  .Select__menu {
+    max-width: 100%;
+  }
 `;
 
 const ControlPanelsTabs = styled(Tabs)`
-  ${({ fullWidth }) =>
-    css`
-      .ant-tabs-nav-list {
-        width: ${fullWidth ? '100%' : '50%'};
-      }
-    `}
+  .ant-tabs-nav-list {
+    width: ${({ fullWidth }) => (fullWidth ? '100%' : '50%')};
+  }
+  .ant-tabs-content-holder {
+    overflow: visible;
+  }
 `;
 
 class ControlPanelsContainer extends React.Component {

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.jsx
@@ -22,7 +22,6 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Alert } from 'react-bootstrap';
-import { css } from '@emotion/core';
 import { t, styled, getChartControlPanelRegistry } from '@superset-ui/core';
 
 import Tabs from 'src/common/components/Tabs';

--- a/superset-frontend/src/explore/components/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane.tsx
@@ -57,6 +57,7 @@ const SouthPane = styled.div`
   position: relative;
   background-color: ${({ theme }) => theme.colors.grayscale.light5};
   z-index: 5;
+  overflow: hidden;
 `;
 
 const TabsWrapper = styled.div<{ contentHeight: number }>`

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -67,6 +67,7 @@ const Styles = styled.div`
   align-content: stretch;
   overflow: auto;
   box-shadow: none;
+  height: 100%;
 
   & > div:last-of-type {
     flex-basis: 100%;
@@ -241,10 +242,7 @@ const ExploreChartPanel = props => {
   });
 
   return (
-    <Styles
-      className="panel panel-default chart-container"
-      style={{ height: props.height }}
-    >
+    <Styles className="panel panel-default chart-container">
       <div className="panel-heading" ref={headerRef}>
         {header}
       </div>

--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -66,6 +66,7 @@ const Styles = styled.div`
   align-items: stretch;
   align-content: stretch;
   overflow: auto;
+  box-shadow: none;
 
   & > div:last-of-type {
     flex-basis: 100%;

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -407,7 +407,7 @@ function ExploreViewContainer(props) {
         />
       )}
       <Resizable
-        defaultSize={{ width: 300 }}
+        defaultSize={{ width: 300, height: '100%' }}
         minWidth={300}
         maxWidth="33%"
         enable={{ right: true }}
@@ -459,7 +459,7 @@ function ExploreViewContainer(props) {
         </div>
       ) : null}
       <Resizable
-        defaultSize={{ width: 320 }}
+        defaultSize={{ width: 320, height: '100%' }}
         minWidth={320}
         maxWidth="33%"
         enable={{ right: true }}

--- a/superset-frontend/src/explore/components/ExploreViewContainer.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer.jsx
@@ -95,6 +95,9 @@ const Styles = styled.div`
     flex: 1;
     min-width: ${({ theme }) => theme.gridUnit * 128}px;
     border-left: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+    .panel {
+      margin-bottom: 0;
+    }
   }
   .controls-column {
     align-self: flex-start;


### PR DESCRIPTION
### SUMMARY

Various style fix on Explore page. Remove unnecessary scrollbars and make select dropdowns more selectable. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

![Snip20210120_202](https://user-images.githubusercontent.com/335541/105318567-8c1f5980-5b78-11eb-8c8f-49396a4e7df2.png)

<img src="https://user-images.githubusercontent.com/335541/105318808-d4d71280-5b78-11eb-8de2-d5829bbbf24b.png" width="400">

#### After

![Snip20210120_203](https://user-images.githubusercontent.com/335541/105318584-90e40d80-5b78-11eb-80a1-71a52f71ba4b.png)

<img src="https://user-images.githubusercontent.com/335541/105318875-e6201f00-5b78-11eb-8e95-02cfd6dd968a.png" width="400">

1. Remove unnecessary scroll bars
2. Remove mysterious box shadow in chart panel
3. Add extra spacing to dropdown menus close to container bottom when opened
4. Allow horizontal scrolls for the dropdown menus so users can see full text of all options (wanted to allow auto-width like in SQL Lab table selector (see below), but it turns out to be much harder to do on the Explore page. We should probably just use `position: absolute` columns once #12593 is merged). 

<img src="https://user-images.githubusercontent.com/335541/105319232-6a72a200-5b79-11eb-9bc0-df92a9196fc6.png" width="500">

We should probably also revert the metrics/columns select in AdhocMetric/Filter popover back to `react-select` so that the same solution can be applied to address #12640 .

### TEST PLAN

Visual verification.

I recommend testing on the "Country of Citizenship" chart.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
