### PR TITLE
chore[explore]: Save date if Ok not clicked

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/frame/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/frame/CustomFrame.tsx
@@ -136,7 +136,7 @@ export function CustomFrame(props: FrameComponentProps) {
               <DatePicker
                 showTime
                 value={dttmToMoment(sinceDatetime)}
-                onChange={(datetime: Moment) =>
+                onSelect={(datetime: Moment) =>
                   onChange('sinceDatetime', datetime.format(MOMENT_FORMAT))
                 }
                 allowClear={false}
@@ -188,7 +188,7 @@ export function CustomFrame(props: FrameComponentProps) {
               <DatePicker
                 showTime
                 value={dttmToMoment(untilDatetime)}
-                onChange={(datetime: Moment) =>
+                onSelect={(datetime: Moment) =>
                   onChange('untilDatetime', datetime.format(MOMENT_FORMAT))
                 }
                 allowClear={false}

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/frame/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/frame/CustomFrame.tsx
@@ -247,7 +247,7 @@ export function CustomFrame(props: FrameComponentProps) {
                 <DatePicker
                   showTime
                   value={dttmToMoment(anchorValue)}
-                  onChange={(datetime: Moment) =>
+                  onSelect={(datetime: Moment) =>
                     onChange('anchorValue', datetime.format(MOMENT_FORMAT))
                   }
                   allowClear={false}


### PR DESCRIPTION
### SUMMARY
If the user does not click on **Ok** button in **Time Range** date picker but clicks outside of the modal instead, the picked date is saved.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/26679866/105689976-bae05b80-5efb-11eb-9190-210b602d1082.mp4

### TEST PLAN
1. Go to 'Explore'
2. Click on 'TIME RANGE'
3. Choose 'Custom' as the 'RANGE TYPE'
4. Choose 'Specific Date/Time' as the 'START'
5. Click on a date
6. Move the mouse off of the 'TIME RANGE' modal and click

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
closes https://github.com/apache/superset/issues/12704 
