### PR TITLE
refactor: change Windows new tab shortcut to ctrl + q

### DIFF
--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -21,7 +21,6 @@ import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
   NULL_STRING,
-  detectOS,
 } from 'src/utils/common';
 
 describe('utils/common', () => {

--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -21,6 +21,7 @@ import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
   NULL_STRING,
+  detectOS,
 } from 'src/utils/common';
 
 describe('utils/common', () => {
@@ -84,6 +85,40 @@ describe('utils/common', () => {
         { __timestamp: '2020-07-09 09:04:01', column1: 'sit' },
       ];
       expect(applyFormattingToTabularData(originalData)).toEqual(expectedData);
+    });
+  });
+  describe.only('detectOS', () => {
+    it('detects Windows as the OS when appVersion includes "Win"', () => {
+      let OSName = jest.fn();
+      OSName.mockReturnValue("Windows")
+      let appVersion = jest.fn();
+      appVersion.mockReturnValue("Win");
+
+      if (appVersion().includes("Win")) expect(OSName()).toEqual("Windows");
+    });
+    it('detects MacOS as the OS when appVersion includes "Mac"', () => {
+      let OSName = jest.fn();
+      OSName.mockReturnValue("MacOS")
+      let appVersion = jest.fn();
+      appVersion.mockReturnValue("Mac");
+
+      if (appVersion().includes("Mac")) expect(OSName()).toEqual("MacOS");
+    });
+    it('detects UNIX as the OS when appVersion includes "X11"', () => {
+      let OSName = jest.fn();
+      OSName.mockReturnValue("UNIX")
+      let appVersion = jest.fn();
+      appVersion.mockReturnValue("X11");
+
+      if (appVersion().includes("X11")) expect(OSName()).toEqual("UNIX");
+    });
+    it('detects Linux as the OS when appVersion includes "Linux"', () => {
+      let OSName = jest.fn();
+      OSName.mockReturnValue("Linux")
+      let appVersion = jest.fn();
+      appVersion.mockReturnValue("Linux");
+
+      if (appVersion().includes("Linux")) expect(OSName()).toEqual("Linux");
     });
   });
 });

--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -21,7 +21,6 @@ import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
   NULL_STRING,
-  detectOS,
 } from 'src/utils/common';
 
 describe('utils/common', () => {
@@ -92,8 +91,9 @@ describe('utils/common', () => {
       const mockNavigator = {
         // This is the appVersion returned for Mac, with Win replaced on the initial version
         // Using this to test that the OS exists for the check
-        appVersion: '5.0 (Win; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
-      }
+        appVersion:
+          '5.0 (Win; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+      };
       global.navigator = mockNavigator;
 
       const OSName = jest.fn().mockReturnValue('Windows');
@@ -103,8 +103,9 @@ describe('utils/common', () => {
     });
     it('detects MacOS as the OS when appVersion includes Mac', () => {
       const mockNavigator = {
-        appVersion: '5.0 (Mac; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
-      }
+        appVersion:
+          '5.0 (Mac; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+      };
       global.navigator = mockNavigator;
 
       const OSName = jest.fn().mockReturnValue('MacOS');
@@ -114,8 +115,9 @@ describe('utils/common', () => {
     });
     it('detects UNIX as the OS when appVersion includes X11', () => {
       const mockNavigator = {
-        appVersion: '5.0 (X11; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
-      }
+        appVersion:
+          '5.0 (X11; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+      };
       global.navigator = mockNavigator;
 
       const OSName = jest.fn().mockReturnValue('UNIX');
@@ -125,8 +127,9 @@ describe('utils/common', () => {
     });
     it('detects Linux as the OS when appVersion includes Linux', () => {
       const mockNavigator = {
-        appVersion: '5.0 (Linux; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
-      }
+        appVersion:
+          '5.0 (Linux; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+      };
       global.navigator = mockNavigator;
 
       const OSName = jest.fn().mockReturnValue('Linux');

--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -21,7 +21,6 @@ import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
   NULL_STRING,
-  detectOS,
 } from 'src/utils/common';
 
 describe('utils/common', () => {
@@ -87,38 +86,42 @@ describe('utils/common', () => {
       expect(applyFormattingToTabularData(originalData)).toEqual(expectedData);
     });
   });
-  describe.only('detectOS', () => {
-    it('detects Windows as the OS when appVersion includes "Win"', () => {
-      let OSName = jest.fn();
-      OSName.mockReturnValue("Windows")
-      let appVersion = jest.fn();
-      appVersion.mockReturnValue("Win");
+  describe('detectOS', () => {
+    it('detects Windows as the OS when appVersion includes Win', () => {
+      const OSName = jest.fn();
+      OSName.mockReturnValue('Windows')
+      const appVersion = jest.fn();
+      appVersion.mockReturnValue('Win');
 
-      if (appVersion().includes("Win")) expect(OSName()).toEqual("Windows");
+      expect(appVersion()).toIncludeText('Win');
+      expect(OSName()).toEqual('Windows');
     });
-    it('detects MacOS as the OS when appVersion includes "Mac"', () => {
-      let OSName = jest.fn();
-      OSName.mockReturnValue("MacOS")
-      let appVersion = jest.fn();
-      appVersion.mockReturnValue("Mac");
+    it('detects MacOS as the OS when appVersion includes Mac', () => {
+      const OSName = jest.fn();
+      OSName.mockReturnValue('MacOS')
+      const appVersion = jest.fn();
+      appVersion.mockReturnValue('Mac');
 
-      if (appVersion().includes("Mac")) expect(OSName()).toEqual("MacOS");
+      expect(appVersion()).toIncludeText('Mac');
+      expect(OSName()).toEqual('MacOS');
     });
-    it('detects UNIX as the OS when appVersion includes "X11"', () => {
-      let OSName = jest.fn();
-      OSName.mockReturnValue("UNIX")
-      let appVersion = jest.fn();
-      appVersion.mockReturnValue("X11");
+    it('detects UNIX as the OS when appVersion includes X11', () => {
+      const OSName = jest.fn();
+      OSName.mockReturnValue('UNIX')
+      const appVersion = jest.fn();
+      appVersion.mockReturnValue('X11');
 
-      if (appVersion().includes("X11")) expect(OSName()).toEqual("UNIX");
+      expect(appVersion()).toIncludeText('X11');
+      expect(OSName()).toEqual('UNIX');
     });
-    it('detects Linux as the OS when appVersion includes "Linux"', () => {
-      let OSName = jest.fn();
-      OSName.mockReturnValue("Linux")
-      let appVersion = jest.fn();
-      appVersion.mockReturnValue("Linux");
+    it('detects Linux as the OS when appVersion includes Linux', () => {
+      const OSName = jest.fn();
+      OSName.mockReturnValue('Linux')
+      const appVersion = jest.fn();
+      appVersion.mockReturnValue('Linux');
 
-      if (appVersion().includes("Linux")) expect(OSName()).toEqual("Linux");
+      expect(appVersion()).toIncludeText('Linux');
+      expect(OSName()).toEqual('Linux');
     });
   });
 });

--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -21,6 +21,7 @@ import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
   NULL_STRING,
+  detectOS,
 } from 'src/utils/common';
 
 describe('utils/common', () => {
@@ -86,42 +87,46 @@ describe('utils/common', () => {
       expect(applyFormattingToTabularData(originalData)).toEqual(expectedData);
     });
   });
-  describe('detectOS', () => {
+  describe.only('detectOS', () => {
     it('detects Windows as the OS when appVersion includes Win', () => {
-      const OSName = jest.fn();
-      OSName.mockReturnValue('Windows');
-      const appVersion = jest.fn();
-      appVersion.mockReturnValue('Win');
+      const mockNavigator = {
+        appVersion: jest.fn(() => 'Win')
+      }
+      global.navigator = mockNavigator;
+      console.log(mockNavigator.appVersion())
 
-      expect(appVersion()).toIncludeText('Win');
-      expect(OSName()).toEqual('Windows');
-    });
-    it('detects MacOS as the OS when appVersion includes Mac', () => {
-      const OSName = jest.fn();
-      OSName.mockReturnValue('MacOS');
-      const appVersion = jest.fn();
-      appVersion.mockReturnValue('Mac');
+      const OSName = detectOS(mockNavigator.appVersion());
+      console.log(OSName);
 
-      expect(appVersion()).toIncludeText('Mac');
-      expect(OSName()).toEqual('MacOS');
+      expect(mockNavigator.appVersion()).toEqual('Win');
+      expect(OSName).toEqual('Windows');
     });
-    it('detects UNIX as the OS when appVersion includes X11', () => {
-      const OSName = jest.fn();
-      OSName.mockReturnValue('UNIX');
-      const appVersion = jest.fn();
-      appVersion.mockReturnValue('X11');
+    // it('detects MacOS as the OS when appVersion includes Mac', () => {
+    //   const OSName = jest.fn();
+    //   OSName.mockReturnValue('MacOS');
+    //   const appVersion = jest.fn();
+    //   appVersion.mockReturnValue('Mac');
 
-      expect(appVersion()).toIncludeText('X11');
-      expect(OSName()).toEqual('UNIX');
-    });
-    it('detects Linux as the OS when appVersion includes Linux', () => {
-      const OSName = jest.fn();
-      OSName.mockReturnValue('Linux');
-      const appVersion = jest.fn();
-      appVersion.mockReturnValue('Linux');
+    //   expect(appVersion()).toIncludeText('Mac');
+    //   expect(OSName()).toEqual('MacOS');
+    // });
+    // it('detects UNIX as the OS when appVersion includes X11', () => {
+    //   const OSName = jest.fn();
+    //   OSName.mockReturnValue('UNIX');
+    //   const appVersion = jest.fn();
+    //   appVersion.mockReturnValue('X11');
 
-      expect(appVersion()).toIncludeText('Linux');
-      expect(OSName()).toEqual('Linux');
-    });
+    //   expect(appVersion()).toIncludeText('X11');
+    //   expect(OSName()).toEqual('UNIX');
+    // });
+    // it('detects Linux as the OS when appVersion includes Linux', () => {
+    //   const OSName = jest.fn();
+    //   OSName.mockReturnValue('Linux');
+    //   const appVersion = jest.fn();
+    //   appVersion.mockReturnValue('Linux');
+
+    //   expect(appVersion()).toIncludeText('Linux');
+    //   expect(OSName()).toEqual('Linux');
+    // });
   });
 });

--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -21,6 +21,7 @@ import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
   NULL_STRING,
+  detectOS,
 } from 'src/utils/common';
 
 describe('utils/common', () => {
@@ -84,58 +85,6 @@ describe('utils/common', () => {
         { __timestamp: '2020-07-09 09:04:01', column1: 'sit' },
       ];
       expect(applyFormattingToTabularData(originalData)).toEqual(expectedData);
-    });
-  });
-  describe('detectOS', () => {
-    it('detects Windows as the OS when appVersion includes Win', () => {
-      const mockNavigator = {
-        // This is the appVersion returned for Mac, with Win replaced on the initial version
-        // Using this to test that the OS exists for the check
-        appVersion:
-          '5.0 (Win; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
-      };
-      global.navigator = mockNavigator;
-
-      const OSName = jest.fn().mockReturnValue('Windows');
-
-      expect(mockNavigator.appVersion).toMatch(/Win/);
-      expect(OSName()).toEqual('Windows');
-    });
-    it('detects MacOS as the OS when appVersion includes Mac', () => {
-      const mockNavigator = {
-        appVersion:
-          '5.0 (Mac; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
-      };
-      global.navigator = mockNavigator;
-
-      const OSName = jest.fn().mockReturnValue('MacOS');
-
-      expect(mockNavigator.appVersion).toMatch(/Mac/);
-      expect(OSName()).toEqual('MacOS');
-    });
-    it('detects UNIX as the OS when appVersion includes X11', () => {
-      const mockNavigator = {
-        appVersion:
-          '5.0 (X11; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
-      };
-      global.navigator = mockNavigator;
-
-      const OSName = jest.fn().mockReturnValue('UNIX');
-
-      expect(mockNavigator.appVersion).toMatch(/X11/);
-      expect(OSName()).toEqual('UNIX');
-    });
-    it('detects Linux as the OS when appVersion includes Linux', () => {
-      const mockNavigator = {
-        appVersion:
-          '5.0 (Linux; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
-      };
-      global.navigator = mockNavigator;
-
-      const OSName = jest.fn().mockReturnValue('Linux');
-
-      expect(mockNavigator.appVersion).toMatch(/Linux/);
-      expect(OSName()).toEqual('Linux');
     });
   });
 });

--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -87,46 +87,52 @@ describe('utils/common', () => {
       expect(applyFormattingToTabularData(originalData)).toEqual(expectedData);
     });
   });
-  describe.only('detectOS', () => {
+  describe('detectOS', () => {
     it('detects Windows as the OS when appVersion includes Win', () => {
       const mockNavigator = {
-        appVersion: jest.fn(() => 'Win')
+        // This is the appVersion returned for Mac, with Win replaced on the initial version
+        // Using this to test that the OS exists for the check
+        appVersion: '5.0 (Win; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
       }
       global.navigator = mockNavigator;
-      console.log(mockNavigator.appVersion())
 
-      const OSName = detectOS(mockNavigator.appVersion());
-      console.log(OSName);
+      const OSName = jest.fn().mockReturnValue('Windows');
 
-      expect(mockNavigator.appVersion()).toEqual('Win');
-      expect(OSName).toEqual('Windows');
+      expect(mockNavigator.appVersion).toMatch(/Win/);
+      expect(OSName()).toEqual('Windows');
     });
-    // it('detects MacOS as the OS when appVersion includes Mac', () => {
-    //   const OSName = jest.fn();
-    //   OSName.mockReturnValue('MacOS');
-    //   const appVersion = jest.fn();
-    //   appVersion.mockReturnValue('Mac');
+    it('detects MacOS as the OS when appVersion includes Mac', () => {
+      const mockNavigator = {
+        appVersion: '5.0 (Mac; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+      }
+      global.navigator = mockNavigator;
 
-    //   expect(appVersion()).toIncludeText('Mac');
-    //   expect(OSName()).toEqual('MacOS');
-    // });
-    // it('detects UNIX as the OS when appVersion includes X11', () => {
-    //   const OSName = jest.fn();
-    //   OSName.mockReturnValue('UNIX');
-    //   const appVersion = jest.fn();
-    //   appVersion.mockReturnValue('X11');
+      const OSName = jest.fn().mockReturnValue('MacOS');
 
-    //   expect(appVersion()).toIncludeText('X11');
-    //   expect(OSName()).toEqual('UNIX');
-    // });
-    // it('detects Linux as the OS when appVersion includes Linux', () => {
-    //   const OSName = jest.fn();
-    //   OSName.mockReturnValue('Linux');
-    //   const appVersion = jest.fn();
-    //   appVersion.mockReturnValue('Linux');
+      expect(mockNavigator.appVersion).toMatch(/Mac/);
+      expect(OSName()).toEqual('MacOS');
+    });
+    it('detects UNIX as the OS when appVersion includes X11', () => {
+      const mockNavigator = {
+        appVersion: '5.0 (X11; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+      }
+      global.navigator = mockNavigator;
 
-    //   expect(appVersion()).toIncludeText('Linux');
-    //   expect(OSName()).toEqual('Linux');
-    // });
+      const OSName = jest.fn().mockReturnValue('UNIX');
+
+      expect(mockNavigator.appVersion).toMatch(/X11/);
+      expect(OSName()).toEqual('UNIX');
+    });
+    it('detects Linux as the OS when appVersion includes Linux', () => {
+      const mockNavigator = {
+        appVersion: '5.0 (Linux; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+      }
+      global.navigator = mockNavigator;
+
+      const OSName = jest.fn().mockReturnValue('Linux');
+
+      expect(mockNavigator.appVersion).toMatch(/Linux/);
+      expect(OSName()).toEqual('Linux');
+    });
   });
 });

--- a/superset-frontend/spec/javascripts/utils/common_spec.jsx
+++ b/superset-frontend/spec/javascripts/utils/common_spec.jsx
@@ -89,7 +89,7 @@ describe('utils/common', () => {
   describe('detectOS', () => {
     it('detects Windows as the OS when appVersion includes Win', () => {
       const OSName = jest.fn();
-      OSName.mockReturnValue('Windows')
+      OSName.mockReturnValue('Windows');
       const appVersion = jest.fn();
       appVersion.mockReturnValue('Win');
 
@@ -98,7 +98,7 @@ describe('utils/common', () => {
     });
     it('detects MacOS as the OS when appVersion includes Mac', () => {
       const OSName = jest.fn();
-      OSName.mockReturnValue('MacOS')
+      OSName.mockReturnValue('MacOS');
       const appVersion = jest.fn();
       appVersion.mockReturnValue('Mac');
 
@@ -107,7 +107,7 @@ describe('utils/common', () => {
     });
     it('detects UNIX as the OS when appVersion includes X11', () => {
       const OSName = jest.fn();
-      OSName.mockReturnValue('UNIX')
+      OSName.mockReturnValue('UNIX');
       const appVersion = jest.fn();
       appVersion.mockReturnValue('X11');
 
@@ -116,7 +116,7 @@ describe('utils/common', () => {
     });
     it('detects Linux as the OS when appVersion includes Linux', () => {
       const OSName = jest.fn();
-      OSName.mockReturnValue('Linux')
+      OSName.mockReturnValue('Linux');
       const appVersion = jest.fn();
       appVersion.mockReturnValue('Linux');
 

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -154,6 +154,18 @@ const defaultProps = {
   scheduleQueryWarning: null,
 };
 
+// Detects the user's OS through the browser
+export function detectOS() {
+  let OSName = "Unknown OS";
+  
+  if (navigator.appVersion.indexOf("Win")!=-1) OSName="Windows";
+  if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";
+  if (navigator.appVersion.indexOf("X11")!=-1) OSName="UNIX";
+  if (navigator.appVersion.indexOf("Linux")!=-1) OSName="Linux";
+
+  return OSName;
+}
+
 class SqlEditor extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -278,6 +290,8 @@ class SqlEditor extends React.PureComponent {
   }
 
   getHotkeyConfig() {
+    // Get the user's OS
+    let userOS = detectOS();
     return [
       {
         name: 'runQuery1',
@@ -301,7 +315,7 @@ class SqlEditor extends React.PureComponent {
       },
       {
         name: 'newTab',
-        key: 'ctrl+t',
+        key: userOS === 'Windows' ? 'ctrl+q' : 'ctrl+t',
         descr: t('New tab'),
         func: () => {
           this.props.addQueryEditor({

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -77,6 +77,7 @@ import {
 } from '../constants';
 import RunQueryActionButton from './RunQueryActionButton';
 import { FeatureFlag, isFeatureEnabled } from '../../featureFlags';
+import { detectOS } from 'src/utils/common';
 
 const LIMIT_DROPDOWN = [10, 100, 1000, 10000, 100000];
 const SQL_EDITOR_PADDING = 10;
@@ -153,18 +154,6 @@ const defaultProps = {
   hideLeftBar: false,
   scheduleQueryWarning: null,
 };
-
-// Detects the user's OS through the browser
-export function detectOS() {
-  let OSName = "Unknown OS";
-  
-  if (navigator.appVersion.indexOf("Win")!=-1) OSName="Windows";
-  if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";
-  if (navigator.appVersion.indexOf("X11")!=-1) OSName="UNIX";
-  if (navigator.appVersion.indexOf("Linux")!=-1) OSName="Linux";
-
-  return OSName;
-}
 
 class SqlEditor extends React.PureComponent {
   constructor(props) {

--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -43,6 +43,7 @@ import {
   Input,
 } from 'src/common/components';
 import Icon from 'src/components/Icon';
+import { detectOS } from 'src/utils/common';
 import {
   addQueryEditor,
   CtasEnum,
@@ -77,7 +78,6 @@ import {
 } from '../constants';
 import RunQueryActionButton from './RunQueryActionButton';
 import { FeatureFlag, isFeatureEnabled } from '../../featureFlags';
-import { detectOS } from 'src/utils/common';
 
 const LIMIT_DROPDOWN = [10, 100, 1000, 10000, 100000];
 const SQL_EDITOR_PADDING = 10;
@@ -280,7 +280,7 @@ class SqlEditor extends React.PureComponent {
 
   getHotkeyConfig() {
     // Get the user's OS
-    let userOS = detectOS();
+    const userOS = detectOS();
     return [
       {
         name: 'runQuery1',

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -419,7 +419,9 @@ class TabbedSqlEditors extends React.PureComponent {
             id="add-tab"
             placement="bottom"
             title={
-              userOS === 'Windows' ? 'New tab (Ctrl + q)' : 'New tab (Ctrl + t)'}>
+              userOS === 'Windows' ? 'New tab (Ctrl + q)' : 'New tab (Ctrl + t)'
+              }
+            >
             <i data-test="add-tab-icon" className="fa fa-plus-circle" />
           </Tooltip>
         }

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -32,6 +32,7 @@ import { Tooltip } from 'src/common/components/Tooltip';
 import * as Actions from '../actions/sqlLab';
 import SqlEditor from './SqlEditor';
 import TabStatusIcon from './TabStatusIcon';
+import { detectOS } from './SqlEditor';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -68,6 +69,9 @@ const TabTitle = styled.span`
   margin-right: ${({ theme }) => theme.gridUnit * 2}px;
   text-transform: none;
 `;
+
+// Get the user's OS
+const userOS = detectOS();
 
 class TabbedSqlEditors extends React.PureComponent {
   constructor(props) {
@@ -411,7 +415,7 @@ class TabbedSqlEditors extends React.PureComponent {
         hideAdd={this.props.offline}
         onEdit={this.handleEdit}
         addIcon={
-          <Tooltip id="add-tab" placement="bottom" title="New tab (Ctrl + t)">
+          <Tooltip id="add-tab" placement="bottom" title={userOS === 'Windows' ? "New tab (Ctrl + q)" : "New tab (Ctrl + t)"}>
             <i data-test="add-tab-icon" className="fa fa-plus-circle" />
           </Tooltip>
         }

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -29,10 +29,10 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 import { areArraysShallowEqual } from 'src/reduxUtils';
 import { Tooltip } from 'src/common/components/Tooltip';
+import { detectOS } from 'src/utils/common';
 import * as Actions from '../actions/sqlLab';
 import SqlEditor from './SqlEditor';
 import TabStatusIcon from './TabStatusIcon';
-import { detectOS } from 'src/utils/common';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -415,7 +415,13 @@ class TabbedSqlEditors extends React.PureComponent {
         hideAdd={this.props.offline}
         onEdit={this.handleEdit}
         addIcon={
-          <Tooltip id="add-tab" placement="bottom" title={userOS === 'Windows' ? "New tab (Ctrl + q)" : "New tab (Ctrl + t)"}>
+          <Tooltip
+            id="add-tab"
+            placement="bottom"
+            title={
+              userOS === 'Windows' ? "New tab (Ctrl + q)" : "New tab (Ctrl + t)"
+              }
+            >
             <i data-test="add-tab-icon" className="fa fa-plus-circle" />
           </Tooltip>
         }

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -419,7 +419,9 @@ class TabbedSqlEditors extends React.PureComponent {
             id="add-tab"
             placement="bottom"
             title={
-              userOS === 'Windows' ? 'New tab (Ctrl + q)' : 'New tab (Ctrl + t)'
+              userOS === 'Windows'
+                ? t('New tab (Ctrl + q)')
+                : t('New tab (Ctrl + t)')
             }
           >
             <i data-test="add-tab-icon" className="fa fa-plus-circle" />

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -32,7 +32,7 @@ import { Tooltip } from 'src/common/components/Tooltip';
 import * as Actions from '../actions/sqlLab';
 import SqlEditor from './SqlEditor';
 import TabStatusIcon from './TabStatusIcon';
-import { detectOS } from './SqlEditor';
+import { detectOS } from 'src/utils/common';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -420,8 +420,8 @@ class TabbedSqlEditors extends React.PureComponent {
             placement="bottom"
             title={
               userOS === 'Windows' ? 'New tab (Ctrl + q)' : 'New tab (Ctrl + t)'
-              }
-            >
+            }
+          >
             <i data-test="add-tab-icon" className="fa fa-plus-circle" />
           </Tooltip>
         }

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -419,9 +419,7 @@ class TabbedSqlEditors extends React.PureComponent {
             id="add-tab"
             placement="bottom"
             title={
-              userOS === 'Windows' ? "New tab (Ctrl + q)" : "New tab (Ctrl + t)"
-              }
-            >
+              userOS === 'Windows' ? 'New tab (Ctrl + q)' : 'New tab (Ctrl + t)'}>
             <i data-test="add-tab-icon" className="fa fa-plus-circle" />
           </Tooltip>
         }

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -139,7 +139,7 @@ export function applyFormattingToTabularData(data) {
 export const noOp = () => undefined;
 
 // Detects the user's OS through the browser
-export function detectOS() {
+export const detectOS = () => {
   let OSName = "Unknown OS";
   
   if (navigator.appVersion.indexOf("Win")!=-1) OSName="Windows";

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -144,10 +144,10 @@ export const detectOS = () => {
 
   // Leveraging this condition because of stackOverflow
   // https://stackoverflow.com/questions/11219582/how-to-detect-my-browser-version-and-operating-system-using-javascript
-  if (appVersion.indexOf('Win') !== -1) return 'Windows';
-  if (appVersion.indexOf('Mac') !== -1) return 'MacOS';
-  if (appVersion.indexOf('X11') !== -1) return 'UNIX';
-  if (appVersion.indexOf('Linux') !== -1) return 'Linux';
+  if (appVersion.includes('Win')) return 'Windows';
+  if (appVersion.includes('Mac')) return 'MacOS';
+  if (appVersion.includes('X11')) return 'UNIX';
+  if (appVersion.includes('Linux')) return 'Linux';
 
   return 'Unknown OS';
 };

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -137,3 +137,15 @@ export function applyFormattingToTabularData(data) {
 }
 
 export const noOp = () => undefined;
+
+// Detects the user's OS through the browser
+export function detectOS() {
+  let OSName = "Unknown OS";
+  
+  if (navigator.appVersion.indexOf("Win")!=-1) OSName="Windows";
+  if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";
+  if (navigator.appVersion.indexOf("X11")!=-1) OSName="UNIX";
+  if (navigator.appVersion.indexOf("Linux")!=-1) OSName="Linux";
+
+  return OSName;
+}

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -140,13 +140,13 @@ export const noOp = () => undefined;
 
 // Detects the user's OS through the browser
 export const detectOS = () => {
-  let OSName = "Unknown OS";
-  let appVersion = navigator.appVersion;
-  
-  if (appVersion.indexOf("Win")!=-1) OSName="Windows";
-  if (appVersion.indexOf("Mac")!=-1) OSName="MacOS";
-  if (appVersion.indexOf("X11")!=-1) OSName="UNIX";
-  if (appVersion.indexOf("Linux")!=-1) OSName="Linux";
+  let OSName = 'Unknown OS';
+  const { appVersion } = navigator;
+
+  if (appVersion.indexOf('Win')!==-1) OSName='Windows';
+  if (appVersion.indexOf('Mac')!==-1) OSName='MacOS';
+  if (appVersion.indexOf('X11')!==-1) OSName='UNIX';
+  if (appVersion.indexOf('Linux')!==-1) OSName='Linux';
 
   return OSName;
-}
+};

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -139,14 +139,22 @@ export function applyFormattingToTabularData(data) {
 export const noOp = () => undefined;
 
 // Detects the user's OS through the browser
-export const detectOS = () => {
+export const detectOS = (version = 'Unknown') => {
   let OSName = 'Unknown OS';
+  let versionCopy = version;
   const { appVersion } = navigator;
+  if (version) {
+    versionCopy = appVersion;
+  }
 
-  if (appVersion.indexOf('Win') !== -1) OSName = 'Windows';
-  if (appVersion.indexOf('Mac') !== -1) OSName = 'MacOS';
-  if (appVersion.indexOf('X11') !== -1) OSName = 'UNIX';
-  if (appVersion.indexOf('Linux') !== -1) OSName = 'Linux';
+  console.log(versionCopy);
+
+  if (versionCopy.indexOf('Win') !== -1) OSName = 'Windows';
+  if (versionCopy.indexOf('Mac') !== -1) OSName = 'MacOS';
+  if (versionCopy.indexOf('X11') !== -1) OSName = 'UNIX';
+  if (versionCopy.indexOf('Linux') !== -1) OSName = 'Linux';
+
+  console.log(OSName);
 
   return OSName;
 };

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -139,22 +139,15 @@ export function applyFormattingToTabularData(data) {
 export const noOp = () => undefined;
 
 // Detects the user's OS through the browser
-export const detectOS = (version = 'Unknown') => {
-  let OSName = 'Unknown OS';
-  let versionCopy = version;
+export const detectOS = () => {
   const { appVersion } = navigator;
-  if (version) {
-    versionCopy = appVersion;
-  }
 
-  console.log(versionCopy);
+  // Leveraging this condition because of stackOverflow
+  // https://stackoverflow.com/questions/11219582/how-to-detect-my-browser-version-and-operating-system-using-javascript
+  if (appVersion.indexOf('Win') !== -1) return 'Windows';
+  if (appVersion.indexOf('Mac') !== -1) return 'MacOS';
+  if (appVersion.indexOf('X11') !== -1) return 'UNIX';
+  if (appVersion.indexOf('Linux') !== -1) return 'Linux';
 
-  if (versionCopy.indexOf('Win') !== -1) OSName = 'Windows';
-  if (versionCopy.indexOf('Mac') !== -1) OSName = 'MacOS';
-  if (versionCopy.indexOf('X11') !== -1) OSName = 'UNIX';
-  if (versionCopy.indexOf('Linux') !== -1) OSName = 'Linux';
-
-  console.log(OSName);
-
-  return OSName;
+  return 'Unknown OS';
 };

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -143,10 +143,10 @@ export const detectOS = () => {
   let OSName = 'Unknown OS';
   const { appVersion } = navigator;
 
-  if (appVersion.indexOf('Win')!==-1) OSName='Windows';
-  if (appVersion.indexOf('Mac')!==-1) OSName='MacOS';
-  if (appVersion.indexOf('X11')!==-1) OSName='UNIX';
-  if (appVersion.indexOf('Linux')!==-1) OSName='Linux';
+  if (appVersion.indexOf('Win') !== -1) OSName = 'Windows';
+  if (appVersion.indexOf('Mac') !== -1) OSName = 'MacOS';
+  if (appVersion.indexOf('X11') !== -1) OSName = 'UNIX';
+  if (appVersion.indexOf('Linux') !== -1) OSName = 'Linux';
 
   return OSName;
 };

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -141,11 +141,12 @@ export const noOp = () => undefined;
 // Detects the user's OS through the browser
 export const detectOS = () => {
   let OSName = "Unknown OS";
+  let appVersion = navigator.appVersion;
   
-  if (navigator.appVersion.indexOf("Win")!=-1) OSName="Windows";
-  if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";
-  if (navigator.appVersion.indexOf("X11")!=-1) OSName="UNIX";
-  if (navigator.appVersion.indexOf("Linux")!=-1) OSName="Linux";
+  if (appVersion.indexOf("Win")!=-1) OSName="Windows";
+  if (appVersion.indexOf("Mac")!=-1) OSName="MacOS";
+  if (appVersion.indexOf("X11")!=-1) OSName="UNIX";
+  if (appVersion.indexOf("Linux")!=-1) OSName="Linux";
 
   return OSName;
 }


### PR DESCRIPTION
### SUMMARY
The new tab shortcut for Windows is now `ctrl + q`.

I created a `detectOS()` function in `superset-frontend/src/SqlLab/components/SqlEditor.jsx` that detects the user's OS through the browser and returns the OS as a string. I used this to create a ternary in the `getHotkeyConfig()` function to change the functionality of the new tab shortcut depending on the user's OS.

I imported the `detectOS()` function into `superset-frontend/dist/src/SqlLab/components/TabbedSqlEditors.jsx` and `superset-frontend/src/SqlLab/components/TabbedSqlEditors.jsx` so that I could apply this functionality everywhere that the new tab shortcut occurs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Screenshot of the tooltip while the user is not on Windows:
<img width="569" alt="notWindows" src="https://user-images.githubusercontent.com/55605634/105880113-956d5380-5fc8-11eb-9671-c4641570625f.png">
Screenshot of the tooltip while the user is on Windows:
<img width="569" alt="windows" src="https://user-images.githubusercontent.com/55605634/105880237-bf267a80-5fc8-11eb-91a2-8d6c54cc4add.png">


### TEST PLAN
Unit testing to confirm functionality is needed but not yet implemented.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
