### PR TITLE
fix: Erroneous uuid generation for mysql fixed.

### DIFF
--- a/superset/migrations/versions/b56500de1855_add_uuid_column_to_import_mixin.py
+++ b/superset/migrations/versions/b56500de1855_add_uuid_column_to_import_mixin.py
@@ -81,7 +81,8 @@ default_batch_size = int(os.environ.get("BATCH_SIZE", 200))
 
 # Add uuids directly using built-in SQL uuid function
 add_uuids_by_dialect = {
-    MySQLDialect: """UPDATE %s SET uuid = UNHEX(REPLACE(uuid(), "-", ""));""",
+# TODO uuid from mysql aren't working as expected. that's why shouldn't be used for now. 
+#    MySQLDialect: """UPDATE %s SET uuid = UNHEX(REPLACE(uuid(), "-", ""));""",
     PGDialect: """UPDATE %s SET uuid = uuid_in(md5(random()::text || clock_timestamp()::text)::cstring);""",
 }
 

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -49,6 +49,7 @@ def cache_chart_thumbnail(
             user = security_manager.get_user_by_username(
                 current_app.config["THUMBNAIL_SELENIUM_USER"], session=session
             )
+        user = session.merge(user)
         screenshot.compute_and_cache(
             user=user,
             cache=thumbnail_cache,
@@ -73,6 +74,7 @@ def cache_dashboard_thumbnail(
             user = security_manager.get_user_by_username(
                 current_app.config["THUMBNAIL_SELENIUM_USER"], session=session
             )
+        user = session.merge(user)
         screenshot.compute_and_cache(
             user=user, cache=thumbnail_cache, force=force, thumb_size=thumb_size,
         )


### PR DESCRIPTION
### SUMMARY
This fix related with #12202. Mysql uuid generation is erroneous and should not be used. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #12202 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
