### PR TITLE
fix: Prevent dashboard with filter_values template cause incompatible indicator

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -103,6 +103,9 @@ METRIC_KEYS = [
     "size",
 ]
 
+# This regex is to get the first param from user defined filter column
+# see the definition of filter_values template:
+# https://github.com/apache/superset/blob/24ad6063d736c1f38ad6f962e586b9b1a21946af/superset/jinja_context.py#L63
 FILTER_VALUES_REGEX = re.compile(r"FILTER_VALUES\(['\"](\w+)['\"]\,", re.IGNORECASE)
 
 

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -47,14 +47,13 @@ import numpy as np
 import pandas as pd
 import polyline
 import simplejson as json
-import sqlparse
 from dateutil import relativedelta as rdelta
 from flask import request
 from flask_babel import lazy_gettext as _
 from geopy.point import Point
 from pandas.tseries.frequencies import to_offset
 
-from superset import app, db, is_feature_enabled, sql_parse
+from superset import app, db, is_feature_enabled
 from superset.constants import NULL_STRING
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
@@ -103,10 +102,10 @@ METRIC_KEYS = [
     "size",
 ]
 
-# This regex is to get the first param from user defined filter column
+# This regex is to get user defined filter column name, which is the first param in the filter_values function.
 # see the definition of filter_values template:
 # https://github.com/apache/superset/blob/24ad6063d736c1f38ad6f962e586b9b1a21946af/superset/jinja_context.py#L63
-FILTER_VALUES_REGEX = re.compile(r"FILTER_VALUES\(['\"](\w+)['\"]\,", re.IGNORECASE)
+FILTER_VALUES_REGEX = re.compile(r"filter_values\(['\"](\w+)['\"]\,")
 
 
 class BaseViz:
@@ -484,12 +483,9 @@ class BaseViz:
 
         # if using virtual datasource, check filter_values
         if self.datasource.sql:
-            statements_without_comments = sqlparse.format(
-                self.datasource.sql, strip_comments=True
-            )
-            parsed_query = sql_parse.ParsedQuery(statements_without_comments)
-            for stmt in parsed_query.get_statements():
-                filter_values_columns += (re.findall(FILTER_VALUES_REGEX, stmt)) or []
+            filter_values_columns = (
+                re.findall(FILTER_VALUES_REGEX, self.datasource.sql)
+            ) or []
 
         applied_time_extras = self.form_data.get("applied_time_extras", {})
         applied_time_columns, rejected_time_columns = utils.get_time_filter_status(


### PR DESCRIPTION
### SUMMARY
step to reproduce/verify:

1. create a static filter_box with a list of dashboard slugs, and make it has a column named `my_dash_list`. Added it to a dashboard:
```
select * from (VALUES ('meta'), ('plus-cx'), ('dashboard-data')) x(my_dash);
```
2. create a virtual dataset that uses filter_values template. For example (using Presto SQL):
```
SELECT id, dashboard_title, slug
FROM superset_production_dashboards_v01
where slug in ( array_join( Array {{ filter_values('my_dash_list', 'births') }}, ',') )
```
3. Create a chart and add it to above dashboard.

### Before
Because `my_dash` column is not a column in the dataset, the chart is showing `incompatible` indicator.
<img width="1274" alt="Screen Shot 2021-01-26 at 2 38 21 PM" src="https://user-images.githubusercontent.com/27990562/105915130-31f11f00-5fe4-11eb-88c4-9d92d4d649c8.png">

### After
<img width="1214" alt="Screen Shot 2021-01-26 at 3 56 33 PM" src="https://user-images.githubusercontent.com/27990562/105922270-30792400-5fef-11eb-8994-d0f939a6ef41.png">



### TEST PLAN
Please follow reproduce steps.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI

cc @john-bodley @suddjian @ktmud 