### PR TITLE
fix(explore): incorrect missing datasource condition

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -157,7 +157,7 @@ class DatasourceControl extends React.PureComponent {
   render() {
     const { showChangeDatasourceModal, showEditDatasourceModal } = this.state;
     const { datasource, onChange } = this.props;
-    const isMissingDatasource = datasource;
+    const isMissingDatasource = datasource.id == null;
     const datasourceMenu = (
       <Menu onClick={this.handleMenuItemClick}>
         {this.props.isEditable && (


### PR DESCRIPTION
### SUMMARY

Fix a regression introduced by #12705 , where I accidentally slipped in a wrong variable after some light refactoring while addressing PR comments.

Thought the change was harmless and didn't test enough.

Thanks for @zhaoyongjie for reporting this!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img width="795" alt="missing-incorrect" src="https://user-images.githubusercontent.com/335541/105798371-df155a00-5f46-11eb-9921-3dd4235a753b.png">

"Missing Dataset" warning displayed even though dataset exits.

#### After

<img width="822" alt="missing-correct" src="https://user-images.githubusercontent.com/335541/105798433-ffddaf80-5f46-11eb-9fc5-ab423b50821d.png">

### TEST PLAN

Manual verificagtion

- Go to any Explore page.

closes #12757 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12705 
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
