### PR TITLE
fix: bar chart data order

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1648,7 +1648,7 @@ class DistributionBarViz(BaseViz):
             raise QueryObjectValidationError(_("Pick at least one metric"))
         if not fd.get("groupby"):
             raise QueryObjectValidationError(_("Pick at least one field for [Series]"))
-        d["orderby"] = [(d["metrics"][0], False)]
+        d["orderby"] = [(metric, False) for metric in d["metrics"]]
         return d
 
     def get_data(self, df: pd.DataFrame) -> VizData:

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -963,11 +963,11 @@ class TestCore(SupersetTestCase):
 
         resp = self.run_sql(
             """
-            SELECT count(name) AS "COUNT(name)", count(ds) AS "COUNT(ds)"
+            SELECT count(name) AS count_name, count(ds) AS count_ds
             FROM birth_names
             WHERE ds >= '1921-01-22 00:00:00.000000' AND ds < '2021-01-22 00:00:00.000000'
-            GROUP BY name ORDER BY "COUNT(name)" DESC, "COUNT(ds)" DESC
-            LIMIT 10
+            GROUP BY name ORDER BY count_name DESC, count_ds DESC
+            LIMIT 10;
             """,
             client_id="client_id_1",
             user_name="admin",
@@ -980,8 +980,8 @@ class TestCore(SupersetTestCase):
             if series["key"] == "COUNT(name)":
                 count_name = series["values"]
         for expected, actual_ds, actual_name in zip(resp["data"], count_ds, count_name):
-            assert expected["COUNT(name)"] == actual_name["y"]
-            assert expected["COUNT(ds)"] == actual_ds["y"]
+            assert expected["count_name"] == actual_name["y"]
+            assert expected["count_ds"] == actual_ds["y"]
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch.dict(


### PR DESCRIPTION
### SUMMARY
Fix order of data returned for a bar chart. Data for a bar chart should be sorted by metrics. Endpoint should return top N values when limit N applied. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN

1. Create bar chart
2. Add metric
3. Add limit N
3. Verify data returned are in descending order.
4. Verify there are top N rows

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
