### PR TITLE
fix: update latest tag action to use set-output

### DIFF
--- a/.github/workflows/latest-release-tag.yml
+++ b/.github/workflows/latest-release-tag.yml
@@ -17,14 +17,9 @@ jobs:
       run: |
         source ./scripts/tag_latest_release.sh $(echo ${{ github.event.release.tag_name }}) --dry-run
 
-        if ${SKIP_TAG}
-        then
-          echo "::set-env name=skip_tag::true"
-        fi
-
     - name: Run latest-tag
       uses: ./.github/actions/latest-tag
-      if: (! env.skip_tag )
+      if: (! ${{ steps.latest-tag.outputs.SKIP_TAG }} )
       with:
         description: Superset latest release
         tag-name: latest

--- a/scripts/tag_latest_release.sh
+++ b/scripts/tag_latest_release.sh
@@ -25,7 +25,7 @@ run_git_tag () {
   exit 0
 }
 
-SKIP_TAG=false
+echo "::set-output name=SKIP_TAG::false"
 DRY_RUN=false
 
 # get params passed in with script when it was run
@@ -62,7 +62,7 @@ fi
 if ! [[ ${GITHUB_TAG_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 then
   echo "This tag ${GITHUB_TAG_NAME} is not a valid release version. Not tagging."
-  SKIP_TAG=true
+  echo "::set-output name=SKIP_TAG::true"
   exit 0
 fi
 
@@ -125,4 +125,4 @@ done
 
 echo "This release tag ${GITHUB_TAG_NAME} is not the latest. Not tagging."
 # if you've gotten this far, then we don't want to run any tags in the next step
-SKIP_TAG=true
+echo "::set-output name=SKIP_TAG::true"


### PR DESCRIPTION
### SUMMARY
GitHub recently deprecated `set-env` with their latest actions security updates. This replaces `set-env` with `set-output`
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

### TEST PLAN
manually tested with nektos/act utility

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
