### PR TITLE
fix: missing select menu background

### DIFF
--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -199,6 +199,7 @@ export const DEFAULT_STYLES: PartialStylesConfig = {
   menuList: (provider, { theme: { borderRadius, colors } }) => [
     provider,
     css`
+      background: ${colors.lightest};
       border-radius: 0 0 ${borderRadius}px ${borderRadius}px;
       border: 1px solid ${colors.grayBorderDark};
       box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
### SUMMARY

Add back the missing select menu background . Regression introduced by #12649 and #12699 

Closes #12746 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before


https://user-images.githubusercontent.com/335541/105801935-18ea5e80-5f4f-11eb-8b91-1776dc4adcf8.mp4


#### After


https://user-images.githubusercontent.com/335541/105801948-1d167c00-5f4f-11eb-8240-a2db2681b63b.mp4

The hover background not extending to full-width is harder to fix. Let's save it for next time.

### TEST PLAN

Manual verification.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: see SUMMARY
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
