### PR TITLE
fix(dashboard): top dropdown indicator in tab moved closer to the bottom edge

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/dnd.less
+++ b/superset-frontend/src/dashboard/stylesheets/dnd.less
@@ -126,8 +126,8 @@
   }
 
   & > .empty-droptarget:first-child {
-    height: 16px;
-    top: -8px;
+    height: 14px;
+    top: -2px;
     z-index: @z-index-above-dashboard-charts;
   }
 


### PR DESCRIPTION
### SUMMARY
Really small fix in drag and drop indicator in tabs area: it is moved a few pixels down to be below the tab name area.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="971" alt="before" src="https://user-images.githubusercontent.com/2536609/105353826-06d78b80-5bf0-11eb-987f-e0594c955f80.png">

After:
<img width="963" alt="after" src="https://user-images.githubusercontent.com/2536609/105353835-0a6b1280-5bf0-11eb-873e-5b448546a57a.png">

### TEST PLAN
1. Go to dashboards
2. Choose a dashboard (can be `Tabbed Dashboard`)
3. Go to edit mode
4. Add chart (or markdown) to the tabs area

I tested with native filters enabled and disabled.

### ADDITIONAL INFORMATION
Connected to: [#12486](https://github.com/apache/superset/issues/12486#issuecomment-762388918)
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
