### PR TITLE
feat(explore): better search for dataset pane

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -19063,10 +19063,27 @@
         "xss": "^1.0.6"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "d3-array": {
           "version": "2.9.1",
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.9.1.tgz",
           "integrity": "sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg=="
+        },
+        "match-sorter": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-4.2.1.tgz",
+          "integrity": "sha512-s+3h9TiZU9U1pWhIERHf8/f4LmBN6IXaRgo2CI17+XGByGS1GvG5VvXK9pcGyCjGe3WM3mSYRC3ipGrd5UEVgw==",
+          "requires": {
+            "@babel/runtime": "^7.10.5",
+            "remove-accents": "0.4.2"
+          }
         }
       }
     },
@@ -39439,11 +39456,11 @@
       }
     },
     "match-sorter": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-4.2.1.tgz",
-      "integrity": "sha512-s+3h9TiZU9U1pWhIERHf8/f4LmBN6IXaRgo2CI17+XGByGS1GvG5VvXK9pcGyCjGe3WM3mSYRC3ipGrd5UEVgw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.1.0.tgz",
+      "integrity": "sha512-sKPMf4kbF7Dm5Crx0bbfLpokK68PUJ/0STUIOPa1ZmTZEA3lCaPK3gapQR573oLmvdkTfGojzySkIwuq6Z6xRQ==",
       "requires": {
-        "@babel/runtime": "^7.10.5",
+        "@babel/runtime": "^7.12.5",
         "remove-accents": "0.4.2"
       },
       "dependencies": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -120,7 +120,7 @@
     "json-stringify-pretty-compact": "^2.0.0",
     "lodash": "^4.17.20",
     "lodash-es": "^4.17.14",
-    "match-sorter": "^4.1.0",
+    "match-sorter": "^6.1.0",
     "mathjs": "^8.0.1",
     "memoize-one": "^5.1.1",
     "moment": "^2.26.0",

--- a/superset-frontend/src/explore/components/DatasourcePanel.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel.tsx
@@ -179,23 +179,23 @@ export default function DataSourcePanel({
     setList({
       columns: matchSorter(columns, value, {
         keys: [
-          'column_name',
           'verbose_name',
+          'column_name',
           {
             key: 'description',
-            threshold: rankings.STARTS_WITH,
+            threshold: rankings.CONTAINS,
           },
           {
             key: 'expression',
-            threshold: rankings.STARTS_WITH,
+            threshold: rankings.CONTAINS,
           },
         ],
         keepDiacritics: true,
       }),
       metrics: matchSorter(metrics, value, {
         keys: [
-          'metric_name',
           'verbose_name',
+          'metric_name',
           {
             key: 'description',
             threshold: rankings.CONTAINS,

--- a/superset-frontend/tsconfig.json
+++ b/superset-frontend/tsconfig.json
@@ -27,7 +27,7 @@
       ],
       // for supressing errors caused by incompatible @types/react when `npm link`
       // Ref: https://github.com/Microsoft/typescript/issues/6496#issuecomment-384786222
-      "*": ["./node_modules/@types/*", "*"]
+      "react": ["./node_modules/@types/react"]
     },
     "skipLibCheck": true,
     "sourceMap": true,


### PR DESCRIPTION
### SUMMARY

Better and faster search for the dataset pane in Explore.

1. Upgrade `match-sorter` from `4.1.0` to `6.1.0`
2. Add a debounce delay of 200 milliseconds to reduce excessive rendering (and searching)
2. Set [`keepDiacritics`](https://github.com/kentcdodds/match-sorter#keepdiacritics-boolean) to `true` to improve performance
3. Display count of filtered results in "Showing x of xx", instead of the total results
3. Rank certified metrics to the top.
    - **Without such ranking**:
       <img src="https://user-images.githubusercontent.com/335541/105442875-6e58ff80-5c1f-11eb-8205-e49fd26e5e33.png" width="300">
    - **With ranking**:
       <img src="https://user-images.githubusercontent.com/335541/105442897-7add5800-5c1f-11eb-9e30-d926630fed7f.png" width="300">

Supersedes #12600 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TEST PLAN

1. Go to a datasource with many metrics or simulate large list of metrics by modifying the code
2. Feel the difference in searching

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12549 #12319 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @pkdotson @nikolagigic 