### PR TITLE
feat(explore): Make metric title respond to changes immediately

### DIFF
--- a/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/AdhocMetricEditPopover_spec.jsx
@@ -56,6 +56,7 @@ function setup(overrides) {
     onChange,
     onClose,
     onResize: () => {},
+    getCurrentLabel: () => {},
     columns,
     ...overrides,
   };

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
@@ -109,13 +109,17 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
 
   componentDidUpdate(prevProps, prevState) {
     if (
-      prevState.adhocMetric?.label !== this.state.adhocMetric?.label ||
+      prevState.adhocMetric?.sqlExpression !==
+        this.state.adhocMetric?.sqlExpression ||
+      prevState.adhocMetric?.aggregate !== this.state.adhocMetric?.aggregate ||
+      prevState.adhocMetric?.column?.column_name !==
+        this.state.adhocMetric?.column?.column_name ||
       prevState.savedMetric?.metric_name !== this.state.savedMetric?.metric_name
     ) {
       this.props.getCurrentLabel(
         this.state.savedMetric?.verbose_name ||
           this.state.savedMetric?.metric_name ||
-          this.state.adhocMetric?.label,
+          this.state.adhocMetric?.getDefaultLabel(),
       );
     }
   }

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
@@ -42,14 +42,11 @@ const propTypes = {
   onClose: PropTypes.func.isRequired,
   onResize: PropTypes.func.isRequired,
   getCurrentTab: PropTypes.func,
+  getCurrentLabel: PropTypes.func,
   columns: PropTypes.arrayOf(columnType),
   savedMetricsOptions: PropTypes.arrayOf(savedMetricType),
   savedMetric: savedMetricType,
   datasourceType: PropTypes.string,
-  title: PropTypes.shape({
-    label: PropTypes.string,
-    hasCustomLabel: PropTypes.bool,
-  }),
 };
 
 const defaultProps = {
@@ -72,7 +69,7 @@ export const SAVED_TAB_KEY = 'SAVED';
 const startingWidth = 320;
 const startingHeight = 240;
 
-export default class AdhocMetricEditPopover extends React.Component {
+export default class AdhocMetricEditPopover extends React.PureComponent {
   // "Saved" is a default tab unless there are no saved metrics for dataset
   defaultActiveTabKey =
     (this.props.savedMetric.metric_name || this.props.adhocMetric.isNew) &&
@@ -110,20 +107,26 @@ export default class AdhocMetricEditPopover extends React.Component {
     this.props.getCurrentTab(this.defaultActiveTabKey);
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      prevState.adhocMetric?.label !== this.state.adhocMetric?.label ||
+      prevState.savedMetric?.metric_name !== this.state.savedMetric?.metric_name
+    ) {
+      this.props.getCurrentLabel(
+        this.state.savedMetric?.verbose_name ||
+          this.state.savedMetric?.metric_name ||
+          this.state.adhocMetric?.label,
+      );
+    }
+  }
+
   componentWillUnmount() {
     document.removeEventListener('mouseup', this.onMouseUp);
     document.removeEventListener('mousemove', this.onMouseMove);
   }
 
   onSave() {
-    const { title } = this.props;
-    const { hasCustomLabel } = title;
-    let { label } = title;
     const { adhocMetric, savedMetric } = this.state;
-    const metricLabel = adhocMetric.label;
-    if (!hasCustomLabel) {
-      label = metricLabel;
-    }
 
     const metric = savedMetric?.metric_name ? savedMetric : adhocMetric;
     const oldMetric = this.props.savedMetric?.metric_name
@@ -132,8 +135,6 @@ export default class AdhocMetricEditPopover extends React.Component {
     this.props.onChange(
       {
         ...metric,
-        label,
-        hasCustomLabel,
       },
       oldMetric,
     );

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover.jsx
@@ -116,11 +116,12 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
         this.state.adhocMetric?.column?.column_name ||
       prevState.savedMetric?.metric_name !== this.state.savedMetric?.metric_name
     ) {
-      this.props.getCurrentLabel(
-        this.state.savedMetric?.verbose_name ||
-          this.state.savedMetric?.metric_name ||
-          this.state.adhocMetric?.getDefaultLabel(),
-      );
+      this.props.getCurrentLabel({
+        savedMetricLabel:
+          this.state.savedMetric?.verbose_name ||
+          this.state.savedMetric?.metric_name,
+        adhocMetricLabel: this.state.adhocMetric?.getDefaultLabel(),
+      });
     }
   }
 

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -27,7 +27,10 @@ import { savedMetricType } from './types';
 
 export type AdhocMetricPopoverTriggerProps = {
   adhocMetric: AdhocMetric;
-  onMetricEdit: () => void;
+  onMetricEdit(
+    newMetric: AdhocMetric | Record<string, any>,
+    oldMetric: AdhocMetric | Record<string, any>,
+  ): void;
   columns: { column_name: string; type: string }[];
   savedMetricsOptions: savedMetricType[];
   savedMetric: savedMetricType;
@@ -53,6 +56,10 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     this.onLabelChange = this.onLabelChange.bind(this);
     this.closePopover = this.closePopover.bind(this);
     this.togglePopover = this.togglePopover.bind(this);
+    this.getCurrentTab = this.getCurrentTab.bind(this);
+    this.getCurrentLabel = this.getCurrentLabel.bind(this);
+    this.onChange = this.onChange.bind(this);
+
     this.state = {
       popoverVisible: false,
       title: {
@@ -65,10 +72,12 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
   }
 
   onLabelChange(e: any) {
+    const { verbose_name, metric_name } = this.props.savedMetric;
+    const { label: propsLabel } = this.props.adhocMetric;
     const label = e.target.value;
     this.setState({
       title: {
-        label: label || this.props.adhocMetric.label,
+        label: label ?? (verbose_name || metric_name) ?? propsLabel,
         hasCustomLabel: !!label,
       },
       labelModified: true,
@@ -92,6 +101,31 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     });
   }
 
+  getCurrentTab(tab: string) {
+    this.setState({
+      isTitleEditDisabled: tab === SAVED_TAB_KEY,
+    });
+  }
+
+  getCurrentLabel(label: string) {
+    if (!this.state.title.hasCustomLabel) {
+      this.setState({
+        title: {
+          label,
+          hasCustomLabel: false,
+        },
+        labelModified: true,
+      });
+    }
+  }
+
+  onChange(
+    newMetric: AdhocMetric | Record<string, any>,
+    oldMetric: AdhocMetric | Record<string, any>,
+  ) {
+    this.props.onMetricEdit({ ...newMetric, ...this.state.title }, oldMetric);
+  }
+
   render() {
     const { adhocMetric, savedMetric } = this.props;
     const { verbose_name, metric_name } = savedMetric;
@@ -110,12 +144,9 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
         datasourceType={this.props.datasourceType}
         onResize={this.onPopoverResize}
         onClose={this.closePopover}
-        onChange={this.props.onMetricEdit}
-        getCurrentTab={(tab: string) =>
-          this.setState({
-            isTitleEditDisabled: tab === SAVED_TAB_KEY,
-          })
-        }
+        onChange={this.onChange}
+        getCurrentTab={this.getCurrentTab}
+        getCurrentLabel={this.getCurrentLabel}
       />
     );
 

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -112,15 +112,22 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     });
   }
 
-  getCurrentLabel(label: string) {
+  getCurrentLabel({
+    savedMetricLabel,
+    adhocMetricLabel,
+  }: {
+    savedMetricLabel: string;
+    adhocMetricLabel: string;
+  }) {
+    const currentLabel = savedMetricLabel || adhocMetricLabel;
     this.setState({
-      currentLabel: label,
+      currentLabel,
       labelModified: true,
     });
-    if (!this.state.title.hasCustomLabel) {
+    if (savedMetricLabel || !this.state.title.hasCustomLabel) {
       this.setState({
         title: {
-          label,
+          label: currentLabel,
           hasCustomLabel: false,
         },
       });
@@ -134,10 +141,16 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
   render() {
     const { adhocMetric, savedMetric } = this.props;
     const { verbose_name, metric_name } = savedMetric;
-    const { label, hasCustomLabel } = adhocMetric;
+    const { hasCustomLabel, label } = adhocMetric;
+    const adhocMetricLabel = hasCustomLabel
+      ? label
+      : adhocMetric.getDefaultLabel();
     const title = this.state.labelModified
       ? this.state.title
-      : { label: verbose_name || metric_name || label, hasCustomLabel };
+      : {
+          label: verbose_name || metric_name || adhocMetricLabel,
+          hasCustomLabel,
+        };
 
     const overlayContent = (
       <AdhocMetricEditPopover

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { ReactNode } from 'react';
+import { Metric } from '@superset-ui/core';
 import Popover from 'src/common/components/Popover';
 import AdhocMetricEditPopoverTitle from 'src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle';
 import AdhocMetricEditPopover, {
@@ -27,10 +28,7 @@ import { savedMetricType } from './types';
 
 export type AdhocMetricPopoverTriggerProps = {
   adhocMetric: AdhocMetric;
-  onMetricEdit(
-    newMetric: AdhocMetric | Record<string, any>,
-    oldMetric: AdhocMetric | Record<string, any>,
-  ): void;
+  onMetricEdit(newMetric: Metric, oldMetric: Metric): void;
   columns: { column_name: string; type: string }[];
   savedMetricsOptions: savedMetricType[];
   savedMetric: savedMetricType;
@@ -129,10 +127,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
     }
   }
 
-  onChange(
-    newMetric: AdhocMetric | Record<string, any>,
-    oldMetric: AdhocMetric | Record<string, any>,
-  ) {
+  onChange(newMetric: Metric, oldMetric: Metric) {
     this.props.onMetricEdit({ ...newMetric, ...this.state.title }, oldMetric);
   }
 

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -42,6 +42,7 @@ export type AdhocMetricPopoverTriggerProps = {
 export type AdhocMetricPopoverTriggerState = {
   popoverVisible: boolean;
   title: { label: string; hasCustomLabel: boolean };
+  currentLabel: string;
   labelModified: boolean;
   isTitleEditDisabled: boolean;
 };
@@ -66,6 +67,7 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
         label: props.adhocMetric.label,
         hasCustomLabel: props.adhocMetric.hasCustomLabel,
       },
+      currentLabel: '',
       labelModified: false,
       isTitleEditDisabled: false,
     };
@@ -73,15 +75,20 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
 
   onLabelChange(e: any) {
     const { verbose_name, metric_name } = this.props.savedMetric;
-    const { label: propsLabel } = this.props.adhocMetric;
+    const defaultMetricLabel = this.props.adhocMetric?.getDefaultLabel();
     const label = e.target.value;
-    this.setState({
+    this.setState(state => ({
       title: {
-        label: label ?? (verbose_name || metric_name) ?? propsLabel,
+        label:
+          label ||
+          state.currentLabel ||
+          verbose_name ||
+          metric_name ||
+          defaultMetricLabel,
         hasCustomLabel: !!label,
       },
       labelModified: true,
-    });
+    }));
   }
 
   onPopoverResize() {
@@ -108,13 +115,16 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
   }
 
   getCurrentLabel(label: string) {
+    this.setState({
+      currentLabel: label,
+      labelModified: true,
+    });
     if (!this.state.title.hasCustomLabel) {
       this.setState({
         title: {
           label,
           hasCustomLabel: false,
         },
-        labelModified: true,
       });
     }
   }


### PR DESCRIPTION
### SUMMARY
When changes are made in metrics popover, the title should show current value immediately rather than after saving and reopening the popover. When there is no custom title set - display title based on current metric value. If there is a custom title set - always display that title, ignore changes in metric values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/15073128/105764831-c8c3ca00-5f57-11eb-8a87-4757682d5fc4.mov

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes https://github.com/apache/superset/issues/12608
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @villebro @junlincc @adam-stasiak @ktmud 