### PR TITLE
fix: keep old names from screenshot images to pypi releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,26 +102,26 @@ Superset can query data from any SQL-speaking datastore or data engine (e.g. Pre
 Here are some of the major database solutions that are supported:
 
 <p align="center">
-  <img src="superset-frontend/images/redshift.png" alt="redshift" border="0" width="106" height="41"/>
-  <img src="superset-frontend/images/google-biquery.png" alt="google-biquery" border="0" width="114" height="43"/>
-  <img src="superset-frontend/images/snowflake.png" alt="snowflake" border="0" width="152" height="46"/>
-  <img src="superset-frontend/images/presto.png" alt="presto" border="0" width="152" height="46"/>
-  <img src="superset-frontend/images/druid.png" alt="druid" border="0" width="135" height="37" />
-  <img src="superset-frontend/images/postgresql.png" alt="postgresql" border="0" width="132" height="81" />
-  <img src="superset-frontend/images/mysql.png" alt="mysql" border="0" width="119" height="62" />
-  <img src="superset-frontend/images/mssql-server.png" alt="mssql-server" border="0" width="93" height="74" />
-  <img src="superset-frontend/images/db2.png" alt="db2" border="0" width="62" height="62" />
-  <img src="superset-frontend/images/sqlite.png" alt="sqlite" border="0" width="102" height="45" />
-  <img src="superset-frontend/images/sybase.png" alt="sybase" border="0" width="128" height="47" />
-  <img src="superset-frontend/images/mariadb.png" alt="mariadb" border="0" width="83" height="63" />
-  <img src="superset-frontend/images/vertica.png" alt="vertica" border="0" width="128" height="40" />
-  <img src="superset-frontend/images/oracle.png" alt="oracle" border="0" width="121" height="66" />
-  <img src="superset-frontend/images/firebird.png" alt="firebird" border="0" width="86" height="56" />
-  <img src="superset-frontend/images/greenplum.png" alt="greenplum" border="0" width="140" height="45" />
-  <img src="superset-frontend/images/clickhouse.png" alt="clickhouse" border="0" width="133" height="34" />
-  <img src="superset-frontend/images/exasol.png" alt="exasol" border="0" width="106" height="59" />
-  <img src="superset-frontend/images/monet-db.png" alt="monet-db" border="0" width="106" height="46" />
-  <img src="superset-frontend/images/apache-kylin.png" alt="apache-kylin" border="0" width="56" height="64"/>
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/redshift.png" alt="redshift" border="0" width="106" height="41"/>
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/google-biquery.png" alt="google-biquery" border="0" width="114" height="43"/>
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/snowflake.png" alt="snowflake" border="0" width="152" height="46"/>
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/presto.png" alt="presto" border="0" width="152" height="46"/>
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/druid.png" alt="druid" border="0" width="135" height="37" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/postgresql.png" alt="postgresql" border="0" width="132" height="81" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/mysql.png" alt="mysql" border="0" width="119" height="62" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/mssql-server.png" alt="mssql-server" border="0" width="93" height="74" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/db2.png" alt="db2" border="0" width="62" height="62" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/sqlite.png" alt="sqlite" border="0" width="102" height="45" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/sybase.png" alt="sybase" border="0" width="128" height="47" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/mariadb.png" alt="mariadb" border="0" width="83" height="63" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/vertica.png" alt="vertica" border="0" width="128" height="40" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/oracle.png" alt="oracle" border="0" width="121" height="66" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/firebird.png" alt="firebird" border="0" width="86" height="56" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/greenplum.png" alt="greenplum" border="0" width="140" height="45" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/clickhouse.png" alt="clickhouse" border="0" width="133" height="34" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/exasol.png" alt="exasol" border="0" width="106" height="59" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/monet-db.png" alt="monet-db" border="0" width="106" height="46" />
+  <img src="https://raw.githubusercontent.com/apache/superset/master/superset-frontend/images/apache-kylin.png" alt="apache-kylin" border="0" width="56" height="64"/>
 </p>
 
 **A more comprehensive list of supported databases** along with the configuration instructions can be found

--- a/superset-frontend/images/screenshots/bank_dash.jpg
+++ b/superset-frontend/images/screenshots/bank_dash.jpg
@@ -1,0 +1,1 @@
+slack_dash.jpg

--- a/superset-frontend/images/screenshots/deckgl_dash.png
+++ b/superset-frontend/images/screenshots/deckgl_dash.png
@@ -1,0 +1,1 @@
+geospatial_dash.jpg

--- a/superset-frontend/images/screenshots/explore.png
+++ b/superset-frontend/images/screenshots/explore.png
@@ -1,0 +1,1 @@
+explore.jpg

--- a/superset-frontend/images/screenshots/gallery.png
+++ b/superset-frontend/images/screenshots/gallery.png
@@ -1,0 +1,1 @@
+gallery.jpg

--- a/superset-frontend/images/screenshots/sqllab.jpg
+++ b/superset-frontend/images/screenshots/sqllab.jpg
@@ -1,0 +1,1 @@
+sql_lab.jpg

--- a/superset-frontend/images/screenshots/visualizations.png
+++ b/superset-frontend/images/screenshots/visualizations.png
@@ -1,0 +1,1 @@
+explore_visualizations.jpg


### PR DESCRIPTION
### SUMMARY
Partially fixes broken images links on Pypi: https://pypi.org/project/apache-superset/

Note same effect on 1.0 branch: https://github.com/apache/superset/tree/1.0

Some images do not render on Pypi because we need to access the raw path on github:
https://github.com/pypa/warehouse/issues/5246

These images were renamed after the 1.0.0 cut. We should think about a way to support these links for a certain period of time

### TEST PLAN

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
