### PR TITLE
fix: remove whitespace at the bottom of select dropdown

### DIFF
--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -191,6 +191,7 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
       width: auto;
       min-width: 100%;
       max-width: 80vw;
+      background: none;
       box-shadow: none;
       border: 0;
     `,


### PR DESCRIPTION
### SUMMARY

#12649 added an unnecessary whitespace at the bottom of the select dropdown. Let's remove it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img width="351" alt="extraneous-whitespace" src="https://user-images.githubusercontent.com/335541/105557262-99dff680-5cc0-11eb-8371-4e41e8813a83.png">

#### After

<img width="344" alt="no-whitespace" src="https://user-images.githubusercontent.com/335541/105557253-95b3d900-5cc0-11eb-9f85-41489eb10425.png">


### TEST PLAN

Go check the dropdowns in the Time section

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
