### PR TITLE
feat: Adding option to set_database_uri CLI command

### DIFF
--- a/superset/cli.py
+++ b/superset/cli.py
@@ -192,15 +192,15 @@ def load_examples(
 @click.option("--database_name", "-d", help="Database name to change")
 @click.option("--uri", "-u", help="Database URI to change")
 @click.option(
-    "--always_create",
-    "-a",
+    "--skip_create",
+    "-s",
     is_flag=True,
-    default=True,
+    default=False,
     help="Create the DB if it doesn't exist",
 )
-def set_database_uri(database_name: str, uri: str, always_create: bool) -> None:
+def set_database_uri(database_name: str, uri: str, skip_create: bool) -> None:
     """Updates a database connection URI """
-    utils.get_or_create_db(database_name, uri, always_create)
+    utils.get_or_create_db(database_name, uri, not skip_create)
 
 
 @superset.command()

--- a/superset/cli.py
+++ b/superset/cli.py
@@ -191,9 +191,16 @@ def load_examples(
 @superset.command()
 @click.option("--database_name", "-d", help="Database name to change")
 @click.option("--uri", "-u", help="Database URI to change")
-def set_database_uri(database_name: str, uri: str) -> None:
+@click.option(
+    "--always_create",
+    "-a",
+    is_flag=True,
+    default=True,
+    help="Create the DB if it doesn't exist",
+)
+def set_database_uri(database_name: str, uri: str, always_create: bool) -> None:
     """Updates a database connection URI """
-    utils.get_or_create_db(database_name, uri)
+    utils.get_or_create_db(database_name, uri, always_create)
 
 
 @superset.command()

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1095,7 +1095,7 @@ def user_label(user: User) -> Optional[str]:
 
 
 def get_or_create_db(
-    database_name: str, sqlalchemy_uri: str, *args: Any, **kwargs: Any
+    database_name: str, sqlalchemy_uri: str, always_create: Optional[bool] = True
 ) -> "Database":
     from superset import db
     from superset.models import core as models
@@ -1104,13 +1104,15 @@ def get_or_create_db(
         db.session.query(models.Database).filter_by(database_name=database_name).first()
     )
 
-    if not database:
+    if not database and always_create:
         logger.info("Creating database reference for %s", database_name)
-        database = models.Database(database_name=database_name, *args, **kwargs)
+        database = models.Database(database_name=database_name)
         db.session.add(database)
 
-    database.set_sqlalchemy_uri(sqlalchemy_uri)
-    db.session.commit()
+    if database:
+        database.set_sqlalchemy_uri(sqlalchemy_uri)
+        db.session.commit()
+
     return database
 
 


### PR DESCRIPTION
### SUMMARY
* Adds new option, `always_create` to the cli `set_database_uri`, which defaults to `True` that allows for the optional creation of the examples DB in the event that it's been removed by end users.
