### PR TITLE
fix(multiline): return all chart data on initial request

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -19011,9 +19011,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-nvd3": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-nvd3/-/legacy-preset-chart-nvd3-0.16.9.tgz",
-      "integrity": "sha512-wfbVZOGqIk/IFUnzW0k44t9N/iHd0VoJzHT6wwM+GgGcCm5mizBDWot9Zuu4U1gf1KLfKUD7/lwEEtyCrs2zXw==",
+      "version": "0.16.10",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-nvd3/-/legacy-preset-chart-nvd3-0.16.10.tgz",
+      "integrity": "sha512-zQPybEGYfthiUpwSOV4E1YUWnSqWY6S4nGXR8rVh2FIUFzyYyr4f5ZzOr6DKmytPlQbL1oXg0m35A8boshOh0g==",
       "requires": {
         "@data-ui/xy-chart": "^0.0.84",
         "@superset-ui/chart-controls": "0.16.9",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -88,7 +88,7 @@
     "@superset-ui/legacy-plugin-chart-world-map": "^0.16.9",
     "@superset-ui/legacy-preset-chart-big-number": "^0.16.9",
     "@superset-ui/legacy-preset-chart-deckgl": "^0.4.1",
-    "@superset-ui/legacy-preset-chart-nvd3": "^0.16.9",
+    "@superset-ui/legacy-preset-chart-nvd3": "^0.16.10",
     "@superset-ui/plugin-chart-echarts": "^0.16.9",
     "@superset-ui/plugin-chart-table": "^0.16.9",
     "@superset-ui/plugin-chart-word-cloud": "^0.16.9",


### PR DESCRIPTION
### SUMMARY
Move the multiline logic from frontend to backend to avoid multiple requests to the backend that were complicated by async framework. Frontend changes done here: https://github.com/apache-superset/superset-ui/pull/899.

### SCREENSHOT
![image](https://user-images.githubusercontent.com/33317356/105480052-eb32ba80-5cad-11eb-8536-8d03bb85aff8.png)

### TEST PLAN
Local testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #12268
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
