### PR TITLE
fix(load examples): revert #12351

### DIFF
--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -30,7 +30,7 @@ from sqlalchemy.sql.visitors import VisitableType
 
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database
-from superset.utils.core import get_example_database
+from superset.utils.core import get_example_database, get_main_database
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def load_data(
             df[column_name] = pd.to_datetime(df[column_name])
 
     # reuse session when loading data if possible, to make import atomic
-    if example_database.sqlalchemy_uri == get_example_database().sqlalchemy_uri:
+    if example_database.sqlalchemy_uri == get_main_database().sqlalchemy_uri:
         logger.info("Loading data inside the import transaction")
         connection = session.connection()
     else:


### PR DESCRIPTION
This reverts commit f354bb3d1b591dcce173e895d46d94b1769b4397.

The change in #12351 makes the examples data to be loaded into the main database instead of the examples database.

@dpgaspar let's discuss a way of not creating the unnecessary connection?

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
