### PR TITLE
fix(native-filters): Show incompatible native filters indicator

### DIFF
--- a/superset-frontend/spec/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/fixtures/mockNativeFilters.ts
@@ -1,0 +1,90 @@
+import { NativeFiltersState } from 'src/dashboard/components/nativeFilters/types';
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+export const nativeFilters: NativeFiltersState = {
+  filters: {
+    'NATIVE_FILTER-e7Q8zKixx': {
+      id: 'NATIVE_FILTER-e7Q8zKixx',
+      name: 'region',
+      type: 'text',
+      targets: [
+        {
+          datasetId: 2,
+          column: {
+            name: 'region',
+          },
+        },
+      ],
+      defaultValue: null,
+      cascadeParentIds: [],
+      scope: {
+        rootPath: ['ROOT_ID'],
+        excluded: [],
+      },
+      inverseSelection: false,
+      isInstant: true,
+      allowsMultipleValues: false,
+      isRequired: false,
+    },
+    'NATIVE_FILTER-x9QPw0so1': {
+      id: 'NATIVE_FILTER-x9QPw0so1',
+      name: 'country_code',
+      type: 'text',
+      targets: [
+        {
+          datasetId: 2,
+          column: {
+            name: 'country_code',
+          },
+        },
+      ],
+      defaultValue: null,
+      cascadeParentIds: [],
+      scope: {
+        rootPath: ['ROOT_ID'],
+        excluded: [],
+      },
+      inverseSelection: false,
+      isInstant: true,
+      allowsMultipleValues: false,
+      isRequired: false,
+    },
+  },
+  filtersState: {
+    'NATIVE_FILTER-e7Q8zKixx': {
+      id: 'NATIVE_FILTER-e7Q8zKixx',
+      extraFormData: {
+        append_form_data: {
+          filters: [
+            {
+              col: 'region',
+              op: 'IN',
+              val: ['East Asia & Pacific'],
+            },
+          ],
+        },
+      },
+    },
+    'NATIVE_FILTER-x9QPw0so1': {
+      id: 'NATIVE_FILTER-x9QPw0so1',
+      extraFormData: {},
+    },
+  },
+};

--- a/superset-frontend/spec/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/fixtures/mockNativeFilters.ts
@@ -1,5 +1,3 @@
-import { NativeFiltersState } from 'src/dashboard/components/nativeFilters/types';
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,6 +16,8 @@ import { NativeFiltersState } from 'src/dashboard/components/nativeFilters/types
  * specific language governing permissions and limitations
  * under the License.
  */
+import { NativeFiltersState } from 'src/dashboard/components/nativeFilters/types';
+
 export const nativeFilters: NativeFiltersState = {
   filters: {
     'NATIVE_FILTER-e7Q8zKixx': {

--- a/superset-frontend/spec/fixtures/mockStore.js
+++ b/superset-frontend/spec/fixtures/mockStore.js
@@ -25,6 +25,7 @@ import mockState from './mockState';
 import { dashboardLayoutWithTabs } from './mockDashboardLayout';
 import { sliceId } from './mockChartQueries';
 import { dashboardFilters } from './mockDashboardFilters';
+import { nativeFilters } from './mockNativeFilters';
 
 export const getMockStore = () =>
   createStore(rootReducer, mockState, compose(applyMiddleware(thunk)));
@@ -54,6 +55,31 @@ export const getMockStoreWithFilters = () =>
   createStore(rootReducer, {
     ...mockState,
     dashboardFilters,
+    charts: {
+      ...mockState.charts,
+      [sliceIdWithAppliedFilter]: {
+        ...mockState.charts[sliceId],
+        queryResponse: {
+          status: 'success',
+          applied_filters: [{ column: 'region' }],
+          rejected_filters: [],
+        },
+      },
+      [sliceIdWithRejectedFilter]: {
+        ...mockState.charts[sliceId],
+        queryResponse: {
+          status: 'success',
+          applied_filters: [],
+          rejected_filters: [{ column: 'region', reason: 'not_in_datasource' }],
+        },
+      },
+    },
+  });
+
+  export const getMockStoreWithNativeFilters = () =>
+  createStore(rootReducer, {
+    ...mockState,
+    nativeFilters,
     charts: {
       ...mockState.charts,
       [sliceIdWithAppliedFilter]: {

--- a/superset-frontend/spec/fixtures/mockStore.js
+++ b/superset-frontend/spec/fixtures/mockStore.js
@@ -76,7 +76,7 @@ export const getMockStoreWithFilters = () =>
     },
   });
 
-  export const getMockStoreWithNativeFilters = () =>
+export const getMockStoreWithNativeFilters = () =>
   createStore(rootReducer, {
     ...mockState,
     nativeFilters,

--- a/superset-frontend/spec/javascripts/dashboard/components/FiltersBadge_spec.tsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/FiltersBadge_spec.tsx
@@ -31,7 +31,6 @@ import {
 import { sliceId } from 'spec/fixtures/mockChartQueries';
 import { dashboardFilters } from 'spec/fixtures/mockDashboardFilters';
 import { dashboardWithFilter } from 'spec/fixtures/mockDashboardLayout';
-import { nativeFilters } from 'spec/fixtures/mockNativeFilters';
 
 describe('FiltersBadge', () => {
   // there's this bizarre "active filters" thing
@@ -147,7 +146,6 @@ describe('FiltersBadge', () => {
             rejected_filters: [],
           },
         ],
-        nativeFilters,
       });
       const wrapper = shallow(
         <Provider store={store}>
@@ -198,7 +196,6 @@ describe('FiltersBadge', () => {
             ],
           },
         ],
-        nativeFilters,
       });
       const wrapper = shallow(
         <FiltersBadge {...{ store }} chartId={sliceId} />,

--- a/superset-frontend/spec/javascripts/dashboard/components/FiltersBadge_spec.tsx
+++ b/superset-frontend/spec/javascripts/dashboard/components/FiltersBadge_spec.tsx
@@ -24,10 +24,14 @@ import * as SupersetUI from '@superset-ui/core';
 import { CHART_UPDATE_SUCCEEDED } from 'src/chart/chartAction';
 import { buildActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
 import FiltersBadge from 'src/dashboard/containers/FiltersBadge';
-import { getMockStoreWithFilters } from 'spec/fixtures/mockStore';
+import {
+  getMockStoreWithFilters,
+  getMockStoreWithNativeFilters,
+} from 'spec/fixtures/mockStore';
 import { sliceId } from 'spec/fixtures/mockChartQueries';
 import { dashboardFilters } from 'spec/fixtures/mockDashboardFilters';
 import { dashboardWithFilter } from 'spec/fixtures/mockDashboardLayout';
+import { nativeFilters } from 'spec/fixtures/mockNativeFilters';
 
 describe('FiltersBadge', () => {
   // there's this bizarre "active filters" thing
@@ -45,83 +49,168 @@ describe('FiltersBadge', () => {
     jest.spyOn(SupersetUI, 'useTheme').mockImplementation(() => supersetTheme);
   });
 
-  it("doesn't show number when there are no active filters", () => {
-    const store = getMockStoreWithFilters();
-    // start with basic dashboard state, dispatch an event to simulate query completion
-    store.dispatch({
-      type: CHART_UPDATE_SUCCEEDED,
-      key: sliceId,
-      queriesResponse: [
-        {
-          status: 'success',
-          applied_filters: [],
-          rejected_filters: [],
-        },
-      ],
-      dashboardFilters,
+  describe('for dashboard filters', () => {
+    it("doesn't show number when there are no active filters", () => {
+      const store = getMockStoreWithFilters();
+      // start with basic dashboard state, dispatch an event to simulate query completion
+      store.dispatch({
+        type: CHART_UPDATE_SUCCEEDED,
+        key: sliceId,
+        queriesResponse: [
+          {
+            status: 'success',
+            applied_filters: [],
+            rejected_filters: [],
+          },
+        ],
+        dashboardFilters,
+      });
+      const wrapper = shallow(
+        <Provider store={store}>
+          <FiltersBadge chartId={sliceId} />,
+        </Provider>,
+      );
+      expect(
+        wrapper.dive().find('[data-test="applied-filter-count"]'),
+      ).not.toExist();
     });
-    const wrapper = shallow(
-      <Provider store={store}>
-        <FiltersBadge chartId={sliceId} />,
-      </Provider>,
-    );
-    expect(
-      wrapper.dive().find('[data-test="applied-filter-count"]'),
-    ).not.toExist();
+
+    it('shows the indicator when filters have been applied', () => {
+      const store = getMockStoreWithFilters();
+      // start with basic dashboard state, dispatch an event to simulate query completion
+      store.dispatch({
+        type: CHART_UPDATE_SUCCEEDED,
+        key: sliceId,
+        queriesResponse: [
+          {
+            status: 'success',
+            applied_filters: [{ column: 'region' }],
+            rejected_filters: [],
+          },
+        ],
+        dashboardFilters,
+      });
+      const wrapper = shallow(
+        <FiltersBadge {...{ store }} chartId={sliceId} />,
+      ).dive();
+      expect(wrapper.dive().find('DetailsPanelPopover')).toExist();
+      expect(
+        wrapper.dive().find('[data-test="applied-filter-count"]'),
+      ).toHaveText('1');
+      expect(wrapper.dive().find('WarningFilled')).not.toExist();
+    });
+
+    it("shows a warning when there's a rejected filter", () => {
+      const store = getMockStoreWithFilters();
+      // start with basic dashboard state, dispatch an event to simulate query completion
+      store.dispatch({
+        type: CHART_UPDATE_SUCCEEDED,
+        key: sliceId,
+        queriesResponse: [
+          {
+            status: 'success',
+            applied_filters: [],
+            rejected_filters: [
+              { column: 'region', reason: 'not_in_datasource' },
+            ],
+          },
+        ],
+        dashboardFilters,
+      });
+      const wrapper = shallow(
+        <FiltersBadge {...{ store }} chartId={sliceId} />,
+      ).dive();
+      expect(wrapper.dive().find('DetailsPanelPopover')).toExist();
+      expect(
+        wrapper.dive().find('[data-test="applied-filter-count"]'),
+      ).toHaveText('0');
+      expect(
+        wrapper.dive().find('[data-test="incompatible-filter-count"]'),
+      ).toHaveText('1');
+      // to look at the shape of the wrapper use:
+      // console.log(wrapper.dive().debug())
+      expect(wrapper.dive().find('Icon[name="alert-solid"]')).toExist();
+    });
   });
 
-  it('shows the indicator when filters have been applied', () => {
-    const store = getMockStoreWithFilters();
-    // start with basic dashboard state, dispatch an event to simulate query completion
-    store.dispatch({
-      type: CHART_UPDATE_SUCCEEDED,
-      key: sliceId,
-      queriesResponse: [
-        {
-          status: 'success',
-          applied_filters: [{ column: 'region' }],
-          rejected_filters: [],
-        },
-      ],
-      dashboardFilters,
+  describe('for native filters', () => {
+    it("doesn't show number when there are no active filters", () => {
+      const store = getMockStoreWithNativeFilters();
+      // start with basic dashboard state, dispatch an event to simulate query completion
+      store.dispatch({
+        type: CHART_UPDATE_SUCCEEDED,
+        key: sliceId,
+        queriesResponse: [
+          {
+            status: 'success',
+            applied_filters: [],
+            rejected_filters: [],
+          },
+        ],
+        nativeFilters,
+      });
+      const wrapper = shallow(
+        <Provider store={store}>
+          <FiltersBadge chartId={sliceId} />,
+        </Provider>,
+      );
+      expect(
+        wrapper.dive().find('[data-test="applied-filter-count"]'),
+      ).not.toExist();
     });
-    const wrapper = shallow(
-      <FiltersBadge {...{ store }} chartId={sliceId} />,
-    ).dive();
-    expect(wrapper.dive().find('DetailsPanelPopover')).toExist();
-    expect(
-      wrapper.dive().find('[data-test="applied-filter-count"]'),
-    ).toHaveText('1');
-    expect(wrapper.dive().find('WarningFilled')).not.toExist();
-  });
 
-  it("shows a warning when there's a rejected filter", () => {
-    const store = getMockStoreWithFilters();
-    // start with basic dashboard state, dispatch an event to simulate query completion
-    store.dispatch({
-      type: CHART_UPDATE_SUCCEEDED,
-      key: sliceId,
-      queriesResponse: [
-        {
-          status: 'success',
-          applied_filters: [],
-          rejected_filters: [{ column: 'region', reason: 'not_in_datasource' }],
-        },
-      ],
-      dashboardFilters,
+    it('shows the indicator when filters have been applied', () => {
+      const store = getMockStoreWithNativeFilters();
+      // start with basic dashboard state, dispatch an event to simulate query completion
+      store.dispatch({
+        type: CHART_UPDATE_SUCCEEDED,
+        key: sliceId,
+        queriesResponse: [
+          {
+            status: 'success',
+            applied_filters: [{ column: 'region' }],
+            rejected_filters: [],
+          },
+        ],
+      });
+      const wrapper = shallow(
+        <FiltersBadge {...{ store }} chartId={sliceId} />,
+      ).dive();
+      expect(wrapper.dive().find('DetailsPanelPopover')).toExist();
+      expect(
+        wrapper.dive().find('[data-test="applied-filter-count"]'),
+      ).toHaveText('1');
+      expect(wrapper.dive().find('WarningFilled')).not.toExist();
     });
-    const wrapper = shallow(
-      <FiltersBadge {...{ store }} chartId={sliceId} />,
-    ).dive();
-    expect(wrapper.dive().find('DetailsPanelPopover')).toExist();
-    expect(
-      wrapper.dive().find('[data-test="applied-filter-count"]'),
-    ).toHaveText('0');
-    expect(
-      wrapper.dive().find('[data-test="incompatible-filter-count"]'),
-    ).toHaveText('1');
-    // to look at the shape of the wrapper use:
-    // console.log(wrapper.dive().debug())
-    expect(wrapper.dive().find('Icon[name="alert-solid"]')).toExist();
+
+    it("shows a warning when there's a rejected filter", () => {
+      const store = getMockStoreWithNativeFilters();
+      // start with basic dashboard state, dispatch an event to simulate query completion
+      store.dispatch({
+        type: CHART_UPDATE_SUCCEEDED,
+        key: sliceId,
+        queriesResponse: [
+          {
+            status: 'success',
+            applied_filters: [],
+            rejected_filters: [
+              { column: 'region', reason: 'not_in_datasource' },
+            ],
+          },
+        ],
+        nativeFilters,
+      });
+      const wrapper = shallow(
+        <FiltersBadge {...{ store }} chartId={sliceId} />,
+      ).dive();
+      expect(wrapper.dive().find('DetailsPanelPopover')).toExist();
+      expect(
+        wrapper.dive().find('[data-test="applied-filter-count"]'),
+      ).toHaveText('0');
+      expect(
+        wrapper.dive().find('[data-test="incompatible-filter-count"]'),
+      ).toHaveText('1');
+      expect(wrapper.dive().find('Icon[name="alert-solid"]')).toExist();
+    });
   });
 });

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel.tsx
@@ -103,6 +103,9 @@ const DetailsPanelPopover = ({
     }
   }
 
+  const indicatorKey = (indicator: Indicator): string =>
+    `${indicator.column} - ${indicator.name}`;
+
   const content = (
     <Panel>
       <Global
@@ -173,7 +176,7 @@ const DetailsPanelPopover = ({
               <Indent>
                 {appliedIndicators.map(indicator => (
                   <Indicator
-                    key={indicator.column}
+                    key={indicatorKey(indicator)}
                     indicator={indicator}
                     onClick={onHighlightFilterSource}
                   />
@@ -197,7 +200,7 @@ const DetailsPanelPopover = ({
               <Indent>
                 {incompatibleIndicators.map(indicator => (
                   <Indicator
-                    key={indicator.column}
+                    key={indicatorKey(indicator)}
                     indicator={indicator}
                     onClick={onHighlightFilterSource}
                   />
@@ -219,7 +222,7 @@ const DetailsPanelPopover = ({
               <Indent>
                 {unsetIndicators.map(indicator => (
                   <Indicator
-                    key={indicator.column}
+                    key={indicatorKey(indicator)}
                     indicator={indicator}
                     onClick={onHighlightFilterSource}
                   />

--- a/superset-frontend/src/dashboard/containers/FiltersBadge.tsx
+++ b/superset-frontend/src/dashboard/containers/FiltersBadge.tsx
@@ -62,7 +62,11 @@ const mapStateToProps = (
     charts,
   );
 
-  const nativeIndicators = selectNativeIndicatorsForChart(nativeFilters);
+  const nativeIndicators = selectNativeIndicatorsForChart(
+    nativeFilters,
+    chartId,
+    charts,
+  );
 
   const indicators = uniqWith(
     sortByStatus([...dashboardIndicators, ...nativeIndicators]),

--- a/superset-frontend/src/dashboard/containers/FiltersBadge.tsx
+++ b/superset-frontend/src/dashboard/containers/FiltersBadge.tsx
@@ -72,6 +72,7 @@ const mapStateToProps = (
     sortByStatus([...dashboardIndicators, ...nativeIndicators]),
     (ind1, ind2) =>
       ind1.column === ind2.column &&
+      ind1.name === ind2.name &&
       (ind1.status !== IndicatorStatus.Applied ||
         ind2.status !== IndicatorStatus.Applied),
   );


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- The aim of this PR was to add **Incompatible** section to filter indicator. ⚠Incompatible filters are created using datasets & fields which are incompatible with a given chart.
- I have also added simple mocks for native filters: _mockStore_ and _mockNativeFilters_ to test displaying filter indicators for native filters.
- I have also slightly changed structure of Filter Badge tests in `FiltersBadge_spec.tsx` - I have divided them into _'for dashboard filters'_ and _'for native filters'_. Section _'for dashboard filters'_ is the same as on master, I have only added analogical tests for native filters.

Fixes #12568
Closes #12568 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before incompatible section for native filters was missing.
Now different configurations:
**With some correct native filters applied and one incompatible:**
<img width="1544" alt="Zrzut ekranu 2021-01-22 o 15 02 38" src="https://user-images.githubusercontent.com/47450693/105500327-0bb93f80-5cc3-11eb-9cee-83638ced5a1e.png">

**With trying to apply two incompatible native filters from two different datasets:**
<img width="1545" alt="Zrzut ekranu 2021-01-22 o 15 09 53" src="https://user-images.githubusercontent.com/47450693/105500993-f0026900-5cc3-11eb-9e89-d1e756907e19.png">

**With one dashboard filter applied and one incompatible native filter:**
<img width="1526" alt="Zrzut ekranu 2021-01-22 o 15 12 35" src="https://user-images.githubusercontent.com/47450693/105501375-6a32ed80-5cc4-11eb-96bc-60b447473d50.png">

**With incompatible dashboard filters (without native filters):**
<img width="1773" alt="Zrzut ekranu 2021-01-22 o 15 23 49" src="https://user-images.githubusercontent.com/47450693/105502681-fbef2a80-5cc5-11eb-9cae-a33cee9486c5.png">

### TEST PLAN
Enable native filters: go to `config.py` and set `"DASHBOARD_NATIVE_FILTERS": True,`
Go to dashboards and create native filters. One one them should be created with incompatible dataset, which cannot be applied to this dashboard.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12568
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @junlincc @rusackas @villebro @suddjian 
@adam-stasiak could you test?