### PR TITLE
fix: Remove double tooltip from metric label

### DIFF
--- a/superset-frontend/src/explore/components/OptionControls.tsx
+++ b/superset-frontend/src/explore/components/OptionControls.tsx
@@ -20,6 +20,7 @@ import React, { useRef } from 'react';
 import { useDrag, useDrop, DropTargetMonitor } from 'react-dnd';
 import { styled, useTheme } from '@superset-ui/core';
 import { ColumnOption } from '@superset-ui/chart-controls';
+import { Tooltip } from 'src/common/components/Tooltip';
 import Icon from 'src/components/Icon';
 import { savedMetricType } from 'src/explore/components/controls/MetricControl/types';
 
@@ -215,7 +216,7 @@ export const OptionControlLabel = ({
       }
       return <ColumnOption column={column} />;
     }
-    return label;
+    return <Tooltip title={label}>{label}</Tooltip>;
   };
 
   const getOptionControlContent = () => (

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
@@ -18,7 +18,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip } from 'src/common/components/Tooltip';
 import columnType from 'src/explore/propTypes/columnType';
 import { OptionControlLabel } from 'src/explore/components/OptionControls';
 import { OPTION_TYPES } from 'src/explore/components/optionTypes';

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
@@ -71,22 +71,17 @@ class AdhocMetricOption extends React.PureComponent {
         savedMetric={savedMetric}
         datasourceType={datasourceType}
       >
-        <Tooltip
-          placement="top"
-          title={savedMetric.expression || adhocMetric.label}
-        >
-          <OptionControlLabel
-            savedMetric={savedMetric}
-            label={adhocMetric.label}
-            onRemove={this.onRemoveMetric}
-            onMoveLabel={onMoveLabel}
-            onDropLabel={onDropLabel}
-            index={index}
-            type={OPTION_TYPES.metric}
-            isAdhoc
-            isFunction
-          />
-        </Tooltip>
+        <DOptionControlLabel
+          savedMetric={savedMetric}
+          label={adhocMetric.label}
+          onRemove={this.onRemoveMetric}
+          onMoveLabel={onMoveLabel}
+          onDropLabel={onDropLabel}
+          index={index}
+          type={OPTION_TYPES.metric}
+          isAdhoc
+          isFunction
+        />
       </AdhocMetricPopoverTrigger>
     );
   }

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
@@ -70,7 +70,7 @@ class AdhocMetricOption extends React.PureComponent {
         savedMetric={savedMetric}
         datasourceType={datasourceType}
       >
-        <DOptionControlLabel
+        <OptionControlLabel
           savedMetric={savedMetric}
           label={adhocMetric.label}
           onRemove={this.onRemoveMetric}


### PR DESCRIPTION
### SUMMARY
TODO: After https://github.com/apache-superset/superset-ui/pull/914 is merged and released, bump superset-ui packages in this PR.
After packages are bumped, this PR should be tested thoroughly as the change in `superset-ui` affects multiple components that used `InfoTooltipWithTrigger` component.
Fixes https://github.com/apache/superset/issues/12671

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/12671
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC: @villebro @junlincc 