### PR TITLE
fix(explore): Dataset icon remains constant when dragging. 

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -176,7 +176,7 @@ class DatasourceControl extends React.PureComponent {
     return (
       <Styles className="DatasourceControl">
         <div className="data-container">
-          <Icon name="dataset-physical" className="dataset-svg"/>
+          <Icon name="dataset-physical" className="dataset-svg" />
           {/* Add a tooltip only for long dataset names */}
           {!isMissingDatasource && datasource.name.length > 25 ? (
             <Tooltip title={datasource.name}>

--- a/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl.jsx
@@ -89,6 +89,7 @@ const Styles = styled.div`
   }
   .dataset-svg {
     margin-right: ${({ theme }) => 2 * theme.gridUnit}px;
+    flex: none;
   }
 `;
 
@@ -175,7 +176,7 @@ class DatasourceControl extends React.PureComponent {
     return (
       <Styles className="DatasourceControl">
         <div className="data-container">
-          <Icon name="dataset-physical" className="dataset-svg" />
+          <Icon name="dataset-physical" className="dataset-svg"/>
           {/* Add a tooltip only for long dataset names */}
           {!isMissingDatasource && datasource.name.length > 25 ? (
             <Tooltip title={datasource.name}>


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When dragging the column dataset icon should not change. This PR changes the styling so it keeps the same size. 

The icon is the one that looks like a grid, under "Dataset" label.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before:
![104241922-a8c3df00-545e-11eb-982b-3df602181738](https://user-images.githubusercontent.com/39133100/105820094-e6864300-5fda-11eb-8f78-d45f9e5cd4f5.gif)
(credits to @adam-stasiak who reported the issue and provided this video)

#### After:
![flex-fix](https://user-images.githubusercontent.com/39133100/105820071-e1c18f00-5fda-11eb-95f7-360748cad0c3.gif)



### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #12421
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
