### PR TITLE
fix: add order by for bar charts

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1648,6 +1648,7 @@ class DistributionBarViz(BaseViz):
             raise QueryObjectValidationError(_("Pick at least one metric"))
         if not fd.get("groupby"):
             raise QueryObjectValidationError(_("Pick at least one field for [Series]"))
+        d["orderby"] = [(d["metrics"][0], False)]
         return d
 
     def get_data(self, df: pd.DataFrame) -> VizData:


### PR DESCRIPTION
### SUMMARY
This adds an order by clause for the bar chart, ordering by the first metric descending. Without the ordering, the query will return an arbitrary set of rows if the query is limited, rather than the top N rows.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
Create a bar chart against a dataset. Limit the result to something less than the total number of rows. The top N rows, based on the metric, should be returned.

### ADDITIONAL INFORMATION

Fixes #12622 

- [X] Has associated issue: #12622 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
