### PR TITLE
docs(db engines): Updade DB2 connection prefix

### DIFF
--- a/docs/src/pages/docs/Connecting to Databases/ibm-db2.mdx
+++ b/docs/src/pages/docs/Connecting to Databases/ibm-db2.mdx
@@ -16,3 +16,9 @@ Here's the recommended connection string:
 ```
 db2+ibm_db://{username}:{passport}@{hostname}:{port}/{database}
 ```
+
+There are two DB2 dialect versions implemented in SQLAlchemy. If you are connecting to a DB2 version without `LIMIT [n]` syntax, the recommended connection string to be able to use the SQL Lab is:
+
+```
+ibm_db_sa://{username}:{passport}@{hostname}:{port}/{database}
+```


### PR DESCRIPTION
The connection prefix should be different if the DB2 dialect is different.
