### PR TITLE
fix(explore): Error message not displayed correctly in Timeseries table chart

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -228,9 +228,7 @@ const TimeTable = ({
             }
           }
         >
-          {errorMsg ? (
-            errorMsg
-          ) : (
+          {errorMsg || (
             <span style={{ color }}>
               <FormattedNumber num={v} format={column.d3format} />
             </span>

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -229,7 +229,7 @@ const TimeTable = ({
           }
         >
           {errorMsg ? (
-            { errorMsg }
+            errorMsg
           ) : (
             <span style={{ color }}>
               <FormattedNumber num={v} format={column.d3format} />


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/12646

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/15073128/105357459-2a510500-5bf5-11eb-8ce9-1498797c5739.png)

After:
![image](https://user-images.githubusercontent.com/15073128/105357401-13121780-5bf5-11eb-8157-709fccc6cae8.png)

### TEST PLAN
Create a time-series table with time lag larger than the number of rows in the table - before the fix it generated a react error, now it displays a proper error message

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12646
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @john-bodley @villebro @adam-stasiak 