### PR TITLE
fix(explore): Certified metric icons are various sizes

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel.tsx
@@ -153,11 +153,6 @@ const LabelContainer = styled.div`
     display: inline;
   }
 
-  .metric-option > .option-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
   .metric-option {
     & > svg {
       min-width: ${({ theme }) => `${theme.gridUnit * 4}px`};
@@ -167,8 +162,6 @@ const LabelContainer = styled.div`
       text-overflow: ellipsis;
     }
   }
-
-  min-width: 16px;
 `;
 
 const DataSourcePanel = ({

--- a/superset-frontend/src/explore/components/DatasourcePanel.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel.tsx
@@ -157,6 +157,18 @@ const LabelContainer = styled.div`
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  .metric-option {
+    & > svg {
+      min-width: ${({ theme }) => `${theme.gridUnit * 4}px`};
+    }
+    & > .option-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  min-width: 16px;
 `;
 
 const DataSourcePanel = ({


### PR DESCRIPTION
### SUMMARY
Closes #12628 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="641" alt="icon_issue_BEFORE" src="https://user-images.githubusercontent.com/60598000/105512317-3f02cb00-5cd1-11eb-9c80-154421ffccdb.png">

AFTER:
<img width="620" alt="icon_issue_AFTER" src="https://user-images.githubusercontent.com/60598000/105512331-43c77f00-5cd1-11eb-95db-e75c9aa67326.png">

### TEST PLAN
1. Open Explore
2. Setup certified metrics with names of various lengths
3. Make sure the certified icon is of the same size for every metric

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12628 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
