### PR TITLE
fix: Replace space with tabulator and enter as separators

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent.jsx
@@ -319,7 +319,7 @@ export default class AdhocFilterEditPopoverSimpleTabContent extends React.Compon
       allowClear: true,
       showSearch: true,
       mode: MULTI_OPERATORS.has(operator) && 'tags',
-      tokenSeparators: [',', ' ', ';'],
+      tokenSeparators: [',', '\n', '\t', ';'],
       loading: this.state.loading,
       value: comparator,
       onChange: this.onComparatorChange,


### PR DESCRIPTION
### SUMMARY
Disable confirming value with space button and replace it with tabulator and enter buttons - now we can use multi-word values like "Russian Federation".
Closes https://github.com/apache/superset/issues/12644
Fixes https://github.com/apache/superset/issues/12644

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/105683463-f414cd80-5ef3-11eb-96b2-d3945b27bc8c.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12644
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @junlincc @zuzana-vej @villebro 