### PR TITLE
fix: session error fixed related to thumbnails.

### DIFF
--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -49,6 +49,7 @@ def cache_chart_thumbnail(
             user = security_manager.get_user_by_username(
                 current_app.config["THUMBNAIL_SELENIUM_USER"], session=session
             )
+        user = session.merge(user)
         screenshot.compute_and_cache(
             user=user,
             cache=thumbnail_cache,
@@ -73,6 +74,7 @@ def cache_dashboard_thumbnail(
             user = security_manager.get_user_by_username(
                 current_app.config["THUMBNAIL_SELENIUM_USER"], session=session
             )
+        user = session.merge(user)
         screenshot.compute_and_cache(
             user=user, cache=thumbnail_cache, force=force, thumb_size=thumb_size,
         )

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -49,7 +49,6 @@ def cache_chart_thumbnail(
             user = security_manager.get_user_by_username(
                 current_app.config["THUMBNAIL_SELENIUM_USER"], session=session
             )
-       
             screenshot.compute_and_cache(
                 user=user,
                 cache=thumbnail_cache,
@@ -74,7 +73,6 @@ def cache_dashboard_thumbnail(
             user = security_manager.get_user_by_username(
                 current_app.config["THUMBNAIL_SELENIUM_USER"], session=session
             )
-        
             screenshot.compute_and_cache(
                 user=user, cache=thumbnail_cache, force=force, thumb_size=thumb_size,
             )

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -49,14 +49,14 @@ def cache_chart_thumbnail(
             user = security_manager.get_user_by_username(
                 current_app.config["THUMBNAIL_SELENIUM_USER"], session=session
             )
-        user = session.merge(user)
-        screenshot.compute_and_cache(
-            user=user,
-            cache=thumbnail_cache,
-            force=force,
-            window_size=window_size,
-            thumb_size=thumb_size,
-        )
+       
+            screenshot.compute_and_cache(
+                user=user,
+                cache=thumbnail_cache,
+                force=force,
+                window_size=window_size,
+                thumb_size=thumb_size,
+            )
         return None
 
 
@@ -74,7 +74,7 @@ def cache_dashboard_thumbnail(
             user = security_manager.get_user_by_username(
                 current_app.config["THUMBNAIL_SELENIUM_USER"], session=session
             )
-        user = session.merge(user)
-        screenshot.compute_and_cache(
-            user=user, cache=thumbnail_cache, force=force, thumb_size=thumb_size,
-        )
+        
+            screenshot.compute_and_cache(
+                user=user, cache=thumbnail_cache, force=force, thumb_size=thumb_size,
+            )


### PR DESCRIPTION
### SUMMARY
Thumbnails stopped working on 1.0.0 because of unbound session of sqlaclhemy. See #12726 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #12726 #10530 
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
