### PR TITLE
fix: Add implicit orderby to certain queries

### DIFF
--- a/superset/charts/commands/data.py
+++ b/superset/charts/commands/data.py
@@ -82,6 +82,10 @@ class ChartDataCommand(BaseCommand):
         except ValidationError as error:
             raise error
 
+        for query in self._query_context.queries:
+            if query.row_limit and query.metrics and not query.orderby:
+                query.orderby = [(query.metrics[0], False)]
+
         return self._query_context
 
     def validate(self) -> None:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1203,6 +1203,17 @@ class NVD3TimeSeriesViz(NVD3Viz):
     is_timeseries = True
     pivot_fill_value: Optional[int] = None
 
+    def query_obj(self) -> QueryObjectDict:
+        d = super().query_obj()
+        if (
+            d.get("groupby")
+            and d.get("metrics")
+            and not d.get("timeseries_limit_metric")
+        ):
+            # default series ordering to metric order
+            d["timeseries_limit_metric"] = d["metrics"][0]
+        return d
+
     def to_series(
         self, df: pd.DataFrame, classed: str = "", title_suffix: str = ""
     ) -> List[Dict[str, Any]]:


### PR DESCRIPTION
### SUMMARY
This PR adds implicit ordering for the line chart and the word cloud chart. Currently, if a line chart has a group by, the series is limited in number, and there is no sort specified, the series selected will be arbitrary rather than the top series based on the metric. Similarly, the word cloud chart, if limited, will select an arbitrary set of results, rather than the top results based on the metric.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TEST PLAN
Create a line chart with group by, limit the series number, and the top N series should be shown. Similarly with the word cloud chart, apply a limit, and the top results should be displayed rather than an arbitrary set.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
