### PR TITLE
chore: skip CI on draft PR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     name: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   build:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   cypress-matrix:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       # when one test fails, DO NOT cancel the other
@@ -103,7 +104,7 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots
   Cypress:
-    if: ${{ always() }}
+    if: github.event.pull_request.draft == false && ${{ always() }}
     name: Cypress (chrome)
     runs-on: ubuntu-20.04
     needs: cypress-matrix

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - "docs/**"
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   cypress-matrix:

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -6,6 +6,7 @@ on:
       - "dependabot/**/docs/**"
       - "dependabot/**/cypress-base/**"
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   build:

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   lint:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -32,6 +33,7 @@ jobs:
         run: pylint -j 0 superset
 
   pre-commit:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -54,6 +56,7 @@ jobs:
         run: pre-commit run --all-files
 
   babel-extract:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -6,6 +6,7 @@ on:
     branches-ignore:
       - "dependabot/npm_and_yarn/**"
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   lint:

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test-postgres-presto:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -67,6 +68,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-postgres-hive:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -6,6 +6,7 @@ on:
     branches-ignore:
       - "dependabot/npm_and_yarn/**"
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   test-postgres-presto:

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -6,6 +6,7 @@ on:
     branches-ignore:
       - "dependabot/npm_and_yarn/**"
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   test-mysql:

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test-mysql:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -55,6 +56,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-postgres:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -102,6 +104,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-sqlite:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   frontend-check:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -22,6 +23,7 @@ jobs:
           npm run check-translation
 
   babel-extract:
+    if: github.event.pull_request.draft == false 
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -24,7 +24,7 @@ jobs:
           npm run check-translation
 
   babel-extract:
-    if: github.event.pull_request.draft == false 
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - "dependabot/npm_and_yarn/**"
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   frontend-check:


### PR DESCRIPTION
### SUMMARY
It feels like lately CI workflows wait for hours before triggering next to release due-date when many PR's are active.
We should push the contributers to start Draft PR's which reduce the amount of  'ready to merge' PRs active in parallel.
this will enable the remaining group to run in iterations much more faster 

solution:
When a PR is a draft CI would skip
every additional commit(push) would still skip CI
when PR is changed to **ready for review** this would trigger the workflow again and CI would run

once PR gets merged CI should just run again based on push event to the master branch

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
