### PR TITLE
feat: weekly build

### DIFF
--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -1,0 +1,34 @@
+on:
+
+  schedule:
+    - cron: '0 0 * * 2'  # https://crontab.guru/#0_0_*_*_2
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get current date # following pair of steps taken from this example: https://stackoverflow.com/questions/60942067/get-current-date-and-time-in-github-workflows
+          id: date
+          run: echo "name=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Test with environment variables
+        run: echo $TAG_NAME - $RELEASE_NAME
+        env:
+          TAG_NAME: weekly-tag-${{ steps.date.outputs.date }}
+          RELEASE_NAME: weekly-release-${{ steps.date.outputs.date }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: weekly-tag-${{ steps.date.outputs.date }}
+          release_name: Reekly-release-${{ steps.date.outputs.date }}
+          body: |
+            ##todo: list of commits
+          draft: false
+          prerelease: false

--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -1,7 +1,7 @@
 on:
 
   schedule:
-    - cron: '0 0 * * 2'  # https://crontab.guru/#0_0_*_*_2
+    - cron: '0 0 * * 2'  # Midnight on every Tuesday
 
 name: Create Release
 
@@ -13,21 +13,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Get current date
-        id: date
-        run: echo "name=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Test with environment variables
-        run: echo $TAG_NAME - $RELEASE_NAME
-        env:
-          TAG_NAME: weekly-tag-${{ steps.date.outputs.date }}
-          RELEASE_NAME: weekly-release-${{ steps.date.outputs.date }}
+        run: echo "::set-output name=todays_date::$(date +'%Y-%m-%d')"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: weekly-tag-${{ steps.date.outputs.date }}
-          release_name: Reekly-release-${{ steps.date.outputs.date }}
+          tag_name: superset-1.0.0-${{ outputs.todays_date.value }}
+          release_name: superset-1.0.0-${{ outputs.todays_date.value }}
           body: |
             ##todo: list of commits
           draft: false

--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Get current date # following pair of steps taken from this example: https://stackoverflow.com/questions/60942067/get-current-date-and-time-in-github-workflows
-          id: date
-          run: echo "name=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Get current date
+        id: date
+        run: echo "name=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Test with environment variables
         run: echo $TAG_NAME - $RELEASE_NAME
         env:

--- a/.github/workflows/scheduled_weekly_build.yml
+++ b/.github/workflows/scheduled_weekly_build.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: '0 0 * * 2'  # Midnight on every Tuesday
 
-name: Create Release
+name: Scheduled weekly build
 
 jobs:
   build:
@@ -14,14 +14,18 @@ jobs:
         uses: actions/checkout@v2
       - name: Get current date
         run: echo "::set-output name=todays_date::$(date +'%Y-%m-%d')"
+      - name: Get latest tag
+        run: |
+          latest_tag_version_value=$(./scripts/find_latest_tag_version.sh)
+          echo "::set-output name=latest_tag_version::${latest_tag_version_value}"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: superset-1.0.0-${{ outputs.todays_date.value }}
-          release_name: superset-1.0.0-${{ outputs.todays_date.value }}
+          tag_name: superset-${{outputs.latest_tag_version.value}}-weekly-build-${{ outputs.todays_date.value }}
+          release_name: superset-${{outputs.latest_tag_version.value}}-weekly-build-${{ outputs.todays_date.value }}
           body: |
             ##todo: list of commits
           draft: false

--- a/.github/workflows/scheduled_weekly_build.yml
+++ b/.github/workflows/scheduled_weekly_build.yml
@@ -26,7 +26,5 @@ jobs:
         with:
           tag_name: superset-${{outputs.latest_tag_version.value}}-weekly-build-${{ outputs.todays_date.value }}
           release_name: superset-${{outputs.latest_tag_version.value}}-weekly-build-${{ outputs.todays_date.value }}
-          body: |
-            ##todo: list of commits
           draft: false
           prerelease: false

--- a/scripts/find_latest_tag_version.sh
+++ b/scripts/find_latest_tag_version.sh
@@ -1,0 +1,49 @@
+#! /bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+get_latest_tag_list() {
+ echo git show-ref latest && git show --pretty=tformat:%d -s latest | grep tag: || echo 'not found'
+}
+
+# look up the 'latest' tag on git
+LATEST_TAG_LIST=$(get_latest_tag_list)
+
+## get all tags that use the same sha as the latest tag. split at comma.
+IFS=$','
+LATEST_TAGS=($LATEST_TAG_LIST)
+
+## loop over those tags and only take action on the one that isn't tagged 'latest'
+## that one will have the version number tag
+for (( i=0; i<${#LATEST_TAGS[@]}; i++ ))
+do
+  if [[ ${LATEST_TAGS[$i]} != *"latest"* ]]
+  then
+    ## extract just the version from this tag
+    LATEST_RELEASE_TAG=$(echo "${LATEST_TAGS[$i]}" | sed -E -e 's/tag:|\(|\)|[[:space:]]*//g')
+
+    # check that this only contains a proper semantic version
+    if ! [[ ${LATEST_RELEASE_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+    then
+      continue
+    fi
+    break
+  fi
+done
+
+echo ${LATEST_RELEASE_TAG}


### PR DESCRIPTION

### SUMMARY
Weekly build will be triggered by a periodic schedule
which will actually trigger 
on:
  release:
    types: [published]

 that does a complete release cycle
 
the solution is based on the following examples:
https://futurestud.io/tutorials/github-actions-trigger-builds-on-schedule-cron
https://stackoverflow.com/questions/60942067/get-current-date-and-time-in-github-workflows
https://github.com/actions/create-release

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
